### PR TITLE
App Transport Security fix

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -124,5 +124,10 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Allow downloading files from http servers (not https).

Since iOS 9 and OS X El Capitan Apple is enforcing https connections by default. Added key allows to download files from http servers too.

Use case (can be observed when compiled under Xcode 7): drag URL to .torrent file from some http site into Transmission window, error is shown: "The torrent could not be downloaded from http://d.rutor.org/download/465530: The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.".

