### PR TITLE
Torrent properties window size is saved as a preference.

### DIFF
--- a/gtk/conf.c
+++ b/gtk/conf.c
@@ -102,6 +102,8 @@ tr_prefs_init_defaults (tr_variant * d)
   tr_variantDictAddStr  (d, TR_KEY_sort_mode, "sort-by-name");
   tr_variantDictAddBool (d, TR_KEY_sort_reversed, FALSE);
   tr_variantDictAddBool (d, TR_KEY_compact_view, FALSE);
+  tr_variantDictAddInt  (d, TR_KEY_details_window_height, 500);
+  tr_variantDictAddInt  (d, TR_KEY_details_window_width, 300);
 }
 
 static tr_variant*

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2692,6 +2692,20 @@ details_free (gpointer gdata)
   g_free (data);
 }
 
+static void
+on_details_response (GtkWidget *d)
+{
+  gint w = 0;
+  gint h = 0;
+
+  gtk_window_get_size (GTK_WINDOW(d), &w, &h);
+
+  gtr_pref_int_set (TR_KEY_details_window_width, w);
+  gtr_pref_int_set (TR_KEY_details_window_height, h);
+
+  gtk_widget_destroy (d);
+}
+
 GtkWidget*
 gtr_torrent_details_dialog_new (GtkWindow * parent, TrCore * core)
 {
@@ -2717,9 +2731,13 @@ gtr_torrent_details_dialog_new (GtkWindow * parent, TrCore * core)
   di->dialog = d;
   gtk_window_set_role (GTK_WINDOW (d), "tr-info");
   g_signal_connect_swapped (d, "response",
-                            G_CALLBACK (gtk_widget_destroy), d);
+                            G_CALLBACK (on_details_response), d);
   gtk_container_set_border_width (GTK_CONTAINER (d), GUI_PAD);
   g_object_set_qdata_full (G_OBJECT (d), DETAILS_KEY, di, details_free);
+
+  gtk_window_set_default_size(GTK_WINDOW(d),
+                              gtr_pref_int_get (TR_KEY_details_window_width),
+                              gtr_pref_int_get (TR_KEY_details_window_height));
 
   n = gtk_notebook_new ();
   gtk_container_set_border_width (GTK_CONTAINER (n), GUI_PAD);

--- a/gtk/open-dialog.c
+++ b/gtk/open-dialog.c
@@ -117,6 +117,8 @@ addResponseCB (GtkDialog * dialog,
                gpointer    gdata)
 {
   struct OpenData * o = gdata;
+  gint w = 0;
+  gint h = 0;
 
   if (o->tor)
     {
@@ -139,6 +141,11 @@ addResponseCB (GtkDialog * dialog,
           save_recent_destination (o->core, o->downloadDir);
         }
     }
+
+  gtk_window_get_size (GTK_WINDOW(dialog), &w, &h);
+
+  gtr_pref_int_set (TR_KEY_details_window_width, w);
+  gtr_pref_int_set (TR_KEY_details_window_height, h);
 
   tr_ctorFree (o->ctor);
   g_free (o->filename);
@@ -288,6 +295,9 @@ gtr_torrent_options_dialog_new (GtkWindow * parent, TrCore * core, tr_ctor * cto
                                            GTK_RESPONSE_ACCEPT,
                                            GTK_RESPONSE_CANCEL,
                                            -1);
+  gtk_window_set_default_size(GTK_WINDOW(d),
+                              gtr_pref_int_get (TR_KEY_details_window_width),
+                              gtr_pref_int_get (TR_KEY_details_window_height));
 
   if (!tr_ctorGetDownloadDir (ctor, TR_FORCE, &str))
     g_assert_not_reached ();

--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -81,6 +81,8 @@ static const struct tr_key_struct my_static[] =
   { "delete-local-data", 17 },
   { "desiredAvailable", 16 },
   { "destination", 11 },
+  { "details-window-height", 21 },
+  { "details-window-width", 20 },
   { "dht-enabled", 11 },
   { "display-name", 12 },
   { "dnd", 3 },

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -83,6 +83,8 @@ enum
   TR_KEY_delete_local_data,
   TR_KEY_desiredAvailable,
   TR_KEY_destination,
+  TR_KEY_details_window_height,
+  TR_KEY_details_window_width,
   TR_KEY_dht_enabled,
   TR_KEY_display_name,
   TR_KEY_dnd,


### PR DESCRIPTION
Oftentimes I find myself enlarging the torrent properties window, so that the filenames can be seen in full. I thought it would nice if Transmission remembered the last size of the properties window.

Tested on Ubuntu 12.04~14.04, Gnome 3.12.2.
