### PR TITLE
Use strncmp instead of memcmp to avoid out-of-bounds reads

### DIFF
--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -10,7 +10,7 @@
 #include <limits.h> /* INT_MAX */
 #include <stdio.h>
 #include <stdlib.h> /* qsort () */
-#include <string.h> /* strcmp (), memcpy () */
+#include <string.h> /* strcmp (), memcpy (), strncmp () */
 
 #include <event2/buffer.h>
 #include <event2/event.h> /* evtimer */
@@ -1219,9 +1219,9 @@ announce_request_delegate (tr_announcer               * announcer,
              request->peer_id);
 #endif
 
-    if (memcmp (request->url, "http", 4) == 0)
+    if (strncmp (request->url, "http", 4) == 0)
         tr_tracker_http_announce (session, request, callback, callback_data);
-    else if (memcmp (request->url, "udp://", 6) == 0)
+    else if (strncmp (request->url, "udp://", 6) == 0)
         tr_tracker_udp_announce (session, request, callback, callback_data);
     else
         tr_logAddError ("Unsupported url: %s", request->url);
@@ -1398,9 +1398,9 @@ scrape_request_delegate (tr_announcer             * announcer,
 {
     tr_session * session = announcer->session;
 
-    if (memcmp (request->url, "http", 4) == 0)
+    if (strncmp (request->url, "http", 4) == 0)
         tr_tracker_http_scrape (session, request, callback, callback_data);
-    else if (memcmp (request->url, "udp://", 6) == 0)
+    else if (strncmp (request->url, "udp://", 6) == 0)
         tr_tracker_udp_scrape (session, request, callback, callback_data);
     else
         tr_logAddError ("Unsupported url: %s", request->url);

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -112,17 +112,18 @@ isMainlineStyle (const uint8_t * peer_id)
 static bool
 decodeBitCometClient (char * buf, size_t buflen, const uint8_t * id)
 {
+    const char * chid = (char *)id;
     bool is_bitlord;
     int major, minor;
     const char * name;
     const char * mod = NULL;
 
-    if (strncmp (id, "exbc", 4) == 0) mod = "";
-    else if (strncmp (id, "FUTB", 4) == 0) mod = " (Solidox Mod) ";
-    else if (strncmp (id, "xUTB", 4) == 0) mod = " (Mod 2) ";
+    if (strncmp (chid, "exbc", 4) == 0) mod = "";
+    else if (strncmp (chid, "FUTB", 4) == 0) mod = " (Solidox Mod) ";
+    else if (strncmp (chid, "xUTB", 4) == 0) mod = " (Mod 2) ";
     else return false;
 
-    is_bitlord = strncmp (id+6, "LORD", 4) == 0;
+    is_bitlord = strncmp (chid+6, "LORD", 4) == 0;
     name = (is_bitlord) ? "BitLord " : "BitComet ";
     major = id[4];
     minor = id[5];
@@ -143,6 +144,7 @@ char *
 tr_clientForId (char * buf, size_t buflen, const void * id_in)
 {
     const uint8_t * id = id_in;
+    const char * chid = (char *)id;
 
     *buf = '\0';
 
@@ -152,38 +154,38 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
     /* Azureus-style */
     if (id[0] == '-' && id[7] == '-')
     {
-        if (strncmp (id+1, "TR", 2) == 0)
+        if (strncmp (chid+1, "TR", 2) == 0)
         {
-            if (strncmp (id+3, "000", 3) == 0) /* very old client style: -TR0006- is 0.6 */
+            if (strncmp (chid+3, "000", 3) == 0) /* very old client style: -TR0006- is 0.6 */
                 tr_snprintf (buf, buflen, "Transmission 0.%c", id[6]);
-            else if (strncmp (id+3, "00", 2) == 0) /* previous client style: -TR0072- is 0.72 */
+            else if (strncmp (chid+3, "00", 2) == 0) /* previous client style: -TR0072- is 0.72 */
                 tr_snprintf (buf, buflen, "Transmission 0.%02d", strint (id+5,2));
             else /* current client style: -TR111Z- is 1.11+ */
                 tr_snprintf (buf, buflen, "Transmission %d.%02d%s", strint (id+3,1), strint (id+4,2),
                           id[6]=='Z' || id[6]=='X' ? "+" : "");
         }
-        else if (strncmp (id+1, "UT", 2) == 0)
+        else if (strncmp (chid+1, "UT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (strncmp (id+1, "BT", 2) == 0)
+        else if (strncmp (chid+1, "BT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitTorrent %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (strncmp (id+1, "UM", 2) == 0)
+        else if (strncmp (chid+1, "UM", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Mac %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (strncmp (id+1, "UE", 2) == 0)
+        else if (strncmp (chid+1, "UE", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
 
-        else if (strncmp (id+1, "AZ", 2) == 0)
+        else if (strncmp (chid+1, "AZ", 2) == 0)
         {
             if (id[3] > '3' || (id[3] == '3' && id[4] >= '1')) /* Vuze starts at version 3.1.0.0 */
                 four_digits (buf, buflen, "Vuze", id+3);
@@ -191,7 +193,7 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
                 four_digits (buf, buflen, "Azureus", id+3);
         }
 
-        else if (strncmp (id+1, "KT", 2) == 0)
+        else if (strncmp (chid+1, "KT", 2) == 0)
         {
             if (id[5] == 'D')
                 tr_snprintf (buf, buflen, "KTorrent %d.%d Dev %d", charint (id[3]), charint (id[4]), charint (id[6]));
@@ -201,108 +203,108 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
                 three_digits (buf, buflen, "KTorrent", id+3);
         }
 
-        else if (strncmp (id+1, "AG", 2) == 0) four_digits (buf, buflen, "Ares", id+3);
-        else if (strncmp (id+1, "AR", 2) == 0) four_digits (buf, buflen, "Arctic", id+3);
-        else if (strncmp (id+1, "AT", 2) == 0) four_digits (buf, buflen, "Artemis", id+3);
-        else if (strncmp (id+1, "AV", 2) == 0) four_digits (buf, buflen, "Avicora", id+3);
-        else if (strncmp (id+1, "BB", 2) == 0) four_digits (buf, buflen, "BitBuddy", id+3);
-        else if (strncmp (id+1, "BE", 2) == 0) four_digits (buf, buflen, "BitTorrent SDK", id+3);
-        else if (strncmp (id+1, "BG", 2) == 0) four_digits (buf, buflen, "BTGetit", id+3);
-        else if (strncmp (id+1, "BH", 2) == 0) four_digits (buf, buflen, "BitZilla", id+3);
-        else if (strncmp (id+1, "BM", 2) == 0) four_digits (buf, buflen, "BitMagnet", id+3);
-        else if (strncmp (id+1, "BP", 2) == 0) four_digits (buf, buflen, "BitTorrent Pro (Azureus + Spyware)", id+3);
-        else if (strncmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
-        else if (strncmp (id+1, "bk", 2) == 0) four_digits (buf, buflen, "BitKitten (libtorrent)", id+3);
-        else if (strncmp (id+1, "BS", 2) == 0) four_digits (buf, buflen, "BTSlave", id+3);
-        else if (strncmp (id+1, "BW", 2) == 0) four_digits (buf, buflen, "BitWombat", id+3);
-        else if (strncmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
-        else if (strncmp (id+1, "EB", 2) == 0) four_digits (buf, buflen, "EBit", id+3);
-        else if (strncmp (id+1, "DE", 2) == 0) four_digits (buf, buflen, "Deluge", id+3);
-        else if (strncmp (id+1, "DP", 2) == 0) four_digits (buf, buflen, "Propogate Data Client", id+3);
-        else if (strncmp (id+1, "FC", 2) == 0) four_digits (buf, buflen, "FileCroc", id+3);
-        else if (strncmp (id+1, "FT", 2) == 0) four_digits (buf, buflen, "FoxTorrent/RedSwoosh", id+3);
-        else if (strncmp (id+1, "GR", 2) == 0) four_digits (buf, buflen, "GetRight", id+3);
-        else if (strncmp (id+1, "GS", 2) == 0) four_digits (buf, buflen, "GSTorrent", id+3);
-        else if (strncmp (id+1, "HK", 2) == 0) four_digits (buf, buflen, "Hekate", id+3);
-        else if (strncmp (id+1, "HN", 2) == 0) four_digits (buf, buflen, "Hydranode", id+3);
-        else if (strncmp (id+1, "KG", 2) == 0) four_digits (buf, buflen, "KGet", id+3);
-        else if (strncmp (id+1, "LC", 2) == 0) four_digits (buf, buflen, "LeechCraft", id+3);
-        else if (strncmp (id+1, "LH", 2) == 0) four_digits (buf, buflen, "LH-ABC", id+3);
-        else if (strncmp (id+1, "NX", 2) == 0) four_digits (buf, buflen, "Net Transport", id+3);
-        else if (strncmp (id+1, "MK", 2) == 0) four_digits (buf, buflen, "Meerkat", id+3);
-        else if (strncmp (id+1, "MO", 2) == 0) four_digits (buf, buflen, "MonoTorrent", id+3);
-        else if (strncmp (id+1, "MR", 2) == 0) four_digits (buf, buflen, "Miro", id+3);
-        else if (strncmp (id+1, "MT", 2) == 0) four_digits (buf, buflen, "Moonlight", id+3);
-        else if (strncmp (id+1, "OS", 2) == 0) four_digits (buf, buflen, "OneSwarm", id+3);
-        else if (strncmp (id+1, "OT", 2) == 0) four_digits (buf, buflen, "OmegaTorrent", id+3);
-        else if (strncmp (id+1, "PD", 2) == 0) four_digits (buf, buflen, "Pando", id+3);
-        else if (strncmp (id+1, "QD", 2) == 0) four_digits (buf, buflen, "QQDownload", id+3);
-        else if (strncmp (id+1, "RS", 2) == 0) four_digits (buf, buflen, "Rufus", id+3);
-        else if (strncmp (id+1, "RT", 2) == 0) four_digits (buf, buflen, "Retriever", id+3);
-        else if (strncmp (id+1, "RZ", 2) == 0) four_digits (buf, buflen, "RezTorrent", id+3);
-        else if (strncmp (id+1, "SD", 2) == 0) four_digits (buf, buflen, "Thunder", id+3);
-        else if (strncmp (id+1, "SM", 2) == 0) four_digits (buf, buflen, "SoMud", id+3);
-        else if (strncmp (id+1, "SS", 2) == 0) four_digits (buf, buflen, "SwarmScope", id+3);
-        else if (strncmp (id+1, "ST", 2) == 0) four_digits (buf, buflen, "SymTorrent", id+3);
-        else if (strncmp (id+1, "SZ", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
-        else if (strncmp (id+1, "S~", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
-        else if (strncmp (id+1, "st", 2) == 0) four_digits (buf, buflen, "SharkTorrent", id+3);
-        else if (strncmp (id+1, "TN", 2) == 0) four_digits (buf, buflen, "Torrent .NET", id+3);
-        else if (strncmp (id+1, "TS", 2) == 0) four_digits (buf, buflen, "TorrentStorm", id+3);
-        else if (strncmp (id+1, "TT", 2) == 0) four_digits (buf, buflen, "TuoTu", id+3);
-        else if (strncmp (id+1, "UL", 2) == 0) four_digits (buf, buflen, "uLeecher!", id+3);
-        else if (strncmp (id+1, "VG", 2) == 0) four_digits (buf, buflen, "Vagaa", id+3);
-        else if (strncmp (id+1, "WT", 2) == 0) four_digits (buf, buflen, "BitLet", id+3);
-        else if (strncmp (id+1, "WY", 2) == 0) four_digits (buf, buflen, "FireTorrent", id+3);
-        else if (strncmp (id+1, "XL", 2) == 0) four_digits (buf, buflen, "Xunlei", id+3);
-        else if (strncmp (id+1, "XS", 2) == 0) four_digits (buf, buflen, "XSwifter", id+3);
-        else if (strncmp (id+1, "XT", 2) == 0) four_digits (buf, buflen, "XanTorrent", id+3);
-        else if (strncmp (id+1, "XX", 2) == 0) four_digits (buf, buflen, "Xtorrent", id+3);
-        else if (strncmp (id+1, "ZT", 2) == 0) four_digits (buf, buflen, "Zip Torrent", id+3);
-        else if (strncmp (id+1, "ZO", 2) == 0) four_digits (buf, buflen, "Zona", id+3);
+        else if (strncmp (chid+1, "AG", 2) == 0) four_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (chid+1, "AR", 2) == 0) four_digits (buf, buflen, "Arctic", id+3);
+        else if (strncmp (chid+1, "AT", 2) == 0) four_digits (buf, buflen, "Artemis", id+3);
+        else if (strncmp (chid+1, "AV", 2) == 0) four_digits (buf, buflen, "Avicora", id+3);
+        else if (strncmp (chid+1, "BB", 2) == 0) four_digits (buf, buflen, "BitBuddy", id+3);
+        else if (strncmp (chid+1, "BE", 2) == 0) four_digits (buf, buflen, "BitTorrent SDK", id+3);
+        else if (strncmp (chid+1, "BG", 2) == 0) four_digits (buf, buflen, "BTGetit", id+3);
+        else if (strncmp (chid+1, "BH", 2) == 0) four_digits (buf, buflen, "BitZilla", id+3);
+        else if (strncmp (chid+1, "BM", 2) == 0) four_digits (buf, buflen, "BitMagnet", id+3);
+        else if (strncmp (chid+1, "BP", 2) == 0) four_digits (buf, buflen, "BitTorrent Pro (Azureus + Spyware)", id+3);
+        else if (strncmp (chid+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
+        else if (strncmp (chid+1, "bk", 2) == 0) four_digits (buf, buflen, "BitKitten (libtorrent)", id+3);
+        else if (strncmp (chid+1, "BS", 2) == 0) four_digits (buf, buflen, "BTSlave", id+3);
+        else if (strncmp (chid+1, "BW", 2) == 0) four_digits (buf, buflen, "BitWombat", id+3);
+        else if (strncmp (chid+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
+        else if (strncmp (chid+1, "EB", 2) == 0) four_digits (buf, buflen, "EBit", id+3);
+        else if (strncmp (chid+1, "DE", 2) == 0) four_digits (buf, buflen, "Deluge", id+3);
+        else if (strncmp (chid+1, "DP", 2) == 0) four_digits (buf, buflen, "Propogate Data Client", id+3);
+        else if (strncmp (chid+1, "FC", 2) == 0) four_digits (buf, buflen, "FileCroc", id+3);
+        else if (strncmp (chid+1, "FT", 2) == 0) four_digits (buf, buflen, "FoxTorrent/RedSwoosh", id+3);
+        else if (strncmp (chid+1, "GR", 2) == 0) four_digits (buf, buflen, "GetRight", id+3);
+        else if (strncmp (chid+1, "GS", 2) == 0) four_digits (buf, buflen, "GSTorrent", id+3);
+        else if (strncmp (chid+1, "HK", 2) == 0) four_digits (buf, buflen, "Hekate", id+3);
+        else if (strncmp (chid+1, "HN", 2) == 0) four_digits (buf, buflen, "Hydranode", id+3);
+        else if (strncmp (chid+1, "KG", 2) == 0) four_digits (buf, buflen, "KGet", id+3);
+        else if (strncmp (chid+1, "LC", 2) == 0) four_digits (buf, buflen, "LeechCraft", id+3);
+        else if (strncmp (chid+1, "LH", 2) == 0) four_digits (buf, buflen, "LH-ABC", id+3);
+        else if (strncmp (chid+1, "NX", 2) == 0) four_digits (buf, buflen, "Net Transport", id+3);
+        else if (strncmp (chid+1, "MK", 2) == 0) four_digits (buf, buflen, "Meerkat", id+3);
+        else if (strncmp (chid+1, "MO", 2) == 0) four_digits (buf, buflen, "MonoTorrent", id+3);
+        else if (strncmp (chid+1, "MR", 2) == 0) four_digits (buf, buflen, "Miro", id+3);
+        else if (strncmp (chid+1, "MT", 2) == 0) four_digits (buf, buflen, "Moonlight", id+3);
+        else if (strncmp (chid+1, "OS", 2) == 0) four_digits (buf, buflen, "OneSwarm", id+3);
+        else if (strncmp (chid+1, "OT", 2) == 0) four_digits (buf, buflen, "OmegaTorrent", id+3);
+        else if (strncmp (chid+1, "PD", 2) == 0) four_digits (buf, buflen, "Pando", id+3);
+        else if (strncmp (chid+1, "QD", 2) == 0) four_digits (buf, buflen, "QQDownload", id+3);
+        else if (strncmp (chid+1, "RS", 2) == 0) four_digits (buf, buflen, "Rufus", id+3);
+        else if (strncmp (chid+1, "RT", 2) == 0) four_digits (buf, buflen, "Retriever", id+3);
+        else if (strncmp (chid+1, "RZ", 2) == 0) four_digits (buf, buflen, "RezTorrent", id+3);
+        else if (strncmp (chid+1, "SD", 2) == 0) four_digits (buf, buflen, "Thunder", id+3);
+        else if (strncmp (chid+1, "SM", 2) == 0) four_digits (buf, buflen, "SoMud", id+3);
+        else if (strncmp (chid+1, "SS", 2) == 0) four_digits (buf, buflen, "SwarmScope", id+3);
+        else if (strncmp (chid+1, "ST", 2) == 0) four_digits (buf, buflen, "SymTorrent", id+3);
+        else if (strncmp (chid+1, "SZ", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
+        else if (strncmp (chid+1, "S~", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
+        else if (strncmp (chid+1, "st", 2) == 0) four_digits (buf, buflen, "SharkTorrent", id+3);
+        else if (strncmp (chid+1, "TN", 2) == 0) four_digits (buf, buflen, "Torrent .NET", id+3);
+        else if (strncmp (chid+1, "TS", 2) == 0) four_digits (buf, buflen, "TorrentStorm", id+3);
+        else if (strncmp (chid+1, "TT", 2) == 0) four_digits (buf, buflen, "TuoTu", id+3);
+        else if (strncmp (chid+1, "UL", 2) == 0) four_digits (buf, buflen, "uLeecher!", id+3);
+        else if (strncmp (chid+1, "VG", 2) == 0) four_digits (buf, buflen, "Vagaa", id+3);
+        else if (strncmp (chid+1, "WT", 2) == 0) four_digits (buf, buflen, "BitLet", id+3);
+        else if (strncmp (chid+1, "WY", 2) == 0) four_digits (buf, buflen, "FireTorrent", id+3);
+        else if (strncmp (chid+1, "XL", 2) == 0) four_digits (buf, buflen, "Xunlei", id+3);
+        else if (strncmp (chid+1, "XS", 2) == 0) four_digits (buf, buflen, "XSwifter", id+3);
+        else if (strncmp (chid+1, "XT", 2) == 0) four_digits (buf, buflen, "XanTorrent", id+3);
+        else if (strncmp (chid+1, "XX", 2) == 0) four_digits (buf, buflen, "Xtorrent", id+3);
+        else if (strncmp (chid+1, "ZT", 2) == 0) four_digits (buf, buflen, "Zip Torrent", id+3);
+        else if (strncmp (chid+1, "ZO", 2) == 0) four_digits (buf, buflen, "Zona", id+3);
 
-        else if (strncmp (id+1, "AG", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
-        else if (strncmp (id+1, "A~", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
-        else if (strncmp (id+1, "ES", 2) == 0) three_digits (buf, buflen, "Electric Sheep", id+3);
-        else if (strncmp (id+1, "HL", 2) == 0) three_digits (buf, buflen, "Halite", id+3);
-        else if (strncmp (id+1, "LT", 2) == 0) three_digits (buf, buflen, "libtorrent (Rasterbar)", id+3);
-        else if (strncmp (id+1, "lt", 2) == 0) three_digits (buf, buflen, "libTorrent (Rakshasa)", id+3);
-        else if (strncmp (id+1, "MP", 2) == 0) three_digits (buf, buflen, "MooPolice", id+3);
-        else if (strncmp (id+1, "pb", 2) == 0) three_digits (buf, buflen, "pbTorrent", id+3);
-        else if (strncmp (id+1, "TT", 2) == 0) three_digits (buf, buflen, "TuoTu", id+3);
-        else if (strncmp (id+1, "qB", 2) == 0) three_digits (buf, buflen, "qBittorrent", id+3);
+        else if (strncmp (chid+1, "AG", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (chid+1, "A~", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (chid+1, "ES", 2) == 0) three_digits (buf, buflen, "Electric Sheep", id+3);
+        else if (strncmp (chid+1, "HL", 2) == 0) three_digits (buf, buflen, "Halite", id+3);
+        else if (strncmp (chid+1, "LT", 2) == 0) three_digits (buf, buflen, "libtorrent (Rasterbar)", id+3);
+        else if (strncmp (chid+1, "lt", 2) == 0) three_digits (buf, buflen, "libTorrent (Rakshasa)", id+3);
+        else if (strncmp (chid+1, "MP", 2) == 0) three_digits (buf, buflen, "MooPolice", id+3);
+        else if (strncmp (chid+1, "pb", 2) == 0) three_digits (buf, buflen, "pbTorrent", id+3);
+        else if (strncmp (chid+1, "TT", 2) == 0) three_digits (buf, buflen, "TuoTu", id+3);
+        else if (strncmp (chid+1, "qB", 2) == 0) three_digits (buf, buflen, "qBittorrent", id+3);
 
-        else if (strncmp (id+1, "AX", 2) == 0) two_major_two_minor (buf, buflen, "BitPump", id+3);
-        else if (strncmp (id+1, "BC", 2) == 0) two_major_two_minor (buf, buflen, "BitComet", id+3);
-        else if (strncmp (id+1, "CD", 2) == 0) two_major_two_minor (buf, buflen, "Enhanced CTorrent", id+3);
-        else if (strncmp (id+1, "LP", 2) == 0) two_major_two_minor (buf, buflen, "Lphant", id+3);
+        else if (strncmp (chid+1, "AX", 2) == 0) two_major_two_minor (buf, buflen, "BitPump", id+3);
+        else if (strncmp (chid+1, "BC", 2) == 0) two_major_two_minor (buf, buflen, "BitComet", id+3);
+        else if (strncmp (chid+1, "CD", 2) == 0) two_major_two_minor (buf, buflen, "Enhanced CTorrent", id+3);
+        else if (strncmp (chid+1, "LP", 2) == 0) two_major_two_minor (buf, buflen, "Lphant", id+3);
 
-        else if (strncmp (id+1, "BF", 2) == 0) no_version (buf, buflen, "BitFlu");
-        else if (strncmp (id+1, "LW", 2) == 0) no_version (buf, buflen, "LimeWire");
+        else if (strncmp (chid+1, "BF", 2) == 0) no_version (buf, buflen, "BitFlu");
+        else if (strncmp (chid+1, "LW", 2) == 0) no_version (buf, buflen, "LimeWire");
 
-        else if (strncmp (id+1, "BB", 2) == 0)
+        else if (strncmp (chid+1, "BB", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitBuddy %c.%c%c%c", id[3], id[4], id[5], id[6]);
         }
-        else if (strncmp (id+1, "BR", 2) == 0)
+        else if (strncmp (chid+1, "BR", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitRocket %c.%c (%c%c)", id[3], id[4], id[5], id[6]);
         }
-        else if (strncmp (id+1, "CT", 2) == 0)
+        else if (strncmp (chid+1, "CT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "CTorrent %d.%d.%02d", charint (id[3]), charint (id[4]), strint (id+5,2));
         }
-        else if (strncmp (id+1, "XC", 2) == 0 || strncmp (id+1, "XX", 2) == 0)
+        else if (strncmp (chid+1, "XC", 2) == 0 || strncmp (chid+1, "XX", 2) == 0)
         {
             tr_snprintf (buf, buflen, "Xtorrent %d.%d (%d)", charint (id[3]), charint (id[4]), strint (id+5,2));
         }
-        else if (strncmp (id+1, "BOW", 3) == 0)
+        else if (strncmp (chid+1, "BOW", 3) == 0)
         {
-                 if (strncmp (&id[4], "A0B", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.5");
-            else if (strncmp (&id[4], "A0C", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.6");
+                 if (strncmp (&chid[4], "A0B", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.5");
+            else if (strncmp (&chid[4], "A0C", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.6");
             else                                   tr_snprintf (buf, buflen, "Bits on Wheels %c.%c.%c", id[4], id[5], id[5]);
         }
-        else if (strncmp (id+1, "MG", 2) == 0)
+        else if (strncmp (chid+1, "MG", 2) == 0)
         {
             tr_snprintf (buf, buflen, "MediaGet %d.%02d", charint (id[3]), charint (id[4]));
         }
@@ -314,17 +316,17 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
     /* uTorrent will replace the trailing dash with an extra digit for longer version numbers */
     if (id[0] == '-')
     {
-        if (strncmp (id+1, "UT", 2) == 0)
+        if (strncmp (chid+1, "UT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
         }
-        else if (strncmp (id+1, "UM", 2) == 0)
+        else if (strncmp (chid+1, "UM", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Mac %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
         }
-        else if (strncmp (id+1, "UE", 2) == 0)
+        else if (strncmp (chid+1, "UE", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
@@ -346,76 +348,76 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
         return buf;
 
     /* Clients with no version */
-         if (strncmp (id, "AZ2500BT", 8) == 0)  no_version (buf, buflen, "BitTyrant (Azureus Mod)");
-    else if (strncmp (id, "LIME", 4) == 0)      no_version (buf, buflen, "Limewire");
-    else if (strncmp (id, "martini", 7) == 0)   no_version (buf, buflen, "Martini Man");
-    else if (strncmp (id, "Pando", 5) == 0)     no_version (buf, buflen, "Pando");
-    else if (strncmp (id, "a00---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
-    else if (strncmp (id, "a02---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
-    else if (strncmp (id, "-G3", 3) == 0)       no_version (buf, buflen, "G3 Torrent");
-    else if (strncmp (id, "10-------", 9) == 0) no_version (buf, buflen, "JVtorrent");
-    else if (strncmp (id, "346-", 4) == 0)      no_version (buf, buflen, "TorrentTopia");
-    else if (strncmp (id, "eX", 2) == 0)        no_version (buf, buflen, "eXeem");
-    else if (strncmp (id, "aria2-", 6) == 0)    no_version (buf, buflen, "aria2");
-    else if (strncmp (id, "-WT-", 4) == 0)      no_version (buf, buflen, "BitLet");
-    else if (strncmp (id, "-FG", 3) == 0)       two_major_two_minor (buf, buflen, "FlashGet", id+3);
+         if (strncmp (chid, "AZ2500BT", 8) == 0)  no_version (buf, buflen, "BitTyrant (Azureus Mod)");
+    else if (strncmp (chid, "LIME", 4) == 0)      no_version (buf, buflen, "Limewire");
+    else if (strncmp (chid, "martini", 7) == 0)   no_version (buf, buflen, "Martini Man");
+    else if (strncmp (chid, "Pando", 5) == 0)     no_version (buf, buflen, "Pando");
+    else if (strncmp (chid, "a00---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
+    else if (strncmp (chid, "a02---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
+    else if (strncmp (chid, "-G3", 3) == 0)       no_version (buf, buflen, "G3 Torrent");
+    else if (strncmp (chid, "10-------", 9) == 0) no_version (buf, buflen, "JVtorrent");
+    else if (strncmp (chid, "346-", 4) == 0)      no_version (buf, buflen, "TorrentTopia");
+    else if (strncmp (chid, "eX", 2) == 0)        no_version (buf, buflen, "eXeem");
+    else if (strncmp (chid, "aria2-", 6) == 0)    no_version (buf, buflen, "aria2");
+    else if (strncmp (chid, "-WT-", 4) == 0)      no_version (buf, buflen, "BitLet");
+    else if (strncmp (chid, "-FG", 3) == 0)       two_major_two_minor (buf, buflen, "FlashGet", id+3);
 
     /* Everything else */
-    else if (strncmp (id, "S3", 2) == 0 && id[2] == '-' && id[4] == '-' && id[6] == '-')
+    else if (strncmp (chid, "S3", 2) == 0 && id[2] == '-' && id[4] == '-' && id[6] == '-')
     {
         tr_snprintf (buf, buflen, "Amazon S3 %c.%c.%c", id[3], id[5], id[7]);
     }
-    else if (strncmp (id, "OP", 2) == 0)
+    else if (strncmp (chid, "OP", 2) == 0)
     {
         tr_snprintf (buf, buflen, "Opera (Build %c%c%c%c)", id[2], id[3], id[4], id[5]);
     }
-    else if (strncmp (id, "-ML", 3) == 0)
+    else if (strncmp (chid, "-ML", 3) == 0)
     {
         tr_snprintf (buf, buflen, "MLDonkey %c%c%c%c%c", id[3], id[4], id[5], id[6], id[7]);
     }
-    else if (strncmp (id, "DNA", 3) == 0)
+    else if (strncmp (chid, "DNA", 3) == 0)
     {
         tr_snprintf (buf, buflen, "BitTorrent DNA %d.%d.%d", strint (id+3,2),
                                                              strint (id+5,2),
                                                              strint (id+7,2));
     }
-    else if (strncmp (id, "Plus", 4) == 0)
+    else if (strncmp (chid, "Plus", 4) == 0)
     {
         tr_snprintf (buf, buflen, "Plus! v2 %c.%c%c", id[4], id[5], id[6]);
     }
-    else if (strncmp (id, "XBT", 3) == 0)
+    else if (strncmp (chid, "XBT", 3) == 0)
     {
         tr_snprintf (buf, buflen, "XBT Client %c.%c.%c%s", id[3], id[4], id[5], getMnemonicEnd (id[6]));
     }
-    else if (strncmp (id, "Mbrst", 5) == 0)
+    else if (strncmp (chid, "Mbrst", 5) == 0)
     {
         tr_snprintf (buf, buflen, "burst! %c.%c.%c", id[5], id[7], id[9]);
     }
-    else if (strncmp (id, "btpd", 4) == 0)
+    else if (strncmp (chid, "btpd", 4) == 0)
     {
         tr_snprintf (buf, buflen, "BT Protocol Daemon %c%c%c", id[5], id[6], id[7]);
     }
-    else if (strncmp (id, "BLZ", 3) == 0)
+    else if (strncmp (chid, "BLZ", 3) == 0)
     {
         tr_snprintf (buf, buflen, "Blizzard Downloader %d.%d", id[3]+1, id[4]);
     }
-    else if (strncmp (id, "-SP", 3) == 0)
+    else if (strncmp (chid, "-SP", 3) == 0)
     {
         three_digits (buf, buflen, "BitSpirit", id+3);
     }
-    else if ('\0' == id[0] && strncmp (id+2, "BS", 2) == 0)
+    else if ('\0' == id[0] && strncmp (chid+2, "BS", 2) == 0)
     {
         tr_snprintf (buf, buflen, "BitSpirit %u", (id[1] == 0 ? 1 : id[1]));
     }
-    else if (strncmp (id, "QVOD", 4) == 0)
+    else if (strncmp (chid, "QVOD", 4) == 0)
     {
         four_digits (buf, buflen, "QVOD", id+4);
     }
-    else if (strncmp (id, "-NE", 3) == 0)
+    else if (strncmp (chid, "-NE", 3) == 0)
     {
         four_digits (buf, buflen, "BT Next Evolution", id+3);
     }
-    else if (strncmp (id, "TIX", 3) == 0)
+    else if (strncmp (chid, "TIX", 3) == 0)
     {
         two_major_two_minor (buf, buflen, "Tixati", id+3);
     }

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -117,12 +117,12 @@ decodeBitCometClient (char * buf, size_t buflen, const uint8_t * id)
     const char * name;
     const char * mod = NULL;
 
-    if (memcmp (id, "exbc", 4) == 0) mod = "";
-    else if (memcmp (id, "FUTB", 4) == 0) mod = " (Solidox Mod) ";
-    else if (memcmp (id, "xUTB", 4) == 0) mod = " (Mod 2) ";
+    if (strncmp (id, "exbc", 4) == 0) mod = "";
+    else if (strncmp (id, "FUTB", 4) == 0) mod = " (Solidox Mod) ";
+    else if (strncmp (id, "xUTB", 4) == 0) mod = " (Mod 2) ";
     else return false;
 
-    is_bitlord = memcmp (id+6, "LORD", 4) == 0;
+    is_bitlord = strncmp (id+6, "LORD", 4) == 0;
     name = (is_bitlord) ? "BitLord " : "BitComet ";
     major = id[4];
     minor = id[5];
@@ -152,38 +152,38 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
     /* Azureus-style */
     if (id[0] == '-' && id[7] == '-')
     {
-        if (memcmp (id+1, "TR", 2) == 0)
+        if (strncmp (id+1, "TR", 2) == 0)
         {
-            if (memcmp (id+3, "000", 3) == 0) /* very old client style: -TR0006- is 0.6 */
+            if (strncmp (id+3, "000", 3) == 0) /* very old client style: -TR0006- is 0.6 */
                 tr_snprintf (buf, buflen, "Transmission 0.%c", id[6]);
-            else if (memcmp (id+3, "00", 2) == 0) /* previous client style: -TR0072- is 0.72 */
+            else if (strncmp (id+3, "00", 2) == 0) /* previous client style: -TR0072- is 0.72 */
                 tr_snprintf (buf, buflen, "Transmission 0.%02d", strint (id+5,2));
             else /* current client style: -TR111Z- is 1.11+ */
                 tr_snprintf (buf, buflen, "Transmission %d.%02d%s", strint (id+3,1), strint (id+4,2),
                           id[6]=='Z' || id[6]=='X' ? "+" : "");
         }
-        else if (memcmp (id+1, "UT", 2) == 0)
+        else if (strncmp (id+1, "UT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (memcmp (id+1, "BT", 2) == 0)
+        else if (strncmp (id+1, "BT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitTorrent %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (memcmp (id+1, "UM", 2) == 0)
+        else if (strncmp (id+1, "UM", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Mac %d.%d.%d%s",
                          strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
-        else if (memcmp (id+1, "UE", 2) == 0)
+        else if (strncmp (id+1, "UE", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,1), getMnemonicEnd (id[6]));
         }
 
-        else if (memcmp (id+1, "AZ", 2) == 0)
+        else if (strncmp (id+1, "AZ", 2) == 0)
         {
             if (id[3] > '3' || (id[3] == '3' && id[4] >= '1')) /* Vuze starts at version 3.1.0.0 */
                 four_digits (buf, buflen, "Vuze", id+3);
@@ -191,7 +191,7 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
                 four_digits (buf, buflen, "Azureus", id+3);
         }
 
-        else if (memcmp (id+1, "KT", 2) == 0)
+        else if (strncmp (id+1, "KT", 2) == 0)
         {
             if (id[5] == 'D')
                 tr_snprintf (buf, buflen, "KTorrent %d.%d Dev %d", charint (id[3]), charint (id[4]), charint (id[6]));
@@ -201,108 +201,108 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
                 three_digits (buf, buflen, "KTorrent", id+3);
         }
 
-        else if (memcmp (id+1, "AG", 2) == 0) four_digits (buf, buflen, "Ares", id+3);
-        else if (memcmp (id+1, "AR", 2) == 0) four_digits (buf, buflen, "Arctic", id+3);
-        else if (memcmp (id+1, "AT", 2) == 0) four_digits (buf, buflen, "Artemis", id+3);
-        else if (memcmp (id+1, "AV", 2) == 0) four_digits (buf, buflen, "Avicora", id+3);
-        else if (memcmp (id+1, "BB", 2) == 0) four_digits (buf, buflen, "BitBuddy", id+3);
-        else if (memcmp (id+1, "BE", 2) == 0) four_digits (buf, buflen, "BitTorrent SDK", id+3);
-        else if (memcmp (id+1, "BG", 2) == 0) four_digits (buf, buflen, "BTGetit", id+3);
-        else if (memcmp (id+1, "BH", 2) == 0) four_digits (buf, buflen, "BitZilla", id+3);
-        else if (memcmp (id+1, "BM", 2) == 0) four_digits (buf, buflen, "BitMagnet", id+3);
-        else if (memcmp (id+1, "BP", 2) == 0) four_digits (buf, buflen, "BitTorrent Pro (Azureus + Spyware)", id+3);
-        else if (memcmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
-        else if (memcmp (id+1, "bk", 2) == 0) four_digits (buf, buflen, "BitKitten (libtorrent)", id+3);
-        else if (memcmp (id+1, "BS", 2) == 0) four_digits (buf, buflen, "BTSlave", id+3);
-        else if (memcmp (id+1, "BW", 2) == 0) four_digits (buf, buflen, "BitWombat", id+3);
-        else if (memcmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
-        else if (memcmp (id+1, "EB", 2) == 0) four_digits (buf, buflen, "EBit", id+3);
-        else if (memcmp (id+1, "DE", 2) == 0) four_digits (buf, buflen, "Deluge", id+3);
-        else if (memcmp (id+1, "DP", 2) == 0) four_digits (buf, buflen, "Propogate Data Client", id+3);
-        else if (memcmp (id+1, "FC", 2) == 0) four_digits (buf, buflen, "FileCroc", id+3);
-        else if (memcmp (id+1, "FT", 2) == 0) four_digits (buf, buflen, "FoxTorrent/RedSwoosh", id+3);
-        else if (memcmp (id+1, "GR", 2) == 0) four_digits (buf, buflen, "GetRight", id+3);
-        else if (memcmp (id+1, "GS", 2) == 0) four_digits (buf, buflen, "GSTorrent", id+3);
-        else if (memcmp (id+1, "HK", 2) == 0) four_digits (buf, buflen, "Hekate", id+3);
-        else if (memcmp (id+1, "HN", 2) == 0) four_digits (buf, buflen, "Hydranode", id+3);
-        else if (memcmp (id+1, "KG", 2) == 0) four_digits (buf, buflen, "KGet", id+3);
-        else if (memcmp (id+1, "LC", 2) == 0) four_digits (buf, buflen, "LeechCraft", id+3);
-        else if (memcmp (id+1, "LH", 2) == 0) four_digits (buf, buflen, "LH-ABC", id+3);
-        else if (memcmp (id+1, "NX", 2) == 0) four_digits (buf, buflen, "Net Transport", id+3);
-        else if (memcmp (id+1, "MK", 2) == 0) four_digits (buf, buflen, "Meerkat", id+3);
-        else if (memcmp (id+1, "MO", 2) == 0) four_digits (buf, buflen, "MonoTorrent", id+3);
-        else if (memcmp (id+1, "MR", 2) == 0) four_digits (buf, buflen, "Miro", id+3);
-        else if (memcmp (id+1, "MT", 2) == 0) four_digits (buf, buflen, "Moonlight", id+3);
-        else if (memcmp (id+1, "OS", 2) == 0) four_digits (buf, buflen, "OneSwarm", id+3);
-        else if (memcmp (id+1, "OT", 2) == 0) four_digits (buf, buflen, "OmegaTorrent", id+3);
-        else if (memcmp (id+1, "PD", 2) == 0) four_digits (buf, buflen, "Pando", id+3);
-        else if (memcmp (id+1, "QD", 2) == 0) four_digits (buf, buflen, "QQDownload", id+3);
-        else if (memcmp (id+1, "RS", 2) == 0) four_digits (buf, buflen, "Rufus", id+3);
-        else if (memcmp (id+1, "RT", 2) == 0) four_digits (buf, buflen, "Retriever", id+3);
-        else if (memcmp (id+1, "RZ", 2) == 0) four_digits (buf, buflen, "RezTorrent", id+3);
-        else if (memcmp (id+1, "SD", 2) == 0) four_digits (buf, buflen, "Thunder", id+3);
-        else if (memcmp (id+1, "SM", 2) == 0) four_digits (buf, buflen, "SoMud", id+3);
-        else if (memcmp (id+1, "SS", 2) == 0) four_digits (buf, buflen, "SwarmScope", id+3);
-        else if (memcmp (id+1, "ST", 2) == 0) four_digits (buf, buflen, "SymTorrent", id+3);
-        else if (memcmp (id+1, "SZ", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
-        else if (memcmp (id+1, "S~", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
-        else if (memcmp (id+1, "st", 2) == 0) four_digits (buf, buflen, "SharkTorrent", id+3);
-        else if (memcmp (id+1, "TN", 2) == 0) four_digits (buf, buflen, "Torrent .NET", id+3);
-        else if (memcmp (id+1, "TS", 2) == 0) four_digits (buf, buflen, "TorrentStorm", id+3);
-        else if (memcmp (id+1, "TT", 2) == 0) four_digits (buf, buflen, "TuoTu", id+3);
-        else if (memcmp (id+1, "UL", 2) == 0) four_digits (buf, buflen, "uLeecher!", id+3);
-        else if (memcmp (id+1, "VG", 2) == 0) four_digits (buf, buflen, "Vagaa", id+3);
-        else if (memcmp (id+1, "WT", 2) == 0) four_digits (buf, buflen, "BitLet", id+3);
-        else if (memcmp (id+1, "WY", 2) == 0) four_digits (buf, buflen, "FireTorrent", id+3);
-        else if (memcmp (id+1, "XL", 2) == 0) four_digits (buf, buflen, "Xunlei", id+3);
-        else if (memcmp (id+1, "XS", 2) == 0) four_digits (buf, buflen, "XSwifter", id+3);
-        else if (memcmp (id+1, "XT", 2) == 0) four_digits (buf, buflen, "XanTorrent", id+3);
-        else if (memcmp (id+1, "XX", 2) == 0) four_digits (buf, buflen, "Xtorrent", id+3);
-        else if (memcmp (id+1, "ZT", 2) == 0) four_digits (buf, buflen, "Zip Torrent", id+3);
-        else if (memcmp (id+1, "ZO", 2) == 0) four_digits (buf, buflen, "Zona", id+3);
+        else if (strncmp (id+1, "AG", 2) == 0) four_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (id+1, "AR", 2) == 0) four_digits (buf, buflen, "Arctic", id+3);
+        else if (strncmp (id+1, "AT", 2) == 0) four_digits (buf, buflen, "Artemis", id+3);
+        else if (strncmp (id+1, "AV", 2) == 0) four_digits (buf, buflen, "Avicora", id+3);
+        else if (strncmp (id+1, "BB", 2) == 0) four_digits (buf, buflen, "BitBuddy", id+3);
+        else if (strncmp (id+1, "BE", 2) == 0) four_digits (buf, buflen, "BitTorrent SDK", id+3);
+        else if (strncmp (id+1, "BG", 2) == 0) four_digits (buf, buflen, "BTGetit", id+3);
+        else if (strncmp (id+1, "BH", 2) == 0) four_digits (buf, buflen, "BitZilla", id+3);
+        else if (strncmp (id+1, "BM", 2) == 0) four_digits (buf, buflen, "BitMagnet", id+3);
+        else if (strncmp (id+1, "BP", 2) == 0) four_digits (buf, buflen, "BitTorrent Pro (Azureus + Spyware)", id+3);
+        else if (strncmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
+        else if (strncmp (id+1, "bk", 2) == 0) four_digits (buf, buflen, "BitKitten (libtorrent)", id+3);
+        else if (strncmp (id+1, "BS", 2) == 0) four_digits (buf, buflen, "BTSlave", id+3);
+        else if (strncmp (id+1, "BW", 2) == 0) four_digits (buf, buflen, "BitWombat", id+3);
+        else if (strncmp (id+1, "BX", 2) == 0) four_digits (buf, buflen, "BittorrentX", id+3);
+        else if (strncmp (id+1, "EB", 2) == 0) four_digits (buf, buflen, "EBit", id+3);
+        else if (strncmp (id+1, "DE", 2) == 0) four_digits (buf, buflen, "Deluge", id+3);
+        else if (strncmp (id+1, "DP", 2) == 0) four_digits (buf, buflen, "Propogate Data Client", id+3);
+        else if (strncmp (id+1, "FC", 2) == 0) four_digits (buf, buflen, "FileCroc", id+3);
+        else if (strncmp (id+1, "FT", 2) == 0) four_digits (buf, buflen, "FoxTorrent/RedSwoosh", id+3);
+        else if (strncmp (id+1, "GR", 2) == 0) four_digits (buf, buflen, "GetRight", id+3);
+        else if (strncmp (id+1, "GS", 2) == 0) four_digits (buf, buflen, "GSTorrent", id+3);
+        else if (strncmp (id+1, "HK", 2) == 0) four_digits (buf, buflen, "Hekate", id+3);
+        else if (strncmp (id+1, "HN", 2) == 0) four_digits (buf, buflen, "Hydranode", id+3);
+        else if (strncmp (id+1, "KG", 2) == 0) four_digits (buf, buflen, "KGet", id+3);
+        else if (strncmp (id+1, "LC", 2) == 0) four_digits (buf, buflen, "LeechCraft", id+3);
+        else if (strncmp (id+1, "LH", 2) == 0) four_digits (buf, buflen, "LH-ABC", id+3);
+        else if (strncmp (id+1, "NX", 2) == 0) four_digits (buf, buflen, "Net Transport", id+3);
+        else if (strncmp (id+1, "MK", 2) == 0) four_digits (buf, buflen, "Meerkat", id+3);
+        else if (strncmp (id+1, "MO", 2) == 0) four_digits (buf, buflen, "MonoTorrent", id+3);
+        else if (strncmp (id+1, "MR", 2) == 0) four_digits (buf, buflen, "Miro", id+3);
+        else if (strncmp (id+1, "MT", 2) == 0) four_digits (buf, buflen, "Moonlight", id+3);
+        else if (strncmp (id+1, "OS", 2) == 0) four_digits (buf, buflen, "OneSwarm", id+3);
+        else if (strncmp (id+1, "OT", 2) == 0) four_digits (buf, buflen, "OmegaTorrent", id+3);
+        else if (strncmp (id+1, "PD", 2) == 0) four_digits (buf, buflen, "Pando", id+3);
+        else if (strncmp (id+1, "QD", 2) == 0) four_digits (buf, buflen, "QQDownload", id+3);
+        else if (strncmp (id+1, "RS", 2) == 0) four_digits (buf, buflen, "Rufus", id+3);
+        else if (strncmp (id+1, "RT", 2) == 0) four_digits (buf, buflen, "Retriever", id+3);
+        else if (strncmp (id+1, "RZ", 2) == 0) four_digits (buf, buflen, "RezTorrent", id+3);
+        else if (strncmp (id+1, "SD", 2) == 0) four_digits (buf, buflen, "Thunder", id+3);
+        else if (strncmp (id+1, "SM", 2) == 0) four_digits (buf, buflen, "SoMud", id+3);
+        else if (strncmp (id+1, "SS", 2) == 0) four_digits (buf, buflen, "SwarmScope", id+3);
+        else if (strncmp (id+1, "ST", 2) == 0) four_digits (buf, buflen, "SymTorrent", id+3);
+        else if (strncmp (id+1, "SZ", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
+        else if (strncmp (id+1, "S~", 2) == 0) four_digits (buf, buflen, "Shareaza", id+3);
+        else if (strncmp (id+1, "st", 2) == 0) four_digits (buf, buflen, "SharkTorrent", id+3);
+        else if (strncmp (id+1, "TN", 2) == 0) four_digits (buf, buflen, "Torrent .NET", id+3);
+        else if (strncmp (id+1, "TS", 2) == 0) four_digits (buf, buflen, "TorrentStorm", id+3);
+        else if (strncmp (id+1, "TT", 2) == 0) four_digits (buf, buflen, "TuoTu", id+3);
+        else if (strncmp (id+1, "UL", 2) == 0) four_digits (buf, buflen, "uLeecher!", id+3);
+        else if (strncmp (id+1, "VG", 2) == 0) four_digits (buf, buflen, "Vagaa", id+3);
+        else if (strncmp (id+1, "WT", 2) == 0) four_digits (buf, buflen, "BitLet", id+3);
+        else if (strncmp (id+1, "WY", 2) == 0) four_digits (buf, buflen, "FireTorrent", id+3);
+        else if (strncmp (id+1, "XL", 2) == 0) four_digits (buf, buflen, "Xunlei", id+3);
+        else if (strncmp (id+1, "XS", 2) == 0) four_digits (buf, buflen, "XSwifter", id+3);
+        else if (strncmp (id+1, "XT", 2) == 0) four_digits (buf, buflen, "XanTorrent", id+3);
+        else if (strncmp (id+1, "XX", 2) == 0) four_digits (buf, buflen, "Xtorrent", id+3);
+        else if (strncmp (id+1, "ZT", 2) == 0) four_digits (buf, buflen, "Zip Torrent", id+3);
+        else if (strncmp (id+1, "ZO", 2) == 0) four_digits (buf, buflen, "Zona", id+3);
 
-        else if (memcmp (id+1, "AG", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
-        else if (memcmp (id+1, "A~", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
-        else if (memcmp (id+1, "ES", 2) == 0) three_digits (buf, buflen, "Electric Sheep", id+3);
-        else if (memcmp (id+1, "HL", 2) == 0) three_digits (buf, buflen, "Halite", id+3);
-        else if (memcmp (id+1, "LT", 2) == 0) three_digits (buf, buflen, "libtorrent (Rasterbar)", id+3);
-        else if (memcmp (id+1, "lt", 2) == 0) three_digits (buf, buflen, "libTorrent (Rakshasa)", id+3);
-        else if (memcmp (id+1, "MP", 2) == 0) three_digits (buf, buflen, "MooPolice", id+3);
-        else if (memcmp (id+1, "pb", 2) == 0) three_digits (buf, buflen, "pbTorrent", id+3);
-        else if (memcmp (id+1, "TT", 2) == 0) three_digits (buf, buflen, "TuoTu", id+3);
-        else if (memcmp (id+1, "qB", 2) == 0) three_digits (buf, buflen, "qBittorrent", id+3);
+        else if (strncmp (id+1, "AG", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (id+1, "A~", 2) == 0) three_digits (buf, buflen, "Ares", id+3);
+        else if (strncmp (id+1, "ES", 2) == 0) three_digits (buf, buflen, "Electric Sheep", id+3);
+        else if (strncmp (id+1, "HL", 2) == 0) three_digits (buf, buflen, "Halite", id+3);
+        else if (strncmp (id+1, "LT", 2) == 0) three_digits (buf, buflen, "libtorrent (Rasterbar)", id+3);
+        else if (strncmp (id+1, "lt", 2) == 0) three_digits (buf, buflen, "libTorrent (Rakshasa)", id+3);
+        else if (strncmp (id+1, "MP", 2) == 0) three_digits (buf, buflen, "MooPolice", id+3);
+        else if (strncmp (id+1, "pb", 2) == 0) three_digits (buf, buflen, "pbTorrent", id+3);
+        else if (strncmp (id+1, "TT", 2) == 0) three_digits (buf, buflen, "TuoTu", id+3);
+        else if (strncmp (id+1, "qB", 2) == 0) three_digits (buf, buflen, "qBittorrent", id+3);
 
-        else if (memcmp (id+1, "AX", 2) == 0) two_major_two_minor (buf, buflen, "BitPump", id+3);
-        else if (memcmp (id+1, "BC", 2) == 0) two_major_two_minor (buf, buflen, "BitComet", id+3);
-        else if (memcmp (id+1, "CD", 2) == 0) two_major_two_minor (buf, buflen, "Enhanced CTorrent", id+3);
-        else if (memcmp (id+1, "LP", 2) == 0) two_major_two_minor (buf, buflen, "Lphant", id+3);
+        else if (strncmp (id+1, "AX", 2) == 0) two_major_two_minor (buf, buflen, "BitPump", id+3);
+        else if (strncmp (id+1, "BC", 2) == 0) two_major_two_minor (buf, buflen, "BitComet", id+3);
+        else if (strncmp (id+1, "CD", 2) == 0) two_major_two_minor (buf, buflen, "Enhanced CTorrent", id+3);
+        else if (strncmp (id+1, "LP", 2) == 0) two_major_two_minor (buf, buflen, "Lphant", id+3);
 
-        else if (memcmp (id+1, "BF", 2) == 0) no_version (buf, buflen, "BitFlu");
-        else if (memcmp (id+1, "LW", 2) == 0) no_version (buf, buflen, "LimeWire");
+        else if (strncmp (id+1, "BF", 2) == 0) no_version (buf, buflen, "BitFlu");
+        else if (strncmp (id+1, "LW", 2) == 0) no_version (buf, buflen, "LimeWire");
 
-        else if (memcmp (id+1, "BB", 2) == 0)
+        else if (strncmp (id+1, "BB", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitBuddy %c.%c%c%c", id[3], id[4], id[5], id[6]);
         }
-        else if (memcmp (id+1, "BR", 2) == 0)
+        else if (strncmp (id+1, "BR", 2) == 0)
         {
             tr_snprintf (buf, buflen, "BitRocket %c.%c (%c%c)", id[3], id[4], id[5], id[6]);
         }
-        else if (memcmp (id+1, "CT", 2) == 0)
+        else if (strncmp (id+1, "CT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "CTorrent %d.%d.%02d", charint (id[3]), charint (id[4]), strint (id+5,2));
         }
-        else if (memcmp (id+1, "XC", 2) == 0 || memcmp (id+1, "XX", 2) == 0)
+        else if (strncmp (id+1, "XC", 2) == 0 || strncmp (id+1, "XX", 2) == 0)
         {
             tr_snprintf (buf, buflen, "Xtorrent %d.%d (%d)", charint (id[3]), charint (id[4]), strint (id+5,2));
         }
-        else if (memcmp (id+1, "BOW", 3) == 0)
+        else if (strncmp (id+1, "BOW", 3) == 0)
         {
-                 if (memcmp (&id[4], "A0B", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.5");
-            else if (memcmp (&id[4], "A0C", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.6");
+                 if (strncmp (&id[4], "A0B", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.5");
+            else if (strncmp (&id[4], "A0C", 3) == 0) tr_snprintf (buf, buflen, "Bits on Wheels 1.0.6");
             else                                   tr_snprintf (buf, buflen, "Bits on Wheels %c.%c.%c", id[4], id[5], id[5]);
         }
-        else if (memcmp (id+1, "MG", 2) == 0)
+        else if (strncmp (id+1, "MG", 2) == 0)
         {
             tr_snprintf (buf, buflen, "MediaGet %d.%02d", charint (id[3]), charint (id[4]));
         }
@@ -314,17 +314,17 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
     /* uTorrent will replace the trailing dash with an extra digit for longer version numbers */
     if (id[0] == '-')
     {
-        if (memcmp (id+1, "UT", 2) == 0)
+        if (strncmp (id+1, "UT", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
         }
-        else if (memcmp (id+1, "UM", 2) == 0)
+        else if (strncmp (id+1, "UM", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Mac %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
         }
-        else if (memcmp (id+1, "UE", 2) == 0)
+        else if (strncmp (id+1, "UE", 2) == 0)
         {
             tr_snprintf (buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s",
                         strint (id+3,1), strint (id+4,1), strint (id+5,2), getMnemonicEnd (id[7]));
@@ -346,76 +346,76 @@ tr_clientForId (char * buf, size_t buflen, const void * id_in)
         return buf;
 
     /* Clients with no version */
-         if (memcmp (id, "AZ2500BT", 8) == 0)  no_version (buf, buflen, "BitTyrant (Azureus Mod)");
-    else if (memcmp (id, "LIME", 4) == 0)      no_version (buf, buflen, "Limewire");
-    else if (memcmp (id, "martini", 7) == 0)   no_version (buf, buflen, "Martini Man");
-    else if (memcmp (id, "Pando", 5) == 0)     no_version (buf, buflen, "Pando");
-    else if (memcmp (id, "a00---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
-    else if (memcmp (id, "a02---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
-    else if (memcmp (id, "-G3", 3) == 0)       no_version (buf, buflen, "G3 Torrent");
-    else if (memcmp (id, "10-------", 9) == 0) no_version (buf, buflen, "JVtorrent");
-    else if (memcmp (id, "346-", 4) == 0)      no_version (buf, buflen, "TorrentTopia");
-    else if (memcmp (id, "eX", 2) == 0)        no_version (buf, buflen, "eXeem");
-    else if (memcmp (id, "aria2-", 6) == 0)    no_version (buf, buflen, "aria2");
-    else if (memcmp (id, "-WT-", 4) == 0)      no_version (buf, buflen, "BitLet");
-    else if (memcmp (id, "-FG", 3) == 0)       two_major_two_minor (buf, buflen, "FlashGet", id+3);
+         if (strncmp (id, "AZ2500BT", 8) == 0)  no_version (buf, buflen, "BitTyrant (Azureus Mod)");
+    else if (strncmp (id, "LIME", 4) == 0)      no_version (buf, buflen, "Limewire");
+    else if (strncmp (id, "martini", 7) == 0)   no_version (buf, buflen, "Martini Man");
+    else if (strncmp (id, "Pando", 5) == 0)     no_version (buf, buflen, "Pando");
+    else if (strncmp (id, "a00---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
+    else if (strncmp (id, "a02---0", 7) == 0)   no_version (buf, buflen, "Swarmy");
+    else if (strncmp (id, "-G3", 3) == 0)       no_version (buf, buflen, "G3 Torrent");
+    else if (strncmp (id, "10-------", 9) == 0) no_version (buf, buflen, "JVtorrent");
+    else if (strncmp (id, "346-", 4) == 0)      no_version (buf, buflen, "TorrentTopia");
+    else if (strncmp (id, "eX", 2) == 0)        no_version (buf, buflen, "eXeem");
+    else if (strncmp (id, "aria2-", 6) == 0)    no_version (buf, buflen, "aria2");
+    else if (strncmp (id, "-WT-", 4) == 0)      no_version (buf, buflen, "BitLet");
+    else if (strncmp (id, "-FG", 3) == 0)       two_major_two_minor (buf, buflen, "FlashGet", id+3);
 
     /* Everything else */
-    else if (memcmp (id, "S3", 2) == 0 && id[2] == '-' && id[4] == '-' && id[6] == '-')
+    else if (strncmp (id, "S3", 2) == 0 && id[2] == '-' && id[4] == '-' && id[6] == '-')
     {
         tr_snprintf (buf, buflen, "Amazon S3 %c.%c.%c", id[3], id[5], id[7]);
     }
-    else if (memcmp (id, "OP", 2) == 0)
+    else if (strncmp (id, "OP", 2) == 0)
     {
         tr_snprintf (buf, buflen, "Opera (Build %c%c%c%c)", id[2], id[3], id[4], id[5]);
     }
-    else if (memcmp (id, "-ML", 3) == 0)
+    else if (strncmp (id, "-ML", 3) == 0)
     {
         tr_snprintf (buf, buflen, "MLDonkey %c%c%c%c%c", id[3], id[4], id[5], id[6], id[7]);
     }
-    else if (memcmp (id, "DNA", 3) == 0)
+    else if (strncmp (id, "DNA", 3) == 0)
     {
         tr_snprintf (buf, buflen, "BitTorrent DNA %d.%d.%d", strint (id+3,2),
                                                              strint (id+5,2),
                                                              strint (id+7,2));
     }
-    else if (memcmp (id, "Plus", 4) == 0)
+    else if (strncmp (id, "Plus", 4) == 0)
     {
         tr_snprintf (buf, buflen, "Plus! v2 %c.%c%c", id[4], id[5], id[6]);
     }
-    else if (memcmp (id, "XBT", 3) == 0)
+    else if (strncmp (id, "XBT", 3) == 0)
     {
         tr_snprintf (buf, buflen, "XBT Client %c.%c.%c%s", id[3], id[4], id[5], getMnemonicEnd (id[6]));
     }
-    else if (memcmp (id, "Mbrst", 5) == 0)
+    else if (strncmp (id, "Mbrst", 5) == 0)
     {
         tr_snprintf (buf, buflen, "burst! %c.%c.%c", id[5], id[7], id[9]);
     }
-    else if (memcmp (id, "btpd", 4) == 0)
+    else if (strncmp (id, "btpd", 4) == 0)
     {
         tr_snprintf (buf, buflen, "BT Protocol Daemon %c%c%c", id[5], id[6], id[7]);
     }
-    else if (memcmp (id, "BLZ", 3) == 0)
+    else if (strncmp (id, "BLZ", 3) == 0)
     {
         tr_snprintf (buf, buflen, "Blizzard Downloader %d.%d", id[3]+1, id[4]);
     }
-    else if (memcmp (id, "-SP", 3) == 0)
+    else if (strncmp (id, "-SP", 3) == 0)
     {
         three_digits (buf, buflen, "BitSpirit", id+3);
     }
-    else if ('\0' == id[0] && memcmp (id+2, "BS", 2) == 0)
+    else if ('\0' == id[0] && strncmp (id+2, "BS", 2) == 0)
     {
         tr_snprintf (buf, buflen, "BitSpirit %u", (id[1] == 0 ? 1 : id[1]));
     }
-    else if (memcmp (id, "QVOD", 4) == 0)
+    else if (strncmp (id, "QVOD", 4) == 0)
     {
         four_digits (buf, buflen, "QVOD", id+4);
     }
-    else if (memcmp (id, "-NE", 3) == 0)
+    else if (strncmp (id, "-NE", 3) == 0)
     {
         four_digits (buf, buflen, "BT Next Evolution", id+3);
     }
-    else if (memcmp (id, "TIX", 3) == 0)
+    else if (strncmp (id, "TIX", 3) == 0)
     {
         two_major_two_minor (buf, buflen, "Tixati", id+3);
     }

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -642,7 +642,7 @@ readHandshake (tr_handshake    * handshake,
   assert (pstrlen == 19);
   tr_peerIoReadBytes (handshake->io, inbuf, pstr, pstrlen);
   pstr[pstrlen] = '\0';
-  if (strncmp (pstr, "BitTorrent protocol", 19) != 0)
+  if (strncmp ((const char *)pstr, "BitTorrent protocol", 19) != 0)
     return tr_handshakeDone (handshake, false);
 
   /* reserved bytes */

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -8,7 +8,7 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <string.h> /* strcmp (), strlen () */
+#include <string.h> /* strcmp (), strlen (), strncmp () */
 
 #include <event2/buffer.h>
 #include <event2/event.h>
@@ -642,7 +642,7 @@ readHandshake (tr_handshake    * handshake,
   assert (pstrlen == 19);
   tr_peerIoReadBytes (handshake->io, inbuf, pstr, pstrlen);
   pstr[pstrlen] = '\0';
-  if (memcmp (pstr, "BitTorrent protocol", 19) != 0)
+  if (strncmp (pstr, "BitTorrent protocol", 19) != 0)
     return tr_handshakeDone (handshake, false);
 
   /* reserved bytes */

--- a/libtransmission/magnet.c
+++ b/libtransmission/magnet.c
@@ -110,7 +110,7 @@ tr_magnetParse (const char * uri)
   uint8_t sha1[SHA_DIGEST_LENGTH];
   tr_magnet_info * info = NULL;
 
-  if (uri != NULL && memcmp (uri, "magnet:?", 8) == 0)
+  if (uri != NULL && strncmp (uri, "magnet:?", 8) == 0)
     {
       const char * walk;
 
@@ -136,7 +136,7 @@ tr_magnetParse (const char * uri)
           else
             vallen = strlen (val);
 
-          if (keylen == 2 && memcmp (key, "xt", 2) == 0 && val != NULL && memcmp (val, "urn:btih:", 9) == 0)
+          if (keylen == 2 && memcmp (key, "xt", 2) == 0 && val != NULL && strncmp (val, "urn:btih:", 9) == 0)
             {
               const char * hash = val + 9;
               const size_t hashlen = vallen - 9;

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -639,7 +639,7 @@ isMartianAddr (const struct tr_address * a)
         case TR_AF_INET6: {
             const unsigned char * address = (const unsigned char*)&a->addr.addr6;
             return (address[0] == 0xFF) ||
-                 (memcmp (address, zeroes, 15) == 0 &&
+                 (strncmp (address, zeroes, 15) == 0 &&
                   (address[15] == 0 || address[15] == 1));
         }
 

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -639,7 +639,7 @@ isMartianAddr (const struct tr_address * a)
         case TR_AF_INET6: {
             const unsigned char * address = (const unsigned char*)&a->addr.addr6;
             return (address[0] == 0xFF) ||
-                 (strncmp (address, zeroes, 15) == 0 &&
+                 (memcmp (address, zeroes, 15) == 0 &&
                   (address[15] == 0 || address[15] == 1));
         }
 

--- a/libtransmission/platform.c
+++ b/libtransmission/platform.c
@@ -393,7 +393,7 @@ tr_getDefaultDownloadDir (void)
                 {
                   *end = '\0';
 
-                  if (memcmp (value, "$HOME/", 6) == 0)
+                  if (strncmp (value, "$HOME/", 6) == 0)
                     user_dir = tr_buildPath (getHomeDir (), value+6, NULL);
                   else if (strcmp (value, "$HOME") == 0)
                     user_dir = tr_strdup (getHomeDir ());


### PR DESCRIPTION
Comparing substrings with memcmp as in `memcmp(str, "literal", 7)` results in an out-of-bounds read when strlen(str) is less than 7. You can use `strncmp`, which also looks for `'\0'` character,  instead.

I made the change only in those places where the code is comparing a substring to a literal and the length of the string isn't accounted for in some obvious way.

This issue was found with american fuzzy lop by Michał Zalewski.
