### PR TITLE
use "Speicherort" consistently in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -179,7 +179,7 @@ msgstr "Alle Torrents starten"
 
 #: ../gtk/actions.c:105
 msgid "Set _Location…"
-msgstr "Ort fest_legen …"
+msgstr "Speicherort fest_legen …"
 
 #: ../gtk/actions.c:106
 msgid "Remove torrent"


### PR DESCRIPTION
error message in `../libtransmission/torrent.c:845` says one should use the `»Speicherort festlegen«` dialog, but that is currently named `Ort fest_legen`.

After replacing Ort→Speicherort, the translation "Speicherort" is consistently used for "Location".