### PR TITLE
Fix placeholer in German translation of "Downloading from %1 of %Ln connected peer"

### DIFF
--- a/qt/translations/transmission_de.ts
+++ b/qt/translations/transmission_de.ts
@@ -2483,8 +2483,8 @@ Um eine weitere primäre URL hinzuzufügen, muss diese nach einer Leerzeile eing
         <source>Downloading from %1 of %Ln connected peer(s)</source>
         <extracomment>First part of phrase &quot;Downloading from ... of ... connected peer(s) and ... web seed(s)&quot;</extracomment>
         <translation>
-            <numerusform>Lade von %1 von &amp;Ln verbundenem Peer herunter</numerusform>
-            <numerusform>Lade von %1 von &amp;Ln verbundenen Peers herunter</numerusform>
+            <numerusform>Lade von %1 von %Ln verbundenem Peer herunter</numerusform>
+            <numerusform>Lade von %1 von %Ln verbundenen Peers herunter</numerusform>
         </translation>
     </message>
     <message numerus="yes">


### PR DESCRIPTION
To solve with issue:

![2017-01-01 23_37_32-transmission](https://cloud.githubusercontent.com/assets/388796/21583309/d7a07eb6-d07b-11e6-9100-a8cca5ff35b7.png)
