### PR TITLE
Remove Info.plist from copy phase and align minimum version

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -468,7 +468,6 @@
 		C12F19791E1AE3C30005E93F /* upnperrors.c in Sources */ = {isa = PBXBuildFile; fileRef = C12F19771E1AE3C30005E93F /* upnperrors.c */; };
 		C12F197B1E1AE4460005E93F /* upnperrors.h in Headers */ = {isa = PBXBuildFile; fileRef = C12F197A1E1AE4460005E93F /* upnperrors.h */; };
 		C1305EBE186A13B100F03351 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = C1305EB8186A134000F03351 /* file.c */; };
-		C15320211C82602500CC21E2 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8D1107310486CEB800E47090 /* Info.plist */; };
 		C1639A741A55F4E000E42033 /* libb64.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1639A6F1A55F4D600E42033 /* libb64.a */; };
 		C1639A781A55F56600E42033 /* cdecode.c in Sources */ = {isa = PBXBuildFile; fileRef = C1639A761A55F56600E42033 /* cdecode.c */; };
 		C1639A791A55F56600E42033 /* cencode.c in Sources */ = {isa = PBXBuildFile; fileRef = C1639A771A55F56600E42033 /* cencode.c */; };
@@ -2650,7 +2649,6 @@
 				A2DC496E15842D5200758FF1 /* Lock@2x.png in Resources */,
 				A2DC497015842D5C00758FF1 /* Magnet@2x.png in Resources */,
 				A2DC497215842D8000758FF1 /* PauseHover@2x.png in Resources */,
-				C15320211C82602500CC21E2 /* Info.plist in Resources */,
 				A2DC497615842D9700758FF1 /* PauseOff@2x.png in Resources */,
 				A2DC497815842D9C00758FF1 /* PauseOn@2x.png in Resources */,
 				A2DC497A15842DC100758FF1 /* PinTemplate@2x.png in Resources */,

--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -63,7 +63,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6.0</string>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
The Info.plist file is currently copied into the bundle twice: Contents/ and Contents/Resources/. It belongs into Contents/ and has no apparent purpose in Contents/Resources/. Xcode flags this as a warning.

I also changed the Info.plist key for the minimum version to `$(MACOSX_DEPLOYMENT_TARGET)` so that it matches the project deployment target. This is the default in new Xcode projects. The current value is 10.6, which is not correct anymore.