### PR TITLE
Allow the RPC server to listen on an IPv6 address

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -136,7 +136,7 @@ static struct tr_option const options[] =
     { 912, "encryption-tolerated", "Prefer unencrypted peer connections", "et", 0, NULL },
     { 'i', "bind-address-ipv4", "Where to listen for peer connections", "i", 1, "<ipv4 addr>" },
     { 'I', "bind-address-ipv6", "Where to listen for peer connections", "I", 1, "<ipv6 addr>" },
-    { 'r', "rpc-bind-address", "Where to listen for RPC connections", "r", 1, "<ipv4 addr>" },
+    { 'r', "rpc-bind-address", "Where to listen for RPC connections", "r", 1, "<ip addr>" },
     { 953, "global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed until a specific ratio", "gsr", 1, "ratio" },
     { 954, "no-global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed regardless of ratio", "GSR", 0, NULL },
     { 'x', "pid-file", "Enable PID file", "x", 1, "<pid-file>" },

--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -41,7 +41,7 @@ via RPC commands from transmission's web interface or
 .It Fl a Fl -allowed Ar x.x.x.x,...
 Allow RPC access to a comma-delimited whitelist of IP addresses.
 Wildcards can be specified in an address by using '*'.
-Default: "127.0.0.1"
+Default: "127.0.0.1,::1"
 Example: "127.0.0.*,192.168.1.*"
 .It Fl b Fl -blocklist
 Enable peer blocklists. Transmission understands the bluetack blocklist file format.
@@ -84,7 +84,7 @@ Listen for IPv4 BitTorrent connections on a specific address. Only one IPv4 list
 .It Fl I Fl -bind-address-ipv6
 Listen for IPv6 BitTorrent connections on a specific address. Only one IPv6 listening address is allowed. Default: :: (All addresses)
 .It Fl r Fl -rpc-bind-address
-Listen for RPC connections on a specific address. This must be an IPv4 address. Only one RPC listening address is allowed. Default: 0.0.0.0 (All addresses)
+Listen for RPC connections on a specific address. This must be an IPv4 or IPv6 address. Only one RPC listening address is allowed. Default: 0.0.0.0 (All IPv4 addresses)
 .It Fl -paused
 Pause all torrents on startup
 .It Fl L Fl -peerlimit-global Ar limit

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -127,7 +127,7 @@ char const* tr_getDefaultDownloadDir(void);
 
 #define TR_DEFAULT_BIND_ADDRESS_IPV4 "0.0.0.0"
 #define TR_DEFAULT_BIND_ADDRESS_IPV6 "::"
-#define TR_DEFAULT_RPC_WHITELIST "127.0.0.1"
+#define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
 #define TR_DEFAULT_RPC_PORT_STR "9091"
 #define TR_DEFAULT_RPC_URL_STR "/transmission/"
 #define TR_DEFAULT_PEER_PORT_STR "51413"


### PR DESCRIPTION
Currently, the RPC listen address is only allowed to be IPv4. This isn't a technical limitation however, and it works fine if it is an IPv6 address. This commit removes this limitation and also allows IPv6 addresses and thus makes the RPC server accessible through IPv6.

Note: it is currently impossible to reliably listen on multiple addresses, as is done with the regular `bind-address-{ipv4,ipv6}` options, because of [libevent#394](https://github.com/libevent/libevent/issues/394) (summary: when binding on `::` with libevent, on most OSs, you are also automatically binding on `0.0.0.0`). I don't think that the approach of my commit is inferior however, as the use of the RPC server is much more limited, and it is fine to just listen on a single protocol/address.

Fixes #59.