### PR TITLE
Correct name of qt client in desktop file

### DIFF
--- a/qt/transmission-qt.desktop
+++ b/qt/transmission-qt.desktop
@@ -1,7 +1,9 @@
 [Desktop Entry]
-Name=Qtransmission Bittorrent Client
+Name=Transmission (Qt)
 GenericName=BitTorrent Client
 Comment=Download and share files over BitTorrent
+# Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+Keywords=torrents;downloading;uploading;share;sharing;
 Exec=transmission-qt %U
 Icon=transmission
 Terminal=false


### PR DESCRIPTION
I don't see the name "Qtransmission" mentioned anywhere else, and it's confusing to not find Tranmission under the letter "T" in my desktop's application launcher.