### PR TITLE
Mac: Added an option to select torrent double-click action in preferences

### DIFF
--- a/macosx/Defaults.plist
+++ b/macosx/Defaults.plist
@@ -180,6 +180,10 @@
 	<string>RatioTotal</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>OnDoubleClickWhenCompletedAction</key>
+	<integer>0</integer>
+	<key>OnDoubleClickWhenDownloadingAction</key>
+	<integer>0</integer>
 	<key>UploadLimit</key>
 	<integer>50</integer>
 	<key>UseIncompleteDownloadFolder</key>

--- a/macosx/TorrentTableView.m
+++ b/macosx/TorrentTableView.m
@@ -401,14 +401,26 @@
         #warning maybe make appear on mouse down
         [self displayTorrentActionPopoverForEvent: event];
     }
-    else if (!pushed && [event clickCount] == 2) //double click
+    else if (row != -1 && !pushed && [event clickCount] == 2) //double click on torrent
     {
-        id item = nil;
-        if (row != -1)
-            item = [self itemAtRow: row];
-
-        if (!item || [item isKindOfClass: [Torrent class]])
-            [fController showInfo: nil];
+        id item = [self itemAtRow: row];
+        // Depending on current preferences, choose double-click action
+        if ([item isKindOfClass: [Torrent class]]) {
+            int action = [item isComplete] ? [fDefaults integerForKey: @"OnDoubleClickWhenCompletedAction"] : [fDefaults integerForKey: @"OnDoubleClickWhenDownloadingAction"];
+            switch (action) {
+                case 0: // show file options menu
+                    [fController showInfo: nil];
+                    break;
+                case 1: // toggle pause/resume for torrent
+                    [self toggleControlForTorrent: item];
+                    break;
+                case 2: // show in finder
+                    [fController revealFile: nil];
+                    break;
+                default:
+                    break;
+            }
+        }
         else
         {
             if ([self isItemExpanded: item])

--- a/macosx/en.lproj/PrefsWindow.xib
+++ b/macosx/en.lproj/PrefsWindow.xib
@@ -286,22 +286,22 @@
                 </textField>
             </subviews>
         </customView>
-        <customView id="41" userLabel="Transfers">
-            <rect key="frame" x="0.0" y="0.0" width="542" height="393"/>
+        <customView misplaced="YES" id="41" userLabel="Transfers">
+            <rect key="frame" x="0.0" y="0.0" width="542" height="443"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <tabView initialItem="253" id="252">
-                    <rect key="frame" x="13" y="10" width="516" height="379"/>
+                    <rect key="frame" x="13" y="10" width="516" height="429"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Adding" identifier="" id="253">
                             <view key="view" id="255">
-                                <rect key="frame" x="10" y="33" width="496" height="333"/>
+                                <rect key="frame" x="10" y="33" width="496" height="383"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <popUpButton verticalHuggingPriority="750" id="51">
-                                        <rect key="frame" x="219" y="299" width="182" height="26"/>
+                                        <rect key="frame" x="219" y="349" width="182" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="57" id="1215">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -344,7 +344,7 @@
                                         </popUpButtonCell>
                                     </popUpButton>
                                     <textField verticalHuggingPriority="750" id="59">
-                                        <rect key="frame" x="108" y="305" width="109" height="17"/>
+                                        <rect key="frame" x="108" y="355" width="109" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Default location:" id="1216">
                                             <font key="font" metaFont="system"/>
@@ -353,7 +353,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="61">
-                                        <rect key="frame" x="44" y="305" width="62" height="17"/>
+                                        <rect key="frame" x="44" y="355" width="62" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Settings:" id="1217">
                                             <font key="font" metaFont="system"/>
@@ -362,7 +362,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button id="115">
-                                        <rect key="frame" x="109" y="236" width="188" height="18"/>
+                                        <rect key="frame" x="109" y="286" width="188" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Trash original torrent files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1218">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -373,7 +373,7 @@
                                         </connections>
                                     </button>
                                     <button id="1939">
-                                        <rect key="frame" x="109" y="216" width="226" height="18"/>
+                                        <rect key="frame" x="109" y="266" width="226" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Append .part to incomplete files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1940">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -385,7 +385,7 @@
                                         </connections>
                                     </button>
                                     <button id="209">
-                                        <rect key="frame" x="109" y="83" width="181" height="18"/>
+                                        <rect key="frame" x="109" y="133" width="181" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Watch for torrent files in:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1219">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -397,7 +397,7 @@
                                         </connections>
                                     </button>
                                     <popUpButton verticalHuggingPriority="750" id="216">
-                                        <rect key="frame" x="293" y="78" width="182" height="26"/>
+                                        <rect key="frame" x="293" y="128" width="182" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="220" id="1220">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -435,7 +435,7 @@
                                         </connections>
                                     </popUpButton>
                                     <textField verticalHuggingPriority="750" id="352">
-                                        <rect key="frame" x="40" y="84" width="66" height="17"/>
+                                        <rect key="frame" x="40" y="134" width="66" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Auto add:" id="1226">
                                             <font key="font" metaFont="system"/>
@@ -444,7 +444,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button id="537">
-                                        <rect key="frame" x="109" y="279" width="178" height="18"/>
+                                        <rect key="frame" x="109" y="329" width="178" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Keep incomplete files in:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1227">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -456,7 +456,7 @@
                                         </connections>
                                     </button>
                                     <popUpButton verticalHuggingPriority="750" id="538">
-                                        <rect key="frame" x="290" y="274" width="182" height="26"/>
+                                        <rect key="frame" x="290" y="324" width="182" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="540" id="1228">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -493,7 +493,7 @@
                                         </connections>
                                     </popUpButton>
                                     <button id="1293">
-                                        <rect key="frame" x="109" y="180" width="307" height="18"/>
+                                        <rect key="frame" x="109" y="230" width="307" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Display a window when opening a torrent file" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1294">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -504,7 +504,7 @@
                                         </connections>
                                     </button>
                                     <button id="1947">
-                                        <rect key="frame" x="109" y="120" width="315" height="18"/>
+                                        <rect key="frame" x="109" y="170" width="315" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Display a window when opening a magnet link" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1948">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -515,7 +515,7 @@
                                         </connections>
                                     </button>
                                     <button id="1334">
-                                        <rect key="frame" x="109" y="256" width="192" height="18"/>
+                                        <rect key="frame" x="109" y="306" width="192" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Start transfers when added" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1335">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -540,7 +540,7 @@
                                         </connections>
                                     </button>
                                     <button id="1476">
-                                        <rect key="frame" x="128" y="140" width="197" height="18"/>
+                                        <rect key="frame" x="128" y="190" width="197" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Only when adding manually" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1477">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -552,7 +552,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="1337">
-                                        <rect key="frame" x="21" y="181" width="86" height="17"/>
+                                        <rect key="frame" x="21" y="231" width="86" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Add window:" id="1338">
                                             <font key="font" metaFont="system"/>
@@ -561,7 +561,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button id="1339">
-                                        <rect key="frame" x="128" y="160" width="235" height="18"/>
+                                        <rect key="frame" x="128" y="210" width="235" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Only when there are multiple files" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1340">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -577,11 +577,11 @@
                         </tabViewItem>
                         <tabViewItem label="Management" identifier="" id="254">
                             <view key="view" id="256">
-                                <rect key="frame" x="10" y="33" width="496" height="333"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                                <rect key="frame" x="10" y="33" width="496" height="383"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" id="257">
-                                        <rect key="frame" x="302" y="175" width="35" height="22"/>
+                                        <rect key="frame" x="302" y="225" width="35" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="1229">
                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" allowsFloats="NO" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="42" id="920">
@@ -602,7 +602,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="262">
-                                        <rect key="frame" x="32" y="177" width="56" height="17"/>
+                                        <rect key="frame" x="32" y="227" width="56" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Queues:" id="1230">
                                             <font key="font" metaFont="system"/>
@@ -610,8 +610,17 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <textField verticalHuggingPriority="750" misplaced="YES" id="pZ5-j8-vMM">
+                                        <rect key="frame" x="1" y="128" width="87" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Double-click:" id="J0K-QI-ExZ">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                     <textField verticalHuggingPriority="750" id="263" customClass="ColorTextField">
-                                        <rect key="frame" x="342" y="177" width="101" height="17"/>
+                                        <rect key="frame" x="342" y="227" width="101" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="active transfers" id="1231">
                                             <font key="font" metaFont="system"/>
@@ -623,7 +632,7 @@
                                         </connections>
                                     </textField>
                                     <button id="264">
-                                        <rect key="frame" x="91" y="302" width="157" height="18"/>
+                                        <rect key="frame" x="91" y="352" width="157" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Stop seeding at ratio:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1232">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -635,7 +644,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="265">
-                                        <rect key="frame" x="254" y="301" width="50" height="22"/>
+                                        <rect key="frame" x="254" y="351" width="50" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="1233">
                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="42" minimumFractionDigits="2" maximumFractionDigits="2" id="840">
@@ -656,7 +665,7 @@
                                         </connections>
                                     </textField>
                                     <button id="1958">
-                                        <rect key="frame" x="91" y="258" width="220" height="18"/>
+                                        <rect key="frame" x="91" y="308" width="220" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Stop seeding when inactive for:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1962">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -668,7 +677,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="1959">
-                                        <rect key="frame" x="317" y="257" width="41" height="22"/>
+                                        <rect key="frame" x="317" y="307" width="41" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="1960">
                                             <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" lenient="YES" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="1961">
@@ -687,7 +696,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="267">
-                                        <rect key="frame" x="41" y="303" width="47" height="17"/>
+                                        <rect key="frame" x="41" y="353" width="47" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Limits:" id="1234">
                                             <font key="font" metaFont="system"/>
@@ -696,7 +705,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="268">
-                                        <rect key="frame" x="109" y="283" width="269" height="14"/>
+                                        <rect key="frame" x="109" y="333" width="269" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Ratio is amount uploaded to amount downloaded" id="1235">
                                             <font key="font" metaFont="smallSystem"/>
@@ -705,7 +714,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button id="337">
-                                        <rect key="frame" x="91" y="176" width="205" height="18"/>
+                                        <rect key="frame" x="91" y="226" width="205" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Download with maximum of:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1236">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -717,7 +726,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="604">
-                                        <rect key="frame" x="288" y="149" width="35" height="22"/>
+                                        <rect key="frame" x="288" y="199" width="35" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="1238">
                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" allowsFloats="NO" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="42" id="921">
@@ -738,7 +747,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="606" customClass="ColorTextField">
-                                        <rect key="frame" x="328" y="151" width="101" height="17"/>
+                                        <rect key="frame" x="328" y="201" width="101" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="active transfers" id="1239">
                                             <font key="font" metaFont="system"/>
@@ -750,7 +759,7 @@
                                         </connections>
                                     </textField>
                                     <button id="607">
-                                        <rect key="frame" x="91" y="150" width="191" height="18"/>
+                                        <rect key="frame" x="91" y="200" width="191" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Seeding with maximum of:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1240">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -762,7 +771,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="636">
-                                        <rect key="frame" x="349" y="123" width="41" height="22"/>
+                                        <rect key="frame" x="349" y="173" width="41" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="1241">
                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0" negativeFormat="#0" allowsFloats="NO" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" currencySymbol="¤" internationalCurrencySymbol="¤¤" id="922">
@@ -783,7 +792,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" id="638" customClass="ColorTextField">
-                                        <rect key="frame" x="395" y="125" width="55" height="17"/>
+                                        <rect key="frame" x="395" y="175" width="55" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="minutes" id="1242">
                                             <font key="font" metaFont="system"/>
@@ -795,7 +804,7 @@
                                         </connections>
                                     </textField>
                                     <button id="639">
-                                        <rect key="frame" x="91" y="124" width="252" height="18"/>
+                                        <rect key="frame" x="91" y="174" width="252" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Transfer is stalled when inactive for:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1243">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -806,8 +815,8 @@
                                             <binding destination="365" name="value" keyPath="values.CheckStalled" id="640"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" id="1297">
-                                        <rect key="frame" x="11" y="85" width="77" height="17"/>
+                                    <textField verticalHuggingPriority="750" misplaced="YES" id="1297">
+                                        <rect key="frame" x="8" y="85" width="77" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Play sound:" id="1310">
                                             <font key="font" metaFont="system"/>
@@ -815,8 +824,8 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <popUpButton verticalHuggingPriority="750" id="1298">
-                                        <rect key="frame" x="289" y="79" width="130" height="26"/>
+                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="1298">
+                                        <rect key="frame" x="289" y="78" width="130" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1309" id="1307">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -835,8 +844,8 @@
                                             <outlet property="nextKeyView" destination="1300" id="1641"/>
                                         </connections>
                                     </popUpButton>
-                                    <button id="1299">
-                                        <rect key="frame" x="91" y="59" width="183" height="18"/>
+                                    <button misplaced="YES" id="1299">
+                                        <rect key="frame" x="91" y="58" width="183" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="When seeding completes:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1306">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -846,8 +855,8 @@
                                             <binding destination="365" name="value" keyPath="values.PlaySeedingSound" id="1346"/>
                                         </connections>
                                     </button>
-                                    <popUpButton verticalHuggingPriority="750" id="1300">
-                                        <rect key="frame" x="289" y="54" width="130" height="26"/>
+                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="1300">
+                                        <rect key="frame" x="289" y="53" width="130" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1305" id="1303">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -865,8 +874,8 @@
                                             <binding destination="365" name="selectedValue" keyPath="values.SeedingSound" previousBinding="1332" id="1333"/>
                                         </connections>
                                     </popUpButton>
-                                    <button id="1301">
-                                        <rect key="frame" x="91" y="84" width="195" height="18"/>
+                                    <button misplaced="YES" id="1301">
+                                        <rect key="frame" x="91" y="83" width="195" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="When download completes:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1302">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -877,7 +886,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="1969" customClass="ColorTextField">
-                                        <rect key="frame" x="363" y="259" width="55" height="17"/>
+                                        <rect key="frame" x="363" y="309" width="55" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="minutes" id="1970">
                                             <font key="font" metaFont="system"/>
@@ -888,8 +897,8 @@
                                             <binding destination="365" name="enabled" keyPath="values.IdleLimitCheck" id="1984"/>
                                         </connections>
                                     </textField>
-                                    <button id="2043">
-                                        <rect key="frame" x="91" y="19" width="195" height="18"/>
+                                    <button misplaced="YES" id="2043">
+                                        <rect key="frame" x="91" y="18" width="195" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="When download completes:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2044">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -900,8 +909,8 @@
                                             <binding destination="365" name="value" keyPath="values.DoneScriptEnabled" id="2058"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" id="2046">
-                                        <rect key="frame" x="16" y="20" width="72" height="17"/>
+                                    <textField verticalHuggingPriority="750" misplaced="YES" id="2046">
+                                        <rect key="frame" x="13" y="20" width="72" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Call script:" id="2047">
                                             <font key="font" metaFont="system"/>
@@ -909,8 +918,8 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <popUpButton verticalHuggingPriority="750" id="2048">
-                                        <rect key="frame" x="289" y="14" width="168" height="26"/>
+                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="2048">
+                                        <rect key="frame" x="289" y="13" width="168" height="26"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="2051" id="2049">
                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -946,8 +955,8 @@
                                             <binding destination="365" name="enabled" keyPath="values.DoneScriptEnabled" id="2061"/>
                                         </connections>
                                     </popUpButton>
-                                    <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="2068">
-                                        <rect key="frame" x="459" y="14" width="25" height="25"/>
+                                    <button horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" id="2068">
+                                        <rect key="frame" x="459" y="13" width="25" height="25"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2069">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -958,7 +967,7 @@
                                         </connections>
                                     </button>
                                     <button id="2118">
-                                        <rect key="frame" x="91" y="235" width="367" height="18"/>
+                                        <rect key="frame" x="91" y="285" width="367" height="18"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <buttonCell key="cell" type="check" title="Remove from the transfer list when seeding completes" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2119">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -970,7 +979,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" id="2122">
-                                        <rect key="frame" x="109" y="217" width="180" height="14"/>
+                                        <rect key="frame" x="109" y="267" width="180" height="14"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Applies to newly added transfers" id="2123">
                                             <font key="font" metaFont="smallSystem"/>
@@ -978,6 +987,60 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" id="m9i-KQ-NPl">
+                                        <rect key="frame" x="91" y="145" width="124" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When downloading:" id="pTc-zC-B5T">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" id="ZyV-0F-jMv">
+                                        <rect key="frame" x="91" y="120" width="173" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When download completed:" id="eSU-LB-Zi2">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="unT-bX-D8Z">
+                                        <rect key="frame" x="289" y="140" width="168" height="26"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <popUpButtonCell key="cell" type="push" title="Show info" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="ycr-2e-2B7" id="5CR-Px-oHN">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="0fl-mR-rhO">
+                                                <items>
+                                                    <menuItem title="Show info" state="on" id="ycr-2e-2B7"/>
+                                                    <menuItem title="Pause/Resume" id="mEq-3P-94H"/>
+                                                    <menuItem title="Show in Finder" id="iOR-Gt-cxr"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                        <connections>
+                                            <binding destination="365" name="selectedIndex" keyPath="values.OnDoubleClickWhenDownloadingAction" id="QwC-wu-Z08"/>
+                                        </connections>
+                                    </popUpButton>
+                                    <popUpButton verticalHuggingPriority="750" misplaced="YES" id="7fq-nr-8re">
+                                        <rect key="frame" x="289" y="115" width="168" height="26"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <popUpButtonCell key="cell" type="push" title="Show info" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="LdR-3G-pcH" id="Kg6-3K-zRd">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="menu"/>
+                                            <menu key="menu" id="zXc-ep-6bE">
+                                                <items>
+                                                    <menuItem title="Show info" state="on" id="LdR-3G-pcH"/>
+                                                    <menuItem title="Pause/Resume" id="H8I-yM-0Zv"/>
+                                                    <menuItem title="Show in Finder" id="waF-ux-ZOf"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                        <connections>
+                                            <binding destination="365" name="selectedIndex" keyPath="values.OnDoubleClickWhenCompletedAction" id="QWW-Dn-rbt"/>
+                                        </connections>
+                                    </popUpButton>
                                 </subviews>
                             </view>
                         </tabViewItem>
@@ -987,6 +1050,7 @@
                     </connections>
                 </tabView>
             </subviews>
+            <point key="canvasLocation" x="132" y="951.5"/>
         </customView>
         <customView id="1760" userLabel="Groups">
             <rect key="frame" x="0.0" y="0.0" width="542" height="240"/>
@@ -1125,7 +1189,7 @@
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
-                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="E807F7CA-C458-4A9B-B24E-2C8941A79CD2" id="1782"/>
+                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="B3BEF162-208A-4E4E-89BD-3E13FA972513" id="1782"/>
                                     </tableColumn>
                                     <tableColumn identifier="Name" editable="NO" width="115" minWidth="40" maxWidth="1000" id="1779">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
@@ -2187,7 +2251,7 @@
         </customObject>
     </objects>
     <resources>
-        <image name="E807F7CA-C458-4A9B-B24E-2C8941A79CD2" width="18" height="18">
+        <image name="B3BEF162-208A-4E4E-89BD-3E13FA972513" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPT5YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
 GR4fIyQrLjE3OlUkbnVsbNUJCgsMDQ4PEBESVk5TU2l6ZVYkY2xhc3NcTlNJbWFnZUZsYWdzVk5TUmVw


### PR DESCRIPTION
uTorrent-like feature for choosing what will happen when a torrent list item is double-clicked.

**Possible values are:**

- Show info (this is the previous value and the default)
- Pause/Resume (pause or resume seeding)
- Show in Finder (shows the selected file(s) in Finder)

<img width="542" alt="double_click_preferences" src="https://cloud.githubusercontent.com/assets/9801173/23824551/6d186ec8-0681-11e7-8f4c-98138ac2fd31.png">
