### PR TITLE
Add SSL support to transmission-qt

### DIFF
--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -280,6 +280,7 @@ static const struct tr_key_struct my_static[] =
   { "remote-session-password", 23 },
   { "remote-session-port", 19 },
   { "remote-session-requres-authentication", 37 },
+  { "remote-session-ssl", 18 },
   { "remote-session-username", 23 },
   { "removed", 7 },
   { "rename-partial-files", 20 },

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -281,6 +281,7 @@ enum
   TR_KEY_remote_session_password,
   TR_KEY_remote_session_port,
   TR_KEY_remote_session_requres_authentication,
+  TR_KEY_remote_session_ssl,
   TR_KEY_remote_session_username,
   TR_KEY_removed,
   TR_KEY_rename_partial_files,
@@ -430,4 +431,3 @@ tr_quark tr_quark_new (const void * str, size_t len);
 #ifdef __cplusplus
 }
 #endif
-

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -49,6 +49,7 @@ namespace
     { 'm', "minimized",  "Start minimized in system tray", "m", 0, NULL },
     { 'p', "port",  "Port to use when connecting to an existing session", "p", 1, "<port>" },
     { 'r', "remote",  "Connect to an existing session at the specified hostname", "r", 1, "<host>" },
+    { 's', "ssl", "Use SSL when connecting to an existing session", "s", 0, NULL },
     { 'u', "username", "Username to use when connecting to an existing session", "u", 1, "<username>" },
     { 'v', "version", "Show version number and exit", "v", 0, NULL },
     { 'w', "password", "Password to use when connecting to an existing session", "w", 1, "<password>" },
@@ -123,6 +124,7 @@ Application::Application (int& argc, char ** argv):
   const char * optarg;
   QString host;
   QString port;
+  bool ssl = false;
   QString username;
   QString password;
   QString configDir;
@@ -134,6 +136,7 @@ Application::Application (int& argc, char ** argv):
           case 'g': configDir = QString::fromUtf8 (optarg); break;
           case 'p': port = QString::fromUtf8 (optarg); break;
           case 'r': host = QString::fromUtf8 (optarg); break;
+          case 's': ssl = true; break;
           case 'u': username = QString::fromUtf8 (optarg); break;
           case 'w': password = QString::fromUtf8 (optarg); break;
           case 'm': minimized = true; break;
@@ -201,6 +204,8 @@ Application::Application (int& argc, char ** argv):
     myPrefs->set (Prefs::SESSION_REMOTE_HOST, host);
   if (!port.isNull ())
     myPrefs->set (Prefs::SESSION_REMOTE_PORT, port.toUInt ());
+  if (ssl)
+    myPrefs->set (Prefs::SESSION_REMOTE_SSL, ssl);
   if (!username.isNull ())
     myPrefs->set (Prefs::SESSION_REMOTE_USERNAME, username);
   if (!password.isNull ())

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -60,6 +60,7 @@ Prefs::PrefItem Prefs::myItems[] =
   { SESSION_IS_REMOTE, TR_KEY_remote_session_enabled, QVariant::Bool },
   { SESSION_REMOTE_HOST, TR_KEY_remote_session_host, QVariant::String },
   { SESSION_REMOTE_PORT, TR_KEY_remote_session_port, QVariant::Int },
+  { SESSION_REMOTE_SSL, TR_KEY_remote_session_ssl, QVariant::Bool },
   { SESSION_REMOTE_AUTH, TR_KEY_remote_session_requres_authentication, QVariant::Bool },
   { SESSION_REMOTE_USERNAME, TR_KEY_remote_session_username, QVariant::String },
   { SESSION_REMOTE_PASSWORD, TR_KEY_remote_session_password, QVariant::String },
@@ -281,6 +282,7 @@ Prefs::initDefaults (tr_variant * d)
   tr_variantDictAddBool (d, TR_KEY_inhibit_desktop_hibernation, false);
   tr_variantDictAddBool (d, TR_KEY_prompt_before_exit, true);
   tr_variantDictAddBool (d, TR_KEY_remote_session_enabled, false);
+  tr_variantDictAddBool (d, TR_KEY_remote_session_ssl, false);
   tr_variantDictAddBool (d, TR_KEY_remote_session_requres_authentication, false);
   tr_variantDictAddBool (d, TR_KEY_show_backup_trackers, false);
   tr_variantDictAddBool (d, TR_KEY_show_extra_peer_details, false),

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -64,6 +64,7 @@ class Prefs: public QObject
       SESSION_IS_REMOTE,
       SESSION_REMOTE_HOST,
       SESSION_REMOTE_PORT,
+      SESSION_REMOTE_SSL,
       SESSION_REMOTE_AUTH,
       SESSION_REMOTE_USERNAME,
       SESSION_REMOTE_PASSWORD,
@@ -186,4 +187,3 @@ class Prefs: public QObject
 
     static PrefItem myItems[];
 };
-

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -307,7 +307,7 @@ Session::start ()
   if (myPrefs.get<bool> (Prefs::SESSION_IS_REMOTE))
     {
       QUrl url;
-      url.setScheme (QLatin1String ("http"));
+      url.setScheme (QLatin1String (myPrefs.get<bool> (Prefs::SESSION_REMOTE_SSL) ? "https" : "http"));
       url.setHost (myPrefs.get<QString> (Prefs::SESSION_REMOTE_HOST));
       url.setPort (myPrefs.get<int> (Prefs::SESSION_REMOTE_PORT));
       url.setPath (QLatin1String ("/transmission/rpc"));

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -20,6 +20,7 @@ SessionDialog::accept ()
   myPrefs.set (Prefs::SESSION_IS_REMOTE, ui.remoteSessionRadio->isChecked ());
   myPrefs.set (Prefs::SESSION_REMOTE_HOST, ui.hostEdit->text ());
   myPrefs.set (Prefs::SESSION_REMOTE_PORT, ui.portSpin->value ());
+  myPrefs.set (Prefs::SESSION_REMOTE_SSL, ui.sslCheck->isChecked ());
   myPrefs.set (Prefs::SESSION_REMOTE_AUTH, ui.authCheck->isChecked ());
   myPrefs.set (Prefs::SESSION_REMOTE_USERNAME, ui.usernameEdit->text ());
   myPrefs.set (Prefs::SESSION_REMOTE_PASSWORD, ui.passwordEdit->text ());
@@ -62,6 +63,9 @@ SessionDialog::SessionDialog (Session& session, Prefs& prefs, QWidget * parent):
 
   ui.portSpin->setValue (prefs.get<int> (Prefs::SESSION_REMOTE_PORT));
   myRemoteWidgets << ui.portLabel << ui.portSpin;
+
+  ui.sslCheck->setChecked (prefs.get<bool> (Prefs::SESSION_REMOTE_SSL));
+  myRemoteWidgets << ui.sslCheck;
 
   ui.authCheck->setChecked (prefs.get<bool> (Prefs::SESSION_REMOTE_AUTH));
   connect (ui.authCheck, SIGNAL (toggled (bool)), this, SLOT (resensitize ()));

--- a/qt/SessionDialog.ui
+++ b/qt/SessionDialog.ui
@@ -80,13 +80,20 @@
       </widget>
      </item>
      <item row="4" column="0" colspan="2">
+      <widget class="QCheckBox" name="sslCheck">
+       <property name="text">
+        <string>&amp;SSL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
       <widget class="QCheckBox" name="authCheck">
        <property name="text">
         <string>&amp;Authentication required</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="usernameLabel">
        <property name="text">
         <string>&amp;Username:</string>
@@ -96,10 +103,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLineEdit" name="usernameEdit"/>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="passwordLabel">
        <property name="text">
         <string>Pass&amp;word:</string>
@@ -109,7 +116,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QLineEdit" name="passwordEdit">
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>


### PR DESCRIPTION
This allows to use HTTPS instead of HTTP when connecting to an existing session:
 * a new checkbox in the session dialog (SSL)
 * a new flag in command-line arguments (`-s --ssl`)
 * a new key in JSON settings (`"remote-session-ssl"`)

I hope I didn't missed anything.
