### PR TITLE
Add support to use the browser magnet link handler in web frontend

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -103,6 +103,11 @@
 						<div class="row"><div class="key"><input type="checkbox" id="idle-seeding-limit-enabled"/><label for="idle-seeding-limit-enabled">Stop seeding if idle for (min):</label></div>
                                                                  <div class="value"><input type="number" min="0" id="idle-seeding-limit"/></div></div>
 					</div>
+					<div class="prefs-section">
+						<div class="title">Browser Magnet Application</div>
+						<div class="row"><div class="key">Transmission:</div>
+						                 <div class="value"><input type="button" id="default_app_button" value="Add To Browser"/></div></div>
+					</div>
 				</div>
 				<div id="prefs-page-speed">
 					<div class="prefs-section">

--- a/web/javascript/common.js
+++ b/web/javascript/common.js
@@ -99,6 +99,53 @@ String.prototype.trim = function () {
     return this.replace(/^\s*/, "").replace(/\s*$/, "");
 };
 
+/*
+ *   Give us the base path of transmission web
+ *   Used for our content / protocol handlers in dialog.js
+ *
+ *   @returns string
+ */
+
+function returnBaseURL( )
+{
+ 	var href = window.location.href;
+	if (href.indexOf('?') != -1)
+		href = href.substring(0, href.indexOf('?'));
+	if (href.indexOf('#') != -1)
+		href = href.substring(0, href.indexOf('#'));
+
+	return href;
+}
+
+/*
+ * Get a list of parameters send through the url
+ *
+ * @returns string[]
+ */
+function getUrlVars()
+{
+	var vars = [], hash;
+	var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+	for(var i = 0; i < hashes.length; i++)
+	{
+		hash = hashes[i].split('=');
+		vars.push(hash[0]);
+		vars[hash[0]] = hash[1];
+	}
+	return vars;
+}
+
+/*
+ * Get a specific url variable
+ *
+ * @param string name
+ * @returns string
+ */
+function getUrlVar ( name )
+{
+	return getUrlVars()[name];
+}
+
 /***
  ****  Preferences
  ***/

--- a/web/javascript/dialog.js
+++ b/web/javascript/dialog.js
@@ -24,6 +24,7 @@ Dialog.prototype = {
         this._message = $('#dialog_message');
         this._cancel_button = $('#dialog_cancel_button');
         this._confirm_button = $('#dialog_confirm_button');
+        this._default_app_button = $('#default_app_button');
         this._callback = null;
 
         // Observe the buttons
@@ -33,6 +34,9 @@ Dialog.prototype = {
         this._confirm_button.bind('click', {
             dialog: this
         }, this.onConfirmClicked);
+        this._default_app_button.bind('click', {
+            dialog: this
+        }, this.onDefaultAppClicked);
     },
 
     /*--------------------------------------------
@@ -56,6 +60,12 @@ Dialog.prototype = {
         var dialog = event.data.dialog;
         dialog._callback();
         dialog.hideDialog();
+    },
+
+    onDefaultAppClicked: function(event) {
+        window.navigator.registerProtocolHandler("magnet", returnBaseURL() + "?addtorrent=%s", "Transmission Web");
+        /* The following is not yet implemented in any browser */
+        window.navigator.registerContentHandler("application/x-bittorrent", returnBaseURL() + "?addtorrent=%s", "Transmission Web");
     },
 
     /*--------------------------------------------

--- a/web/javascript/remote.js
+++ b/web/javascript/remote.js
@@ -252,6 +252,15 @@ TransmissionRemote.prototype = {
             remote._controller.refreshTorrents();
         });
     },
+    checkForAddTorrentInUrl: function() {
+        var url = getUrlVar('addtorrent');
+
+        if(url){
+            var paused = this._controller.shouldAddedTorrentsStart;
+            this.addTorrentByUrl(unescape(url), { paused: paused });
+            history.replaceState(null, "", location.href.split("?")[0]);
+        }
+    },
     savePrefs: function (args) {
         var remote = this;
         var o = {

--- a/web/javascript/transmission.js
+++ b/web/javascript/transmission.js
@@ -107,6 +107,10 @@ Transmission.prototype = {
         this.loadDaemonPrefs(async);
         this.loadDaemonStats(async);
         this.initializeTorrents();
+
+        // Check for a new torrent provided using the url (#2404)
+        this.remote.checkForAddTorrentInUrl();
+
         this.refreshTorrents();
         this.togglePeriodicSessionRefresh(true);
 


### PR DESCRIPTION
This adds a button in the web page settings dialog. When clicked this registers the
page as a handler for magnet urls. When clicking on a magnet url the browser
will open the web page adding the torrent automatically

This is based on earlier work by lembregtse (see https://trac.transmissionbt.com/ticket/2404)