### PR TITLE
Add null check for tr_torrentHasMetadata

### DIFF
--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1810,6 +1810,7 @@ struct tr_info
 
 static inline bool tr_torrentHasMetadata (const tr_torrent * tor)
 {
+    if (!tor) { return false; }
     return tr_torrentInfo (tor)->fileCount > 0;
 }
 


### PR DESCRIPTION
I caught a bad memory access while experimenting with macOS App Sandboxing.