### PR TITLE
default trackers

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -102,7 +102,7 @@ static auto constexpr Options = std::array<tr_option, 43>{
       { 'C', "no-watch-dir", "Disable the watch-dir", "C", false, nullptr },
       { 941, "incomplete-dir", "Where to store new torrents until they're complete", nullptr, true, "<directory>" },
       { 942, "no-incomplete-dir", "Don't store incomplete torrents in a different location", nullptr, false, nullptr },
-      { 'd', "dump-settings", "Dump the settings and exit", "d", false, nullptr },
+    { 943, "default-trackers", "Default trackers to be automatically added to public torrents", NULL, true, "<list>" },
       { 'e', "logfile", "Dump the log messages to this filename", "e", true, "<filename>" },
       { 'f', "foreground", "Run in the foreground instead of daemonizing", "f", false, nullptr },
       { 'g', "config-dir", "Where to look for configuration files", "g", true, "<path>" },
@@ -414,6 +414,10 @@ static bool parse_args(
 
         case 942:
             tr_variantDictAddBool(settings, TR_KEY_incomplete_dir_enabled, false);
+            break;
+
+        case 943:
+            tr_variantDictAddStr(settings, TR_KEY_default_trackers, optarg);
             break;
 
         case 'd':

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -103,7 +103,7 @@ static auto constexpr Options = std::array<tr_option, 44>{
       { 941, "incomplete-dir", "Where to store new torrents until they're complete", nullptr, true, "<directory>" },
       { 942, "no-incomplete-dir", "Don't store incomplete torrents in a different location", nullptr, false, nullptr },
       { 'd', "dump-settings", "Dump the settings and exit", "d", false, nullptr },
-      { 943, "default-trackers", "Default trackers to be automatically added to public torrents", nullptr, true, "<list>" },
+      { 943, "default-trackers", "Trackers for public torrents to use automatically", nullptr, true, "<list>" },
       { 'e', "logfile", "Dump the log messages to this filename", "e", true, "<filename>" },
       { 'f', "foreground", "Run in the foreground instead of daemonizing", "f", false, nullptr },
       { 'g', "config-dir", "Where to look for configuration files", "g", true, "<path>" },

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -94,7 +94,7 @@ static struct event_base* ev_base = nullptr;
 ****  Config File
 ***/
 
-static auto constexpr Options = std::array<tr_option, 43>{
+static auto constexpr Options = std::array<tr_option, 44>{
     { { 'a', "allowed", "Allowed IP addresses. (Default: " TR_DEFAULT_RPC_WHITELIST ")", "a", true, "<list>" },
       { 'b', "blocklist", "Enable peer blocklists", "b", false, nullptr },
       { 'B', "no-blocklist", "Disable peer blocklists", "B", false, nullptr },
@@ -102,7 +102,8 @@ static auto constexpr Options = std::array<tr_option, 43>{
       { 'C', "no-watch-dir", "Disable the watch-dir", "C", false, nullptr },
       { 941, "incomplete-dir", "Where to store new torrents until they're complete", nullptr, true, "<directory>" },
       { 942, "no-incomplete-dir", "Don't store incomplete torrents in a different location", nullptr, false, nullptr },
-    { 943, "default-trackers", "Default trackers to be automatically added to public torrents", NULL, true, "<list>" },
+      { 'd', "dump-settings", "Dump the settings and exit", "d", false, nullptr },
+      { 943, "default-trackers", "Default trackers to be automatically added to public torrents", nullptr, true, "<list>" },
       { 'e', "logfile", "Dump the log messages to this filename", "e", true, "<filename>" },
       { 'f', "foreground", "Run in the foreground instead of daemonizing", "f", false, nullptr },
       { 'g', "config-dir", "Where to look for configuration files", "g", true, "<path>" },
@@ -417,7 +418,7 @@ static bool parse_args(
             break;
 
         case 943:
-            tr_variantDictAddStr(settings, TR_KEY_default_trackers, optarg);
+            tr_variantDictAddStr(settings, TR_KEY_default_trackers, optstr);
             break;
 
         case 'd':

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1022,6 +1022,10 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         tr_sessionSetEncryption(tr, static_cast<tr_encryption_mode>(gtr_pref_int_get(key)));
         break;
 
+    case TR_KEY_default_trackers:
+        tr_sessionSetDefaultTrackers(tr, gtr_pref_string_get(key).c_str());
+        break;
+
     case TR_KEY_download_dir:
         tr_sessionSetDownloadDir(tr, gtr_pref_string_get(key).c_str());
         break;

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -180,9 +180,7 @@ void text_buffer_changed_cb(Glib::RefPtr<Gtk::TextBuffer> buffer, tr_quark const
 {
     Gtk::TextBuffer::iterator start, end;
     buffer->get_bounds(start, end);
-    Glib::ustring value = buffer->get_text(start, end, FALSE);
-
-    core->set_pref(key, value);
+    core->set_pref(key, buffer->get_text(start, end, FALSE));
 }
 
 Gtk::Widget* new_text_view(tr_quark const key, Glib::RefPtr<Session> const& core)

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -1080,8 +1080,7 @@ Gtk::Widget* PrefsDialog::Impl::networkPage()
 
     t->add_section_title(row, _("Default Trackers"));
     auto tv = new_text_view(TR_KEY_default_trackers, core_);
-    tv->set_tooltip_text(
-        _("Trackers for public torrents to use automatically"));
+    tv->set_tooltip_text(_("Trackers for public torrents to use automatically"));
     t->add_wide_control(row, *tv);
 
     return t;

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -187,17 +187,13 @@ void text_buffer_changed_cb(Glib::RefPtr<Gtk::TextBuffer> buffer, tr_quark const
 
 Gtk::Widget* new_text_view(tr_quark const key, Glib::RefPtr<Session> const& core)
 {
-    auto* scroll = Gtk::make_managed<Gtk::ScrolledWindow>();
     auto* w = Gtk::make_managed<Gtk::TextView>();
     auto buffer = w->get_buffer();
-    auto value = gtr_pref_string_get(key);
 
-    if (!value.empty())
-    {
-        buffer->set_text(value);
-    }
+    buffer->set_text(gtr_pref_string_get(key));
 
     /* set up the scrolled window and put the text view in it */
+    auto* scroll = Gtk::make_managed<Gtk::ScrolledWindow>();
     scroll->set_policy(Gtk::PolicyType::POLICY_AUTOMATIC, Gtk::PolicyType::POLICY_AUTOMATIC);
     scroll->set_shadow_type(Gtk::ShadowType::SHADOW_IN);
     scroll->add(*w);
@@ -1087,7 +1083,7 @@ Gtk::Widget* PrefsDialog::Impl::networkPage()
     t->add_section_title(row, _("Default Trackers"));
     auto tv = new_text_view(TR_KEY_default_trackers, core_);
     tv->set_tooltip_text(
-        _("a list of default trackers to be added to new public torrents (and existing ones, after a reload)"));
+        _("a list of default trackers to be added to new public torrents (and existing ones, after restarting)"));
     t->add_wide_control(row, *tv);
 
     return t;

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -1081,7 +1081,7 @@ Gtk::Widget* PrefsDialog::Impl::networkPage()
     t->add_section_title(row, _("Default Trackers"));
     auto tv = new_text_view(TR_KEY_default_trackers, core_);
     tv->set_tooltip_text(
-        _("a list of default trackers to be added to new public torrents (and existing ones, after restarting)"));
+        _("Trackers for public torrents to use automatically"));
     t->add_wide_control(row, *tv);
 
     return t;

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr my_static = std::array<std::string_view, 388>{ ""sv,
+auto constexpr my_static = std::array<std::string_view, 389>{ ""sv,
                                                               "activeTorrentCount"sv,
                                                               "activity-date"sv,
                                                               "activityDate"sv,
@@ -74,6 +74,7 @@ auto constexpr my_static = std::array<std::string_view, 388>{ ""sv,
                                                               "current-stats"sv,
                                                               "date"sv,
                                                               "dateCreated"sv,
+                                                              "default-trackers"sv,
                                                               "delete-local-data"sv,
                                                               "desiredAvailable"sv,
                                                               "destination"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -77,6 +77,7 @@ enum
     TR_KEY_current_stats,
     TR_KEY_date,
     TR_KEY_dateCreated,
+    TR_KEY_default_trackers,
     TR_KEY_delete_local_data,
     TR_KEY_desiredAvailable,
     TR_KEY_destination,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1789,6 +1789,11 @@ static char const* sessionSet(
         tr_sessionSetQueueStalledEnabled(session, boolVal);
     }
 
+    if (tr_variantDictFindStr(args_in, TR_KEY_default_trackers, &str, NULL))
+    {
+        tr_sessionSetDefaultTrackers(session, str);
+    }
+
     if (tr_variantDictFindInt(args_in, TR_KEY_download_queue_size, &i))
     {
         tr_sessionSetQueueSize(session, TR_DOWN, (int)i);
@@ -2069,6 +2074,10 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
 
     case TR_KEY_config_dir:
         tr_variantDictAddStr(d, key, tr_sessionGetConfigDir(s));
+        break;
+
+    case TR_KEY_default_trackers:
+        tr_variantDictAddStr(d, key, tr_sessionGetDefaultTrackers(s));
         break;
 
     case TR_KEY_download_dir:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1789,9 +1789,9 @@ static char const* sessionSet(
         tr_sessionSetQueueStalledEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_default_trackers, &str, NULL))
+    if (tr_variantDictFindStrView(args_in, TR_KEY_default_trackers, &sv))
     {
-        tr_sessionSetDefaultTrackers(session, str);
+        session->setDefaultTrackers(sv);
     }
 
     if (tr_variantDictFindInt(args_in, TR_KEY_download_queue_size, &i))
@@ -2077,7 +2077,7 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_default_trackers:
-        tr_variantDictAddStr(d, key, tr_sessionGetDefaultTrackers(s));
+        tr_variantDictAddStr(d, key, s->defaultTrackers());
         break;
 
     case TR_KEY_download_dir:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -408,7 +408,6 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_blocklist_enabled, s->useBlocklist());
     tr_variantDictAddStr(d, TR_KEY_blocklist_url, s->blocklistUrl());
     tr_variantDictAddInt(d, TR_KEY_cache_size_mb, tr_sessionGetCacheLimit_MB(s));
-    tr_variantDictAddStr(d, TR_KEY_default_trackers, s->defaultTrackers());
     tr_variantDictAddBool(d, TR_KEY_dht_enabled, s->isDHTEnabled);
     tr_variantDictAddBool(d, TR_KEY_utp_enabled, s->isUTPEnabled);
     tr_variantDictAddBool(d, TR_KEY_lpd_enabled, s->isLPDEnabled);
@@ -2255,19 +2254,18 @@ int tr_sessionGetCacheLimit_MB(tr_session const* session)
 void tr_session::setDefaultTrackers(std::string_view trackers)
 {
     /* keep the string */
-    this->default_trackers_ = trackers;
+    this->default_trackers_str_ = trackers;
 
     /* clear out the old list entries */
     this->defaultTrackersList.clear();
 
     /* build the new list entries */
     auto urlStart = std::string::npos;
-    auto urlEnd = std::string::npos;
-    char const* delimiters = " ,;\r\n\t";
-    auto fragment = default_trackers_;
-    while ((urlStart = fragment.find_first_not_of(delimiters)) != std::string::npos)
+    auto constexpr Delimiters = " ,;\r\n\t"sv;
+    auto fragment = default_trackers_str_;
+    while ((urlStart = fragment.find_first_not_of(Delimiters)) != std::string::npos)
     {
-        urlEnd = fragment.find_first_of(delimiters, urlStart);
+        auto urlEnd = fragment.find_first_of(Delimiters, urlStart);
         if (urlEnd == std::string::npos)
         {
             urlEnd = fragment.size() - 1;
@@ -2294,13 +2292,6 @@ void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers)
     TR_ASSERT(tr_isSession(session));
 
     session->setDefaultTrackers(trackers ? trackers : "");
-}
-
-char const* tr_sessionGetDefaultTrackers(tr_session const* session)
-{
-    TR_ASSERT(tr_isSession(session));
-
-    return session->defaultTrackers().c_str();
 }
 
 /***

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -332,6 +332,7 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_dht_enabled, true);
     tr_variantDictAddBool(d, TR_KEY_utp_enabled, true);
     tr_variantDictAddBool(d, TR_KEY_lpd_enabled, false);
+    tr_variantDictAddStr(d, TR_KEY_default_trackers, "");
     tr_variantDictAddStr(d, TR_KEY_download_dir, tr_getDefaultDownloadDir());
     tr_variantDictAddInt(d, TR_KEY_speed_limit_down, 100);
     tr_variantDictAddBool(d, TR_KEY_speed_limit_down_enabled, false);
@@ -407,6 +408,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_blocklist_enabled, s->useBlocklist());
     tr_variantDictAddStr(d, TR_KEY_blocklist_url, s->blocklistUrl());
     tr_variantDictAddInt(d, TR_KEY_cache_size_mb, tr_sessionGetCacheLimit_MB(s));
+    tr_variantDictAddStr(d, TR_KEY_default_trackers, tr_sessionGetDefaultTrackers(s));
     tr_variantDictAddBool(d, TR_KEY_dht_enabled, s->isDHTEnabled);
     tr_variantDictAddBool(d, TR_KEY_utp_enabled, s->isUTPEnabled);
     tr_variantDictAddBool(d, TR_KEY_lpd_enabled, s->isLPDEnabled);
@@ -809,6 +811,11 @@ static void sessionSetImpl(void* vdata)
     if (tr_variantDictFindInt(settings, TR_KEY_cache_size_mb, &i))
     {
         tr_sessionSetCacheLimit_MB(session, i);
+    }
+
+    if (tr_variantDictFindStr(settings, TR_KEY_default_trackers, &str, NULL))
+    {
+        tr_sessionSetDefaultTrackers(session, str);
     }
 
     if (tr_variantDictFindInt(settings, TR_KEY_peer_limit_per_torrent, &i))
@@ -2001,6 +2008,8 @@ void tr_sessionClose(tr_session* session)
     tr_session_id_free(session->session_id);
 
     delete session;
+    tr_list_free(&session->defaultTrackers, NULL);
+    tr_free(session->defaultTrackersStr);
 }
 
 struct sessionLoadTorrentsData
@@ -2238,6 +2247,55 @@ int tr_sessionGetCacheLimit_MB(tr_session const* session)
     TR_ASSERT(tr_isSession(session));
 
     return tr_toMemMB(tr_cacheGetLimit(session->cache));
+}
+
+/***
+****
+***/
+
+void tr_sessionSetDefaultTrackers(tr_session* session, char const* defaultTrackersStr)
+{
+    void* tmp;
+    char const* walk;
+
+    TR_ASSERT(tr_isSession(session));
+
+    /* keep the string */
+    tmp = session->defaultTrackersStr;
+    session->defaultTrackersStr = tr_strdup(defaultTrackersStr);
+    tr_free(tmp);
+
+    /* clear out the old list entries */
+    while ((tmp = tr_list_pop_front(&session->defaultTrackers)))
+    {
+        tr_free(tmp);
+    }
+
+    /* build the new list entries */
+    for (walk = defaultTrackersStr; walk && *walk;)
+    {
+        char const* delimiters = " ,;\r\n\t";
+        size_t const len = strcspn(walk, delimiters);
+        if (len)
+        {
+            char* token = tr_strndup(walk, len);
+            tr_list_append(&session->defaultTrackers, token);
+        }
+
+        if (walk[len] == '\0')
+        {
+            break;
+        }
+
+        walk += len + 1;
+    }
+}
+
+char const* tr_sessionGetDefaultTrackers(tr_session const* session)
+{
+    TR_ASSERT(tr_isSession(session));
+
+    return session->defaultTrackersStr ? session->defaultTrackersStr : NULL;
 }
 
 /***

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -154,7 +154,7 @@ public:
 
     std::string const& defaultTrackers() const
     {
-        return default_trackers_;
+        return default_trackers_str_;
     }
 
     void setDefaultTrackers(std::string_view trackers);
@@ -409,7 +409,7 @@ private:
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
     std::string blocklist_url_;
     std::string download_dir_;
-    std::string default_trackers_;
+    std::string default_trackers_str_;
     std::string incomplete_dir_;
     std::string peer_congestion_algorithm_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -387,6 +387,8 @@ public:
 
     std::unique_ptr<tr_rpc_server> rpc_server_;
 
+    struct tr_list* defaultTrackers;
+    char* defaultTrackersStr;
     // One of <netinet/ip.h>'s IPTOS_ values.
     // See tr_netTos*() in libtransmission/net.h for more info
     // Only session.cc should use this.

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -150,6 +150,15 @@ public:
         download_dir_ = dir;
     }
 
+    // default trackers
+
+    std::string const& defaultTrackers() const
+    {
+        return default_trackers_;
+    }
+
+    void setDefaultTrackers(std::string_view trackers);
+
     // incomplete dir
 
     std::string const& incompleteDir() const
@@ -387,8 +396,8 @@ public:
 
     std::unique_ptr<tr_rpc_server> rpc_server_;
 
-    struct tr_list* defaultTrackers;
-    char* defaultTrackersStr;
+    std::list<std::string> defaultTrackersList;
+
     // One of <netinet/ip.h>'s IPTOS_ values.
     // See tr_netTos*() in libtransmission/net.h for more info
     // Only session.cc should use this.
@@ -400,6 +409,7 @@ private:
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
     std::string blocklist_url_;
     std::string download_dir_;
+    std::string default_trackers_;
     std::string incomplete_dir_;
     std::string peer_congestion_algorithm_;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -861,7 +861,6 @@ static void tr_torrentAddDefaultTrackers(tr_torrent* tor)
     }
     /* tell the announcer to reload this torrent's tracker list */
     tr_announcerResetTorrent(tor->session->announcer, tor);
-    tor->announceList().save(tor->torrentFile());
 }
 
 tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -819,45 +819,14 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
 static void tr_torrentAddDefaultTrackers(tr_torrent* tor)
 {
-    std::list<std::string> trackerURLs = {};
-    int numExistingTrackers = tr_torrentTrackerCount(tor);
-    int numNewTrackers = tor->session->defaultTrackersList.size();
-
-    if (!numNewTrackers || tor->isPrivate())
+    if (tor->isPrivate())
     {
         return;
     }
-
-    // copy existing tracker URLs
-    for (int i = 0; i < numExistingTrackers; ++i)
+    
+    for (auto const& url : tor->session->defaultTrackersList)
     {
-        auto tracker = tr_torrentTracker(tor, i);
-        trackerURLs.push_back(tracker.announce);
-    }
-
-    // add the new ones
-    for (std::string_view url : tor->session->defaultTrackersList)
-    {
-        if (tr_urlIsValidTracker(url))
-        {
-            // check for duplicates
-            bool duplicate = false;
-            for (auto trackerURL : trackerURLs)
-            {
-                if (trackerURL == url)
-                {
-                    duplicate = true;
-                    break;
-                }
-            }
-
-            if (duplicate)
-            {
-                continue;
-            }
-
             tor->announceList().add(url);
-        }
     }
     /* tell the announcer to reload this torrent's tracker list */
     tr_announcerResetTorrent(tor->session->announcer, tor);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -817,6 +817,53 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     }
 }
 
+static void tr_torrentAddDefaultTrackers(tr_torrent* tor)
+{
+    std::list<std::string> trackerURLs = {};
+    int numExistingTrackers = tr_torrentTrackerCount(tor);
+    int numNewTrackers = tor->session->defaultTrackersList.size();
+
+    if (!numNewTrackers || tor->isPrivate())
+    {
+        return;
+    }
+
+    // copy existing tracker URLs
+    for (int i = 0; i < numExistingTrackers; ++i)
+    {
+        auto tracker = tr_torrentTracker(tor, i);
+        trackerURLs.push_back(tracker.announce);
+    }
+
+    // add the new ones
+    for (std::string_view url : tor->session->defaultTrackersList)
+    {
+        if (tr_urlIsValidTracker(url))
+        {
+            // check for duplicates
+            bool duplicate = false;
+            for (auto trackerURL : trackerURLs)
+            {
+                if (trackerURL == url)
+                {
+                    duplicate = true;
+                    break;
+                }
+            }
+
+            if (duplicate)
+            {
+                continue;
+            }
+
+            tor->announceList().add(url);
+        }
+    }
+    /* tell the announcer to reload this torrent's tracker list */
+    tr_announcerResetTorrent(tor->session->announcer, tor);
+    tor->announceList().save(tor->torrentFile());
+}
+
 tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)
 {
     TR_ASSERT(ctor != nullptr);
@@ -843,6 +890,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)
 
     auto* const tor = new tr_torrent{ std::move(metainfo) };
     torrentInit(tor, ctor);
+    tr_torrentAddDefaultTrackers(tor);
     return tor;
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -823,11 +823,12 @@ static void tr_torrentAddDefaultTrackers(tr_torrent* tor)
     {
         return;
     }
-    
+
     for (auto const& url : tor->session->defaultTrackersList)
     {
-            tor->announceList().add(url);
+        tor->announceList().add(url);
     }
+
     /* tell the announcer to reload this torrent's tracker list */
     tr_announcerResetTorrent(tor->session->announcer, tor);
 }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -480,6 +480,8 @@ int tr_sessionGetCacheLimit_MB(tr_session const* session);
 
 tr_encryption_mode tr_sessionGetEncryption(tr_session* session);
 void tr_sessionSetEncryption(tr_session* session, tr_encryption_mode mode);
+void tr_sessionSetDefaultTrackers(tr_session* session, char const* defaultTrackersStr);
+char const* tr_sessionGetDefaultTrackers(tr_session const* session);
 
 /***********************************************************************
 ** Incoming Peer Connections Port

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -394,8 +394,6 @@ char const* tr_sessionGetRPCBindAddress(tr_session const* session);
 
 void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers);
 
-char const* tr_sessionGetDefaultTrackers(tr_session const* session);
-
 enum tr_rpc_callback_type
 {
     TR_RPC_TORRENT_ADDED,

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -392,6 +392,10 @@ bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
 
 char const* tr_sessionGetRPCBindAddress(tr_session const* session);
 
+void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers);
+
+char const* tr_sessionGetDefaultTrackers(tr_session const* session);
+
 enum tr_rpc_callback_type
 {
     TR_RPC_TORRENT_ADDED,
@@ -480,8 +484,6 @@ int tr_sessionGetCacheLimit_MB(tr_session const* session);
 
 tr_encryption_mode tr_sessionGetEncryption(tr_session* session);
 void tr_sessionSetEncryption(tr_session* session, tr_encryption_mode mode);
-void tr_sessionSetDefaultTrackers(tr_session* session, char const* defaultTrackersStr);
-char const* tr_sessionGetDefaultTrackers(tr_session const* session);
 
 /***********************************************************************
 ** Incoming Peer Connections Port

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -109,6 +109,7 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items{
     { ALT_SPEED_LIMIT_TIME_DAY, TR_KEY_alt_speed_time_day, QVariant::Int },
     { BLOCKLIST_ENABLED, TR_KEY_blocklist_enabled, QVariant::Bool },
     { BLOCKLIST_URL, TR_KEY_blocklist_url, QVariant::String },
+    { DEFAULT_TRACKERS, TR_KEY_default_trackers, QVariant::String },
     { DSPEED, TR_KEY_speed_limit_down, QVariant::Int },
     { DSPEED_ENABLED, TR_KEY_speed_limit_down_enabled, QVariant::Bool },
     { DOWNLOAD_DIR, TR_KEY_download_dir, QVariant::String },

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -83,6 +83,7 @@ public:
         ALT_SPEED_LIMIT_TIME_DAY,
         BLOCKLIST_ENABLED,
         BLOCKLIST_URL,
+        DEFAULT_TRACKERS,
         DSPEED,
         DSPEED_ENABLED,
         DOWNLOAD_DIR,

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -237,10 +237,14 @@ void PrefsDialog::linkWidgetToPref(QWidget* widget, int pref_key)
     if (auto const* spin_box = qobject_cast<QAbstractSpinBox*>(widget); spin_box != nullptr)
     {
         connect(spin_box, &QAbstractSpinBox::editingFinished, this, &PrefsDialog::spinBoxEditingFinished);
+        return;
     }
-    else if (pref_widget.is<QPlainTextEdit>())
+
+    auto const* plain_text_edit = qobject_cast<QPlainTextEdit*>(widget);
+    if (plain_text_edit != nullptr)
     {
-        connect(widget, SIGNAL(textChanged()), SLOT(plainTextChanged()));
+        connect(plain_text_edit, &QPlainTextEdit::textChanged, this, &PrefsDialog::plainTextChanged);
+        return;
     }
 }
 

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -34,6 +34,7 @@ private slots:
     void timeEditingFinished();
     void lineEditingFinished();
     void pathChanged(QString const& path);
+    void plainTextChanged();
     void refreshPref(int key);
     void encryptionEdited(int);
     void altSpeedDaysEdited(int);

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -983,6 +983,26 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QLabel" name="defaultTrackersLabel">
+           <property name="toolTip">
+            <string>a list of default trackers to be added to new public torrents (and existing ones, after a reload)</string>
+           </property>
+           <property name="text">
+            <string>Default Trackers:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPlainTextEdit" name="defaultTrackersPlainTextEdit">
+           <property name="lineWrapMode">
+            <enum>QPlainTextEdit::NoWrap</enum>
+           </property>
+           <property name="plainText">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -155,6 +155,7 @@ void Session::updatePref(int key)
         case Prefs::BLOCKLIST_DATE:
         case Prefs::BLOCKLIST_ENABLED:
         case Prefs::BLOCKLIST_URL:
+        case Prefs::DEFAULT_TRACKERS:
         case Prefs::DHT_ENABLED:
         case Prefs::DOWNLOAD_QUEUE_ENABLED:
         case Prefs::DOWNLOAD_QUEUE_SIZE:

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -109,6 +109,7 @@ TEST_F(RpcTest, sessionGet)
         TR_KEY_blocklist_url,
         TR_KEY_cache_size_mb,
         TR_KEY_config_dir,
+        TR_KEY_default_trackers,
         TR_KEY_dht_enabled,
         TR_KEY_download_dir,
         TR_KEY_download_dir_free_space,

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -94,7 +94,7 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 
     // what we expected
-    auto const expected_keys = std::array<tr_quark, 57>{
+    auto const expected_keys = std::array<tr_quark, 58>{
         TR_KEY_alt_speed_down,
         TR_KEY_alt_speed_enabled,
         TR_KEY_alt_speed_time_begin,

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -63,6 +63,10 @@ export class PrefsDialog extends EventTarget {
   }
 
   static _getValue(e) {
+    if (e.tagName === 'TEXTAREA') {
+      return e.value;
+    }
+
     switch (e.type) {
       case 'checkbox':
       case 'radio':
@@ -118,6 +122,15 @@ export class PrefsDialog extends EventTarget {
           const n = Formatter.number(value);
           element.innerHTML = `Blocklist has <span class="blocklist-size-number">${n}</span> rules`;
           setTextContent(this.elements.peers.blocklist_update_button, 'Update');
+        } else if (element.tagName === 'TEXTAREA') {
+          if (
+            // eslint-disable-next-line eqeqeq
+            element.value != value &&
+            element !== document.activeElement
+          ) {
+            element.value = value;
+            element.dispatchEvent(new Event('change'));
+          }
         } else {
           switch (element.type) {
             case 'checkbox':
@@ -646,7 +659,25 @@ export class PrefsDialog extends EventTarget {
     root.append(cal.root);
     const utp_check = cal.check;
 
+    label = document.createElement('div');
+    label.textContent = 'Default trackers';
+    label.classList.add('section-label');
+    root.append(label);
+
+    label = document.createElement('label');
+    label.textContent =
+      '(added to new public torrents and to existing ones on reload):';
+    root.append(label);
+
+    const textarea = document.createElement('textarea');
+    textarea.dataset.key = 'default-trackers';
+    textarea.id = 'default-trackers';
+    label.setAttribute('for', textarea.id);
+    root.append(textarea);
+    const default_trackers_textarea = textarea;
+
     return {
+      default_trackers_textarea,
       port_forwarding_check,
       port_input,
       port_status_label,
@@ -714,6 +745,8 @@ export class PrefsDialog extends EventTarget {
               console.trace(`unhandled input: ${element.type}`);
               break;
           }
+        } else if (element.tagName === 'TEXTAREA') {
+          element.addEventListener('change', on_change);
         }
       }
     };

--- a/web/style/transmission-app.scss
+++ b/web/style/transmission-app.scss
@@ -762,6 +762,10 @@ $popup-top: 61px; // TODO: ugly that this is hardcoded
     grid-column: span 2;
   }
 
+  #default-trackers {
+    height: 300px;
+  }
+
   .blocklist-size-label,
   .blocklist-update-button,
   .port-status {


### PR DESCRIPTION
Some torrents benefit greatly from a default list of trackers that speeds up the search for peers. This patch implements that (only for public torrents) for the daemon, web interface, GTK and Qt clients.

The default trackers will be added to new public torrents and to existing ones, after a reload.

The concept comes from this Deluge plugin: https://github.com/stefantalpalaru/deluge-default-trackers
