### PR TITLE
Fix sorting by progress (Qt client)

### DIFF
--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -314,7 +314,7 @@ public:
 
     double percentComplete() const
     {
-        return haveTotal() / static_cast<double>(totalSize());
+        return totalSize() != 0 ? haveTotal() / static_cast<double>(totalSize()) : 0;
     }
 
     double percentDone() const

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -155,6 +155,11 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     // fall through
 
     case SortMode::SORT_BY_PROGRESS:
+        if (a->isMagnet() != b->isMagnet())
+        {
+            val = -compare(a->isMagnet(), b->isMagnet());
+        }
+
         if (val == 0)
         {
             val = compare(a->percentComplete(), b->percentComplete());

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -155,7 +155,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     // fall through
 
     case SortMode::SORT_BY_PROGRESS:
-        if (a->isMagnet() != b->isMagnet())
+        if (val == 0)
         {
             val = -compare(a->isMagnet(), b->isMagnet());
         }


### PR DESCRIPTION
Magnet transfers caused the by-progress sorting to become non-stable, as their
percentComplete() could return NaN. This patch fixes this by preferring active
downloads over magnet transfers, then sorting them by percentComplete().