### PR TITLE
Add Peer ID for Xfplay torrent client

### DIFF
--- a/libtransmission/clients-test.c
+++ b/libtransmission/clients-test.c
@@ -30,6 +30,12 @@ int main(void)
     TEST_CLIENT("-BT791\0-", "BitTorrent 7.9.1");
     TEST_CLIENT("-BT791B-", "BitTorrent 7.9.1 (Beta)");
 
+    /* Xfplay 9.9.92 to 9.9.94 uses "-XF9992-" */
+    TEST_CLIENT("-XF9992-", "Xfplay 9.9.92");
+
+    /* Older Xfplay versions have three digit version number */
+    TEST_CLIENT("-XF9990-", "Xfplay 9.9.9");
+
     /* gobbledygook */
     TEST_CLIENT("-IIO\x10\x2D\x04-", "-IIO%10-%04-");
     TEST_CLIENT("-I\05O\x08\x03\x01-", "-I%05O%08%03%01-");

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -587,6 +587,17 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             tr_snprintf(buf, buflen, "MediaGet %d.%02d", charint(id[3]), charint(id[4]));
         }
+        else if (strncmp(chid + 1, "XF", 2) == 0)
+        {
+            if (chid[6] == '0')
+            {
+                three_digits(buf, buflen, "Xfplay", id + 3);
+            }
+            else
+            {
+                tr_snprintf(buf, buflen, "Xfplay %d.%d.%d", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5, 2));
+            }
+        }
 
         if (*buf)
         {


### PR DESCRIPTION
This is based on the following resources,

http://www.xfplay.com/history.html
https://down.xfplay.com/xfplay9.994.exe
https://down.xfplay.com/xfplay9.992.exe
https://down.xfplay.com/xfplay9.991.exe
https://down.xfplay.com/xfplay9.99.exe
http://q.xfplay.com/

This fixes issue https://github.com/transmission/transmission/issues/252.