### PR TITLE
Unicode typography in user-visible strings

### DIFF
--- a/gtk/details.c
+++ b/gtk/details.c
@@ -727,7 +727,7 @@ static void refreshInfo(struct DetailsImpl* di, tr_torrent** torrents, int n)
         }
         else if (baseline)
         {
-            str = _("Private to this tracker -- DHT and PEX disabled");
+            str = _("Private to this tracker — DHT and PEX disabled");
         }
         else
         {
@@ -1862,11 +1862,11 @@ static gboolean onPeerViewQueryTooltip(GtkWidget* widget, gint x, gint y, gboole
                 break;
 
             case 'K':
-                s = _("Peer has unchoked us, but we're not interested");
+                s = _("Peer has unchoked us, but we’re not interested");
                 break;
 
             case '?':
-                s = _("We unchoked this peer, but they're not interested");
+                s = _("We unchoked this peer, but they’re not interested");
                 break;
 
             case 'E':
@@ -2209,7 +2209,7 @@ static void buildTrackerSummary(GString* gstr, char const* key, tr_tracker_stat 
 
         if (key != NULL)
         {
-            str = g_markup_printf_escaped("%s - %s", st->host, key);
+            str = g_markup_printf_escaped("%s — %s", st->host, key);
         }
         else
         {
@@ -2240,7 +2240,7 @@ static void buildTrackerSummary(GString* gstr, char const* key, tr_tracker_stat 
             }
             else
             {
-                g_string_append_printf(gstr, _("Got an error %1$s\"%2$s\"%3$s %4$s ago"), err_markup_begin,
+                g_string_append_printf(gstr, _("Got an error %1$s“%2$s”%3$s %4$s ago"), err_markup_begin,
                     st->lastAnnounceResult, err_markup_end, timebuf);
             }
         }
@@ -2284,7 +2284,7 @@ static void buildTrackerSummary(GString* gstr, char const* key, tr_tracker_stat 
                 }
                 else
                 {
-                    g_string_append_printf(gstr, _("Got a scrape error \"%s%s%s\" %s ago"), err_markup_begin,
+                    g_string_append_printf(gstr, _("Got a scrape error “%s%s%s” %s ago"), err_markup_begin,
                         st->lastScrapeResult, err_markup_end, timebuf);
                 }
             }
@@ -2685,7 +2685,7 @@ static void on_edit_trackers(GtkButton* button, gpointer data)
         int const torrent_id = tr_torrentId(tor);
 
         g_string_truncate(gstr, 0);
-        g_string_append_printf(gstr, _("%s - Edit Trackers"), tr_torrentName(tor));
+        g_string_append_printf(gstr, _("%s — Edit Trackers"), tr_torrentName(tor));
         d = gtk_dialog_new_with_buttons(gstr->str, win, GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
             GTK_RESPONSE_CANCEL, GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT, NULL);
         g_signal_connect(d, "response", G_CALLBACK(on_edit_trackers_response), data);
@@ -2795,7 +2795,7 @@ static void on_tracker_list_add_button_clicked(GtkButton* button UNUSED, gpointe
         GString* gstr = di->gstr; /* buffer for temporary strings */
 
         g_string_truncate(gstr, 0);
-        g_string_append_printf(gstr, _("%s - Add Tracker"), tr_torrentName(tor));
+        g_string_append_printf(gstr, _("%s — Add Tracker"), tr_torrentName(tor));
         w = gtk_dialog_new_with_buttons(gstr->str, GTK_WINDOW(di->dialog), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
             GTK_RESPONSE_CANCEL, GTK_STOCK_ADD, GTK_RESPONSE_ACCEPT, NULL);
         gtk_dialog_set_alternative_button_order(GTK_DIALOG(w), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);

--- a/gtk/dialogs.c
+++ b/gtk/dialogs.c
@@ -103,8 +103,8 @@ void gtr_confirm_remove(GtkWindow* parent, TrCore* core, GSList* torrent_ids, gb
     }
     else
     {
-        g_string_printf(primary_text, ngettext("Delete this torrent's downloaded files?",
-            "Delete these %d torrents' downloaded files?", count), count);
+        g_string_printf(primary_text, ngettext("Delete this torrent’s downloaded files?",
+            "Delete these %d torrents’ downloaded files?", count), count);
     }
 
     secondary_text = g_string_new(NULL);

--- a/gtk/file-list.c
+++ b/gtk/file-list.c
@@ -833,7 +833,7 @@ static int on_rename_done_idle(struct rename_data* data)
     else
     {
         GtkWidget* w = gtk_message_dialog_new(GTK_WINDOW(gtk_widget_get_toplevel(data->file_data->top)), GTK_DIALOG_MODAL,
-            GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Unable to rename file as \"%s\": %s"), data->newname,
+            GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Unable to rename file as “%s”: %s"), data->newname,
             tr_strerror(data->error));
         gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), "%s", _("Please correct the errors and try again."));
         gtk_dialog_run(GTK_DIALOG(w));

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -70,7 +70,7 @@ static char const* LICENSE =
     "but WITHOUT ANY WARRANTY; without even the implied warranty of "
     "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"
     "\n"
-    "Some of Transmission's source files have more permissive licenses. "
+    "Some of Transmission’s source files have more permissive licenses. "
     "Those files may, of course, be used on their own under their own terms.\n";
 
 struct cbdata
@@ -648,7 +648,7 @@ int main(int argc, char** argv)
 
     if (!g_option_context_parse(option_context, &argc, &argv, &error))
     {
-        g_print(_("%s\nRun '%s --help' to see a full list of available command line options.\n"), error->message, argv[0]);
+        g_print(_("%s\nRun “%s --help” to see a full list of available command line options.\n"), error->message, argv[0]);
         g_error_free(error);
         g_option_context_free(option_context);
         return 1;
@@ -1046,13 +1046,13 @@ static void flush_torrent_errors(struct cbdata* cbdata)
 {
     if (cbdata->error_list != NULL)
     {
-        show_torrent_errors(cbdata->wind, ngettext("Couldn't add corrupt torrent", "Couldn't add corrupt torrents",
+        show_torrent_errors(cbdata->wind, ngettext("Couldn’t add corrupt torrent", "Couldn’t add corrupt torrents",
             g_slist_length(cbdata->error_list)), &cbdata->error_list);
     }
 
     if (cbdata->duplicates_list != NULL)
     {
-        show_torrent_errors(cbdata->wind, ngettext("Couldn't add duplicate torrent", "Couldn't add duplicate torrents",
+        show_torrent_errors(cbdata->wind, ngettext("Couldn’t add duplicate torrent", "Couldn’t add duplicate torrents",
             g_slist_length(cbdata->duplicates_list)), &cbdata->duplicates_list);
     }
 }
@@ -1372,7 +1372,7 @@ static void show_about_dialog(GtkWindow* parent)
     gtk_show_about_dialog(parent,
         "authors", authors,
         "comments", _("A fast and easy BitTorrent client"),
-        "copyright", _("Copyright (c) The Transmission Project"),
+        "copyright", _("Copyright © The Transmission Project"),
         "logo-icon-name", MY_CONFIG_NAME,
         "name", g_get_application_name(),
         /* Translators: translate "translator-credits" as your name

--- a/gtk/makemeta-ui.c
+++ b/gtk/makemeta-ui.c
@@ -67,15 +67,15 @@ static gboolean onProgressDialogRefresh(gpointer data)
     /* progress label */
     if (!b->isDone)
     {
-        str = g_strdup_printf(_("Creating \"%s\""), base);
+        str = g_strdup_printf(_("Creating “%s”"), base);
     }
     else if (b->result == TR_MAKEMETA_OK)
     {
-        str = g_strdup_printf(_("Created \"%s\"!"), base);
+        str = g_strdup_printf(_("Created “%s”!"), base);
     }
     else if (b->result == TR_MAKEMETA_URL)
     {
-        str = g_strdup_printf(_("Error: invalid announce URL \"%s\""), b->errfile);
+        str = g_strdup_printf(_("Error: invalid announce URL “%s”"), b->errfile);
     }
     else if (b->result == TR_MAKEMETA_CANCELLED)
     {
@@ -83,11 +83,11 @@ static gboolean onProgressDialogRefresh(gpointer data)
     }
     else if (b->result == TR_MAKEMETA_IO_READ)
     {
-        str = g_strdup_printf(_("Error reading \"%s\": %s"), b->errfile, g_strerror(b->my_errno));
+        str = g_strdup_printf(_("Error reading “%s”: %s"), b->errfile, g_strerror(b->my_errno));
     }
     else if (b->result == TR_MAKEMETA_IO_WRITE)
     {
-        str = g_strdup_printf(_("Error writing \"%s\": %s"), b->errfile, g_strerror(b->my_errno));
+        str = g_strdup_printf(_("Error writing “%s”: %s"), b->errfile, g_strerror(b->my_errno));
     }
     else
     {

--- a/gtk/msgwin.c
+++ b/gtk/msgwin.c
@@ -143,7 +143,7 @@ static void doSave(GtkWindow* parent, struct MsgData* data, char const* filename
 
     if (fp == NULL)
     {
-        GtkWidget* w = gtk_message_dialog_new(parent, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Couldn't save \"%s\""),
+        GtkWidget* w = gtk_message_dialog_new(parent, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Couldn’t save “%s”"),
             filename);
         gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), "%s", g_strerror(errno));
         g_signal_connect_swapped(w, "response", G_CALLBACK(gtk_widget_destroy), w);

--- a/gtk/relocate.c
+++ b/gtk/relocate.c
@@ -57,7 +57,7 @@ static void startMovingNextTorrent(struct relocate_dialog_data* data)
 
     data->torrent_ids = g_slist_delete_link(data->torrent_ids, data->torrent_ids);
 
-    str = g_strdup_printf(_("Moving \"%s\""), tr_torrentName(tor));
+    str = g_strdup_printf(_("Moving “%s”"), tr_torrentName(tor));
     gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(data->message_dialog), str);
     g_free(str);
 }
@@ -73,7 +73,7 @@ static gboolean onTimer(gpointer gdata)
     {
         int const flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
         GtkWidget* w = gtk_message_dialog_new(GTK_WINDOW(data->message_dialog), flags, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-            "%s", _("Couldn't move torrent"));
+            "%s", _("Couldn’t move torrent"));
         gtk_dialog_run(GTK_DIALOG(w));
         gtk_widget_destroy(GTK_WIDGET(data->message_dialog));
     }

--- a/gtk/stats.c
+++ b/gtk/stats.c
@@ -90,7 +90,7 @@ static void dialogResponse(GtkDialog* dialog, gint response, gpointer gdata)
     {
         char const* primary = _("Reset your statistics?");
         char const* secondary = _("These statistics are for your information only. "
-            "Resetting them doesn't affect the statistics logged by your BitTorrent trackers.");
+            "Resetting them doesn’t affect the statistics logged by your BitTorrent trackers.");
         int const flags = GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL;
         GtkWidget* w = gtk_message_dialog_new(GTK_WINDOW(dialog), flags, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s", primary);
         gtk_dialog_add_buttons(GTK_DIALOG(w), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, _("_Reset"), TR_RESPONSE_RESET, NULL);

--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -128,7 +128,7 @@ static void getProgressString(GString* gstr, tr_torrent const* tor, tr_info cons
     if (st->activity == TR_STATUS_DOWNLOAD || (hasSeedRatio && st->activity == TR_STATUS_SEED))
     {
         int const eta = st->eta;
-        g_string_append(gstr, " - ");
+        g_string_append(gstr, " — ");
 
         if (eta < 0)
         {
@@ -232,8 +232,8 @@ static void getStatusString(GString* gstr, tr_torrent const* tor, tr_stat const*
         char const* fmt[] =
         {
             NULL,
-            N_("Tracker gave a warning: \"%s\""),
-            N_("Tracker gave an error: \"%s\""),
+            N_("Tracker gave a warning: “%s”"),
+            N_("Tracker gave an error: “%s”"),
             N_("Error: %s")
         };
 
@@ -299,7 +299,7 @@ static void getStatusString(GString* gstr, tr_torrent const* tor, tr_stat const*
 
         if (*buf != '\0')
         {
-            g_string_append_printf(gstr, " - %s", buf);
+            g_string_append_printf(gstr, " — %s", buf);
         }
     }
 }

--- a/gtk/tr-core.c
+++ b/gtk/tr-core.c
@@ -1241,7 +1241,7 @@ static void add_file_async_callback(GObject* file, GAsyncResult* result, gpointe
 
     if (!g_file_load_contents_finish(G_FILE(file), result, &contents, &length, NULL, &error))
     {
-        g_message(_("Couldn't read \"%s\": %s"), g_file_get_parse_name(G_FILE(file)), error->message);
+        g_message(_("Couldn’t read “%s”: %s"), g_file_get_parse_name(G_FILE(file)), error->message);
         g_error_free(error);
     }
     else if (tr_ctorSetMetainfo(data->ctor, (uint8_t const*)contents, length) == 0)
@@ -1337,7 +1337,7 @@ static bool add_file(TrCore* core, GFile* file, gboolean do_start, gboolean do_p
         else
         {
             tr_ctorFree(ctor);
-            g_message(_("Skipping unknown torrent \"%s\""), g_file_get_parse_name(file));
+            g_message(_("Skipping unknown torrent “%s”"), g_file_get_parse_name(file));
         }
     }
 
@@ -1619,7 +1619,7 @@ static gboolean gtr_inhibit_hibernation(guint* cookie)
     }
     else
     {
-        tr_logAddError(_("Couldn't inhibit desktop hibernation: %s"), err->message);
+        tr_logAddError(_("Couldn’t inhibit desktop hibernation: %s"), err->message);
         g_error_free(err);
     }
 

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -297,7 +297,7 @@ static GtkWidget* downloadingPage(GObject* core, struct prefs_dialog_data* data)
     hig_workarea_add_section_divider(t, &row);
     hig_workarea_add_section_title(t, &row, _("Incomplete"));
 
-    s = _("Append \"._part\" to incomplete files' names");
+    s = _("Append “._part” to incomplete files’ names");
     w = new_check_button(s, TR_KEY_rename_partial_files, core);
     hig_workarea_add_wide_control(t, &row, w);
 
@@ -1170,16 +1170,16 @@ static GtkWidget* networkPage(GObject* core)
     hig_workarea_add_section_title(t, &row, _("Options"));
 
 #ifdef WITH_UTP
-    s = _("Enable _uTP for peer communication");
+    s = _("Enable µTP for peer comm_unication");
     w = new_check_button(s, TR_KEY_utp_enabled, core);
-    s = _("uTP is a tool for reducing network congestion.");
+    s = _("µTP is a tool for reducing network congestion.");
     gtk_widget_set_tooltip_text(w, s);
     hig_workarea_add_wide_control(t, &row, w);
 #endif
 
     s = _("Use PE_X to find more peers");
     w = new_check_button(s, TR_KEY_pex_enabled, core);
-    s = _("PEX is a tool for exchanging peer lists with the peers you're connected to.");
+    s = _("PEX is a tool for exchanging peer lists with the peers you’re connected to.");
     gtk_widget_set_tooltip_text(w, s);
     hig_workarea_add_wide_control(t, &row, w);
 

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -257,16 +257,16 @@ void gtr_add_torrent_error_dialog(GtkWidget* child, int err, tr_torrent* duplica
 
     if (err == TR_PARSE_ERR)
     {
-        secondary = g_strdup_printf(_("The torrent file \"%s\" contains invalid data."), filename);
+        secondary = g_strdup_printf(_("The torrent file “%s” contains invalid data."), filename);
     }
     else if (err == TR_PARSE_DUPLICATE)
     {
-        secondary = g_strdup_printf(_("The torrent file \"%s\" is already in use by \"%s.\""), filename,
+        secondary = g_strdup_printf(_("The torrent file “%s” is already in use by “%s.”"), filename,
             tr_torrentName(duplicate_torrent));
     }
     else
     {
-        secondary = g_strdup_printf(_("The torrent file \"%s\" encountered an unknown error."), filename);
+        secondary = g_strdup_printf(_("The torrent file “%s” encountered an unknown error."), filename);
     }
 
     w = gtk_message_dialog_new(win, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s",
@@ -584,9 +584,9 @@ void gtr_http_failure_dialog(GtkWidget* parent, char const* url, long response_c
 {
     GtkWindow* window = getWindow(parent);
 
-    GtkWidget* w = gtk_message_dialog_new(window, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Error opening \"%s\""), url);
+    GtkWidget* w = gtk_message_dialog_new(window, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, _("Error opening “%s”"), url);
 
-    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), _("Server returned \"%1$ld %2$s\""), response_code,
+    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), _("Server returned “%1$ld %2$s”"), response_code,
         tr_webGetResponseStr(response_code));
 
     g_signal_connect_swapped(w, "response", G_CALLBACK(gtk_widget_destroy), w);
@@ -603,13 +603,13 @@ void gtr_unrecognized_url_dialog(GtkWidget* parent, char const* url)
 
     GtkWidget* w = gtk_message_dialog_new(window, 0, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s", _("Unrecognized URL"));
 
-    g_string_append_printf(gstr, _("Transmission doesn't know how to use \"%s\""), url);
+    g_string_append_printf(gstr, _("Transmission doesn’t know how to use “%s”"), url);
 
     if (gtr_is_magnet_link(url) && strstr(url, xt) == NULL)
     {
         g_string_append_printf(gstr, "\n \n");
         g_string_append_printf(gstr, _("This magnet link appears to be intended for something other than BitTorrent. "
-            "BitTorrent magnet links have a section containing \"%s\"."), xt);
+            "BitTorrent magnet links have a section containing “%s”."), xt);
     }
 
     gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), "%s", gstr->str);

--- a/libtransmission/blocklist.c
+++ b/libtransmission/blocklist.c
@@ -60,7 +60,7 @@ static void blocklistLoad(tr_blocklistFile* b)
     tr_sys_path_info info;
     char* base;
     tr_error* error = NULL;
-    char const* err_fmt = _("Couldn't read \"%1$s\": %2$s");
+    char const* err_fmt = _("Couldn’t read “%1$s”: %2$s");
 
     blocklistClose(b);
 
@@ -100,7 +100,7 @@ static void blocklistLoad(tr_blocklistFile* b)
     b->ruleCount = byteCount / sizeof(struct tr_ipv4_range);
 
     base = tr_sys_path_basename(b->filename, NULL);
-    tr_logAddInfo(_("Blocklist \"%s\" contains %zu entries"), base, b->ruleCount);
+    tr_logAddInfo(_("Blocklist “%s” contains %zu entries"), base, b->ruleCount);
     tr_free(base);
 }
 
@@ -326,7 +326,7 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     tr_sys_file_t out;
     int inCount = 0;
     char line[2048];
-    char const* err_fmt = _("Couldn't read \"%1$s\": %2$s");
+    char const* err_fmt = _("Couldn’t read “%1$s”: %2$s");
     struct tr_ipv4_range* ranges = NULL;
     size_t ranges_alloc = 0;
     size_t ranges_count = 0;
@@ -429,13 +429,13 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
 
     if (!tr_sys_file_write(out, ranges, sizeof(struct tr_ipv4_range) * ranges_count, NULL, &error))
     {
-        tr_logAddError(_("Couldn't save file \"%1$s\": %2$s"), b->filename, error->message);
+        tr_logAddError(_("Couldn’t save file “%1$s”: %2$s"), b->filename, error->message);
         tr_error_free(error);
     }
     else
     {
         char* base = tr_sys_path_basename(b->filename, NULL);
-        tr_logAddInfo(_("Blocklist \"%s\" updated with %zu entries"), base, ranges_count);
+        tr_logAddInfo(_("Blocklist “%s” updated with %zu entries"), base, ranges_count);
         tr_free(base);
     }
 

--- a/libtransmission/fdlimit.c
+++ b/libtransmission/fdlimit.c
@@ -173,13 +173,13 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
 
         if (dir == NULL)
         {
-            tr_logAddError(_("Couldn't get directory for \"%1$s\": %2$s"), filename, error->message);
+            tr_logAddError(_("Couldn’t get directory for “%1$s”: %2$s"), filename, error->message);
             goto fail;
         }
 
         if (!tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
         {
-            tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), dir, error->message);
+            tr_logAddError(_("Couldn’t create “%1$s”: %2$s"), dir, error->message);
             tr_free(dir);
             goto fail;
         }
@@ -200,7 +200,7 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
 
     if (fd == TR_BAD_SYS_FILE)
     {
-        tr_logAddError(_("Couldn't open \"%1$s\": %2$s"), filename, error->message);
+        tr_logAddError(_("Couldn’t open “%1$s”: %2$s"), filename, error->message);
         goto fail;
     }
 
@@ -224,12 +224,12 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
 
         if (!success)
         {
-            tr_logAddError(_("Couldn't preallocate file \"%1$s\" (%2$s, size: %3$" PRIu64 "): %4$s"),
+            tr_logAddError(_("Couldn’t preallocate file “%1$s” (%2$s, size: %3$" PRIu64 "): %4$s"),
                 filename, type, file_size, error->message);
             goto fail;
         }
 
-        tr_logAddDebug(_("Preallocated file \"%1$s\" (%2$s, size: %3$" PRIu64 ")"), filename, type, file_size);
+        tr_logAddDebug(_("Preallocated file “%1$s” (%2$s, size: %3$" PRIu64 ")"), filename, type, file_size);
     }
 
     /* If the file already exists and it's too large, truncate it.
@@ -240,7 +240,7 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
      */
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
-        tr_logAddError(_("Couldn't truncate \"%1$s\": %2$s"), filename, error->message);
+        tr_logAddError(_("Couldn’t truncate “%1$s”: %2$s"), filename, error->message);
         goto fail;
     }
 
@@ -559,7 +559,7 @@ tr_socket_t tr_fdSocketCreate(tr_session* session, int domain, int type)
             if (sockerrno != EAFNOSUPPORT)
             {
                 char err_buf[512];
-                tr_logAddError(_("Couldn't create socket: %s"), tr_net_strerror(err_buf, sizeof(err_buf), sockerrno));
+                tr_logAddError(_("Couldn’t create socket: %s"), tr_net_strerror(err_buf, sizeof(err_buf), sockerrno));
             }
         }
     }

--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -184,7 +184,7 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
             /* Folder doesn't exist yet */
             if (!tr_sys_dir_create(path, 0, permissions, &my_error))
             {
-                tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), path, my_error->message);
+                tr_logAddError(_("Couldn’t create “%1$s”: %2$s"), path, my_error->message);
                 tr_free(path);
                 tr_error_propagate(error, &my_error);
                 return false;
@@ -193,8 +193,8 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
         else if ((sb.st_mode & S_IFMT) != S_IFDIR)
         {
             /* Node exists but isn't a folder */
-            char* const buf = tr_strdup_printf(_("File \"%s\" is in the way"), path);
-            tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), path_in, buf);
+            char* const buf = tr_strdup_printf(_("File “%s” is in the way"), path);
+            tr_logAddError(_("Couldn’t create “%1$s”: %2$s"), path_in, buf);
             tr_free(buf);
             tr_free(path);
             set_system_error(error, ENOTDIR);

--- a/libtransmission/makemeta.c
+++ b/libtransmission/makemeta.c
@@ -52,7 +52,7 @@ static struct FileList* getFiles(char const* dir, char const* base, struct FileL
 
     if (!tr_sys_path_get_info(buf, 0, &info, &error))
     {
-        tr_logAddError(_("Torrent Creator is skipping file \"%s\": %s"), buf, error->message);
+        tr_logAddError(_("Torrent Creator is skipping file “%s”: %s"), buf, error->message);
         tr_free(buf);
         tr_error_free(error);
         return list;

--- a/libtransmission/metainfo.c
+++ b/libtransmission/metainfo.c
@@ -654,7 +654,7 @@ bool tr_metainfoParse(tr_session const* session, tr_variant const* meta_in, tr_i
 
     if (badTag != NULL)
     {
-        tr_logAddNamedError(inf->name, _("Invalid metadata entry \"%s\""), badTag);
+        tr_logAddNamedError(inf->name, _("Invalid metadata entry “%s”"), badTag);
         tr_metainfoFree(inf);
     }
 

--- a/libtransmission/natpmp.c
+++ b/libtransmission/natpmp.c
@@ -135,7 +135,7 @@ int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled,
         {
             char str[128];
             evutil_inet_ntop(AF_INET, &response.pnu.publicaddress.addr, str, sizeof(str));
-            tr_logAddNamedInfo(getKey(), _("Found public address \"%s\""), str);
+            tr_logAddNamedInfo(getKey(), _("Found public address “%s”"), str);
             nat->state = TR_NATPMP_IDLE;
         }
         else if (val != NATPMP_TRYAGAIN)

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -283,7 +283,7 @@ tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr
 
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
     {
-        tr_logAddError(_("Couldn't set source address %s on %" PRIdMAX ": %s"), tr_address_to_string(source_addr), (intmax_t)s,
+        tr_logAddError(_("Couldn’t set source address %s on %" PRIdMAX ": %s"), tr_address_to_string(source_addr), (intmax_t)s,
             tr_net_strerror(err_buf, sizeof(err_buf), sockerrno));
         tr_netClose(session, s);
         return TR_BAD_SOCKET; /* -errno */
@@ -300,7 +300,7 @@ tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr
 
         if ((tmperrno != ENETUNREACH && tmperrno != EHOSTUNREACH) || addr->type == TR_AF_INET)
         {
-            tr_logAddError(_("Couldn't connect socket %" PRIdMAX " to %s, port %d (errno %d - %s)"), (intmax_t)s,
+            tr_logAddError(_("Couldn’t connect socket %" PRIdMAX " to %s, port %d (errno %d — %s)"), (intmax_t)s,
                 tr_address_to_string(addr), (int)ntohs(port), tmperrno, tr_net_strerror(err_buf, sizeof(err_buf), tmperrno));
         }
 
@@ -397,11 +397,11 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
             if (hint == NULL)
             {
-                fmt = _("Couldn't bind port %d on %s: %s");
+                fmt = _("Couldn’t bind port %d on %s: %s");
             }
             else
             {
-                fmt = _("Couldn't bind port %d on %s: %s (%s)");
+                fmt = _("Couldn’t bind port %d on %s: %s (%s)");
             }
 
             tr_logAddError(fmt, port, tr_address_to_string(addr), tr_net_strerror(err_buf, sizeof(err_buf), err), hint);

--- a/libtransmission/platform.c
+++ b/libtransmission/platform.c
@@ -466,7 +466,7 @@ static bool isWebClientDir(char const* path)
 {
     char* tmp = tr_buildPath(path, "index.html", NULL);
     bool const ret = tr_sys_path_exists(tmp, NULL);
-    tr_logAddInfo(_("Searching for web interface file \"%s\""), tmp);
+    tr_logAddInfo(_("Searching for web interface file “%s”"), tmp);
     tr_free(tmp);
 
     return ret;

--- a/libtransmission/port-forwarding.c
+++ b/libtransmission/port-forwarding.c
@@ -103,7 +103,7 @@ static void natPulse(tr_shared* s, bool do_check)
 
     if (newStatus != oldStatus)
     {
-        tr_logAddNamedInfo(getKey(), _("State changed from \"%1$s\" to \"%2$s\""), getNatStateStr(oldStatus),
+        tr_logAddNamedInfo(getKey(), _("State changed from “%1$s” to “%2$s”"), getNatStateStr(oldStatus),
             getNatStateStr(newStatus));
     }
 }

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -997,7 +997,7 @@ void tr_rpcClose(tr_rpc_server** ps)
 static void missing_settings_key(tr_quark const q)
 {
     char const* str = tr_quark_get_string(q, NULL);
-    tr_logAddNamedError(MY_NAME, _("Couldn't find settings key \"%s\""), str);
+    tr_logAddNamedError(MY_NAME, _("Couldn’t find settings key “%s”"), str);
 }
 
 tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -1576,7 +1576,7 @@ static void gotNewBlocklist(tr_session* session, bool did_connect UNUSED, bool d
 
         if (fd == TR_BAD_SYS_FILE)
         {
-            tr_snprintf(result, sizeof(result), _("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
+            tr_snprintf(result, sizeof(result), _("Couldn’t save file “%1$s”: %2$s"), filename, error->message);
             tr_error_clear(&error);
         }
 
@@ -1590,7 +1590,7 @@ static void gotNewBlocklist(tr_session* session, bool did_connect UNUSED, bool d
             {
                 if (!tr_sys_file_write(fd, buf, buflen - stream.avail_out, NULL, &error))
                 {
-                    tr_snprintf(result, sizeof(result), _("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
+                    tr_snprintf(result, sizeof(result), _("Couldn’t save file “%1$s”: %2$s"), filename, error->message);
                     tr_error_clear(&error);
                     break;
                 }
@@ -1613,7 +1613,7 @@ static void gotNewBlocklist(tr_session* session, bool did_connect UNUSED, bool d
         {
             if (!tr_sys_file_write(fd, response, response_byte_count, NULL, &error))
             {
-                tr_snprintf(result, sizeof(result), _("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
+                tr_snprintf(result, sizeof(result), _("Couldn’t save file “%1$s”: %2$s"), filename, error->message);
                 tr_error_clear(&error);
             }
         }

--- a/libtransmission/torrent-magnet.c
+++ b/libtransmission/torrent-magnet.c
@@ -314,7 +314,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
 
                     if (success && !tr_getBlockSize(info.pieceSize))
                     {
-                        tr_torrentSetLocalError(tor, "%s", _("Magnet torrent's metadata is not usable"));
+                        tr_torrentSetLocalError(tor, "%s", _("Magnet torrent’s metadata is not usable"));
                         tr_metainfoFree(&info);
                         success = false;
                     }

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -619,14 +619,14 @@ static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, vo
         }
 
     case TR_TRACKER_WARNING:
-        tr_logAddTorErr(tor, _("Tracker warning: \"%s\""), event->text);
+        tr_logAddTorErr(tor, _("Tracker warning: “%s”"), event->text);
         tor->error = TR_STAT_TRACKER_WARNING;
         tr_strlcpy(tor->errorTracker, event->tracker, sizeof(tor->errorTracker));
         tr_strlcpy(tor->errorString, event->text, sizeof(tor->errorString));
         break;
 
     case TR_TRACKER_ERROR:
-        tr_logAddTorErr(tor, _("Tracker error: \"%s\""), event->text);
+        tr_logAddTorErr(tor, _("Tracker error: “%s”"), event->text);
         tor->error = TR_STAT_TRACKER_ERROR;
         tr_strlcpy(tor->errorTracker, event->tracker, sizeof(tor->errorTracker));
         tr_strlcpy(tor->errorString, event->text, sizeof(tor->errorString));
@@ -921,7 +921,7 @@ static bool setLocalErrorIfFilesDisappeared(tr_torrent* tor)
     if (disappeared)
     {
         tr_deeplog_tor(tor, "%s", "[LAZY] uh oh, the files disappeared");
-        tr_torrentSetLocalError(tor, "%s", _("No data found! Ensure your drives are connected or use \"Set Location\". "
+        tr_torrentSetLocalError(tor, "%s", _("No data found! Ensure your drives are connected or use “Set Location”. "
             "To re-download, remove the torrent and re-add it."));
     }
 
@@ -1862,7 +1862,7 @@ static void torrentStart(tr_torrent* tor, bool bypass_queue)
     /* allow finished torrents to be resumed */
     if (tr_torrentIsSeedRatioDone(tor))
     {
-        tr_logAddTorInfo(tor, "%s", _("Restarted manually -- disabling its seed ratio"));
+        tr_logAddTorInfo(tor, "%s", _("Restarted manually — disabling its seed ratio"));
         tr_torrentSetRatioMode(tor, TR_RATIOLIMIT_UNLIMITED);
     }
 
@@ -2377,7 +2377,7 @@ void tr_torrentRecheckCompleteness(tr_torrent* tor)
 
         if (recentChange)
         {
-            tr_logAddTorInfo(tor, _("State changed from \"%1$s\" to \"%2$s\""), getCompletionString(tor->completeness),
+            tr_logAddTorInfo(tor, _("State changed from “%1$s” to “%2$s”"), getCompletionString(tor->completeness),
                 getCompletionString(completeness));
         }
 

--- a/libtransmission/upnp.c
+++ b/libtransmission/upnp.c
@@ -197,8 +197,8 @@ int tr_upnpPulse(tr_upnp* handle, int port, bool isEnabled, bool doPortCheck)
         if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, handle->lanaddr,
             sizeof(handle->lanaddr)) == UPNP_IGD_VALID_CONNECTED)
         {
-            tr_logAddNamedInfo(getKey(), _("Found Internet Gateway Device \"%s\""), handle->urls.controlURL);
-            tr_logAddNamedInfo(getKey(), _("Local Address is \"%s\""), handle->lanaddr);
+            tr_logAddNamedInfo(getKey(), _("Found Internet Gateway Device “%s”"), handle->urls.controlURL);
+            tr_logAddNamedInfo(getKey(), _("Local Address is “%s”"), handle->lanaddr);
             handle->state = TR_UPNP_IDLE;
             handle->hasDiscovered = true;
         }
@@ -225,7 +225,7 @@ int tr_upnpPulse(tr_upnp* handle, int port, bool isEnabled, bool doPortCheck)
         if (tr_upnpGetSpecificPortMappingEntry(handle, "TCP") != UPNPCOMMAND_SUCCESS ||
             tr_upnpGetSpecificPortMappingEntry(handle, "UDP") != UPNPCOMMAND_SUCCESS)
         {
-            tr_logAddNamedInfo(getKey(), _("Port %d isn't forwarded"), handle->port);
+            tr_logAddNamedInfo(getKey(), _("Port %d isn’t forwarded"), handle->port);
             handle->isMapped = false;
         }
     }
@@ -235,7 +235,7 @@ int tr_upnpPulse(tr_upnp* handle, int port, bool isEnabled, bool doPortCheck)
         tr_upnpDeletePortMapping(handle, "TCP", handle->port);
         tr_upnpDeletePortMapping(handle, "UDP", handle->port);
 
-        tr_logAddNamedInfo(getKey(), _("Stopping port forwarding through \"%s\", service \"%s\""), handle->urls.controlURL,
+        tr_logAddNamedInfo(getKey(), _("Stopping port forwarding through “%s”, service “%s”"), handle->urls.controlURL,
             handle->data.first.servicetype);
 
         handle->isMapped = false;
@@ -272,7 +272,7 @@ int tr_upnpPulse(tr_upnp* handle, int port, bool isEnabled, bool doPortCheck)
             handle->isMapped = err_tcp == 0 || err_udp == 0;
         }
 
-        tr_logAddNamedInfo(getKey(), _("Port forwarding through \"%s\", service \"%s\". (local address: %s:%d)"),
+        tr_logAddNamedInfo(getKey(), _("Port forwarding through “%s”, service “%s”. (local address: %s:%d)"),
             handle->urls.controlURL, handle->data.first.servicetype, handle->lanaddr, port);
 
         if (handle->isMapped)

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -238,7 +238,7 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     tr_sys_path_info info;
     tr_sys_file_t fd;
     tr_error* my_error = NULL;
-    char const* const err_fmt = _("Couldn't read \"%1$s\": %2$s");
+    char const* const err_fmt = _("Couldn’t read “%1$s”: %2$s");
 
     /* try to stat the file */
     if (!tr_sys_path_get_info(path, 0, &info, &my_error))

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -1191,7 +1191,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
 
         if (nleft > 0)
         {
-            tr_logAddError(_("Couldn't save temporary file \"%1$s\": %2$s"), tmp, error->message);
+            tr_logAddError(_("Couldn’t save temporary file “%1$s”: %2$s"), tmp, error->message);
             tr_sys_path_remove(tmp, NULL);
             tr_error_free(error);
         }
@@ -1201,12 +1201,12 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
 
             if (tr_sys_path_rename(tmp, filename, &error))
             {
-                tr_logAddInfo(_("Saved \"%s\""), filename);
+                tr_logAddInfo(_("Saved “%s”"), filename);
             }
             else
             {
                 err = error->code;
-                tr_logAddError(_("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
+                tr_logAddError(_("Couldn’t save file “%1$s”: %2$s"), filename, error->message);
                 tr_sys_path_remove(tmp, NULL);
                 tr_error_free(error);
             }
@@ -1215,7 +1215,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
     else
     {
         err = error->code;
-        tr_logAddError(_("Couldn't save temporary file \"%1$s\": %2$s"), tmp, error->message);
+        tr_logAddError(_("Couldn’t save temporary file “%1$s”: %2$s"), tmp, error->message);
         tr_error_free(error);
     }
 

--- a/macosx/AddMagnetWindowController.m
+++ b/macosx/AddMagnetWindowController.m
@@ -185,7 +185,7 @@
     [panel setCanChooseDirectories: YES];
     [panel setCanCreateDirectories: YES];
 
-    [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the download folder for \"%@\"",
+    [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the download folder for “%@”",
                         "Add -> select destination folder"), [fTorrent name]]];
 
     [panel beginSheetModalForWindow: [self window] completionHandler: ^(NSInteger result) {

--- a/macosx/AddWindowController.m
+++ b/macosx/AddWindowController.m
@@ -174,7 +174,7 @@
     [panel setCanChooseDirectories: YES];
     [panel setCanCreateDirectories: YES];
 
-    [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the download folder for \"%@\"",
+    [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the download folder for “%@”",
                         "Add -> select destination folder"), [fTorrent name]]];
 
     [panel beginSheetModalForWindow: [self window] completionHandler: ^(NSInteger result) {

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -709,7 +709,7 @@ static void removeKeRangerRansomware()
             const BOOL allowNeverAgain = lastDonateDate != nil; //hide the "don't show again" check the first time - give them time to try the app
             [alert setShowsSuppressionButton: allowNeverAgain];
             if (allowNeverAgain)
-                [[alert suppressionButton] setTitle: NSLocalizedString(@"Don't bug me about this ever again.", "Donation beg -> button")];
+                [[alert suppressionButton] setTitle: NSLocalizedString(@"Don’t bug me about this ever again.", "Donation beg -> button")];
 
             const NSInteger donateResult = [alert runModal];
             if (donateResult == NSAlertFirstButtonReturn)
@@ -890,7 +890,7 @@ static void removeKeRangerRansomware()
         }
 
         NSRunAlertPanel(NSLocalizedString(@"Torrent download failed", "Download not a torrent -> title"),
-            [NSString stringWithFormat: NSLocalizedString(@"It appears that the file \"%@\" from %@ is not a torrent file.",
+            [NSString stringWithFormat: NSLocalizedString(@"It appears that the file “%@” from %@ is not a torrent file.",
             "Download not a torrent -> message"), suggestedName,
             [[[[download request] URL] absoluteString] stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding]],
             NSLocalizedString(@"OK", "Download not a torrent -> button"), nil, nil);
@@ -1233,7 +1233,7 @@ static void removeKeRangerRansomware()
         return;
 
     NSAlert * alert = [[NSAlert alloc] init];
-    [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"\"%@\" is not a valid torrent file.",
+    [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"“%@” is not a valid torrent file.",
                             "Open invalid alert -> title"), filename]];
     [alert setInformativeText:
             NSLocalizedString(@"The torrent file cannot be opened because it contains invalid data.",
@@ -1254,7 +1254,7 @@ static void removeKeRangerRansomware()
 
     NSAlert * alert = [[NSAlert alloc] init];
     [alert setMessageText: NSLocalizedString(@"Adding magnetized transfer failed.", "Magnet link failed -> title")];
-    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"There was an error when adding the magnet link \"%@\"."
+    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"There was an error when adding the magnet link “%@”."
                                 " The transfer will not occur.", "Magnet link failed -> message"), address]];
     [alert setAlertStyle: NSWarningAlertStyle];
     [alert addButtonWithTitle: NSLocalizedString(@"OK", "Magnet link failed -> button")];
@@ -1271,7 +1271,7 @@ static void removeKeRangerRansomware()
         return;
 
     NSAlert * alert = [[NSAlert alloc] init];
-    [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"A transfer of \"%@\" already exists.",
+    [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"A transfer of “%@” already exists.",
                             "Open duplicate alert -> title"), name]];
     [alert setInformativeText:
             NSLocalizedString(@"The transfer cannot be added because it is a duplicate of an already existing transfer.",
@@ -1293,13 +1293,13 @@ static void removeKeRangerRansomware()
 
     NSAlert * alert = [[NSAlert alloc] init];
     if (name)
-        [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"A transfer of \"%@\" already exists.",
+        [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"A transfer of “%@” already exists.",
                                 "Open duplicate magnet alert -> title"), name]];
     else
         [alert setMessageText: NSLocalizedString(@"Magnet link is a duplicate of an existing transfer.",
                                 "Open duplicate magnet alert -> title")];
     [alert setInformativeText: [NSString stringWithFormat:
-            NSLocalizedString(@"The magnet link  \"%@\" cannot be added because it is a duplicate of an already existing transfer.",
+            NSLocalizedString(@"The magnet link  “%@” cannot be added because it is a duplicate of an already existing transfer.",
                             "Open duplicate magnet alert -> message"), address]];
     [alert setAlertStyle: NSWarningAlertStyle];
     [alert addButtonWithTitle: NSLocalizedString(@"OK", "Open duplicate magnet alert -> button")];
@@ -1476,11 +1476,11 @@ static void removeKeRangerRansomware()
 
                 if (deleteData)
                     title = [NSString stringWithFormat:
-                                NSLocalizedString(@"Are you sure you want to remove \"%@\" from the transfer list"
+                                NSLocalizedString(@"Are you sure you want to remove “%@” from the transfer list"
                                 " and trash the data file?", "Removal confirm panel -> title"), torrentName];
                 else
                     title = [NSString stringWithFormat:
-                                NSLocalizedString(@"Are you sure you want to remove \"%@\" from the transfer list?",
+                                NSLocalizedString(@"Are you sure you want to remove “%@” from the transfer list?",
                                 "Removal confirm panel -> title"), torrentName];
 
                 message = NSLocalizedString(@"This transfer is active."
@@ -1643,7 +1643,7 @@ static void removeKeRangerRansomware()
         if ([torrents count] == 1)
         {
             NSString * torrentName = [(Torrent *)[torrents objectAtIndex: 0] name];
-            message = [NSString stringWithFormat: NSLocalizedString(@"Are you sure you want to remove \"%@\" from the transfer list?",
+            message = [NSString stringWithFormat: NSLocalizedString(@"Are you sure you want to remove “%@” from the transfer list?",
                                                                   "Remove completed confirm panel -> title"), torrentName];
 
             info = NSLocalizedString(@"Once removed, continuing the transfer will require the torrent file or magnet link.",
@@ -1693,7 +1693,7 @@ static void removeKeRangerRansomware()
 
     NSInteger count = [torrents count];
     if (count == 1)
-        [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the new folder for \"%@\".",
+        [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the new folder for “%@”.",
                             "Move torrent -> select destination folder"), [(Torrent *)[torrents objectAtIndex: 0] name]]];
     else
         [panel setMessage: [NSString stringWithFormat: NSLocalizedString(@"Select the new folder for %d data files.",
@@ -1746,7 +1746,7 @@ static void removeKeRangerRansomware()
         {
             NSAlert * alert = [[NSAlert alloc] init];
             [alert addButtonWithTitle: NSLocalizedString(@"OK", "Torrent file copy alert -> button")];
-            [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"Copy of \"%@\" Cannot Be Created",
+            [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"Copy of “%@” Cannot Be Created",
                                     "Torrent file copy alert -> title"), [torrent name]]];
             [alert setInformativeText: [NSString stringWithFormat:
                     NSLocalizedString(@"The torrent file (%@) cannot be found.", "Torrent file copy alert -> message"),

--- a/macosx/CreatorWindowController.m
+++ b/macosx/CreatorWindowController.m
@@ -495,7 +495,7 @@
         [alert setMessageText: NSLocalizedString(@"The chosen torrent file location does not exist.",
                                                 "Create torrent -> directory doesn't exist warning -> title")];
         [alert setInformativeText: [NSString stringWithFormat:
-                NSLocalizedString(@"The directory \"%@\" does not currently exist. "
+                NSLocalizedString(@"The directory “%@” does not currently exist. "
                     "Create this directory or choose a different one to create the torrent file.",
                     "Create torrent -> directory doesn't exist warning -> warning"),
                     [[fLocation URLByDeletingLastPathComponent] path]]];
@@ -516,7 +516,7 @@
         [alert setMessageText: NSLocalizedString(@"A torrent file with this name and directory cannot be created.",
                                                 "Create torrent -> file already exists warning -> title")];
         [alert setInformativeText: [NSString stringWithFormat:
-                NSLocalizedString(@"A file with the name \"%@\" already exists in the directory \"%@\". "
+                NSLocalizedString(@"A file with the name “%@” already exists in the directory “%@”. "
                     "Choose a new name or directory to create the torrent file.",
                     "Create torrent -> file already exists warning -> warning"),
                     [pathComponents objectAtIndex: count-1], [pathComponents objectAtIndex: count-2]]];
@@ -580,15 +580,15 @@
             default:
                 alert = [[[NSAlert alloc] init] autorelease];
                 [alert addButtonWithTitle: NSLocalizedString(@"OK", "Create torrent -> failed -> button")];
-                [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"Creation of \"%@\" failed.",
+                [alert setMessageText: [NSString stringWithFormat: NSLocalizedString(@"Creation of “%@” failed.",
                                                 "Create torrent -> failed -> title"), [fLocation lastPathComponent]]];
                 [alert setAlertStyle: NSWarningAlertStyle];
 
                 if (fInfo->result == TR_MAKEMETA_IO_READ)
-                    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"Could not read \"%s\": %s.",
+                    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"Could not read “%s”: %s.",
                         "Create torrent -> failed -> warning"), fInfo->errfile, strerror(fInfo->my_errno)]];
                 else if (fInfo->result == TR_MAKEMETA_IO_WRITE)
-                    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"Could not write \"%s\": %s.",
+                    [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"Could not write “%s”: %s.",
                         "Create torrent -> failed -> warning"), fInfo->errfile, strerror(fInfo->my_errno)]];
                 else //invalid url should have been caught before creating
                     [alert setInformativeText: [NSString stringWithFormat: @"%@ (%d)",

--- a/macosx/FileOutlineController.m
+++ b/macosx/FileOutlineController.m
@@ -298,7 +298,7 @@ typedef enum
         switch ([cell state])
         {
             case NSOffState:
-                return NSLocalizedString(@"Don't Download", "files tab -> tooltip");
+                return NSLocalizedString(@"Don’t Download", "files tab -> tooltip");
             case NSOnState:
                 return NSLocalizedString(@"Download", "files tab -> tooltip");
             case NSMixedState:

--- a/macosx/FileRenameSheetController.m
+++ b/macosx/FileRenameSheetController.m
@@ -87,7 +87,7 @@ typedef void (^CompletionBlock)(BOOL);
     [super windowDidLoad];
 
     self.originalName = [self.node name] ?: [self.torrent name];
-    NSString * label = [NSString stringWithFormat: NSLocalizedString(@"Rename the file \"%@\":", "rename sheet label"), self.originalName];
+    NSString * label = [NSString stringWithFormat: NSLocalizedString(@"Rename the file “%@”:", "rename sheet label"), self.originalName];
     [self.labelField setStringValue: label];
 
     [self.inputField setStringValue: self.originalName];

--- a/macosx/MessageWindowController.m
+++ b/macosx/MessageWindowController.m
@@ -424,7 +424,7 @@
                 [alert addButtonWithTitle: NSLocalizedString(@"OK", "Save log alert panel -> button")];
                 [alert setMessageText: NSLocalizedString(@"Log Could Not Be Saved", "Save log alert panel -> title")];
                 [alert setInformativeText: [NSString stringWithFormat:
-                                            NSLocalizedString(@"There was a problem creating the file \"%@\".",
+                                            NSLocalizedString(@"There was a problem creating the file “%@”.",
                                                               "Save log alert panel -> message"), [[[panel URL] path] lastPathComponent]]];
                 [alert setAlertStyle: NSWarningAlertStyle];
 

--- a/macosx/Torrent.m
+++ b/macosx/Torrent.m
@@ -566,7 +566,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
         [alert setMessageText: NSLocalizedString(@"A folder cannot be moved to inside itself.",
                                                     "Move inside itself alert -> title")];
         [alert setInformativeText: [NSString stringWithFormat:
-                        NSLocalizedString(@"The move operation of \"%@\" cannot be done.",
+                        NSLocalizedString(@"The move operation of “%@” cannot be done.",
                                             "Move inside itself alert -> message"), [self name]]];
         [alert addButtonWithTitle: NSLocalizedString(@"OK", "Move inside itself alert -> button")];
 
@@ -589,7 +589,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
         NSAlert * alert = [[NSAlert alloc] init];
         [alert setMessageText: NSLocalizedString(@"There was an error moving the data file.", "Move error alert -> title")];
         [alert setInformativeText: [NSString stringWithFormat:
-                NSLocalizedString(@"The move operation of \"%@\" cannot be done.", "Move error alert -> message"), [self name]]];
+                NSLocalizedString(@"The move operation of “%@” cannot be done.", "Move error alert -> message"), [self name]]];
         [alert addButtonWithTitle: NSLocalizedString(@"OK", "Move error alert -> button")];
 
         [alert runModal];
@@ -622,7 +622,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
 
             NSAlert * alert = [[NSAlert alloc] init];
             [alert setMessageText: [NSString stringWithFormat:
-                                    NSLocalizedString(@"Not enough remaining disk space to download \"%@\" completely.",
+                                    NSLocalizedString(@"Not enough remaining disk space to download “%@” completely.",
                                         "Torrent disk space alert -> title"), [self name]]];
             [alert setInformativeText: [NSString stringWithFormat: NSLocalizedString(@"The transfer will be paused."
                                         " Clear up space on %@ or deselect files in the torrent inspector to continue.",

--- a/qt/AboutDialog.ui
+++ b/qt/AboutDialog.ui
@@ -47,7 +47,7 @@
    <item>
     <widget class="QLabel" name="copyrightsLabel">
      <property name="text">
-      <string>Copyright (c) The Transmission Project</string>
+      <string>Copyright © The Transmission Project</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -819,7 +819,7 @@ void DetailsDialog::refresh()
     if (!torrents.empty())
     {
         bool b = torrents[0]->isPrivate();
-        string = b ? tr("Private to this tracker -- DHT and PEX disabled") : tr("Public torrent");
+        string = b ? tr("Private to this tracker — DHT and PEX disabled") : tr("Public torrent");
 
         for (Torrent const* const t : torrents)
         {
@@ -1120,11 +1120,11 @@ void DetailsDialog::refresh()
                     break;
 
                 case 'K':
-                    txt = tr("Peer has unchoked us, but we're not interested");
+                    txt = tr("Peer has unchoked us, but we’re not interested");
                     break;
 
                 case '?':
-                    txt = tr("We unchoked this peer, but they're not interested");
+                    txt = tr("We unchoked this peer, but they’re not interested");
                     break;
 
                 case 'E':
@@ -1144,7 +1144,7 @@ void DetailsDialog::refresh()
                     break;
 
                 case 'T':
-                    txt = tr("Peer is connected over uTP");
+                    txt = tr("Peer is connected over µTP");
                     break;
                 }
 
@@ -1319,7 +1319,7 @@ void DetailsDialog::onAddTrackerClicked()
     }
     else if (!QUrl(url).isValid())
     {
-        QMessageBox::warning(this, tr("Error"), tr("Invalid URL \"%1\"").arg(url));
+        QMessageBox::warning(this, tr("Error"), tr("Invalid URL “%1”").arg(url));
     }
     else
     {
@@ -1365,7 +1365,7 @@ void DetailsDialog::onEditTrackerClicked()
     }
     else if (!QUrl(newval).isValid())
     {
-        QMessageBox::warning(this, tr("Error"), tr("Invalid URL \"%1\"").arg(newval));
+        QMessageBox::warning(this, tr("Error"), tr("Invalid URL “%1”").arg(newval));
     }
     else
     {

--- a/qt/DetailsDialog.ui
+++ b/qt/DetailsDialog.ui
@@ -61,7 +61,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -87,7 +87,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -113,7 +113,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -139,7 +139,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -165,7 +165,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -191,7 +191,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -217,7 +217,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -243,7 +243,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -269,7 +269,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -321,7 +321,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -340,7 +340,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -380,7 +380,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -399,7 +399,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>
@@ -432,7 +432,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="textFormat">
             <enum>Qt::PlainText</enum>

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -399,7 +399,7 @@ void FileTreeView::initContextMenu()
     myContextMenu->addSeparator();
 
     myOpenAction = myContextMenu->addAction(tr("Open"), this, SLOT(openSelectedItem()));
-    myRenameAction = myContextMenu->addAction(tr("Rename..."), this, SLOT(renameSelectedItem()));
+    myRenameAction = myContextMenu->addAction(tr("Rename…"), this, SLOT(renameSelectedItem()));
 
     connect(myContextMenu, SIGNAL(aboutToShow()), SLOT(refreshContextMenuActionsSensitivity()));
 }

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -274,7 +274,7 @@ FilterBar::FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter c
 
     myLineEdit = new QLineEdit(this);
     myLineEdit->setClearButtonEnabled(true);
-    myLineEdit->setPlaceholderText(tr("Search..."));
+    myLineEdit->setPlaceholderText(tr("Search…"));
     myLineEdit->setMaximumWidth(250);
     h->addWidget(myLineEdit, 1);
     connect(myLineEdit, SIGNAL(textChanged(QString)), this, SLOT(onTextChanged(QString)));

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -49,7 +49,7 @@ void FreeSpaceLabel::setPath(QString const& path)
 {
     if (myPath != path)
     {
-        setText(tr("<i>Calculating Free Space...</i>"));
+        setText(tr("<i>Calculating Free Space…</i>"));
         myPath = path;
         onTimer();
     }

--- a/qt/LicenseDialog.ui
+++ b/qt/LicenseDialog.ui
@@ -28,7 +28,7 @@ In addition, linking to and/or using OpenSSL is allowed.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-Some of Transmission's source files have more permissive licenses. Those files may, of course, be used on their own under their own terms.</string>
+Some of Transmission’s source files have more permissive licenses. Those files may, of course, be used on their own under their own terms.</string>
      </property>
     </widget>
    </item>

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -696,9 +696,9 @@ void MainWindow::refreshTitle()
 
     if (!url.isEmpty())
     {
-        //: Second (optional) part of main window title "Transmission - host:port" (added when connected to remote session);
-        //: notice that leading space (before the dash) is included here
-        title += tr(" - %1:%2").arg(url.host()).arg(url.port());
+        //: Second (optional) part of main window title "Transmission — host:port" (added when connected to remote session);
+        //: notice that leading space (before the em-dash) is included here
+        title += tr(" — %1:%2").arg(url.host()).arg(url.port());
     }
 
     setWindowTitle(title);
@@ -1356,8 +1356,8 @@ void MainWindow::removeTorrents(bool const deleteFiles)
     }
     else
     {
-        primary_text = count == 1 ? tr("Delete this torrent's downloaded files?") :
-            tr("Delete these %Ln torrent(s)' downloaded files?", nullptr, count);
+        primary_text = count == 1 ? tr("Delete this torrent’s downloaded files?") :
+            tr("Delete these %Ln torrent(s)’ downloaded files?", nullptr, count);
     }
 
     if (!incomplete && !connected)

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -312,7 +312,7 @@
   </widget>
   <action name="action_OpenFile">
    <property name="text">
-    <string>&amp;Open...</string>
+    <string>&amp;Open…</string>
    </property>
    <property name="iconText">
     <string>Open</string>
@@ -326,7 +326,7 @@
   </action>
   <action name="action_New">
    <property name="text">
-    <string>&amp;New...</string>
+    <string>&amp;New…</string>
    </property>
    <property name="toolTip">
     <string>Create a new torrent</string>
@@ -351,7 +351,7 @@
     <string>Open Fold&amp;er</string>
    </property>
    <property name="toolTip">
-    <string>Open the torrent's folder</string>
+    <string>Open the torrent’s folder</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+E</string>
@@ -701,7 +701,7 @@
   </action>
   <action name="action_SessionDialog">
    <property name="text">
-    <string>&amp;Change Session...</string>
+    <string>&amp;Change Session…</string>
    </property>
    <property name="toolTip">
     <string extracomment="Start a local session or connect to a running session">Choose Session</string>
@@ -709,7 +709,7 @@
   </action>
   <action name="action_SetLocation">
    <property name="text">
-    <string>Set &amp;Location...</string>
+    <string>Set &amp;Location…</string>
    </property>
   </action>
   <action name="action_CopyMagnetToClipboard">
@@ -719,7 +719,7 @@
   </action>
   <action name="action_AddURL">
    <property name="text">
-    <string>Open &amp;URL...</string>
+    <string>Open &amp;URL…</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+U</string>

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -96,15 +96,15 @@ void MakeProgressDialog::onProgress()
 
     if (!b.isDone)
     {
-        str = tr("Creating \"%1\"").arg(base);
+        str = tr("Creating “%1”").arg(base);
     }
     else if (b.result == TR_MAKEMETA_OK)
     {
-        str = tr("Created \"%1\"!").arg(base);
+        str = tr("Created “%1”!").arg(base);
     }
     else if (b.result == TR_MAKEMETA_URL)
     {
-        str = tr("Error: invalid announce URL \"%1\"").arg(QString::fromUtf8(b.errfile));
+        str = tr("Error: invalid announce URL “%1”").arg(QString::fromUtf8(b.errfile));
     }
     else if (b.result == TR_MAKEMETA_CANCELLED)
     {
@@ -112,12 +112,12 @@ void MakeProgressDialog::onProgress()
     }
     else if (b.result == TR_MAKEMETA_IO_READ)
     {
-        str = tr("Error reading \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
+        str = tr("Error reading “%1”: %2").arg(QString::fromUtf8(b.errfile)).
                 arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
     }
     else if (b.result == TR_MAKEMETA_IO_WRITE)
     {
-        str = tr("Error writing \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
+        str = tr("Error writing “%1”: %2").arg(QString::fromUtf8(b.errfile)).
                 arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
     }
 

--- a/qt/MakeDialog.ui
+++ b/qt/MakeDialog.ui
@@ -75,7 +75,7 @@
      <item row="3" column="1">
       <widget class="QLabel" name="sourceSizeLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>

--- a/qt/MakeProgressDialog.ui
+++ b/qt/MakeProgressDialog.ui
@@ -26,7 +26,7 @@
       </size>
      </property>
      <property name="text">
-      <string notr="true">...</string>
+      <string notr="true">…</string>
      </property>
     </widget>
    </item>

--- a/qt/OptionsDialog.ui
+++ b/qt/OptionsDialog.ui
@@ -58,7 +58,7 @@
    <item row="2" column="1">
     <widget class="FreeSpaceLabel" name="freeSpaceLabel">
      <property name="text">
-      <string notr="true">...</string>
+      <string notr="true">…</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -397,7 +397,7 @@ void PrefsDialog::onPortTested(bool isOpen)
 
 void PrefsDialog::onPortTest()
 {
-    ui.peerPortStatusLabel->setText(tr("Testing TCP Port..."));
+    ui.peerPortStatusLabel->setText(tr("Testing TCP Port…"));
     ui.testPeerPortButton->setEnabled(false);
     myWidgets[Prefs::PEER_PORT]->setEnabled(false);
     mySession.portTest();
@@ -453,7 +453,7 @@ void PrefsDialog::onBlocklistUpdated(int n)
 void PrefsDialog::onUpdateBlocklistClicked()
 {
     myBlocklistDialog = new QMessageBox(QMessageBox::Information, QString(),
-        tr("<b>Update Blocklist</b><p>Getting new blocklist..."), QMessageBox::Close, this);
+        tr("<b>Update Blocklist</b><p>Getting new blocklist…"), QMessageBox::Close, this);
     connect(myBlocklistDialog, SIGNAL(rejected()), this, SLOT(onUpdateBlocklistCancelled()));
     connect(&mySession, SIGNAL(blocklistUpdated(int)), this, SLOT(onBlocklistUpdated(int)));
     myBlocklistDialog->show();
@@ -538,7 +538,7 @@ void PrefsDialog::initDownloadingTab()
     ui.watchDirButton->setTitle(tr("Select Watch Directory"));
     ui.downloadDirButton->setTitle(tr("Select Destination"));
     ui.incompleteDirButton->setTitle(tr("Select Incomplete Directory"));
-    ui.completionScriptButton->setTitle(tr("Select \"Torrent Done\" Script"));
+    ui.completionScriptButton->setTitle(tr("Select “Torrent Done” Script"));
 
     ui.watchDirStack->setMinimumWidth(200);
 

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -338,7 +338,7 @@
          <item row="5" column="1">
           <widget class="FreeSpaceLabel" name="downloadDirFreeSpaceLabel">
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -460,7 +460,7 @@
          <item row="0" column="0" colspan="2">
           <widget class="QCheckBox" name="renamePartialFilesCheck">
            <property name="text">
-            <string>Append &quot;.&amp;part&quot; to incomplete files' names</string>
+            <string>Append “.&amp;part” to incomplete files’ names</string>
            </property>
           </widget>
          </item>
@@ -690,7 +690,7 @@
          <item row="1" column="0" colspan="2">
           <widget class="QLabel" name="blocklistStatusLabel">
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true">…</string>
            </property>
           </widget>
          </item>
@@ -914,17 +914,17 @@
          <item>
           <widget class="QCheckBox" name="enableUtpCheck">
            <property name="toolTip">
-            <string>uTP is a tool for reducing network congestion.</string>
+            <string>µTP is a tool for reducing network congestion.</string>
            </property>
            <property name="text">
-            <string>Enable &amp;uTP for peer connections</string>
+            <string>Enable µ&amp;TP for peer connections</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="enablePexCheck">
            <property name="toolTip">
-            <string>PEX is a tool for exchanging peer lists with the peers you're connected to.</string>
+            <string>PEX is a tool for exchanging peer lists with the peers you’re connected to.</string>
            </property>
            <property name="text">
             <string>Use PE&amp;X to find more peers</string>

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -539,7 +539,7 @@ void Session::torrentRenamePath(QSet<int> const& ids, QString const& oldpath, QS
             tr_variantDictFindStr(r.args.get(), TR_KEY_name, &name, nullptr);
 
             QMessageBox* d = new QMessageBox(QMessageBox::Information, tr("Error Renaming Path"),
-                tr("<p><b>Unable to rename \"%1\" as \"%2\": %3.</b></p><p>Please correct the errors and try again.</p>").
+                tr("<p><b>Unable to rename “%1” as “%2”: %3.</b></p><p>Please correct the errors and try again.</p>").
                     arg(QString::fromUtf8(path)).arg(QString::fromUtf8(name)).arg(r.result), QMessageBox::Close,
                 qApp->activeWindow());
             connect(d, SIGNAL(rejected()), d, SLOT(deleteLater()));
@@ -1005,7 +1005,7 @@ void Session::addTorrent(AddData const& addMe, tr_variant* args, bool trashOrigi
             {
                 QString const name = QString::fromUtf8(str);
                 QMessageBox* d = new QMessageBox(QMessageBox::Warning, tr("Add Torrent"),
-                    tr("<p><b>Unable to add \"%1\".</b></p><p>It is a duplicate of \"%2\" which is already added.</p>").
+                    tr("<p><b>Unable to add “%1”.</b></p><p>It is a duplicate of “%2” which is already added.</p>").
                         arg(addMe.readableShortName()).arg(name), QMessageBox::Close, qApp->activeWindow());
                 connect(d, SIGNAL(rejected()), d, SLOT(deleteLater()));
                 d->show();

--- a/qt/StatsDialog.ui
+++ b/qt/StatsDialog.ui
@@ -42,7 +42,7 @@
      <item row="0" column="1">
       <widget class="QLabel" name="currentUploadedValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -56,7 +56,7 @@
      <item row="1" column="1">
       <widget class="QLabel" name="currentDownloadedValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -70,7 +70,7 @@
      <item row="2" column="1">
       <widget class="QLabel" name="currentRatioValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -84,7 +84,7 @@
      <item row="3" column="1">
       <widget class="QLabel" name="currentDurationValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -124,7 +124,7 @@
      <item row="0" column="0" colspan="2">
       <widget class="QLabel" name="startCountLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -138,7 +138,7 @@
      <item row="1" column="1">
       <widget class="QLabel" name="totalUploadedValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -152,7 +152,7 @@
      <item row="2" column="1">
       <widget class="QLabel" name="totalDownloadedValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -166,7 +166,7 @@
      <item row="3" column="1">
       <widget class="QLabel" name="totalRatioValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>
@@ -180,7 +180,7 @@
      <item row="4" column="1">
       <widget class="QLabel" name="totalDurationValueLabel">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true">…</string>
        </property>
       </widget>
      </item>

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -174,7 +174,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
     {
         //: First part of torrent progress string;
         //: %1 is the percentage of torrent metadata downloaded
-        str = tr("Magnetized transfer - retrieving metadata (%1%)").
+        str = tr("Magnetized transfer — retrieving metadata (%1%)").
                 arg(Formatter::percentToString(tor.metadataPercentDone() * 100.0));
     }
     else if (!isDone) // downloading
@@ -249,13 +249,13 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: Second (optional) part of torrent progress string;
             //: %1 is duration;
             //: notice that leading space (before the dash) is included here
-            str += tr(" - %1 left").arg(Formatter::timeToString(tor.getETA()));
+            str += tr(" — %1 left").arg(Formatter::timeToString(tor.getETA()));
         }
         else
         {
             //: Second (optional) part of torrent progress string;
             //: notice that leading space (before the dash) is included here
-            str += tr(" - Remaining time unknown");
+            str += tr(" — Remaining time unknown");
         }
     }
 
@@ -382,7 +382,7 @@ QString TorrentDelegate::statusString(Torrent const& tor)
 
         if (!s.isEmpty())
         {
-            str += tr(" - ") + s;
+            str += tr(" — ") + s;
         }
     }
 

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -227,7 +227,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
             else
             {
                 //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
-                str += tr("Got an error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastAnnounceResult).
+                str += tr("Got an error %1“%2”%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastAnnounceResult).
                         arg(err_markup_end).arg(tstr);
             }
         }
@@ -258,7 +258,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
                 QString const tstr(timeToStringRounded(now - inf.st.lastAnnounceStartTime));
                 str += QLatin1String("<br/>\n");
                 //: %1 is duration
-                str += tr("Asking for more peers now... <small>%1</small>").arg(tstr);
+                str += tr("Asking for more peers now… <small>%1</small>").arg(tstr);
                 break;
             }
         }
@@ -294,7 +294,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
                 else
                 {
                     //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
-                    str += tr("Got a scrape error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastScrapeResult).
+                    str += tr("Got a scrape error %1“%2”%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastScrapeResult).
                             arg(err_markup_end).arg(tstr);
                 }
             }
@@ -325,7 +325,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
                     str += QLatin1String("<br/>\n");
                     QString const tstr(timeToStringRounded(now - inf.st.lastScrapeStartTime));
                     //: %1 is duration
-                    str += tr("Asking for peer counts now... <small>%1</small>").arg(tstr);
+                    str += tr("Asking for peer counts now… <small>%1</small>").arg(tstr);
                     break;
                 }
             }


### PR DESCRIPTION
These patches convert ASCII characters to Unicode, as recommended by <https://developer.gnome.org/hig/stable/typography.html>.

I’m not sure if I got every “ - ” string, as most of them are not marked for translation.