### PR TITLE
Add option to sort by uploaded amount

### DIFF
--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -81,6 +81,7 @@ public:
         SORT_BY_SIZE,
         SORT_BY_STATE,
         SORT_BY_ID,
+        SORT_BY_UPLOADED,
         NUM_MODES
     };
 

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -249,7 +249,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     ui_.listView->setModel(&filter_model_);
     connect(ui_.listView->selectionModel(), &QItemSelectionModel::selectionChanged, refresh_action_sensitivity_soon);
 
-    std::array<std::pair<QAction*, int>, 9> const sort_modes =
+    std::array<std::pair<QAction*, int>, 10> const sort_modes =
     {{
         { ui_.action_SortByActivity, SortMode::SORT_BY_ACTIVITY },
         { ui_.action_SortByAge, SortMode::SORT_BY_AGE },
@@ -258,6 +258,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
         { ui_.action_SortByProgress, SortMode::SORT_BY_PROGRESS },
         { ui_.action_SortByQueue, SortMode::SORT_BY_QUEUE },
         { ui_.action_SortByRatio, SortMode::SORT_BY_RATIO },
+        { ui_.action_SortByUploaded, SortMode::SORT_BY_UPLOADED },
         { ui_.action_SortBySize, SortMode::SORT_BY_SIZE },
         { ui_.action_SortByState, SortMode::SORT_BY_STATE }
     }};

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -252,6 +252,7 @@
     <addaction name="action_SortByProgress"/>
     <addaction name="action_SortByQueue"/>
     <addaction name="action_SortByRatio"/>
+    <addaction name="action_SortByUploaded"/>
     <addaction name="action_SortBySize"/>
     <addaction name="action_SortByState"/>
     <addaction name="action_SortByETA"/>
@@ -561,6 +562,14 @@
    </property>
    <property name="text">
     <string>Sort by Rati&amp;o</string>
+   </property>
+  </action>
+  <action name="action_SortByUploaded">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Sort by &amp;Uploaded</string>
    </property>
   </action>
   <action name="action_SortBySize">

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -204,6 +204,14 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
         break;
 
+    case SortMode::SORT_BY_UPLOADED:
+        if (val == 0)
+        {
+            val = compare(a->uploadedEver(), b->uploadedEver());
+        }
+
+        break;
+
     case SortMode::SORT_BY_ETA:
         if (val == 0)
         {


### PR DESCRIPTION
Useful for getting a good estimate of how much bandwidth overall you've
dumped into a torrent, which is arguably more useful than any individual
per-torrent ratio stat in determining which torrents are live or dead.