### PR TITLE
LibreSSL compatibility

### DIFF
--- a/libtransmission/crypto-utils-openssl.c
+++ b/libtransmission/crypto-utils-openssl.c
@@ -49,7 +49,7 @@ static void log_openssl_error(char const* file, int line)
 
         if (!strings_loaded)
         {
-#if OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
             ERR_load_crypto_strings();
 #else
             OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
@@ -238,7 +238,7 @@ void tr_rc4_process(tr_rc4_ctx_t handle, void const* input, void* output, size_t
 ****
 ***/
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER)
 
 static inline int DH_set0_pqg(DH* dh, BIGNUM* p, BIGNUM* q, BIGNUM* g)
 {


### PR DESCRIPTION
This seems to be the idiomatic way to fix libressl compatibility issues,
judging by what most other open source projects seem to be doing.

I've confirmed that transmission builds with libressl for me after this
patch is applied.