### PR TITLE
Add Peer ID for PicoTorrent

### DIFF
--- a/libtransmission/clients-test.c
+++ b/libtransmission/clients-test.c
@@ -36,6 +36,10 @@ int main(void)
     /* Older Xfplay versions have three digit version number */
     TEST_CLIENT("-XF9990-", "Xfplay 9.9.9");
 
+    /* PicoTorrent */
+    TEST_CLIENT("-PI0091-", "PicoTorrent 0.09.1");
+    TEST_CLIENT("-PI0120-", "PicoTorrent 0.12.0");
+
     /* gobbledygook */
     TEST_CLIENT("-IIO\x10\x2D\x04-", "-IIO%10-%04-");
     TEST_CLIENT("-I\05O\x08\x03\x01-", "-I%05O%08%03%01-");

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -599,6 +599,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
                 tr_snprintf(buf, buflen, "Xfplay %d.%d.%d", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5, 2));
             }
         }
+        else if (strncmp(chid + 1, "PI", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "PicoTorrent %d.%d%d.%d", charint(id[3]), charint(id[4]), charint(id[5]), charint(id[6]));
+        }
 
         if (*buf != '\0')
         {


### PR DESCRIPTION
Based on information from https://github.com/picotorrent/picotorrent and http://www.picotorrent.org/.

PicoTorrent uses Azureus-style peer ID: -PI-. Example: -PI0091- (major: 0, minor: 09, patch: 1).

Here is an screenshot of PicoTorrent 0.12.0 in action after this patch is applied,

![picotorrent-in-action](https://cloud.githubusercontent.com/assets/79528/26281877/d3d86abe-3e21-11e7-9482-ef14f72f4ca5.png)

NOTE: ` strint(id + 4, 2)` does not parse `09` value correctly, hence we use `%d%d` hack along with two `charint` function calls.

