### PR TITLE
Add support for browser magnet link handler

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -103,6 +103,14 @@
 						<div class="row"><div class="key"><input type="checkbox" id="idle-seeding-limit-enabled"/><label for="idle-seeding-limit-enabled">Stop seeding if idle for (min):</label></div>
                                                                  <div class="value"><input type="number" min="1" max="40320" id="idle-seeding-limit"/></div></div>
 					</div>
+					<div class="prefs-section">
+						<div class="title">Magnet Protocol Handler</div>
+						<div class="row"><div class="key">Transmission:</div>
+											<div class="value"><input type="button" id="add-magnet-handler" value="Add Browser Handler"/></div>
+											<div class="value ui-helper-hidden"><input type="button" id="remove-magnet-handler" value="Remove Browser Handler"/></div>
+						</div>
+						<div class="checkbox-row"><input type="checkbox" id="open-dialog-for-magnet-handler"/><label for="open-dialog-for-magnet-handler">Open dialog to pick destination folder</label></div>
+					</div>
 				</div>
 				<div id="prefs-page-speed">
 					<div class="prefs-section">

--- a/web/javascript/common.js
+++ b/web/javascript/common.js
@@ -64,7 +64,7 @@ function setTextContent(e, text) {
     };
 };
 
-/*
+/**
  *   Given a numerator and denominator, return a ratio string
  */
 Math.ratio = function (numerator, denominator) {
@@ -92,12 +92,32 @@ Number.prototype.toStringWithCommas = function () {
     return this.toString().replace(/\B(?=(?:\d{3})+(?!\d))/g, ",");
 };
 
-/*
+/**
  * Trim whitespace from a string
  */
 String.prototype.trim = function () {
     return this.replace(/^\s*/, "").replace(/\s*$/, "");
 };
+
+/**
+ * Give us the base path of transmission web
+ * Used for our content / protocol handlers
+ *
+ * @returns string
+ */
+function getBaseURL() {
+    return (location.origin||(location.protocol+"//"+location.host))+location.pathname; // no query string, no hash
+}
+
+/**
+ * Extracts a single query string parameter for a given key.
+ * 
+ * @param {string} key 
+ * @returns string
+ */
+function getURLParameter(key) {
+    return decodeURIComponent(parseUri(location.href).queryKey[key]);
+}
 
 /***
  ****  Preferences
@@ -131,6 +151,7 @@ Prefs._SortByRatio = 'ratio';
 Prefs._SortByState = 'state';
 
 Prefs._CompactDisplayState = 'compact_display_state';
+Prefs._OpenDialogForMagnetHandler = 'open_dialog_for_magnet_handler';
 
 Prefs._Defaults = {
     'filter': 'all',
@@ -138,10 +159,11 @@ Prefs._Defaults = {
     'sort_direction': 'ascending',
     'sort_method': 'name',
     'turtle-state': false,
-    'compact_display_state': false
+    'compact_display_state': false,
+    'open_dialog_for_magnet_handler': true
 };
 
-/*
+/**
  * Set a preference option
  */
 Prefs.setValue = function (key, val) {

--- a/web/javascript/prefs-dialog.js
+++ b/web/javascript/prefs-dialog.js
@@ -297,6 +297,10 @@ function PrefsDialog(remote) {
         return data.elements.root.find('#start-added-torrents')[0].checked;
     };
 
+    this.shouldOpenDialogForMagnetHandler = function() {
+        return data.elements.root.find("#open-dialog-for-magnet-handler")[0].checked;
+    };
+
     data.dialog = this;
     initialize(remote);
 };


### PR DESCRIPTION
- adds a section in the settings dialog to add/remove a protocol handler for "magnet:" URIs in browser.
- also adds a checkbox there to control whether to open the upload torrent dialog or just add the torrent immediately
(default: open dialog)

This is based on work by hvmp (hvmp/transmission:magnethandler) #223,
itself based on earlier work by lembregtse
(see https://trac.transmissionbt.com/ticket/2404)