### PR TITLE
Add Peer ID for Free Download Manager (FDM)

### DIFF
--- a/libtransmission/clients-test.c
+++ b/libtransmission/clients-test.c
@@ -40,6 +40,11 @@ int main(void)
     TEST_CLIENT("-PI0091-", "PicoTorrent 0.09.1");
     TEST_CLIENT("-PI0120-", "PicoTorrent 0.12.0");
 
+    /* Free Download Manager */
+    TEST_CLIENT("-FD51R\xFF-", "Free Download Manager 5.1.27");
+    TEST_CLIENT("-FD51W\xFF-", "Free Download Manager 5.1.32");
+    TEST_CLIENT("-FD51@\xFF-", "Free Download Manager 5.1.x"); /* Negative test case */
+
     /* gobbledygook */
     TEST_CLIENT("-IIO\x10\x2D\x04-", "-IIO%10-%04-");
     TEST_CLIENT("-I\05O\x08\x03\x01-", "-I%05O%08%03%01-");

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -50,6 +50,20 @@ static bool getShadowInt(uint8_t ch, int* setme)
     return true;
 }
 
+static bool getFDMInt(uint8_t ch, int* setme)
+{
+    char const* str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_.!~*()";
+    char const* pch = strchr(str, ch);
+
+    if (pch == NULL)
+    {
+        return false;
+    }
+
+    *setme = pch - str;
+    return true;
+}
+
 static int strint(void const* pch, int span)
 {
     char tmp[64];
@@ -602,6 +616,19 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "PI", 2) == 0)
         {
             tr_snprintf(buf, buflen, "PicoTorrent %d.%d%d.%d", charint(id[3]), charint(id[4]), charint(id[5]), charint(id[6]));
+        }
+        else if (strncmp(chid + 1, "FD", 2) == 0)
+        {
+            int c;
+
+            if (getFDMInt(id[5], &c))
+            {
+                tr_snprintf(buf, buflen, "Free Download Manager %d.%d.%d", charint(id[3]), charint(id[4]), c);
+            }
+            else
+            {
+                tr_snprintf(buf, buflen, "Free Download Manager %d.%d.x", charint(id[3]), charint(id[4]));
+            }
         }
 
         if (*buf != '\0')


### PR DESCRIPTION
Based on experiments with FDM 5.1.32 running on Windows 10.

FDM uses Azureus-style peer ID with `-FD` prefix.

This fixes issue https://github.com/transmission/transmission/issues/335.