### PR TITLE
Improving ToS on IPv6 connections

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -128,7 +128,7 @@ tr_socket_t tr_netBindTCP(tr_address const* addr, tr_port port, bool suppressMsg
 
 tr_socket_t tr_netAccept(tr_session* session, tr_socket_t bound, tr_address* setme_addr, tr_port* setme_port);
 
-void tr_netSetTOS(tr_socket_t s, int tos);
+void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type);
 
 void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm);
 

--- a/libtransmission/peer-io.c
+++ b/libtransmission/peer-io.c
@@ -637,7 +637,7 @@ static tr_peerIo* tr_peerIoNew(tr_session* session, tr_bandwidth* parent, tr_add
 
     if (socket.type == TR_PEER_SOCKET_TYPE_TCP)
     {
-        tr_netSetTOS(socket.handle.tcp, session->peerSocketTOS);
+        tr_netSetTOS(socket.handle.tcp, session->peerSocketTOS, addr->type);
         maybeSetCongestionAlgorithm(socket.handle.tcp, session->peer_congestion_algorithm);
     }
 
@@ -993,7 +993,7 @@ int tr_peerIoReconnect(tr_peerIo* io)
     io->event_write = event_new(session->event_base, io->socket.handle.tcp, EV_WRITE, event_write_cb, io);
 
     event_enable(io, pendingEvents);
-    tr_netSetTOS(io->socket.handle.tcp, session->peerSocketTOS);
+    tr_netSetTOS(io->socket.handle.tcp, session->peerSocketTOS, io->addr.type);
     maybeSetCongestionAlgorithm(io->socket.handle.tcp, session->peer_congestion_algorithm);
 
     return 0;


### PR DESCRIPTION
When Transmission tries to set TOS on an IPv6 connection, it triggers error since the original code only supports IPv4. This patch should fix issues like #128 and #341 . Also, we can finally say goodbye to the annoying `"can't set tos '0': invalid argument"` messages

(Already tested on MacOS with latest master && 2.92 codebase.)