### PR TITLE
Add Peer ID for Folx

### DIFF
--- a/libtransmission/clients-test.c
+++ b/libtransmission/clients-test.c
@@ -45,6 +45,9 @@ int main(void)
     TEST_CLIENT("-FD51W\xFF-", "Free Download Manager 5.1.32");
     TEST_CLIENT("-FD51@\xFF-", "Free Download Manager 5.1.x"); /* Negative test case */
 
+    /* Folx */
+    TEST_CLIENT("-FL51FF-", "Folx 5.x"); /* Folx v5.2.1.13690 */
+
     /* gobbledygook */
     TEST_CLIENT("-IIO\x10\x2D\x04-", "-IIO%10-%04-");
     TEST_CLIENT("-I\05O\x08\x03\x01-", "-I%05O%08%03%01-");

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -630,6 +630,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
                 tr_snprintf(buf, buflen, "Free Download Manager %d.%d.x", charint(id[3]), charint(id[4]));
             }
         }
+        else if (strncmp(chid + 1, "FL", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "Folx %d.x", charint(id[3]));
+        }
 
         if (*buf != '\0')
         {


### PR DESCRIPTION
Based on experiments with Folx version 5.2.1.13690 running on macOS Sierra.

Folx uses Azureus-style Peer ID with "-FL" prefix.

This fixes issue https://github.com/transmission/transmission/issues/359.

Before this commit,

![before-commit](https://user-images.githubusercontent.com/79528/28993764-109c2f76-79dc-11e7-9855-1c207a74d259.png)

After this commit,

![after-commit](https://user-images.githubusercontent.com/79528/28993767-212ecda8-79dc-11e7-9904-889df1ab6477.png)

