### PR TITLE
Download/upload speed typography changes for web ui

### DIFF
--- a/web/javascript/torrent-row.js
+++ b/web/javascript/torrent-row.js
@@ -100,11 +100,11 @@ TorrentRendererHelper.renderProgressbar = function (controller, t, progressbar) 
 };
 
 TorrentRendererHelper.formatUL = function (t) {
-    return '↑ ' + Transmission.fmt.speedBps(t.getUploadSpeed());
+    return '▲' + Transmission.fmt.speedBps(t.getUploadSpeed());
 };
 
 TorrentRendererHelper.formatDL = function (t) {
-    return '↓ ' + Transmission.fmt.speedBps(t.getDownloadSpeed());
+    return '▼' + Transmission.fmt.speedBps(t.getDownloadSpeed());
 };
 
 TorrentRendererHelper.formatETA = function(t) {
@@ -181,7 +181,7 @@ TorrentRendererFull.prototype = {
                     fmt.countString('peer', 'peers', peer_count),
                     'and',
                     fmt.countString('web seed', 'web seeds', webseed_count),
-                    '-',
+                    '–',
                     TorrentRendererHelper.formatDL(t),
                     TorrentRendererHelper.formatUL(t)
                 ].join(' ');
@@ -189,7 +189,7 @@ TorrentRendererFull.prototype = {
                 // Downloading from 2 webseed(s)
                 return ['Downloading from',
                     fmt.countString('web seed', 'web seeds', webseed_count),
-                    '-',
+                    '–',
                     TorrentRendererHelper.formatDL(t),
                     TorrentRendererHelper.formatUL(t)
                 ].join(' ');
@@ -199,7 +199,7 @@ TorrentRendererFull.prototype = {
                     t.getPeersSendingToUs(),
                     'of',
                     fmt.countString('peer', 'peers', peer_count),
-                    '-',
+                    '–',
                     TorrentRendererHelper.formatDL(t),
                     TorrentRendererHelper.formatUL(t)
                 ].join(' ');


### PR DESCRIPTION
The current icons are very hard to read at the line's small font size and it's not immediately visible which icon is which. The new arrow symbols are just as well supported but are more recognizable at virtually any text size, as well as being heavier to draw attention to more important live-updated info (download/upload speeds).

Additionally, spaces after icons are removed because upload icon `↑` is equally positioned between DL/UL speeds (like so `↓ 273 kB/s ↑ 167 kB/s`) which requires reading the whole line to make sense of which number the arrow applies to.

To further separate one type of information from another the hyphen is replaced by the slightly wider en dash.

Old vs New:
<sub>Downloading from 7 of 19 peers - ↓ 273 kB/s ↑ 167 kB/s</sub>
<sub>Downloading from 7 of 19 peers – ▼273 kB/s ▲167 kB/s</sub>