### PR TITLE
Disable autocomplete on torrent url field from WebUI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -372,7 +372,7 @@
 				<div class="dialog_logo" id="upload_dialog_logo"></div>
 				<h2 class="dialog_heading">Upload Torrent Files</h2>
 				<form action="#" method="post" id="torrent_upload_form"
-					enctype="multipart/form-data" target="torrent_upload_frame">
+					enctype="multipart/form-data" target="torrent_upload_frame" autocomplete="off">
 					<div class="dialog_message">
 						<label for="torrent_upload_file">Please select a torrent file to upload:</label>
 							<input type="file" name="torrent_files[]" id="torrent_upload_file" multiple="multiple" />


### PR DESCRIPTION
It disrupts the view and I can't come up a daily usage scenario that needs to utilize autocomplete function.

![autocomplete](https://user-images.githubusercontent.com/2229479/29181992-b484b390-7e2f-11e7-85cf-bd8e3dcefee0.png)
