### PR TITLE
Modify the filter bar to allow showing trackerless torrents

### DIFF
--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -143,10 +143,16 @@ void FilterBar::refreshTrackers()
         Torrent const* tor = index.data(TorrentModel::TorrentRole).value<Torrent const*>();
         QSet<QString> torrentNames;
 
-        for (QString const& host : tor->hosts())
+        auto hosts = tor->hosts();
+        for (QString const& host : hosts)
         {
             newHosts.insert(host);
             torrentNames.insert(readableHostName(host));
+        }
+        if (hosts.empty())
+        {
+            newHosts.insert(TorrentFilter::TRACKERLESS_FILTER);
+            torrentNames.insert(TorrentFilter::TRACKERLESS_FILTER);
         }
 
         for (QString const& name : torrentNames)

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -15,6 +15,8 @@
 #include "TorrentModel.h"
 #include "Utils.h"
 
+const QString TorrentFilter::TRACKERLESS_FILTER = tr("(trackerless)");
+
 TorrentFilter::TorrentFilter(Prefs const& prefs) :
     myPrefs(prefs)
 {
@@ -218,7 +220,14 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
 bool TorrentFilter::trackerFilterAcceptsTorrent(Torrent const* tor, QString const& tracker) const
 {
-    return tracker.isEmpty() || tor->hasTrackerSubstring(tracker);
+    if (tracker == TRACKERLESS_FILTER)
+    {
+        return tor->hosts().empty();
+    }
+    else
+    {
+        return tracker.isEmpty() || tor->hasTrackerSubstring(tracker);
+    }
 }
 
 bool TorrentFilter::activityFilterAcceptsTorrent(Torrent const* tor, FilterMode const& m) const

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -35,6 +35,8 @@ public:
     int hiddenRowCount() const;
 
     void countTorrentsPerMode(int* setmeCounts) const;
+    
+    static const QString TRACKERLESS_FILTER;
 
 protected:
     // QSortFilterProxyModel


### PR DESCRIPTION
Show the number of currently loaded trackerless torrents and allow filtering them in the filter bar.

Comments welcome : I wasn't really sure how to handle the no-tracker case well enough, so this is a "works, but not ideal" solution in terms of code. Most importantly, it makes settings.json non-portable between different language versions of the client. Any other solutions that I can think of now would have to include passing around a QVariant instead of a QString as the tracker filter. An alternative would be to introduce a null QString which means "all trackers" and an empty QString which means "trackerless" when used as the tracker filter. However, the serialisation mechanism does not distinguish between null and empty strings.