### PR TITLE
Add Peer ID for Baidu Netdisk

### DIFF
--- a/libtransmission/clients-test.c
+++ b/libtransmission/clients-test.c
@@ -48,6 +48,9 @@ int main(void)
     /* Folx */
     TEST_CLIENT("-FL51FF-", "Folx 5.x"); /* Folx v5.2.1.13690 */
 
+    /* Baidu Netdisk */
+    TEST_CLIENT("-BN0001-", "Baidu Netdisk"); /* Baidu Netdisk Client v5.5.4 */
+
     /* gobbledygook */
     TEST_CLIENT("-IIO\x10\x2D\x04-", "-IIO%10-%04-");
     TEST_CLIENT("-I\05O\x08\x03\x01-", "-I%05O%08%03%01-");

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -634,6 +634,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             tr_snprintf(buf, buflen, "Folx %d.x", charint(id[3]));
         }
+        else if (strncmp(chid + 1, "BN", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "Baidu Netdisk");
+        }
 
         if (*buf != '\0')
         {


### PR DESCRIPTION
Baidu Netdisk uses Azureus-style Peer ID with "-BN" prefix.

This fixes https://github.com/transmission/transmission/issues/240.

Deriving the exact version number from the Peer ID does not seem to be possible.
