### PR TITLE
Fix `No @interface declares "containsIndex:"`

### DIFF
--- a/macosx/FileOutlineController.m
+++ b/macosx/FileOutlineController.m
@@ -617,7 +617,7 @@ typedef enum
 
     __block NSUInteger retIndex = NSNotFound;
 
-    [list enumerateObjectsAtIndexes: indexes options: NSEnumerationConcurrent usingBlock: ^(id checkNode, NSUInteger index, BOOL * stop) {
+    [list enumerateObjectsAtIndexes: indexes options: NSEnumerationConcurrent usingBlock: ^(FileListNode * checkNode, NSUInteger index, BOOL * stop) {
         if ([[checkNode indexes] containsIndex: [[node indexes] firstIndex]])
         {
             if (![checkNode isFolder])


### PR DESCRIPTION
This fixes the `No visible @interface for NSArray declares the selector "containsIndex:"` error that prevented Xcode (9b6) from compiling:

<img width="1153" alt="Xcode compilation error" src="https://user-images.githubusercontent.com/5808474/29897735-093f880e-8deb-11e7-9a05-769c1aa9d8ff.png">