### PR TITLE
Qt: Show file names in tooltips in Torrent Properties

### DIFF
--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -101,6 +101,7 @@ QVariant FileTreeItem::data(int column, int role) const
         value.setValue(isComplete());
         break;
 
+    case Qt::ToolTipRole:
     case Qt::EditRole:
         if (column == FileTreeModel::COL_NAME)
         {


### PR DESCRIPTION
File names are often too long to fit. Hovering is much easier than
resizing the column and possibly the window.

And by the way, why is the tree view's horizontal scroll bar disabled?