### PR TITLE
Fix autogen.sh failed

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,6 +24,7 @@ export LIBTOOLIZE
 
 ./update-version-h.sh
 
+rm m4/glib-gettext.m4 || die
 autoreconf -fi || exit 1;
 
 


### PR DESCRIPTION
m4/glib-gettext.m4:39: error: m4_copy: won't overwrite defined macro: glib_DEFUN