### PR TITLE
remove whitespace and a comma in the manuals

### DIFF
--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -1,10 +1,10 @@
 .\"
 .\"  Copyright (c) Deanna Phillips <deanna@sdf.lonestar.org>
-.\" 
+.\"
 .\"  Permission to use, copy, modify, and distribute this software for any
 .\"  purpose with or without fee is hereby granted, provided that the above
 .\"  copyright notice and this permission notice appear in all copies.
-.\" 
+.\"
 .\"  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 .\"  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 .\"  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -57,7 +57,7 @@ Set the maximum download speed in KB/s
 Don't limit the download speed
 .It Fl er Fl -encryption-required
 Encrypt all peer connections.
-.It Fl ep Fl -encryption-preferred 
+.It Fl ep Fl -encryption-preferred
 Prefer encrypted peer connections.
 .It Fl et Fl -encryption-tolerated
 Prefer unencrypted peer connections.
@@ -117,7 +117,7 @@ keeps torrent information for future seeding and resume operations.
 .Sh AUTHORS
 The
 .Nm
-program was written by 
+program was written by
 .An -nosplit
 .An Eric Petit ,
 .An Josh Elsasser ,

--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -101,7 +101,7 @@ Enable distributed hash table (DHT).
 Disable distribued hash table (DHT).
 .It Fl p Fl -port Ar port
 Port to open and listen for RPC requests on. Default: 9091
-.It Fl P, -peerport Ar port
+.It Fl P Fl -peerport Ar port
 Port to listen for incoming peers on. Default: 51413
 .It Fl t Fl -auth
 Require clients to authenticate themselves.

--- a/daemon/transmission-remote.1
+++ b/daemon/transmission-remote.1
@@ -72,7 +72,7 @@ and
 .Sh DESCRIPTION
 .Nm
 is a remote control utility for
-.Xr transmission 1 
+.Xr transmission 1
 and
 .Xr transmission-daemon 1 .
 .Pp

--- a/utils/transmission-create.1
+++ b/utils/transmission-create.1
@@ -7,8 +7,8 @@
 .Sh SYNOPSIS
 .Bk -words
 .Nm
-.Op Fl h 
-.Op Fl p 
+.Op Fl h
+.Op Fl p
 .Op Fl o Ar file
 .Op Fl c Ar comment
 .Op Fl t Ar tracker

--- a/utils/transmission-edit.1
+++ b/utils/transmission-edit.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Bk -words
 .Nm
-.Op Fl h 
+.Op Fl h
 .Op Fl a Ar url
 .Op Fl d Ar url
 .Op Fl r Ar search Ar replace


### PR DESCRIPTION
Hi. I had troubles with `transmission-daemon` and was reading up on the manual. I saw something trivial.

This commit is to remove a comma to make `transmission-daemon` manual a bit more flawless. I'm also removing whitespace in other manuals too to make things a bit more nice... to kill two birds with one stone.