### PR TITLE
remove twice 

### DIFF
--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -532,10 +532,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             three_digits(buf, buflen, "pbTorrent", id + 3);
         }
-        else if (strncmp(chid + 1, "TT", 2) == 0)
-        {
-            three_digits(buf, buflen, "TuoTu", id + 3);
-        }
         else if (strncmp(chid + 1, "qB", 2) == 0)
         {
             three_digits(buf, buflen, "qBittorrent", id + 3);

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -279,10 +279,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             four_digits(buf, buflen, "Avicora", id + 3);
         }
-        else if (strncmp(chid + 1, "BB", 2) == 0)
-        {
-            four_digits(buf, buflen, "BitBuddy", id + 3);
-        }
         else if (strncmp(chid + 1, "BE", 2) == 0)
         {
             four_digits(buf, buflen, "BitTorrent SDK", id + 3);
@@ -318,10 +314,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "BW", 2) == 0)
         {
             four_digits(buf, buflen, "BitWombat", id + 3);
-        }
-        else if (strncmp(chid + 1, "BX", 2) == 0)
-        {
-            four_digits(buf, buflen, "BittorrentX", id + 3);
         }
         else if (strncmp(chid + 1, "EB", 2) == 0)
         {
@@ -500,10 +492,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
             four_digits(buf, buflen, "Zona", id + 3);
         }
         /* */
-        else if (strncmp(chid + 1, "AG", 2) == 0)
-        {
-            three_digits(buf, buflen, "Ares", id + 3);
-        }
         else if (strncmp(chid + 1, "A~", 2) == 0)
         {
             three_digits(buf, buflen, "Ares", id + 3);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: err V517 The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence.