### PR TITLE
Add support for creating torrents with a source flag

### DIFF
--- a/gtk/makemeta-ui.c
+++ b/gtk/makemeta-ui.c
@@ -34,6 +34,8 @@ typedef struct
     GtkWidget* comment_check;
     GtkWidget* comment_entry;
     GtkWidget* private_check;
+    GtkWidget* source_flag_check;
+    GtkWidget* source_flag_entry;
     GtkWidget* progress_label;
     GtkWidget* progress_bar;
     GtkWidget* progress_dialog;
@@ -225,11 +227,15 @@ static void onResponse(GtkDialog* d, int response, gpointer user_data)
             char* tracker_text;
             char** tracker_strings;
             GtkEntry* c_entry = GTK_ENTRY(ui->comment_entry);
+            GtkEntry* s_entry = GTK_ENTRY(ui->source_flag_entry);
             GtkToggleButton* p_check = GTK_TOGGLE_BUTTON(ui->private_check);
             GtkToggleButton* c_check = GTK_TOGGLE_BUTTON(ui->comment_check);
+            GtkToggleButton* s_check = GTK_TOGGLE_BUTTON(ui->source_flag_check);
             char const* comment = gtk_entry_get_text(c_entry);
+            char const* sourceFlag = gtk_entry_get_text(s_entry);
             gboolean const isPrivate = gtk_toggle_button_get_active(p_check);
             gboolean const useComment = gtk_toggle_button_get_active(c_check);
+            gboolean const useSourceFlag = gtk_toggle_button_get_active(s_check);
             tr_tracker_info* trackers;
 
             /* destination file */
@@ -265,7 +271,8 @@ static void onResponse(GtkDialog* d, int response, gpointer user_data)
 
             /* build the .torrent */
             makeProgressDialog(GTK_WIDGET(d), ui);
-            tr_makeMetaInfo(ui->builder, ui->target, trackers, n, useComment ? comment : NULL, isPrivate);
+            tr_makeMetaInfo(ui->builder, ui->target, trackers, n, useComment ? comment : NULL,
+                            isPrivate, useSourceFlag ? sourceFlag : NULL);
 
             /* cleanup */
             g_free(trackers);
@@ -501,6 +508,15 @@ GtkWidget* gtr_torrent_creation_dialog_new(GtkWindow* parent, TrCore* core)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(l), FALSE);
     w = gtk_entry_new();
     ui->comment_entry = w;
+    gtk_widget_set_sensitive(GTK_WIDGET(w), FALSE);
+    g_signal_connect(l, "toggled", G_CALLBACK(onSourceToggled), w);
+    hig_workarea_add_row_w(t, &row, l, w, NULL);
+    
+    l = gtk_check_button_new_with_mnemonic(_("_Source flag:"));
+    ui->source_flag_check = l;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(l), FALSE);
+    w = gtk_entry_new();
+    ui->source_flag_entry = w;
     gtk_widget_set_sensitive(GTK_WIDGET(w), FALSE);
     g_signal_connect(l, "toggled", G_CALLBACK(onSourceToggled), w);
     hig_workarea_add_row_w(t, &row, l, w, NULL);

--- a/libtransmission/makemeta-test.c
+++ b/libtransmission/makemeta-test.c
@@ -17,7 +17,7 @@
 #include <string.h> /* strlen() */
 
 static int test_single_file_impl(tr_tracker_info const* trackers, size_t const trackerCount, void const* payload,
-    size_t const payloadSize, char const* comment, bool isPrivate)
+    size_t const payloadSize, char const* comment, bool isPrivate, char const* sourceFlag)
 {
     char* sandbox;
     char* input_file;
@@ -45,10 +45,11 @@ static int test_single_file_impl(tr_tracker_info const* trackers, size_t const t
 
     /* have tr_makeMetaInfo() build the .torrent file */
     torrent_file = tr_strdup_printf("%s.torrent", input_file);
-    tr_makeMetaInfo(builder, torrent_file, trackers, trackerCount, comment, isPrivate);
+    tr_makeMetaInfo(builder, torrent_file, trackers, trackerCount, comment, isPrivate, sourceFlag);
     check_bool(isPrivate, ==, builder->isPrivate);
     check_str(builder->outputFile, ==, torrent_file);
     check_str(builder->comment, ==, comment);
+    check_str(builder->sourceFlag, ==, sourceFlag);
     check_int(builder->trackerCount, ==, trackerCount);
 
     while (!builder->isDone)
@@ -71,6 +72,7 @@ static int test_single_file_impl(tr_tracker_info const* trackers, size_t const t
     check_str(inf.comment, ==, comment);
     check_int(inf.fileCount, ==, 1);
     check_int(inf.isPrivate, ==, isPrivate);
+    check_str(inf.sourceFlag, ==, sourceFlag);
     check(!inf.isFolder);
     check_int(inf.trackerCount, ==, trackerCount);
 
@@ -92,6 +94,7 @@ static int test_single_file(void)
     bool isPrivate;
     char const* comment;
     char const* payload;
+    char const* sourceFlag;
     size_t payloadSize;
 
     trackerCount = 0;
@@ -105,13 +108,14 @@ static int test_single_file(void)
     payloadSize = strlen(payload);
     comment = "This is the comment";
     isPrivate = false;
-    test_single_file_impl(trackers, trackerCount, payload, payloadSize, comment, isPrivate);
+    sourceFlag = "FOOBAR";
+    test_single_file_impl(trackers, trackerCount, payload, payloadSize, comment, isPrivate, sourceFlag);
 
     return 0;
 }
 
 static int test_single_directory_impl(tr_tracker_info const* trackers, size_t const trackerCount, void const** payloads,
-    size_t const* payloadSizes, size_t const payloadCount, char const* comment, bool const isPrivate)
+    size_t const* payloadSizes, size_t const payloadCount, char const* comment, bool const isPrivate, char const* sourceFlag)
 {
     char* sandbox;
     char* torrent_file;
@@ -162,10 +166,11 @@ static int test_single_directory_impl(tr_tracker_info const* trackers, size_t co
 
     /* call tr_makeMetaInfo() to build the .torrent file */
     torrent_file = tr_strdup_printf("%s.torrent", top);
-    tr_makeMetaInfo(builder, torrent_file, trackers, trackerCount, comment, isPrivate);
+    tr_makeMetaInfo(builder, torrent_file, trackers, trackerCount, comment, isPrivate, sourceFlag);
     check_bool(isPrivate, ==, builder->isPrivate);
     check_str(builder->outputFile, ==, torrent_file);
     check_str(builder->comment, ==, comment);
+    check_str(builder->sourceFlag, ==, sourceFlag);
     check_int(builder->trackerCount, ==, trackerCount);
 
     while (!builder->isDone)
@@ -186,6 +191,7 @@ static int test_single_directory_impl(tr_tracker_info const* trackers, size_t co
     check_str(inf.name, ==, tmpstr);
     tr_free(tmpstr);
     check_str(inf.comment, ==, comment);
+    check_str(inf.sourceFlag, ==, sourceFlag);
     check_int(inf.fileCount, ==, payloadCount);
     check_int(inf.isPrivate, ==, isPrivate);
     check_int(inf.isFolder, ==, builder->isFolder);
@@ -211,7 +217,7 @@ static int test_single_directory_impl(tr_tracker_info const* trackers, size_t co
 }
 
 static int test_single_directory_random_payload_impl(tr_tracker_info const* trackers, size_t const trackerCount,
-    size_t const maxFileCount, size_t const maxFileSize, char const* comment, bool const isPrivate)
+    size_t const maxFileCount, size_t const maxFileSize, char const* comment, bool const isPrivate, char const* sourceFlag)
 {
     void** payloads;
     size_t* payloadSizes;
@@ -231,7 +237,7 @@ static int test_single_directory_random_payload_impl(tr_tracker_info const* trac
     }
 
     /* run the test */
-    test_single_directory_impl(trackers, trackerCount, (void const**)payloads, payloadSizes, payloadCount, comment, isPrivate);
+    test_single_directory_impl(trackers, trackerCount, (void const**)payloads, payloadSizes, payloadCount, comment, isPrivate, sourceFlag);
 
     /* cleanup */
     for (size_t i = 0; i < payloadCount; i++)
@@ -254,6 +260,7 @@ static int test_single_directory_random_payload(void)
     size_t trackerCount;
     bool isPrivate;
     char const* comment;
+    char const* sourceFlag;
 
     trackerCount = 0;
     trackers[trackerCount].tier = trackerCount;
@@ -264,11 +271,12 @@ static int test_single_directory_random_payload(void)
     ++trackerCount;
     comment = "This is the comment";
     isPrivate = false;
+    sourceFlag = "TESTME";
 
     for (size_t i = 0; i < 10; i++)
     {
         test_single_directory_random_payload_impl(trackers, trackerCount, DEFAULT_MAX_FILE_COUNT, DEFAULT_MAX_FILE_SIZE,
-            comment, isPrivate);
+            comment, isPrivate, sourceFlag);
     }
 
     return 0;

--- a/libtransmission/makemeta.c
+++ b/libtransmission/makemeta.c
@@ -224,6 +224,7 @@ void tr_metaInfoBuilderFree(tr_metainfo_builder* builder)
         tr_free(builder->files);
         tr_free(builder->top);
         tr_free(builder->comment);
+        tr_free(builder->sourceFlag);
 
         for (int i = 0; i < builder->trackerCount; ++i)
         {
@@ -474,6 +475,10 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
         {
             tr_variantDictAddStr(&top, TR_KEY_comment, builder->comment);
         }
+        if (builder->sourceFlag != NULL && *builder->sourceFlag != '\0')
+        {
+            tr_variantDictAddStr(&top, TR_KEY_source, builder->sourceFlag);
+        }
 
         tr_variantDictAddStr(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
         tr_variantDictAddInt(&top, TR_KEY_creation_date, time(NULL));
@@ -556,7 +561,7 @@ static void makeMetaWorkerFunc(void* unused UNUSED)
 }
 
 void tr_makeMetaInfo(tr_metainfo_builder* builder, char const* outputFile, tr_tracker_info const* trackers, int trackerCount,
-    char const* comment, bool isPrivate)
+    char const* comment, bool isPrivate, char const* sourceFlag)
 {
     tr_lock* lock;
 
@@ -568,6 +573,7 @@ void tr_makeMetaInfo(tr_metainfo_builder* builder, char const* outputFile, tr_tr
 
     tr_free(builder->trackers);
     tr_free(builder->comment);
+    tr_free(builder->sourceFlag);
     tr_free(builder->outputFile);
 
     /* initialize the builder variables */
@@ -586,6 +592,7 @@ void tr_makeMetaInfo(tr_metainfo_builder* builder, char const* outputFile, tr_tr
 
     builder->comment = tr_strdup(comment);
     builder->isPrivate = isPrivate;
+    builder->sourceFlag = tr_strdup(sourceFlag);
 
     if (outputFile != NULL && *outputFile != '\0')
     {

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -56,6 +56,7 @@ typedef struct tr_metainfo_builder
     char* comment;
     char* outputFile;
     bool isPrivate;
+    char* sourceFlag;
 
     /**
     ***  These are set inside tr_makeMetaInfo() so the client
@@ -115,7 +116,7 @@ void tr_metaInfoBuilderFree(tr_metainfo_builder*);
  * @param trackerCount size of the `trackers' array
  */
 void tr_makeMetaInfo(tr_metainfo_builder* builder, char const* outputFile, tr_tracker_info const* trackers, int trackerCount,
-    char const* comment, bool isPrivate);
+    char const* comment, bool isPrivate, char const* sourceFlag);
 
 #ifdef __cplusplus
 }

--- a/libtransmission/metainfo.c
+++ b/libtransmission/metainfo.c
@@ -590,6 +590,16 @@ static char const* tr_metainfoParseImpl(tr_session const* session, tr_info* inf,
 
     inf->isPrivate = i != 0;
 
+    /* source flag */
+    len = 0;
+    if (!tr_variantDictFindStr(meta, TR_KEY_source, &str, &len))
+    {
+        str = "";
+    }
+
+    tr_free(inf->sourceFlag);
+    inf->sourceFlag = tr_utf8clean(str, len);
+    
     /* piece length */
     if (!isMagnet)
     {

--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -330,6 +330,7 @@ static struct tr_key_struct const my_static[] =
     { "sizeWhenDone", 12 },
     { "sort-mode", 9 },
     { "sort-reversed", 13 },
+    { "source", 6 },
     { "speed", 5 },
     { "speed-Bps", 9 },
     { "speed-bytes", 11 },

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -332,6 +332,7 @@ enum
     TR_KEY_sizeWhenDone,
     TR_KEY_sort_mode,
     TR_KEY_sort_reversed,
+    TR_KEY_source,
     TR_KEY_speed,
     TR_KEY_speed_Bps,
     TR_KEY_speed_bytes,

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1631,6 +1631,7 @@ struct tr_info
     /* Flags */
     bool isPrivate;
     bool isFolder;
+    char* sourceFlag;
 };
 
 static inline bool tr_torrentHasMetadata(tr_torrent const* tor)

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -175,10 +175,19 @@ void MakeDialog::makeTorrent()
     {
         comment = ui.commentEdit->text();
     }
+    
+    // source flag
+    QString sourceFlag;
+
+    if (ui.sourceFlagCheck->isChecked())
+    {
+        sourceFlag = ui.sourceFlagEdit->text();
+    }
 
     // start making the torrent
     tr_makeMetaInfo(myBuilder.get(), target.toUtf8().constData(), trackers.isEmpty() ? nullptr : trackers.data(),
-        trackers.size(), comment.isEmpty() ? nullptr : comment.toUtf8().constData(), ui.privateCheck->isChecked());
+        trackers.size(), comment.isEmpty() ? nullptr : comment.toUtf8().constData(), ui.privateCheck->isChecked(),
+        sourceFlag.isEmpty() ? nullptr : sourceFlag.toUtf8().constData());
 
     // pop up the dialog
     MakeProgressDialog* dialog = new MakeProgressDialog(mySession, *myBuilder, this);

--- a/qt/MakeDialog.ui
+++ b/qt/MakeDialog.ui
@@ -157,7 +157,21 @@ To add another primary URL, add it after a blank line.</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="2">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="sourceFlagCheck">
+       <property name="text">
+        <string>&amp;Source flag:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="sourceFlagEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
       <widget class="QCheckBox" name="privateCheck">
        <property name="text">
         <string>&amp;Private torrent</string>
@@ -232,6 +246,22 @@ To add another primary URL, add it after a blank line.</string>
     <hint type="destinationlabel">
      <x>360</x>
      <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sourceFlagCheck</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>sourceFlagEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>75</x>
+     <y>347</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>342</x>
+     <y>347</y>
     </hint>
    </hints>
   </connection>

--- a/utils/create.c
+++ b/utils/create.c
@@ -31,10 +31,12 @@ static char const* comment = NULL;
 static char const* outfile = NULL;
 static char const* infile = NULL;
 static uint32_t piecesize_kib = 0;
+static char const* source_flag = NULL;
 
 static tr_option options[] =
 {
     { 'p', "private", "Allow this torrent to only be used with the specified tracker(s)", "p", 0, NULL },
+    { 'r', "source", "Set the source flag for private trackers", "r", 1, "<flag>" },
     { 'o', "outfile", "Save the generated .torrent to this filename", "o", 1, "<file>" },
     { 's', "piecesize", "Set how many KiB each piece should be, overriding the preferred default", "s", 1, "<size in KiB>" },
     { 'c', "comment", "Add a comment", "c", 1, "<comment>" },
@@ -95,6 +97,10 @@ static int parseCommandLine(int argc, char const* const* argv)
                 }
             }
 
+            break;
+
+        case 'r':
+            source_flag = optarg;
             break;
 
         case TR_OPT_UNK:
@@ -197,7 +203,7 @@ int tr_main(int argc, char* argv[])
         tr_metaInfoBuilderSetPieceSize(b, piecesize_kib * KiB);
     }
 
-    tr_makeMetaInfo(b, outfile, trackers, trackerCount, comment, isPrivate);
+    tr_makeMetaInfo(b, outfile, trackers, trackerCount, comment, isPrivate, source_flag);
 
     while (!b->isDone)
     {


### PR DESCRIPTION
Allow creating torrents with the "source flag" set, which is an optional field in the torrent file meant to identify the source of the torrent and cause the infohash to be different depending on the flag's value.

This is an unofficial extension to the already existing format, but it's used by a number of private trackers. It's already been implemented in a number of utilities for creating torrents, most namely [mktorrent](https://github.com/Rudde/mktorrent/commit/905ccc2273a96ff0b6c774a67798a83af8cb334b).