### PR TITLE
Fix a few cppcheck warnings.

### DIFF
--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1818,7 +1818,7 @@ static void copy_tier_attributes(struct tr_torrent_tiers* tt, tr_tier const* src
     {
         for (int j = 0; !found && j < tt->tiers[i].tracker_count; ++j)
         {
-            if ((found = tr_strcmp0(src->currentTracker->announce, tt->tiers[i].trackers[j].announce) == 0))
+            if ((found = tr_strcmp0(src->currentTracker->announce, tt->tiers[i].trackers[j].announce)) == 0)
             {
                 copy_tier_attributes_impl(&tt->tiers[i], j, src);
             }

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -279,10 +279,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             four_digits(buf, buflen, "Avicora", id + 3);
         }
-        else if (strncmp(chid + 1, "BB", 2) == 0)
-        {
-            four_digits(buf, buflen, "BitBuddy", id + 3);
-        }
         else if (strncmp(chid + 1, "BE", 2) == 0)
         {
             four_digits(buf, buflen, "BitTorrent SDK", id + 3);
@@ -302,10 +298,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "BP", 2) == 0)
         {
             four_digits(buf, buflen, "BitTorrent Pro (Azureus + Spyware)", id + 3);
-        }
-        else if (strncmp(chid + 1, "BX", 2) == 0)
-        {
-            four_digits(buf, buflen, "BittorrentX", id + 3);
         }
         else if (strncmp(chid + 1, "bk", 2) == 0)
         {
@@ -500,10 +492,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
             four_digits(buf, buflen, "Zona", id + 3);
         }
         /* */
-        else if (strncmp(chid + 1, "AG", 2) == 0)
-        {
-            three_digits(buf, buflen, "Ares", id + 3);
-        }
         else if (strncmp(chid + 1, "A~", 2) == 0)
         {
             three_digits(buf, buflen, "Ares", id + 3);
@@ -531,10 +519,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "pb", 2) == 0)
         {
             three_digits(buf, buflen, "pbTorrent", id + 3);
-        }
-        else if (strncmp(chid + 1, "TT", 2) == 0)
-        {
-            three_digits(buf, buflen, "TuoTu", id + 3);
         }
         else if (strncmp(chid + 1, "qB", 2) == 0)
         {

--- a/libtransmission/fdlimit.c
+++ b/libtransmission/fdlimit.c
@@ -475,7 +475,7 @@ bool tr_fdFileGetCachedMTime(tr_session* s, int torrent_id, tr_file_index_t i, t
     tr_sys_path_info info;
     struct tr_cached_file* o = fileset_lookup(get_fileset(s), torrent_id, i);
 
-    if ((success = o != NULL && tr_sys_file_get_info(o->fd, &info, NULL)))
+    if ((success = o) != NULL && tr_sys_file_get_info(o->fd, &info, NULL))
     {
         *mtime = info.last_modified_at;
     }

--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -497,11 +497,11 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
     }
 
     native_flags |=
-        (flags & TR_SYS_FILE_CREATE ? O_CREAT : 0) |
-        (flags & TR_SYS_FILE_CREATE_NEW ? O_CREAT | O_EXCL : 0) |
-        (flags & TR_SYS_FILE_APPEND ? O_APPEND : 0) |
-        (flags & TR_SYS_FILE_TRUNCATE ? O_TRUNC : 0) |
-        (flags & TR_SYS_FILE_SEQUENTIAL ? O_SEQUENTIAL : 0) |
+        ((flags & TR_SYS_FILE_CREATE) ? O_CREAT : 0) |
+        ((flags & TR_SYS_FILE_CREATE_NEW) ? O_CREAT | O_EXCL : 0) |
+        ((flags & TR_SYS_FILE_APPEND) ? O_APPEND : 0) |
+        ((flags & TR_SYS_FILE_TRUNCATE) ? O_TRUNC : 0) |
+        ((flags & TR_SYS_FILE_SEQUENTIAL) ? O_SEQUENTIAL : 0) |
         O_BINARY | O_LARGEFILE | O_CLOEXEC;
 
     ret = open(path, native_flags, permissions);

--- a/libtransmission/file-test.c
+++ b/libtransmission/file-test.c
@@ -53,7 +53,7 @@ static bool create_symlink(char const* dst_path, char const* src_path, bool dst_
 
     wchar_t* wide_src_path;
     wchar_t* wide_dst_path;
-    bool ret = false;
+    bool ret;
 
     wide_src_path = tr_win32_utf8_to_native(src_path, -1);
     wide_dst_path = tr_win32_utf8_to_native(dst_path, -1);

--- a/libtransmission/magnet-test.c
+++ b/libtransmission/magnet-test.c
@@ -40,7 +40,7 @@ static int test1(void)
     check_mem(info->hash, ==, dec, 20);
 
     tr_magnetFree(info);
-    info = NULL;
+    info;
 
     /* same thing but in base32 encoding */
     uri =

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -113,14 +113,14 @@ bool tr_address_from_string(tr_address* dst, char const* src)
 {
     bool ok;
 
-    if ((ok = evutil_inet_pton(AF_INET, src, &dst->addr) == 1))
+    if ((ok = evutil_inet_pton(AF_INET, src, &dst->addr)) == 1)
     {
         dst->type = TR_AF_INET;
     }
 
     if (!ok) /* try IPv6 */
     {
-        if ((ok = evutil_inet_pton(AF_INET6, src, &dst->addr) == 1))
+        if ((ok = evutil_inet_pton(AF_INET6, src, &dst->addr)) == 1)
         {
             dst->type = TR_AF_INET6;
         }

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -1153,7 +1153,7 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
 
     tr_peerIoReadBytes(msgs->io, inbuf, tmp, msglen);
 
-    if (tr_torrentAllowsPex(tor) && (loaded = tr_variantFromBenc(&val, tmp, msglen) == 0))
+    if (tr_torrentAllowsPex(tor) && (loaded = tr_variantFromBenc(&val, tmp, msglen)) == 0)
     {
         if (tr_variantDictFindRaw(&val, TR_KEY_added, &added, &added_len))
         {

--- a/libtransmission/stats.c
+++ b/libtransmission/stats.c
@@ -51,7 +51,7 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
 {
     tr_variant top;
     char* filename;
-    bool loaded = false;
+    bool loaded;
 
     filename = getFilename(session);
     loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_JSON, filename, NULL);

--- a/libtransmission/torrent-magnet.c
+++ b/libtransmission/torrent-magnet.c
@@ -275,14 +275,14 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
         dbgmsg(tor, "metainfo piece %d was the last one", piece);
         tr_sha1(sha1, m->metadata, m->metadata_size, NULL);
 
-        if ((checksumPassed = memcmp(sha1, tor->info.hash, SHA_DIGEST_LENGTH) == 0))
+        if ((checksumPassed = memcmp(sha1, tor->info.hash, SHA_DIGEST_LENGTH)) == 0)
         {
             /* checksum passed; now try to parse it as benc */
             tr_variant infoDict;
             int const err = tr_variantFromBenc(&infoDict, m->metadata, m->metadata_size);
             dbgmsg(tor, "err is %d", err);
 
-            if ((metainfoParsed = err == 0))
+            if ((metainfoParsed = err) == 0)
             {
                 /* yay we have bencoded metainfo... merge it into our .torrent file */
                 tr_variant newMetainfo;

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -171,7 +171,7 @@ bool tr_torrentIsPieceTransferAllowed(tr_torrent const* tor, tr_direction direct
 
         if (tr_sessionGetActiveSpeedLimit_Bps(tor->session, direction, &limit))
         {
-            if (limit <= 0)
+            if (limit == 0)
             {
                 allowed = false;
             }

--- a/libtransmission/tr-udp.c
+++ b/libtransmission/tr-udp.c
@@ -171,11 +171,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
-
-    if (ipv6 != NULL)
-    {
-        memcpy(&sin6.sin6_addr, ipv6, 16);
-    }
+    memcpy(&sin6.sin6_addr, ipv6, 16);
 
     sin6.sin6_port = htons(ss->udp_port);
     public_addr = tr_sessionGetPublicAddress(ss, TR_AF_INET6, &is_default);

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -759,7 +759,7 @@ void tr_binary_to_hex(void const* input, char* output, size_t byte_length)
 
 void tr_hex_to_binary(char const* input, void* output, size_t byte_length)
 {
-    static char const hex[] = "0123456789abcdef";
+    static char const *hex = "0123456789abcdef";
     uint8_t* output_octets = output;
 
     for (size_t i = 0; i < byte_length; ++i)
@@ -776,7 +776,7 @@ void tr_hex_to_binary(char const* input, void* output, size_t byte_length)
 
 static bool isValidURLChars(char const* url, size_t url_len)
 {
-    static char const rfc2396_valid_chars[] =
+    static char const *rfc2396_valid_chars =
         "abcdefghijklmnopqrstuvwxyz" /* lowalpha */
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ" /* upalpha */
         "0123456789" /* digit */

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -349,7 +349,7 @@ bool tr_variantGetBool(tr_variant const* v, bool* setme)
 
     if (!success && tr_variantIsInt(v))
     {
-        if ((success = v->val.i == 0 || v->val.i == 1))
+        if ((success = v->val.i) == 0 || v->val.i == 1)
         {
             *setme = v->val.i != 0;
         }
@@ -357,7 +357,7 @@ bool tr_variantGetBool(tr_variant const* v, bool* setme)
 
     if (!success && tr_variantGetStr(v, &str, NULL))
     {
-        if ((success = strcmp(str, "true") == 0 || strcmp(str, "false") == 0))
+        if ((success = strcmp(str, "true")) == 0 || strcmp(str, "false") == 0)
         {
             *setme = strcmp(str, "true") == 0;
         }
@@ -391,7 +391,7 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
         d = strtod(getStr(v), &endptr);
         restore_locale(&locale_ctx);
 
-        if ((success = getStr(v) != endptr && *endptr == '\0'))
+        if ((success = getStr(v)) != endptr && *endptr == '\0')
         {
             *setme = d;
         }


### PR DESCRIPTION
Mainly style fixes and some dead assignments.

The parentheses changes should be fine. Please look.

The removed if statements are duplicates. char[] to *char reduces compiled size. No idea why.