### PR TITLE
Standardize the AppStream ID and use "com.transmissionbt.Transmission"

### DIFF
--- a/gtk/transmission-gtk.appdata.xml.in
+++ b/gtk/transmission-gtk.appdata.xml.in
@@ -4,7 +4,8 @@ Copyright 2014 Richard Hughes <richard@hughsie.com>
 Copyright 2017 Endless Mobile, Inc.
  -->
 <component type="desktop-application">
-  <id type="desktop">transmission-gtk.desktop</id>
+  <id>com.transmissionbt.Transmission</id>
+  <launchable type="desktop-id">transmission-gtk.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0 OR GPL-3.0</project_license>
 


### PR DESCRIPTION
Transmission's Appstream ID on Flathub is `com.transmissionbt.Transmission` (https://github.com/flathub/com.transmissionbt.Transmission/blob/master/com.transmissionbt.Transmission.json#L2)

But Transmission's AppStream file here uses a different AppStream ID: `transmission-gtk.desktop` (https://github.com/transmission/transmission/blob/master/gtk/transmission-gtk.appdata.xml.in#L7)

This causes problems: if the same app has different AppStream IDs in different distribution channels, then it'll erroneously show up as different apps in clients that can display content from multiple sources, such as GNOME Software Center and KDE Discover. Here's what it looks like in KDE discover:

![two transmissions](https://user-images.githubusercontent.com/1097249/34315691-d02ae6b2-e740-11e7-8f91-c9144742be9f.png)

The top one is the Flathub version, the bottom one is provided by my distro's packages.

If you unify the AppStream IDs (ideally standardizing on a reverse-DNS style such as `com.transmissionbt.Transmission`), then Discover and GNOME Software (and similar apps) can perform de-duplication correctly, marking both as the same app and offering the user the choice of which version they want to install.

In this PR, I've opted to not to rename the desktop file and instead add the <launchable> tag to associate the AppStream data with the desktop file. An alternative approach is to remove/not add the <launchable> tag, and instead rename the desktop file to match the AppStream ID (i.e. `com.transmissionbt.Transmission`).

Relevant part of the AppStream spec: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html