### PR TITLE
Add support for torrent-get calls with the key percentComplete

### DIFF
--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -235,6 +235,7 @@ static struct tr_key_struct const my_static[] =
     { "peersFrom", 9 },
     { "peersGettingFromUs", 18 },
     { "peersSendingToUs", 16 },
+    { "percentComplete", 15 },
     { "percentDone", 11 },
     { "pex-enabled", 11 },
     { "piece", 5 },

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -237,6 +237,7 @@ enum
     TR_KEY_peersFrom,
     TR_KEY_peersGettingFromUs,
     TR_KEY_peersSendingToUs,
+    TR_KEY_percentComplete,
     TR_KEY_percentDone,
     TR_KEY_pex_enabled,
     TR_KEY_piece,

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -662,6 +662,10 @@ static void addField(tr_torrent* const tor, tr_info const* const inf, tr_stat co
         tr_variantDictAddReal(d, key, st->percentDone);
         break;
 
+    case TR_KEY_percentComplete:
+        tr_variantDictAddReal(d, key, st->percentComplete);
+        break;
+
     case TR_KEY_peer_limit:
         tr_variantDictAddInt(d, key, tr_torrentGetPeerLimit(tor));
         break;


### PR DESCRIPTION
`percentDone` is already available as a key when calling `torrent-get` over RPC - it describes the amount of data downloaded as a percent of the files that are wanted in the torrent. I'm interested in getting `percentComplete` - the data downloaded as a percent of the complete torrent size. `percentComplete` is already included in `tr_stat` so it's an easy add.