### PR TITLE
Return 0 when dumping daemon settings

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -406,6 +406,7 @@ static bool parse_args(int argc, char const** argv, tr_variant* settings, bool* 
 
         case 'd':
             *dump_settings = true;
+            *exit_code = 0;
             break;
 
         case 'e':


### PR DESCRIPTION
Currently transmission-daemon does not populate exitcode value, and returns inconsistent random number, when used with option --dump-settings. This gets in the way of automated deployment. This pull request patches it to always return 0 (success) with this option.