### PR TITLE
Qt: Fix assert with one-letter root folder names

### DIFF
--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -47,7 +47,7 @@ public:
 
     bool hasNext() const
     {
-        return mySlashIndex > 0;
+        return mySlashIndex > -1;
     }
 
     QString const& next()


### PR DESCRIPTION
An assertion failure happens shortly after opening the "Torrent properties" dialog if the torrent's root folder has a one-letter name, e. g.
```
A/
A/Some Linux distro.iso
A/Some other Linux distro.iso
```

Both current master and 2.93 are affected.

Off by one errors are great, eh?

This fixes https://trac.transmissionbt.com/ticket/6141 (reported by me).