### PR TITLE
Set compression to curl defaults

### DIFF
--- a/libtransmission/web.c
+++ b/libtransmission/web.c
@@ -183,7 +183,7 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
     task->timeout_secs = getTimeoutFromURL(task);
 
     curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
-    curl_easy_setopt(e, CURLOPT_ENCODING, "gzip;q=1.0, deflate, identity");
+    curl_easy_setopt(e, CURLOPT_ENCODING, "");
     curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(e, CURLOPT_MAXREDIRS, -1L);
     curl_easy_setopt(e, CURLOPT_NOSIGNAL, 1L);


### PR DESCRIPTION
While zlib is mandatory for transmission, it is not mandatory for curl.

A libcurl that has been compiled with no support for zlib will return no data if compressed responses are set to on.

In the basic case this prevents the port checking functionality from working properly. It also prevents web seeding from working as well.