### PR TITLE
Qt: Fix assert when the details dialog is open for a while

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -936,7 +936,12 @@ DetailsDialog::refresh ()
   if (!single)
     ui.filesView->clear ();
   if (single)
-    ui.filesView->update (torrents[0]->files (), myChangedTorrents);
+    {
+      if (torrents.empty ())
+        ui.filesView->clear ();
+      else
+        ui.filesView->update (torrents[0]->files (), myChangedTorrents);
+    }
 
   myChangedTorrents = false;
   myHavePendingRefresh = false;


### PR DESCRIPTION
``torrents.empty()`` somehow becomes true, and then ``torrents[0]`` causes an assertion failure in QList. I saw that other parts of the function check ``torrents.empty()`` so I did the same here.

Even though this part of the code looks about the same in git master, I have only been able to reproduce the crash with 2.93 and some older version(s) (I noticed this bug a while ago).