### PR TITLE
Ensure buffer contents are null-terminated

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -2108,6 +2108,7 @@ static int flush(char const* rpcurl, tr_variant** benc)
             break;
 
         default:
+            evbuffer_add(buf, "", 1);
             fprintf(stderr, "Unexpected response: %s\n", evbuffer_pullup(buf, -1));
             status |= EXIT_FAILURE;
             break;


### PR DESCRIPTION
Data added with `evbuffer_add` isn't null-terminated. This was causing
extra characters to appear at the end of the output.

Fixes: #174