### PR TITLE
Show magnet link button added to context menu

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -262,6 +262,10 @@
 			<p id="about-blurb">A fast and easy BitTorrent client</p>
 			<p id="about-copyright">Copyright (c) The Transmission Project</p>
 		</div>
+		
+		<div class="ui-helper-hidden" id="magnet-links-dialog">
+			<div class="magnet-links-section"></div>
+		</div>
 
 		<div class="ui-helper-hidden" id="stats-dialog">
 			<div class="prefs-section">
@@ -375,7 +379,7 @@
 					enctype="multipart/form-data" target="torrent_upload_frame" autocomplete="off">
 					<div class="dialog_message">
 						<label for="torrent_upload_file">Please select a torrent file to upload:</label>
-							<input type="file" name="torrent_files[]" id="torrent_upload_file" multiple="multiple" />
+							<input type="file" name="torrent_files[]" id="torrent_upload_file" multiple />
 						<label for="torrent_upload_url">Or enter a URL:</label>
 							<input type="url" id="torrent_upload_url"/>
 						<label id='add-dialog-folder-label' for="add-dialog-folder-input">Destination folder:</label>
@@ -515,6 +519,8 @@
 			<li>---</li>
 			<li data-command="reannounce">Ask tracker for more peers</li>
 			<li>---</li>
+			<li data-command="show_magnet_link">Show magnet link</li>
+                        <li>---</li>
 			<li data-command="select_all">Select All</li>
 			<li data-command="deselect_all">Deselect All</li>
 		</ul>

--- a/web/index.html
+++ b/web/index.html
@@ -379,7 +379,7 @@
 					enctype="multipart/form-data" target="torrent_upload_frame" autocomplete="off">
 					<div class="dialog_message">
 						<label for="torrent_upload_file">Please select a torrent file to upload:</label>
-							<input type="file" name="torrent_files[]" id="torrent_upload_file" multiple />
+							<input type="file" name="torrent_files[]" id="torrent_upload_file" multiple="multiple" />
 						<label for="torrent_upload_url">Or enter a URL:</label>
 							<input type="url" id="torrent_upload_url"/>
 						<label id='add-dialog-folder-label' for="add-dialog-folder-input">Destination folder:</label>
@@ -520,7 +520,7 @@
 			<li data-command="reannounce">Ask tracker for more peers</li>
 			<li>---</li>
 			<li data-command="show_magnet_link">Show magnet link</li>
-                        <li>---</li>
+			<li>---</li>
 			<li data-command="select_all">Select All</li>
 			<li data-command="deselect_all">Deselect All</li>
 		</ul>

--- a/web/javascript/remote.js
+++ b/web/javascript/remote.js
@@ -236,6 +236,20 @@ TransmissionRemote.prototype = {
     reannounceTorrents: function (torrent_ids, callback, context) {
         this.sendTorrentActionRequests('torrent-reannounce', torrent_ids, callback, context);
     },
+	getMagnetLinks: function (torrent_ids, callback, context) {
+		var remote = this;
+        var o = {
+            method: 'torrent-get',
+            arguments: {
+                fields: ["magnetLink"],
+				ids: torrent_ids
+            }
+        };
+        this.sendRequest(o, function (response) {
+            var args = response['arguments'];
+            callback.call(context, args);
+        });
+    },
     addTorrentByUrl: function (url, options) {
         var remote = this;
         if (url.match(/^[0-9a-f]{40}$/i)) {

--- a/web/javascript/remote.js
+++ b/web/javascript/remote.js
@@ -236,8 +236,8 @@ TransmissionRemote.prototype = {
     reannounceTorrents: function (torrent_ids, callback, context) {
         this.sendTorrentActionRequests('torrent-reannounce', torrent_ids, callback, context);
     },
-	getMagnetLinks: function (torrent_ids, callback, context) {
-		var remote = this;
+    getMagnetLinks: function (torrent_ids, callback, context) {
+        var remote = this;
         var o = {
             method: 'torrent-get',
             arguments: {

--- a/web/javascript/remote.js
+++ b/web/javascript/remote.js
@@ -242,7 +242,7 @@ TransmissionRemote.prototype = {
             method: 'torrent-get',
             arguments: {
                 fields: ["magnetLink"],
-				ids: torrent_ids
+                ids: torrent_ids
             }
         };
         this.sendRequest(o, function (response) {

--- a/web/javascript/transmission.js
+++ b/web/javascript/transmission.js
@@ -1280,11 +1280,9 @@ Transmission.prototype = {
     reannounceSelectedTorrents: function () {
         this.reannounceTorrents(this.getSelectedTorrents());
     },
-	
     showmagnetlinkSelectedTorrents: function () {
         this.showmagnetlinkTorrents(this.getSelectedTorrents());
     },
-
     startAllTorrents: function (force) {
         this.startTorrents(this.getAllTorrents(), force);
     },

--- a/web/javascript/transmission.js
+++ b/web/javascript/transmission.js
@@ -1281,9 +1281,9 @@ Transmission.prototype = {
         this.reannounceTorrents(this.getSelectedTorrents());
     },
 	
-	showmagnetlinkSelectedTorrents: function () {
-		this.showmagnetlinkTorrents(this.getSelectedTorrents());
-	},
+    showmagnetlinkSelectedTorrents: function () {
+        this.showmagnetlinkTorrents(this.getSelectedTorrents());
+    },
 
     startAllTorrents: function (force) {
         this.startTorrents(this.getAllTorrents(), force);
@@ -1311,39 +1311,36 @@ Transmission.prototype = {
     reannounceTorrents: function (torrents) {
         this.remote.reannounceTorrents(this.getTorrentIds(torrents), this.refreshTorrents, this);
     },
-	
-	showmagnetlinkTorrents: function(torrents) {
-		for (i = 0; t = torrents[i]; ++i) {
-			if (typeof t.getHashString() != "string" || t.getHashString().length != 40 || typeof t.getTrackers() != "object" || t.getTrackers().length < 1) {
-				break;
-			};
-			if (i == torrents.length-1) {
-				var data = [];
-				for (i = 0; t = torrents[i]; ++i) {
-					data.push("magnet:?xt=urn:btih:" + t.getHashString() + "&dn=" + encodeURIComponent(t.getName()) + "&tr=" + t.getTrackers().map(function(e){return encodeURIComponent(e.announce);}).join('&tr='));
-				};
-				this.showMagnetLinks(torrents, data);
-				return;
-			};
-		};
-		this.remote.getMagnetLinks(this.getTorrentIds(torrents), function(data) {
-			this.showMagnetLinks(torrents, Array.from(data.torrents, x => x.magnetLink));
-		}, this);
+    showmagnetlinkTorrents: function(torrents) {
+        for (i = 0; t = torrents[i]; ++i) {
+            if (typeof t.getHashString() != "string" || t.getHashString().length != 40 || typeof t.getTrackers() != "object" || t.getTrackers().length < 1) {
+                break;
+            };
+            if (i == torrents.length-1) {
+                var data = [];
+                for (i = 0; t = torrents[i]; ++i) {
+                    data.push("magnet:?xt=urn:btih:" + t.getHashString() + "&dn=" + encodeURIComponent(t.getName()) + "&tr=" + t.getTrackers().map(function(e){return encodeURIComponent(e.announce);}).join('&tr='));
+                };
+                this.showMagnetLinks(torrents, data);
+                return;
+            };
+        };
+        this.remote.getMagnetLinks(this.getTorrentIds(torrents), function(data) {
+            this.showMagnetLinks(torrents, Array.from(data.torrents, x => x.magnetLink));
+        }, this);
 		
-	},
-	
-	showMagnetLinks: function(torrents, data) {
-		$('#magnet-links-dialog > div').html('');
-		for (i = 0; t = torrents[i]; ++i) {
-			$('#magnet-links-dialog > div').append('<div class="title">' + t.getName() + '</div><div class="row"><input type="text" value="' + data[i] + '" readonly/></div>');
-		};
-		$('#magnet-links-dialog').dialog({
+    },
+    showMagnetLinks: function(torrents, data) {
+        $('#magnet-links-dialog > div').html('');
+        for (i = 0; t = torrents[i]; ++i) {
+            $('#magnet-links-dialog > div').append('<div class="title">' + t.getName() + '</div><div class="row"><input type="text" value="' + data[i] + '" readonly/></div>');
+        };
+        $('#magnet-links-dialog').dialog({
             show: 'fade',
             hide: 'fade',
             title: 'Magnet Links'
         });
-	},
-
+    },
     stopAllTorrents: function () {
         this.stopTorrents(this.getAllTorrents());
     },

--- a/web/style/transmission/common.css
+++ b/web/style/transmission/common.css
@@ -326,20 +326,20 @@ ul.torrent_list {
 ****
 ***/
 .magnet-links-section .title {
-	word-wrap: break-word;
-    font-weight: bold;
-    font-size: larger;
-    padding-left: 0px;
+  word-wrap: break-word;
+  font-weight: bold;
+  font-size: larger;
+  padding-left: 0px;
 }
-.magnet-links-section .title:not(:first-of-type) {
-	margin-top: 20px;
+  .magnet-links-section .title:not(:first-of-type) {
+  margin-top: 20px;
 }
-.magnet-links-section .row {
-	margin-top: 5px;
+  .magnet-links-section .row {
+  margin-top: 5px;
 }
 .magnet-links-section input {
-	width: 90%;
-	padding: 5px;
+  width: 90%;
+  padding: 5px;
 }
 /***
 ****

--- a/web/style/transmission/common.css
+++ b/web/style/transmission/common.css
@@ -1124,4 +1124,4 @@ iframe#torrent_upload_frame {
 #torrent_context_menu,
 #footer_super_menu {
   font-size: 1em;
-  z-index: 3; }
+  z-index: 5; }

--- a/web/style/transmission/common.css
+++ b/web/style/transmission/common.css
@@ -322,6 +322,27 @@ ul.torrent_list {
 
 /***
 ****
+****  MAGNET LINKS
+****
+***/
+.magnet-links-section .title {
+	word-wrap: break-word;
+    font-weight: bold;
+    font-size: larger;
+    padding-left: 0px;
+}
+.magnet-links-section .title:not(:first-of-type) {
+	margin-top: 20px;
+}
+.magnet-links-section .row {
+	margin-top: 5px;
+}
+.magnet-links-section input {
+	width: 90%;
+	padding: 5px;
+}
+/***
+****
 ****  PREFERENCES
 ****
 ***/


### PR DESCRIPTION
A small addition to the web context menu that adds a button that shows the torrent's magnet link. This is a feature I use a lot to share torrents. It is especially useful for the web interface, as it can be accessed from almost anywhere.

Also can be used as a way to effectively download torrents from servers, by just using the magnet link and a local client. It is a faff otherwise to go and find the saved .torrent file on the server, or download the data via FTP, or build the magnet link by hand(!), or go and find the original .torrent location.

PS: Also included in this PR is a little bug fix, for me the contextmenu would appear beneath the inspector when right clicking near it. Changing the `z-index` from 3 to 5 fixed it.

**Pros:**
- Easy sharing of torrents
- Code includes a check to see if the required information to generate the magnet link is already known to the client, and therefore saves bandwidth when it does not need to make another RPC request.
- Supports multiple torrent selections

**Cons:**
- Makes the contextmenu slightly larger
- Extra feature on a minimalist interface