### PR TITLE
Support for multihomed hosts.

### DIFF
--- a/libtransmission/announcer-udp.c
+++ b/libtransmission/announcer-udp.c
@@ -54,12 +54,17 @@ static int tau_sendto(tr_session* session, struct evutil_addrinfo* ai, tr_port p
 
     for (l = session->udp_sockets; l; l = l->next)
     {
-        const struct tr_bindinfo * b = l->data;
+        struct tr_bindinfo const* b = l->data;
+
         if (b->socket == TR_BAD_SOCKET)
+        {
             continue;
+        }
         if ((ai->ai_addr->sa_family == AF_INET && b->addr->type == TR_AF_INET) ||
             (ai->ai_addr->sa_family == AF_INET6 && b->addr->type == TR_AF_INET6))
+        {
             sendto (b->socket, buf, buflen, 0, ai->ai_addr, ai->ai_addrlen);
+        }
     }
 
     return 0;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -114,6 +114,11 @@ static inline bool tr_address_is_valid(tr_address const* a)
     return a != NULL && (a->type == TR_AF_INET || a->type == TR_AF_INET6);
 }
 
+static inline const tr_address* tr_address_default(tr_address_type type)
+{
+    return type == TR_AF_INET ? &tr_inaddr_any : type == TR_AF_INET6 ? &tr_in6addr_any : NULL;
+}
+
 /***********************************************************************
  * Sockets
  **********************************************************************/

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -128,13 +128,6 @@ void tr_sessionSetEncryption(tr_session* session, tr_encryption_mode mode)
 ****
 ***/
 
-struct tr_bindinfo
-{
-    tr_socket_t socket;
-    tr_address addr;
-    struct event* ev;
-};
-
 static void close_bindinfo(struct tr_bindinfo* b)
 {
     if (b != NULL && b->socket != TR_BAD_SOCKET)
@@ -147,19 +140,18 @@ static void close_bindinfo(struct tr_bindinfo* b)
 
 static void close_incoming_peer_port(tr_session* session)
 {
-    close_bindinfo(session->public_ipv4);
-    close_bindinfo(session->public_ipv6);
+    struct tr_bindinfo* b;
+
+    while ((b = tr_list_pop_front(&session->peer_sockets)))
+    {
+        close_bindinfo(b);
+        tr_free(b);
+    }
 }
 
 static void free_incoming_peer_port(tr_session* session)
 {
-    close_bindinfo(session->public_ipv4);
-    tr_free(session->public_ipv4);
-    session->public_ipv4 = NULL;
-
-    close_bindinfo(session->public_ipv6);
-    tr_free(session->public_ipv6);
-    session->public_ipv6 = NULL;
+    close_incoming_peer_port(session);
 }
 
 static void accept_incoming_peer(evutil_socket_t fd, short what UNUSED, void* vsession)
@@ -182,60 +174,105 @@ static void accept_incoming_peer(evutil_socket_t fd, short what UNUSED, void* vs
 static void open_incoming_peer_port(tr_session* session)
 {
     struct tr_bindinfo* b;
+    int tr_af_type;
+    tr_list const* l;
 
-    /* bind an ipv4 port to listen for incoming peers... */
-    b = session->public_ipv4;
-    b->socket = tr_netBindTCP(&b->addr, session->private_peer_port, false);
-
-    if (b->socket != TR_BAD_SOCKET)
+    /* listen for incoming peers... */
+    for (tr_af_type = 0; tr_af_type < NUM_TR_AF_INET_TYPES; tr_af_type++)
+    for (l = session->public_addrs[tr_af_type]; l; l = l->next)
     {
+        tr_address* addr = l->data;
+        int sock = tr_netBindTCP(addr, session->private_peer_port, false);
+        if (sock == TR_BAD_SOCKET)
+            continue;
+        b = tr_new(struct tr_bindinfo, 1);
+        b->session = session;
+        b->addr = addr;
+        b->socket = sock;
         b->ev = event_new(session->event_base, b->socket, EV_READ | EV_PERSIST, accept_incoming_peer, session);
         event_add(b->ev, NULL);
-    }
-
-    /* and do the exact same thing for ipv6, if it's supported... */
-    if (tr_net_hasIPv6(session->private_peer_port))
-    {
-        b = session->public_ipv6;
-        b->socket = tr_netBindTCP(&b->addr, session->private_peer_port, false);
-
-        if (b->socket != TR_BAD_SOCKET)
-        {
-            b->ev = event_new(session->event_base, b->socket, EV_READ | EV_PERSIST, accept_incoming_peer, session);
-            event_add(b->ev, NULL);
-        }
+        tr_list_append(&session->peer_sockets, b);
     }
 }
 
-tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_af_type, bool* is_default_value)
+tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_af_type, int idx)
 {
-    char const* default_value;
-    struct tr_bindinfo const* bindinfo;
+    tr_list const* l;
 
-    switch (tr_af_type)
+    if (tr_af_type >= NUM_TR_AF_INET_TYPES)
+        return 0;
+
+    if (idx < 0)
+        idx = tr_rand_int_weak(tr_list_size(session->public_addrs[tr_af_type]));
+
+    for (l = session->public_addrs[tr_af_type]; l; l = l->next)
     {
-    case TR_AF_INET:
-        bindinfo = session->public_ipv4;
-        default_value = TR_DEFAULT_BIND_ADDRESS_IPV4;
-        break;
-
-    case TR_AF_INET6:
-        bindinfo = session->public_ipv6;
-        default_value = TR_DEFAULT_BIND_ADDRESS_IPV6;
-        break;
-
-    default:
-        bindinfo = NULL;
-        default_value = "";
-        break;
+        if (idx-- == 0)
+            return l->data;
     }
 
-    if (is_default_value != NULL && bindinfo != NULL)
+    return 0;
+}
+
+char const* tr_sessionGetBindAddress(tr_session const* session, int tr_af_type)
+{
+    static char* buf = NULL;
+    static size_t bufsize = 0;
+    tr_list const* l;
+    size_t len = 0;
+
+    assert(tr_af_type < NUM_TR_AF_INET_TYPES);
+     
+    for (l = session->public_addrs[tr_af_type]; l; l = l->next)
     {
-        *is_default_value = tr_strcmp0(default_value, tr_address_to_string(&bindinfo->addr)) == 0;
+        char const* s = tr_address_to_string(l->data);
+        int n = strlen(s);
+
+        if (len+n+1 > bufsize)
+            buf = tr_realloc(buf, bufsize = len+n+1);
+        memcpy(buf+len, s, n); len += n;
+        buf[len++] = ',';
     }
 
-    return bindinfo != NULL ? &bindinfo->addr : NULL;
+    if (buf == NULL)
+        buf = tr_malloc(bufsize = len = 1);
+    buf[--len] = '\0';
+    return buf;
+}
+
+void tr_sessionAddBindAddress(tr_session* session, int tr_af_type, char const* str)
+{
+    tr_address addr;
+
+    if (!tr_address_from_string(&addr, str))
+        return;
+
+    if (!tr_list_find(session->public_addrs[tr_af_type], &addr, (TrListCompareFunc)tr_address_compare))
+    {
+        tr_address* a = tr_memdup(&addr, sizeof(tr_address));
+        tr_list_append(&session->public_addrs[tr_af_type], a);
+    }
+}
+
+void tr_sessionSetBindAddress(tr_session* session, int tr_af_type, char const* str)
+{
+    assert(tr_af_type < NUM_TR_AF_INET_TYPES);
+
+    if (session->public_addrs[tr_af_type])
+    {
+        tr_list_free(&session->public_addrs[tr_af_type], tr_free);
+    }
+
+    if (str)
+    {
+        char* temp = tr_strdup (str);
+        char* walk = temp;
+        char const* token;
+        while ((token = tr_strsep(&walk, ", ")))
+            if (*token)
+                tr_sessionAddBindAddress(session, tr_af_type, token);
+        tr_free(temp);
+    }
 }
 
 /***
@@ -462,8 +499,8 @@ void tr_sessionGetSettings(tr_session* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, tr_sessionIsSpeedLimited(s, TR_UP));
     tr_variantDictAddInt(d, TR_KEY_umask, s->umask);
     tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, s->uploadSlotsPerTorrent);
-    tr_variantDictAddStr(d, TR_KEY_bind_address_ipv4, tr_address_to_string(&s->public_ipv4->addr));
-    tr_variantDictAddStr(d, TR_KEY_bind_address_ipv6, tr_address_to_string(&s->public_ipv6->addr));
+    tr_variantDictAddStr(d, TR_KEY_bind_address_ipv4, tr_sessionGetBindAddress(s, TR_AF_INET));
+    tr_variantDictAddStr(d, TR_KEY_bind_address_ipv6, tr_sessionGetBindAddress(s, TR_AF_INET6));
     tr_variantDictAddBool(d, TR_KEY_start_added_torrents, !tr_sessionGetPaused(s));
     tr_variantDictAddBool(d, TR_KEY_trash_original_torrent_files, tr_sessionGetDeleteSource(s));
 }
@@ -608,8 +645,6 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
 
     /* initialize the bare skeleton of the session object */
     session = tr_new0(tr_session, 1);
-    session->udp_socket = TR_BAD_SOCKET;
-    session->udp6_socket = TR_BAD_SOCKET;
     session->lock = tr_lockNew();
     session->cache = tr_cacheNew(1024 * 1024 * 2);
     session->magicNumber = SESSION_MAGIC_NUMBER;
@@ -776,7 +811,7 @@ static void tr_sessionInitImpl(void* vdata)
 
     if (session->isLPDEnabled)
     {
-        tr_lpdInit(session, &session->public_ipv4->addr);
+        tr_lpdInit(session, NULL);
     }
 
     /* cleanup */
@@ -801,7 +836,6 @@ static void sessionSetImpl(void* vdata)
     double d;
     bool boolVal;
     char const* str;
-    struct tr_bindinfo b;
     struct tr_turtle_info* turtle = &session->turtle;
 
     if (tr_variantDictFindInt(settings, TR_KEY_message_level, &i))
@@ -965,28 +999,15 @@ static void sessionSetImpl(void* vdata)
     session->rpcServer = tr_rpcInit(session, settings);
 
     /* public addresses */
-
-    free_incoming_peer_port(session);
-
-    tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, NULL);
-
-    if (!tr_address_from_string(&b.addr, str) || b.addr.type != TR_AF_INET)
+    if (tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, NULL))
     {
-        b.addr = tr_inaddr_any;
+        tr_sessionSetBindAddress(session, TR_AF_INET, str);
     }
 
-    b.socket = TR_BAD_SOCKET;
-    session->public_ipv4 = tr_memdup(&b, sizeof(struct tr_bindinfo));
-
-    tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, NULL);
-
-    if (!tr_address_from_string(&b.addr, str) || b.addr.type != TR_AF_INET6)
+    if (tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, NULL))
     {
-        b.addr = tr_in6addr_any;
+        tr_sessionSetBindAddress(session, TR_AF_INET6, str);
     }
-
-    b.socket = TR_BAD_SOCKET;
-    session->public_ipv6 = tr_memdup(&b, sizeof(struct tr_bindinfo));
 
     /* incoming peer port */
     if (tr_variantDictFindInt(settings, TR_KEY_peer_port_random_low, &i))
@@ -2311,7 +2332,7 @@ static void toggleLPDImpl(void* data)
 
     if (session->isLPDEnabled)
     {
-        tr_lpdInit(session, &session->public_ipv4->addr);
+        tr_lpdInit(session, NULL);
     }
 }
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -49,7 +49,6 @@ struct evdns_base;
 struct tr_address;
 struct tr_announcer;
 struct tr_announcer_udp;
-struct tr_bindsockets;
 struct tr_cache;
 struct tr_fdInfo;
 struct tr_device_info;
@@ -91,6 +90,14 @@ struct tr_turtle_info
 
     /* recent action that was done by turtle's automatic switch */
     tr_auto_switch_state_t autoTurtleState;
+};
+
+struct tr_bindinfo
+{
+    tr_socket_t socket;
+    const tr_address* addr;
+    struct event* ev;
+    struct tr_session* session;
 };
 
 /** @brief handle to an active libtransmission session */
@@ -149,16 +156,13 @@ struct tr_session
 
     /* The UDP sockets used for the DHT and uTP. */
     tr_port udp_port;
-    tr_socket_t udp_socket;
-    tr_socket_t udp6_socket;
-    unsigned char* udp6_bound;
-    struct event* udp_event;
-    struct event* udp6_event;
+    struct tr_list* udp_sockets;
 
     struct event* utp_timer;
 
     /* The open port on the local machine for incoming peer requests */
     tr_port private_peer_port;
+    struct tr_list* peer_sockets;
 
     /**
      * The open port on the public device for incoming peer requests.
@@ -220,8 +224,7 @@ struct tr_session
 
     uint16_t idleLimitMinutes;
 
-    struct tr_bindinfo* public_ipv4;
-    struct tr_bindinfo* public_ipv6;
+    struct tr_list* public_addrs[NUM_TR_AF_INET_TYPES];
 };
 
 static inline tr_port tr_sessionGetPublicPeerPort(tr_session const* session)
@@ -245,7 +248,7 @@ void tr_sessionUnlock(tr_session*);
 
 bool tr_sessionIsLocked(tr_session const*);
 
-struct tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_af_type, bool* is_default_value);
+struct tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_af_type, int idx);
 
 struct tr_bindsockets* tr_sessionGetBindSockets(tr_session*);
 

--- a/libtransmission/tr-udp.c
+++ b/libtransmission/tr-udp.c
@@ -119,7 +119,7 @@ void tr_udpSetSocketBuffers(tr_session* session)
 
     for (l = session->udp_sockets; l; l = l->next)
     {
-	b = l->data;
+        b = l->data;
         set_socket_buffers(b->socket, utp);
     }
 }
@@ -131,11 +131,11 @@ static struct tr_bindinfo* find_socket(tr_session* session, int s)
 
     for (l = session->udp_sockets; l; l = l->next)
     {
-	b = l->data;
-	if (b->socket == s)
-	{
-	    return b;
-	}
+        b = l->data;
+        if (b->socket == s)
+        {
+            return b;
+        }
     }
 
     return NULL;
@@ -214,8 +214,8 @@ void tr_udpInit(tr_session* ss)
     while ((public_addr = tr_sessionGetPublicAddress(ss, TR_AF_INET, idx++)))
     {
         struct sockaddr_in sin;
-	struct tr_bindinfo* b;
-	int sock;
+        struct tr_bindinfo* b;
+        int sock;
 
         memset(&sin, 0, sizeof(sin));
         sin.sin_family = AF_INET;
@@ -224,14 +224,14 @@ void tr_udpInit(tr_session* ss)
 
         sock = socket(PF_INET, SOCK_DGRAM, 0);
         if (sock == TR_BAD_SOCKET)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't create IPv4 socket");
             break;
         }
 
         rc = bind(sock, (struct sockaddr*)&sin, sizeof(sin));
         if (rc < 0)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't bind IPv4 socket");
             tr_netCloseSocket(sock);
             continue;
@@ -243,13 +243,13 @@ void tr_udpInit(tr_session* ss)
         b->session = ss;
         b->ev = event_new(ss->event_base, sock, EV_READ | EV_PERSIST, event_callback, ss);
         if (b->ev == NULL)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't allocate IPv4 event");
-	}
-	else
-	{
-	    event_add(b->ev, NULL);
-	}
+        }
+        else
+        {
+            event_add(b->ev, NULL);
+        }
         tr_list_append(&ss->udp_sockets, b);
     }
 
@@ -257,8 +257,8 @@ void tr_udpInit(tr_session* ss)
     while ((public_addr = tr_sessionGetPublicAddress(ss, TR_AF_INET6, idx++)))
     {
         struct sockaddr_in6 sin6;
-	struct tr_bindinfo* b;
-	int sock;
+        struct tr_bindinfo* b;
+        int sock;
 
         memset(&sin6, 0, sizeof(sin6));
         sin6.sin6_family = AF_INET6;
@@ -266,25 +266,25 @@ void tr_udpInit(tr_session* ss)
         sin6.sin6_port = htons(ss->udp_port);
 
         if (!tr_address_compare(public_addr, tr_address_default(TR_AF_INET6)))
-	{
+        {
             const unsigned char *ipv6 = tr_globalIPv6();
             if (!ipv6)
-	    {
-		continue;
-	    }
+            {
+                continue;
+            }
             memcpy(&sin6.sin6_addr, ipv6, sizeof(struct in6_addr));
         }
 
         sock = socket(PF_INET6, SOCK_DGRAM, 0);
         if (sock == TR_BAD_SOCKET)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't create IPv6 socket");
             break;
         }
 
         rc = bind(sock, (struct sockaddr*)&sin6, sizeof(sin6));
         if (rc < 0)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't bind IPv6 socket");
             tr_netCloseSocket(sock);
             continue;
@@ -296,13 +296,13 @@ void tr_udpInit(tr_session* ss)
         b->session = ss;
         b->ev = event_new(ss->event_base, sock, EV_READ | EV_PERSIST, event_callback, ss);
         if (b->ev == NULL)
-	{
+        {
             tr_logAddNamedError("UDP", "Couldn't allocate IPv6 event");
-	}
-	else
-	{
-	    event_add(b->ev, NULL);
-	}
+        }
+        else
+        {
+            event_add(b->ev, NULL);
+        }
         tr_list_append(&ss->udp_sockets, b);
     }
 
@@ -323,11 +323,11 @@ void tr_udpUninit(tr_session* ss)
     while ((b = tr_list_pop_front(&ss->udp_sockets)))
     {
         if (b->socket != TR_BAD_SOCKET)
-	{
+        {
             tr_netCloseSocket(b->socket);
         }
         if (b->ev)
-	{
+        {
             event_free(b->ev);
         }
         tr_free (b);
@@ -340,30 +340,30 @@ struct tr_bindinfo* tr_udpGetSocket(tr_session* ss, int tr_af_type, int idx)
 
     while ((a = tr_sessionGetPublicAddress(ss, tr_af_type, idx)))
     {
-	tr_list const* l;
+        tr_list const* l;
         int count = 0;
 
         for (l = ss->udp_sockets; l; l = l->next)
-	{
+        {
             struct tr_bindinfo* b = l->data;
 
             if (b->socket == TR_BAD_SOCKET)
-	    {
+            {
                 continue;
-	    }
+            }
             if (b->addr == a)
-	    {
+            {
                 return b;
-	    }
+            }
             if (b->addr->type == tr_af_type)
-	    {
+            {
                 count++;
-	    }
+            }
         }
         if (count == 0 || idx >= 0)
-	{
+        {
             break;
-	}
+        }
     }
 
     return NULL;

--- a/libtransmission/tr-udp.h
+++ b/libtransmission/tr-udp.h
@@ -30,5 +30,6 @@ THE SOFTWARE.
 void tr_udpInit(tr_session*);
 void tr_udpUninit(tr_session*);
 void tr_udpSetSocketBuffers(tr_session*);
+struct tr_bindinfo* tr_udpGetSocket(tr_session*, int tr_af_type, int idx);
 
 bool tau_handle_message(tr_session* session, uint8_t const* msg, size_t msglen);

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #error only libtransmission should #include this header.
 #endif
 
-int tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, tr_session* ss);
+int tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, struct tr_bindinfo* b);
 
 void tr_utpClose(tr_session*);
 

--- a/libtransmission/web.c
+++ b/libtransmission/web.c
@@ -176,7 +176,6 @@ static long getTimeoutFromURL(struct tr_web_task const* task)
 
 static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* task)
 {
-    bool is_default_value;
     tr_address const* addr;
     CURL* e = task->curl_easy = curl_easy_init();
 
@@ -211,11 +210,11 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
     curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
     curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);
 
-    if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET, &is_default_value)) != NULL && !is_default_value)
+    if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET, -1)) != NULL && tr_address_compare(addr, tr_address_default(TR_AF_INET)))
     {
         curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
     }
-    else if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, &is_default_value)) != NULL && !is_default_value)
+    else if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, -1)) != NULL && tr_address_compare(addr, tr_address_default(TR_AF_INET6)))
     {
         curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
     }


### PR DESCRIPTION
I've recently found myself in need of distributing a huge amount of data and I could not fully take advantage of my two upstream ISPs with the existing code, so I went ahead and added the multihoming support. Now that the project is done, I thought someone else might benefit from this effort.

It's straightforward to use: instead of a single address, set bind-address-ipv4 or bind-address-ipv6 to a comma or space separated list of addresses.
