### PR TITLE
Fix setting the ETA timestamps

### DIFF
--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -1429,10 +1429,10 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     case TR_STATUS_DOWNLOAD:
         if (tor->etaDLSpeedCalculatedAt + 800 < now)
         {
-            tor->etaDLSpeedCalculatedAt = now;
             tor->etaDLSpeed_Bps = tor->etaDLSpeedCalculatedAt + 4000 < now ?
                 pieceDownloadSpeed_Bps : /* if no recent previous speed, no need to smooth */
                 (tor->etaDLSpeed_Bps * 4.0 + pieceDownloadSpeed_Bps) / 5.0; /* smooth across 5 readings */
+            tor->etaDLSpeedCalculatedAt = now;
         }
 
         if (s->leftUntilDone > s->desiredAvailable && tor->info.webseedCount < 1)
@@ -1460,10 +1460,10 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
         {
             if (tor->etaULSpeedCalculatedAt + 800 < now)
             {
-                tor->etaULSpeedCalculatedAt = now;
                 tor->etaULSpeed_Bps = tor->etaULSpeedCalculatedAt + 4000 < now ?
                     pieceUploadSpeed_Bps : /* if no recent previous speed, no need to smooth */
                     (tor->etaULSpeed_Bps * 4.0 + pieceUploadSpeed_Bps) / 5.0; /* smooth across 5 readings */
+                tor->etaULSpeedCalculatedAt = now;
             }
 
             if (tor->etaULSpeed_Bps == 0)


### PR DESCRIPTION
Field `etaDLSpeedCalculatedAt` was set too early, causing the condition following it to always be false (the 4000 ms comparison with `now`). The same for `etaULSpeedCalculatedAt`.