### PR TITLE
Qt: Fix bad downloaded percentage in DetailsDialog

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -513,7 +513,7 @@ void DetailsDialog::refresh()
             }
         }
 
-        double const d = 100.0 * (sizeWhenDone != 0 ? (sizeWhenDone - leftUntilDone) / sizeWhenDone : 1);
+        double const d = sizeWhenDone != 0 ? 100.0 * (sizeWhenDone - leftUntilDone) / sizeWhenDone : 100.0;
         QString pct = Formatter::percentToString(d);
 
         if (haveUnverified == 0 && leftUntilDone == 0)


### PR DESCRIPTION
It was always 0.0% as long as the torrent was not finished.