### PR TITLE
fix logic for setting the curl ca bundle file

### DIFF
--- a/libtransmission/web.c
+++ b/libtransmission/web.c
@@ -196,7 +196,10 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
 
     if (web->curl_ssl_verify)
     {
-        curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
+        if (web->curl_ca_bundle != NULL)
+        {
+            curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
+        }
     }
     else
     {


### PR DESCRIPTION
This fix is needed to successfully connect to https trackers with default settings.

@realPy has mentioned this bug in the comments for https://github.com/transmission/transmission/commit/44411d719c0bd6c17a794ab03eb8148f20a79b81 but I think @mikedld misunderstood what the issue actually was so this never got fixed