### PR TITLE
transmission-show: Prevent crash with invalid creation date

### DIFF
--- a/utils/show.c
+++ b/utils/show.c
@@ -93,6 +93,33 @@ static int compare_files_by_name(void const* va, void const* vb)
     return strcmp(a->name, b->name);
 }
 
+static char const* unix_timestamp_to_str(time_t timestamp)
+{
+    if (timestamp == 0)
+    {
+        return "Unknown";
+    }
+
+    struct tm const* const local_time = localtime(&timestamp);
+
+    if (local_time == NULL)
+    {
+        return "Invalid";
+    }
+
+    static char buffer[32];
+    tr_strlcpy(buffer, asctime(local_time), TR_N_ELEMENTS(buffer));
+
+    char* const newline_pos = strchr(buffer, '\n');
+
+    if (newline_pos != NULL)
+    {
+        *newline_pos = '\0';
+    }
+
+    return buffer;
+}
+
 static void showInfo(tr_info const* inf)
 {
     char buf[128];
@@ -107,23 +134,7 @@ static void showInfo(tr_info const* inf)
     printf("  Name: %s\n", inf->name);
     printf("  Hash: %s\n", inf->hashString);
     printf("  Created by: %s\n", inf->creator ? inf->creator : "Unknown");
-
-    if (inf->dateCreated == 0)
-    {
-        printf("  Created on: Unknown\n");
-    }
-    else
-    {
-        struct tm *created_on = localtime(&inf->dateCreated);
-        if (created_on == NULL)
-        {
-            printf("  Created on: Invalid date\n");
-        }
-        else
-        {
-            printf("  Created on: %s", asctime(created_on));
-        }
-    }
+    printf("  Created on: %s\n", unix_timestamp_to_str(inf->dateCreated));
 
     if (inf->comment != NULL && *inf->comment != '\0')
     {

--- a/utils/show.c
+++ b/utils/show.c
@@ -114,8 +114,15 @@ static void showInfo(tr_info const* inf)
     }
     else
     {
-        struct tm tm = *localtime(&inf->dateCreated);
-        printf("  Created on: %s", asctime(&tm));
+        struct tm *created_on = localtime(&inf->dateCreated);
+        if (created_on == NULL)
+        {
+            printf("  Created on: Invalid date\n");
+        }
+        else
+        {
+            printf("  Created on: %s", asctime(created_on));
+        }
     }
 
     if (inf->comment != NULL && *inf->comment != '\0')


### PR DESCRIPTION
`transmission-show` does not check the return value of `localtime`. If a torrent file with an invalid creation date is shown, the return value for `localtime` may be `NULL`. Since the value is immediately dereferenced, the program crashes with a segfault.

This PR checks the return value of `localtime` before displaying the date.