### PR TITLE
use metainfo folder instead of appdata

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -199,7 +199,7 @@ endif()
 
 if(ENABLE_NLS)
     install(FILES ${${PROJECT_NAME}_DESKTOP_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-    install(FILES ${${PROJECT_NAME}_APPDATA_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/appdata)
+    install(FILES ${${PROJECT_NAME}_APPDATA_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 else()
     install(FILES transmission-gtk.desktop.in DESTINATION ${CMAKE_INSTALL_DATADIR}/applications RENAME ${TR_NAME}-gtk.desktop)
 endif()


### PR DESCRIPTION
Lintian tag: appstream-metadata-in-legacy-location

AppStream metadata file was found in /usr/share/appdata/. The AppStream
XML files should be placed in /usr/share/metainfo/.

Refer to https://wiki.debian.org/AppStream/Guidelines for details.