### PR TITLE
Rawhash

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -307,7 +307,7 @@ int tr_main(int argc, char* argv[])
     {
         tr_ctorSetMetainfo(ctor, fileContents, fileLength);
     }
-    else if (memcmp(torrentPath, "magnet:?", 8) == 0)
+    else if (memcmp(torrentPath, "magnet:?", 8) == 0 || tr_maybeHash(torrentPath))
     {
         tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath);
     }
@@ -320,10 +320,6 @@ int tr_main(int argc, char* argv[])
         {
             tr_wait_msec(1000);
         }
-    }
-    else if (tr_maybeHash(torrentPath))
-    {
-        tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath);
     }
     else
     {

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -307,7 +307,7 @@ int tr_main(int argc, char* argv[])
     {
         tr_ctorSetMetainfo(ctor, fileContents, fileLength);
     }
-    else if (memcmp(torrentPath, "magnet:?", 8) == 0 || tr_maybeHash(torrentPath))
+    else if (tr_isMagnet(torrentPath) || tr_maybeHash(torrentPath))
     {
         tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath);
     }

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -321,6 +321,10 @@ int tr_main(int argc, char* argv[])
             tr_wait_msec(1000);
         }
     }
+    else if (tr_maybeHash(torrentPath))
+    {
+        tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath);
+    }
     else
     {
         fprintf(stderr, "ERROR: Unrecognized torrent \"%s\".\n", torrentPath);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1208,8 +1208,7 @@ bool Session::Impl::add_file(Glib::RefPtr<Gio::File> const& file, bool do_start,
 
             if (gtr_is_hex_hashcode(str))
             {
-                auto const magnet = gtr_sprintf("magnet:?xt=urn:btih:%s", str);
-                loaded = !tr_ctorSetMetainfoFromMagnetLink(ctor, magnet.c_str());
+                loaded = !tr_ctorSetMetainfoFromMagnetLink(ctor, str.c_str());
             }
         }
 

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -7,7 +7,6 @@
  */
 
 #include <array>
-#include <ctype.h> /* isxdigit() */
 #include <errno.h>
 #include <limits.h> /* INT_MAX */
 #include <stdarg.h>
@@ -177,25 +176,12 @@ bool gtr_is_supported_url(Glib::ustring const& str)
 
 bool gtr_is_magnet_link(Glib::ustring const& str)
 {
-    return !str.empty() && Glib::str_has_prefix(str, "magnet:?");
+    return tr_isMagnet(str.c_str());
 }
 
 bool gtr_is_hex_hashcode(std::string const& str)
 {
-    if (str.size() != 40)
-    {
-        return false;
-    }
-
-    for (int i = 0; i < 40; ++i)
-    {
-        if (!isxdigit(str[i]))
-        {
-            return false;
-        }
-    }
-
-    return true;
+    return tr_maybeHash(str.c_str());
 }
 
 namespace

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -38,8 +38,6 @@ static int constexpr base32Lookup[] = {
     0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF /* 'x', 'y', 'z', '{', '|', '}', '~', 'DEL' */
 };
 
-static int const base32LookupLen = TR_N_ELEMENTS(base32Lookup);
-
 static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
 {
     TR_ASSERT(inlen == 32);
@@ -55,7 +53,7 @@ static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
         int lookup = in[i] - '0';
 
         /* Skip chars outside the lookup table */
-        if (lookup < 0 || lookup >= base32LookupLen)
+        if (lookup < 0) /* Assume char type never will be unsigned, so don't check upper limit */
         {
             continue;
         }
@@ -135,7 +133,7 @@ static bool tr_isBase32(char const* in, size_t const inlen)
     {
         int lookup = in[i] - '0';
 
-        if (lookup < 0 || lookup >= base32LookupLen)
+        if (lookup < 0) /* Assume char type never will be unsigned, so don't check upper limit */
         {
             return false;
         }

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -38,6 +38,8 @@ static int constexpr base32Lookup[] = {
     0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF /* 'x', 'y', 'z', '{', '|', '}', '~', 'DEL' */
 };
 
+static int const base32LookupLen = TR_N_ELEMENTS(base32Lookup);
+
 static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
 {
     TR_ASSERT(inlen == 32);
@@ -53,7 +55,7 @@ static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
         int lookup = in[i] - '0';
 
         /* Skip chars outside the lookup table */
-        if (lookup < 0)
+        if (lookup < 0 || lookup >= base32LookupLen)
         {
             continue;
         }

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -105,20 +105,22 @@ static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
 ****
 ***/
 
-static bool tr_isHex(const char* in, const size_t inlen)
+static bool tr_isHex(char const* in, size_t const inlen)
 {
     size_t i;
 
     for (i = 0; i < inlen; ++i)
     {
         if (!isxdigit(in[i]))
+        {
             return false;
+        }
     }
 
     return true;
 }
 
-static bool tr_isBase32(const char* in, const size_t inlen)
+static bool tr_isBase32(char const* in, size_t const inlen)
 {
     size_t i;
 
@@ -127,10 +129,14 @@ static bool tr_isBase32(const char* in, const size_t inlen)
         int lookup = in[i] - '0';
 
         if (lookup < 0 || lookup >= base32LookupLen)
+        {
             return false;
+        }
 
         if (base32Lookup[lookup] == 0xFF)
+        {
             return false;
+        }
     }
 
     return true;
@@ -149,7 +155,7 @@ bool tr_maybeHash(char const* uri)
     return false;
 }
 
-static bool hash_to_sha1(uint8_t* sha1, const char* hash, size_t hashlen)
+static bool hash_to_sha1(uint8_t* sha1, char const* hash, size_t hashlen)
 {
     if (hashlen == 40)
     {
@@ -252,7 +258,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
     }
     else if (uri != NULL)
     {
-        const size_t hashlen = strlen(uri);
+        size_t const hashlen = strlen(uri);
         got_checksum = hash_to_sha1(sha1, uri, hashlen);
     }
 

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -152,15 +152,21 @@ bool tr_maybeHash(char const* uri)
     size_t len;
 
     if (uri == NULL)
+    {
         return false;
+    }
 
     len = strlen(uri);
 
     if ((len == 32) && tr_isBase32(uri, len))
+    {
         return true;
+    }
 
     if ((len == 40) && tr_isHex(uri, len))
+    {
         return true;
+    }
 
     return false;
 }

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -105,6 +105,11 @@ static void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
 ****
 ***/
 
+bool tr_isMagnet(char const* uri)
+{
+    return uri != NULL && strncmp(uri, "magnet:?", 8) == 0;
+}
+
 static bool tr_isHex(char const* in, size_t const inlen)
 {
     size_t i;
@@ -144,9 +149,14 @@ static bool tr_isBase32(char const* in, size_t const inlen)
 
 bool tr_maybeHash(char const* uri)
 {
-    size_t len = strlen(uri);
+    size_t len;
 
-    if((len == 32) && tr_isBase32(uri, len))
+    if (uri == NULL)
+        return false;
+
+    len = strlen(uri);
+
+    if ((len == 32) && tr_isBase32(uri, len))
         return true;
 
     if ((len == 40) && tr_isHex(uri, len))
@@ -185,7 +195,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
     uint8_t sha1[SHA_DIGEST_LENGTH];
     tr_magnet_info* info = nullptr;
 
-    if (uri != nullptr && strncmp(uri, "magnet:?", 8) == 0)
+    if (tr_isMagnet(uri))
     {
         for (char const* walk = uri + 8; !tr_str_is_empty(walk);)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1834,6 +1834,10 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         {
             tr_ctorSetMetainfoFromMagnetLink(ctor, fname);
         }
+        else if (tr_maybeHash(fname) && !tr_sys_path_exists(fname, NULL))
+        {
+            tr_ctorSetMetainfoFromMagnetLink(ctor, fname);
+        }
         else
         {
             tr_ctorSetMetainfoFromFile(ctor, fname);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1830,7 +1830,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
             tr_ctorSetMetainfo(ctor, (uint8_t*)metainfo, len);
             tr_free(metainfo);
         }
-        else if (strncmp(fname, "magnet:?", 8) == 0 || tr_maybeHash(fname))
+        else if (tr_isMagnet(fname) || tr_maybeHash(fname))
         {
             tr_ctorSetMetainfoFromMagnetLink(ctor, fname);
         }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1830,11 +1830,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
             tr_ctorSetMetainfo(ctor, (uint8_t*)metainfo, len);
             tr_free(metainfo);
         }
-        else if (strncmp(fname, "magnet:?", 8) == 0)
-        {
-            tr_ctorSetMetainfoFromMagnetLink(ctor, fname);
-        }
-        else if (tr_maybeHash(fname) && !tr_sys_path_exists(fname, NULL))
+        else if (strncmp(fname, "magnet:?", 8) == 0 || tr_maybeHash(fname))
         {
             tr_ctorSetMetainfoFromMagnetLink(ctor, fname);
         }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -971,6 +971,10 @@ void tr_metainfoFree(tr_info* inf);
  */
 tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_duplicate_id);
 
+
+/** @brief Check if uri may be interpreted as raw hash */
+bool tr_maybeHash(char const* uri);
+
 /** @} */
 
 /***********************************************************************

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -971,6 +971,8 @@ void tr_metainfoFree(tr_info* inf);
  */
 tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_duplicate_id);
 
+/** @brief Check if uri is 'magnet:' (with NULL check) */
+bool tr_isMagnet(char const* uri);
 
 /** @brief Check if uri may be interpreted as raw hash */
 bool tr_maybeHash(char const* uri);

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -62,7 +62,7 @@ int AddData::set(QString const& key)
     }
     else if (Utils::isHexHashcode(key))
     {
-        magnet = QStringLiteral("magnet:?xt=urn:btih:") + key;
+        magnet = key;
         type = MAGNET;
     }
     else

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1562,7 +1562,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 
     if (mime->hasFormat(QStringLiteral("application/x-bittorrent")) || mime->hasUrls() ||
         mime->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
-        mime->text().startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
+        Utils::isMagnetLink(mime->text()) || Utils::isHexHashcode(mime->text()))
     {
         event->acceptProposedAction();
     }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1561,8 +1561,8 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
     QMimeData const* mime = event->mimeData();
 
     if (mime->hasFormat(QStringLiteral("application/x-bittorrent")) || mime->hasUrls() ||
-        mime->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
-        Utils::isMagnetLink(mime->text()) || Utils::isHexHashcode(mime->text()))
+        mime->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) || Utils::isMagnetLink(mime->text()) ||
+        Utils::isHexHashcode(mime->text()))
     {
         event->acceptProposedAction();
     }

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <cctype> // isxdigit()
 #include <functional>
+#include <libtransmission/transmission.h>
 
 #include <QHash>
 #include <QPointer>
@@ -84,25 +84,12 @@ public:
 
     static bool isMagnetLink(QString const& s)
     {
-        return s.startsWith(QStringLiteral("magnet:?"));
+        return tr_isMagnet(s.toUtf8().constData());
     }
 
     static bool isHexHashcode(QString const& s)
     {
-        if (s.length() != 40)
-        {
-            return false;
-        }
-
-        for (auto const& ch : s)
-        {
-            if (!isxdigit(ch.unicode()))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return tr_maybeHash(s.toUtf8().constData());
     }
 
     static bool isUriWithSupportedScheme(QString const& s)


### PR DESCRIPTION
 Add support for raw magnet hash (without 'magnet:' prefix) to transmission-cli and transmission-remote (RPC).