### PR TITLE
Service startup heeds options

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -3,9 +3,9 @@ Description=Transmission BitTorrent Daemon
 After=network.target
 
 [Service]
-User=transmission
+User=$USER
 Type=notify
-ExecStart=/usr/bin/transmission-daemon -f --log-error
+ExecStart=/usr/bin/transmission-daemon -f --log-error $OPTIONS
 ExecReload=/bin/kill -s HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Things like alternative user to start under or config directory are nicely setup in /etc/default/transmission-daemon and /etc/init.d/transmission-daemon, but are then overwritten with hardcoded values in the service file.