### PR TITLE
web: fix sorting of renamed torrents by name

### DIFF
--- a/web/javascript/torrent.js
+++ b/web/javascript/torrent.js
@@ -186,6 +186,12 @@ Torrent.prototype = {
                     changed |= this.setField(this.fields, key, data[key]);
                 };
                 break;
+            case 'name':
+                if (this.setField(this.fields, key, data[key])) {
+                    this.fields.collatedName = '';
+                    changed = true;
+                };
+                break;
             default:
                 changed |= this.setField(this.fields, key, data[key]);
             };


### PR DESCRIPTION
collatedName was not being recalculated on torrent renames, preserving
the old ordering