### PR TITLE
Change order of checks to reduce work in cache_block_compare

### DIFF
--- a/libtransmission/cache.c
+++ b/libtransmission/cache.c
@@ -293,16 +293,16 @@ static int cache_block_compare(void const* va, void const* vb)
     struct cache_block const* a = va;
     struct cache_block const* b = vb;
 
-    /* primary key: torrent id */
-    if (a->tor->uniqueId != b->tor->uniqueId)
-    {
-        return a->tor->uniqueId < b->tor->uniqueId ? -1 : 1;
-    }
-
-    /* secondary key: block # */
+    /* key: block # */
     if (a->block != b->block)
     {
         return a->block < b->block ? -1 : 1;
+    }
+
+    /* key: torrent id */
+    if (a->tor->uniqueId != b->tor->uniqueId)
+    {
+        return a->tor->uniqueId < b->tor->uniqueId ? -1 : 1;
     }
 
     /* they're equal */


### PR DESCRIPTION
Cache_block_compare compares two blocks on both torrent ID and block number. If we assume we download a low number of torrents with a large number of blocks, the block number is more often different than the torrent ID. This means we get a performance improvement if we check the block number before the torrent ID.

This reduces the distinction between "primary" and "secondary" key. It would be more logical to check the primary key before the secondary key, but there is really no order in these keys.