### PR TITLE
Correct handling of begin and end variables in countRange

### DIFF
--- a/libtransmission/bitfield-test.c
+++ b/libtransmission/bitfield-test.c
@@ -39,7 +39,7 @@ static int test_bitfield_count_range(void)
     }
     while (end == begin);
 
-    /* ensure end <= begin */
+    /* ensure begin <= end */
     if (end < begin)
     {
         int const tmp = begin;

--- a/libtransmission/bitfield.c
+++ b/libtransmission/bitfield.c
@@ -122,7 +122,7 @@ static size_t countRange(tr_bitfield const* b, size_t begin, size_t end)
         }
     }
 
-    TR_ASSERT(ret <= (begin - end));
+    TR_ASSERT(ret <= (end - begin));
     return ret;
 }
 


### PR DESCRIPTION
We check from begin to end, excluding end. This means that at most end - begin bits are enabled. Assert that the return value of countRange is indeed less than the total number of bits that we checked.

This used to be begin - end, and the reason that worked was because both are unsigned. The subtraction wraps around and the assertion tests that the return value is less than 4 billion and something.

Begin should be smaller than end. The code reflects this, since we swap them if end < begin. Now the comment correctly states this too.