### PR TITLE
avoid memory copies/compactions on cache access, add benchmarks for file writes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 set(CMAKE_MACOSX_RPATH ON)
 
+include(CheckCSourceRuns)
 include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
@@ -479,6 +480,38 @@ foreach(F ${NEEDED_FUNCTIONS})
         add_definitions(-DHAVE_${F_ID})
     endif()
 endforeach()
+
+check_c_source_runs(
+      "
+    #include <stdlib.h>
+    #include <time.h>
+    #include <sys/time.h>
+    int main(void)
+    {
+        int ret;
+        struct timespec ts;
+        ret = clock_gettime(CLOCK_MONOTONIC, &ts);
+        exit(ret);
+        return 0;
+    }
+    "
+      HAVE_CLOCK_MONOTONIC)
+
+check_c_source_runs(
+      "
+    #include <stdlib.h>
+    #include <time.h>
+    #include <sys/time.h>
+    int main(void)
+    {
+        int ret;
+        struct timespec ts;
+        ret = clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+        exit(ret);
+        return 0;
+    }
+    "
+      HAVE_CLOCK_MONOTONIC_RAW)
 
 if(ICONV_FOUND)
     add_definitions(-DHAVE_ICONV)

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -36,7 +36,7 @@ int tr_cacheWriteBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t pi
     struct evbuffer* writeme);
 
 int tr_cacheReadBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t piece, uint32_t offset, uint32_t len,
-    uint8_t* setme);
+    struct evbuffer* setme);
 
 int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t piece, uint32_t offset, uint32_t len);
 

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -10,6 +10,7 @@
 
 #include <inttypes.h>
 #include <time.h>
+#include <event2/buffer.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -394,6 +395,25 @@ bool tr_sys_file_read_at(tr_sys_file_t handle, void* buffer, uint64_t size, uint
     struct tr_error** error);
 
 /**
+ * @brief Like `pread()`, except that the position is undefined afterwards.
+ *        Not thread-safe.
+ *
+ * @param[in]  handle     Valid file descriptor.
+ * @param[out] evbuf      evbuffer to which to store data read.
+ * @param[in]  size       Number of bytes to read.
+ * @param[in]  offset     File offset in bytes to start reading from.
+ * @param[out] bytes_read Number of bytes actually read. Optional, pass `NULL`
+ *                        if you are not interested.
+ * @param[out] error      Pointer to error object. Optional, pass `NULL` if you
+ *                        are not interested in error details.
+ *
+ * @return `True` on success, `false` otherwise (with `error` set accordingly).
+ */
+bool tr_sys_file_read_evbuffer_at(tr_sys_file_t handle, struct evbuffer* evbuf, uint64_t size, uint64_t offset, uint64_t* bytes_read,
+    struct tr_error** error);
+
+
+/**
  * @brief Portability wrapper for `write()`.
  *
  * @param[in]  handle        Valid file descriptor.
@@ -426,6 +446,25 @@ bool tr_sys_file_write(tr_sys_file_t handle, void const* buffer, uint64_t size, 
  */
 bool tr_sys_file_write_at(tr_sys_file_t handle, void const* buffer, uint64_t size, uint64_t offset, uint64_t* bytes_written,
     struct tr_error** error);
+
+/**
+ * @brief Like `pwrite()`, except that the position is undefined afterwards.
+ *        Not thread-safe.
+ *
+ * @param[in]  handle        Valid file descriptor.
+ * @param[in]  evbuf         evbuffer from which to get data.
+ * @param[in]  size          Number of bytes to write.
+ * @param[in]  offset        File offset in bytes to start writing from.
+ * @param[out] bytes_written Number of bytes actually written. Optional, pass
+ *                           `NULL` if you are not interested.
+ * @param[out] error         Pointer to error object. Optional, pass `NULL` if you
+ *                           are not interested in error details.
+ *
+ * @return `True` on success, `false` otherwise (with `error` set accordingly).
+ */
+bool tr_sys_file_write_evbuffer_at(tr_sys_file_t handle, struct evbuffer * evbuf, uint64_t size, uint64_t offset, uint64_t * bytes_written,
+				   struct tr_error ** error);
+
 
 /**
  * @brief Portability wrapper for `fsync()`.

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -23,7 +23,7 @@ struct tr_torrent;
  * Reads the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-int tr_ioRead(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, uint8_t* setme);
+int tr_ioRead(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, struct evbuffer* setme);
 
 int tr_ioPrefetch(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uint32_t len);
 
@@ -31,7 +31,7 @@ int tr_ioPrefetch(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, 
  * Writes the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-int tr_ioWrite(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, uint8_t const* writeme);
+int tr_ioWrite(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, struct evbuffer* writeme);
 
 /**
  * @brief Test to see if the piece matches its metainfo's SHA1 checksum.

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -2090,7 +2090,6 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
             int err;
             uint32_t const msglen = 4 + 1 + 4 + 4 + req.length;
             struct evbuffer* out;
-            struct evbuffer_iovec iovec[1];
 
             out = evbuffer_new();
             evbuffer_expand(out, msglen);
@@ -2100,11 +2099,8 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
             evbuffer_add_uint32(out, req.index);
             evbuffer_add_uint32(out, req.offset);
 
-            evbuffer_reserve_space(out, req.length, iovec, 1);
             err = tr_cacheReadBlock(getSession(msgs)->cache, msgs->torrent, req.index, req.offset, req.length,
-                iovec[0].iov_base);
-            iovec[0].iov_len = req.length;
-            evbuffer_commit_space(out, iovec, 1);
+                out);
 
             /* check the piece if it needs checking... */
             if (err == 0 && tr_torrentPieceNeedsCheck(msgs->torrent, req.index))

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -649,6 +649,32 @@ void tr_wait_msec(long int msec)
 #endif
 }
 
+clockid_t get_clock(void) {
+#ifdef HAVE_CLOCK_MONOTONIC_RAW
+  return CLOCK_MONOTONIC_RAW;
+#else
+#ifdef HAVE_CLOCK_MONOTONIC
+  return CLOCK_MONOTONIC;
+#else
+  return CLOCK_REALTIME;
+#endif
+#endif
+}
+
+void timespec_diff(struct timespec *start, struct timespec *stop,
+		   struct timespec *result)
+{
+  if ((stop->tv_nsec - start->tv_nsec) < 0) {
+    result->tv_sec = stop->tv_sec - start->tv_sec - 1;
+    result->tv_nsec = stop->tv_nsec - start->tv_nsec + 1000000000;
+  } else {
+    result->tv_sec = stop->tv_sec - start->tv_sec;
+    result->tv_nsec = stop->tv_nsec - start->tv_nsec;
+  }
+
+  return;
+}
+
 /***
 ****
 ***/

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -105,6 +105,16 @@ uint64_t tr_time_msec(void);
 void tr_wait_msec(long int delay_milliseconds);
 
 /**
+ * @brief Computes the time difference, \p stop - \p start into \p result. \p stop must correspond to a later point in time than \p start.
+ *
+*/
+void timespec_diff(struct timespec *start, struct timespec *stop,
+		   struct timespec *result) TR_GNUC_NONNULL(1, 2, 3);
+
+/** @brief returns a clock for use with clock_gettime() */
+clockid_t get_clock(void);
+
+/**
  * @brief make a copy of 'str' whose non-utf8 content has been corrected or stripped
  * @return a newly-allocated string that must be freed with tr_free()
  * @param str the string to make a clean copy of


### PR DESCRIPTION
The previous code performed some unnecessary memory->memory copies and compactions. Flushing the cache would copy a cache block into memory, free the evbuffer, then write the block to disk. This is avoided by writing directly from the evbuffer to disk. Similarly, reading a cache block would compact the evbuffer data into a contiguous buffer, even though the next operation on the buffer (populating an evbuffer to send to a peer or rehashing a piece) did not require this.

The included benchmarks measure mostly memory-memory copy time (for test_file_write_at) and buffer cache write time for a 100MB file written in 1MB chunks.

Benchmark results:
model name      : AMD Ryzen 5 1600 Six-Core Processor
$ ./transmission-test-file 
test_file_write_evbuffer_at: 0.597934s; 0.000298967s per file iteration
test_file_write_at: 0.818430s; 0.000409215s per file iteration

heavily IO-loaded:
model name	: VIA C7 Processor 1000MHz
$ libtransmission/transmission-test-file 
test_file_write_evbuffer_at: 27.919874s; 0.0139599s per file iteration
test_file_write_at: 43.084492s; 0.0215422s per file iteration

From the benchmarks, the new code is ~30% faster at filling the system buffer cache.