### PR TITLE
Fix text appearance for macOS 10.14

### DIFF
--- a/macosx/TorrentCell.m
+++ b/macosx/TorrentCell.m
@@ -376,7 +376,7 @@
     else
     {
         titleColor = [NSColor controlTextColor];
-        statusColor = [NSColor darkGrayColor];
+        statusColor = [NSColor secondaryLabelColor];
     }
 
     fTitleAttributes[NSForegroundColorAttributeName] = titleColor;


### PR DESCRIPTION
The text was dark gray on black. There still are some other appearance issues, but that was the most annoying