### PR TITLE
Qt: Raise present window if launched with no new files

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -35,6 +35,7 @@
 #include "OptionsDialog.h"
 #include "Prefs.h"
 #include "Session.h"
+#include "SessionDialog.h"
 #include "TorrentModel.h"
 #include "WatchDir.h"
 
@@ -225,6 +226,12 @@ Application::Application(int& argc, char** argv) :
             }
         }
 
+        // simply raise already open window if no files were selected
+        if (!delegated && filenames.isEmpty())
+        {
+            delegated = interopClient.raisePresent();
+        }
+
         if (delegated)
         {
             quitLater();
@@ -342,7 +349,11 @@ Application::Application(int& argc, char** argv) :
 
     if (!firstTime)
     {
-        mySession->restart();
+        if (!mySession->restart())
+        {
+            SessionDialog::warnDuplicateSession();
+            quitLater();
+        }
     }
     else
     {
@@ -623,6 +634,7 @@ void Application::addTorrent(AddData const& addme)
 
 void Application::raise()
 {
+    myWindow->toggleWindows(true);
     alert(myWindow);
 }
 

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -46,6 +46,11 @@ QVariant ComInteropHelper::addMetainfo(QString const& metainfo)
     return m_client->dynamicCall("AddMetainfo(QString)", metainfo);
 }
 
+bool ComInteropHelper::raisePresent()
+{
+    return m_client->dynamicCall("PresentWindow()");
+}
+
 void ComInteropHelper::initialize()
 {
     qAxOutProcServer = true;

--- a/qt/ComInteropHelper.h
+++ b/qt/ComInteropHelper.h
@@ -24,6 +24,7 @@ public:
     bool isConnected() const;
 
     QVariant addMetainfo(QString const& metainfo);
+    bool raisePresent();
 
     static void initialize();
     static void registerObject(QObject* parent);

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -41,6 +41,15 @@ QVariant DBusInteropHelper::addMetainfo(QString const& metainfo)
     return response.isValid() ? QVariant(response.value()) : QVariant();
 }
 
+bool DBusInteropHelper::raisePresent()
+{
+    QDBusMessage const request = QDBusMessage::createMethodCall(DBUS_SERVICE, DBUS_OBJECT_PATH, DBUS_INTERFACE,
+        QLatin1String("PresentWindow"));
+
+    QDBusReply<bool> const response = QDBusConnection::sessionBus().call(request);
+    return response.isValid() && response.value();
+}
+
 void DBusInteropHelper::registerObject(QObject* parent)
 {
     QDBusConnection bus = QDBusConnection::sessionBus();

--- a/qt/DBusInteropHelper.h
+++ b/qt/DBusInteropHelper.h
@@ -18,6 +18,7 @@ public:
     bool isConnected() const;
 
     QVariant addMetainfo(QString const& metainfo);
+    bool raisePresent();
 
     static void registerObject(QObject* parent);
 };

--- a/qt/InteropHelper.cc
+++ b/qt/InteropHelper.cc
@@ -64,6 +64,21 @@ bool InteropHelper::addMetainfo(QString const& metainfo)
     return false;
 }
 
+bool InteropHelper::raisePresent()
+{
+#ifdef ENABLE_DBUS_INTEROP
+    {
+        return myDbusClient.raisePresent();
+    }
+#endif
+
+#ifdef ENABLE_COM_INTEROP
+    {
+        return myComClient.raisePresent();
+    }
+#endif
+}
+
 void InteropHelper::initialize()
 {
 #ifdef ENABLE_COM_INTEROP

--- a/qt/InteropHelper.h
+++ b/qt/InteropHelper.h
@@ -25,6 +25,7 @@ public:
     bool isConnected() const;
 
     bool addMetainfo(QString const& metainfo);
+    bool raisePresent();
 
     static void initialize();
     static void registerObject(QObject* parent);

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -83,6 +83,8 @@ public slots:
 
     void openSession();
 
+    void toggleWindows(bool doShow);
+
 protected:
     // QWidget
     virtual void contextMenuEvent(QContextMenuEvent*);
@@ -133,7 +135,6 @@ private slots:
     void dataReadProgress();
     void dataSendProgress();
     void onNetworkResponse(QNetworkReply::NetworkError code, QString const& message);
-    void toggleWindows(bool doShow);
     void onSetPrefs();
     void onSetPrefs(bool);
     void onSessionSourceChanged();

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <QLockFile>
 #include <QObject>
 #include <QSet>
 #include <QString>
@@ -36,7 +37,7 @@ public:
     virtual ~Session();
 
     void stop();
-    void restart();
+    bool restart();
 
     QUrl const& getRemoteUrl() const
     {
@@ -125,7 +126,7 @@ signals:
     void httpAuthenticationRequired();
 
 private:
-    void start();
+    bool start();
 
     void updateStats(tr_variant* args);
     void updateInfo(tr_variant* args);
@@ -140,6 +141,7 @@ private:
 private:
     QString const myConfigDir;
     Prefs& myPrefs;
+    QLockFile myLock;
 
     int64_t myBlocklistSize;
     tr_session* mySession;

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -6,6 +6,8 @@
  *
  */
 
+#include <QMessageBox>
+
 #include "Prefs.h"
 #include "Session.h"
 #include "SessionDialog.h"
@@ -22,7 +24,12 @@ void SessionDialog::accept()
     myPrefs.set(Prefs::SESSION_REMOTE_AUTH, ui.authCheck->isChecked());
     myPrefs.set(Prefs::SESSION_REMOTE_USERNAME, ui.usernameEdit->text());
     myPrefs.set(Prefs::SESSION_REMOTE_PASSWORD, ui.passwordEdit->text());
-    mySession.restart();
+
+    if (!mySession.restart())
+    {
+        warnDuplicateSession();
+    }
+
     BaseDialog::accept();
 }
 
@@ -76,4 +83,11 @@ SessionDialog::SessionDialog(Session& session, Prefs& prefs, QWidget* parent) :
     myAuthWidgets << ui.passwordLabel << ui.passwordEdit;
 
     resensitize();
+}
+
+void SessionDialog::warnDuplicateSession()
+{
+    QMessageBox::warning(nullptr, QString(),
+        tr("A different session of transmission is already active on the specified configuration."),
+        QMessageBox::Ok);
 }

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -28,6 +28,8 @@ public:
     {
     }
 
+    void static warnDuplicateSession();
+
 public slots:
     // QDialog
     virtual void accept();


### PR DESCRIPTION
Previously, transmission-qt would only delegate and quit if new files
are added otherwise it would launch a new instance.
This would make it call PresentWindow on DBus if there are no files.

Closes #731 