### PR TITLE
Parse session-id header case-insensitively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ set(NEEDED_FUNCTIONS
     pread
     pwrite
     statvfs
+    strcasestr
     strlcpy
     strsep
     syslog

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -2949,6 +2949,7 @@
 					"-DHAVE_ASPRINTF",
 					"-DHAVE_LIBGEN",
 					"-DHAVE_STRCASECMP",
+					"-DHAVE_STRCASESTR",
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);
@@ -3124,6 +3125,7 @@
 					"-DHAVE_ASPRINTF",
 					"-DHAVE_LIBGEN",
 					"-DHAVE_STRCASECMP",
+					"-DHAVE_STRCASESTR",
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);
@@ -3352,6 +3354,7 @@
 					"-DHAVE_ASPRINTF",
 					"-DHAVE_LIBGEN",
 					"-DHAVE_STRCASECMP",
+					"-DHAVE_STRCASESTR",
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ AC_HEADER_STDC
 AC_HEADER_TIME
 
 AC_CHECK_HEADERS([xlocale.h])
-AC_CHECK_FUNCS([iconv pread pwrite lrintf strlcpy daemon dirname basename canonicalize_file_name strcasecmp localtime_r fallocate64 posix_fallocate memmem strsep strtold syslog valloc getpagesize posix_memalign statvfs htonll ntohll mkdtemp uselocale _configthreadlocale])
+AC_CHECK_FUNCS([iconv pread pwrite lrintf strlcpy daemon dirname basename canonicalize_file_name strcasecmp localtime_r fallocate64 posix_fallocate memmem strsep strtold syslog valloc getpagesize posix_memalign statvfs htonll ntohll mkdtemp uselocale _configthreadlocale strcasestr])
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 ACX_PTHREAD

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -268,6 +268,10 @@ if(ICONV_FOUND)
     target_link_libraries(${TR_NAME} ${ICONV_LIBRARIES})
 endif()
 
+if(WIN32)
+    target_link_libraries(${TR_NAME} shlwapi)
+endif()
+
 if(ENABLE_TESTS)
     add_library(${TR_NAME}-test STATIC
         libtransmission-test.c

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -184,7 +184,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
         {
             struct tr_mimepart* p = tr_ptrArrayNth(&parts, i);
 
-            if (tr_memmem(p->headers, p->headers_len, TR_RPC_SESSION_ID_HEADER, strlen(TR_RPC_SESSION_ID_HEADER)) != NULL)
+            if (tr_strcasestr(p->headers, TR_RPC_SESSION_ID_HEADER) != NULL)
             {
                 char const* ours = get_current_session_id(server);
                 size_t const ourlen = strlen(ours);

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -29,6 +29,7 @@
 #include <ws2tcpip.h> /* WSAStartup() */
 #include <windows.h> /* Sleep(), GetSystemTimeAsFileTime(), GetEnvironmentVariable() */
 #include <shellapi.h> /* CommandLineToArgv() */
+#include <shlwapi.h> /* StrStrIA() */
 #else
 #include <sys/time.h>
 #include <unistd.h> /* getpagesize() */
@@ -452,6 +453,23 @@ char const* tr_memmem(char const* haystack, size_t haystacklen, char const* need
     }
 
     return NULL;
+
+#endif
+}
+
+char const* tr_strcasestr(char const* haystack, char const* needle)
+{
+#ifdef HAVE_STRCASESTR
+
+    return strcasestr(haystack, needle);
+
+#elif defined(_WIN32)
+
+    return StrStrIA(haystack, needle);
+
+#else
+
+#error please open a PR to implement tr_strcasestr() for your platform
 
 #endif
 }

--- a/utils/remote.c
+++ b/utils/remote.c
@@ -14,6 +14,7 @@
 #include <string.h> /* strcmp */
 
 #include <event2/buffer.h>
+#include <event2/util.h>
 
 #define CURL_DISABLE_TYPECHECK /* otherwise -Wunreachable-code goes insane */
 #include <curl/curl.h>
@@ -792,7 +793,7 @@ static size_t parseResponseHeader(void* ptr, size_t size, size_t nmemb, void* st
     char const* key = TR_RPC_SESSION_ID_HEADER ": ";
     size_t const key_len = strlen(key);
 
-    if (line_len >= key_len && memcmp(line, key, key_len) == 0)
+    if (line_len >= key_len && evutil_ascii_strncasecmp(line, key, key_len) == 0)
     {
         char const* begin = line + key_len;
         char const* end = begin;


### PR DESCRIPTION
RFC 2616 defines headers as case-insensitive, so if rpc is behind a
reverse proxy that lowers the case of headers, transmission will not
parse the headers correctly.