### PR TITLE
Web: Improves responsive design

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,11 +13,8 @@
 		<script type="text/javascript" src="./javascript/jquery/jquery-ui.min.js"></script>
 		<script type="text/javascript" src="./javascript/jquery/jquery.ui-contextmenu.min.js"></script>
 		<link rel="stylesheet" href="./style/jqueryui/jquery-ui.min.css" type="text/css" media="all" />
-<!--
-		<link media="screen" href="./style/transmission/mobile.css" type= "text/css" rel="stylesheet" />
--->
-		<link media="only screen and (max-device-width: 480px)" href="./style/transmission/mobile.css" type= "text/css" rel="stylesheet" />
-		<link media="screen and (min-device-width: 481px)" href="./style/transmission/common.css" type="text/css" rel="stylesheet" />
+		<link media="only screen and (max-width: 480px)" href="./style/transmission/mobile.css" type= "text/css" rel="stylesheet" />
+		<link media="screen and (min-width: 481px)" href="./style/transmission/common.css" type="text/css" rel="stylesheet" />
 		<!--[if IE 8]>
 		<link media="screen" href="./style/transmission/common.css" type="text/css" rel="stylesheet" />
 		<![endif]-->

--- a/web/style/transmission/common.css
+++ b/web/style/transmission/common.css
@@ -376,6 +376,8 @@ div#torrent_inspector {
   top: 68px;
   position: fixed;
   width: 570px;
+  max-width: 100%;
+  box-sizing: border-box;
   z-index: 5;
   border-left: 1px solid #888;
   bottom: 22px;

--- a/web/style/transmission/common.scss
+++ b/web/style/transmission/common.scss
@@ -513,6 +513,8 @@ div#torrent_inspector
 	top: $torrent-container-top;
 	position: fixed;
 	width: $inspector-width;
+	max-width: 100%;
+	box-sizing: border-box;
 	z-index: 5;
 	border-left: 1px solid #888;
 	bottom: 22px;

--- a/web/style/transmission/mobile.css
+++ b/web/style/transmission/mobile.css
@@ -316,6 +316,7 @@ div#torrent_inspector {
   overflow: auto;
   text-align: left;
   padding: 15px;
+  box-sizing: border-box;
   top: 0;
   position: relative;
   width: 100%;
@@ -734,7 +735,8 @@ div.file-priority-radiobox {
 div.torrent_footer {
   height: 22px;
   border-top: 1px solid #555;
-  position: relative;
+  position: fixed;
+  bottom: 0;
   width: 100%;
   z-index: 3;
   background-color: #cccccc;

--- a/web/style/transmission/mobile.scss
+++ b/web/style/transmission/mobile.scss
@@ -428,6 +428,7 @@ div#torrent_inspector
 	overflow: auto;
 	text-align: left;
 	padding: 15px;
+	box-sizing: border-box;
 	top: 0;
 	position: relative;
 	width: 100%;
@@ -688,7 +689,8 @@ div.torrent_footer
 {
 	height: 22px;
 	border-top: 1px solid #555;
-	position: relative;
+	position: fixed;
+	bottom: 0;
 	width: 100%;
 	z-index: 3;
 


### PR DESCRIPTION
Changes:

1. Loads mobile.css based on max-width instead of max-device-width.
The device-width CSS media feature [is deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-width), and using it can cause unexpected behaviour if the viewport width is 480px or less but the device's total screen width is greater than 480px.

2. Prevents the torrent inspector from overflowing the viewport.

3. Positions the footer at the bottom of the viewport on narrow devices, just like on larger ones.