### PR TITLE
Update Info.plist

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -75,6 +75,8 @@
 	<string>Copyright © 2005-2018 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>False</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSServices</key>


### PR DESCRIPTION
Added string required to enable macOS Mojave dark-mode. Won't effect previous releases.