### PR TITLE
Updated copyright strings to 2019

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright 2005-2018. All code is copyrighted by the respective authors.
+Copyright 2005-2019. All code is copyrighted by the respective authors.
 
 Transmission can be redistributed and/or modified under the terms of
 the GNU GPLv2 (http://www.gnu.org/licenses/license-list.html#GPLv2),

--- a/cmake/Transmission.rc.in
+++ b/cmake/Transmission.rc.in
@@ -32,7 +32,7 @@ BEGIN
             VALUE "FileDescription",  "${TR_FILE_DESCRIPTION}"
             VALUE "FileVersion",      LONG_VERSION_STRING
             VALUE "InternalName",     "${TR_INTERNAL_NAME}"
-            VALUE "LegalCopyright",   "2005-2016 Transmission Project"
+            VALUE "LegalCopyright",   "2005-2019 Transmission Project"
             VALUE "OriginalFilename", "${TR_ORIGINAL_FILENAME}"
             VALUE "ProductName",      "Transmission"
             VALUE "ProductVersion",   LONG_VERSION_STRING

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -59,7 +59,7 @@
 
 #define SHOW_LICENSE
 static char const* LICENSE =
-    "Copyright 2005-2018. All code is copyrighted by the respective authors.\n"
+    "Copyright 2005-2019. All code is copyrighted by the respective authors.\n"
     "\n"
     "Transmission can be redistributed and/or modified under the terms of the "
     "GNU GPL versions 2 or 3 or by any future license endorsed by Mnemosyne LLC.\n"

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/Info.plist.in
+++ b/macosx/Info.plist.in
@@ -72,7 +72,7 @@
 		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2016 The Transmission Project</string>
+	<string>Copyright © 2005-2019 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/NSStringAdditions.m
+++ b/macosx/NSStringAdditions.m
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/PrefsController.m
+++ b/macosx/PrefsController.m
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
+++ b/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
@@ -49,7 +49,7 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2018 The Transmission Project</string>
+	<string>Copyright © 2005-2019 The Transmission Project</string>
 	<key>QLNeedsToBeRunInMainThread</key>
 	<false/>
 	<key>QLPreviewHeight</key>

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/TorrentTableView.m
+++ b/macosx/TorrentTableView.m
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/da.lproj/InfoPlist.strings
+++ b/macosx/da.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/de.lproj/InfoPlist.strings
+++ b/macosx/de.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005–2018 Transmission-Projekt";
+NSHumanReadableCopyright = "Copyright © 2005–2019 Transmission-Projekt";

--- a/macosx/en.lproj/InfoPlist.strings
+++ b/macosx/en.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/es.lproj/InfoPlist.strings
+++ b/macosx/es.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/fr.lproj/InfoPlist.strings
+++ b/macosx/fr.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/it.lproj/InfoPlist.strings
+++ b/macosx/it.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/main.m
+++ b/macosx/main.m
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005-2012 Transmission authors and contributors
+ * Copyright (c) 2005-2019 Transmission authors and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/macosx/nl.lproj/InfoPlist.strings
+++ b/macosx/nl.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 Het Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 Het Transmission Project";

--- a/macosx/pt_PT.lproj/InfoPlist.strings
+++ b/macosx/pt_PT.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2018 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2019 The Transmission Project";

--- a/macosx/ru.lproj/InfoPlist.strings
+++ b/macosx/ru.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "© 2005-2018 The Transmission Project, все права защищены";
+NSHumanReadableCopyright = "© 2005-2019 The Transmission Project, все права защищены";

--- a/macosx/tr.lproj/InfoPlist.strings
+++ b/macosx/tr.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "© 2005-2018 The Transmission Project, tüm hakları saklıdır";
+NSHumanReadableCopyright = "© 2005-2019 The Transmission Project, tüm hakları saklıdır";

--- a/qt/LicenseDialog.ui
+++ b/qt/LicenseDialog.ui
@@ -20,7 +20,7 @@
       <bool>true</bool>
      </property>
      <property name="plainText">
-      <string notr="true">Copyright 2005-2016. All code is copyrighted by the respective authors.
+      <string notr="true">Copyright 2005-2019. All code is copyrighted by the respective authors.
 
 Transmission can be redistributed and/or modified under the terms of the GNU GPL versions 2 or 3 or by any future license endorsed by Mnemosyne LLC.
 


### PR DESCRIPTION
Updated Transmission Project copyright dates to 2005-2019 in headers and code.