### PR TITLE
Fix typo in CLI manpage.

### DIFF
--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -50,7 +50,7 @@ The options are as follows:
 Enable peer blocklists. Transmission understands the bluetack blocklist file format.
 New blocklists can be added by copying them into the config-dir's "blocklists" subdirectory.
 .It Fl B Fl -no-blocklist
-Disble blocklists.
+Disable blocklists.
 .It Fl d, -downlimit Ar number
 Set the maximum download speed in KB/s
 .It Fl D, -no-downlimit


### PR DESCRIPTION
@mikedld fixed a small typo in the manpage.