### PR TITLE
feat: throttle multiscrapes

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -22,11 +22,18 @@
 enum
 {
     /* pick a number small enough for common tracker software:
+     *
+     * Some numbers reported in the wild:
      *  - ocelot has no upper bound
      *  - opentracker has an upper bound of 64
      *  - udp protocol has an upper bound of 74
-     *  - xbtt has no upper bound */
-    TR_MULTISCRAPE_MAX = 64
+     *  - xbtt has no upper bound
+     *
+     * Note that announcer.c dials down this number if a multiscrape
+     * errors out so its not the end of the world if this number
+     * is too high
+     */
+    TR_MULTISCRAPE_MAX = 100
 };
 
 typedef struct

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1312,6 +1312,17 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
 ****
 ***/
 
+static bool multiscrape_too_big(char const* errmsg)
+{ 
+  if (strstr(errmsg, "GET string too long"))
+    return true;
+
+  /* Found a tracker that returns some bespoke string for this case?
+     Add your patch here and open a PR */
+
+  return false;
+}
+
 static void on_scrape_error(tr_session* session, tr_tier* tier, char const* errmsg)
 {
     int interval;
@@ -1326,7 +1337,7 @@ static void on_scrape_error(tr_session* session, tr_tier* tier, char const* errm
     dbgmsg(tier, "Scrape error: %s", errmsg);
     tr_logAddTorInfo(tier->tor, "Scrape error: %s", errmsg);
     tr_strlcpy(tier->lastScrapeStr, errmsg, sizeof(tier->lastScrapeStr));
-    if (strstr(errmsg, "GET string too long")) {
+    if (multiscrape_too_big(errmsg)) {
       const int n = tier->currentTracker->multiscrapeMax - TR_MULTISCRAPE_STEP;
       if (n >= TR_MULTISCRAPE_MIN) {
         tr_logAddTorInfo(tier->tor, "Reducing announce max to %d", n);

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -308,7 +308,7 @@ static char const* torrentStop(tr_session* session, tr_variant* args_in, tr_vari
     {
         tr_torrent* tor = torrents[i];
 
-        if (tor->isRunning || tr_torrentIsQueued(tor))
+        if (tor->isRunning || tr_torrentIsQueued(tor) || tor->verifyState > TR_VERIFY_NONE)
         {
             tor->isStopping = true;
             notify(session, TR_RPC_TORRENT_STOPPED, tor);

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -2328,6 +2328,8 @@ void tr_torrentRecheckCompleteness(tr_torrent* tor)
 
             if (tr_sessionIsTorrentDoneScriptEnabled(tor->session))
             {
+                tr_torrentSave(tor);
+
                 torrentCallScript(tor, tr_sessionGetTorrentDoneScript(tor->session));
             }
         }


### PR DESCRIPTION
1. Make multiscrape_max a per-scrape-url property rather than a global fixed constant.

2. Incrementally lower that limit when multiscrapes error out with messages like `GET string too long`.