### PR TITLE
feat: make multiscrape limits adaptive

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -22,16 +22,13 @@
 enum
 {
     /* pick a number small enough for common tracker software:
-     *
-     * Some numbers reported in the wild:
      *  - ocelot has no upper bound
      *  - opentracker has an upper bound of 64
      *  - udp protocol has an upper bound of 74
      *  - xbtt has no upper bound
      *
-     * Note that announcer.c dials down this number if a multiscrape
-     * errors out so its not the end of the world if this number
-     * is too high
+     * This is only an upper bound: if the tracker complains about
+     * length, announcer will incrementally lower the batch size.
      */
     TR_MULTISCRAPE_MAX = 100
 };

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -22,11 +22,18 @@
 enum
 {
     /* pick a number small enough for common tracker software:
+     *
+     * Some numbers reported in the wild:
      *  - ocelot has no upper bound
      *  - opentracker has an upper bound of 64
      *  - udp protocol has an upper bound of 74
-     *  - xbtt has no upper bound */
-    TR_MULTISCRAPE_MAX = 64
+     *  - xbtt has no upper bound
+     *
+     * Note that announcer.c dials down this number if a multiscrape
+     * errors out so its not the end of the world if this number
+     * is too high
+     */
+    TR_MULTISCRAPE_MAX = 100
 };
 
 typedef struct

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -158,7 +158,7 @@ static void scrapeInfoFree(void *va)
     tr_free(a);
 }
 
-static int compareScrapeInfo(const void* va, const void* vb)
+static int compareScrapeInfo(void const* va, void const* vb)
 {
     const struct tr_scrape_info* a = va;
     const struct tr_scrape_info* b = vb;
@@ -181,7 +181,7 @@ typedef struct tr_announcer
 }
 tr_announcer;
 
-static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* announcer, const char* url)
+static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* announcer, char const* url)
 {
     struct tr_scrape_info* info = NULL;
 
@@ -1516,7 +1516,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
 
         if (*multiscrape_max == response->row_count)
         {
-            const int n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
+            int const n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
             if (*multiscrape_max != n)
             {
                 char* host = NULL;

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1360,7 +1360,7 @@ static bool multiscrape_too_big(char const* errmsg)
 
     /* Found a tracker that returns some bespoke string for this case?
        Add your patch here and open a PR */
-    static char const* too_long_errors[3] =
+    static char const* const too_long_errors[] =
     {
         "Bad Request",
         "GET string too long",

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -61,8 +61,6 @@ enum
     /* this is how often to call the UDP tracker upkeep */
     TAU_UPKEEP_INTERVAL_SECS = 5,
 
-    /* minimum number of infohashes to put in a multiscrape */
-    TR_MULTISCRAPE_MIN = 16,
     /* how many infohashes to remove when we get a scrape-too-long error */
     TR_MULTISCRAPE_STEP = 5
 };
@@ -1529,7 +1527,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
            error out, lower the value once for that batch, not N times. */
         if (*multiscrape_max >= response->row_count)
         {
-            int const n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
+            int const n = MAX(1, *multiscrape_max - TR_MULTISCRAPE_STEP);
             if (*multiscrape_max != n)
             {
                 char* scheme = NULL;

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1508,16 +1508,16 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
         }
     }
 
-    /* Maybe dial down the number of torrents in a multiscrape req */
+    /* Maybe reduce the number of torrents in a multiscrape req */
     if (multiscrape_too_big(response->errmsg))
     {
         char const* url = response->url;
-        int* multiscrape_max = &(tr_announcerGetScrapeInfo(announcer, url)->multiscrape_max);
+        int* multiscrape_max = &tr_announcerGetScrapeInfo(announcer, url)->multiscrape_max;
 
         if (*multiscrape_max == response->row_count)
         {
-            const int n = *multiscrape_max - TR_MULTISCRAPE_STEP;
-            if (n >= TR_MULTISCRAPE_MIN)
+            const int n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
+            if (*multiscrape_max != n)
             {
                 char* host = NULL;
                 if (tr_urlParse(url, strlen(url), NULL, &host, NULL, NULL))

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1518,8 +1518,14 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
             const int n = *multiscrape_max - TR_MULTISCRAPE_STEP;
             if (n >= TR_MULTISCRAPE_MIN)
             {
-              tr_logAddNamedInfo(url, "Reducing multiscrape max to %d", n);
-              *multiscrape_max = n;
+                char* host = NULL;
+                if (tr_urlParse(url, strlen(url), NULL, &host, NULL, NULL))
+                {
+                    tr_logAddNamedInfo(host, "Reducing multiscrape max to %d", n);
+                    tr_free(host);
+                }
+
+                *multiscrape_max = n;
             }
         }
     }

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -185,7 +185,7 @@ static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* ann
 {
     struct tr_scrape_info* info = NULL;
 
-    if (url && *url)
+    if (url != NULL && *url != '\0')
     {
         int pos;
         bool found;

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1528,11 +1528,17 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
             int const n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
             if (*multiscrape_max != n)
             {
+                char* scheme = NULL;
                 char* host = NULL;
-                if (tr_urlParse(url, strlen(url), NULL, &host, NULL, NULL))
+                int port;
+                if (tr_urlParse(url, strlen(url), &scheme, &host, &port, NULL))
                 {
+                    /* don't log the full URL, since that might have a personal announce id */
+                    char* sanitized_url = tr_strdup_printf("%s://%s:%d", scheme, host, port);
                     tr_logAddNamedInfo(host, "Reducing multiscrape max to %d", n);
+                    tr_free(sanitized_url);
                     tr_free(host);
+                    tr_free(scheme);
                 }
 
                 *multiscrape_max = n;

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1357,21 +1357,31 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
 ***/
 
 static bool multiscrape_too_big(char const* errmsg)
-{ 
-  if (!errmsg)
-      return false;
+{
+    unsigned int i;
 
-  if (strstr(errmsg, "GET string too long"))
-      return true;
-  if (strstr(errmsg, "Request-URI Too Long"))
-      return true;
-  if (strstr(errmsg, "Bad Request"))
-      return true;
+    /* Found a tracker that returns some bespoke string for this case?
+       Add your patch here and open a PR */
+    static char const* too_long_errors[3] = {
+        "Bad Request",
+        "GET string too long",
+        "Request-URI Too Long"
+    };
 
-  /* Found a tracker that returns some bespoke string for this case?
-     Add your patch here and open a PR */
+    if (!errmsg)
+    {
+        return false;
+    }
 
-  return false;
+    for (i=0; i<TR_N_ELEMENTS(too_long_errors); ++i)
+    {
+        if (strstr(errmsg, too_long_errors[i]))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static void on_scrape_error(tr_session* session, tr_tier* tier, char const* errmsg)

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1523,7 +1523,10 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
         char const* url = response->url;
         int* multiscrape_max = &tr_announcerGetScrapeInfo(announcer, url)->multiscrape_max;
 
-        if (*multiscrape_max == response->row_count)
+        /* Lower the max only if it hasn't already lowered for a similar error.
+           For example if N parallel multiscrapes all have the same `max` and
+           error out, lower the value once for that batch, not N times. */
+        if (*multiscrape_max >= response->row_count)
         {
             int const n = MAX(TR_MULTISCRAPE_MIN, *multiscrape_max - TR_MULTISCRAPE_STEP);
             if (*multiscrape_max != n)

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -190,16 +190,17 @@ static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* ann
         bool found;
         struct tr_scrape_info const key = { .url = (char*)url };
         int const pos = tr_ptrArrayLowerBound(&announcer->scrape_info, &key, compareScrapeInfo, &found);
-
-        if (!found)
+        if (found)
+        {
+            info = tr_ptrArrayNth(&announcer->scrape_info, pos);
+        }
+        else
         {
             info = tr_new0(struct tr_scrape_info, 1);
             info->url = tr_strdup(url);
             info->multiscrape_max = TR_MULTISCRAPE_MAX;
             tr_ptrArrayInsert(&announcer->scrape_info, info, pos);
         }
-
-        info = tr_ptrArrayNth(&announcer->scrape_info, pos);
     }
 
     return info;

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -145,12 +145,12 @@ static int compareStops(void const* va, void const* vb)
 
 struct tr_scrape_info
 {
-    char * url;
+    char* url;
 
     int multiscrape_max;
 };
 
-static void scrapeInfoFree(void *va)
+static void scrapeInfoFree(void* va)
 {
     struct tr_scrape_info* a = va;
 
@@ -1362,7 +1362,8 @@ static bool multiscrape_too_big(char const* errmsg)
 
     /* Found a tracker that returns some bespoke string for this case?
        Add your patch here and open a PR */
-    static char const* too_long_errors[3] = {
+    static char const* too_long_errors[3] =
+    {
         "Bad Request",
         "GET string too long",
         "Request-URI Too Long"
@@ -1373,7 +1374,7 @@ static bool multiscrape_too_big(char const* errmsg)
         return false;
     }
 
-    for (i=0; i<TR_N_ELEMENTS(too_long_errors); ++i)
+    for (i = 0; i < TR_N_ELEMENTS(too_long_errors); ++i)
     {
         if (strstr(errmsg, too_long_errors[i]))
         {
@@ -1418,9 +1419,9 @@ static tr_tier* find_tier(tr_torrent* tor, char const* scrape)
     {
         tr_tracker const* const tracker = tt->tiers[i].currentTracker;
 
-        if (tracker != NULL
-            && tracker->scrape_info
-            && tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
+        if (tracker != NULL &&
+            tracker->scrape_info &&
+            tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
         {
             return &tt->tiers[i];
         }

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -187,12 +187,10 @@ static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* ann
 
     if (url != NULL && *url != '\0')
     {
-        int pos;
         bool found;
-        struct tr_scrape_info key;
+        struct tr_scrape_info const key = { .url = (char*)url };
+        int const pos = tr_ptrArrayLowerBound(&announcer->scrape_info, &key, compareScrapeInfo, &found);
 
-        key.url = (char*) url;
-        pos = tr_ptrArrayLowerBound(&announcer->scrape_info, &key, compareScrapeInfo, &found);
         if (!found)
         {
             info = tr_new0(struct tr_scrape_info, 1);

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1418,7 +1418,7 @@ static tr_tier* find_tier(tr_torrent* tor, char const* scrape)
         tr_tracker const* const tracker = tt->tiers[i].currentTracker;
 
         if (tracker != NULL &&
-            tracker->scrape_info &&
+            tracker->scrape_info != NULL &&
             tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
         {
             return &tt->tiers[i];

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -61,10 +61,9 @@ enum
     /* this is how often to call the UDP tracker upkeep */
     TAU_UPKEEP_INTERVAL_SECS = 5,
 
-    /* minimum number of info hashes to put in a multiscrape */
+    /* minimum number of infohashes to put in a multiscrape */
     TR_MULTISCRAPE_MIN = 16,
-    /* when we get a scrape-too-long error, how many infohashes to trim
-       off in the next try */
+    /* how many infohashes to remove when we get a scrape-too-long error */
     TR_MULTISCRAPE_STEP = 5
 };
 
@@ -172,14 +171,13 @@ static int compareScrapeInfo(const void* va, const void* vb)
 typedef struct tr_announcer
 {
     tr_ptrArray stops; /* tr_announce_request */
+    tr_ptrArray scrape_info; /* struct tr_scrape_info */
 
     tr_session* session;
     struct event* upkeepTimer;
     int slotsAvailable;
     int key;
     time_t tauUpkeepAt;
-
-    tr_ptrArray scrape_info;
 }
 tr_announcer;
 

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1374,7 +1374,7 @@ static bool multiscrape_too_big(char const* errmsg)
 
     for (i = 0; i < TR_N_ELEMENTS(too_long_errors); ++i)
     {
-        if (strstr(errmsg, too_long_errors[i]))
+        if (strstr(errmsg, too_long_errors[i]) != NULL)
         {
             return true;
         }

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -59,7 +59,13 @@ enum
     /* */
     UPKEEP_INTERVAL_SECS = 1,
     /* this is how often to call the UDP tracker upkeep */
-    TAU_UPKEEP_INTERVAL_SECS = 5
+    TAU_UPKEEP_INTERVAL_SECS = 5,
+
+    /* minimum number of info hashes to put in a multiscrape */
+    TR_MULTISCRAPE_MIN = 16,
+    /* when we get a scrape-too-long error, how many infohashes to trim
+       off in the next try */
+    TR_MULTISCRAPE_STEP = 5
 };
 
 /***
@@ -130,13 +136,35 @@ static int compareStops(void const* va, void const* vb)
         return i;
     }
 
-    /* tertiary key: the tracker's announec url */
+    /* tertiary key: the tracker's announce url */
     return tr_strcmp0(a->url, b->url);
 }
 
 /***
 ****
 ***/
+
+struct tr_scrape_info
+{
+    char * url;
+
+    int multiscrape_max;
+};
+
+static void scrapeInfoFree(void *va)
+{
+    struct tr_scrape_info* a = va;
+
+    tr_free(a->url);
+    tr_free(a);
+}
+
+static int compareScrapeInfo(const void* va, const void* vb)
+{
+    const struct tr_scrape_info* a = va;
+    const struct tr_scrape_info* b = vb;
+    return tr_strcmp0(a->url, b->url);
+}
 
 /**
  * "global" (per-tr_session) fields
@@ -150,8 +178,36 @@ typedef struct tr_announcer
     int slotsAvailable;
     int key;
     time_t tauUpkeepAt;
+
+    tr_ptrArray scrape_info;
 }
 tr_announcer;
+
+static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* announcer, const char* url)
+{
+    struct tr_scrape_info* info = NULL;
+
+    if (url && *url)
+    {
+        int pos;
+        bool found;
+        struct tr_scrape_info key;
+
+        key.url = (char*) url;
+        pos = tr_ptrArrayLowerBound(&announcer->scrape_info, &key, compareScrapeInfo, &found);
+        if (!found)
+        {
+            info = tr_new0(struct tr_scrape_info, 1);
+            info->url = tr_strdup(url);
+            info->multiscrape_max = TR_MULTISCRAPE_MAX;
+            tr_ptrArrayInsert(&announcer->scrape_info, info, pos);
+        }
+
+        info = tr_ptrArrayNth(&announcer->scrape_info, pos);
+    }
+
+    return info;
+}
 
 bool tr_announcerHasBacklog(struct tr_announcer const* announcer)
 {
@@ -189,6 +245,7 @@ void tr_announcerClose(tr_session* session)
     announcer->upkeepTimer = NULL;
 
     tr_ptrArrayDestruct(&announcer->stops, NULL);
+    tr_ptrArrayDestruct(&announcer->scrape_info, scrapeInfoFree);
 
     session->announcer = NULL;
     tr_free(announcer);
@@ -203,7 +260,7 @@ typedef struct
 {
     char* key;
     char* announce;
-    char* scrape;
+    struct tr_scrape_info* scrape_info;
 
     char* tracker_id_str;
 
@@ -234,12 +291,12 @@ static char* getKey(char const* url)
     return ret;
 }
 
-static void trackerConstruct(tr_tracker* tracker, tr_tracker_info const* inf)
+static void trackerConstruct(tr_announcer* announcer, tr_tracker* tracker, tr_tracker_info const* inf)
 {
     memset(tracker, 0, sizeof(tr_tracker));
     tracker->key = getKey(inf->announce);
     tracker->announce = tr_strdup(inf->announce);
-    tracker->scrape = tr_strdup(inf->scrape);
+    tracker->scrape_info = tr_announcerGetScrapeInfo(announcer, inf->scrape);
     tracker->id = inf->id;
     tracker->seederCount = -1;
     tracker->leecherCount = -1;
@@ -249,7 +306,6 @@ static void trackerConstruct(tr_tracker* tracker, tr_tracker_info const* inf)
 static void trackerDestruct(tr_tracker* tracker)
 {
     tr_free(tracker->tracker_id_str);
-    tr_free(tracker->scrape);
     tr_free(tracker->announce);
     tr_free(tracker->key);
 }
@@ -681,7 +737,7 @@ static void addTorrentToTier(tr_torrent_tiers* tt, tr_torrent* tor)
 
     for (int i = 0; i < n; ++i)
     {
-        trackerConstruct(&tt->trackers[i], &infos[i]);
+        trackerConstruct(tor->session->announcer, &tt->trackers[i], &infos[i]);
     }
 
     /* count how many tiers there are */
@@ -1195,7 +1251,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
             /* if the tracker included scrape fields in its announce response,
                then a separate scrape isn't needed */
-            if (scrape_fields >= 3 || (scrape_fields >= 1 && tracker->scrape == NULL))
+            if (scrape_fields >= 3 || (scrape_fields >= 1 && tracker->scrape_info == NULL))
             {
                 tr_logAddTorDbg(tier->tor, "Announce response contained scrape info; "
                     "rescheduling next scrape to %d seconds from now.", tier->scrapeIntervalSec);
@@ -1303,6 +1359,21 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
 ****
 ***/
 
+static bool multiscrape_too_big(char const* errmsg)
+{ 
+  if (!errmsg)
+    return false;
+  if (strstr(errmsg, "GET string too long"))
+    return true;
+  if (strstr(errmsg, "Request-URI Too Long"))
+    return true;
+
+  /* Found a tracker that returns some bespoke string for this case?
+     Add your patch here and open a PR */
+
+  return false;
+}
+
 static void on_scrape_error(tr_session* session, tr_tier* tier, char const* errmsg)
 {
     int interval;
@@ -1337,7 +1408,9 @@ static tr_tier* find_tier(tr_torrent* tor, char const* scrape)
     {
         tr_tracker const* const tracker = tt->tiers[i].currentTracker;
 
-        if (tracker != NULL && tr_strcmp0(scrape, tracker->scrape) == 0)
+        if (tracker != NULL
+            && tracker->scrape_info
+            && tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
         {
             return &tt->tiers[i];
         }
@@ -1434,6 +1507,23 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
         }
     }
 
+    /* Maybe dial down the number of torrents in a multiscrape req */
+    if (multiscrape_too_big(response->errmsg))
+    {
+        char const* url = response->url;
+        int* multiscrape_max = &(tr_announcerGetScrapeInfo(announcer, url)->multiscrape_max);
+
+        if (*multiscrape_max == response->row_count)
+        {
+            const int n = *multiscrape_max - TR_MULTISCRAPE_STEP;
+            if (n >= TR_MULTISCRAPE_MIN)
+            {
+              tr_logAddNamedInfo(url, "Reducing multiscrape max to %d", n);
+              *multiscrape_max = n;
+            }
+        }
+    }
+
     if (announcer)
     {
         ++announcer->slotsAvailable;
@@ -1471,23 +1561,23 @@ static void multiscrape(tr_announcer* announcer, tr_ptrArray* tiers)
     for (int i = 0; i < tier_count; ++i)
     {
         tr_tier* tier = tr_ptrArrayNth(tiers, i);
-        char* url = tier->currentTracker->scrape;
+        struct tr_scrape_info* const scrape_info = tier->currentTracker->scrape_info;
         uint8_t const* hash = tier->tor->info.hash;
         bool found = false;
 
-        TR_ASSERT(url != NULL);
+        TR_ASSERT(scrape_info != NULL);
 
         /* if there's a request with this scrape URL and a free slot, use it */
         for (int j = 0; !found && j < request_count; ++j)
         {
             tr_scrape_request* req = &requests[j];
 
-            if (req->info_hash_count >= TR_MULTISCRAPE_MAX)
+            if (req->info_hash_count >= scrape_info->multiscrape_max)
             {
                 continue;
             }
 
-            if (tr_strcmp0(req->url, url) != 0)
+            if (tr_strcmp0(req->url, scrape_info->url) != 0)
             {
                 continue;
             }
@@ -1502,7 +1592,7 @@ static void multiscrape(tr_announcer* announcer, tr_ptrArray* tiers)
         if (!found && request_count < max_request_count)
         {
             tr_scrape_request* req = &requests[request_count++];
-            req->url = url;
+            req->url = scrape_info->url;
             tier_build_log_name(tier, req->log_name, sizeof(req->log_name));
 
             memcpy(req->info_hash[req->info_hash_count++], hash, SHA_DIGEST_LENGTH);
@@ -1540,7 +1630,7 @@ static bool tierNeedsToAnnounce(tr_tier const* tier, time_t const now)
 static bool tierNeedsToScrape(tr_tier const* tier, time_t const now)
 {
     return !tier->isScraping && tier->scrapeAt != 0 && tier->scrapeAt <= now && tier->currentTracker != NULL &&
-           tier->currentTracker->scrape != NULL;
+           tier->currentTracker->scrape_info != NULL;
 }
 
 static int compareTiers(void const* va, void const* vb)
@@ -1691,9 +1781,9 @@ tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerC
             st->isBackup = tracker != tier->currentTracker;
             st->lastScrapeStartTime = tier->lastScrapeStartTime;
 
-            if (tracker->scrape != NULL)
+            if (tracker->scrape_info != NULL)
             {
-                tr_strlcpy(st->scrape, tracker->scrape, sizeof(st->scrape));
+                tr_strlcpy(st->scrape, tracker->scrape_info->url, sizeof(st->scrape));
             }
             else
             {

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1539,7 +1539,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                 {
                     /* don't log the full URL, since that might have a personal announce id */
                     char* sanitized_url = tr_strdup_printf("%s://%s:%d", scheme, host, port);
-                    tr_logAddNamedInfo(host, "Reducing multiscrape max to %d", n);
+                    tr_logAddNamedInfo(sanitized_url, "Reducing multiscrape max to %d", n);
                     tr_free(sanitized_url);
                     tr_free(host);
                     tr_free(scheme);

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1362,11 +1362,14 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
 static bool multiscrape_too_big(char const* errmsg)
 { 
   if (!errmsg)
-    return false;
+      return false;
+
   if (strstr(errmsg, "GET string too long"))
-    return true;
+      return true;
   if (strstr(errmsg, "Request-URI Too Long"))
-    return true;
+      return true;
+  if (strstr(errmsg, "Bad Request"))
+      return true;
 
   /* Found a tracker that returns some bespoke string for this case?
      Add your patch here and open a PR */

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1367,7 +1367,7 @@ static bool multiscrape_too_big(char const* errmsg)
         "Request-URI Too Long"
     };
 
-    if (!errmsg)
+    if (errmsg == NULL)
     {
         return false;
     }

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -158,8 +158,8 @@ static void scrapeInfoFree(void* va)
 
 static int compareScrapeInfo(void const* va, void const* vb)
 {
-    const struct tr_scrape_info* a = va;
-    const struct tr_scrape_info* b = vb;
+    struct tr_scrape_info const* a = va;
+    struct tr_scrape_info const* b = vb;
     return tr_strcmp0(a->url, b->url);
 }
 
@@ -1356,8 +1356,6 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
 
 static bool multiscrape_too_big(char const* errmsg)
 {
-    unsigned int i;
-
     /* Found a tracker that returns some bespoke string for this case?
        Add your patch here and open a PR */
     static char const* const too_long_errors[] =
@@ -1372,7 +1370,7 @@ static bool multiscrape_too_big(char const* errmsg)
         return false;
     }
 
-    for (i = 0; i < TR_N_ELEMENTS(too_long_errors); ++i)
+    for (size_t i = 0; i < TR_N_ELEMENTS(too_long_errors); ++i)
     {
         if (strstr(errmsg, too_long_errors[i]) != NULL)
         {


### PR DESCRIPTION
1. Make multiscrape_max a per-scrape-url property rather than a global fixed constant.

2. Incrementally lower that limit when multiscrapes error out with messages like `GET string too long`.
