### PR TITLE
Update to Uncrustify 0.68.1

### DIFF
--- a/cli/cli.c
+++ b/cli/cli.c
@@ -99,8 +99,8 @@ static struct tr_option const options[] =
 static char const* getUsage(void)
 {
     return "A fast and easy BitTorrent client\n"
-           "\n"
-           "Usage: " MY_READABLE_NAME " [options] <file|url|magnet>";
+        "\n"
+        "Usage: " MY_READABLE_NAME " [options] <file|url|magnet>";
 }
 
 static int parseCommandLine(tr_variant*, int argc, char const** argv);

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -87,13 +87,13 @@ static struct event_base* ev_base = NULL;
 static char const* getUsage(void)
 {
     return "Transmission " LONG_VERSION_STRING "  https://transmissionbt.com/\n"
-           "A fast and easy BitTorrent client\n"
-           "\n"
-           MY_NAME " is a headless Transmission session\n"
-           "that can be controlled via transmission-remote\n"
-           "or the web interface.\n"
-           "\n"
-           "Usage: " MY_NAME " [options]";
+        "A fast and easy BitTorrent client\n"
+        "\n"
+        MY_NAME " is a headless Transmission session\n"
+        "that can be controlled via transmission-remote\n"
+        "or the web interface.\n"
+        "\n"
+        "Usage: " MY_NAME " [options]";
 }
 
 static struct tr_option const options[] =
@@ -129,16 +129,20 @@ static struct tr_option const options[] =
     { 'P', "peerport", "Port for incoming peers (Default: " TR_DEFAULT_PEER_PORT_STR ")", "P", 1, "<port>" },
     { 'm', "portmap", "Enable portmapping via NAT-PMP or UPnP", "m", 0, NULL },
     { 'M', "no-portmap", "Disable portmapping", "M", 0, NULL },
-    { 'L', "peerlimit-global", "Maximum overall number of peers (Default: " TR_DEFAULT_PEER_LIMIT_GLOBAL_STR ")", "L", 1, "<limit>" },
-    { 'l', "peerlimit-torrent", "Maximum number of peers per torrent (Default: " TR_DEFAULT_PEER_LIMIT_TORRENT_STR ")", "l", 1, "<limit>" },
+    { 'L', "peerlimit-global", "Maximum overall number of peers (Default: " TR_DEFAULT_PEER_LIMIT_GLOBAL_STR ")", "L", 1,
+        "<limit>" },
+    { 'l', "peerlimit-torrent", "Maximum number of peers per torrent (Default: " TR_DEFAULT_PEER_LIMIT_TORRENT_STR ")", "l", 1,
+        "<limit>" },
     { 910, "encryption-required", "Encrypt all peer connections", "er", 0, NULL },
     { 911, "encryption-preferred", "Prefer encrypted peer connections", "ep", 0, NULL },
     { 912, "encryption-tolerated", "Prefer unencrypted peer connections", "et", 0, NULL },
     { 'i', "bind-address-ipv4", "Where to listen for peer connections", "i", 1, "<ipv4 addr>" },
     { 'I', "bind-address-ipv6", "Where to listen for peer connections", "I", 1, "<ipv6 addr>" },
     { 'r', "rpc-bind-address", "Where to listen for RPC connections", "r", 1, "<ip addr>" },
-    { 953, "global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed until a specific ratio", "gsr", 1, "ratio" },
-    { 954, "no-global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed regardless of ratio", "GSR", 0, NULL },
+    { 953, "global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed until a specific ratio",
+        "gsr", 1, "ratio" },
+    { 954, "no-global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed regardless of ratio",
+        "GSR", 0, NULL },
     { 'x', "pid-file", "Enable PID file", "x", 1, "<pid-file>" },
     { 0, NULL, NULL, NULL, 0, NULL }
 };
@@ -147,8 +151,8 @@ static bool reopen_log_file(char const* filename)
 {
     tr_error* error = NULL;
     tr_sys_file_t const old_log_file = logfile;
-    tr_sys_file_t const new_log_file = tr_sys_file_open(filename, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_APPEND, 0666,
-        &error);
+    tr_sys_file_t const new_log_file = tr_sys_file_open(filename, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_APPEND,
+        0666, &error);
 
     if (new_log_file == TR_BAD_SYS_FILE)
     {
@@ -648,7 +652,8 @@ static int daemon_start(void* raw_arg, bool foreground)
     if (pid_filename != NULL && *pid_filename != '\0')
     {
         tr_error* error = NULL;
-        tr_sys_file_t fp = tr_sys_file_open(pid_filename, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0666, &error);
+        tr_sys_file_t fp = tr_sys_file_open(pid_filename, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0666,
+            &error);
 
         if (fp != TR_BAD_SYS_FILE)
         {

--- a/gtk/actions.c
+++ b/gtk/actions.c
@@ -86,7 +86,8 @@ static GtkActionEntry entries[] =
     { "open-torrent-toolbar", GTK_STOCK_OPEN, NULL, NULL, N_("Open a torrent"), G_CALLBACK(action_cb) },
     { "open-torrent-menu", GTK_STOCK_OPEN, NULL, NULL, N_("Open a torrent"), G_CALLBACK(action_cb) },
     { "torrent-start", GTK_STOCK_MEDIA_PLAY, N_("_Start"), "<control>S", N_("Start torrent"), G_CALLBACK(action_cb) },
-    { "torrent-start-now", GTK_STOCK_MEDIA_PLAY, N_("Start _Now"), "<shift><control>S", N_("Start torrent now"), G_CALLBACK(action_cb) },
+    { "torrent-start-now", GTK_STOCK_MEDIA_PLAY, N_("Start _Now"), "<shift><control>S", N_("Start torrent now"),
+        G_CALLBACK(action_cb) },
     { "show-stats", NULL, N_("_Statistics"), NULL, NULL, G_CALLBACK(action_cb) },
     { "donate", NULL, N_("_Donate"), NULL, NULL, G_CALLBACK(action_cb) },
     { "torrent-verify", NULL, N_("_Verify Local Data"), "<control>V", NULL, G_CALLBACK(action_cb) },
@@ -206,14 +207,16 @@ void gtr_actions_init(GtkUIManager* ui_manager, gpointer callback_user_data)
     gtk_action_group_add_radio_actions(action_group, sort_radio_entries, G_N_ELEMENTS(sort_radio_entries), active,
         G_CALLBACK(sort_changed_cb), NULL);
 
-    gtk_action_group_add_toggle_actions(action_group, show_toggle_entries, G_N_ELEMENTS(show_toggle_entries), callback_user_data);
+    gtk_action_group_add_toggle_actions(action_group, show_toggle_entries, G_N_ELEMENTS(show_toggle_entries),
+        callback_user_data);
 
     for (size_t i = 0; i < G_N_ELEMENTS(pref_toggle_entries); ++i)
     {
         pref_toggle_entries[i].is_active = gtr_pref_flag_get(tr_quark_new(pref_toggle_entries[i].name, TR_BAD_SIZE));
     }
 
-    gtk_action_group_add_toggle_actions(action_group, pref_toggle_entries, G_N_ELEMENTS(pref_toggle_entries), callback_user_data);
+    gtk_action_group_add_toggle_actions(action_group, pref_toggle_entries, G_N_ELEMENTS(pref_toggle_entries),
+        callback_user_data);
 
     gtk_action_group_add_actions(action_group, entries, n_entries, callback_user_data);
 

--- a/gtk/file-list.c
+++ b/gtk/file-list.c
@@ -135,7 +135,7 @@ static gboolean refreshFilesForeach(GtkTreeModel* model, GtkTreePath* path UNUSE
                     (refresh_data->sort_column_id == FC_ENABLED && enabled != old_enabled)))
                 {
                     refresh_data->resort_needed = TRUE;
-                    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE( data->model),
+                    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(data->model),
                         GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, GTK_SORT_ASCENDING);
                 }
             }

--- a/gtk/filter.c
+++ b/gtk/filter.c
@@ -493,7 +493,7 @@ static gboolean test_torrent_activity(tr_torrent* tor, int type)
 
     case ACTIVITY_FILTER_ACTIVE:
         return st->peersSendingToUs > 0 || st->peersGettingFromUs > 0 || st->webseedsSendingToUs > 0 ||
-               st->activity == TR_STATUS_CHECK;
+            st->activity == TR_STATUS_CHECK;
 
     case ACTIVITY_FILTER_PAUSED:
         return st->activity == TR_STATUS_STOPPED;
@@ -779,7 +779,7 @@ static gboolean is_row_visible(GtkTreeModel* model, GtkTreeIter* iter, gpointer 
     text = (char const*)g_object_get_qdata(o, TEXT_KEY);
 
     return tor != NULL && test_tracker(tor, data->active_tracker_type, data->active_tracker_host) &&
-           test_torrent_activity(tor, data->active_activity_type) && testText(tor, text);
+        test_torrent_activity(tor, data->active_activity_type) && testText(tor, text);
 }
 
 static void selection_changed_cb(GtkComboBox* combo, gpointer vdata)

--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -568,7 +568,8 @@ static void gtr_cell_renderer_render(GtkCellRenderer* renderer, GtrDrawable* dra
 }
 
 static void render_compact(TorrentCellRenderer* cell, GtrDrawable* window, GtkWidget* widget,
-    GdkRectangle const* background_area, GdkRectangle const* cell_area UNUSED, GtkCellRendererState flags)
+    GdkRectangle const* background_area, GdkRectangle const* cell_area UNUSED,
+    GtkCellRendererState flags)
 {
     int xpad;
     int ypad;
@@ -754,7 +755,8 @@ static void render_full(TorrentCellRenderer* cell, GtrDrawable* window, GtkWidge
 }
 
 static void torrent_cell_renderer_render(GtkCellRenderer* cell, GtrDrawable* window, GtkWidget* widget,
-    GdkRectangle const* background_area, GdkRectangle const* cell_area, GtkCellRendererState flags)
+    GdkRectangle const* background_area, GdkRectangle const* cell_area,
+    GtkCellRendererState flags)
 {
     TorrentCellRenderer* self = TORRENT_CELL_RENDERER(cell);
 

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -206,7 +206,7 @@ void gtr_get_host_from_url(char* buf, size_t buflen, char const* url)
 static gboolean gtr_is_supported_url(char const* str)
 {
     return str != NULL && (g_str_has_prefix(str, "ftp://") || g_str_has_prefix(str, "http://") ||
-           g_str_has_prefix(str, "https://"));
+        g_str_has_prefix(str, "https://"));
 }
 
 gboolean gtr_is_magnet_link(char const* str)

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1534,13 +1534,13 @@ static void flushCloseMessages(tr_announcer* announcer)
 static bool tierNeedsToAnnounce(tr_tier const* tier, time_t const now)
 {
     return !tier->isAnnouncing && !tier->isScraping && tier->announceAt != 0 && tier->announceAt <= now &&
-           tier->announce_event_count > 0;
+        tier->announce_event_count > 0;
 }
 
 static bool tierNeedsToScrape(tr_tier const* tier, time_t const now)
 {
     return !tier->isScraping && tier->scrapeAt != 0 && tier->scrapeAt <= now && tier->currentTracker != NULL &&
-           tier->currentTracker->scrape != NULL;
+        tier->currentTracker->scrape != NULL;
 }
 
 static int compareTiers(void const* va, void const* vb)

--- a/libtransmission/blocklist.c
+++ b/libtransmission/blocklist.c
@@ -305,17 +305,20 @@ static bool parseLine2(char const* line, struct tr_ipv4_range* range)
  * CIDR notation: "0.0.0.0/8", IPv4 only
  * https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
  */
-static bool parseLine3(char const* line, struct tr_ipv4_range* range) {
+static bool parseLine3(char const* line, struct tr_ipv4_range* range)
+{
     unsigned ip[4];
     unsigned pflen;
     uint32_t ip_u;
     uint32_t mask = 0xffffffff;
 
-    if (sscanf(line, "%u.%u.%u.%u/%u", &ip[0], &ip[1], &ip[2], &ip[3], &pflen) != 5) {
+    if (sscanf(line, "%u.%u.%u.%u/%u", &ip[0], &ip[1], &ip[2], &ip[3], &pflen) != 5)
+    {
         return false;
     }
 
-    if (pflen > 32 || ip[0] > 0xff || ip[1] > 0xff || ip[2] > 0xff || ip[3] > 0xff) {
+    if (pflen > 32 || ip[0] > 0xff || ip[1] > 0xff || ip[2] > 0xff || ip[3] > 0xff)
+    {
         return false;
     }
 

--- a/libtransmission/crypto-utils-cyassl.c
+++ b/libtransmission/crypto-utils-cyassl.c
@@ -6,6 +6,7 @@
  *
  */
 
+/* *INDENT-OFF* */
 #if defined(CYASSL_IS_WOLFSSL)
 #define API_HEADER(x) <wolfssl/x>
 #define API_HEADER_CRYPT(x) API_HEADER(wolfcrypt/x)
@@ -24,6 +25,7 @@
 #include API_HEADER_CRYPT(random.h)
 #include API_HEADER_CRYPT(sha.h)
 #include API_HEADER(version.h)
+/* *INDENT-ON* */
 
 #include "transmission.h"
 #include "crypto-utils.h"

--- a/libtransmission/crypto-utils-polarssl.c
+++ b/libtransmission/crypto-utils-polarssl.c
@@ -6,6 +6,7 @@
  *
  */
 
+/* *INDENT-OFF* */
 #if defined(POLARSSL_IS_MBEDTLS)
 #define API_HEADER(x) <mbedtls/x>
 #define API(x) mbedtls_ ## x
@@ -15,6 +16,7 @@
 #define API(x) x
 #define API_VERSION_NUMBER POLARSSL_VERSION_NUMBER
 #endif
+/* *INDENT-ON* */
 
 #include API_HEADER(arc4.h)
 #include API_HEADER(base64.h)
@@ -39,6 +41,11 @@
 ***/
 
 #define MY_NAME "tr_crypto_utils"
+
+typedef API (ctr_drbg_context) api_ctr_drbg_context;
+typedef API (sha1_context) api_sha1_context;
+typedef API (arc4_context) api_arc4_context;
+typedef API (dhm_context) api_dhm_context;
 
 static void log_polarssl_error(int error_code, char const* file, int line)
 {
@@ -89,9 +96,9 @@ static int my_rand(void* context UNUSED, unsigned char* buffer, size_t buffer_si
     return 0;
 }
 
-static API(ctr_drbg_context)* get_rng(void)
+static api_ctr_drbg_context* get_rng(void)
 {
-    static API(ctr_drbg_context) rng;
+    static api_ctr_drbg_context rng;
     static bool rng_initialized = false;
 
     if (!rng_initialized)
@@ -132,7 +139,7 @@ static tr_lock* get_rng_lock(void)
 
 tr_sha1_ctx_t tr_sha1_init(void)
 {
-    API(sha1_context)* handle = tr_new0(API(sha1_context), 1);
+    api_sha1_context* handle = tr_new0(api_sha1_context, 1);
 
 #if API_VERSION_NUMBER >= 0x01030800
     API(sha1_init)(handle);
@@ -180,7 +187,7 @@ bool tr_sha1_final(tr_sha1_ctx_t handle, uint8_t* hash)
 
 tr_rc4_ctx_t tr_rc4_new(void)
 {
-    API(arc4_context)* handle = tr_new0(API(arc4_context), 1);
+    api_arc4_context* handle = tr_new0(api_arc4_context, 1);
 
 #if API_VERSION_NUMBER >= 0x01030800
     API(arc4_init)(handle);
@@ -231,7 +238,7 @@ tr_dh_ctx_t tr_dh_new(uint8_t const* prime_num, size_t prime_num_length, uint8_t
     TR_ASSERT(prime_num != NULL);
     TR_ASSERT(generator_num != NULL);
 
-    API(dhm_context)* handle = tr_new0(API(dhm_context), 1);
+    api_dhm_context* handle = tr_new0(api_dhm_context, 1);
 
 #if API_VERSION_NUMBER >= 0x01030800
     API(dhm_init)(handle);
@@ -264,7 +271,7 @@ bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* 
     TR_ASSERT(raw_handle != NULL);
     TR_ASSERT(public_key != NULL);
 
-    API(dhm_context)* handle = raw_handle;
+    api_dhm_context* handle = raw_handle;
 
     if (public_key_length != NULL)
     {
@@ -279,7 +286,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
     TR_ASSERT(raw_handle != NULL);
     TR_ASSERT(other_public_key != NULL);
 
-    API(dhm_context)* handle = raw_handle;
+    api_dhm_context* handle = raw_handle;
     struct tr_dh_secret* ret;
     size_t secret_key_length;
 

--- a/libtransmission/file-test.c
+++ b/libtransmission/file-test.c
@@ -990,7 +990,7 @@ static int test_path_remove(void)
 
 static int test_path_native_separators(void)
 {
-    check_str(tr_sys_path_native_separators(NULL), == , NULL);
+    check_str(tr_sys_path_native_separators(NULL), ==, NULL);
 
     char path1[] = "";
     char path2[] = "a";

--- a/libtransmission/inout.c
+++ b/libtransmission/inout.c
@@ -89,7 +89,7 @@ static int readOrWriteBytes(tr_session* session, tr_torrent* tor, int ioMode, tr
             int const prealloc = (file->dnd || !doWrite) ? TR_PREALLOCATE_NONE : tor->session->preallocationMode;
 
             if ((fd = tr_fdFileCheckout(session, tor->uniqueId, fileIndex, filename, doWrite, prealloc,
-                    file->length)) == TR_BAD_SYS_FILE)
+                file->length)) == TR_BAD_SYS_FILE)
             {
                 err = errno;
                 tr_logAddTorErr(tor, "tr_fdFileCheckout failed for \"%s\": %s", filename, tr_strerror(err));

--- a/libtransmission/libtransmission-test.c
+++ b/libtransmission/libtransmission-test.c
@@ -54,7 +54,7 @@ bool libtest_check(char const* file, int line, bool pass, bool condition, char c
 {
     if (should_print(pass))
     {
-        fprintf(stderr, "%s %s:%d: %s (%s)\n", pass ? "PASS" : "FAIL", file, line, condition_str, condition ? "true": "false");
+        fprintf(stderr, "%s %s:%d: %s (%s)\n", pass ? "PASS" : "FAIL", file, line, condition_str, condition ? "true" : "false");
     }
 
     return pass;

--- a/libtransmission/libtransmission-test.h
+++ b/libtransmission/libtransmission-test.h
@@ -59,11 +59,12 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        bool const check_bool_lhs = (lhs); \
-        bool const check_bool_rhs = (rhs); \
+        bool const check_lhs = (lhs); \
+        bool const check_rhs = (rhs); \
         \
-        if (!libtest_check_bool(__FILE__, __LINE__, check_bool_lhs op check_bool_rhs, check_bool_lhs, check_bool_rhs, #lhs, \
-            #op, #rhs)) \
+        bool const check_result = check_lhs op check_rhs; \
+        \
+        if (!libtest_check_bool(__FILE__, __LINE__, check_result, check_lhs, check_rhs, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \
@@ -75,11 +76,12 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        char const* const check_str_lhs = (lhs); \
-        char const* const check_str_rhs = (rhs); \
+        char const* const check_lhs = (lhs); \
+        char const* const check_rhs = (rhs); \
         \
-        if (!libtest_check_str(__FILE__, __LINE__, tr_strcmp0(check_str_lhs, check_str_rhs) op 0, check_str_lhs, \
-            check_str_rhs, #lhs, #op, #rhs)) \
+        bool const check_result = tr_strcmp0(check_lhs, check_rhs) op 0; \
+        \
+        if (!libtest_check_str(__FILE__, __LINE__, check_result, check_lhs, check_rhs, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \
@@ -91,12 +93,13 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        void const* const check_mem_lhs = (lhs); \
-        void const* const check_mem_rhs = (rhs); \
-        size_t const check_mem_size = (size);\
+        void const* const check_lhs = (lhs); \
+        void const* const check_rhs = (rhs); \
+        size_t const check_mem_size = (size); \
         \
-        if (!libtest_check_mem(__FILE__, __LINE__, tr_memcmp0(check_mem_lhs, check_mem_rhs, check_mem_size) op 0, \
-            check_mem_lhs, check_mem_rhs, check_mem_size, #lhs, #op, #rhs)) \
+        bool const check_result = tr_memcmp0(check_lhs, check_rhs, check_mem_size) op 0; \
+        \
+        if (!libtest_check_mem(__FILE__, __LINE__, check_result, check_lhs, check_rhs, check_mem_size, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \
@@ -108,11 +111,12 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        intmax_t const check_int_lhs = (lhs); \
-        intmax_t const check_int_rhs = (rhs); \
+        intmax_t const check_lhs = (lhs); \
+        intmax_t const check_rhs = (rhs); \
         \
-        if (!libtest_check_int(__FILE__, __LINE__, check_int_lhs op check_int_rhs, check_int_lhs, check_int_rhs, #lhs, #op, \
-            #rhs)) \
+        bool const check_result = check_lhs op check_rhs; \
+        \
+        if (!libtest_check_int(__FILE__, __LINE__, check_result, check_lhs, check_rhs, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \
@@ -124,11 +128,12 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        uintmax_t const check_uint_lhs = (lhs); \
-        uintmax_t const check_uint_rhs = (rhs); \
+        uintmax_t const check_lhs = (lhs); \
+        uintmax_t const check_rhs = (rhs); \
         \
-        if (!libtest_check_uint(__FILE__, __LINE__, check_uint_lhs op check_uint_rhs, check_uint_lhs, check_uint_rhs, #lhs, \
-            #op, #rhs)) \
+        bool const check_result = check_lhs op check_rhs; \
+        \
+        if (!libtest_check_uint(__FILE__, __LINE__, check_result, check_lhs, check_rhs, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \
@@ -140,11 +145,12 @@ bool libtest_check_ptr(char const* file, int line, bool pass, void const* lhs, v
     { \
         ++current_test; \
         \
-        void const* const check_ptr_lhs = (lhs); \
-        void const* const check_ptr_rhs = (rhs); \
+        void const* const check_lhs = (lhs); \
+        void const* const check_rhs = (rhs); \
         \
-        if (!libtest_check_ptr(__FILE__, __LINE__, check_ptr_lhs op check_ptr_rhs, check_ptr_lhs, check_ptr_rhs, #lhs, #op, \
-            #rhs)) \
+        bool const check_result = check_lhs op check_rhs; \
+        \
+        if (!libtest_check_ptr(__FILE__, __LINE__, check_result, check_lhs, check_rhs, #lhs, #op, #rhs)) \
         { \
             return current_test; \
         } \

--- a/libtransmission/list.h
+++ b/libtransmission/list.h
@@ -28,7 +28,7 @@ typedef struct tr_list
 }
 tr_list;
 
-typedef int (* TrListCompareFunc)(void const* a, void const* b);
+typedef tr_voidptr_compare_func TrListCompareFunc;
 typedef void (* TrListForeachFunc)(void*);
 
 /**

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -27,7 +27,7 @@ static inline bool tr_logLevelIsActive(tr_log_level level)
     return tr_logGetLevel() >= level;
 }
 
-void tr_logAddMessage(char const* file, int line, tr_log_level level, char const* torrent, char const* fmt, ...)
+void tr_logAddMessage(char const* file, int line, tr_log_level level, char const* torrent, char const* fmt, ...) \
     TR_GNUC_PRINTF(5, 6);
 
 #define tr_logAddNamed(level, name, ...) \
@@ -61,7 +61,7 @@ tr_sys_file_t tr_logGetFile(void);
 /** @brief return true if deep logging has been enabled by the user; false otherwise */
 bool tr_logGetDeepEnabled(void);
 
-void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt, ...) TR_GNUC_PRINTF(4, 5)
+void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt, ...) TR_GNUC_PRINTF(4, 5) \
     TR_GNUC_NONNULL(1, 4);
 
 #define tr_logAddDeepNamed(name, ...) \

--- a/libtransmission/makemeta-test.c
+++ b/libtransmission/makemeta-test.c
@@ -111,7 +111,8 @@ static int test_single_file(void)
 }
 
 static int test_single_directory_impl(tr_tracker_info const* trackers, size_t const trackerCount, void const** payloads,
-    size_t const* payloadSizes, size_t const payloadCount, char const* comment, bool const isPrivate)
+    size_t const* payloadSizes, size_t const payloadCount, char const* comment,
+    bool const isPrivate)
 {
     char* sandbox;
     char* torrent_file;
@@ -211,7 +212,8 @@ static int test_single_directory_impl(tr_tracker_info const* trackers, size_t co
 }
 
 static int test_single_directory_random_payload_impl(tr_tracker_info const* trackers, size_t const trackerCount,
-    size_t const maxFileCount, size_t const maxFileSize, char const* comment, bool const isPrivate)
+    size_t const maxFileCount, size_t const maxFileSize, char const* comment,
+    bool const isPrivate)
 {
     void** payloads;
     size_t* payloadSizes;

--- a/libtransmission/metainfo.c
+++ b/libtransmission/metainfo.c
@@ -89,7 +89,7 @@ static char* getTorrentFilename(tr_session const* session, tr_info const* inf, e
 static bool path_component_is_suspicious(char const* component)
 {
     return component == NULL || strpbrk(component, PATH_DELIMITER_CHARS) != NULL || strcmp(component, ".") == 0 ||
-           strcmp(component, "..") == 0;
+        strcmp(component, "..") == 0;
 }
 
 static bool getfile(char** setme, char const* root, tr_variant* path, struct evbuffer* buf)
@@ -626,7 +626,8 @@ static char const* tr_metainfoParseImpl(tr_session const* session, tr_info* inf,
     /* files */
     if (!isMagnet)
     {
-        if ((str = parseFiles(inf, tr_variantDictFind(infoDict, TR_KEY_files), tr_variantDictFind(infoDict, TR_KEY_length))) != NULL)
+        if ((str = parseFiles(inf, tr_variantDictFind(infoDict, TR_KEY_files), tr_variantDictFind(infoDict,
+            TR_KEY_length))) != NULL)
         {
             return str;
         }

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -375,7 +375,8 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
     return ret;
 }
 
-struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed UNUSED)
+struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port,
+    bool clientIsSeed UNUSED)
 {
     struct tr_peer_socket ret = TR_PEER_SOCKET_INIT;
 
@@ -776,5 +777,5 @@ static bool isMartianAddr(struct tr_address const* a)
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port)
 {
     return port != 0 && tr_address_is_valid(addr) && !isIPv6LinkLocalAddress(addr) && !isIPv4MappedAddress(addr) &&
-           !isMartianAddr(addr);
+        !isMartianAddr(addr);
 }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -128,7 +128,7 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io);
 static inline bool tr_isPeerIo(tr_peerIo const* io)
 {
     return io != NULL && io->magicNumber == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 && tr_isBandwidth(&io->bandwidth) &&
-           tr_address_is_valid(&io->addr);
+        tr_address_is_valid(&io->addr);
 }
 
 /**

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -149,7 +149,7 @@ struct peer_atom
 static bool tr_isAtom(struct peer_atom const* atom)
 {
     return atom != NULL && atom->fromFirst < TR_PEER_FROM__MAX && atom->fromBest < TR_PEER_FROM__MAX &&
-           tr_address_is_valid(&atom->addr);
+        tr_address_is_valid(&atom->addr);
 }
 
 #endif
@@ -411,7 +411,7 @@ static bool peerIsInUse(tr_swarm const* cs, struct peer_atom const* atom)
     TR_ASSERT(swarmIsLocked(s));
 
     return atom->peer != NULL || getExistingHandshake(&s->outgoingHandshakes, &atom->addr) ||
-           getExistingHandshake(&s->manager->incomingHandshakes, &atom->addr);
+        getExistingHandshake(&s->manager->incomingHandshakes, &atom->addr);
 }
 
 static inline bool replicationExists(tr_swarm const* s)
@@ -3643,8 +3643,7 @@ static int comparePeerLiveliness(void const* va, void const* vb)
     return 0;
 }
 
-static void sortPeersByLivelinessImpl(tr_peer** peers, void** clientData, int n, uint64_t now, int (* compare)(void const* va,
-    void const* vb))
+static void sortPeersByLivelinessImpl(tr_peer** peers, void** clientData, int n, uint64_t now, tr_voidptr_compare_func compare)
 {
     struct peer_liveliness* lives;
     struct peer_liveliness* l;

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -2316,8 +2316,8 @@ typedef void (* tr_set_func)(void* element, void* userData);
  * @param in_both called for items that are in both sets
  * @param userData user data passed along to in_a, in_b, and in_both
  */
-static void tr_set_compare(void const* va, size_t aCount, void const* vb, size_t bCount, int (* compare)(void const* a,
-    void const* b), size_t elementSize, tr_set_func in_a_cb, tr_set_func in_b_cb, tr_set_func in_both_cb, void* userData)
+static void tr_set_compare(void const* va, size_t aCount, void const* vb, size_t bCount, tr_voidptr_compare_func compare,
+    size_t elementSize, tr_set_func in_a_cb, tr_set_func in_b_cb, tr_set_func in_both_cb, void* userData)
 {
     uint8_t const* a = va;
     uint8_t const* b = vb;

--- a/libtransmission/platform-quota.c
+++ b/libtransmission/platform-quota.c
@@ -386,7 +386,7 @@ static int64_t getquota(char const* device)
 #ifdef __APPLE__
         return freespace < 0 ? 0 : freespace;
 #else
-        return freespace < 0 ? 0 : freespace * 1024;
+        return freespace < 0 ? 0 : (freespace * 1024);
 #endif
     }
 
@@ -426,7 +426,7 @@ static int64_t getxfsquota(char* device)
         }
 
         freespace = limit - (dq.d_bcount >> 1);
-        return freespace < 0 ? 0 : freespace * 1024;
+        return freespace < 0 ? 0 : (freespace * 1024);
     }
 
     /* something went wrong */

--- a/libtransmission/ptrarray.c
+++ b/libtransmission/ptrarray.c
@@ -101,7 +101,7 @@ void tr_ptrArrayErase(tr_ptrArray* t, int begin, int end)
 ***
 **/
 
-int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, int (* compare)(void const*, void const*), bool* exact_match)
+int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, tr_voidptr_compare_func compare, bool* exact_match)
 {
     int pos = -1;
     bool match = false;
@@ -168,7 +168,7 @@ int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, int (* compare)
 
 #else
 
-static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, int (* compare)(void const*, void const*))
+static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, tr_voidptr_compare_func compare)
 {
     for (int i = 0; i < t->n_items - 2; ++i)
     {
@@ -176,7 +176,7 @@ static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, int (* compare)(v
     }
 }
 
-static void assertIndexIsSortedAndUnique(tr_ptrArray const* t, int pos, int (* compare)(void const*, void const*))
+static void assertIndexIsSortedAndUnique(tr_ptrArray const* t, int pos, tr_voidptr_compare_func compare)
 {
     if (pos > 0)
     {
@@ -191,7 +191,7 @@ static void assertIndexIsSortedAndUnique(tr_ptrArray const* t, int pos, int (* c
 
 #endif
 
-int tr_ptrArrayInsertSorted(tr_ptrArray* t, void* ptr, int (* compare)(void const*, void const*))
+int tr_ptrArrayInsertSorted(tr_ptrArray* t, void* ptr, tr_voidptr_compare_func compare)
 {
     int pos;
     int ret;
@@ -204,14 +204,14 @@ int tr_ptrArrayInsertSorted(tr_ptrArray* t, void* ptr, int (* compare)(void cons
     return ret;
 }
 
-void* tr_ptrArrayFindSorted(tr_ptrArray* t, void const* ptr, int (* compare)(void const*, void const*))
+void* tr_ptrArrayFindSorted(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare)
 {
     bool match = false;
     int const pos = tr_ptrArrayLowerBound(t, ptr, compare, &match);
     return match ? t->items[pos] : NULL;
 }
 
-static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, int (* compare)(void const*, void const*))
+static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare)
 {
     int pos;
     bool match;
@@ -232,7 +232,7 @@ static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, int (
     return ret;
 }
 
-void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, int (* compare)(void const*, void const*))
+void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare)
 {
     void* removed = tr_ptrArrayRemoveSortedValue(t, ptr, compare);
 

--- a/libtransmission/ptrarray.h
+++ b/libtransmission/ptrarray.h
@@ -31,7 +31,7 @@ typedef struct tr_ptrArray
 }
 tr_ptrArray;
 
-typedef int (* PtrArrayCompareFunc)(void const* a, void const* b);
+typedef tr_voidptr_compare_func PtrArrayCompareFunc;
 
 typedef void (* PtrArrayForeachFunc)(void*);
 
@@ -113,18 +113,17 @@ static inline bool tr_ptrArrayEmpty(tr_ptrArray const* a)
     return tr_ptrArraySize(a) == 0;
 }
 
-int tr_ptrArrayLowerBound(tr_ptrArray const* array, void const* key, int (* compare)(void const* arrayItem, void const* key),
-    bool* exact_match);
+int tr_ptrArrayLowerBound(tr_ptrArray const* array, void const* key, tr_voidptr_compare_func compare, bool* exact_match);
 
 /** @brief Insert a pointer into the array at the position determined by the sort function
     @return the index of the stored pointer */
-int tr_ptrArrayInsertSorted(tr_ptrArray* array, void* value, int (* compare)(void const*, void const*));
+int tr_ptrArrayInsertSorted(tr_ptrArray* array, void* value, tr_voidptr_compare_func compare);
 
 /** @brief Remove this specific pointer from a sorted ptrarray */
-void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, int (* compare)(void const*, void const*));
+void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare);
 
 /** @brief Find a pointer from an array sorted by the specified sort function
     @return the matching pointer, or NULL if no match was found */
-void* tr_ptrArrayFindSorted(tr_ptrArray* array, void const* key, int (* compare)(void const*, void const*));
+void* tr_ptrArrayFindSorted(tr_ptrArray* array, void const* key, tr_voidptr_compare_func compare);
 
 /* @} */

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -555,7 +555,7 @@ static bool isIPAddressWithOptionalPort(char const* host)
     int address_len = sizeof(address);
 
     /* TODO: move to net.{c,h} */
-    return evutil_parse_sockaddr_port(host, (struct sockaddr *) &address, &address_len) != -1;
+    return evutil_parse_sockaddr_port(host, (struct sockaddr*)&address, &address_len) != -1;
 }
 
 static bool isHostnameAllowed(tr_rpc_server const* server, struct evhttp_request* req)
@@ -672,7 +672,8 @@ static void handle_request(struct evhttp_request* req, void* arg)
         {
             evhttp_add_header(req->output_headers, "WWW-Authenticate", "Basic realm=\"" MY_REALM "\"");
             server->loginattempts++;
-            char* unauthuser = tr_strdup_printf("<p>Unauthorized User. %d unsuccessful login attempts.</p>", server->loginattempts);
+            char* unauthuser = tr_strdup_printf("<p>Unauthorized User. %d unsuccessful login attempts.</p>",
+                server->loginattempts);
             send_simple_response(req, 401, unauthuser);
             tr_free(unauthuser);
             tr_free(user);
@@ -1236,7 +1237,8 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     if (s->isEnabled)
     {
-        tr_logAddNamedInfo(MY_NAME, _("Serving RPC and Web requests on %s:%d%s"), tr_rpcGetBindAddress(s), (int)s->port, s->url);
+        tr_logAddNamedInfo(MY_NAME, _("Serving RPC and Web requests on %s:%d%s"), tr_rpcGetBindAddress(s), (int)s->port,
+            s->url);
         tr_runInEventThread(session, startServer, s);
 
         if (s->isWhitelistEnabled)

--- a/libtransmission/subprocess-test.c
+++ b/libtransmission/subprocess-test.c
@@ -34,10 +34,10 @@ static int test_spawn_async_missing_exe(void)
 
     tr_error* error = NULL;
     bool const ret = tr_spawn_async(args, NULL, NULL, &error);
-    check_bool(ret, == , false);
-    check_ptr(error, != , NULL);
-    check_int(error->code, != , 0);
-    check_str(error->message, != , NULL);
+    check_bool(ret, ==, false);
+    check_ptr(error, !=, NULL);
+    check_int(error->code, !=, 0);
+    check_str(error->message, !=, NULL);
 
     tr_error_clear(&error);
 
@@ -89,12 +89,12 @@ static int test_spawn_async_args(void)
     check_str(buffer, ==, test_arg_2);
 
     check(tr_sys_file_read_line(fd, buffer, sizeof(buffer), NULL));
-    check_str(buffer, == , test_arg_3);
+    check_str(buffer, ==, test_arg_3);
 
     if (allow_batch_metachars)
     {
         check(tr_sys_file_read_line(fd, buffer, sizeof(buffer), NULL));
-        check_str(buffer, == , test_arg_4);
+        check_str(buffer, ==, test_arg_4);
     }
 
     check(!tr_sys_file_read_line(fd, buffer, sizeof(buffer), NULL));

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -509,7 +509,7 @@ static bool tr_torrentIsSeedIdleLimitDone(tr_torrent* tor)
 {
     uint16_t idleMinutes;
     return tr_torrentGetSeedIdle(tor, &idleMinutes) &&
-           difftime(tr_time(), MAX(tor->startDate, tor->activityDate)) >= idleMinutes * 60u;
+        difftime(tr_time(), MAX(tor->startDate, tor->activityDate)) >= idleMinutes * 60u;
 }
 
 /***
@@ -1317,7 +1317,7 @@ static time_t torrentGetIdleSecs(tr_torrent const* tor)
 bool tr_torrentIsStalled(tr_torrent const* tor)
 {
     return tr_sessionGetQueueStalledEnabled(tor->session) &&
-           torrentGetIdleSecs(tor) > tr_sessionGetQueueStalledMinutes(tor->session) * 60;
+        torrentGetIdleSecs(tor) > tr_sessionGetQueueStalledMinutes(tor->session) * 60;
 }
 
 static double getVerifyProgress(tr_torrent const* tor)
@@ -3769,7 +3769,7 @@ void tr_torrentSetQueueStartCallback(tr_torrent* torrent, void (* callback)(tr_t
 static bool renameArgsAreValid(char const* oldpath, char const* newname)
 {
     return oldpath != NULL && *oldpath != '\0' && newname != NULL && *newname != '\0' && strcmp(newname, ".") != 0 &&
-           strcmp(newname, "..") != 0 && strchr(newname, TR_PATH_DELIMITER) == NULL;
+        strcmp(newname, "..") != 0 && strchr(newname, TR_PATH_DELIMITER) == NULL;
 }
 
 static tr_file_index_t* renameFindAffectedFiles(tr_torrent* tor, char const* oldpath, size_t* setme_n)

--- a/libtransmission/tr-lpd.c
+++ b/libtransmission/tr-lpd.c
@@ -517,7 +517,8 @@ bool tr_lpdSendAnnounce(tr_torrent const* t)
 
         /* destination address info has already been set up in tr_lpdInit(),
          * so we refrain from preparing another sockaddr_in here */
-        int res = sendto(lpd_socket2, (void const*)query, len, 0, (struct sockaddr const*)&lpd_mcastAddr, sizeof(lpd_mcastAddr));
+        int res = sendto(lpd_socket2, (void const*)query, len, 0, (struct sockaddr const*)&lpd_mcastAddr,
+            sizeof(lpd_mcastAddr));
 
         if (res != len)
         {

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -140,7 +140,7 @@
 #else
 #define TR_STATIC_ASSERT(x, msg) \
     { \
-        typedef char __tr_static_check__[(x) ? 1 : -1] UNUSED; \
+        typedef char __tr_static_check__ [(x) ? 1 : -1] UNUSED; \
     }
 #endif
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -49,6 +49,8 @@ struct tr_variant;
 
 typedef int8_t tr_priority_t;
 
+typedef int (* tr_voidptr_compare_func)(void const* lhs, void const* rhs);
+
 #define TR_RPC_SESSION_ID_HEADER "X-Transmission-Session-Id"
 
 typedef enum

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -811,7 +811,7 @@ bool tr_urlIsValidTracker(char const* url)
     size_t const url_len = strlen(url);
 
     return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, NULL, NULL, NULL, NULL) &&
-           (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "udp://", 6) == 0);
+        (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "udp://", 6) == 0);
 }
 
 bool tr_urlIsValid(char const* url, size_t url_len)
@@ -827,8 +827,8 @@ bool tr_urlIsValid(char const* url, size_t url_len)
     }
 
     return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, NULL, NULL, NULL, NULL) &&
-           (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "ftp://", 6) == 0 ||
-           memcmp(url, "sftp://", 7) == 0);
+        (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "ftp://", 6) == 0 ||
+            memcmp(url, "sftp://", 7) == 0);
 }
 
 bool tr_addressIsIP(char const* str)
@@ -979,8 +979,8 @@ void tr_removeElementFromArray(void* array, unsigned int index_to_remove, size_t
         sizeof_element * (--nmemb - index_to_remove));
 }
 
-int tr_lowerBound(void const* key, void const* base, size_t nmemb, size_t size, int (* compar)(void const* key,
-    void const* arrayMember), bool* exact_match)
+int tr_lowerBound(void const* key, void const* base, size_t nmemb, size_t size, tr_voidptr_compare_func compar,
+    bool* exact_match)
 {
     size_t first = 0;
     char const* cbase = base;
@@ -1038,7 +1038,7 @@ int tr_lowerBound(void const* key, void const* base, size_t nmemb, size_t size, 
     } \
     while (0)
 
-static size_t quickfindPartition(char* base, size_t left, size_t right, size_t size, int (* compar)(void const*, void const*),
+static size_t quickfindPartition(char* base, size_t left, size_t right, size_t size, tr_voidptr_compare_func compar,
     size_t pivotIndex)
 {
     size_t storeIndex;
@@ -1081,8 +1081,7 @@ static size_t quickfindPartition(char* base, size_t left, size_t right, size_t s
     return storeIndex;
 }
 
-static void quickfindFirstK(char* base, size_t left, size_t right, size_t size, int (* compar)(void const*, void const*),
-    size_t k)
+static void quickfindFirstK(char* base, size_t left, size_t right, size_t size, tr_voidptr_compare_func compar, size_t k)
 {
     if (right > left)
     {
@@ -1103,7 +1102,7 @@ static void quickfindFirstK(char* base, size_t left, size_t right, size_t size, 
 
 #ifdef TR_ENABLE_ASSERTS
 
-static void checkBestScoresComeFirst(char* base, size_t nmemb, size_t size, int (* compar)(void const*, void const*), size_t k)
+static void checkBestScoresComeFirst(char* base, size_t nmemb, size_t size, tr_voidptr_compare_func compar, size_t k)
 {
     size_t worstFirstPos = 0;
 
@@ -1128,7 +1127,7 @@ static void checkBestScoresComeFirst(char* base, size_t nmemb, size_t size, int 
 
 #endif
 
-void tr_quickfindFirstK(void* base, size_t nmemb, size_t size, int (* compar)(void const*, void const*), size_t k)
+void tr_quickfindFirstK(void* base, size_t nmemb, size_t size, tr_voidptr_compare_func compar, size_t k)
 {
     if (k < nmemb)
     {

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -126,6 +126,7 @@ void tr_win32_make_args_utf8(int* argc, char*** argv);
 
 int tr_main_win32(int argc, char** argv, int (* real_main)(int, char**));
 
+/* *INDENT-OFF* */
 #define tr_main(...) \
     main_impl(__VA_ARGS__); \
     int main(int argc, char* argv[]) \
@@ -133,6 +134,7 @@ int tr_main_win32(int argc, char** argv, int (* real_main)(int, char**));
         return tr_main_win32(argc, argv, &main_impl); \
     } \
     int main_impl(__VA_ARGS__)
+/* *INDENT-ON* */
 
 #else
 
@@ -167,6 +169,7 @@ void tr_free_ptrv(void* const* p);
  */
 void* tr_memdup(void const* src, size_t byteCount);
 
+/* *INDENT-OFF* */
 #define tr_new(struct_type, n_structs) \
     ((struct_type*)tr_malloc(sizeof(struct_type) * (size_t)(n_structs)))
 
@@ -175,6 +178,7 @@ void* tr_memdup(void const* src, size_t byteCount);
 
 #define tr_renew(struct_type, mem, n_structs) \
     ((struct_type*)tr_realloc((mem), sizeof(struct_type) * (size_t)(n_structs)))
+/* *INDENT-ON* */
 
 void* tr_valloc(size_t bufLen);
 
@@ -206,11 +210,11 @@ int tr_memcmp0(void const* lhs, void const* rhs, size_t size);
 char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len);
 
 /** @brief similar to bsearch() but returns the index of the lower bound */
-int tr_lowerBound(void const* key, void const* base, size_t nmemb, size_t size, int (* compar)(void const* key,
-    void const* arrayMember), bool* exact_match) TR_GNUC_HOT TR_GNUC_NONNULL(1, 5, 6);
+int tr_lowerBound(void const* key, void const* base, size_t nmemb, size_t size, tr_voidptr_compare_func compar,
+    bool* exact_match) TR_GNUC_HOT TR_GNUC_NONNULL(1, 5, 6);
 
 /** @brief moves the best k items to the first slots in the array. O(n) */
-void tr_quickfindFirstK(void* base, size_t nmemb, size_t size, int (* compar)(void const*, void const*), size_t k);
+void tr_quickfindFirstK(void* base, size_t nmemb, size_t size, tr_voidptr_compare_func compar, size_t k);
 
 /**
  * @brief sprintf() a string into a newly-allocated buffer large enough to hold it

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -117,7 +117,7 @@ static bool tr_variantIsContainer(tr_variant const* v)
 static bool tr_variantIsSomething(tr_variant const* v)
 {
     return tr_variantIsContainer(v) || tr_variantIsInt(v) || tr_variantIsString(v) || tr_variantIsReal(v) ||
-           tr_variantIsBool(v);
+        tr_variantIsBool(v);
 }
 
 void tr_variantInit(tr_variant* v, char type)

--- a/libtransmission/watchdir-generic.c
+++ b/libtransmission/watchdir-generic.c
@@ -87,7 +87,7 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
     backend->base.free_func = &tr_watchdir_generic_free;
 
     if ((backend->event = event_new(tr_watchdir_get_event_base(handle), -1, EV_PERSIST, &tr_watchdir_generic_on_event,
-            handle)) == NULL)
+        handle)) == NULL)
     {
         log_error("Failed to create event: %s", tr_strerror(errno));
         goto fail;

--- a/libtransmission/watchdir-kqueue.c
+++ b/libtransmission/watchdir-kqueue.c
@@ -145,7 +145,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
 
     /* Create libevent task for event descriptor */
     if ((backend->event = event_new(tr_watchdir_get_event_base(handle), backend->kq, EV_READ | EV_ET | EV_PERSIST,
-            &tr_watchdir_kqueue_on_event, handle)) == NULL)
+        &tr_watchdir_kqueue_on_event, handle)) == NULL)
     {
         log_error("Failed to create event: %s", tr_strerror(errno));
         goto fail;

--- a/libtransmission/watchdir-win32.c
+++ b/libtransmission/watchdir-win32.c
@@ -63,7 +63,7 @@ tr_watchdir_win32;
 static BOOL tr_get_overlapped_result_ex(HANDLE handle, LPOVERLAPPED overlapped, LPDWORD bytes_transferred, DWORD timeout,
     BOOL alertable)
 {
-    typedef BOOL (WINAPI * impl_t)(HANDLE, LPOVERLAPPED, LPDWORD, DWORD, BOOL);
+    typedef BOOL (WINAPI* impl_t)(HANDLE, LPOVERLAPPED, LPDWORD, DWORD, BOOL);
 
     static impl_t real_impl = NULL;
     static bool is_real_impl_valid = false;
@@ -268,7 +268,7 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
     }
 
     if ((backend->fd = CreateFileW(wide_path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
-            OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL)) == INVALID_HANDLE_VALUE)
+        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL)) == INVALID_HANDLE_VALUE)
     {
         log_error("Failed to open directory \"%s\"", path);
         goto fail;

--- a/libtransmission/web.c
+++ b/libtransmission/web.c
@@ -268,7 +268,8 @@ static void task_finish_func(void* vtask)
 static void tr_webThreadFunc(void* vsession);
 
 static struct tr_web_task* tr_webRunImpl(tr_session* session, int torrentId, char const* url, char const* range,
-    char const* cookies, tr_web_done_func done_func, void* done_func_user_data, struct evbuffer* buffer)
+    char const* cookies, tr_web_done_func done_func, void* done_func_user_data,
+    struct evbuffer* buffer)
 {
     struct tr_web_task* task = NULL;
 
@@ -744,7 +745,7 @@ char* tr_http_unescape(char const* str, size_t len)
 static bool is_rfc2396_alnum(uint8_t ch)
 {
     return ('0' <= ch && ch <= '9') || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ch == '.' || ch == '-' ||
-           ch == '_' || ch == '~';
+        ch == '_' || ch == '~';
 }
 
 void tr_http_escape_sha1(char* out, uint8_t const* sha1_digest)

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -59,7 +59,7 @@ tr_option const opts[] =
 char const* getUsage()
 {
     return "Usage:\n"
-           "  transmission [OPTIONS...] [torrent files]";
+        "  transmission [OPTIONS...] [torrent files]";
 }
 
 enum

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -164,7 +164,7 @@ private:
                 {
                     quint32 const ipv4Address = ipAddress.toIPv4Address();
                     collatedAddress = QLatin1String("1-") + QString::fromLatin1(QByteArray::number(ipv4Address, 16).
-                            rightJustified(8, '0'));
+                        rightJustified(8, '0'));
                 }
                 else if (ipAddress.protocol() == QAbstractSocket::IPv6Protocol)
                 {
@@ -529,7 +529,7 @@ void DetailsDialog::refresh()
             //: %2 is overall size of torrent data,
             //: %3 is percentage (%1/%2*100)
             string = tr("%1 of %2 (%3%)").arg(Formatter::sizeToString(haveVerified)).arg(Formatter::sizeToString(sizeWhenDone)).
-                    arg(pct);
+                arg(pct);
         }
         else
         {
@@ -539,7 +539,7 @@ void DetailsDialog::refresh()
             //: %3 is percentage (%1/%2*100),
             //: %4 is amount of downloaded but not yet verified data
             string = tr("%1 of %2 (%3%), %4 Unverified").arg(Formatter::sizeToString(haveVerified + haveUnverified)).
-                    arg(Formatter::sizeToString(sizeWhenDone)).arg(pct).arg(Formatter::sizeToString(haveUnverified));
+                arg(Formatter::sizeToString(sizeWhenDone)).arg(pct).arg(Formatter::sizeToString(haveUnverified));
         }
     }
 
@@ -784,7 +784,7 @@ void DetailsDialog::refresh()
         else if (pieceSize > 0)
         {
             string = tr("%1 (%Ln pieces @ %2)", "", pieces).arg(Formatter::sizeToString(size)).
-                    arg(Formatter::memToString(pieceSize));
+                arg(Formatter::memToString(pieceSize));
         }
         else
         {

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -23,12 +23,14 @@ class FileTreeItem
     Q_DISABLE_COPY(FileTreeItem)
 
 public:
+/* *INDENT-OFF* */
     enum
     {
         LOW = (1 << 0),
         NORMAL = (1 << 1),
         HIGH = (1 << 2)
     };
+/* *INDENT-ON* */
 
 public:
     FileTreeItem(QString const& name = QString(), int fileIndex = -1, uint64_t size = 0) :

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -686,7 +686,7 @@ void MainWindow::openAbout()
 void MainWindow::openHelp()
 {
     QDesktopServices::openUrl(QUrl(QString::fromLatin1("https://transmissionbt.com/help/gtk/%1.%2x").arg(MAJOR_VERSION).
-            arg(MINOR_VERSION / 10)));
+        arg(MINOR_VERSION / 10)));
 }
 
 void MainWindow::refreshTitle()
@@ -769,13 +769,13 @@ void MainWindow::refreshStatusBar()
     {
         tr_session_stats const& stats(mySession.getStats());
         str = tr("Down: %1, Up: %2").arg(Formatter::sizeToString(stats.downloadedBytes)).
-                arg(Formatter::sizeToString(stats.uploadedBytes));
+            arg(Formatter::sizeToString(stats.uploadedBytes));
     }
     else if (mode == TotalTransferStatsModeName)
     {
         tr_session_stats const& stats(mySession.getCumulativeStats());
         str = tr("Down: %1, Up: %2").arg(Formatter::sizeToString(stats.downloadedBytes)).
-                arg(Formatter::sizeToString(stats.uploadedBytes));
+            arg(Formatter::sizeToString(stats.uploadedBytes));
     }
     else // default is "total-ratio"
     {

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -113,12 +113,12 @@ void MakeProgressDialog::onProgress()
     else if (b.result == TR_MAKEMETA_IO_READ)
     {
         str = tr("Error reading \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
-                arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
+            arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
     }
     else if (b.result == TR_MAKEMETA_IO_WRITE)
     {
         str = tr("Error writing \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
-                arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
+            arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
     }
 
     ui.progressLabel->setText(str);
@@ -221,7 +221,7 @@ void MakeDialog::onSourceChanged()
         QString files = tr("%Ln File(s)", nullptr, myBuilder->fileCount);
         QString pieces = tr("%Ln Piece(s)", nullptr, myBuilder->pieceCount);
         text = tr("%1 in %2; %3 @ %4").arg(Formatter::sizeToString(myBuilder->totalSize)).arg(files).arg(pieces).
-                arg(Formatter::sizeToString(myBuilder->pieceSize));
+            arg(Formatter::sizeToString(myBuilder->pieceSize));
     }
 
     ui.sourceSizeLabel->setText(text);

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -92,5 +92,5 @@ RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, QSet
 QString RelocateDialog::newLocation() const
 {
     return ui.newLocationStack->currentWidget() == ui.newLocationButton ? ui.newLocationButton->path() :
-           ui.newLocationEdit->text();
+        ui.newLocationEdit->text();
 }

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -222,7 +222,7 @@ void RpcClient::networkRequestFinished(QNetworkReply* reply)
     reply->deleteLater();
 
     QFutureInterface<RpcResponse> promise = reply->property(REQUEST_FUTUREINTERFACE_PROPERTY_KEY).
-            value<QFutureInterface<RpcResponse>>();
+        value<QFutureInterface<RpcResponse>>();
 
 #ifdef DEBUG_HTTP
     std::cerr << "http response header: " << std::endl;

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -52,7 +52,7 @@ public:
 private:
     // Internally queued function. Takes the last response future, makes a
     // request and returns a new response future.
-    typedef std::function<RpcResponseFuture (RpcResponseFuture const&)> QueuedFunction;
+    typedef std::function<RpcResponseFuture(RpcResponseFuture const&)> QueuedFunction;
 
     // Internally stored error handler function. Takes the last response future and returns nothing.
     typedef std::function<void (RpcResponseFuture const&)> ErrorHandlerFunction;
@@ -68,7 +68,7 @@ private:
     // normal closure, takes response and returns new future
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func(RpcResponse const&)>::type, RpcResponseFuture>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     QueuedFunction normalizeFunc(Func const& func)
     {
         return [func](RpcResponseFuture const& r)
@@ -80,7 +80,7 @@ private:
     // closure without argument (first step), takes nothing and returns new future
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func()>::type, RpcResponseFuture>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     QueuedFunction normalizeFunc(Func const& func)
     {
         return [func](RpcResponseFuture const&)
@@ -92,7 +92,7 @@ private:
     // closure without return value ("auxiliary"), takes response and returns nothing -- internally we reuse the last future
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func(RpcResponse const&)>::type, void>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     QueuedFunction normalizeFunc(Func const& func)
     {
         return [func](RpcResponseFuture const& r)
@@ -105,7 +105,7 @@ private:
     // closure without argument and return value, takes nothing and returns nothing -- next function will also get nothing
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func()>::type, void>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     QueuedFunction normalizeFunc(Func const& func)
     {
         return [func](RpcResponseFuture const& r)
@@ -118,7 +118,7 @@ private:
     // normal error handler, takes last response
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func(RpcResponse const&)>::type, void>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     ErrorHandlerFunction normalizeErrorHandler(Func const& func)
     {
         return [func](RpcResponseFuture const& r)
@@ -130,7 +130,7 @@ private:
     // error handler without an argument, takes nothing
     template<typename Func, typename std::enable_if<
         std::is_same<typename std::result_of<Func()>::type, void>::value
-    >::type* = nullptr>
+        >::type* = nullptr>
     ErrorHandlerFunction normalizeErrorHandler(Func const& func)
     {
         return [func](RpcResponseFuture const& r)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -147,11 +147,16 @@ void Session::copyMagnetLinkToClipboard(int torrentId)
     q->add([this](RpcResponse const& r)
         {
             tr_variant* torrents;
-            tr_variant* child;
+
+            if (!tr_variantDictFindList(r.args.get(), TR_KEY_torrents, &torrents))
+            {
+                return;
+            }
+
+            tr_variant* const child = tr_variantListChild(torrents, 0);
             char const* str;
 
-            if (tr_variantDictFindList(r.args.get(), TR_KEY_torrents, &torrents) &&
-                (child = tr_variantListChild(torrents, 0)) && tr_variantDictFindStr(child, TR_KEY_magnetLink, &str, nullptr))
+            if (child != nullptr && tr_variantDictFindStr(child, TR_KEY_magnetLink, &str, nullptr))
             {
                 qApp->clipboard()->setText(QString::fromUtf8(str));
             }
@@ -998,10 +1003,15 @@ void Session::addTorrent(AddData const& addMe, tr_variant* args, bool trashOrigi
     q->add([this, addMe](RpcResponse const& r)
         {
             tr_variant* dup;
+
+            if (!tr_variantDictFindDict(r.args.get(), TR_KEY_torrent_duplicate, &dup))
+            {
+                return;
+            }
+
             char const* str;
 
-            if (tr_variantDictFindDict(r.args.get(), TR_KEY_torrent_duplicate, &dup) &&
-                tr_variantDictFindStr(dup, TR_KEY_name, &str, nullptr))
+            if (tr_variantDictFindStr(dup, TR_KEY_name, &str, nullptr))
             {
                 QString const name = QString::fromUtf8(str);
                 QMessageBox* d = new QMessageBox(QMessageBox::Warning, tr("Add Torrent"),

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -10,12 +10,12 @@
 
 QIcon::Mode StyleHelper::getIconMode(QStyle::State state)
 {
-    if ((state & QStyle::State_Enabled) == 0)
+    if (!state.testFlag(QStyle::State_Enabled))
     {
         return QIcon::Disabled;
     }
 
-    if ((state & QStyle::State_Selected) != 0)
+    if (state.testFlag(QStyle::State_Selected))
     {
         return QIcon::Selected;
     }

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -175,7 +175,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
         //: First part of torrent progress string;
         //: %1 is the percentage of torrent metadata downloaded
         str = tr("Magnetized transfer - retrieving metadata (%1%)").
-                arg(Formatter::percentToString(tor.metadataPercentDone() * 100.0));
+            arg(Formatter::percentToString(tor.metadataPercentDone() * 100.0));
     }
     else if (!isDone) // downloading
     {
@@ -184,7 +184,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
         //: %2 is how much we'll have when done,
         //: %3 is a percentage of the two
         str = tr("%1 of %2 (%3%)").arg(Formatter::sizeToString(haveTotal)).arg(Formatter::sizeToString(tor.sizeWhenDone())).
-                arg(Formatter::percentToString(tor.percentDone() * 100.0));
+            arg(Formatter::percentToString(tor.percentDone() * 100.0));
     }
     else if (!isSeed) // partial seed
     {
@@ -198,10 +198,10 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %5 is our upload-to-download ratio,
             //: %6 is the ratio we want to reach before we stop uploading
             str = tr("%1 of %2 (%3%), uploaded %4 (Ratio: %5 Goal: %6)").arg(Formatter::sizeToString(haveTotal)).
-                    arg(Formatter::sizeToString(tor.totalSize())).
-                    arg(Formatter::percentToString(tor.percentComplete() * 100.0)).
-                    arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio())).
-                    arg(Formatter::ratioToString(seedRatio));
+                arg(Formatter::sizeToString(tor.totalSize())).
+                arg(Formatter::percentToString(tor.percentComplete() * 100.0)).
+                arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio())).
+                arg(Formatter::ratioToString(seedRatio));
         }
         else
         {
@@ -212,9 +212,9 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %4 is how much we've uploaded,
             //: %5 is our upload-to-download ratio
             str = tr("%1 of %2 (%3%), uploaded %4 (Ratio: %5)").arg(Formatter::sizeToString(haveTotal)).
-                    arg(Formatter::sizeToString(tor.totalSize())).
-                    arg(Formatter::percentToString(tor.percentComplete() * 100.0)).
-                    arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio()));
+                arg(Formatter::sizeToString(tor.totalSize())).
+                arg(Formatter::percentToString(tor.percentComplete() * 100.0)).
+                arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio()));
         }
     }
     else // seeding
@@ -227,8 +227,8 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %3 is our upload-to-download ratio,
             //: %4 is the ratio we want to reach before we stop uploading
             str = tr("%1, uploaded %2 (Ratio: %3 Goal: %4)").arg(Formatter::sizeToString(haveTotal)).
-                    arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio())).
-                    arg(Formatter::ratioToString(seedRatio));
+                arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio())).
+                arg(Formatter::ratioToString(seedRatio));
         }
         else // seeding w/o a ratio
         {
@@ -237,7 +237,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %2 is how much we've uploaded,
             //: %3 is our upload-to-download ratio
             str = tr("%1, uploaded %2 (Ratio: %3)").arg(Formatter::sizeToString(haveTotal)).
-                    arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio()));
+                arg(Formatter::sizeToString(tor.uploadedEver())).arg(Formatter::ratioToString(tor.ratio()));
         }
     }
 
@@ -329,7 +329,7 @@ QString TorrentDelegate::statusString(Torrent const& tor)
             if (!tor.hasMetadata())
             {
                 str = tr("Downloading metadata from %Ln peer(s) (%1% done)", nullptr, tor.peersWeAreDownloadingFrom()).
-                        arg(Formatter::percentToString(100.0 * tor.metadataPercentDone()));
+                    arg(Formatter::percentToString(100.0 * tor.metadataPercentDone()));
             }
             else
             {
@@ -344,7 +344,7 @@ QString TorrentDelegate::statusString(Torrent const& tor)
                 {
                     //: First part of phrase "Downloading from ... of ... connected peer(s) and ... web seed(s)"
                     str = tr("Downloading from %1 of %Ln connected peer(s)", nullptr, tor.connectedPeersAndWebseeds()).
-                            arg(tor.peersWeAreDownloadingFrom());
+                        arg(tor.peersWeAreDownloadingFrom());
                 }
 
                 if (tor.webseedsWeAreDownloadingFrom())
@@ -364,7 +364,8 @@ QString TorrentDelegate::statusString(Torrent const& tor)
             }
             else
             {
-                str = tr("Seeding to %1 of %Ln connected peer(s)", nullptr, tor.connectedPeers()).arg(tor.peersWeAreUploadingTo());
+                str = tr("Seeding to %1 of %Ln connected peer(s)", nullptr, tor.connectedPeers()).
+                    arg(tor.peersWeAreUploadingTo());
             }
 
             break;

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -113,7 +113,7 @@ ItemLayout::ItemLayout(QString const& nameText, QString const& statusText, QIcon
     QSize const barSize(barStyle.rect.width() * 2 - style->subElementRect(QStyle::SE_ProgressBarGroove, &barStyle).width(),
         barStyle.rect.height());
 
-    QRect baseRect(topLeft, QSize(width, std::max({iconSize, nameSize.height(), statusSize.height(), barSize.height()})));
+    QRect baseRect(topLeft, QSize(width, std::max({ iconSize, nameSize.height(), statusSize.height(), barSize.height() })));
 
     iconRect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(iconSize, iconSize), baseRect);
     emblemRect = style->alignedRect(direction, Qt::AlignRight | Qt::AlignBottom, emblemIcon.actualSize(iconRect.size() / 2,

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -215,20 +215,20 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
             if (inf.st.lastAnnounceSucceeded)
             {
                 //: %1 and %2 are replaced with HTML markup, %3 is duration
-                str += tr("Got a list of%1 %Ln peer(s)%2 %3 ago", nullptr, inf.st.lastAnnouncePeerCount).arg(success_markup_begin).
-                        arg(success_markup_end).arg(tstr);
+                str += tr("Got a list of%1 %Ln peer(s)%2 %3 ago", nullptr, inf.st.lastAnnouncePeerCount).
+                    arg(success_markup_begin).arg(success_markup_end).arg(tstr);
             }
             else if (inf.st.lastAnnounceTimedOut)
             {
                 //: %1 and %2 are replaced with HTML markup, %3 is duration
                 str += tr("Peer list request %1timed out%2 %3 ago; will retry").arg(timeout_markup_begin).
-                        arg(timeout_markup_end).arg(tstr);
+                    arg(timeout_markup_end).arg(tstr);
             }
             else
             {
                 //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
                 str += tr("Got an error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastAnnounceResult).
-                        arg(err_markup_end).arg(tstr);
+                    arg(err_markup_end).arg(tstr);
             }
         }
 
@@ -277,25 +277,25 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
                         //: First part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
                         //: %1 and %2 are replaced with HTML markup
                         str += tr("Tracker had%1 %Ln seeder(s)%2", nullptr, inf.st.seederCount).arg(success_markup_begin).
-                                arg(success_markup_end);
+                            arg(success_markup_end);
                         //: Second part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
                         //: %1 and %2 are replaced with HTML markup, %3 is duration;
                         //: notice that leading space (before "and") is included here
                         str += tr(" and%1 %Ln leecher(s)%2 %3 ago", nullptr, inf.st.leecherCount).arg(success_markup_begin).
-                                arg(success_markup_end).arg(tstr);
+                            arg(success_markup_end).arg(tstr);
                     }
                     else
                     {
                         //: %1 and %2 are replaced with HTML markup, %3 is duration
                         str += tr("Tracker had %1no information%2 on peer counts %3 ago").arg(success_markup_begin).
-                                arg(success_markup_end).arg(tstr);
+                            arg(success_markup_end).arg(tstr);
                     }
                 }
                 else
                 {
                     //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
                     str += tr("Got a scrape error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.lastScrapeResult).
-                            arg(err_markup_end).arg(tstr);
+                        arg(err_markup_end).arg(tstr);
                 }
             }
 

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -210,7 +210,7 @@ int Utils::measureViewItem(QAbstractItemView* view, QString const& text)
     option.font = view->font();
 
     return view->style()->sizeFromContents(QStyle::CT_ItemViewItem, &option, QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX), view).
-               width();
+        width();
 }
 
 int Utils::measureHeaderItem(QHeaderView* view, QString const& text)

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -51,7 +51,7 @@ public:
     {
         if (dialog.isNull())
         {
-            dialog = new DialogT(std::forward<ArgsT>(args) ...);
+            dialog = new DialogT(std::forward<ArgsT>(args)...);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
         }

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,1961 +1,663 @@
-# Uncrustify 0.64
-
-#
-# General options
-#
-
-# The type of line endings. Default=Auto
-newlines                        = auto     # auto/lf/crlf/cr
-
-# The original size of tabs in the input. Default=8
-input_tab_size                  = 8        # number
-
-# The size of tabs in the output (only used if align_with_tabs=true). Default=8
-output_tab_size                 = 8        # number
-
-# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
-string_escape_char              = 92       # number
-
-# Alternate string escape char for Pawn. Only works right before the quote char.
-string_escape_char2             = 0        # number
-
-# Replace tab characters found in string literals with the escape sequence \t instead.
-string_replace_tab_chars        = false    # false/true
-
-# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
-# If true, 'assert(x<0 && y>=3)' will be broken. Default=False
-# Improvements to template detection may make this option obsolete.
-tok_split_gte                   = false    # false/true
-
-# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
-disable_processing_cmt          = ""         # string
-
-# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
-enable_processing_cmt           = ""         # string
-
-# Enable parsing of digraphs. Default=False
-enable_digraphs                 = false    # false/true
-
-# Control what to do with the UTF-8 BOM (recommend 'remove')
-utf8_bom                        = ignore   # ignore/add/remove/force
-
-# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
-utf8_byte                       = false    # false/true
-
-# Force the output encoding to UTF-8
-utf8_force                      = false    # false/true
-
-#
-# Indenting
-#
-
-# The number of columns to indent per level.
-# Usually 2, 3, 4, or 8. Default=8
-indent_columns                  = 4        # number
-
-# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
-# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
-indent_continue                 = 4        # number
-
-# How to use tabs when indenting code
-# 0=spaces only
-# 1=indent with tabs to brace level, align with spaces (default)
-# 2=indent and align with tabs, using spaces when not on a tabstop
-indent_with_tabs                = 0        # number
-
-# Comments that are not a brace level are indented with tabs on a tabstop.
-# Requires indent_with_tabs=2. If false, will use spaces.
-indent_cmt_with_tabs            = false    # false/true
-
-# Whether to indent strings broken by '\' so that they line up
-indent_align_string             = false    # false/true
-
-# The number of spaces to indent multi-line XML strings.
-# Requires indent_align_string=True
-indent_xml_string               = 0        # number
-
-# Spaces to indent '{' from level
-indent_brace                    = 0        # number
-
-# Whether braces are indented to the body level
-indent_braces                   = false    # false/true
-
-# Disabled indenting function braces if indent_braces is true
-indent_braces_no_func           = false    # false/true
-
-# Disabled indenting class braces if indent_braces is true
-indent_braces_no_class          = false    # false/true
-
-# Disabled indenting struct braces if indent_braces is true
-indent_braces_no_struct         = false    # false/true
-
-# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
-indent_brace_parent             = false    # false/true
-
-# Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
-indent_paren_open_brace         = false    # false/true
-
-# indent a C# delegate by another level, default is to not indent by another level.
-indent_cs_delegate_brace        = false    # false/true
-
-# Whether the 'namespace' body is indented
-indent_namespace                = false    # false/true
-
-# Only indent one namespace and no sub-namespaces.
-# Requires indent_namespace=true.
-indent_namespace_single_indent  = false    # false/true
-
-# The number of spaces to indent a namespace block
-indent_namespace_level          = 0        # number
-
-# If the body of the namespace is longer than this number, it won't be indented.
-# Requires indent_namespace=true. Default=0 (no limit)
-indent_namespace_limit          = 0        # number
-
-# Whether the 'extern "C"' body is indented
-indent_extern                   = false    # false/true
-
-# Whether the 'class' body is indented
-indent_class                    = true     # false/true
-
-# Whether to indent the stuff after a leading base class colon
-indent_class_colon              = false    # false/true
-
-# Indent based on a class colon instead of the stuff after the colon.
-# Requires indent_class_colon=true. Default=False
-indent_class_on_colon           = false    # false/true
-
-# Whether to indent the stuff after a leading class initializer colon
-indent_constr_colon             = false    # false/true
-
-# Virtual indent from the ':' for member initializers. Default=2
-indent_ctor_init_leading        = 2        # number
-
-# Additional indenting for constructor initializer list
-indent_ctor_init                = 0        # number
-
-# False=treat 'else\nif' as 'else if' for indenting purposes
-# True=indent the 'if' one level
-indent_else_if                  = false    # false/true
-
-# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
-indent_var_def_blk              = 0        # number
-
-# Indent continued variable declarations instead of aligning.
-indent_var_def_cont             = false    # false/true
-
-# Indent continued shift expressions ('<<' and '>>') instead of aligning.
-# Turn align_left_shift off when enabling this.
-indent_shift                    = true     # false/true
-
-# True:  force indentation of function definition to start in column 1
-# False: use the default behavior
-indent_func_def_force_col1      = false    # false/true
-
-# True:  indent continued function call parameters one indent level
-# False: align parameters under the open paren
-indent_func_call_param          = true     # false/true
-
-# Same as indent_func_call_param, but for function defs
-indent_func_def_param           = true     # false/true
-
-# Same as indent_func_call_param, but for function protos
-indent_func_proto_param         = true     # false/true
-
-# Same as indent_func_call_param, but for class declarations
-indent_func_class_param         = true     # false/true
-
-# Same as indent_func_call_param, but for class variable constructors
-indent_func_ctor_var_param      = true     # false/true
-
-# Same as indent_func_call_param, but for templates
-indent_template_param           = true     # false/true
-
-# Double the indent for indent_func_xxx_param options
-indent_func_param_double        = false    # false/true
-
-# Indentation column for standalone 'const' function decl/proto qualifier
-indent_func_const               = 0        # number
-
-# Indentation column for standalone 'throw' function decl/proto qualifier
-indent_func_throw               = 0        # number
-
-# The number of spaces to indent a continued '->' or '.'
-# Usually set to 0, 1, or indent_columns.
-indent_member                   = 4        # number
-
-# Spaces to indent single line ('//') comments on lines before code
-indent_sing_line_comments       = 0        # number
-
-# If set, will indent trailing single line ('//') comments relative
-# to the code instead of trying to keep the same absolute column
-indent_relative_single_line_comments = false    # false/true
-
-# Spaces to indent 'case' from 'switch'
-# Usually 0 or indent_columns.
-indent_switch_case              = 0        # number
-
-# Spaces to shift the 'case' line, without affecting any other lines
-# Usually 0.
-indent_case_shift               = 0        # number
-
-# Spaces to indent '{' from 'case'.
-# By default, the brace will appear under the 'c' in case.
-# Usually set to 0 or indent_columns.
-indent_case_brace               = 4        # number
-
-# Whether to indent comments found in first column
-indent_col1_comment             = false    # false/true
-
-# How to indent goto labels
-#   >0: absolute column where 1 is the leftmost column
-#  <=0: subtract from brace indent
-# Default=1
-indent_label                    = 1        # number
-
-# Same as indent_label, but for access specifiers that are followed by a colon. Default=1
-indent_access_spec              = 1        # number
-
-# Indent the code after an access specifier by one level.
-# If set, this option forces 'indent_access_spec=0'
-indent_access_spec_body         = false    # false/true
-
-# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
-indent_paren_nl                 = false    # false/true
-
-# Controls the indent of a close paren after a newline.
-# 0: Indent to body level
-# 1: Align under the open paren
-# 2: Indent to the brace level
-indent_paren_close              = 0        # number
-
-# Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
-indent_comma_paren              = false    # false/true
-
-# Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
-indent_bool_paren               = false    # false/true
-
-# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
-indent_first_bool_expr          = false    # false/true
-
-# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
-indent_square_nl                = false    # false/true
-
-# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
-indent_preserve_sql             = false    # false/true
-
-# Align continued statements at the '='. Default=True
-# If FALSE or the '=' is followed by a newline, the next line is indent one tab.
-indent_align_assign             = false    # false/true
-
-# Indent OC blocks at brace level instead of usual rules.
-indent_oc_block                 = false    # false/true
-
-# Indent OC blocks in a message relative to the parameter name.
-# 0=use indent_oc_block rules, 1+=spaces to indent
-indent_oc_block_msg             = 0        # number
-
-# Minimum indent for subsequent parameters
-indent_oc_msg_colon             = 0        # number
-
-# If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
-# Default=True.
-indent_oc_msg_prioritize_first_colon = true     # false/true
-
-# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
-indent_oc_block_msg_xcode_style = false    # false/true
-
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
-indent_oc_block_msg_from_keyword = false    # false/true
-
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
-indent_oc_block_msg_from_colon  = false    # false/true
-
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
-indent_oc_block_msg_from_caret  = false    # false/true
-
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
-indent_oc_block_msg_from_brace  = false    # false/true
-
-# When identing after virtual brace open and newline add further spaces to reach this min. indent.
-indent_min_vbrace_open          = 0        # number
-
-# TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
-indent_vbrace_open_on_tabstop   = false    # false/true
-
-# If true, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
-indent_token_after_brace        = false    # false/true
-
-# If true, cpp lambda body will be indentedDefault=False.
-indent_cpp_lambda_body          = true     # false/true
-
-#
-# Spacing options
-#
-
-# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
-# also '>>>' '<<' '>>' '%' '|'
-sp_arith                        = force    # ignore/add/remove/force
-
-# Add or remove space around assignment operator '=', '+=', etc
-sp_assign                       = force    # ignore/add/remove/force
-
-# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
-sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
-
-# Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_paren             = remove   # ignore/add/remove/force
-
-# Add or remove space around assignment operator '=' in a prototype
-sp_assign_default               = force    # ignore/add/remove/force
-
-# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_before_assign                = ignore   # ignore/add/remove/force
-
-# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_after_assign                 = ignore   # ignore/add/remove/force
-
-# Add or remove space in 'NS_ENUM ('
-sp_enum_paren                   = ignore   # ignore/add/remove/force
-
-# Add or remove space around assignment '=' in enum
-sp_enum_assign                  = force    # ignore/add/remove/force
-
-# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_before_assign           = ignore   # ignore/add/remove/force
-
-# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_after_assign            = ignore   # ignore/add/remove/force
-
-# Add or remove space around preprocessor '##' concatenation operator. Default=Add
-sp_pp_concat                    = force    # ignore/add/remove/force
-
-# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
-sp_pp_stringify                 = ignore   # ignore/add/remove/force
-
-# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
-sp_before_pp_stringify          = ignore   # ignore/add/remove/force
-
-# Add or remove space around boolean operators '&&' and '||'
-sp_bool                         = force    # ignore/add/remove/force
-
-# Add or remove space around compare operator '<', '>', '==', etc
-sp_compare                      = force    # ignore/add/remove/force
-
-# Add or remove space inside '(' and ')'
-sp_inside_paren                 = remove   # ignore/add/remove/force
-
-# Add or remove space between nested parens: '((' vs ') )'
-sp_paren_paren                  = remove   # ignore/add/remove/force
-
-# Add or remove space between back-to-back parens: ')(' vs ') ('
-sp_cparen_oparen                = remove   # ignore/add/remove/force
-
-# Whether to balance spaces inside nested parens
-sp_balance_nested_parens        = false    # false/true
-
-# Add or remove space between ')' and '{'
-sp_paren_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove space before pointer star '*'
-sp_before_ptr_star              = remove   # ignore/add/remove/force
-
-# Add or remove space before pointer star '*' that isn't followed by a variable name
-# If set to 'ignore', sp_before_ptr_star is used instead.
-sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
-
-# Add or remove space between pointer stars '*'
-sp_between_ptr_star             = remove   # ignore/add/remove/force
-
-# Add or remove space after pointer star '*', if followed by a word.
-sp_after_ptr_star               = force    # ignore/add/remove/force
-
-# Add or remove space after pointer star '*', if followed by a qualifier.
-sp_after_ptr_star_qualifier     = force    # ignore/add/remove/force
-
-# Add or remove space after a pointer star '*', if followed by a func proto/def.
-sp_after_ptr_star_func          = force    # ignore/add/remove/force
-
-# Add or remove space after a pointer star '*', if followed by an open paren (function types).
-sp_ptr_star_paren               = force    # ignore/add/remove/force
-
-# Add or remove space before a pointer star '*', if followed by a func proto/def.
-sp_before_ptr_star_func         = remove   # ignore/add/remove/force
-
-# Add or remove space before a reference sign '&'
-sp_before_byref                 = remove   # ignore/add/remove/force
-
-# Add or remove space before a reference sign '&' that isn't followed by a variable name
-# If set to 'ignore', sp_before_byref is used instead.
-sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
-
-# Add or remove space after reference sign '&', if followed by a word.
-sp_after_byref                  = force    # ignore/add/remove/force
-
-# Add or remove space after a reference sign '&', if followed by a func proto/def.
-sp_after_byref_func             = force    # ignore/add/remove/force
-
-# Add or remove space before a reference sign '&', if followed by a func proto/def.
-sp_before_byref_func            = force    # ignore/add/remove/force
-
-# Add or remove space between type and word. Default=Force
-sp_after_type                   = force    # ignore/add/remove/force
-
-# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
-sp_before_template_paren        = ignore   # ignore/add/remove/force
-
-# Add or remove space in 'template <' vs 'template<'.
-# If set to ignore, sp_before_angle is used.
-sp_template_angle               = remove   # ignore/add/remove/force
-
-# Add or remove space before '<>'
-sp_before_angle                 = remove   # ignore/add/remove/force
-
-# Add or remove space inside '<' and '>'
-sp_inside_angle                 = remove   # ignore/add/remove/force
-
-# Add or remove space after '<>'
-sp_after_angle                  = force    # ignore/add/remove/force
-
-# Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'
-sp_angle_paren                  = remove   # ignore/add/remove/force
-
-# Add or remove space between '<>' and '()' as found in 'new List<byte>();'
-sp_angle_paren_empty            = remove   # ignore/add/remove/force
-
-# Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'
-sp_angle_word                   = force    # ignore/add/remove/force
-
-# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
-sp_angle_shift                  = remove   # ignore/add/remove/force
-
-# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
-# sp_angle_shift cannot remove the space without this option.
-sp_permit_cpp11_shift           = true     # false/true
-
-# Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
-sp_before_sparen                = force    # ignore/add/remove/force
-
-# Add or remove space inside if-condition '(' and ')'
-sp_inside_sparen                = remove   # ignore/add/remove/force
-
-# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
-sp_inside_sparen_close          = ignore   # ignore/add/remove/force
-
-# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
-sp_inside_sparen_open           = ignore   # ignore/add/remove/force
-
-# Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
-sp_after_sparen                 = ignore   # ignore/add/remove/force
-
-# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
-sp_sparen_brace                 = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'invariant' and '(' in the D language.
-sp_invariant_paren              = ignore   # ignore/add/remove/force
-
-# Add or remove space after the ')' in 'invariant (C) c' in the D language.
-sp_after_invariant_paren        = ignore   # ignore/add/remove/force
-
-# Add or remove space before empty statement ';' on 'if', 'for' and 'while'
-sp_special_semi                 = ignore   # ignore/add/remove/force
-
-# Add or remove space before ';'. Default=Remove
-sp_before_semi                  = remove   # ignore/add/remove/force
-
-# Add or remove space before ';' in non-empty 'for' statements
-sp_before_semi_for              = ignore   # ignore/add/remove/force
-
-# Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty        = ignore   # ignore/add/remove/force
-
-# Add or remove space after ';', except when followed by a comment. Default=Add
-sp_after_semi                   = force    # ignore/add/remove/force
-
-# Add or remove space after ';' in non-empty 'for' statements. Default=Force
-sp_after_semi_for               = force    # ignore/add/remove/force
-
-# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
-sp_after_semi_for_empty         = remove   # ignore/add/remove/force
-
-# Add or remove space before '[' (except '[]')
-sp_before_square                = remove   # ignore/add/remove/force
-
-# Add or remove space before '[]'
-sp_before_squares               = remove   # ignore/add/remove/force
-
-# Add or remove space inside a non-empty '[' and ']'
-sp_inside_square                = remove   # ignore/add/remove/force
-
-# Add or remove space after ','
-sp_after_comma                  = force    # ignore/add/remove/force
-
-# Add or remove space before ','. Default=Remove
-sp_before_comma                 = remove   # ignore/add/remove/force
-
-# Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
-sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
-
-# Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
-sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
-
-# Add or remove space between ',' in multidimensional array type 'int[,,]'
-sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
-
-# Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force
-sp_paren_comma                  = force    # ignore/add/remove/force
-
-# Add or remove space before the variadic '...' when preceded by a non-punctuator
-sp_before_ellipsis              = remove   # ignore/add/remove/force
-
-# Add or remove space after class ':'
-sp_after_class_colon            = ignore   # ignore/add/remove/force
-
-# Add or remove space before class ':'
-sp_before_class_colon           = force    # ignore/add/remove/force
-
-# Add or remove space after class constructor ':'
-sp_after_constr_colon           = ignore   # ignore/add/remove/force
-
-# Add or remove space before class constructor ':'
-sp_before_constr_colon          = force    # ignore/add/remove/force
-
-# Add or remove space before case ':'. Default=Remove
-sp_before_case_colon            = remove   # ignore/add/remove/force
-
-# Add or remove space between 'operator' and operator sign
-sp_after_operator               = force    # ignore/add/remove/force
-
-# Add or remove space between the operator symbol and the open paren, as in 'operator ++('
-sp_after_operator_sym           = remove   # ignore/add/remove/force
-
-# Add or remove space between the operator symbol and the open paren when the operator has no arguments, as in 'operator *()'
-sp_after_operator_sym_empty     = remove   # ignore/add/remove/force
-
-# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
-sp_after_cast                   = remove   # ignore/add/remove/force
-
-# Add or remove spaces inside cast parens
-sp_inside_paren_cast            = remove   # ignore/add/remove/force
-
-# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
-sp_cpp_cast_paren               = remove   # ignore/add/remove/force
-
-# Add or remove space between 'sizeof' and '('
-sp_sizeof_paren                 = remove   # ignore/add/remove/force
-
-# Add or remove space after the tag keyword (Pawn)
-sp_after_tag                    = ignore   # ignore/add/remove/force
-
-# Add or remove space inside enum '{' and '}'
-sp_inside_braces_enum           = ignore   # ignore/add/remove/force
-
-# Add or remove space inside struct/union '{' and '}'
-sp_inside_braces_struct         = ignore   # ignore/add/remove/force
-
-# Add or remove space inside '{' and '}'
-sp_inside_braces                = ignore   # ignore/add/remove/force
-
-# Add or remove space inside '{}'
-sp_inside_braces_empty          = remove   # ignore/add/remove/force
-
-# Add or remove space between return type and function name
-# A minimum of 1 is forced except for pointer return types.
-sp_type_func                    = force    # ignore/add/remove/force
-
-# Add or remove space between function name and '(' on function declaration
-sp_func_proto_paren             = remove   # ignore/add/remove/force
-
-# Add or remove space between function name and '()' on function declaration without parameters
-sp_func_proto_paren_empty       = remove   # ignore/add/remove/force
-
-# Add or remove space between function name and '(' on function definition
-sp_func_def_paren               = remove   # ignore/add/remove/force
-
-# Add or remove space between function name and '()' on function definition without parameters
-sp_func_def_paren_empty         = remove   # ignore/add/remove/force
-
-# Add or remove space inside empty function '()'
-sp_inside_fparens               = remove   # ignore/add/remove/force
-
-# Add or remove space inside function '(' and ')'
-sp_inside_fparen                = remove   # ignore/add/remove/force
-
-# Add or remove space inside the first parens in the function type: 'void (*x)(...)'
-sp_inside_tparen                = remove   # ignore/add/remove/force
-
-# Add or remove between the parens in the function type: 'void (*x)(...)'
-sp_after_tparen_close           = remove   # ignore/add/remove/force
-
-# Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                = remove   # ignore/add/remove/force
-
-# Add or remove space between ')' and '{' of function
-sp_fparen_brace                 = ignore   # ignore/add/remove/force
-
-# Java: Add or remove space between ')' and '{{' of double brace initializer.
-sp_fparen_dbrace                = ignore   # ignore/add/remove/force
-
-# Add or remove space between function name and '(' on function calls
-sp_func_call_paren              = remove   # ignore/add/remove/force
-
-# Add or remove space between function name and '()' on function calls without parameters.
-# If set to 'ignore' (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
-
-# Add or remove space between the user function name and '(' on function calls
-# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
-sp_func_call_user_paren         = ignore   # ignore/add/remove/force
-
-# Add or remove space between a constructor/destructor and the open paren
-sp_func_class_paren             = remove   # ignore/add/remove/force
-
-# Add or remove space between a constructor without parameters or destructor and '()'
-sp_func_class_paren_empty       = remove   # ignore/add/remove/force
-
-# Add or remove space between 'return' and '('
-sp_return_paren                 = force    # ignore/add/remove/force
-
-# Add or remove space between '__attribute__' and '('
-sp_attribute_paren              = remove   # ignore/add/remove/force
-
-# Add or remove space between 'defined' and '(' in '#if defined (FOO)'
-sp_defined_paren                = remove   # ignore/add/remove/force
-
-# Add or remove space between 'throw' and '(' in 'throw (something)'
-sp_throw_paren                  = force    # ignore/add/remove/force
-
-# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
-sp_after_throw                  = force    # ignore/add/remove/force
-
-# Add or remove space between 'catch' and '(' in 'catch (something) { }'
-# If set to ignore, sp_before_sparen is used.
-sp_catch_paren                  = force    # ignore/add/remove/force
-
-# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
-# If set to ignore, sp_before_sparen is used.
-sp_version_paren                = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
-# If set to ignore, sp_before_sparen is used.
-sp_scope_paren                  = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove
-sp_super_paren                  = remove   # ignore/add/remove/force
-
-# Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove
-sp_this_paren                   = remove   # ignore/add/remove/force
-
-# Add or remove space between macro and value
-sp_macro                        = ignore   # ignore/add/remove/force
-
-# Add or remove space between macro function ')' and value
-sp_macro_func                   = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'else' and '{' if on the same line
-sp_else_brace                   = ignore   # ignore/add/remove/force
-
-# Add or remove space between '}' and 'else' if on the same line
-sp_brace_else                   = ignore   # ignore/add/remove/force
-
-# Add or remove space between '}' and the name of a typedef on the same line
-sp_brace_typedef                = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'catch' and '{' if on the same line
-sp_catch_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove space between '}' and 'catch' if on the same line
-sp_brace_catch                  = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'finally' and '{' if on the same line
-sp_finally_brace                = ignore   # ignore/add/remove/force
-
-# Add or remove space between '}' and 'finally' if on the same line
-sp_brace_finally                = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'try' and '{' if on the same line
-sp_try_brace                    = ignore   # ignore/add/remove/force
-
-# Add or remove space between get/set and '{' if on the same line
-sp_getset_brace                 = ignore   # ignore/add/remove/force
-
-# Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
-sp_word_brace                   = remove   # ignore/add/remove/force
-
-# Add or remove space between a variable and '{' for a namespace. Default=Add
-sp_word_brace_ns                = add      # ignore/add/remove/force
-
-# Add or remove space before the '::' operator
-sp_before_dc                    = remove   # ignore/add/remove/force
-
-# Add or remove space after the '::' operator
-sp_after_dc                     = remove   # ignore/add/remove/force
-
-# Add or remove around the D named array initializer ':' operator
-sp_d_array_colon                = ignore   # ignore/add/remove/force
-
-# Add or remove space after the '!' (not) operator. Default=Remove
-sp_not                          = remove   # ignore/add/remove/force
-
-# Add or remove space after the '~' (invert) operator. Default=Remove
-sp_inv                          = remove   # ignore/add/remove/force
-
-# Add or remove space after the '&' (address-of) operator. Default=Remove
-# This does not affect the spacing after a '&' that is part of a type.
-sp_addr                         = remove   # ignore/add/remove/force
-
-# Add or remove space around the '.' or '->' operators. Default=Remove
-sp_member                       = remove   # ignore/add/remove/force
-
-# Add or remove space after the '*' (dereference) operator. Default=Remove
-# This does not affect the spacing after a '*' that is part of a type.
-sp_deref                        = remove   # ignore/add/remove/force
-
-# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
-sp_sign                         = remove   # ignore/add/remove/force
-
-# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
-sp_incdec                       = remove   # ignore/add/remove/force
-
-# Add or remove space before a backslash-newline at the end of a line. Default=Add
-sp_before_nl_cont               = add      # ignore/add/remove/force
-
-# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
-sp_after_oc_scope               = ignore   # ignore/add/remove/force
-
-# Add or remove space after the colon in message specs
-# '-(int) f:(int) x;' vs '-(int) f: (int) x;'
-sp_after_oc_colon               = ignore   # ignore/add/remove/force
-
-# Add or remove space before the colon in message specs
-# '-(int) f: (int) x;' vs '-(int) f : (int) x;'
-sp_before_oc_colon              = ignore   # ignore/add/remove/force
-
-# Add or remove space after the colon in immutable dictionary expression
-# 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
-
-# Add or remove space before the colon in immutable dictionary expression
-# 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
-
-# Add or remove space after the colon in message specs
-# '[object setValue:1];' vs '[object setValue: 1];'
-sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
-
-# Add or remove space before the colon in message specs
-# '[object setValue:1];' vs '[object setValue :1];'
-sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
-
-# Add or remove space after the (type) in message specs
-# '-(int)f: (int) x;' vs '-(int)f: (int)x;'
-sp_after_oc_type                = ignore   # ignore/add/remove/force
-
-# Add or remove space after the first (type) in message specs
-# '-(int) f:(int)x;' vs '-(int)f:(int)x;'
-sp_after_oc_return_type         = ignore   # ignore/add/remove/force
-
-# Add or remove space between '@selector' and '('
-# '@selector(msgName)' vs '@selector (msgName)'
-# Also applies to @protocol() constructs
-sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
-
-# Add or remove space between '@selector(x)' and the following word
-# '@selector(foo) a:' vs '@selector(foo)a:'
-sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
-
-# Add or remove space inside '@selector' parens
-# '@selector(foo)' vs '@selector( foo )'
-# Also applies to @protocol() constructs
-sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
-
-# Add or remove space before a block pointer caret
-# '^int (int arg){...}' vs. ' ^int (int arg){...}'
-sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
-
-# Add or remove space after a block pointer caret
-# '^int (int arg){...}' vs. '^ int (int arg){...}'
-sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
-
-# Add or remove space between the receiver and selector in a message.
-# '[receiver selector ...]'
-sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
-
-# Add or remove space after @property.
-sp_after_oc_property            = ignore   # ignore/add/remove/force
-
-# Add or remove space around the ':' in 'b ? t : f'
-sp_cond_colon                   = force    # ignore/add/remove/force
-
-# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_before            = ignore   # ignore/add/remove/force
-
-# Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_after             = ignore   # ignore/add/remove/force
-
-# Add or remove space around the '?' in 'b ? t : f'
-sp_cond_question                = force    # ignore/add/remove/force
-
-# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_before         = ignore   # ignore/add/remove/force
-
-# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_after          = ignore   # ignore/add/remove/force
-
-# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
-sp_cond_ternary_short           = ignore   # ignore/add/remove/force
-
-# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
-sp_case_label                   = force    # ignore/add/remove/force
-
-# Control the space around the D '..' operator.
-sp_range                        = ignore   # ignore/add/remove/force
-
-# Control the spacing after ':' in 'for (TYPE VAR : EXPR)'
-sp_after_for_colon              = force    # ignore/add/remove/force
-
-# Control the spacing before ':' in 'for (TYPE VAR : EXPR)'
-sp_before_for_colon             = force    # ignore/add/remove/force
-
-# Control the spacing in 'extern (C)' (D)
-sp_extern_paren                 = ignore   # ignore/add/remove/force
-
-# Control the space after the opening of a C++ comment '// A' vs '//A'
-sp_cmt_cpp_start                = add      # ignore/add/remove/force
-
-# TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
-sp_cmt_cpp_doxygen              = true     # false/true
-
-# TRUE: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
-sp_cmt_cpp_qttr                 = true     # false/true
-
-# Controls the spaces between #else or #endif and a trailing comment
-sp_endif_cmt                    = force    # ignore/add/remove/force
-
-# Controls the spaces after 'new', 'delete' and 'delete[]'
-sp_after_new                    = force    # ignore/add/remove/force
-
-# Controls the spaces between new and '(' in 'new()'
-sp_between_new_paren            = ignore   # ignore/add/remove/force
-
-# Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt            = force    # ignore/add/remove/force
-
-# Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt        = 1        # number
-
-# Control space between a Java annotation and the open paren.
-sp_annotation_paren             = ignore   # ignore/add/remove/force
-
-# If true, vbrace tokens are dropped to the previous token and skipped.
-sp_skip_vbrace_tokens           = false    # false/true
-
-#
-# Code alignment (not left column spaces/tabs)
-#
-
-# Whether to keep non-indenting tabs
-align_keep_tabs                 = false    # false/true
-
-# Whether to use tabs for aligning
-align_with_tabs                 = false    # false/true
-
-# Whether to bump out to the next tab when aligning
-align_on_tabstop                = false    # false/true
-
-# Whether to left-align numbers
-align_number_left               = false    # false/true
-
-# Whether to keep whitespace not required for alignment.
-align_keep_extra_space          = false    # false/true
-
-# Align variable definitions in prototypes and functions
-align_func_params               = false    # false/true
-
-# Align parameters in single-line functions that have the same name.
-# The function names must already be aligned with each other.
-align_same_func_call_params     = false    # false/true
-
-# The span for aligning variable definitions (0=don't align)
-align_var_def_span              = 0        # number
-
-# How to align the star in variable definitions.
-#  0=Part of the type     'void *   foo;'
-#  1=Part of the variable 'void     *foo;'
-#  2=Dangling             'void    *foo;'
-align_var_def_star_style        = 0        # number
-
-# How to align the '&' in variable definitions.
-#  0=Part of the type
-#  1=Part of the variable
-#  2=Dangling
-align_var_def_amp_style         = 0        # number
-
-# The threshold for aligning variable definitions (0=no limit)
-align_var_def_thresh            = 0        # number
-
-# The gap for aligning variable definitions
-align_var_def_gap               = 0        # number
-
-# Whether to align the colon in struct bit fields
-align_var_def_colon             = false    # false/true
-
-# Whether to align any attribute after the variable name
-align_var_def_attribute         = false    # false/true
-
-# Whether to align inline struct/enum/union variable definitions
-align_var_def_inline            = false    # false/true
-
-# The span for aligning on '=' in assignments (0=don't align)
-align_assign_span               = 0        # number
-
-# The threshold for aligning on '=' in assignments (0=no limit)
-align_assign_thresh             = 0        # number
-
-# The span for aligning on '=' in enums (0=don't align)
-align_enum_equ_span             = 0        # number
-
-# The threshold for aligning on '=' in enums (0=no limit)
-align_enum_equ_thresh           = 0        # number
-
-# The span for aligning class (0=don't align)
-align_var_class_span            = 0        # number
-
-# The threshold for aligning class member definitions (0=no limit)
-align_var_class_thresh          = 0        # number
-
-# The gap for aligning class member definitions
-align_var_class_gap             = 0        # number
-
-# The span for aligning struct/union (0=don't align)
-align_var_struct_span           = 0        # number
-
-# The threshold for aligning struct/union member definitions (0=no limit)
-align_var_struct_thresh         = 0        # number
-
-# The gap for aligning struct/union member definitions
-align_var_struct_gap            = 0        # number
-
-# The span for aligning struct initializer values (0=don't align)
-align_struct_init_span          = 0        # number
-
-# The minimum space between the type and the synonym of a typedef
-align_typedef_gap               = 0        # number
-
-# The span for aligning single-line typedefs (0=don't align)
-align_typedef_span              = 0        # number
-
-# How to align typedef'd functions with other typedefs
-# 0: Don't mix them at all
-# 1: align the open paren with the types
-# 2: align the function type name with the other type names
-align_typedef_func              = 0        # number
-
-# Controls the positioning of the '*' in typedefs. Just try it.
-# 0: Align on typedef type, ignore '*'
-# 1: The '*' is part of type name: typedef int  *pint;
-# 2: The '*' is part of the type, but dangling: typedef int *pint;
-align_typedef_star_style        = 0        # number
-
-# Controls the positioning of the '&' in typedefs. Just try it.
-# 0: Align on typedef type, ignore '&'
-# 1: The '&' is part of type name: typedef int  &pint;
-# 2: The '&' is part of the type, but dangling: typedef int &pint;
-align_typedef_amp_style         = 0        # number
-
-# The span for aligning comments that end lines (0=don't align)
-align_right_cmt_span            = 0        # number
-
-# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
-align_right_cmt_mix             = false    # false/true
-
-# If a trailing comment is more than this number of columns away from the text it follows,
-# it will qualify for being aligned. This has to be > 0 to do anything.
-align_right_cmt_gap             = 0        # number
-
-# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
-align_right_cmt_at_col          = 0        # number
-
-# The span for aligning function prototypes (0=don't align)
-align_func_proto_span           = 0        # number
-
-# Minimum gap between the return type and the function name.
-align_func_proto_gap            = 0        # number
-
-# Align function protos on the 'operator' keyword instead of what follows
-align_on_operator               = false    # false/true
-
-# Whether to mix aligning prototype and variable declarations.
-# If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
-align_mix_var_proto             = false    # false/true
-
-# Align single-line functions with function prototypes, uses align_func_proto_span
-align_single_line_func          = false    # false/true
-
-# Aligning the open brace of single-line functions.
-# Requires align_single_line_func=true, uses align_func_proto_span
-align_single_line_brace         = false    # false/true
-
-# Gap for align_single_line_brace.
-align_single_line_brace_gap     = 0        # number
-
-# The span for aligning ObjC msg spec (0=don't align)
-align_oc_msg_spec_span          = 0        # number
-
-# Whether to align macros wrapped with a backslash and a newline.
-# This will not work right if the macro contains a multi-line comment.
-align_nl_cont                   = false    # false/true
-
-# # Align macro functions and variables together
-align_pp_define_together        = false    # false/true
-
-# The minimum space between label and value of a preprocessor define
-align_pp_define_gap             = 0        # number
-
-# The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
-align_pp_define_span            = 0        # number
-
-# Align lines that start with '<<' with previous '<<'. Default=True
-align_left_shift                = true     # false/true
-
-# Align text after asm volatile () colons.
-align_asm_colon                 = false    # false/true
-
-# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
-align_oc_msg_colon_span         = 0        # number
-
-# If true, always align with the first parameter, even if it is too short.
-align_oc_msg_colon_first        = false    # false/true
-
-# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
-align_oc_decl_colon             = false    # false/true
-
-#
-# Newline adding and removing options
-#
-
-# Whether to collapse empty blocks between '{' and '}'
-nl_collapse_empty_body          = false    # false/true
-
-# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
-nl_assign_leave_one_liners      = true     # false/true
-
-# Don't split one-line braced statements inside a class xx { } body
-nl_class_leave_one_liners       = true     # false/true
-
-# Don't split one-line enums: 'enum foo { BAR = 15 };'
-nl_enum_leave_one_liners        = false    # false/true
-
-# Don't split one-line get or set functions
-nl_getset_leave_one_liners      = false    # false/true
-
-# Don't split one-line function definitions - 'int foo() { return 0; }'
-nl_func_leave_one_liners        = false    # false/true
-
-# Don't split one-line C++11 lambdas - '[]() { return 0; }'
-nl_cpp_lambda_leave_one_liners  = true    # false/true
-
-# Don't split one-line if/else statements - 'if(a) b++;'
-nl_if_leave_one_liners          = false    # false/true
-
-# Don't split one-line while statements - 'while(a) b++;'
-nl_while_leave_one_liners       = false    # false/true
-
-# Don't split one-line OC messages
-nl_oc_msg_leave_one_liner       = false    # false/true
-
-# Add or remove newline between Objective-C block signature and '{'
-nl_oc_block_brace               = ignore   # ignore/add/remove/force
-
-# Add or remove newlines at the start of the file
-nl_start_of_file                = remove   # ignore/add/remove/force
-
-# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
-nl_start_of_file_min            = 0        # number
-
-# Add or remove newline at the end of the file
-nl_end_of_file                  = force    # ignore/add/remove/force
-
-# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
-nl_end_of_file_min              = 1        # number
-
-# Add or remove newline between '=' and '{'
-nl_assign_brace                 = force    # ignore/add/remove/force
-
-# Add or remove newline between '=' and '[' (D only)
-nl_assign_square                = ignore   # ignore/add/remove/force
-
-# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
-nl_after_square_assign          = ignore   # ignore/add/remove/force
-
-# The number of blank lines after a block of variable definitions at the top of a function body
-# 0 = No change (default)
-nl_func_var_def_blk             = 0        # number
-
-# The number of newlines before a block of typedefs
-# 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'
-nl_typedef_blk_start            = 0        # number
-
-# The number of newlines after a block of typedefs
-# 0 = No change (default)
-nl_typedef_blk_end              = 0        # number
-
-# The maximum consecutive newlines within a block of typedefs
-# 0 = No change (default)
-nl_typedef_blk_in               = 0        # number
-
-# The number of newlines before a block of variable definitions not at the top of a function body
-# 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'
-nl_var_def_blk_start            = 0        # number
-
-# The number of newlines after a block of variable definitions not at the top of a function body
-# 0 = No change (default)
-nl_var_def_blk_end              = 0        # number
-
-# The maximum consecutive newlines within a block of variable definitions
-# 0 = No change (default)
-nl_var_def_blk_in               = 0        # number
-
-# Add or remove newline between a function call's ')' and '{', as in:
-# list_for_each(item, &list) { }
-nl_fcall_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'enum' and '{'
-nl_enum_brace                   = force    # ignore/add/remove/force
-
-# Add or remove newline between 'struct and '{'
-nl_struct_brace                 = force    # ignore/add/remove/force
-
-# Add or remove newline between 'union' and '{'
-nl_union_brace                  = force    # ignore/add/remove/force
-
-# Add or remove newline between 'if' and '{'
-nl_if_brace                     = force    # ignore/add/remove/force
-
-# Add or remove newline between '}' and 'else'
-nl_brace_else                   = force    # ignore/add/remove/force
-
-# Add or remove newline between 'else if' and '{'
-# If set to ignore, nl_if_brace is used instead
-nl_elseif_brace                 = force    # ignore/add/remove/force
-
-# Add or remove newline between 'else' and '{'
-nl_else_brace                   = force    # ignore/add/remove/force
-
-# Add or remove newline between 'else' and 'if'
-nl_else_if                      = remove   # ignore/add/remove/force
-
-# Add or remove newline between '}' and 'finally'
-nl_brace_finally                = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'finally' and '{'
-nl_finally_brace                = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'try' and '{'
-nl_try_brace                    = force    # ignore/add/remove/force
-
-# Add or remove newline between get/set and '{'
-nl_getset_brace                 = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'for' and '{'
-nl_for_brace                    = force    # ignore/add/remove/force
-
-# Add or remove newline between 'catch' and '{'
-nl_catch_brace                  = force    # ignore/add/remove/force
-
-# Add or remove newline between '}' and 'catch'
-nl_brace_catch                  = force    # ignore/add/remove/force
-
-# Add or remove newline between '}' and ']'
-nl_brace_square                 = ignore   # ignore/add/remove/force
-
-# Add or remove newline between '}' and ')' in a function invocation
-nl_brace_fparen                 = remove   # ignore/add/remove/force
-
-# Add or remove newline between 'while' and '{'
-nl_while_brace                  = force    # ignore/add/remove/force
-
-# Add or remove newline between 'scope (x)' and '{' (D)
-nl_scope_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'unittest' and '{' (D)
-nl_unittest_brace               = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'version (x)' and '{' (D)
-nl_version_brace                = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'using' and '{'
-nl_using_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove newline between two open or close braces.
-# Due to general newline/brace handling, REMOVE may not work.
-nl_brace_brace                  = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'do' and '{'
-nl_do_brace                     = force    # ignore/add/remove/force
-
-# Add or remove newline between '}' and 'while' of 'do' statement
-nl_brace_while                  = force    # ignore/add/remove/force
-
-# Add or remove newline between 'switch' and '{'
-nl_switch_brace                 = force    # ignore/add/remove/force
-
-# Add or remove newline between 'synchronized' and '{'
-nl_synchronized_brace           = ignore   # ignore/add/remove/force
-
-# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
-# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
-nl_multi_line_cond              = false    # false/true
-
-# Force a newline in a define after the macro name for multi-line defines.
-nl_multi_line_define            = false    # false/true
-
-# Whether to put a newline before 'case' statement, not after the first 'case'
-nl_before_case                  = true     # false/true
-
-# Add or remove newline between ')' and 'throw'
-nl_before_throw                 = ignore   # ignore/add/remove/force
-
-# Whether to put a newline after 'case' statement
-nl_after_case                   = true     # false/true
-
-# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
-nl_case_colon_brace             = ignore   # ignore/add/remove/force
-
-# Newline between namespace and {
-nl_namespace_brace              = force    # ignore/add/remove/force
-
-# Add or remove newline between 'template<>' and whatever follows.
-nl_template_class               = force    # ignore/add/remove/force
-
-# Add or remove newline between 'class' and '{'
-nl_class_brace                  = force    # ignore/add/remove/force
-
-# Add or remove newline before/after each ',' in the base class list,
-#   (tied to pos_class_comma).
-nl_class_init_args              = ignore   # ignore/add/remove/force
-
-# Add or remove newline after each ',' in the constructor member initialization.
-# Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
-nl_constr_init_args             = force    # ignore/add/remove/force
-
-# Add or remove newline before first element, after comma, and after last element in enum
-nl_enum_own_lines               = force    # ignore/add/remove/force
-
-# Add or remove newline between return type and function name in a function definition
-nl_func_type_name               = remove   # ignore/add/remove/force
-
-# Add or remove newline between return type and function name inside a class {}
-# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
-nl_func_type_name_class         = ignore   # ignore/add/remove/force
-
-# Add or remove newline between class specification and '::' in 'void A::f() { }'
-# Only appears in separate member implementation (does not appear with in-line implmementation)
-nl_func_class_scope             = ignore   # ignore/add/remove/force
-
-# Add or remove newline between function scope and name
-# Controls the newline after '::' in 'void A::f() { }'
-nl_func_scope_name              = ignore   # ignore/add/remove/force
-
-# Add or remove newline between return type and function name in a prototype
-nl_func_proto_type_name         = remove   # ignore/add/remove/force
-
-# Add or remove newline between a function name and the opening '(' in the declaration
-nl_func_paren                   = remove   # ignore/add/remove/force
-
-# Add or remove newline between a function name and the opening '(' in the definition
-nl_func_def_paren               = remove   # ignore/add/remove/force
-
-# Add or remove newline after '(' in a function declaration
-nl_func_decl_start              = remove   # ignore/add/remove/force
-
-# Add or remove newline after '(' in a function definition
-nl_func_def_start               = remove   # ignore/add/remove/force
-
-# Overrides nl_func_decl_start when there is only one parameter.
-nl_func_decl_start_single       = ignore   # ignore/add/remove/force
-
-# Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = ignore   # ignore/add/remove/force
-
-# Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
-nl_func_decl_start_multi_line   = false    # false/true
-
-# Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
-nl_func_def_start_multi_line    = false    # false/true
-
-# Add or remove newline after each ',' in a function declaration
-nl_func_decl_args               = remove   # ignore/add/remove/force
-
-# Add or remove newline after each ',' in a function definition
-nl_func_def_args                = remove   # ignore/add/remove/force
-
-# Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
-nl_func_decl_args_multi_line    = false    # false/true
-
-# Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
-nl_func_def_args_multi_line     = false    # false/true
-
-# Add or remove newline before the ')' in a function declaration
-nl_func_decl_end                = remove   # ignore/add/remove/force
-
-# Add or remove newline before the ')' in a function definition
-nl_func_def_end                 = remove   # ignore/add/remove/force
-
-# Overrides nl_func_decl_end when there is only one parameter.
-nl_func_decl_end_single         = ignore   # ignore/add/remove/force
-
-# Overrides nl_func_def_end when there is only one parameter.
-nl_func_def_end_single          = ignore   # ignore/add/remove/force
-
-# Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
-nl_func_decl_end_multi_line     = false    # false/true
-
-# Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
-nl_func_def_end_multi_line      = false    # false/true
-
-# Add or remove newline between '()' in a function declaration.
-nl_func_decl_empty              = remove   # ignore/add/remove/force
-
-# Add or remove newline between '()' in a function definition.
-nl_func_def_empty               = remove   # ignore/add/remove/force
-
-# Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
-nl_func_call_start_multi_line   = false    # false/true
-
-# Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
-nl_func_call_args_multi_line    = false    # false/true
-
-# Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
-nl_func_call_end_multi_line     = false    # false/true
-
-# Whether to put each OC message parameter on a separate line
-# See nl_oc_msg_leave_one_liner
-nl_oc_msg_args                  = false    # false/true
-
-# Add or remove newline between function signature and '{'
-nl_fdef_brace                   = force    # ignore/add/remove/force
-
-# Add or remove newline between C++11 lambda signature and '{'
-nl_cpp_ldef_brace               = force    # ignore/add/remove/force
-
-# Add or remove a newline between the return keyword and return expression.
-nl_return_expr                  = remove   # ignore/add/remove/force
-
-# Whether to put a newline after semicolons, except in 'for' statements
-nl_after_semicolon              = true     # false/true
-
-# Java: Control the newline between the ')' and '{{' of the double brace initializer.
-nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
-
-# Whether to put a newline after brace open.
-# This also adds a newline before the matching brace close.
-nl_after_brace_open             = true     # false/true
-
-# If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
-# placed between the open brace and a trailing single-line comment.
-nl_after_brace_open_cmt         = false    # false/true
-
-# Whether to put a newline after a virtual brace open with a non-empty body.
-# These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open            = false    # false/true
-
-# Whether to put a newline after a virtual brace open with an empty body.
-# These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open_empty      = false    # false/true
-
-# Whether to put a newline after a brace close.
-# Does not apply if followed by a necessary ';'.
-nl_after_brace_close            = true     # false/true
-
-# Whether to put a newline after a virtual brace close.
-# Would add a newline before return in: 'if (foo) a++; return;'
-nl_after_vbrace_close           = false    # false/true
-
-# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
-# Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close
-nl_brace_struct_var             = ignore   # ignore/add/remove/force
-
-# Whether to alter newlines in '#define' macros
-nl_define_macro                 = false    # false/true
-
-# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
-nl_squeeze_ifdef                = false    # false/true
-
-# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
-nl_squeeze_ifdef_top_level      = false    # false/true
-
-# Add or remove blank line before 'if'
-nl_before_if                    = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'if' statement
-nl_after_if                     = force    # ignore/add/remove/force
-
-# Add or remove blank line before 'for'
-nl_before_for                   = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'for' statement
-nl_after_for                    = force    # ignore/add/remove/force
-
-# Add or remove blank line before 'while'
-nl_before_while                 = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'while' statement
-nl_after_while                  = force    # ignore/add/remove/force
-
-# Add or remove blank line before 'switch'
-nl_before_switch                = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'switch' statement
-nl_after_switch                 = force    # ignore/add/remove/force
-
-# Add or remove blank line before 'synchronized'
-nl_before_synchronized          = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'synchronized' statement
-nl_after_synchronized           = force    # ignore/add/remove/force
-
-# Add or remove blank line before 'do'
-nl_before_do                    = force    # ignore/add/remove/force
-
-# Add or remove blank line after 'do/while' statement
-nl_after_do                     = force    # ignore/add/remove/force
-
-# Whether to double-space commented-entries in struct/union/enum
-nl_ds_struct_enum_cmt           = false    # false/true
-
-# force nl before } of a struct/union/enum
-# (lower priority than 'eat_blanks_before_close_brace')
-nl_ds_struct_enum_close_brace   = false    # false/true
-
-# Add or remove blank line before 'func_class_def'
-nl_before_func_class_def        = 0        # number
-
-# Add or remove blank line before 'func_class_proto'
-nl_before_func_class_proto      = 0        # number
-
-# Add or remove a newline before/after a class colon,
-#   (tied to pos_class_colon).
-nl_class_colon                  = ignore   # ignore/add/remove/force
-
-# Add or remove a newline around a class constructor colon.
-# Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
-nl_constr_colon                 = ignore   # ignore/add/remove/force
-
-# Change simple unbraced if statements into a one-liner
-# 'if(b)\n i++;' => 'if(b) i++;'
-nl_create_if_one_liner          = false    # false/true
-
-# Change simple unbraced for statements into a one-liner
-# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
-nl_create_for_one_liner         = false    # false/true
-
-# Change simple unbraced while statements into a one-liner
-# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
-nl_create_while_one_liner       = false    # false/true
-
-#  Change a one-liner if statement into simple unbraced if
-# 'if(b) i++;' => 'if(b) i++;'
-nl_split_if_one_liner           = false    # false/true
-
-# Change a one-liner for statement into simple unbraced for
-# 'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++) foo(i);'
-nl_split_for_one_liner          = false    # false/true
-
-# Change simple unbraced while statements into a one-liner while
-# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
-nl_split_while_one_liner        = false    # false/true
-
-#
-# Positioning options
-#
-
-# The position of arithmetic operators in wrapped expressions
-pos_arith                       = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of assignment in wrapped expressions.
-# Do not affect '=' followed by '{'
-pos_assign                      = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of boolean operators in wrapped expressions
-pos_bool                        = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of comparison operators in wrapped expressions
-pos_compare                     = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of conditional (b ? t : f) operators in wrapped expressions
-pos_conditional                 = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of the comma in wrapped expressions
-pos_comma                       = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of the comma in enum entries
-pos_enum_comma                  = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of the comma in the base class list if there are more than one line,
-#   (tied to nl_class_init_args).
-pos_class_comma                 = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of the comma in the constructor initialization list.
-# Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
-pos_constr_comma                = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of trailing/leading class colon, between class and base class list
-#   (tied to nl_class_colon).
-pos_class_colon                 = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-# The position of colons between constructor and member initialization,
-# (tied to UO_nl_constr_colon).
-# Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
-pos_constr_colon                = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
-
-#
-# Line Splitting options
-#
-
-# Try to limit code width to N number of columns
-code_width                      = 128      # number
-
-# Whether to fully split long 'for' statements at semi-colons
-ls_for_split_full               = false    # false/true
-
-# Whether to fully split long function protos/calls at commas
-ls_func_split_full              = false    # false/true
-
-# Whether to split lines as close to code_width as possible and ignore some groupings
-ls_code_width                   = false    # false/true
-
-#
-# Blank line options
-#
-
-# The maximum consecutive newlines (3 = 2 blank lines)
-nl_max                          = 2        # number
-
-# The number of newlines after a function prototype, if followed by another function prototype
-nl_after_func_proto             = 0        # number
-
-# The number of newlines after a function prototype, if not followed by another function prototype
-nl_after_func_proto_group       = 0        # number
-
-# The number of newlines after a function class prototype, if followed by another function class prototype
-nl_after_func_class_proto       = 0        # number
-
-# The number of newlines after a function class prototype, if not followed by another function class prototype
-nl_after_func_class_proto_group = 0        # number
-
-# The number of newlines before a multi-line function def body
-nl_before_func_body_def         = 0        # number
-
-# The number of newlines before a multi-line function prototype body
-nl_before_func_body_proto       = 0        # number
-
-# The number of newlines after '}' of a multi-line function body
-nl_after_func_body              = 0        # number
-
-# The number of newlines after '}' of a multi-line function body in a class declaration
-nl_after_func_body_class        = 0        # number
-
-# The number of newlines after '}' of a single line function body
-nl_after_func_body_one_liner    = 0        # number
-
-# The minimum number of newlines before a multi-line comment.
-# Doesn't apply if after a brace open or another multi-line comment.
-nl_before_block_comment         = 0        # number
-
-# The minimum number of newlines before a single-line C comment.
-# Doesn't apply if after a brace open or other single-line C comments.
-nl_before_c_comment             = 0        # number
-
-# The minimum number of newlines before a CPP comment.
-# Doesn't apply if after a brace open or other CPP comments.
-nl_before_cpp_comment           = 0        # number
-
-# Whether to force a newline after a multi-line comment.
-nl_after_multiline_comment      = false    # false/true
-
-# Whether to force a newline after a label's colon.
-nl_after_label_colon            = false    # false/true
-
-# The number of newlines after '}' or ';' of a struct/enum/union definition
-nl_after_struct                 = 0        # number
-
-# The number of newlines before a class definition
-nl_before_class                 = 0        # number
-
-# The number of newlines after '}' or ';' of a class definition
-nl_after_class                  = 0        # number
-
-# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
-# Will not change the newline count if after a brace open.
-# 0 = No change.
-nl_before_access_spec           = 2        # number
-
-# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
-# 0 = No change.
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'
-nl_after_access_spec            = 1        # number
-
-# The number of newlines between a function def and the function comment.
-# 0 = No change.
-nl_comment_func_def             = 0        # number
-
-# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
-# 0 = No change.
-nl_after_try_catch_finally      = 2        # number
-
-# The number of newlines before and after a property, indexer or event decl.
-# 0 = No change.
-nl_around_cs_property           = 0        # number
-
-# The number of newlines between the get/set/add/remove handlers in C#.
-# 0 = No change.
-nl_between_get_set              = 0        # number
-
-# Add or remove newline between C# property and the '{'
-nl_property_brace               = ignore   # ignore/add/remove/force
-
-# Whether to remove blank lines after '{'
-eat_blanks_after_open_brace     = false    # false/true
-
-# Whether to remove blank lines before '}'
-eat_blanks_before_close_brace   = false    # false/true
-
-# How aggressively to remove extra newlines not in preproc.
-# 0: No change
-# 1: Remove most newlines not handled by other config
-# 2: Remove all newlines and reformat completely by config
-nl_remove_extra_newlines        = 0        # number
-
-# Whether to put a blank line before 'return' statements, unless after an open brace.
-nl_before_return                = false    # false/true
-
-# Whether to put a blank line after 'return' statements, unless followed by a close brace.
-nl_after_return                 = false    # false/true
-
-# Whether to put a newline after a Java annotation statement.
-# Only affects annotations that are after a newline.
-nl_after_annotation             = ignore   # ignore/add/remove/force
-
-# Controls the newline between two annotations.
-nl_between_annotation           = ignore   # ignore/add/remove/force
-
-#
-# Code modifying options (non-whitespace)
-#
-
-# Add or remove braces on single-line 'do' statement
-mod_full_brace_do               = force    # ignore/add/remove/force
-
-# Add or remove braces on single-line 'for' statement
-mod_full_brace_for              = force    # ignore/add/remove/force
-
-# Add or remove braces on single-line function definitions. (Pawn)
-mod_full_brace_function         = ignore   # ignore/add/remove/force
-
-# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if               = force    # ignore/add/remove/force
-
-# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
-# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
-mod_full_brace_if_chain         = false    # false/true
-
-# Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
-# If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
-# and simple 'if' statements will lose them (if possible).
-mod_full_brace_if_chain_only    = false    # false/true
-
-# Don't remove braces around statements that span N newlines
-mod_full_brace_nl               = 0        # number
-
-# Add or remove braces on single-line 'while' statement
-mod_full_brace_while            = force    # ignore/add/remove/force
-
-# Add or remove braces on single-line 'using ()' statement
-mod_full_brace_using            = ignore   # ignore/add/remove/force
-
-# Add or remove unnecessary paren on 'return' statement
-mod_paren_on_return             = remove   # ignore/add/remove/force
-
-# Whether to change optional semicolons to real semicolons
-mod_pawn_semicolon              = false    # false/true
-
-# Add parens on 'while' and 'if' statement around bools
-mod_full_paren_if_bool          = false    # false/true
-
-# Whether to remove superfluous semicolons
-mod_remove_extra_semicolon      = false    # false/true
-
-# If a function body exceeds the specified number of newlines and doesn't have a comment after
-# the close brace, a comment will be added.
-mod_add_long_function_closebrace_comment = 0        # number
-
-# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
-# the close brace, a comment will be added.
-mod_add_long_namespace_closebrace_comment = 0        # number
-
-# If a class body exceeds the specified number of newlines and doesn't have a comment after
-# the close brace, a comment will be added.
-mod_add_long_class_closebrace_comment = 0        # number
-
-# If a switch body exceeds the specified number of newlines and doesn't have a comment after
-# the close brace, a comment will be added.
-mod_add_long_switch_closebrace_comment = 0        # number
-
-# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
-# the #endif, a comment will be added.
-mod_add_long_ifdef_endif_comment = 0        # number
-
-# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
-# the #else, a comment will be added.
-mod_add_long_ifdef_else_comment = 0        # number
-
-# If TRUE, will sort consecutive single-line 'import' statements [Java, D]
-mod_sort_import                 = false    # false/true
-
-# If TRUE, will sort consecutive single-line 'using' statements [C#]
-mod_sort_using                  = false    # false/true
-
-# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
-# This is generally a bad idea, as it may break your code.
-mod_sort_include                = false    # false/true
-
-# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
-mod_move_case_break             = false    # false/true
-
-# Will add or remove the braces around a fully braced case statement.
-# Will only remove the braces if there are no variable declarations in the block.
-mod_case_brace                  = ignore   # ignore/add/remove/force
-
-# If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
-mod_remove_empty_return         = false    # false/true
-
-# If TRUE, it will organize the properties (Obj-C)
-mod_sort_oc_properties          = false    # false/true
-
-# Determines weight of atomic/nonatomic (Obj-C)
-mod_sort_oc_property_thread_safe_weight = 0        # number
-
-# Determines weight of readwrite (Obj-C)
-mod_sort_oc_property_readwrite_weight = 0        # number
-
-# Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C)
-mod_sort_oc_property_reference_weight = 0        # number
-
-# Determines weight of getter type (getter=) (Obj-C)
-mod_sort_oc_property_getter_weight = 0        # number
-
-# Determines weight of setter type (setter=) (Obj-C)
-mod_sort_oc_property_setter_weight = 0        # number
-
-# Determines weight of nullability type (nullable/nonnull) (Obj-C)
-mod_sort_oc_property_nullability_weight = 0        # number
-
-#
-# Comment modifications
-#
-
-# Try to wrap comments at cmt_width columns
-cmt_width                       = 0        # number
-
-# Set the comment reflow mode (default: 0)
-# 0: no reflowing (apart from the line wrapping due to cmt_width)
-# 1: no touching at all
-# 2: full reflow
-cmt_reflow_mode                 = 0        # number
-
-# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
-cmt_convert_tab_to_spaces       = false    # false/true
-
-# If false, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
-# Default=True.
-cmt_indent_multi                = false    # false/true
-
-# Whether to group c-comments that look like they are in a block
-cmt_c_group                     = false    # false/true
-
-# Whether to put an empty '/*' on the first line of the combined c-comment
-cmt_c_nl_start                  = false    # false/true
-
-# Whether to put a newline before the closing '*/' of the combined c-comment
-cmt_c_nl_end                    = false    # false/true
-
-# Whether to group cpp-comments that look like they are in a block
-cmt_cpp_group                   = false    # false/true
-
-# Whether to put an empty '/*' on the first line of the combined cpp-comment
-cmt_cpp_nl_start                = false    # false/true
-
-# Whether to put a newline before the closing '*/' of the combined cpp-comment
-cmt_cpp_nl_end                  = false    # false/true
-
-# Whether to change cpp-comments into c-comments
-cmt_cpp_to_c                    = false    # false/true
-
-# Whether to put a star on subsequent comment lines
-cmt_star_cont                   = false    # false/true
-
-# The number of spaces to insert at the start of subsequent comment lines
-cmt_sp_before_star_cont         = 0        # number
-
-# The number of spaces to insert after the star on subsequent comment lines
-cmt_sp_after_star_cont          = 0        # number
-
-# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
-# the comment are the same length. Default=True
-cmt_multi_check_last            = true     # false/true
-
-# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
-# the comment are the same length AND if the length is bigger as the first_len minimum. Default=4
-cmt_multi_first_len_minimum     = 4        # number
-
-# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
-# Will substitute $(filename) with the current file's name.
-cmt_insert_file_header          = ""         # string
-
-# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
-# Will substitute $(filename) with the current file's name.
-cmt_insert_file_footer          = ""         # string
-
-# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
-# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
-# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
-cmt_insert_func_header          = ""         # string
-
-# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
-# Will substitute $(class) with the class name.
-cmt_insert_class_header         = ""         # string
-
-# The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
-# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
-cmt_insert_oc_msg_header        = ""         # string
-
-# If a preprocessor is encountered when stepping backwards from a function name, then
-# this option decides whether the comment should be inserted.
-# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
-cmt_insert_before_preproc       = false    # false/true
-
-# If a function is declared inline to a class definition, then
-# this option decides whether the comment should be inserted.
-# Affects cmt_insert_func_header.
-cmt_insert_before_inlines       = true     # false/true
-
-# If the function is a constructor/destructor, then
-# this option decides whether the comment should be inserted.
-# Affects cmt_insert_func_header.
-cmt_insert_before_ctor_dtor     = false    # false/true
-
-#
-# Preprocessor options
-#
-
-# Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
-pp_indent                       = remove   # ignore/add/remove/force
-
-# Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
-pp_indent_at_level              = false    # false/true
-
-# Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
-# If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
-# Default=1.
-pp_indent_count                 = 1        # number
-
-# Add or remove space after # based on pp_level of #if blocks
-pp_space                        = ignore   # ignore/add/remove/force
-
-# Sets the number of spaces added with pp_space
-pp_space_count                  = 0        # number
-
-# The indent for #region and #endregion in C# and '#pragma region' in C/C++
-pp_indent_region                = 0        # number
-
-# Whether to indent the code between #region and #endregion
-pp_region_indent_code           = false    # false/true
-
-# If pp_indent_at_level=true, sets the indent for #if, #else and #endif when not at file-level.
-# 0:  indent preprocessors using output_tab_size.
-# >0: column at which all preprocessors will be indented.
-pp_indent_if                    = 0        # number
-
-# Control whether to indent the code between #if, #else and #endif.
-pp_if_indent_code               = false    # false/true
-
-# Whether to indent '#define' at the brace level (true) or from column 1 (false)
-pp_define_at_level              = false    # false/true
-
-#
-# Use or Do not Use options
-#
-
-# True:  indent_func_call_param will be used (default)
-# False: indent_func_call_param will NOT be used
-use_indent_func_call_param      = true     # false/true
-
-# The value of the indentation for a continuation line is calculate differently if the line is:
-#   a declaration :your case with QString fileName ...
-#   an assigment  :your case with pSettings = new QSettings( ...
-# At the second case the option value might be used twice:
-#   at the assigment
-#   at the function call (if present)
-# To prevent the double use of the option value, use this option with the value 'true'.
-# True:  indent_continue will be used only once
-# False: indent_continue will be used every time (default)
-use_indent_continue_only_once   = true     # false/true
-
-# SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
-# Default=True.
-use_options_overriding_for_qt_macros = false    # false/true
-
-#
-# Warn levels - 1: error, 2: warning (default), 3: note
-#
-
-# Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
-warn_level_tabs_found_in_verbatim_string_literals = 2        # number
-
-# You can force a token to be a type with the 'type' option.
-# Example:
-# type myfoo1 myfoo2
-#
-# You can create custom macro-based indentation using macro-open,
-# macro-else and macro-close.
-# Example:
-# macro-open  BEGIN_TEMPLATE_MESSAGE_MAP
-# macro-open  BEGIN_MESSAGE_MAP
-# macro-close END_MESSAGE_MAP
-#
-# You can assign any keyword to any type with the set option.
-# set func_call_user _ N_
-#
-# The full syntax description of all custom definition config entries
-# is shown below:
-#
-# define custom tokens as:
-# - embed whitespace in token using '' escape character, or
-#   put token in quotes
-# - these: ' " and ` are recognized as quote delimiters
-#
-# type token1 token2 token3 ...
-#             ^ optionally specify multiple tokens on a single line
-# define def_token output_token
-#                  ^ output_token is optional, then NULL is assumed
-# macro-open token
-# macro-close token
-# macro-else token
-# set id token1 token2 ...
-#               ^ optionally specify multiple tokens on a single line
-#     ^ id is one of the names in token_enum.h sans the CT_ prefix,
-#       e.g. PP_PRAGMA
-#
-# all tokens are separated by any mix of ',' commas, '=' equal signs
-# and whitespace (space, tab)
-#
-# You can add support for other file extensions using the 'file_ext' command.
-# The first arg is the language name used with the '-l' option.
-# The remaining args are file extensions, matched with 'endswith'.
-#   file_ext CPP .ch .cxx .cpp.in
-#
-# option(s) with 'not default' value: 0
+# Uncrustify-0.68_f
+newlines                        = auto
+input_tab_size                  = 8
+output_tab_size                 = 8
+string_escape_char              = 92
+string_escape_char2             = 0
+string_replace_tab_chars        = false
+tok_split_gte                   = false
+disable_processing_cmt          = " *INDENT-OFF*"
+enable_processing_cmt           = " *INDENT-ON*"
+enable_digraphs                 = false
+utf8_bom                        = ignore
+utf8_byte                       = false
+utf8_force                      = false
+sp_arith                        = force
+sp_arith_additive               = force
+sp_assign                       = force
+sp_cpp_lambda_assign            = remove
+sp_cpp_lambda_paren             = remove
+sp_assign_default               = force
+sp_before_assign                = ignore
+sp_after_assign                 = ignore
+sp_enum_paren                   = ignore
+sp_enum_assign                  = force
+sp_enum_before_assign           = ignore
+sp_enum_after_assign            = ignore
+sp_enum_colon                   = force
+sp_pp_concat                    = force
+sp_pp_stringify                 = ignore
+sp_before_pp_stringify          = ignore
+sp_bool                         = force
+sp_compare                      = force
+sp_inside_paren                 = remove
+sp_paren_paren                  = remove
+sp_cparen_oparen                = remove
+sp_balance_nested_parens        = false
+sp_paren_brace                  = ignore
+sp_brace_brace                  = remove
+sp_before_ptr_star              = remove
+sp_before_unnamed_ptr_star      = ignore
+sp_between_ptr_star             = remove
+sp_after_ptr_star               = force
+sp_after_ptr_block_caret        = ignore
+sp_after_ptr_star_qualifier     = force
+sp_after_ptr_star_func          = force
+sp_ptr_star_paren               = force
+sp_before_ptr_star_func         = remove
+sp_before_byref                 = remove
+sp_before_unnamed_byref         = remove
+sp_after_byref                  = force
+sp_after_byref_func             = force
+sp_before_byref_func            = remove
+sp_after_type                   = force
+sp_after_decltype               = force
+sp_before_template_paren        = ignore
+sp_template_angle               = remove
+sp_before_angle                 = remove
+sp_inside_angle                 = remove
+sp_angle_colon                  = remove
+sp_after_angle                  = remove
+sp_angle_paren                  = remove
+sp_angle_paren_empty            = remove
+sp_angle_word                   = force
+sp_angle_shift                  = remove
+sp_permit_cpp11_shift           = true
+sp_before_sparen                = force
+sp_inside_sparen                = remove
+sp_inside_sparen_open           = ignore
+sp_inside_sparen_close          = ignore
+sp_after_sparen                 = ignore
+sp_sparen_brace                 = ignore
+sp_invariant_paren              = ignore
+sp_after_invariant_paren        = ignore
+sp_special_semi                 = ignore
+sp_before_semi                  = remove
+sp_before_semi_for              = ignore
+sp_before_semi_for_empty        = ignore
+sp_after_semi                   = force
+sp_after_semi_for               = force
+sp_after_semi_for_empty         = remove
+sp_before_square                = remove
+sp_before_squares               = remove
+sp_cpp_before_struct_binding    = ignore
+sp_inside_square                = remove
+sp_inside_square_oc_array       = ignore
+sp_after_comma                  = force
+sp_before_comma                 = remove
+sp_after_mdatype_commas         = ignore
+sp_before_mdatype_commas        = ignore
+sp_between_mdatype_commas       = ignore
+sp_paren_comma                  = force
+sp_before_ellipsis              = remove
+sp_type_ellipsis                = remove
+sp_paren_ellipsis               = remove
+sp_after_class_colon            = ignore
+sp_before_class_colon           = force
+sp_after_constr_colon           = ignore
+sp_before_constr_colon          = force
+sp_before_case_colon            = remove
+sp_after_operator               = force
+sp_after_operator_sym           = remove
+sp_after_operator_sym_empty     = remove
+sp_after_cast                   = remove
+sp_inside_paren_cast            = remove
+sp_cpp_cast_paren               = remove
+sp_sizeof_paren                 = remove
+sp_sizeof_ellipsis              = remove
+sp_sizeof_ellipsis_paren        = remove
+sp_decltype_paren               = remove
+sp_after_tag                    = ignore
+sp_inside_braces_enum           = ignore
+sp_inside_braces_struct         = ignore
+sp_inside_braces_oc_dict        = ignore
+sp_after_type_brace_init_lst_open = force
+sp_before_type_brace_init_lst_close = force
+sp_inside_type_brace_init_lst   = force
+sp_inside_braces                = force
+sp_inside_braces_empty          = remove
+sp_type_func                    = force
+sp_type_brace_init_lst          = remove
+sp_func_proto_paren             = remove
+sp_func_proto_paren_empty       = remove
+sp_func_def_paren               = remove
+sp_func_def_paren_empty         = remove
+sp_inside_fparens               = remove
+sp_inside_fparen                = remove
+sp_inside_tparen                = remove
+sp_after_tparen_close           = remove
+sp_square_fparen                = remove
+sp_fparen_brace                 = force
+sp_fparen_brace_initializer     = force
+sp_fparen_dbrace                = ignore
+sp_func_call_paren              = remove
+sp_func_call_paren_empty        = ignore
+sp_func_call_user_paren         = ignore
+sp_func_call_user_inside_fparen = remove
+sp_func_call_user_paren_paren   = remove
+sp_func_class_paren             = remove
+sp_func_class_paren_empty       = remove
+sp_return_paren                 = force
+sp_return_brace                 = force
+sp_attribute_paren              = remove
+sp_defined_paren                = remove
+sp_throw_paren                  = force
+sp_after_throw                  = force
+sp_catch_paren                  = force
+sp_oc_catch_paren               = ignore
+sp_version_paren                = ignore
+sp_scope_paren                  = ignore
+sp_super_paren                  = remove
+sp_this_paren                   = remove
+sp_macro                        = ignore
+sp_macro_func                   = ignore
+sp_else_brace                   = ignore
+sp_brace_else                   = ignore
+sp_brace_typedef                = ignore
+sp_catch_brace                  = ignore
+sp_oc_catch_brace               = ignore
+sp_brace_catch                  = ignore
+sp_oc_brace_catch               = ignore
+sp_finally_brace                = ignore
+sp_brace_finally                = ignore
+sp_try_brace                    = ignore
+sp_getset_brace                 = ignore
+sp_word_brace                   = remove
+sp_word_brace_ns                = add
+sp_before_dc                    = remove
+sp_after_dc                     = remove
+sp_d_array_colon                = ignore
+sp_not                          = remove
+sp_inv                          = remove
+sp_addr                         = remove
+sp_member                       = remove
+sp_deref                        = remove
+sp_sign                         = remove
+sp_incdec                       = remove
+sp_before_nl_cont               = add
+sp_after_oc_scope               = ignore
+sp_after_oc_colon               = ignore
+sp_before_oc_colon              = ignore
+sp_after_oc_dict_colon          = ignore
+sp_before_oc_dict_colon         = ignore
+sp_after_send_oc_colon          = ignore
+sp_before_send_oc_colon         = ignore
+sp_after_oc_type                = ignore
+sp_after_oc_return_type         = ignore
+sp_after_oc_at_sel              = ignore
+sp_after_oc_at_sel_parens       = ignore
+sp_inside_oc_at_sel_parens      = ignore
+sp_before_oc_block_caret        = ignore
+sp_after_oc_block_caret         = ignore
+sp_after_oc_msg_receiver        = ignore
+sp_after_oc_property            = ignore
+sp_after_oc_synchronized        = ignore
+sp_cond_colon                   = force
+sp_cond_colon_before            = ignore
+sp_cond_colon_after             = ignore
+sp_cond_question                = force
+sp_cond_question_before         = ignore
+sp_cond_question_after          = ignore
+sp_cond_ternary_short           = ignore
+sp_case_label                   = force
+sp_range                        = ignore
+sp_after_for_colon              = force
+sp_before_for_colon             = force
+sp_extern_paren                 = ignore
+sp_cmt_cpp_start                = add
+sp_cmt_cpp_doxygen              = true
+sp_cmt_cpp_qttr                 = true
+sp_endif_cmt                    = force
+sp_after_new                    = force
+sp_between_new_paren            = force
+sp_after_newop_paren            = force
+sp_inside_newop_paren           = remove
+sp_inside_newop_paren_open      = remove
+sp_inside_newop_paren_close     = remove
+sp_before_tr_emb_cmt            = force
+sp_num_before_tr_emb_cmt        = 1
+sp_annotation_paren             = ignore
+sp_skip_vbrace_tokens           = false
+sp_after_noexcept               = remove
+force_tab_after_define          = false
+indent_columns                  = 4
+indent_continue                 = 4
+indent_continue_class_head      = 0
+indent_single_newlines          = false
+indent_param                    = 0
+indent_with_tabs                = 0
+indent_cmt_with_tabs            = false
+indent_align_string             = false
+indent_xml_string               = 0
+indent_brace                    = 0
+indent_braces                   = false
+indent_braces_no_func           = false
+indent_braces_no_class          = false
+indent_braces_no_struct         = false
+indent_brace_parent             = false
+indent_paren_open_brace         = false
+indent_cs_delegate_brace        = false
+indent_cs_delegate_body         = false
+indent_namespace                = false
+indent_namespace_single_indent  = false
+indent_namespace_level          = 0
+indent_namespace_limit          = 0
+indent_extern                   = false
+indent_class                    = true
+indent_class_colon              = false
+indent_class_on_colon           = false
+indent_constr_colon             = false
+indent_ctor_init_leading        = 2
+indent_ctor_init                = 0
+indent_else_if                  = false
+indent_var_def_blk              = 0
+indent_var_def_cont             = false
+indent_shift                    = true
+indent_func_def_force_col1      = false
+indent_func_call_param          = true
+indent_func_def_param           = true
+indent_func_proto_param         = true
+indent_func_class_param         = true
+indent_func_ctor_var_param      = true
+indent_template_param           = true
+indent_func_param_double        = false
+indent_func_const               = 0
+indent_func_throw               = 0
+indent_member                   = 4
+indent_member_single            = true
+indent_sing_line_comments       = 0
+indent_relative_single_line_comments = false
+indent_switch_case              = 0
+indent_switch_pp                = true
+indent_case_shift               = 0
+indent_case_brace               = 4
+indent_col1_comment             = false
+indent_label                    = 1
+indent_access_spec              = 1
+indent_access_spec_body         = false
+indent_paren_nl                 = false
+indent_paren_close              = 0
+indent_paren_after_func_def     = false
+indent_paren_after_func_decl    = false
+indent_paren_after_func_call    = false
+indent_comma_paren              = false
+indent_bool_paren               = false
+indent_semicolon_for_paren      = false
+indent_first_bool_expr          = false
+indent_first_for_expr           = false
+indent_square_nl                = false
+indent_preserve_sql             = false
+indent_align_assign             = false
+indent_align_paren              = false
+indent_oc_block                 = false
+indent_oc_block_msg             = 0
+indent_oc_msg_colon             = 0
+indent_oc_msg_prioritize_first_colon = true
+indent_oc_block_msg_xcode_style = false
+indent_oc_block_msg_from_keyword = false
+indent_oc_block_msg_from_colon  = false
+indent_oc_block_msg_from_caret  = false
+indent_oc_block_msg_from_brace  = false
+indent_min_vbrace_open          = 0
+indent_vbrace_open_on_tabstop   = false
+indent_token_after_brace        = false
+indent_cpp_lambda_body          = true
+indent_using_block              = true
+indent_ternary_operator         = 0
+indent_off_after_return_new     = false
+indent_single_after_return      = true
+indent_ignore_asm_block         = false
+nl_collapse_empty_body          = false
+nl_assign_leave_one_liners      = true
+nl_class_leave_one_liners       = true
+nl_enum_leave_one_liners        = false
+nl_getset_leave_one_liners      = false
+nl_cs_property_leave_one_liners = false
+nl_func_leave_one_liners        = false
+nl_cpp_lambda_leave_one_liners  = true
+nl_if_leave_one_liners          = false
+nl_while_leave_one_liners       = false
+nl_for_leave_one_liners         = false
+nl_oc_msg_leave_one_liner       = false
+nl_oc_mdef_brace                = ignore
+nl_oc_block_brace               = ignore
+nl_oc_interface_brace           = ignore
+nl_oc_implementation_brace      = ignore
+nl_start_of_file                = remove
+nl_start_of_file_min            = 0
+nl_end_of_file                  = force
+nl_end_of_file_min              = 1
+nl_assign_brace                 = force
+nl_assign_square                = ignore
+nl_tsquare_brace                = ignore
+nl_after_square_assign          = ignore
+nl_func_var_def_blk             = 0
+nl_typedef_blk_start            = 0
+nl_typedef_blk_end              = 0
+nl_typedef_blk_in               = 0
+nl_var_def_blk_start            = 0
+nl_var_def_blk_end              = 0
+nl_var_def_blk_in               = 0
+nl_fcall_brace                  = ignore
+nl_enum_brace                   = force
+nl_enum_class                   = ignore
+nl_enum_class_identifier        = ignore
+nl_enum_identifier_colon        = ignore
+nl_enum_colon_type              = ignore
+nl_struct_brace                 = force
+nl_union_brace                  = force
+nl_if_brace                     = force
+nl_brace_else                   = force
+nl_elseif_brace                 = force
+nl_else_brace                   = force
+nl_else_if                      = remove
+nl_before_if_closing_paren      = remove
+nl_brace_finally                = ignore
+nl_finally_brace                = ignore
+nl_try_brace                    = force
+nl_getset_brace                 = ignore
+nl_for_brace                    = force
+nl_catch_brace                  = force
+nl_oc_catch_brace               = ignore
+nl_brace_catch                  = force
+nl_oc_brace_catch               = ignore
+nl_brace_square                 = ignore
+nl_brace_fparen                 = remove
+nl_while_brace                  = force
+nl_scope_brace                  = ignore
+nl_unittest_brace               = ignore
+nl_version_brace                = ignore
+nl_using_brace                  = ignore
+nl_brace_brace                  = ignore
+nl_do_brace                     = force
+nl_brace_while                  = force
+nl_switch_brace                 = force
+nl_synchronized_brace           = ignore
+nl_multi_line_cond              = false
+nl_multi_line_define            = false
+nl_before_case                  = true
+nl_after_case                   = true
+nl_case_colon_brace             = ignore
+nl_before_throw                 = ignore
+nl_namespace_brace              = force
+nl_template_class               = force
+nl_class_brace                  = force
+nl_class_init_args              = ignore
+nl_constr_init_args             = force
+nl_enum_own_lines               = ignore
+nl_func_type_name               = remove
+nl_func_type_name_class         = ignore
+nl_func_class_scope             = ignore
+nl_func_scope_name              = ignore
+nl_func_proto_type_name         = remove
+nl_func_paren                   = remove
+nl_func_paren_empty             = remove
+nl_func_def_paren               = remove
+nl_func_def_paren_empty         = remove
+nl_func_call_paren              = remove
+nl_func_call_paren_empty        = remove
+nl_func_decl_start              = remove
+nl_func_def_start               = remove
+nl_func_decl_start_single       = ignore
+nl_func_def_start_single        = ignore
+nl_func_decl_start_multi_line   = false
+nl_func_def_start_multi_line    = false
+nl_func_decl_args               = remove
+nl_func_def_args                = remove
+nl_func_decl_args_multi_line    = false
+nl_func_def_args_multi_line     = false
+nl_func_decl_end                = remove
+nl_func_def_end                 = remove
+nl_func_decl_end_single         = ignore
+nl_func_def_end_single          = ignore
+nl_func_decl_end_multi_line     = false
+nl_func_def_end_multi_line      = false
+nl_func_decl_empty              = remove
+nl_func_def_empty               = remove
+nl_func_call_empty              = remove
+nl_func_call_start_multi_line   = false
+nl_func_call_args_multi_line    = false
+nl_func_call_end_multi_line     = false
+nl_oc_msg_args                  = false
+nl_fdef_brace                   = force
+nl_cpp_ldef_brace               = force
+nl_return_expr                  = remove
+nl_after_semicolon              = true
+nl_paren_dbrace_open            = ignore
+nl_type_brace_init_lst          = ignore
+nl_type_brace_init_lst_open     = ignore
+nl_type_brace_init_lst_close    = ignore
+nl_after_brace_open             = true
+nl_after_brace_open_cmt         = false
+nl_after_vbrace_open            = false
+nl_after_vbrace_open_empty      = false
+nl_after_brace_close            = true
+nl_after_vbrace_close           = false
+nl_brace_struct_var             = ignore
+nl_define_macro                 = false
+nl_squeeze_paren_close          = false
+nl_squeeze_ifdef                = false
+nl_squeeze_ifdef_top_level      = false
+nl_before_if                    = ignore
+nl_after_if                     = force
+nl_before_for                   = ignore
+nl_after_for                    = force
+nl_before_while                 = ignore
+nl_after_while                  = force
+nl_before_switch                = ignore
+nl_after_switch                 = force
+nl_before_synchronized          = ignore
+nl_after_synchronized           = force
+nl_before_do                    = ignore
+nl_after_do                     = force
+nl_ds_struct_enum_cmt           = false
+nl_ds_struct_enum_close_brace   = false
+nl_class_colon                  = ignore
+nl_constr_colon                 = ignore
+nl_namespace_two_to_one_liner   = false
+nl_create_if_one_liner          = false
+nl_create_for_one_liner         = false
+nl_create_while_one_liner       = false
+nl_create_func_def_one_liner    = false
+nl_split_if_one_liner           = false
+nl_split_for_one_liner          = false
+nl_split_while_one_liner        = false
+nl_max                          = 2
+nl_max_blank_in_func            = 0
+nl_before_func_body_proto       = 0
+nl_before_func_body_def         = 0
+nl_before_func_class_proto      = 0
+nl_before_func_class_def        = 0
+nl_after_func_proto             = 0
+nl_after_func_proto_group       = 0
+nl_after_func_class_proto       = 0
+nl_after_func_class_proto_group = 0
+nl_class_leave_one_liner_groups = false
+nl_after_func_body              = 0
+nl_after_func_body_class        = 0
+nl_after_func_body_one_liner    = 0
+nl_before_block_comment         = 0
+nl_before_c_comment             = 0
+nl_before_cpp_comment           = 0
+nl_after_multiline_comment      = false
+nl_after_label_colon            = false
+nl_after_struct                 = 0
+nl_before_class                 = 0
+nl_after_class                  = 0
+nl_before_access_spec           = 2
+nl_after_access_spec            = 1
+nl_comment_func_def             = 0
+nl_after_try_catch_finally      = 2
+nl_around_cs_property           = 0
+nl_between_get_set              = 0
+nl_property_brace               = ignore
+nl_inside_namespace             = 2
+eat_blanks_after_open_brace     = false
+eat_blanks_before_close_brace   = false
+nl_remove_extra_newlines        = 0
+nl_before_return                = false
+nl_after_return                 = false
+nl_after_annotation             = ignore
+nl_between_annotation           = ignore
+pos_arith                       = trail
+pos_assign                      = trail
+pos_bool                        = trail
+pos_compare                     = trail
+pos_conditional                 = trail
+pos_comma                       = trail
+pos_enum_comma                  = trail
+pos_class_comma                 = trail
+pos_constr_comma                = trail
+pos_class_colon                 = trail
+pos_constr_colon                = trail
+code_width                      = 128
+ls_for_split_full               = false
+ls_func_split_full              = false
+ls_code_width                   = false
+align_keep_tabs                 = false
+align_with_tabs                 = false
+align_on_tabstop                = false
+align_number_right              = false
+align_keep_extra_space          = false
+align_func_params               = false
+align_func_params_span          = 0
+align_func_params_thresh        = 0
+align_func_params_gap           = 0
+align_same_func_call_params     = false
+align_same_func_call_params_span = 0
+align_same_func_call_params_thresh = 0
+align_var_def_span              = 0
+align_var_def_star_style        = 0
+align_var_def_amp_style         = 0
+align_var_def_thresh            = 0
+align_var_def_gap               = 0
+align_var_def_colon             = false
+align_var_def_colon_gap         = 0
+align_var_def_attribute         = false
+align_var_def_inline            = false
+align_assign_span               = 0
+align_assign_thresh             = 0
+align_assign_decl_func          = 0
+align_enum_equ_span             = 0
+align_enum_equ_thresh           = 0
+align_var_class_span            = 0
+align_var_class_thresh          = 0
+align_var_class_gap             = 0
+align_var_struct_span           = 0
+align_var_struct_thresh         = 0
+align_var_struct_gap            = 0
+align_struct_init_span          = 0
+align_typedef_gap               = 0
+align_typedef_span              = 0
+align_typedef_func              = 0
+align_typedef_star_style        = 0
+align_typedef_amp_style         = 0
+align_right_cmt_span            = 0
+align_right_cmt_mix             = false
+align_right_cmt_same_level      = false
+align_right_cmt_gap             = 0
+align_right_cmt_at_col          = 0
+align_func_proto_span           = 0
+align_func_proto_gap            = 0
+align_on_operator               = false
+align_mix_var_proto             = false
+align_single_line_func          = false
+align_single_line_brace         = false
+align_single_line_brace_gap     = 0
+align_oc_msg_spec_span          = 0
+align_nl_cont                   = false
+align_pp_define_together        = false
+align_pp_define_gap             = 0
+align_pp_define_span            = 0
+align_left_shift                = true
+align_asm_colon                 = false
+align_oc_msg_colon_span         = 0
+align_oc_msg_colon_first        = false
+align_oc_decl_colon             = false
+cmt_width                       = 0
+cmt_reflow_mode                 = 0
+cmt_convert_tab_to_spaces       = false
+cmt_indent_multi                = false
+cmt_c_group                     = false
+cmt_c_nl_start                  = false
+cmt_c_nl_end                    = false
+cmt_cpp_to_c                    = false
+cmt_cpp_group                   = false
+cmt_cpp_nl_start                = false
+cmt_cpp_nl_end                  = false
+cmt_star_cont                   = false
+cmt_sp_before_star_cont         = 0
+cmt_sp_after_star_cont          = 0
+cmt_multi_check_last            = true
+cmt_multi_first_len_minimum     = 4
+cmt_insert_file_header          = ""
+cmt_insert_file_footer          = ""
+cmt_insert_func_header          = ""
+cmt_insert_class_header         = ""
+cmt_insert_oc_msg_header        = ""
+cmt_insert_before_preproc       = false
+cmt_insert_before_inlines       = true
+cmt_insert_before_ctor_dtor     = false
+mod_full_brace_do               = force
+mod_full_brace_for              = force
+mod_full_brace_function         = ignore
+mod_full_brace_if               = force
+mod_full_brace_if_chain         = false
+mod_full_brace_if_chain_only    = false
+mod_full_brace_while            = force
+mod_full_brace_using            = ignore
+mod_full_brace_nl               = 0
+mod_full_brace_nl_block_rem_mlcond = false
+mod_paren_on_return             = remove
+mod_pawn_semicolon              = false
+mod_full_paren_if_bool          = false
+mod_remove_extra_semicolon      = false
+mod_add_long_function_closebrace_comment = 0
+mod_add_long_namespace_closebrace_comment = 0
+mod_add_long_class_closebrace_comment = 0
+mod_add_long_switch_closebrace_comment = 0
+mod_add_long_ifdef_endif_comment = 0
+mod_add_long_ifdef_else_comment = 0
+mod_sort_import                 = false
+mod_sort_using                  = false
+mod_sort_include                = false
+mod_move_case_break             = false
+mod_case_brace                  = ignore
+mod_remove_empty_return         = false
+mod_enum_last_comma             = ignore
+mod_sort_oc_properties          = false
+mod_sort_oc_property_class_weight = 0
+mod_sort_oc_property_thread_safe_weight = 0
+mod_sort_oc_property_readwrite_weight = 0
+mod_sort_oc_property_reference_weight = 0
+mod_sort_oc_property_getter_weight = 0
+mod_sort_oc_property_setter_weight = 0
+mod_sort_oc_property_nullability_weight = 0
+pp_indent                       = remove
+pp_indent_at_level              = false
+pp_indent_count                 = 1
+pp_space                        = ignore
+pp_space_count                  = 0
+pp_indent_region                = 0
+pp_region_indent_code           = false
+pp_indent_if                    = 0
+pp_if_indent_code               = false
+pp_define_at_level              = false
+pp_ignore_define_body           = false
+pp_indent_case                  = true
+pp_indent_func_def              = true
+pp_indent_extern                = true
+pp_indent_brace                 = true
+include_category_0              = ""
+include_category_1              = ""
+include_category_2              = ""
+use_indent_func_call_param      = true
+use_indent_continue_only_once   = true
+indent_cpp_lambda_only_once     = true
+use_options_overriding_for_qt_macros = false
+warn_level_tabs_found_in_verbatim_string_literals = 2
+type                             PtrArrayCompareFunc
+type                             SIZE_T
+type                             tr_session
+# option(s) with 'not default' value: 218
 #

--- a/utils/remote.c
+++ b/utils/remote.c
@@ -238,15 +238,15 @@ enum
 static char const* getUsage(void)
 {
     return MY_NAME " " LONG_VERSION_STRING "\n"
-           "A fast and easy BitTorrent client\n"
-           "https://transmissionbt.com/\n"
-           "\n"
-           "Usage: " MY_NAME " [host] [options]\n"
-           "       " MY_NAME " [port] [options]\n"
-           "       " MY_NAME " [host:port] [options]\n"
-           "       " MY_NAME " [http(s?)://host:port/transmission/] [options]\n"
-           "\n"
-           "See the man page for detailed explanations and many examples.";
+        "A fast and easy BitTorrent client\n"
+        "https://transmissionbt.com/\n"
+        "\n"
+        "Usage: " MY_NAME " [host] [options]\n"
+        "       " MY_NAME " [port] [options]\n"
+        "       " MY_NAME " [host:port] [options]\n"
+        "       " MY_NAME " [http(s?)://host:port/transmission/] [options]\n"
+        "\n"
+        "See the man page for detailed explanations and many examples.";
 }
 
 /***
@@ -271,7 +271,8 @@ static tr_option opts[] =
     { 'c', "incomplete-dir", "Where to store new torrents until they're complete", "c", 1, "<dir>" },
     { 'C', "no-incomplete-dir", "Don't store incomplete torrents in a different location", "C", 0, NULL },
     { 'b', "debug", "Print debugging information", "b", 0, NULL },
-    { 'd', "downlimit", "Set the max download speed in "SPEED_K_STR " for the current torrent(s) or globally", "d", 1, "<speed>" },
+    { 'd', "downlimit", "Set the max download speed in "SPEED_K_STR " for the current torrent(s) or globally", "d", 1,
+        "<speed>" },
     { 'D', "no-downlimit", "Disable max download speed for the current torrent(s) or globally", "D", 0, NULL },
     { 'e', "cache", "Set the maximum size of the session's memory cache (in " MEM_M_STR ")", "e", 1, "<size>" },
     { 910, "encryption-required", "Encrypt all peer connections", "er", 0, NULL },
@@ -317,8 +318,10 @@ static tr_option opts[] =
     { 950, "seedratio", "Let the current torrent(s) seed until a specific ratio", "sr", 1, "ratio" },
     { 951, "seedratio-default", "Let the current torrent(s) use the global seedratio settings", "srd", 0, NULL },
     { 952, "no-seedratio", "Let the current torrent(s) seed regardless of ratio", "SR", 0, NULL },
-    { 953, "global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed until a specific ratio", "gsr", 1, "ratio" },
-    { 954, "no-global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed regardless of ratio", "GSR", 0, NULL },
+    { 953, "global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed until a specific ratio",
+        "gsr", 1, "ratio" },
+    { 954, "no-global-seedratio", "All torrents, unless overridden by a per-torrent setting, should seed regardless of ratio",
+        "GSR", 0, NULL },
     { 710, "tracker-add", "Add a tracker to a torrent", "td", 1, "<tracker>" },
     { 712, "tracker-remove", "Remove a tracker from a torrent", "tr", 1, "<trackerId>" },
     { 's', "start", "Start the current torrent(s)", "s", 0, NULL },
@@ -336,7 +339,8 @@ static tr_option opts[] =
     { 831, "no-utp", "Disable uTP for peer connections", NULL, 0, NULL },
     { 'v', "verify", "Verify the current torrent(s)", "v", 0, NULL },
     { 'V', "version", "Show version number and exit", "V", 0, NULL },
-    { 'w', "download-dir", "When used in conjunction with --add, set the new torrent's download folder. Otherwise, set the default download folder", "w", 1, "<path>" },
+    { 'w', "download-dir", "When used in conjunction with --add, set the new torrent's download folder. "
+        "Otherwise, set the default download folder", "w", 1, "<path>" },
     { 'x', "pex", "Enable peer exchange (PEX)", "x", 0, NULL },
     { 'X', "no-pex", "Disable peer exchange (PEX)", "X", 0, NULL },
     { 'y', "lpd", "Enable local peer discovery (LPD)", "y", 0, NULL },
@@ -1033,7 +1037,8 @@ static void printDetails(tr_variant* top)
                 }
             }
 
-            if (tr_variantDictFindInt(t, TR_KEY_peersConnected, &i) && tr_variantDictFindInt(t, TR_KEY_peersGettingFromUs, &j) &&
+            if (tr_variantDictFindInt(t, TR_KEY_peersConnected, &i) &&
+                tr_variantDictFindInt(t, TR_KEY_peersGettingFromUs, &j) &&
                 tr_variantDictFindInt(t, TR_KEY_peersSendingToUs, &k))
             {
                 printf("  Peers: connected to %" PRId64 ", uploading to %" PRId64 ", downloading from %" PRId64 "\n", i, j, k);
@@ -1126,7 +1131,8 @@ static void printDetails(tr_variant* top)
 
             printf("LIMITS & BANDWIDTH\n");
 
-            if (tr_variantDictFindBool(t, TR_KEY_downloadLimited, &boolVal) && tr_variantDictFindInt(t, TR_KEY_downloadLimit, &i))
+            if (tr_variantDictFindBool(t, TR_KEY_downloadLimited, &boolVal) &&
+                tr_variantDictFindInt(t, TR_KEY_downloadLimit, &i))
             {
                 printf("  Download Limit: ");
 
@@ -1230,8 +1236,10 @@ static void printFileList(tr_variant* top)
                     char const* filename;
                     tr_variant* file = tr_variantListChild(files, j);
 
-                    if (tr_variantDictFindInt(file, TR_KEY_length, &length) && tr_variantDictFindStr(file, TR_KEY_name, &filename, NULL) &&
-                        tr_variantDictFindInt(file, TR_KEY_bytesCompleted, &have) && tr_variantGetInt(tr_variantListChild(priorities, j), &priority) &&
+                    if (tr_variantDictFindInt(file, TR_KEY_length, &length) &&
+                        tr_variantDictFindStr(file, TR_KEY_name, &filename, NULL) &&
+                        tr_variantDictFindInt(file, TR_KEY_bytesCompleted, &have) &&
+                        tr_variantGetInt(tr_variantListChild(priorities, j), &priority) &&
                         tr_variantGetInt(tr_variantListChild(wanteds, j), &wanted))
                     {
                         char sizestr[64];
@@ -1277,12 +1285,15 @@ static void printPeersImpl(tr_variant* peers)
         int64_t rateToPeer;
         tr_variant* d = tr_variantListChild(peers, i);
 
-        if (tr_variantDictFindStr(d, TR_KEY_address, &address, NULL) && tr_variantDictFindStr(d, TR_KEY_clientName, &client, NULL) &&
-            tr_variantDictFindReal(d, TR_KEY_progress, &progress) && tr_variantDictFindStr(d, TR_KEY_flagStr, &flagstr, NULL) &&
-            tr_variantDictFindInt(d, TR_KEY_rateToClient, &rateToClient) && tr_variantDictFindInt(d, TR_KEY_rateToPeer, &rateToPeer))
+        if (tr_variantDictFindStr(d, TR_KEY_address, &address, NULL) &&
+            tr_variantDictFindStr(d, TR_KEY_clientName, &client, NULL) &&
+            tr_variantDictFindReal(d, TR_KEY_progress, &progress) &&
+            tr_variantDictFindStr(d, TR_KEY_flagStr, &flagstr, NULL) &&
+            tr_variantDictFindInt(d, TR_KEY_rateToClient, &rateToClient) &&
+            tr_variantDictFindInt(d, TR_KEY_rateToPeer, &rateToPeer))
         {
-            printf("%-40s  %-12s  %-5.1f %6.1f  %6.1f  %s\n", address, flagstr, (progress * 100.0), rateToClient / (double)tr_speed_K,
-                rateToPeer / (double)tr_speed_K, client);
+            printf("%-40s  %-12s  %-5.1f %6.1f  %6.1f  %s\n", address, flagstr, (progress * 100.0),
+                rateToClient / (double)tr_speed_K, rateToPeer / (double)tr_speed_K, client);
         }
     }
 }
@@ -1351,7 +1362,8 @@ static void printPieces(tr_variant* top)
             size_t rawlen;
             tr_variant* torrent = tr_variantListChild(torrents, i);
 
-            if (tr_variantDictFindRaw(torrent, TR_KEY_pieces, &raw, &rawlen) && tr_variantDictFindInt(torrent, TR_KEY_pieceCount, &j))
+            if (tr_variantDictFindRaw(torrent, TR_KEY_pieces, &raw, &rawlen) &&
+                tr_variantDictFindInt(torrent, TR_KEY_pieceCount, &j))
             {
                 assert(j >= 0);
                 printPiecesImpl(raw, rawlen, (size_t)j);
@@ -1392,8 +1404,8 @@ static void printTorrentList(tr_variant* top)
         double total_down = 0;
         char haveStr[32];
 
-        printf("%-4s   %-4s  %9s  %-8s  %6s  %6s  %-5s  %-11s  %s\n", "ID", "Done", "Have", "ETA", "Up", "Down", "Ratio", "Status",
-            "Name");
+        printf("%-4s   %-4s  %9s  %-8s  %6s  %6s  %-5s  %-11s  %s\n", "ID", "Done", "Have", "ETA", "Up", "Down", "Ratio",
+            "Status", "Name");
 
         for (int i = 0, n = tr_variantListSize(list); i < n; ++i)
         {
@@ -1408,10 +1420,14 @@ static void printTorrentList(tr_variant* top)
             char const* name;
             tr_variant* d = tr_variantListChild(list, i);
 
-            if (tr_variantDictFindInt(d, TR_KEY_eta, &eta) && tr_variantDictFindInt(d, TR_KEY_id, &id) &&
-                tr_variantDictFindInt(d, TR_KEY_leftUntilDone, &leftUntilDone) && tr_variantDictFindStr(d, TR_KEY_name, &name, NULL) &&
-                tr_variantDictFindInt(d, TR_KEY_rateDownload, &down) && tr_variantDictFindInt(d, TR_KEY_rateUpload, &up) &&
-                tr_variantDictFindInt(d, TR_KEY_sizeWhenDone, &sizeWhenDone) && tr_variantDictFindInt(d, TR_KEY_status, &status) &&
+            if (tr_variantDictFindInt(d, TR_KEY_eta, &eta) &&
+                tr_variantDictFindInt(d, TR_KEY_id, &id) &&
+                tr_variantDictFindInt(d, TR_KEY_leftUntilDone, &leftUntilDone) &&
+                tr_variantDictFindStr(d, TR_KEY_name, &name, NULL) &&
+                tr_variantDictFindInt(d, TR_KEY_rateDownload, &down) &&
+                tr_variantDictFindInt(d, TR_KEY_rateUpload, &up) &&
+                tr_variantDictFindInt(d, TR_KEY_sizeWhenDone, &sizeWhenDone) &&
+                tr_variantDictFindInt(d, TR_KEY_status, &status) &&
                 tr_variantDictFindReal(d, TR_KEY_uploadRatio, &ratio))
             {
                 char etaStr[16];
@@ -1790,9 +1806,9 @@ static void printSession(tr_variant* top)
                     tr_strlcpy(buf, "Unlimited", sizeof(buf));
                 }
 
-                printf("  Upload speed limit: %s (%s limit: %s; %s turtle limit: %s)\n", buf, upEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(buf2, upLimit, sizeof(buf2)), altEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(buf3, altUp, sizeof(buf3)));
+                printf("  Upload speed limit: %s (%s limit: %s; %s turtle limit: %s)\n", buf,
+                    upEnabled ? "Enabled" : "Disabled", tr_formatter_speed_KBps(buf2, upLimit, sizeof(buf2)),
+                    altEnabled ? "Enabled" : "Disabled", tr_formatter_speed_KBps(buf3, altUp, sizeof(buf3)));
 
                 if (altEnabled)
                 {
@@ -1807,14 +1823,14 @@ static void printSession(tr_variant* top)
                     tr_strlcpy(buf, "Unlimited", sizeof(buf));
                 }
 
-                printf("  Download speed limit: %s (%s limit: %s; %s turtle limit: %s)\n", buf, downEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(buf2, downLimit, sizeof(buf2)), altEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(buf3, altDown, sizeof(buf3)));
+                printf("  Download speed limit: %s (%s limit: %s; %s turtle limit: %s)\n", buf,
+                    downEnabled ? "Enabled" : "Disabled", tr_formatter_speed_KBps(buf2, downLimit, sizeof(buf2)),
+                    altEnabled ? "Enabled" : "Disabled", tr_formatter_speed_KBps(buf3, altDown, sizeof(buf3)));
 
                 if (altTimeEnabled)
                 {
-                    printf("  Turtle schedule: %02d:%02d - %02d:%02d  ", (int)(altBegin / 60), (int)(altBegin % 60), (int)(altEnd / 60),
-                        (int)(altEnd % 60));
+                    printf("  Turtle schedule: %02d:%02d - %02d:%02d  ", (int)(altBegin / 60), (int)(altBegin % 60),
+                        (int)(altEnd / 60), (int)(altEnd % 60));
 
                     if ((altDay & TR_SCHED_SUN) != 0)
                     {
@@ -1895,8 +1911,10 @@ static void printSessionStats(tr_variant* top)
             printf("  Duration:   %s\n", tr_strltime(buf, secs, sizeof(buf)));
         }
 
-        if (tr_variantDictFindDict(args, TR_KEY_cumulative_stats, &d) && tr_variantDictFindInt(d, TR_KEY_sessionCount, &sessions) &&
-            tr_variantDictFindInt(d, TR_KEY_uploadedBytes, &up) && tr_variantDictFindInt(d, TR_KEY_downloadedBytes, &down) &&
+        if (tr_variantDictFindDict(args, TR_KEY_cumulative_stats, &d) &&
+            tr_variantDictFindInt(d, TR_KEY_sessionCount, &sessions) &&
+            tr_variantDictFindInt(d, TR_KEY_uploadedBytes, &up) &&
+            tr_variantDictFindInt(d, TR_KEY_downloadedBytes, &down) &&
             tr_variantDictFindInt(d, TR_KEY_secondsActive, &secs))
         {
             printf("\nTOTAL\n");
@@ -1918,7 +1936,8 @@ static int processResponse(char const* rpcurl, void const* response, size_t len)
 
     if (debug)
     {
-        fprintf(stderr, "got response (len %d):\n--------\n%*.*s\n--------\n", (int)len, (int)len, (int)len, (char const*)response);
+        fprintf(stderr, "got response (len %d):\n--------\n%*.*s\n--------\n", (int)len, (int)len, (int)len,
+            (char const*)response);
     }
 
     if (tr_variantFromJson(&top, response, len) != 0)
@@ -1985,7 +2004,8 @@ static int processResponse(char const* rpcurl, void const* response, size_t len)
                         int64_t i;
                         tr_variant* b = &top;
 
-                        if (tr_variantDictFindDict(&top, ARGUMENTS, &b) && tr_variantDictFindDict(b, TR_KEY_torrent_added, &b) &&
+                        if (tr_variantDictFindDict(&top, ARGUMENTS, &b) &&
+                            tr_variantDictFindDict(b, TR_KEY_torrent_added, &b) &&
                             tr_variantDictFindInt(b, TR_KEY_id, &i))
                         {
                             tr_snprintf(id, sizeof(id), "%" PRId64, i);

--- a/utils/show.c
+++ b/utils/show.c
@@ -194,7 +194,7 @@ static void showInfo(tr_info const* inf)
     {
         files[i] = &inf->files[i];
     }
-    
+
     if (!unsorted)
     {
         qsort(files, inf->fileCount, sizeof(tr_file*), compare_files_by_name);


### PR DESCRIPTION
Tweak a few rules in the process. Now all code in cli, daemon, gtk, libtransmission, qt, and utils is properly formatted with no manual intervention.