### PR TITLE
fix: Coverity warnings

### DIFF
--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -1086,9 +1086,9 @@ static void parseUtMetadata(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer*
 
     if (tr_variantFromBencFull(&dict, tmp, msglen, NULL, &benc_end) == 0)
     {
-        (void) tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
-        (void) tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
-        (void) tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
+        (void)tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
+        (void)tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
+        (void)tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
         tr_variantFree(&dict);
     }
 

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -1164,8 +1164,8 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
 
             if (!tr_variantDictFindRaw(&val, TR_KEY_added_f, &added_f, &added_f_len))
             {
-                added_f = NULL;
                 added_f_len = 0;
+                added_f = NULL;
             }
 
             pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
@@ -1191,10 +1191,15 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         {
             tr_pex* pex;
             size_t n;
-            size_t added_f_len = 0;
-            uint8_t const* added_f = NULL;
+            size_t added_f_len;
+            uint8_t const* added_f;
 
-            tr_variantDictFindRaw(&val, TR_KEY_added6_f, &added_f, &added_f_len);
+            if (!tr_variantDictFindRaw(&val, TR_KEY_added6_f, &added_f, &added_f_len))
+            {
+                added_f_len = 0;
+                added_f = NULL;
+            }
+
             pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
 
             n = MIN(n, MAX_PEX_PEER_COUNT);

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -1159,10 +1159,15 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         {
             tr_pex* pex;
             size_t n;
-            size_t added_f_len = 0;
-            uint8_t const* added_f = NULL;
+            size_t added_f_len;
+            uint8_t const* added_f;
 
-            tr_variantDictFindRaw(&val, TR_KEY_added_f, &added_f, &added_f_len);
+            if (!tr_variantDictFindRaw(&val, TR_KEY_added_f, &added_f, &added_f_len))
+            {
+                added_f = NULL;
+                added_f_len = 0;
+            }
+
             pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
 
             n = MIN(n, MAX_PEX_PEER_COUNT);

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -1086,9 +1086,9 @@ static void parseUtMetadata(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer*
 
     if (tr_variantFromBencFull(&dict, tmp, msglen, NULL, &benc_end) == 0)
     {
-        tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
-        tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
-        tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
+        (void) tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
+        (void) tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
+        (void) tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
         tr_variantFree(&dict);
     }
 

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -912,12 +912,14 @@ static char const* torrentGet(tr_session* session, tr_variant* args_in, tr_varia
 
         while ((d = tr_variantListChild(&session->removedTorrents, n++)) != NULL)
         {
-            int64_t intVal;
+            int64_t date;
+            int64_t id;
 
-            if (tr_variantDictFindInt(d, TR_KEY_date, &intVal) && intVal >= now - interval)
+            if (tr_variantDictFindInt(d, TR_KEY_date, &date) &&
+                date >= now - interval &&
+                tr_variantDictFindInt(d, TR_KEY_id, &id))
             {
-                tr_variantDictFindInt(d, TR_KEY_id, &intVal);
-                tr_variantListAddInt(removed_out, intVal);
+                tr_variantListAddInt(removed_out, id);
             }
         }
     }

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -351,11 +351,13 @@ static void saveStringFunc(tr_variant const* v, void* evbuf)
 {
     size_t len;
     char const* str;
-    if (tr_variantGetStr(v, &str, &len))
+    if (!tr_variantGetStr(v, &str, &len))
     {
-        evbuffer_add_printf(evbuf, "%zu:", len);
-        evbuffer_add(evbuf, str, len);
+        len = 0;
+        str = NULL;
     }
+    evbuffer_add_printf(evbuf, "%zu:", len);
+    evbuffer_add(evbuf, str, len);
 }
 
 static void saveDictBeginFunc(tr_variant const* val UNUSED, void* evbuf)

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -356,6 +356,7 @@ static void saveStringFunc(tr_variant const* v, void* evbuf)
         len = 0;
         str = NULL;
     }
+
     evbuffer_add_printf(evbuf, "%zu:", len);
     evbuffer_add(evbuf, str, len);
 }

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -351,9 +351,11 @@ static void saveStringFunc(tr_variant const* v, void* evbuf)
 {
     size_t len;
     char const* str;
-    tr_variantGetStr(v, &str, &len);
-    evbuffer_add_printf(evbuf, "%zu:", len);
-    evbuffer_add(evbuf, str, len);
+    if (tr_variantGetStr(v, &str, &len))
+    {
+        evbuffer_add_printf(evbuf, "%zu:", len);
+        evbuffer_add(evbuf, str, len);
+    }
 }
 
 static void saveDictBeginFunc(tr_variant const* val UNUSED, void* evbuf)

--- a/utils/show.c
+++ b/utils/show.c
@@ -287,10 +287,18 @@ static void doScrape(tr_info const* inf)
                         {
                             if (memcmp(inf->hash, tr_quark_get_string(key, NULL), SHA_DIGEST_LENGTH) == 0)
                             {
-                                int64_t seeders = -1;
-                                int64_t leechers = -1;
-                                tr_variantDictFindInt(val, TR_KEY_complete, &seeders);
-                                tr_variantDictFindInt(val, TR_KEY_incomplete, &leechers);
+                                int64_t seeders;
+                                if (!tr_variantDictFindInt(val, TR_KEY_complete, &seeders))
+                                {
+                                    seeders = -1;
+                                }
+
+                                int64_t leechers;
+                                if (!tr_variantDictFindInt(val, TR_KEY_incomplete, &leechers))
+                                {
+                                    leechers = -1;
+                                }
+
                                 printf("%d seeders, %d leechers\n", (int)seeders, (int)leechers);
                                 matched = true;
                             }


### PR DESCRIPTION
Fixes a handful of warnings that Coverity sent to my inbox.

These are generally cases where we weren't testing a return value from `tr_variantGetFoo()` because the field was optional or because we'd already confirmed the field elsewhere, so this PR is more about making Coverity happy. These probably don't need to be backported to the maintenance line.