### PR TITLE
Slashes fixes

### DIFF
--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -1136,7 +1136,10 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
     }
     else
     {
-        s->url = tr_strdup(str);
+        if (str[strlen(str)-1] != '/')
+            s->url = tr_strdup_printf("%s/", str);
+        else
+            s->url = tr_strdup(str);
     }
 
     key = TR_KEY_rpc_whitelist_enabled;

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -682,7 +682,7 @@ static void handle_request(struct evhttp_request* req, void* arg)
 
         server->loginattempts = 0;
 
-        if (strncmp(req->uri, server->url, strlen(server->url)) != 0)
+        if (strstr(req->uri, server->url) != NULL && req->uri[strlen(server->url)] == '\0')
         {
             char* location = tr_strdup_printf("%sweb/", server->url);
             evhttp_add_header(req->output_headers, "Location", location);

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -682,7 +682,8 @@ static void handle_request(struct evhttp_request* req, void* arg)
 
         server->loginattempts = 0;
 
-        if (strstr(req->uri, server->url) != NULL && req->uri[strlen(server->url)] == '\0')
+        if (strstr(req->uri, server->url) == NULL || req->uri[strlen(server->url)] == '\0' ||
+            (strncmp(req->uri + strlen(server->url), "web", 3) == 0 && req->uri[strlen(server->url) + 3] == '\0'))
         {
             char* location = tr_strdup_printf("%sweb/", server->url);
             evhttp_add_header(req->output_headers, "Location", location);


### PR DESCRIPTION
This fixes some minor issues in URLs and settings handling by transmission RPC server.

In fact, there were a few sensitive problems:
- Trying to access a URL what exactly matches 'rpc-url' setting causes 409 or 404 error (like "http://someserver/transmission/")
- Trying to access a valid URL without trailing slash (like "http://someserver/transmission/web") also causes 409/404 error
- Setting 'rpc-url' option to a value without trailing slash caused strange 409/404 errors and wrong redirects.

The first two problems were intensified by the fact, that these basic urls (/transmission/ and /transmission/web/) are often specified manually in links, browser address bar, scripts, reverse-proxy config, etc. by the user. So missing trailing slash is a common issue, and that produced a lot of questions on forums and even here on Github (https://github.com/transmission/transmission/issues/231, https://github.com/transmission/transmission/issues/525).