### PR TITLE
gtk: added option to minimize the window instead of quitting

### DIFF
--- a/gtk/conf.c
+++ b/gtk/conf.c
@@ -86,6 +86,7 @@ static void tr_prefs_init_defaults(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_show_statusbar, TRUE);
     tr_variantDictAddBool(d, TR_KEY_trash_can_enabled, TRUE);
     tr_variantDictAddBool(d, TR_KEY_show_notification_area_icon, FALSE);
+    tr_variantDictAddBool(d, TR_KEY_minimize_on_close, TRUE);
     tr_variantDictAddBool(d, TR_KEY_show_tracker_scrapes, FALSE);
     tr_variantDictAddBool(d, TR_KEY_show_extra_peer_details, FALSE);
     tr_variantDictAddBool(d, TR_KEY_show_backup_trackers, FALSE);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -816,7 +816,7 @@ static gboolean winclose(GtkWidget* w UNUSED, GdkEvent* event UNUSED, gpointer g
     }
     else if (gtr_pref_flag_get(TR_KEY_minimize_on_close))
     {
-       gtk_window_iconify (cbdata->wind);
+        gtk_window_iconify (cbdata->wind);
     }
     else
     {

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -814,6 +814,10 @@ static gboolean winclose(GtkWidget* w UNUSED, GdkEvent* event UNUSED, gpointer g
     {
         gtr_action_activate("toggle-main-window");
     }
+    else if (gtr_pref_flag_get(TR_KEY_minimize_on_close))
+    {
+       gtk_window_iconify (cbdata->wind);
+    }
     else
     {
         on_app_exit(cbdata);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -816,7 +816,7 @@ static gboolean winclose(GtkWidget* w UNUSED, GdkEvent* event UNUSED, gpointer g
     }
     else if (gtr_pref_flag_get(TR_KEY_minimize_on_close))
     {
-        gtk_window_iconify (cbdata->wind);
+        gtk_window_iconify(cbdata->wind);
     }
     else
     {

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -372,6 +372,10 @@ static GtkWidget* desktopPage(GObject* core)
     w = new_check_button(s, TR_KEY_show_notification_area_icon, core);
     hig_workarea_add_wide_control(t, &row, w);
 
+    s = _("Minimize window instead of closing");
+    w = new_check_button(s, TR_KEY_minimize_on_close, core);
+    hig_workarea_add_wide_control(t, &row, w);
+
     hig_workarea_add_section_divider(t, &row);
     hig_workarea_add_section_title(t, &row, _("Notification"));
 

--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -203,6 +203,7 @@ static struct tr_key_struct const my_static[] =
     Q("method"),
     Q("min interval"),
     Q("min_request_interval"),
+    Q("minimize_on_close"),
     Q("move"),
     Q("msg_type"),
     Q("mtimes"),

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -203,6 +203,7 @@ enum
     TR_KEY_method,
     TR_KEY_min_interval,
     TR_KEY_min_request_interval,
+    TR_KEY_minimize_on_close,
     TR_KEY_move,
     TR_KEY_msg_type,
     TR_KEY_mtimes,


### PR DESCRIPTION
This branch adds an option to minimize the application window instead of quitting when clicking on the close button on the window titlebar.
This is useful for desktop environments such as GNOME that neither provide a system tray area nor a minimize button on titlebars.