### PR TITLE
[2.9x] uClibc-ng since 1.0.18 has sys/quota.h synced with GNU libc

### DIFF
--- a/libtransmission/platform-quota.c
+++ b/libtransmission/platform-quota.c
@@ -285,7 +285,7 @@ getquota (const char * device)
       spaceused = (int64_t) dq.dqb_curblocks >> 1;
 #elif defined(__APPLE__)
       spaceused = (int64_t) dq.dqb_curbytes;
-#elif defined(__UCLIBC__)
+#elif defined (__UCLIBC__) && !TR_UCLIBC_CHECK_VERSION (1, 0, 18)
       spaceused = (int64_t) btodb(dq.dqb_curblocks);
 #elif defined(__sun) || (defined(_LINUX_QUOTA_VERSION) && _LINUX_QUOTA_VERSION < 2)
       spaceused = (int64_t) dq.dqb_curblocks >> 1;


### PR DESCRIPTION
Backport for 2.9x. It's causing build failures on OpenWrt:

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/transmission/openssl/compile.txt