### PR TITLE
Don't set the path attribute when setting a cookie.

### DIFF
--- a/web/javascript/common.js
+++ b/web/javascript/common.js
@@ -151,7 +151,7 @@ Prefs.setValue = function (key, val) {
 
     var date = new Date();
     date.setFullYear(date.getFullYear() + 1);
-    document.cookie = key + "=" + val + "; expires=" + date.toGMTString() + "; path=/";
+    document.cookie = key + "=" + val + "; expires=" + date.toGMTString();
 };
 
 /**


### PR DESCRIPTION
If you run several Transmission web servers behind a reverse proxy at a common public domain, the explicit cookie path attribute of "/" will cause the preferences set in one web client to take effect on all other web clients at that domain. I find this behaviour counter-intuitive. I see no reason why the path should not be left at the default, in which case each web client will have a private set of preferences.