### PR TITLE
Replace some instances of -UTF8String with -fileSystemRepresentation

### DIFF
--- a/macosx/BlocklistDownloader.m
+++ b/macosx/BlocklistDownloader.m
@@ -132,7 +132,7 @@ BlocklistDownloader * fBLDownloader = nil;
         [self decompressBlocklist];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            const int count = tr_blocklistSetContent([(Controller *)[NSApp delegate] sessionHandle], [fDestination UTF8String]);
+            const int count = tr_blocklistSetContent([(Controller *)[NSApp delegate] sessionHandle], [fDestination fileSystemRepresentation]);
 
             //delete downloaded file
             [[NSFileManager defaultManager] removeItemAtPath: fDestination error: NULL];

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -343,13 +343,13 @@ static void removeKeRangerRansomware()
             tr_variantDictAddStr(&settings, TR_KEY_blocklist_url, [[fDefaults stringForKey: @"BlocklistURL"] UTF8String]);
         tr_variantDictAddBool(&settings, TR_KEY_dht_enabled, [fDefaults boolForKey: @"DHTGlobal"]);
         tr_variantDictAddStr(&settings, TR_KEY_download_dir, [[[fDefaults stringForKey: @"DownloadFolder"]
-                                                                    stringByExpandingTildeInPath] UTF8String]);
+                                                                    stringByExpandingTildeInPath] fileSystemRepresentation]);
         tr_variantDictAddBool(&settings, TR_KEY_download_queue_enabled, [fDefaults boolForKey: @"Queue"]);
         tr_variantDictAddInt(&settings, TR_KEY_download_queue_size, [fDefaults integerForKey: @"QueueDownloadNumber"]);
         tr_variantDictAddInt(&settings, TR_KEY_idle_seeding_limit, [fDefaults integerForKey: @"IdleLimitMinutes"]);
         tr_variantDictAddBool(&settings, TR_KEY_idle_seeding_limit_enabled, [fDefaults boolForKey: @"IdleLimitCheck"]);
         tr_variantDictAddStr(&settings, TR_KEY_incomplete_dir, [[[fDefaults stringForKey: @"IncompleteDownloadFolder"]
-                                                                    stringByExpandingTildeInPath] UTF8String]);
+                                                                    stringByExpandingTildeInPath] fileSystemRepresentation]);
         tr_variantDictAddBool(&settings, TR_KEY_incomplete_dir_enabled, [fDefaults boolForKey: @"UseIncompleteDownloadFolder"]);
         tr_variantDictAddBool(&settings, TR_KEY_lpd_enabled, [fDefaults boolForKey: @"LocalPeerDiscoveryGlobal"]);
         tr_variantDictAddInt(&settings, TR_KEY_message_level, TR_LOG_DEBUG);
@@ -382,7 +382,7 @@ static void removeKeRangerRansomware()
         tr_variantDictAddInt(&settings, TR_KEY_seed_queue_size, [fDefaults integerForKey: @"QueueSeedNumber"]);
         tr_variantDictAddBool(&settings, TR_KEY_start_added_torrents, [fDefaults boolForKey: @"AutoStartDownload"]);
         tr_variantDictAddBool(&settings, TR_KEY_script_torrent_done_enabled, [fDefaults boolForKey: @"DoneScriptEnabled"]);
-        tr_variantDictAddStr(&settings, TR_KEY_script_torrent_done_filename, [[fDefaults stringForKey: @"DoneScriptPath"] UTF8String]);
+        tr_variantDictAddStr(&settings, TR_KEY_script_torrent_done_filename, [[fDefaults stringForKey: @"DoneScriptPath"] fileSystemRepresentation]);
         tr_variantDictAddBool(&settings, TR_KEY_utp_enabled, [fDefaults boolForKey: @"UTPGlobal"]);
 
         // TODO: Add to GUI
@@ -424,7 +424,7 @@ static void removeKeRangerRansomware()
         fLib = tr_sessionInit(configDir, YES, &settings);
         tr_variantFree(&settings);
 
-        fConfigDirectory = [[NSString alloc] initWithUTF8String: configDir];
+        fConfigDirectory = [[NSFileManager defaultManager] stringWithFileSystemRepresentation: configDir length: strlen(configDir)];
 
         [NSApp setDelegate: self];
 
@@ -922,7 +922,7 @@ static void removeKeRangerRansomware()
     {
         //ensure torrent doesn't already exist
         tr_ctor * ctor = tr_ctorNew(fLib);
-        tr_ctorSetMetainfoFromFile(ctor, [torrentPath UTF8String]);
+        tr_ctorSetMetainfoFromFile(ctor, [torrentPath fileSystemRepresentation]);
 
         tr_info info;
         const tr_parse_result result = tr_torrentParse(ctor, &info);
@@ -2835,7 +2835,7 @@ static void removeKeRangerRansomware()
             continue;
 
         tr_ctor * ctor = tr_ctorNew(fLib);
-        tr_ctorSetMetainfoFromFile(ctor, [fullFile UTF8String]);
+        tr_ctorSetMetainfoFromFile(ctor, [fullFile fileSystemRepresentation]);
 
         switch (tr_torrentParse(ctor, NULL))
         {
@@ -3123,7 +3123,7 @@ static void removeKeRangerRansomware()
             {
                 torrent = YES;
                 tr_ctor * ctor = tr_ctorNew(fLib);
-                tr_ctorSetMetainfoFromFile(ctor, [file UTF8String]);
+                tr_ctorSetMetainfoFromFile(ctor, [file fileSystemRepresentation]);
                 if (tr_torrentParse(ctor, NULL) == TR_PARSE_OK)
                 {
                     if (!fOverlayWindow)
@@ -3185,7 +3185,7 @@ static void removeKeRangerRansomware()
             {
                 torrent = YES;
                 tr_ctor * ctor = tr_ctorNew(fLib);
-                tr_ctorSetMetainfoFromFile(ctor, [file UTF8String]);
+                tr_ctorSetMetainfoFromFile(ctor, [file fileSystemRepresentation]);
                 if (tr_torrentParse(ctor, NULL) == TR_PARSE_OK)
                     [filesToOpen addObject: file];
                 tr_ctorFree(ctor);

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -4581,8 +4581,10 @@ static void removeKeRangerRansomware()
 - (void) rpcAddTorrentStruct: (struct tr_torrent *) torrentStruct
 {
     NSString * location = nil;
-    if (tr_torrentGetDownloadDir(torrentStruct) != NULL)
-        location = @(tr_torrentGetDownloadDir(torrentStruct));
+    if (tr_torrentGetDownloadDir(torrentStruct) != NULL) {
+        const char * tmpLoc = tr_torrentGetDownloadDir(torrentStruct);
+        location = [[NSFileManager defaultManager] stringWithFileSystemRepresentation: tmpLoc length: strlen(tmpLoc)];
+    }
 
     Torrent * torrent = [[Torrent alloc] initWithTorrentStruct: torrentStruct location: location lib: fLib];
 

--- a/macosx/CreatorWindowController.m
+++ b/macosx/CreatorWindowController.m
@@ -76,7 +76,7 @@ NSMutableSet *creatorWindowControllerSet = nil;
         fStarted = NO;
 
         fPath = path;
-        fInfo = tr_metaInfoBuilderCreate([[fPath path] UTF8String]);
+        fInfo = tr_metaInfoBuilderCreate([[fPath path] fileSystemRepresentation]);
 
         if (fInfo->fileCount == 0)
         {
@@ -536,7 +536,7 @@ NSMutableSet *creatorWindowControllerSet = nil;
     [[self window] setRestorable: NO];
 
     [[NSNotificationCenter defaultCenter] postNotificationName: @"BeginCreateTorrentFile" object: fLocation userInfo: nil];
-    tr_makeMetaInfo(fInfo, [[fLocation path] UTF8String], trackerInfo, [fTrackers count], [[fCommentView string] UTF8String], [fPrivateCheck state] == NSOnState);
+    tr_makeMetaInfo(fInfo, [[fLocation path] fileSystemRepresentation], trackerInfo, [fTrackers count], [[fCommentView string] UTF8String], [fPrivateCheck state] == NSOnState);
     tr_free(trackerInfo);
 
     fTimer = [NSTimer scheduledTimerWithTimeInterval: 0.1 target: self selector: @selector(checkProgress) userInfo: nil repeats: YES];

--- a/macosx/CreatorWindowController.m
+++ b/macosx/CreatorWindowController.m
@@ -76,7 +76,7 @@ NSMutableSet *creatorWindowControllerSet = nil;
         fStarted = NO;
 
         fPath = path;
-        fInfo = tr_metaInfoBuilderCreate([[fPath path] fileSystemRepresentation]);
+        fInfo = tr_metaInfoBuilderCreate([fPath fileSystemRepresentation]);
 
         if (fInfo->fileCount == 0)
         {
@@ -536,7 +536,7 @@ NSMutableSet *creatorWindowControllerSet = nil;
     [[self window] setRestorable: NO];
 
     [[NSNotificationCenter defaultCenter] postNotificationName: @"BeginCreateTorrentFile" object: fLocation userInfo: nil];
-    tr_makeMetaInfo(fInfo, [[fLocation path] fileSystemRepresentation], trackerInfo, [fTrackers count], [[fCommentView string] UTF8String], [fPrivateCheck state] == NSOnState);
+    tr_makeMetaInfo(fInfo, [fLocation fileSystemRepresentation], trackerInfo, [fTrackers count], [[fCommentView string] UTF8String], [fPrivateCheck state] == NSOnState);
     tr_free(trackerInfo);
 
     fTimer = [NSTimer scheduledTimerWithTimeInterval: 0.1 target: self selector: @selector(checkProgress) userInfo: nil repeats: YES];

--- a/macosx/DragOverlayWindow.m
+++ b/macosx/DragOverlayWindow.m
@@ -92,7 +92,7 @@
             || [[file pathExtension] caseInsensitiveCompare: @"torrent"] == NSOrderedSame)
         {
             tr_ctor * ctor = tr_ctorNew(fLib);
-            tr_ctorSetMetainfoFromFile(ctor, [file UTF8String]);
+            tr_ctorSetMetainfoFromFile(ctor, [file fileSystemRepresentation]);
             tr_info info;
             if (tr_torrentParse(ctor, &info) == TR_PARSE_OK)
             {

--- a/macosx/PrefsController.m
+++ b/macosx/PrefsController.m
@@ -1320,7 +1320,8 @@
     const BOOL doneScriptEnabled = tr_sessionIsTorrentDoneScriptEnabled(fHandle);
     [fDefaults setBool: doneScriptEnabled forKey: @"DoneScriptEnabled"];
 
-    NSString * doneScriptPath = @(tr_sessionGetTorrentDoneScript(fHandle));
+    const char * doneScriptCStr = tr_sessionGetTorrentDoneScript(fHandle);
+    NSString * doneScriptPath = [[NSFileManager defaultManager] stringWithFileSystemRepresentation: doneScriptCStr length: strlen(doneScriptCStr)];
     [fDefaults setObject: doneScriptPath forKey: @"DoneScriptPath"];
 
     //update gui if loaded

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.m
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.m
@@ -45,7 +45,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
     //try to parse the torrent file
     tr_info inf;
     tr_ctor * ctor = tr_ctorNew(NULL);
-    tr_ctorSetMetainfoFromFile(ctor, [[(__bridge NSURL *)url path] fileSystemRepresentation]);
+    tr_ctorSetMetainfoFromFile(ctor, [(__bridge NSURL *)url fileSystemRepresentation]);
     const int err = tr_torrentParse(ctor, &inf);
     tr_ctorFree(ctor);
     if (err)

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.m
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.m
@@ -45,7 +45,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
     //try to parse the torrent file
     tr_info inf;
     tr_ctor * ctor = tr_ctorNew(NULL);
-    tr_ctorSetMetainfoFromFile(ctor, [[(__bridge NSURL *)url path] UTF8String]);
+    tr_ctorSetMetainfoFromFile(ctor, [[(__bridge NSURL *)url path] fileSystemRepresentation]);
     const int err = tr_torrentParse(ctor, &inf);
     tr_ctorFree(ctor);
     if (err)

--- a/macosx/Torrent.m
+++ b/macosx/Torrent.m
@@ -264,7 +264,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
     //if data existed in original download location, unexclude it before changing the location
     [self setTimeMachineExclude: NO];
 
-    tr_torrentSetDownloadDir(fHandle, [folder UTF8String]);
+    tr_torrentSetDownloadDir(fHandle, [folder fileSystemRepresentation]);
 
     fDownloadFolderDetermination = determinationType;
 }
@@ -562,7 +562,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
     }
 
     volatile int status;
-    tr_torrentSetLocation(fHandle, [folder UTF8String], YES, NULL, &status);
+    tr_torrentSetLocation(fHandle, [folder fileSystemRepresentation], YES, NULL, &status);
 
     while (status == TR_LOC_MOVING) //block while moving (for now)
         [NSThread sleepForTimeInterval: 0.05];
@@ -846,7 +846,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
     NSDictionary * contextInfo = @{ @"Torrent" : self, @"Nodes" : @[ node ], @"CompletionHandler" : [completionHandler copy] };
 
     NSString * oldPath = [[node path] stringByAppendingPathComponent: [node name]];
-    tr_torrentRenamePath(fHandle, [oldPath UTF8String], [newName UTF8String], renameCallback, (__bridge_retained void *)(contextInfo));
+    tr_torrentRenamePath(fHandle, [oldPath fileSystemRepresentation], [newName UTF8String], renameCallback, (__bridge_retained void *)(contextInfo));
 }
 
 - (CGFloat) progress
@@ -1662,13 +1662,13 @@ bool trashDataFile(const char * filename, tr_error ** error)
 
         tr_ctorSetPaused(ctor, TR_FORCE, YES);
         if (downloadFolder)
-            tr_ctorSetDownloadDir(ctor, TR_FORCE, [downloadFolder UTF8String]);
+            tr_ctorSetDownloadDir(ctor, TR_FORCE, [downloadFolder fileSystemRepresentation]);
         if (incompleteFolder)
-            tr_ctorSetIncompleteDir(ctor, [incompleteFolder UTF8String]);
+            tr_ctorSetIncompleteDir(ctor, [incompleteFolder fileSystemRepresentation]);
 
         tr_parse_result result = TR_PARSE_ERR;
         if (path)
-            result = tr_ctorSetMetainfoFromFile(ctor, [path UTF8String]);
+            result = tr_ctorSetMetainfoFromFile(ctor, [path fileSystemRepresentation]);
 
         if (result != TR_PARSE_OK && magnetAddress)
             result = tr_ctorSetMetainfoFromMagnetLink(ctor, [magnetAddress UTF8String]);
@@ -1853,7 +1853,7 @@ bool trashDataFile(const char * filename, tr_error ** error)
             {
                 NSString * dataLocation = [[self currentDirectory] stringByAppendingPathComponent: [self name]];
                 FSRef ref;
-                if (FSPathMakeRef((const UInt8 *)[dataLocation UTF8String], &ref, NULL) == noErr)
+                if (FSPathMakeRef((const UInt8 *)[dataLocation fileSystemRepresentation], &ref, NULL) == noErr)
                 {
                     if (LSSetItemAttribute(&ref, kLSRolesAll, kLSItemQuarantineProperties, (__bridge CFTypeRef)(quarantineProperties)) != noErr)
                         NSLog(@"Failed to quarantine: %@", dataLocation);


### PR DESCRIPTION
`-[NSString fileSystemRepresentation]` is better for passing paths to UNIX file APIs than using `-[NSString UTF8String]`.

Also use `[[NSFileManager defaultManager] stringWithFileSystemRepresentation:length:]` when creating a path for an NSString.