### PR TITLE
Allow setting labels in the torrent constructor

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -394,6 +394,7 @@
    "priority-high"      | array       indices of high-priority file(s)
    "priority-low"       | array       indices of low-priority file(s)
    "priority-normal"    | array       indices of normal-priority file(s)
+   "labels"             | array       array of string labels
 
    Either "filename" OR "metainfo" MUST be included.
    All other arguments are optional.

--- a/libtransmission/torrent-ctor.c
+++ b/libtransmission/torrent-ctor.c
@@ -41,6 +41,7 @@ struct tr_ctor
     bool isSet_delete;
     tr_variant metainfo;
     char* sourceFile;
+    tr_ptrArray labels;
 
     struct optional_args optionalArgs[2];
 
@@ -465,6 +466,31 @@ tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
 ****
 ***/
 
+void tr_ctorSetLabels(tr_ctor* ctor, struct tr_ptrArray const* labels)
+{
+    TR_ASSERT(ctor != NULL);
+
+    tr_ptrArrayDestruct(&ctor->labels, tr_free);
+    ctor->labels = TR_PTR_ARRAY_INIT;
+    char** l = (char**)tr_ptrArrayBase(labels);
+    int const n = tr_ptrArraySize(labels);
+    for (int i = 0; i < n; i++)
+    {
+        tr_ptrArrayAppend(&ctor->labels, tr_strdup(l[i]));
+    }
+}
+
+struct tr_ptrArray const* tr_ctorGetLabels(tr_ctor const* ctor)
+{
+    TR_ASSERT(ctor != NULL);
+
+    return &ctor->labels;
+}
+
+/***
+****
+***/
+
 tr_ctor* tr_ctorNew(tr_session const* session)
 {
     tr_ctor* ctor = tr_new0(struct tr_ctor, 1);
@@ -495,5 +521,6 @@ void tr_ctorFree(tr_ctor* ctor)
     tr_free(ctor->low);
     tr_free(ctor->high);
     tr_free(ctor->normal);
+    tr_ptrArrayDestruct(&ctor->labels, tr_free);
     tr_free(ctor);
 }

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -938,7 +938,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->uniqueId = nextUniqueId++;
     tor->magicNumber = TORRENT_MAGIC_NUMBER;
     tor->queuePosition = session->torrentCount;
-    tor->labels = TR_PTR_ARRAY_INIT;
+    tr_torrentSetLabels(tor, tr_ctorGetLabels(ctor));
 
     tr_sha1(tor->obfuscatedHash, "req2", 4, tor->info.hash, SHA_DIGEST_LENGTH, NULL);
 
@@ -2524,7 +2524,7 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 ****
 ***/
 
-void tr_torrentSetLabels(tr_torrent* tor, tr_ptrArray* labels)
+void tr_torrentSetLabels(tr_torrent* tor, tr_ptrArray const* labels)
 {
     TR_ASSERT(tr_isTorrent(tor));
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -43,7 +43,7 @@ void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 /* just like tr_torrentSetFileDLs but doesn't trigger a fastresume save */
 void tr_torrentInitFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file_index_t fileCount, bool do_download);
 
-void tr_torrentSetLabels(tr_torrent* tor, tr_ptrArray* labels);
+void tr_torrentSetLabels(tr_torrent* tor, tr_ptrArray const* labels);
 
 void tr_torrentRecheckCompleteness(tr_torrent*);
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -46,6 +46,7 @@ typedef struct tr_session tr_session;
 
 struct tr_error;
 struct tr_variant;
+struct tr_ptrArray;
 
 typedef int8_t tr_priority_t;
 
@@ -259,6 +260,16 @@ void tr_ctorSetBandwidthPriority(tr_ctor* ctor, tr_priority_t priority);
  * @brief Get the torrent's bandwidth priority.
  */
 tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor);
+
+/**
+ * @brief Set the torrent's labels.
+ */
+void tr_ctorSetLabels(tr_ctor* ctor, struct tr_ptrArray const* labels);
+
+/**
+ * @brief Get the torrent's labels.
+ */
+struct tr_ptrArray const* tr_ctorGetLabels(tr_ctor const* ctor);
 
 /**
  * @brief set the per-session incomplete download folder.

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -259,7 +259,7 @@ size_t tr_variantListSize(tr_variant const* list)
     return tr_variantIsList(list) ? list->val.l.count : 0;
 }
 
-tr_variant* tr_variantListChild(tr_variant* v, size_t i)
+tr_variant* tr_variantListChild(tr_variant const* v, size_t i)
 {
     tr_variant* ret = NULL;
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -227,7 +227,7 @@ tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const addme);
 tr_variant* tr_variantListAddRaw(tr_variant* list, void const* addme_value, size_t addme_len);
 tr_variant* tr_variantListAddList(tr_variant* list, size_t reserve_count);
 tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count);
-tr_variant* tr_variantListChild(tr_variant* list, size_t pos);
+tr_variant* tr_variantListChild(tr_variant const* list, size_t pos);
 
 bool tr_variantListRemove(tr_variant* list, size_t pos);
 size_t tr_variantListSize(tr_variant const* list);


### PR DESCRIPTION
I see that labels can only be set on pre-added torrents with the "torrent-set" method. This will allow setting labels with "torrent-add" too.