### PR TITLE
Add Sort by Queue menu item to popup menu

### DIFF
--- a/gtk/transmission-ui.xml
+++ b/gtk/transmission-ui.xml
@@ -86,6 +86,7 @@
       <menuitem action='sort-by-age'/> 
       <menuitem action='sort-by-name'/> 
       <menuitem action='sort-by-progress'/> 
+      <menuitem action='sort-by-queue'/> 
       <menuitem action='sort-by-ratio'/> 
       <menuitem action='sort-by-size'/> 
       <menuitem action='sort-by-state'/> 


### PR DESCRIPTION
Currently there is Sort by Queue menu item in View menu:

![image](https://user-images.githubusercontent.com/481910/62427785-c04b5400-b711-11e9-923b-6cc288ecca52.png)

, but there is no such item in popup menu:
![image](https://user-images.githubusercontent.com/481910/62427796-da853200-b711-11e9-99c0-15161b09c335.png)
