### PR TITLE
Fix incomplete error checking

### DIFF
--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -658,7 +658,7 @@ static int tr_globalAddress(int af, void* addr, int* addr_len)
         return -1;
     }
 
-    if (global_unicast_address((struct sockaddr*)&ss) == 0)
+    if (!global_unicast_address((struct sockaddr*)&ss))
     {
         return -1;
     }


### PR DESCRIPTION
global_unicast_address can return -1 when it cannot find any compatible IP protocols.