### PR TITLE
refactor: less jank in Qt client

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -469,7 +469,7 @@ void Application::onNewTorrentChanged(int id)
 
     if (tor != nullptr && !tor->name().isEmpty())
     {
-        int const age_secs = tor->dateAdded().secsTo(QDateTime::currentDateTime());
+        int const age_secs = int(difftime(time(nullptr), tor->dateAdded()));
 
         if (age_secs < 30)
         {

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -40,6 +40,8 @@ private:
 private slots:
     void recountSoon();
     void recount();
+    void filterTextSoon();
+    void filterText();
     void refreshPref(int key);
     void onActivityIndexChanged(int index);
     void onTrackerIndexChanged(int index);
@@ -55,6 +57,7 @@ private:
     QLabel* myCountLabel;
     QStandardItemModel* myTrackerModel;
     QTimer* myRecountTimer;
+    QTimer* myFilterTextTimer;
     bool myIsBootstrapping;
     QLineEdit* myLineEdit;
 };

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -818,12 +818,13 @@ void MainWindow::refreshActionSensitivity()
     int selectedAndPaused(0);
     int selectedAndQueued(0);
     int selectedWithMetadata(0);
-    int canAnnounce(0);
+    int canAnnounceSelected(0);
     QAbstractItemModel const* model(ui.listView->model());
     QItemSelectionModel const* selectionModel(ui.listView->selectionModel());
     int const rowCount(model->rowCount());
 
     // count how many torrents are selected, paused, etc
+    time_t const now = time(nullptr);
     for (int row = 0; row < rowCount; ++row)
     {
         QModelIndex const modelIndex(model->index(row, 0));
@@ -836,11 +837,6 @@ void MainWindow::refreshActionSensitivity()
             bool const isPaused(tor->isPaused());
             bool const isQueued(tor->isQueued());
 
-            if (isSelected)
-            {
-                ++selected;
-            }
-
             if (isQueued)
             {
                 ++queued;
@@ -851,24 +847,29 @@ void MainWindow::refreshActionSensitivity()
                 ++paused;
             }
 
-            if (isSelected && isPaused)
+            if (isSelected)
             {
-                ++selectedAndPaused;
-            }
+                ++selected;
 
-            if (isSelected && isQueued)
-            {
-                ++selectedAndQueued;
-            }
+                if (isPaused)
+                {
+                    ++selectedAndPaused;
+                }
 
-            if (isSelected && tor->hasMetadata())
-            {
-                ++selectedWithMetadata;
-            }
+                if (isQueued)
+                {
+                    ++selectedAndQueued;
+                }
 
-            if (tor->canManualAnnounce())
-            {
-                ++canAnnounce;
+                if (tor->hasMetadata())
+                {
+                    ++selectedWithMetadata;
+                }
+
+                if (tor->canManualAnnounce(now))
+                {
+                    ++canAnnounceSelected;
+                }
             }
         }
     }
@@ -893,7 +894,7 @@ void MainWindow::refreshActionSensitivity()
     ui.action_Start->setEnabled(selectedAndPaused > 0);
     ui.action_StartNow->setEnabled(selectedAndPaused + selectedAndQueued > 0);
     ui.action_Pause->setEnabled(selectedAndPaused < selected);
-    ui.action_Announce->setEnabled(selected > 0 && (canAnnounce == selected));
+    ui.action_Announce->setEnabled(selected > 0 && (canAnnounceSelected == selected));
 
     ui.action_QueueMoveTop->setEnabled(haveSelection);
     ui.action_QueueMoveUp->setEnabled(haveSelection);

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -10,7 +10,6 @@
 #include <iostream>
 
 #include <QApplication>
-#include <QFileIconProvider>
 #include <QFileInfo>
 #include <QSet>
 #include <QString>
@@ -41,7 +40,7 @@ Torrent::Torrent(Prefs const& prefs, int id) :
 #endif
 
     setInt(ID, id);
-    setIcon(MIME_ICON, qApp->style()->standardIcon(QStyle::SP_FileIcon));
+    setIcon(MIME_ICON, Utils::getFileIcon());
 }
 
 Torrent::~Torrent()
@@ -484,7 +483,7 @@ void Torrent::updateMimeIcon()
 
     if (files.size() > 1)
     {
-        icon = QFileIconProvider().icon(QFileIconProvider::Folder);
+        icon = Utils::getFolderIcon();
     }
     else if (files.size() == 1)
     {

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -207,16 +207,13 @@ bool Torrent::setDouble(int i, double value)
     return changed;
 }
 
-bool Torrent::setDateTime(int i, QDateTime const& value)
+bool Torrent::setEpochTime(int i, int64_t value)
 {
     bool changed = false;
 
-    assert(0 <= i && i < PROPERTY_COUNT);
-    assert(myProperties[i].type == QVariant::DateTime);
-
-    if (myValues[i].isNull() || myValues[i].toDateTime() != value)
+    if (getEpochTime(i) != value)
     {
-        myValues[i].setValue(value);
+        myValues[i].setValue(int64_t(value));
         changed = true;
     }
 
@@ -272,12 +269,12 @@ int Torrent::getInt(int i) const
     return myValues[i].toInt();
 }
 
-QDateTime Torrent::getDateTime(int i) const
+int64_t Torrent::getEpochTime(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::DateTime);
 
-    return myValues[i].toDateTime();
+    return myValues[i].toLongLong();
 }
 
 bool Torrent::getBool(int i) const
@@ -616,7 +613,7 @@ void Torrent::update(tr_variant* d)
 
                 if (tr_variantGetInt(child, &val) && val)
                 {
-                    changed |= setDateTime(property_index, QDateTime::fromTime_t(val));
+                    changed |= setEpochTime(property_index, val);
                 }
 
                 break;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -11,7 +11,6 @@
 #include <QObject>
 #include <QIcon>
 #include <QMetaType>
-#include <QDateTime>
 #include <QString>
 #include <QStringList>
 #include <QList>
@@ -357,34 +356,34 @@ public:
         return getInt(ETA);
     }
 
-    QDateTime lastActivity() const
+    int64_t lastActivity() const
     {
-        return getDateTime(DATE_ACTIVITY);
+        return getEpochTime(DATE_ACTIVITY);
     }
 
-    QDateTime lastStarted() const
+    int64_t lastStarted() const
     {
-        return getDateTime(DATE_STARTED);
+        return getEpochTime(DATE_STARTED);
     }
 
-    QDateTime dateAdded() const
+    int64_t dateAdded() const
     {
-        return getDateTime(DATE_ADDED);
+        return getEpochTime(DATE_ADDED);
     }
 
-    QDateTime dateCreated() const
+    int64_t dateCreated() const
     {
-        return getDateTime(DATE_CREATED);
+        return getEpochTime(DATE_CREATED);
     }
 
-    QDateTime manualAnnounceTime() const
+    int64_t manualAnnounceTime() const
     {
-        return getDateTime(MANUAL_ANNOUNCE_TIME);
+        return getEpochTime(MANUAL_ANNOUNCE_TIME);
     }
 
-    bool canManualAnnounce() const
+    bool canManualAnnounce(time_t now) const
     {
-        return isReadyToTransfer() && (manualAnnounceTime() <= QDateTime::currentDateTime());
+        return isReadyToTransfer() && (manualAnnounceTime() <= now);
     }
 
     int peersWeAreDownloadingFrom() const
@@ -624,7 +623,7 @@ private:
     double getDouble(int key) const;
     qulonglong getSize(int key) const;
     QString getString(int key) const;
-    QDateTime getDateTime(int key) const;
+    int64_t getEpochTime(int key) const;
 
     bool setInt(int key, int value);
     bool setBool(int key, bool value);
@@ -632,7 +631,7 @@ private:
     bool setDouble(int key, double);
     bool setString(int key, char const*);
     bool setSize(int key, qulonglong);
-    bool setDateTime(int key, QDateTime const&);
+    bool setEpochTime(int key, int64_t);
 
     char const* getMimeTypeString() const;
     void updateMimeIcon();

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -130,8 +130,8 @@ ItemLayout::ItemLayout(QString const& nameText, QString const& statusText, QIcon
 
 QSize TorrentDelegateMin::sizeHint(QStyleOptionViewItem const& option, Torrent const& /*tor*/) const
 {
-    QSize ret (option.rect.width(), QFontMetrics(option.font).height());
-    ret += margin(*qApp->style())*2;
+    QSize ret(option.rect.width(), QFontMetrics(option.font).height());
+    ret += margin(*qApp->style()) * 2;
     return ret;
 }
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -128,13 +128,11 @@ ItemLayout::ItemLayout(QString const& nameText, QString const& statusText, QIcon
 
 } // namespace
 
-QSize TorrentDelegateMin::sizeHint(QStyleOptionViewItem const& option, Torrent const& tor) const
+QSize TorrentDelegateMin::sizeHint(QStyleOptionViewItem const& option, Torrent const& /*tor*/) const
 {
-    bool const isMagnet(!tor.hasMetadata());
-    QSize const m(margin(*qApp->style()));
-    ItemLayout const layout(isMagnet ? progressString(tor) : tor.name(), shortStatusString(tor), QIcon(), option.font,
-        option.direction, QPoint(0, 0), option.rect.width() - m.width() * 2);
-    return layout.size() + m * 2;
+    QSize ret (option.rect.width(), QFontMetrics(option.font).height());
+    ret += margin(*qApp->style())*2;
+    return ret;
 }
 
 void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const& tor) const

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -26,6 +26,6 @@ public:
 
 protected:
     // TorrentDelegate
-    virtual QSize sizeHint(QStyleOptionViewItem const&, Torrent const&) const;
-    virtual void drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const&) const;
+    QSize sizeHint(QStyleOptionViewItem const&, Torrent const&) const override;
+    void drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const&) const override;
 };

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -109,7 +109,10 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
         break;
 
     case SortMode::SORT_BY_AGE:
-        val = compare(a->dateAdded().toTime_t(), b->dateAdded().toTime_t());
+        if (val == 0)
+        {
+            val = compare(a->dateAdded(), b->dateAdded());
+        }
         break;
 
     case SortMode::SORT_BY_ID:

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -113,6 +113,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
         {
             val = compare(a->dateAdded(), b->dateAdded());
         }
+
         break;
 
     case SortMode::SORT_BY_ID:

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -86,8 +86,9 @@ int compare(T const a, T const b)
 bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) const
 {
     int val = 0;
-    Torrent const* a = sourceModel()->data(left, TorrentModel::TorrentRole).value<Torrent const*>();
-    Torrent const* b = sourceModel()->data(right, TorrentModel::TorrentRole).value<Torrent const*>();
+    TorrentModel const* model = static_cast<TorrentModel const*>(sourceModel());
+    Torrent const* a = model->getTorrent(left);
+    Torrent const* b = model->getTorrent(right);
 
     switch (myPrefs.get<SortMode>(Prefs::SORT_MODE).mode())
     {

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -60,7 +60,7 @@ QVariant TorrentModel::data(QModelIndex const& index, int role) const
 {
     QVariant var;
 
-    Torrent const* t = myTorrents.value(index.row(), nullptr);
+    Torrent const* t = getTorrent(index);
 
     if (t != nullptr)
     {
@@ -136,6 +136,11 @@ TorrentModel::~TorrentModel()
 /***
 ****
 ***/
+
+Torrent const* TorrentModel::getTorrent(QModelIndex const& index) const
+{
+    return myTorrents.value(index.row(), nullptr);
+}
 
 Torrent* TorrentModel::getTorrentFromId(int id)
 {

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -41,6 +41,8 @@ public:
     Torrent* getTorrentFromId(int id);
     Torrent const* getTorrentFromId(int id) const;
 
+    Torrent const* getTorrent(QModelIndex const& index) const;
+
     void getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed, size_t& downloadPeerCount);
 
     // QAbstractItemModel

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -90,10 +90,9 @@ bool isSlashChar(QChar const& c)
     return c == QLatin1Char('/') || c == QLatin1Char('\\');
 }
 
+std::map<std::string, QIcon> iconCache;
 
-std::map<std::string,QIcon> iconCache;
-
-const QIcon& getMimeIcon(QMimeType const& mimeType)
+QIcon const& getMimeIcon(QMimeType const& mimeType)
 {
     static QIcon const fallback = qApp->style()->standardIcon(QStyle::SP_FileIcon);
 
@@ -105,7 +104,7 @@ const QIcon& getMimeIcon(QMimeType const& mimeType)
     auto& icon = iconCache[mimeType.iconName().toStdString()];
     if (icon.isNull())
     {
-      icon = QIcon::fromTheme(mimeType.iconName(), QIcon::fromTheme(mimeType.genericIconName(), fallback));
+        icon = QIcon::fromTheme(mimeType.iconName(), QIcon::fromTheme(mimeType.genericIconName(), fallback));
     }
 
     return icon;
@@ -120,6 +119,7 @@ QIcon& Utils::getFolderIcon()
     {
         icon = QFileIconProvider().icon(QFileIconProvider::Folder);
     }
+
     return icon;
 }
 
@@ -130,6 +130,7 @@ QIcon& Utils::getFileIcon()
     {
         icon = qApp->style()->standardIcon(QStyle::SP_FileIcon);
     }
+
     return icon;
 }
 

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -23,6 +23,8 @@ class QModelIndex;
 class Utils
 {
 public:
+    static QIcon& getFileIcon();
+    static QIcon& getFolderIcon();
     static QIcon guessMimeIcon(QString const& filename);
     static QIcon getIconFromIndex(QModelIndex const& index);
 


### PR DESCRIPTION
Speed up some of the hotspots that make the Qt client slow when dealing with large torrent counts.

1.  When the user enters text into the filterbar's entry field, debounce the filtering to 500 msec intervals. Previously there was no debouncing.
1. Cache the file, folder, and mime-type icons to avoid having to reload them from the theme for every torrent
1. Speed up `sizeHint()` calculation in compact layout mode
1. Torrent time properties come across RPC in time_t format. Keep them in that since comparison is very cheap, while sorting by QDateTime is expensive.
1. When sorting torrents in the TorrentFilter, access the Torrent objects directly via a new `TorrentModel::getTorrent(QModelIndex)` method. This last one is kind of a hack, but it works. :stuck_out_tongue: 