### PR TITLE
fix: use bash, not sh, for code_style.sh script

### DIFF
--- a/code_style.sh
+++ b/code_style.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
The script uses "set -o", which doesn't exist in vanilla sh, causing failure on systems that bind sh to dash rather than bash. This PR makes the bash requirement explicit.