### PR TITLE
on startup, don't request duplicate torrent fields

### DIFF
--- a/qt/Application.h
+++ b/qt/Application.h
@@ -18,6 +18,7 @@
 class AddData;
 class Prefs;
 class Session;
+class Torrent;
 class TorrentModel;
 class MainWindow;
 class WatchDir;
@@ -44,25 +45,35 @@ private:
     void loadTranslations();
     void quitLater();
 
+    void popupsInit(Torrent&);
+    void popupsShowTorrentAdded(Torrent const&) const;
+    void popupsShowTorrentComplete(Torrent const&) const;
+
+    void torStateInit();
+    QTimer myTorStateTimer;
+    time_t myTorStateLastFullUpdate = 0;
+
 private slots:
     void consentGiven(int result);
     void onSessionSourceChanged();
     void refreshPref(int key);
-    void refreshTorrents();
     void onTorrentsAdded(QSet<int> const& torrents);
-    void onTorrentCompleted(int);
-    void onNewTorrentChanged(int);
+
+    void popupsOnTorrentChanged(Torrent&);
+    void popupsOnTorrentCompleted(Torrent&);
+
+    void torStateOnSessionChanged();
+    void torStateOnBootstrapped();
+    void torStateOnTimer();
 
 private:
-    Prefs* myPrefs;
-    Session* mySession;
-    TorrentModel* myModel;
-    MainWindow* myWindow;
-    WatchDir* myWatchDir;
-    QTimer myModelTimer;
+    Prefs* myPrefs = nullptr;
+    Session* mySession = nullptr;
+    TorrentModel* myModel = nullptr;
+    MainWindow* myWindow = nullptr;
+    WatchDir* myWatchDir = nullptr;
     QTimer myStatsTimer;
     QTimer mySessionTimer;
-    time_t myLastFullUpdateTime;
     QTranslator myQtTranslator;
     QTranslator myAppTranslator;
     FaviconCache myFavicons;

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -579,8 +579,9 @@ void Session::refreshTorrents(QSet<int> const& ids, KeyList const& keys)
         });
 
     bool const allTorrents = ids.empty();
+    bool const bootstrap = allTorrents && (keys == getStatKeys() + getInfoKeys());
 
-    q->add([this, allTorrents](RpcResponse const& r)
+    q->add([this, allTorrents, bootstrap](RpcResponse const& r)
         {
             tr_variant* torrents;
 
@@ -592,6 +593,11 @@ void Session::refreshTorrents(QSet<int> const& ids, KeyList const& keys)
             if (tr_variantDictFindList(r.args.get(), TR_KEY_removed, &torrents))
             {
                 emit torrentsRemoved(torrents);
+            }
+
+            if (bootstrap)
+            {
+                emit torrentsBootstrapped();
             }
         });
 
@@ -669,6 +675,13 @@ void Session::refreshAllTorrents()
     refreshTorrents(allIds, getStatKeys());
 }
 
+// get info and stats for all torrents
+void Session::bootstrapTorrents()
+{
+    initTorrents({});
+}
+
+// get info and stats for the specified torrents
 void Session::initTorrents(QSet<int> const& ids)
 {
     refreshTorrents(ids, getStatKeys() + getInfoKeys());

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -99,6 +99,7 @@ public slots:
     void refreshSessionStats();
     void refreshActiveTorrents();
     void refreshAllTorrents();
+    void bootstrapTorrents();
     void initTorrents(QSet<int> const& ids = QSet<int>());
     void addNewlyCreatedTorrent(QString const& filename, QString const& localPath);
     void addTorrent(AddData const& addme);
@@ -119,6 +120,8 @@ signals:
     void blocklistUpdated(int);
     void torrentsUpdated(tr_variant* torrentList, bool completeList);
     void torrentsRemoved(tr_variant* torrentList);
+    void bootstrapTorrentsDone();
+    void torrentsBootstrapped();
     void dataReadProgress();
     void dataSendProgress();
     void networkResponse(QNetworkReply::NetworkError code, QString const& message);

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -990,12 +990,12 @@ void Torrent::update(tr_variant* d)
 
     if (changed)
     {
-        emit torrentChanged(id());
+        emit torrentChanged(*this);
     }
 
     if (!was_seed && isSeed() && old_verified_size > 0)
     {
-        emit torrentCompleted(id());
+        emit torrentCompleted(*this);
     }
 }
 

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -596,8 +596,8 @@ public:
     static KeyList const& getExtraStatKeys();
 
 signals:
-    void torrentChanged(int id);
-    void torrentCompleted(int id);
+    void torrentChanged(Torrent&);
+    void torrentCompleted(Torrent&);
 
 private:
     enum Group

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -153,9 +153,9 @@ Torrent const* TorrentModel::getTorrentFromId(int id) const
 ****
 ***/
 
-void TorrentModel::onTorrentChanged(int torrentId)
+void TorrentModel::onTorrentChanged(Torrent& tor)
 {
-    torrents_t::iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), torrentId, TorrentIdLessThan());
+    torrents_t::iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), tor.id(), TorrentIdLessThan());
 
     if (torrentIt == myTorrents.end())
     {
@@ -225,7 +225,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
                     }
 
                     newTorrents.append(tor);
-                    connect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onTorrentChanged(int)));
+                    connect(tor, &Torrent::torrentChanged, this, &TorrentModel::onTorrentChanged);
                 }
                 else
                 {
@@ -233,6 +233,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
 
                     if (tor->isMagnet() && tor->hasMetadata())
                     {
+                        std::cerr << "was a magnet, now is not" << tor->id() << " " << qPrintable(tor->name()) << std::endl;
                         addIds.insert(tor->id());
                         tor->setMagnet(false);
                     }

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -64,7 +64,7 @@ private:
     QSet<int> getIds() const;
 
 private slots:
-    void onTorrentChanged(int propertyId);
+    void onTorrentChanged(Torrent&);
 
 private:
     Prefs const& myPrefs;


### PR DESCRIPTION
Refactor the Application class to decouple popup notification states and torrent upkeep states. The latter now bootstraps torrent info + stats on startup, then starts the stat upkeep timer _after_ bootstrapping finishes.

The popup notification refactor makes it easier to see which signals are connected, when, and why.