### PR TITLE
refactor: keep torrent's time properties as time_t

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -469,7 +469,7 @@ void Application::onNewTorrentChanged(int id)
 
     if (tor != nullptr && !tor->name().isEmpty())
     {
-        int const age_secs = tor->dateAdded().secsTo(QDateTime::currentDateTime());
+        int const age_secs = int(std::difftime(time(nullptr), tor->dateAdded()));
 
         if (age_secs < 30)
         {

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -208,14 +208,11 @@ bool Torrent::setDouble(int i, double value)
     return changed;
 }
 
-bool Torrent::setDateTime(int i, QDateTime const& value)
+bool Torrent::setTime(int i, time_t value)
 {
     bool changed = false;
 
-    assert(0 <= i && i < PROPERTY_COUNT);
-    assert(myProperties[i].type == QVariant::DateTime);
-
-    if (myValues[i].isNull() || myValues[i].toDateTime() != value)
+    if (getTime(i) != value)
     {
         myValues[i].setValue(value);
         changed = true;
@@ -273,12 +270,12 @@ int Torrent::getInt(int i) const
     return myValues[i].toInt();
 }
 
-QDateTime Torrent::getDateTime(int i) const
+time_t Torrent::getTime(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::DateTime);
 
-    return myValues[i].toDateTime();
+    return time_t(myValues[i].toLongLong());
 }
 
 bool Torrent::getBool(int i) const
@@ -617,7 +614,7 @@ void Torrent::update(tr_variant* d)
 
                 if (tr_variantGetInt(child, &val) && val)
                 {
-                    changed |= setDateTime(property_index, QDateTime::fromTime_t(val));
+                    changed |= setTime(property_index, time_t(val));
                 }
 
                 break;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -632,7 +632,7 @@ private:
     bool setDouble(int key, double);
     bool setString(int key, char const*);
     bool setSize(int key, qulonglong);
-    bool setTime(int key, int64_t);
+    bool setTime(int key, time_t);
 
     char const* getMimeTypeString() const;
     void updateMimeIcon();

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
+#include <ctime> // time_t
+
 #include <QObject>
 #include <QIcon>
 #include <QMetaType>
-#include <QDateTime>
 #include <QString>
 #include <QStringList>
 #include <QList>
@@ -357,34 +358,34 @@ public:
         return getInt(ETA);
     }
 
-    QDateTime lastActivity() const
+    time_t lastActivity() const
     {
-        return getDateTime(DATE_ACTIVITY);
+        return getTime(DATE_ACTIVITY);
     }
 
-    QDateTime lastStarted() const
+    time_t lastStarted() const
     {
-        return getDateTime(DATE_STARTED);
+        return getTime(DATE_STARTED);
     }
 
-    QDateTime dateAdded() const
+    time_t dateAdded() const
     {
-        return getDateTime(DATE_ADDED);
+        return getTime(DATE_ADDED);
     }
 
-    QDateTime dateCreated() const
+    time_t dateCreated() const
     {
-        return getDateTime(DATE_CREATED);
+        return getTime(DATE_CREATED);
     }
 
-    QDateTime manualAnnounceTime() const
+    time_t manualAnnounceTime() const
     {
-        return getDateTime(MANUAL_ANNOUNCE_TIME);
+        return getTime(MANUAL_ANNOUNCE_TIME);
     }
 
-    bool canManualAnnounce() const
+    bool canManualAnnounceAt(time_t t) const
     {
-        return isReadyToTransfer() && (manualAnnounceTime() <= QDateTime::currentDateTime());
+        return isReadyToTransfer() && (manualAnnounceTime() <= t);
     }
 
     int peersWeAreDownloadingFrom() const
@@ -619,12 +620,11 @@ private:
 private:
     int getInt(int key) const;
     bool getBool(int key) const;
-    QTime getTime(int key) const;
     QIcon getIcon(int key) const;
     double getDouble(int key) const;
     qulonglong getSize(int key) const;
     QString getString(int key) const;
-    QDateTime getDateTime(int key) const;
+    time_t getTime(int key) const;
 
     bool setInt(int key, int value);
     bool setBool(int key, bool value);
@@ -632,7 +632,7 @@ private:
     bool setDouble(int key, double);
     bool setString(int key, char const*);
     bool setSize(int key, qulonglong);
-    bool setDateTime(int key, QDateTime const&);
+    bool setTime(int key, int64_t);
 
     char const* getMimeTypeString() const;
     void updateMimeIcon();

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -108,7 +108,11 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
         break;
 
     case SortMode::SORT_BY_AGE:
-        val = compare(a->dateAdded().toTime_t(), b->dateAdded().toTime_t());
+        if (val == 0)
+        {
+            val = compare(a->dateAdded(), b->dateAdded());
+        }
+
         break;
 
     case SortMode::SORT_BY_ID:


### PR DESCRIPTION
Comparing QDateTimes is surprisingly expensive. time_t wrangling is cheaper -- _and_ that's the form given to us by the RPC API -- so let's just keep it that way and only use QDateTime when necessary.