### PR TITLE
Edit date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TR_NAME ${PROJECT_NAME})
 #         "Z" for unsupported trunk builds,
 #         "0" for stable, supported releases
 # these should be the only two lines you need to change
-set(TR_USER_AGENT_PREFIX "2.94+")
-set(TR_PEER_ID_PREFIX "-TR294Z-")
+set(TR_USER_AGENT_PREFIX "3.00+")
+set(TR_PEER_ID_PREFIX "-TR300Z-")
 
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+).*" TR_VERSION "${TR_USER_AGENT_PREFIX}")
 set(TR_VERSION_MAJOR "${CMAKE_MATCH_1}")

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@ dnl STATUS: "X" for prerelease beta builds,
 dnl         "Z" for unsupported trunk builds,
 dnl         "0" for stable, supported releases
 dnl these should be the only two lines you need to change
-m4_define([user_agent_prefix],[2.94+])
-m4_define([peer_id_prefix],[-TR294Z-])
+m4_define([user_agent_prefix],[3.00+])
+m4_define([peer_id_prefix],[-TR300Z-])
 
 AC_INIT([transmission],[user_agent_prefix],[https://github.com/transmission/transmission])
 AC_SUBST(USERAGENT_PREFIX,[user_agent_prefix])

--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -176,6 +176,7 @@
    downloadedEver              | number                      | tr_stat
    downloadLimit               | number                      | tr_torrent
    downloadLimited             | boolean                     | tr_torrent
+   editDate                    | number                      | tr_stat
    error                       | number                      | tr_stat
    errorString                 | string                      | tr_stat
    eta                         | number                      | tr_stat
@@ -792,6 +793,7 @@
          |         | yes       | session-get          | new arg "session-id"
          |         | yes       | torrent-get          | new arg "labels"
          |         | yes       | torrent-set          | new arg "labels"
+         |         | yes       | torrent-set          | new arg "editDate"
 
 
 5.1.  Upcoming Breakage

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -279,10 +279,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             four_digits(buf, buflen, "Avicora", id + 3);
         }
-        else if (strncmp(chid + 1, "BB", 2) == 0)
-        {
-            four_digits(buf, buflen, "BitBuddy", id + 3);
-        }
         else if (strncmp(chid + 1, "BE", 2) == 0)
         {
             four_digits(buf, buflen, "BitTorrent SDK", id + 3);
@@ -318,10 +314,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "BW", 2) == 0)
         {
             four_digits(buf, buflen, "BitWombat", id + 3);
-        }
-        else if (strncmp(chid + 1, "BX", 2) == 0)
-        {
-            four_digits(buf, buflen, "BittorrentX", id + 3);
         }
         else if (strncmp(chid + 1, "EB", 2) == 0)
         {
@@ -500,10 +492,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
             four_digits(buf, buflen, "Zona", id + 3);
         }
         /* */
-        else if (strncmp(chid + 1, "AG", 2) == 0)
-        {
-            three_digits(buf, buflen, "Ares", id + 3);
-        }
         else if (strncmp(chid + 1, "A~", 2) == 0)
         {
             three_digits(buf, buflen, "Ares", id + 3);
@@ -531,10 +519,6 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "pb", 2) == 0)
         {
             three_digits(buf, buflen, "pbTorrent", id + 3);
-        }
-        else if (strncmp(chid + 1, "TT", 2) == 0)
-        {
-            three_digits(buf, buflen, "TuoTu", id + 3);
         }
         else if (strncmp(chid + 1, "qB", 2) == 0)
         {

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -176,33 +176,11 @@ void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type)
     else if (type == TR_AF_INET6)
     {
 #if defined(IPV6_TCLASS) && !defined(_WIN32)
-
-        int dscp = 0;
-
-        switch (tos)
-        {
-        case 0x10:
-            dscp = 0x20; /* lowcost (CS1) */
-            break;
-
-        case 0x08:
-            dscp = 0x28; /* throughput (AF11) */
-            break;
-
-        case 0x04:
-            dscp = 0x04; /* reliability */
-            break;
-
-        case 0x02:
-            dscp = 0x30; /* low delay (AF12) */
-            break;
-        }
-
-        if (setsockopt(s, IPPROTO_IPV6, IPV6_TCLASS, (void const*)&dscp, sizeof(dscp)) == -1)
+        if (setsockopt(s, IPPROTO_IPV6, IPV6_TCLASS, (void const*)&tos, sizeof(tos)) == -1)
         {
             char err_buf[512];
             tr_net_strerror(err_buf, sizeof(err_buf), sockerrno);
-            tr_logAddNamedInfo("Net", "Can't set IPv6 QoS '%d': %s", dscp, err_buf);
+            tr_logAddNamedInfo("Net", "Can't set IPv6 QoS '%d': %s", tos, err_buf);
         }
 
 #else

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -118,6 +118,15 @@ static inline bool tr_address_is_valid(tr_address const* a)
  * Sockets
  **********************************************************************/
 
+/* https://en.wikipedia.org/wiki/Differentiated_services#Class_Selector */
+enum
+{
+    TR_IPTOS_LOWCOST = 0x38, /* AF13: low prio, high drop */
+    TR_IPTOS_LOWDELAY = 0x70, /* AF32: high prio, mid drop */
+    TR_IPTOS_THRUPUT = 0x20, /* CS1: low prio, undef drop */
+    TR_IPTOS_RELIABLE = 0x28 /* AF11: low prio, low drop */
+};
+
 struct tr_session;
 
 struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);

--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -105,6 +105,7 @@ static struct tr_key_struct const my_static[] =
     Q("dropped"),
     Q("dropped6"),
     Q("e"),
+    Q("editDate"),
     Q("encoding"),
     Q("encryption"),
     Q("error"),

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -105,6 +105,7 @@ enum
     TR_KEY_dropped,
     TR_KEY_dropped6,
     TR_KEY_e,
+    TR_KEY_editDate,
     TR_KEY_encoding,
     TR_KEY_encryption,
     TR_KEY_error,

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -631,6 +631,10 @@ static void addField(tr_torrent* const tor, tr_info const* const inf, tr_stat co
         tr_variantDictAddInt(d, key, st->id);
         break;
 
+    case TR_KEY_editDate:
+        tr_variantDictAddInt(d, key, st->editDate);
+        break;
+
     case TR_KEY_isFinished:
         tr_variantDictAddBool(d, key, st->finished);
         break;

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -265,27 +265,27 @@ static int parse_tos(char const* str)
 
     if (evutil_ascii_strcasecmp(str, "lowcost") == 0)
     {
-        return 0x10;
+        return TR_IPTOS_LOWCOST;
     }
 
     if (evutil_ascii_strcasecmp(str, "mincost") == 0)
     {
-        return 0x10;
+        return TR_IPTOS_LOWCOST;
     }
 
     if (evutil_ascii_strcasecmp(str, "throughput") == 0)
     {
-        return 0x08;
+        return TR_IPTOS_THRUPUT;
     }
 
     if (evutil_ascii_strcasecmp(str, "reliability") == 0)
     {
-        return 0x04;
+        return TR_IPTOS_RELIABLE;
     }
 
     if (evutil_ascii_strcasecmp(str, "lowdelay") == 0)
     {
-        return 0x02;
+        return TR_IPTOS_LOWDELAY;
     }
 
     value = strtol(str, &p, 0);
@@ -307,16 +307,16 @@ static char const* format_tos(int value)
     case 0:
         return "default";
 
-    case 0x10:
+    case TR_IPTOS_LOWCOST:
         return "lowcost";
 
-    case 0x08:
+    case TR_IPTOS_THRUPUT:
         return "throughput";
 
-    case 0x04:
+    case TR_IPTOS_RELIABLE:
         return "reliability";
 
-    case 0x02:
+    case TR_IPTOS_LOWDELAY:
         return "lowdelay";
 
     default:

--- a/libtransmission/torrent-magnet.c
+++ b/libtransmission/torrent-magnet.c
@@ -340,6 +340,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
             tor->isStopping = true;
             tor->magnetVerify = true;
             tor->startAfterVerify = true;
+            tr_torrentMarkEdited(tor);
         }
         else /* drat. */
         {

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -1191,6 +1191,8 @@ void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path)
     {
         tr_free(tor->downloadDir);
         tor->downloadDir = tr_strdup(path);
+
+        tr_torrentMarkEdited(tor);
         tr_torrentSetDirty(tor);
     }
 
@@ -1406,6 +1408,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->activityDate = tor->activityDate;
     s->addedDate = tor->addedDate;
     s->doneDate = tor->doneDate;
+    s->editDate = tor->editDate;
     s->startDate = tor->startDate;
     s->secondsSeeding = tor->secondsSeeding;
     s->secondsDownloading = tor->secondsDownloading;
@@ -2862,6 +2865,7 @@ bool tr_torrentSetAnnounceList(tr_torrent* tor, tr_tracker_info const* trackers_
             tor->info.trackerCount = tmpInfo.trackerCount;
             tmpInfo.trackers = swap.trackers;
             tmpInfo.trackerCount = swap.trackerCount;
+            tr_torrentMarkEdited(tor);
 
             tr_metainfoFree(&tmpInfo);
             tr_variantToFile(&metainfo, TR_VARIANT_FMT_BENC, tor->info.torrent);
@@ -3998,6 +4002,7 @@ static void torrentRenamePath(void* vdata)
                     tor->info.name = tr_strdup(newname);
                 }
 
+                tr_torrentMarkEdited(tor);
                 tr_torrentSetDirty(tor);
             }
         }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -185,11 +185,12 @@ struct tr_torrent
     uint64_t etaULSpeedCalculatedAt;
     unsigned int etaULSpeed_Bps;
 
-    time_t addedDate;
     time_t activityDate;
-    time_t doneDate;
-    time_t startDate;
+    time_t addedDate;
     time_t anyDate;
+    time_t doneDate;
+    time_t editDate;
+    time_t startDate;
 
     int secondsDownloading;
     int secondsSeeding;
@@ -341,6 +342,14 @@ static inline void tr_torrentSetDirty(tr_torrent* tor)
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->isDirty = true;
+}
+
+/* note that the torrent's tr_info just changed */
+static inline void tr_torrentMarkEdited(tr_torrent* tor)
+{
+    TR_ASSERT(tr_isTorrent(tor));
+
+    tor->editDate = tr_time();
 }
 
 uint32_t tr_getBlockSize(uint32_t pieceSize);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1828,6 +1828,12 @@ typedef struct tr_stat
     /** The last time we uploaded or downloaded piece data on this torrent. */
     time_t activityDate;
 
+    /** The last time during this session that a rarely-changing field
+        changed -- e.g. any tr_info field (trackers, filenames, name)
+        or download directory. RPC clients can monitor this to know when
+        to reload fields that rarely change. */
+    time_t editDate;
+
     /** Number of seconds since the last activity (or since started).
         -1 if activity is not seeding or downloading. */
     int idleSecs;

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -18,6 +18,7 @@
 class AddData;
 class Prefs;
 class Session;
+class Torrent;
 class TorrentModel;
 class MainWindow;
 class WatchDir;
@@ -40,18 +41,20 @@ public slots:
     void addTorrent(AddData const&);
 
 private:
+    void initTorrentNotifications(Torrent*);
     void maybeUpdateBlocklist();
     void loadTranslations();
     void quitLater();
 
 private slots:
     void consentGiven(int result);
+    void onNewTorrentChanged(int);
     void onSessionSourceChanged();
+    void onTorrentCompleted(int);
+    void onTorrentEdited(Torrent&);
+    void onTorrentsAdded(QSet<int> const& torrents);
     void refreshPref(int key);
     void refreshTorrents();
-    void onTorrentsAdded(QSet<int> const& torrents);
-    void onTorrentCompleted(int);
-    void onNewTorrentChanged(int);
 
 private:
     Prefs* myPrefs;

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -264,7 +264,8 @@ void DetailsDialog::setIds(QSet<int> const& ids)
 
         if (tor != nullptr)
         {
-            disconnect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onTorrentChanged()));
+            disconnect(tor, &Torrent::torrentChanged, this, &DetailsDialog::onTorrentChanged);
+            disconnect(tor, &Torrent::torrentEdited, this, &DetailsDialog::onTorrentEdited);
         }
     }
 
@@ -279,7 +280,8 @@ void DetailsDialog::setIds(QSet<int> const& ids)
 
         if (tor != nullptr)
         {
-            connect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onTorrentChanged()));
+            connect(tor, &Torrent::torrentChanged, this, &DetailsDialog::onTorrentChanged);
+            connect(tor, &Torrent::torrentEdited, this, &DetailsDialog::onTorrentEdited);
         }
     }
 
@@ -351,6 +353,12 @@ void DetailsDialog::getNewData()
 
         mySession.refreshExtraStats(myIds);
     }
+}
+
+void DetailsDialog::onTorrentEdited(Torrent& tor)
+{
+#warning FIXME: depends on https://github.com/transmission/transmission/pull/1030
+    // refreshDetailInfo({ tor.id() });
 }
 
 void DetailsDialog::onTorrentChanged()

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -59,6 +59,7 @@ private slots:
     void refreshPref(int key);
 
     void onTorrentChanged();
+    void onTorrentEdited(Torrent&);
     void onTimer();
 
     // Tracker tab

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -110,6 +110,7 @@ Torrent::Property Torrent::myProperties[] =
     { PEERS, TR_KEY_peers, CustomVariantType::PeerList, STAT_EXTRA },
     { BANDWIDTH_PRIORITY, TR_KEY_bandwidthPriority, QVariant::Int, STAT_EXTRA },
     { QUEUE_POSITION, TR_KEY_queuePosition, QVariant::Int, STAT },
+    { EDIT_DATE, TR_KEY_editDate, QVariant::DateTime, STAT },
 };
 
 Torrent::KeyList Torrent::buildKeyList(Group group)
@@ -614,10 +615,15 @@ void Torrent::update(tr_variant* d)
         case QVariant::DateTime:
             {
                 int64_t val;
-
-                if (tr_variantGetInt(child, &val) && val)
+                if (tr_variantGetInt(child, &val) && val
+                    && setDateTime(property_index, QDateTime::fromTime_t(val)))
                 {
-                    changed |= setDateTime(property_index, QDateTime::fromTime_t(val));
+                    changed = true;
+
+                    if (key == TR_KEY_editDate)
+                    {
+                        emit torrentEdited(*this);
+                    }
                 }
 
                 break;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -183,6 +183,7 @@ public:
         PEERS,
         BANDWIDTH_PRIORITY,
         QUEUE_POSITION,
+        EDIT_DATE,
         //
         PROPERTY_COUNT
     };
@@ -596,8 +597,15 @@ public:
     static KeyList const& getExtraStatKeys();
 
 signals:
-    void torrentChanged(int id);
+    // The torrent was previously downloading and is now complete.
     void torrentCompleted(int id);
+
+    // The torrent's tr_info has changed on the backend
+    // and we must resync our local copies
+    void torrentEdited(Torrent&);
+
+    // Any field in this torrent object changed
+    void torrentChanged(int id);
 
 private:
     enum Group


### PR DESCRIPTION
The last time during this session that any tr_info field changed (e.g. trackers/filenames edited or magnet torrent got metadata). RPC clients can monitor this to know when to reload fields which don't usually change.