### PR TITLE
Fix some gtk warnings

### DIFF
--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2713,7 +2713,6 @@ static void on_tracker_list_add_button_clicked(GtkButton* button UNUSED, gpointe
         g_string_append_printf(gstr, _("%s - Add Tracker"), tr_torrentName(tor));
         w = gtk_dialog_new_with_buttons(gstr->str, GTK_WINDOW(di->dialog), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
             GTK_RESPONSE_CANCEL, GTK_STOCK_ADD, GTK_RESPONSE_ACCEPT, NULL);
-        gtk_dialog_set_alternative_button_order(GTK_DIALOG(w), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
         g_signal_connect(w, "response", G_CALLBACK(on_add_tracker_response), gdi);
 
         row = 0;

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -1226,7 +1226,7 @@ static GtkWidget* info_page_new(struct DetailsImpl* di)
     gtk_frame_set_shadow_type(GTK_FRAME(fr), GTK_SHADOW_IN);
     gtk_container_add(GTK_CONTAINER(fr), sw);
     w = hig_workarea_add_tall_row(t, &row, _("Comment:"), fr, NULL);
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.0F);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, NULL);
 
     hig_workarea_add_section_divider(t, &row);
     return t;
@@ -2614,7 +2614,7 @@ static void on_edit_trackers(GtkButton* button, gpointer data)
         gtk_label_set_markup(GTK_LABEL(l), _("To add a backup URL, add it on the line after the primary URL.\n"
             "To add another primary URL, add it after a blank line."));
         gtk_label_set_justify(GTK_LABEL(l), GTK_JUSTIFY_LEFT);
-        gtk_misc_set_alignment(GTK_MISC(l), 0.0, 0.5);
+        g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
         hig_workarea_add_wide_control(t, &row, l);
 
         w = gtk_text_view_new();

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2838,7 +2838,7 @@ static GtkWidget* tracker_page_new(struct DetailsImpl* di)
     gtk_box_pack_start(GTK_BOX(v), w, FALSE, FALSE, 0);
 
     w = gtk_button_new_with_mnemonic(_("_Edit"));
-    gtk_button_set_image(GTK_BUTTON(w), gtk_image_new_from_stock(GTK_STOCK_EDIT, GTK_ICON_SIZE_BUTTON));
+    gtk_button_set_image(GTK_BUTTON(w), gtk_image_new_from_icon_name(GTK_STOCK_EDIT, GTK_ICON_SIZE_BUTTON));
     g_signal_connect(w, "clicked", G_CALLBACK(on_edit_trackers), di);
     di->edit_trackers_button = w;
     gtk_box_pack_start(GTK_BOX(v), w, FALSE, FALSE, 0);

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2028,7 +2028,6 @@ static GtkWidget* peer_page_new(struct DetailsImpl* di)
     store = di->webseed_store = webseed_model_new();
     v = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
     g_signal_connect(v, "button-release-event", G_CALLBACK(on_tree_view_button_released), NULL);
-    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(v), TRUE);
     g_object_unref(store);
 
     str = getWebseedColumnNames(WEBSEED_COL_URL);
@@ -2804,7 +2803,6 @@ static GtkWidget* tracker_page_new(struct DetailsImpl* di)
     gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(v), FALSE);
     g_signal_connect(v, "button-press-event", G_CALLBACK(on_tree_view_button_pressed), NULL);
     g_signal_connect(v, "button-release-event", G_CALLBACK(on_tree_view_button_released), NULL);
-    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(v), TRUE);
 
     sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(v));
     g_signal_connect(sel, "changed", G_CALLBACK(on_tracker_list_selection_changed), di);

--- a/gtk/dialogs.c
+++ b/gtk/dialogs.c
@@ -154,7 +154,6 @@ void gtr_confirm_remove(GtkWindow* parent, TrCore* core, GSList* torrent_ids, gb
     gtk_dialog_add_buttons(GTK_DIALOG(d), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
         delete_files ? GTK_STOCK_DELETE : GTK_STOCK_REMOVE, GTK_RESPONSE_ACCEPT, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(d), GTK_RESPONSE_CANCEL);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(d), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
     g_signal_connect(d, "response", G_CALLBACK(on_remove_dialog_response), dd);
     gtk_widget_show_all(d);
 

--- a/gtk/file-list.c
+++ b/gtk/file-list.c
@@ -925,7 +925,6 @@ GtkWidget* gtr_file_list_new(TrCore* core, int torrentId)
     /* create the view */
     view = gtk_tree_view_new();
     tree_view = GTK_TREE_VIEW(view);
-    gtk_tree_view_set_rules_hint(tree_view, TRUE);
     gtk_container_set_border_width(GTK_CONTAINER(view), GUI_PAD_BIG);
     g_signal_connect(view, "button-press-event", G_CALLBACK(onViewButtonPressed), data);
     g_signal_connect(view, "row_activated", G_CALLBACK(onRowActivated), data);

--- a/gtk/filter.c
+++ b/gtk/filter.c
@@ -959,12 +959,20 @@ GtkWidget* gtr_filter_bar_new(tr_session* session, GtkTreeModel* tmodel, GtkTree
     gtk_label_set_mnemonic_widget(GTK_LABEL(l), w);
     gtk_box_pack_start(h_box, l, FALSE, FALSE, 0);
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
+#if GTK_CHECK_VERSION(3,12,0)
+    gtk_widget_set_margin_end(w, GUI_PAD);
+#else
     gtk_widget_set_margin_right(w, GUI_PAD);
+#endif
 
     /* add the tracker combobox */
     w = tracker;
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
+#if GTK_CHECK_VERSION(3,12,0)
+    gtk_widget_set_margin_end(w, GUI_PAD);
+#else
     gtk_widget_set_margin_right(w, GUI_PAD);
+#endif
 
     /* add the entry field */
     s = gtk_entry_new();

--- a/gtk/filter.c
+++ b/gtk/filter.c
@@ -959,20 +959,12 @@ GtkWidget* gtr_filter_bar_new(tr_session* session, GtkTreeModel* tmodel, GtkTree
     gtk_label_set_mnemonic_widget(GTK_LABEL(l), w);
     gtk_box_pack_start(h_box, l, FALSE, FALSE, 0);
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
-
-    /* add a spacer */
-    w = gtk_alignment_new(0.0F, 0.0F, 0.0F, 0.0F);
-    gtk_widget_set_size_request(w, 0U, GUI_PAD_BIG);
-    gtk_box_pack_start(h_box, w, FALSE, FALSE, 0);
+    gtk_widget_set_margin_right(w, GUI_PAD);
 
     /* add the tracker combobox */
     w = tracker;
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
-
-    /* add a spacer */
-    w = gtk_alignment_new(0.0F, 0.0F, 0.0F, 0.0F);
-    gtk_widget_set_size_request(w, 0U, GUI_PAD_BIG);
-    gtk_box_pack_start(h_box, w, FALSE, FALSE, 0);
+    gtk_widget_set_margin_right(w, GUI_PAD);
 
     /* add the entry field */
     s = gtk_entry_new();

--- a/gtk/filter.c
+++ b/gtk/filter.c
@@ -959,7 +959,7 @@ GtkWidget* gtr_filter_bar_new(tr_session* session, GtkTreeModel* tmodel, GtkTree
     gtk_label_set_mnemonic_widget(GTK_LABEL(l), w);
     gtk_box_pack_start(h_box, l, FALSE, FALSE, 0);
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
-#if GTK_CHECK_VERSION(3,12,0)
+#if GTK_CHECK_VERSION(3, 12, 0)
     gtk_widget_set_margin_end(w, GUI_PAD);
 #else
     gtk_widget_set_margin_right(w, GUI_PAD);
@@ -968,7 +968,7 @@ GtkWidget* gtr_filter_bar_new(tr_session* session, GtkTreeModel* tmodel, GtkTree
     /* add the tracker combobox */
     w = tracker;
     gtk_box_pack_start(h_box, w, TRUE, TRUE, 0);
-#if GTK_CHECK_VERSION(3,12,0)
+#if GTK_CHECK_VERSION(3, 12, 0)
     gtk_widget_set_margin_end(w, GUI_PAD);
 #else
     gtk_widget_set_margin_right(w, GUI_PAD);

--- a/gtk/hig.c
+++ b/gtk/hig.c
@@ -43,7 +43,7 @@ void hig_workarea_add_section_title(GtkWidget* t, guint* row, char const* sectio
 
     g_snprintf(buf, sizeof(buf), "<b>%s</b>", section_title);
     l = gtk_label_new(buf);
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_label_set_use_markup(GTK_LABEL(l), TRUE);
     hig_workarea_add_section_title_widget(t, row, l);
 }
@@ -78,7 +78,7 @@ void hig_workarea_add_label_w(GtkWidget* t, guint row, GtkWidget* w)
 
     if (GTK_IS_MISC(w))
     {
-        gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.5F);
+        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     }
 
     if (GTK_IS_LABEL(w))
@@ -93,7 +93,7 @@ static void hig_workarea_add_tall_control(GtkWidget* t, guint row, GtkWidget* co
 {
     if (GTK_IS_MISC(control))
     {
-        gtk_misc_set_alignment(GTK_MISC(control), 0.0F, 0.5F);
+        g_object_set(control, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     }
 
     g_object_set(control, "expand", TRUE, NULL);
@@ -104,7 +104,7 @@ static void hig_workarea_add_control(GtkWidget* t, guint row, GtkWidget* control
 {
     if (GTK_IS_MISC(control))
     {
-        gtk_misc_set_alignment(GTK_MISC(control), 0.0F, 0.5F);
+        g_object_set(control, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     }
 
     gtk_widget_set_hexpand(control, TRUE);

--- a/gtk/hig.c
+++ b/gtk/hig.c
@@ -51,7 +51,11 @@ void hig_workarea_add_section_title(GtkWidget* t, guint* row, char const* sectio
 void hig_workarea_add_wide_control(GtkWidget* t, guint* row, GtkWidget* w)
 {
     gtk_widget_set_hexpand(w, TRUE);
+#if GTK_CHECK_VERSION(3,12,0)
+    gtk_widget_set_margin_start(w, 18);
+#else
     gtk_widget_set_margin_left(w, 18);
+#endif
     gtk_grid_attach(GTK_GRID(t), w, 0, *row, 2, 1);
     ++*row;
 }
@@ -74,7 +78,11 @@ GtkWidget* hig_workarea_add_wide_checkbutton(GtkWidget* t, guint* row, char cons
 
 void hig_workarea_add_label_w(GtkWidget* t, guint row, GtkWidget* w)
 {
+#if GTK_CHECK_VERSION(3,12,0)
+    gtk_widget_set_margin_start(w, 18);
+#else
     gtk_widget_set_margin_left(w, 18);
+#endif
 
     if (GTK_IS_MISC(w))
     {

--- a/gtk/hig.c
+++ b/gtk/hig.c
@@ -22,7 +22,7 @@ GtkWidget* hig_workarea_create(void)
 
 void hig_workarea_add_section_divider(GtkWidget* t, guint* row)
 {
-    GtkWidget* w = gtk_alignment_new(0.0F, 0.0F, 0.0F, 0.0F);
+    GtkWidget* w = gtk_fixed_new();
 
     gtk_widget_set_size_request(w, 0U, 6U);
     gtk_grid_attach(GTK_GRID(t), w, 0, *row, 2, 1);

--- a/gtk/hig.c
+++ b/gtk/hig.c
@@ -51,7 +51,7 @@ void hig_workarea_add_section_title(GtkWidget* t, guint* row, char const* sectio
 void hig_workarea_add_wide_control(GtkWidget* t, guint* row, GtkWidget* w)
 {
     gtk_widget_set_hexpand(w, TRUE);
-#if GTK_CHECK_VERSION(3,12,0)
+#if GTK_CHECK_VERSION(3, 12, 0)
     gtk_widget_set_margin_start(w, 18);
 #else
     gtk_widget_set_margin_left(w, 18);
@@ -78,7 +78,7 @@ GtkWidget* hig_workarea_add_wide_checkbutton(GtkWidget* t, guint* row, char cons
 
 void hig_workarea_add_label_w(GtkWidget* t, guint row, GtkWidget* w)
 {
-#if GTK_CHECK_VERSION(3,12,0)
+#if GTK_CHECK_VERSION(3, 12, 0)
     gtk_widget_set_margin_start(w, 18);
 #else
     gtk_widget_set_margin_left(w, 18);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -972,7 +972,7 @@ static void on_app_exit(gpointer vdata)
     p = g_object_new(GTK_TYPE_GRID, "column-spacing", GUI_PAD_BIG, "halign", GTK_ALIGN_CENTER, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_container_add(GTK_CONTAINER(c), p);
 
-    w = gtk_image_new_from_stock(GTK_STOCK_NETWORK, GTK_ICON_SIZE_DIALOG);
+    w = gtk_image_new_from_icon_name(GTK_STOCK_NETWORK, GTK_ICON_SIZE_DIALOG);
     gtk_grid_attach(GTK_GRID(p), w, 0, 0, 1, 2);
 
     w = gtk_label_new(NULL);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -939,7 +939,6 @@ static void exit_now_cb(GtkWidget* w UNUSED, gpointer data UNUSED)
 static void on_app_exit(gpointer vdata)
 {
     GtkWidget* p;
-    GtkWidget* b;
     GtkWidget* w;
     GtkWidget* c;
     struct cbdata* cbdata = vdata;

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -968,7 +968,9 @@ static void on_app_exit(gpointer vdata)
     c = GTK_WIDGET(cbdata->wind);
     gtk_container_remove(GTK_CONTAINER(c), gtk_bin_get_child(GTK_BIN(c)));
 
-    p = g_object_new(GTK_TYPE_GRID, "column-spacing", GUI_PAD_BIG, "halign", GTK_ALIGN_CENTER, "valign", GTK_ALIGN_CENTER, NULL);
+    p =
+        g_object_new(GTK_TYPE_GRID, "column-spacing", GUI_PAD_BIG, "halign", GTK_ALIGN_CENTER, "valign", GTK_ALIGN_CENTER,
+        NULL);
     gtk_container_add(GTK_CONTAINER(c), p);
 
     w = gtk_image_new_from_icon_name(GTK_STOCK_NETWORK, GTK_ICON_SIZE_DIALOG);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -938,7 +938,6 @@ static void exit_now_cb(GtkWidget* w UNUSED, gpointer data UNUSED)
 
 static void on_app_exit(gpointer vdata)
 {
-    GtkWidget* r;
     GtkWidget* p;
     GtkWidget* b;
     GtkWidget* w;
@@ -970,12 +969,8 @@ static void on_app_exit(gpointer vdata)
     c = GTK_WIDGET(cbdata->wind);
     gtk_container_remove(GTK_CONTAINER(c), gtk_bin_get_child(GTK_BIN(c)));
 
-    r = gtk_alignment_new(0.5, 0.5, 0.01, 0.01);
-    gtk_container_add(GTK_CONTAINER(c), r);
-
-    p = gtk_grid_new();
-    gtk_grid_set_column_spacing(GTK_GRID(p), GUI_PAD_BIG);
-    gtk_container_add(GTK_CONTAINER(r), p);
+    p = g_object_new(GTK_TYPE_GRID, "column-spacing", GUI_PAD_BIG, "halign", GTK_ALIGN_CENTER, "valign", GTK_ALIGN_CENTER, NULL);
+    gtk_container_add(GTK_CONTAINER(c), p);
 
     w = gtk_image_new_from_stock(GTK_STOCK_NETWORK, GTK_ICON_SIZE_DIALOG);
     gtk_grid_attach(GTK_GRID(p), w, 0, 0, 1, 2);
@@ -989,13 +984,12 @@ static void on_app_exit(gpointer vdata)
     g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(GTK_GRID(p), w, 1, 1, 1, 1);
 
-    b = gtk_alignment_new(0.0, 1.0, 0.01, 0.01);
     w = gtk_button_new_with_mnemonic(_("_Quit Now"));
+    g_object_set(w, "margin-top", GUI_PAD, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_END, NULL);
     g_signal_connect(w, "clicked", G_CALLBACK(exit_now_cb), NULL);
-    gtk_container_add(GTK_CONTAINER(b), w);
-    gtk_grid_attach(GTK_GRID(p), b, 1, 2, 1, 1);
+    gtk_grid_attach(GTK_GRID(p), w, 1, 2, 1, 1);
 
-    gtk_widget_show_all(r);
+    gtk_widget_show_all(p);
     gtk_widget_grab_focus(w);
 
     /* clear the UI */

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -982,11 +982,11 @@ static void on_app_exit(gpointer vdata)
 
     w = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(w), _("<b>Closing Connections</b>"));
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0, 0.5);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(GTK_GRID(p), w, 1, 0, 1, 1);
 
     w = gtk_label_new(_("Sending upload/download totals to tracker…"));
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0, 0.5);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(GTK_GRID(p), w, 1, 1, 1, 1);
 
     b = gtk_alignment_new(0.0, 1.0, 0.01, 0.01);

--- a/gtk/makemeta-ui.c
+++ b/gtk/makemeta-ui.c
@@ -192,7 +192,7 @@ static void makeProgressDialog(GtkWidget* parent, MakeMetaUI* ui)
     gtk_container_add(GTK_CONTAINER(fr), v);
 
     l = gtk_label_new(_("Creating torrent…"));
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0, 0.5);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_label_set_justify(GTK_LABEL(l), GTK_JUSTIFY_LEFT);
     ui->progress_label = l;
     gtk_box_pack_start(GTK_BOX(v), l, FALSE, FALSE, 0);
@@ -493,7 +493,7 @@ GtkWidget* gtr_torrent_creation_dialog_new(GtkWindow* parent, TrCore* core)
     gtk_label_set_markup(GTK_LABEL(l), _("To add a backup URL, add it on the line after the primary URL.\n"
         "To add another primary URL, add it after a blank line."));
     gtk_label_set_justify(GTK_LABEL(l), GTK_JUSTIFY_LEFT);
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0, 0.5);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_box_pack_start(GTK_BOX(v), l, FALSE, FALSE, 0);
     hig_workarea_add_tall_row(t, &row, str, v, NULL);
 

--- a/gtk/msgwin.c
+++ b/gtk/msgwin.c
@@ -209,7 +209,6 @@ static void onSaveRequest(GtkWidget* w, gpointer data)
     GtkWidget* d = gtk_file_chooser_dialog_new(_("Save Log"), window, GTK_FILE_CHOOSER_ACTION_SAVE, GTK_STOCK_CANCEL,
         GTK_RESPONSE_CANCEL, GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT, NULL);
 
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(d), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
     g_signal_connect(d, "response", G_CALLBACK(onSaveDialogResponse), data);
     gtk_widget_show(d);
 }

--- a/gtk/msgwin.c
+++ b/gtk/msgwin.c
@@ -489,7 +489,7 @@ GtkWidget* gtr_message_log_window_new(GtkWindow* parent, TrCore* core)
     gtk_toolbar_insert(GTK_TOOLBAR(toolbar), item, -1);
 
     w = gtk_label_new(_("Level"));
-    gtk_misc_set_padding(GTK_MISC(w), GUI_PAD, 0);
+    g_object_set(w, "margin", GUI_PAD, NULL);
     item = gtk_tool_item_new();
     gtk_container_add(GTK_CONTAINER(item), w);
     gtk_toolbar_insert(GTK_TOOLBAR(toolbar), item, -1);

--- a/gtk/msgwin.c
+++ b/gtk/msgwin.c
@@ -527,7 +527,6 @@ GtkWidget* gtr_message_log_window_new(GtkWindow* parent, TrCore* core)
     g_object_unref(data->sort);
     g_signal_connect(view, "button-release-event", G_CALLBACK(on_tree_view_button_released), NULL);
     data->view = GTK_TREE_VIEW(view);
-    gtk_tree_view_set_rules_hint(data->view, TRUE);
     appendColumn(data->view, COL_SEQUENCE);
     appendColumn(data->view, COL_NAME);
     appendColumn(data->view, COL_MESSAGE);

--- a/gtk/open-dialog.c
+++ b/gtk/open-dialog.c
@@ -284,7 +284,6 @@ GtkWidget* gtr_torrent_options_dialog_new(GtkWindow* parent, TrCore* core, tr_ct
     d = gtk_dialog_new_with_buttons(_("Torrent Options"), parent, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
         GTK_RESPONSE_CANCEL, GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(d), GTK_RESPONSE_ACCEPT);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(d), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
 
     if (!tr_ctorGetDownloadDir(ctor, TR_FORCE, &str))
     {
@@ -455,7 +454,6 @@ GtkWidget* gtr_torrent_open_from_file_dialog_new(GtkWindow* parent, TrCore* core
 
     w = gtk_file_chooser_dialog_new(_("Open a Torrent"), parent, GTK_FILE_CHOOSER_ACTION_OPEN, GTK_STOCK_CANCEL,
         GTK_RESPONSE_CANCEL, GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(w), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
     gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(w), TRUE);
     addTorrentFilters(GTK_FILE_CHOOSER(w));
     g_signal_connect(w, "response", G_CALLBACK(onOpenDialogResponse), core);
@@ -519,7 +517,6 @@ GtkWidget* gtr_torrent_open_from_url_dialog_new(GtkWindow* parent, TrCore* core)
 
     w = gtk_dialog_new_with_buttons(_("Open URL"), parent, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL,
         GTK_RESPONSE_CANCEL, GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(w), GTK_RESPONSE_ACCEPT, GTK_RESPONSE_CANCEL, -1);
     g_signal_connect(w, "response", G_CALLBACK(onOpenURLResponse), core);
 
     row = 0;

--- a/gtk/open-dialog.c
+++ b/gtk/open-dialog.c
@@ -317,7 +317,7 @@ GtkWidget* gtr_torrent_options_dialog_new(GtkWindow* parent, TrCore* core, tr_ct
 
     /* "torrent file" row */
     l = gtk_label_new_with_mnemonic(_("_Torrent file:"));
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(grid, l, 0, row, 1, 1);
     w = gtk_file_chooser_button_new(_("Select Source File"), GTK_FILE_CHOOSER_ACTION_OPEN);
     source_chooser = w;
@@ -330,7 +330,7 @@ GtkWidget* gtr_torrent_options_dialog_new(GtkWindow* parent, TrCore* core, tr_ct
     /* "destination folder" row */
     row++;
     l = gtk_label_new_with_mnemonic(_("_Destination folder:"));
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(grid, l, 0, row, 1, 1);
     w = gtk_file_chooser_button_new(_("Select Destination Folder"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
 
@@ -354,7 +354,7 @@ GtkWidget* gtr_torrent_options_dialog_new(GtkWindow* parent, TrCore* core, tr_ct
     row++;
     l = data->freespace_label = gtr_freespace_label_new(core, data->downloadDir);
     gtk_widget_set_margin_bottom(l, GUI_PAD_BIG);
-    gtk_misc_set_alignment(GTK_MISC(l), 1.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_END, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(grid, l, 0, row, 2, 1);
 
     /* file list row */
@@ -367,7 +367,7 @@ GtkWidget* gtr_torrent_options_dialog_new(GtkWindow* parent, TrCore* core, tr_ct
     /* torrent priority row */
     row++;
     l = gtk_label_new_with_mnemonic(_("Torrent _priority:"));
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_grid_attach(grid, l, 0, row, 1, 1);
     w = data->priority_combo;
     gtk_label_set_mnemonic_widget(GTK_LABEL(l), w);

--- a/gtk/relocate.c
+++ b/gtk/relocate.c
@@ -139,7 +139,6 @@ GtkWidget* gtr_relocate_dialog_new(GtkWindow* parent, TrCore* core, GSList* torr
     d = gtk_dialog_new_with_buttons(_("Set Torrent Location"), parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
         GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, GTK_STOCK_APPLY, GTK_RESPONSE_APPLY, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(d), GTK_RESPONSE_CANCEL);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(d), GTK_RESPONSE_APPLY, GTK_RESPONSE_CANCEL, -1);
     g_signal_connect(d, "response", G_CALLBACK(onResponse), NULL);
 
     row = 0;

--- a/gtk/stats.c
+++ b/gtk/stats.c
@@ -123,7 +123,6 @@ GtkWidget* gtr_stats_dialog_new(GtkWindow* parent, TrCore* core)
     d = gtk_dialog_new_with_buttons(_("Statistics"), parent, GTK_DIALOG_DESTROY_WITH_PARENT, _("_Reset"), TR_RESPONSE_RESET,
         GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(d), GTK_RESPONSE_CLOSE);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(d), GTK_RESPONSE_CLOSE, TR_RESPONSE_RESET, -1);
     t = hig_workarea_create();
     ui->core = core;
 

--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -903,8 +903,8 @@ static void torrent_cell_renderer_init(TorrentCellRenderer* self)
 {
     struct TorrentCellRendererPrivate* p;
 
-#if GLIB_CHECK_VERSION(2,58,0)
-    p = self->priv= torrent_cell_renderer_get_instance_private(self);
+#if GLIB_CHECK_VERSION(2, 58, 0)
+    p = self->priv = torrent_cell_renderer_get_instance_private(self);
 #else
     p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, TORRENT_CELL_RENDERER_TYPE, struct TorrentCellRendererPrivate);
 #endif

--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -903,7 +903,11 @@ static void torrent_cell_renderer_init(TorrentCellRenderer* self)
 {
     struct TorrentCellRendererPrivate* p;
 
+#if GLIB_CHECK_VERSION(2,58,0)
+    p = self->priv= torrent_cell_renderer_get_instance_private(self);
+#else
     p = self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, TORRENT_CELL_RENDERER_TYPE, struct TorrentCellRendererPrivate);
+#endif
 
     p->tor = NULL;
     p->gstr1 = g_string_new(NULL);

--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -309,7 +309,7 @@ static void getStatusString(GString* gstr, tr_torrent const* tor, tr_stat const*
 ****
 ***/
 
-struct TorrentCellRendererPrivate
+typedef struct TorrentCellRendererPrivate
 {
     tr_torrent* tor;
     GtkCellRenderer* text_renderer;
@@ -329,7 +329,8 @@ struct TorrentCellRendererPrivate
     double download_speed_KBps;
 
     gboolean compact;
-};
+}
+TorrentCellRendererPrivate;
 
 /***
 ****
@@ -852,7 +853,7 @@ static void torrent_cell_renderer_get_property(GObject* object, guint property_i
     }
 }
 
-G_DEFINE_TYPE(TorrentCellRenderer, torrent_cell_renderer, GTK_TYPE_CELL_RENDERER)
+G_DEFINE_TYPE_WITH_CODE(TorrentCellRenderer, torrent_cell_renderer, GTK_TYPE_CELL_RENDERER, G_ADD_PRIVATE(TorrentCellRenderer))
 
 static void torrent_cell_renderer_dispose(GObject* o)
 {
@@ -875,8 +876,6 @@ static void torrent_cell_renderer_class_init(TorrentCellRendererClass* klass)
 {
     GObjectClass* gobject_class = G_OBJECT_CLASS(klass);
     GtkCellRendererClass* cell_class = GTK_CELL_RENDERER_CLASS(klass);
-
-    g_type_class_add_private(klass, sizeof(struct TorrentCellRendererPrivate));
 
     cell_class->render = torrent_cell_renderer_render;
     cell_class->get_size = torrent_cell_renderer_get_size;

--- a/gtk/tr-core.c
+++ b/gtk/tr-core.c
@@ -61,7 +61,7 @@ static guint signals[LAST_SIGNAL] = { 0 };
 
 static void core_maybe_inhibit_hibernation(TrCore* core);
 
-struct TrCorePrivate
+typedef struct TrCorePrivate
 {
     GFileMonitor* monitor;
     gulong monitor_tag;
@@ -79,14 +79,15 @@ struct TrCorePrivate
     GtkTreeModel* sorted_model;
     tr_session* session;
     GStringChunk* string_chunk;
-};
+}
+TrCorePrivate;
 
 static int core_is_disposed(TrCore const* core)
 {
     return core == NULL || core->priv->sorted_model == NULL;
 }
 
-G_DEFINE_TYPE(TrCore, tr_core, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_CODE(TrCore, tr_core, G_TYPE_OBJECT, G_ADD_PRIVATE(TrCore));
 
 static void core_dispose(GObject* o)
 {
@@ -115,8 +116,6 @@ static void tr_core_class_init(TrCoreClass* core_class)
 {
     GObjectClass* gobject_class;
     GType core_type = G_TYPE_FROM_CLASS(core_class);
-
-    g_type_class_add_private(core_class, sizeof(struct TrCorePrivate));
 
     gobject_class = G_OBJECT_CLASS(core_class);
     gobject_class->dispose = core_dispose;

--- a/gtk/tr-core.c
+++ b/gtk/tr-core.c
@@ -167,7 +167,11 @@ static void tr_core_init(TrCore* core)
         G_TYPE_INT /* MC_ACTIVE_PEER_COUNT */
     };
 
+#if GLIB_CHECK_VERSION(2,58,0)
+    p = core->priv= tr_core_get_instance_private(core);    
+#else
     p = core->priv = G_TYPE_INSTANCE_GET_PRIVATE(core, TR_CORE_TYPE, struct TrCorePrivate);
+#endif
 
     /* create the model used to store torrent data */
     g_assert(G_N_ELEMENTS(types) == MC_ROW_COUNT);

--- a/gtk/tr-core.c
+++ b/gtk/tr-core.c
@@ -167,8 +167,8 @@ static void tr_core_init(TrCore* core)
         G_TYPE_INT /* MC_ACTIVE_PEER_COUNT */
     };
 
-#if GLIB_CHECK_VERSION(2,58,0)
-    p = core->priv= tr_core_get_instance_private(core);    
+#if GLIB_CHECK_VERSION(2, 58, 0)
+    p = core->priv = tr_core_get_instance_private(core);
 #else
     p = core->priv = G_TYPE_INSTANCE_GET_PRIVATE(core, TR_CORE_TYPE, struct TrCorePrivate);
 #endif

--- a/gtk/tr-icon.c
+++ b/gtk/tr-icon.c
@@ -38,7 +38,7 @@ static void popup(GtkStatusIcon* self, guint button, guint when, gpointer data U
 {
     GtkWidget* w = gtr_action_get_widget("/icon-popup");
 
-#if GTK_CHECK_VERSION(3,22,0)
+#if GTK_CHECK_VERSION(3, 22, 0)
     gtk_menu_popup_at_widget(GTK_MENU(w), GTK_WIDGET(self), GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH, NULL);
 #else
     gtk_menu_popup(GTK_MENU(w), NULL, NULL, gtk_status_icon_position_menu, self, button, when);

--- a/gtk/tr-icon.c
+++ b/gtk/tr-icon.c
@@ -38,7 +38,11 @@ static void popup(GtkStatusIcon* self, guint button, guint when, gpointer data U
 {
     GtkWidget* w = gtr_action_get_widget("/icon-popup");
 
+#if GTK_CHECK_VERSION(3,22,0)
+    gtk_menu_popup_at_widget(GTK_MENU(w), GTK_WIDGET(self), GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH, NULL);
+#else
     gtk_menu_popup(GTK_MENU(w), NULL, NULL, gtk_status_icon_position_menu, self, button, when);
+#endif
 }
 
 void gtr_icon_refresh(gpointer vicon)

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -834,7 +834,8 @@ static GtkWidget* remotePage(GObject* core)
 
         s = _("Addresses:");
         w = hig_workarea_add_row(t, &row, s, w, NULL);
-        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, "margin-top", GUI_PAD, "margin-bottom", GUI_PAD, NULL);
+        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, "margin-top", GUI_PAD, "margin-bottom", GUI_PAD,
+            NULL);
         page->whitelist_widgets = g_slist_prepend(page->whitelist_widgets, w);
 
         h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, GUI_PAD);

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -995,7 +995,7 @@ static GtkWidget* speedPage(GObject* core)
     g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_label_set_use_markup(GTK_LABEL(w), TRUE);
     gtk_box_pack_start(GTK_BOX(h), w, FALSE, FALSE, 0);
-    w = gtk_image_new_from_stock("alt-speed-on", -1);
+    w = gtk_image_new_from_icon_name("alt-speed-on", GTK_ICON_SIZE_MENU);
     gtk_box_pack_start(GTK_BOX(h), w, FALSE, FALSE, 0);
     hig_workarea_add_section_title_widget(t, &row, h);
 

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -834,8 +834,7 @@ static GtkWidget* remotePage(GObject* core)
 
         s = _("Addresses:");
         w = hig_workarea_add_row(t, &row, s, w, NULL);
-        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, NULL);
-        gtk_misc_set_padding(GTK_MISC(w), 0, GUI_PAD);
+        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, "margin-top", GUI_PAD, "margin-bottom", GUI_PAD, NULL);
         page->whitelist_widgets = g_slist_prepend(page->whitelist_widgets, w);
 
         h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, GUI_PAD);

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -847,11 +847,9 @@ static GtkWidget* remotePage(GObject* core)
         w = gtk_button_new_from_stock(GTK_STOCK_ADD);
         page->whitelist_widgets = g_slist_prepend(page->whitelist_widgets, w);
         g_signal_connect(w, "clicked", G_CALLBACK(onAddWhitelistClicked), page);
+        g_object_set(h, "halign", GTK_ALIGN_END, "valign", GTK_ALIGN_CENTER, NULL);
         gtk_box_pack_start(GTK_BOX(h), w, TRUE, TRUE, 0);
-        w = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-        gtk_box_pack_start(GTK_BOX(w), gtk_alignment_new(0, 0, 0, 0), TRUE, TRUE, 0);
-        gtk_box_pack_start(GTK_BOX(w), h, FALSE, FALSE, 0);
-        hig_workarea_add_wide_control(t, &row, w);
+        hig_workarea_add_wide_control(t, &row, h);
     }
 
     refreshRPCSensitivity(page);

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -280,7 +280,7 @@ static GtkWidget* downloadingPage(GObject* core, struct prefs_dialog_data* data)
     hig_workarea_add_row(t, &row, _("Save to _Location:"), w, NULL);
 
     l = data->freespace_label = gtr_freespace_label_new(TR_CORE(core), NULL);
-    gtk_misc_set_alignment(GTK_MISC(l), 1.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_END, "valign", GTK_ALIGN_CENTER, NULL);
     hig_workarea_add_wide_control(t, &row, l);
 
     hig_workarea_add_section_divider(t, &row);
@@ -526,7 +526,7 @@ static GtkWidget* privacyPage(GObject* core)
     target_cb(b, e);
 
     w = gtk_label_new("");
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.5F);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     updateBlocklistText(w, TR_CORE(core));
     data->label = w;
     h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, GUI_PAD_BIG);
@@ -834,7 +834,7 @@ static GtkWidget* remotePage(GObject* core)
 
         s = _("Addresses:");
         w = hig_workarea_add_row(t, &row, s, w, NULL);
-        gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.0F);
+        g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_START, NULL);
         gtk_misc_set_padding(GTK_MISC(w), 0, GUI_PAD);
         page->whitelist_widgets = g_slist_prepend(page->whitelist_widgets, w);
 
@@ -994,7 +994,7 @@ static GtkWidget* speedPage(GObject* core)
     h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, GUI_PAD);
     g_snprintf(buf, sizeof(buf), "<b>%s</b>", _("Alternative Speed Limits"));
     w = gtk_label_new(buf);
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.5F);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_label_set_use_markup(GTK_LABEL(w), TRUE);
     gtk_box_pack_start(GTK_BOX(h), w, FALSE, FALSE, 0);
     w = gtk_image_new_from_stock("alt-speed-on", -1);
@@ -1005,7 +1005,7 @@ static GtkWidget* speedPage(GObject* core)
     g_snprintf(buf, sizeof(buf), "<small>%s</small>", s);
     w = gtk_label_new(buf);
     gtk_label_set_use_markup(GTK_LABEL(w), TRUE);
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0F, 0.5F);
+    g_object_set(w, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     hig_workarea_add_wide_control(t, &row, w);
 
     g_snprintf(buf, sizeof(buf), _("U_pload (%s):"), _(speed_K_str));
@@ -1137,7 +1137,7 @@ static GtkWidget* networkPage(GObject* core)
 
     h = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, GUI_PAD_BIG);
     l = data->portLabel = gtk_label_new(_("Status unknown"));
-    gtk_misc_set_alignment(GTK_MISC(l), 0.0F, 0.5F);
+    g_object_set(l, "halign", GTK_ALIGN_START, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_box_pack_start(GTK_BOX(h), l, TRUE, TRUE, 0);
     w = data->portButton = gtk_button_new_with_mnemonic(_("Te_st Port"));
     gtk_box_pack_end(GTK_BOX(h), w, FALSE, FALSE, 0);

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -79,7 +79,7 @@ static void on_popup_menu(GtkWidget* self UNUSED, GdkEventButton* event)
 {
     GtkWidget* menu = gtr_action_get_widget("/main-window-popup");
 
-#if GTK_CHECK_VERSION(3,22,0)
+#if GTK_CHECK_VERSION(3, 22, 0)
     gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
 #else
     gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event != NULL ? event->button : 0, event != NULL ? event->time : 0);
@@ -208,7 +208,7 @@ static void onYinYangClicked(GtkWidget* w UNUSED, gpointer vprivate)
 {
     PrivateData* p = vprivate;
 
-#if GTK_CHECK_VERSION(3,22,0)
+#if GTK_CHECK_VERSION(3, 22, 0)
     gtk_menu_popup_at_widget(GTK_MENU(p->status_menu), GTK_WIDGET(w), GDK_GRAVITY_NORTH_EAST, GDK_GRAVITY_SOUTH_EAST, NULL);
 #else
     gtk_menu_popup(GTK_MENU(p->status_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
@@ -536,8 +536,9 @@ static void onOptionsClicked(GtkButton* button, gpointer vp)
     b = gtr_pref_flag_get(TR_KEY_ratio_limit_enabled);
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b ? p->ratio_on_item : p->ratio_off_item), TRUE);
 
-#if GTK_CHECK_VERSION(3,22,0)
-    gtk_menu_popup_at_widget(GTK_MENU(p->options_menu), GTK_WIDGET(button), GDK_GRAVITY_NORTH_WEST, GDK_GRAVITY_SOUTH_WEST, NULL);
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_widget(GTK_MENU(p->options_menu), GTK_WIDGET(button), GDK_GRAVITY_NORTH_WEST, GDK_GRAVITY_SOUTH_WEST,
+        NULL);
 #else
     gtk_menu_popup(GTK_MENU(p->options_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
 #endif
@@ -688,7 +689,6 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     g_signal_connect(w, "clicked", G_CALLBACK(onYinYangClicked), p);
     gtk_container_add(GTK_CONTAINER(grid), w);
-
 
     /**
     *** Workarea

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -551,11 +551,11 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     GtkWidget* w;
     GtkWidget* self;
     GtkWidget* menu;
-    GtkWidget* h;
-    GtkBox* h_box;
+    GtkWidget* grid_w;
     GtkWindow* win;
     GtkCssProvider* css_provider;
     GSList* l;
+    GtkGrid* grid;
 
     p = g_new0(PrivateData, 1);
 
@@ -622,9 +622,10 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     *** Statusbar
     **/
 
-    h = status = p->status = gtk_hbox_new(FALSE, GUI_PAD);
-    h_box = GTK_BOX(h);
-    gtk_container_set_border_width(GTK_CONTAINER(h), GUI_PAD_SMALL);
+    grid_w = status = p->status = gtk_grid_new();
+    gtk_orientable_set_orientation(GTK_ORIENTABLE(grid_w), GTK_ORIENTATION_HORIZONTAL);
+    grid = GTK_GRID(grid_w);
+    gtk_container_set_border_width(GTK_CONTAINER(grid), GUI_PAD_SMALL);
 
     /* gear */
     w = gtk_button_new();
@@ -633,7 +634,7 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     p->options_menu = createOptionsMenu(p);
     g_signal_connect(w, "clicked", G_CALLBACK(onOptionsClicked), p);
-    gtk_box_pack_start(h_box, w, false, false, 0);
+    gtk_container_add(GTK_CONTAINER(grid), w);
 
     /* turtle */
     p->alt_speed_image = gtk_image_new();
@@ -641,7 +642,32 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_button_set_image(GTK_BUTTON(w), p->alt_speed_image);
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     g_signal_connect(w, "toggled", G_CALLBACK(alt_speed_toggled_cb), p);
-    gtk_box_pack_start(h_box, w, false, false, 0);
+    gtk_container_add(GTK_CONTAINER(grid), w);
+
+    /* spacer */
+    w = gtk_fixed_new();
+    gtk_widget_set_hexpand(w, TRUE);
+    gtk_container_add(GTK_CONTAINER(grid), w);
+
+    /* download */
+    w = dl_lb = gtk_label_new(NULL);
+    p->dl_lb = GTK_LABEL(w);
+    gtk_label_set_single_line_mode(p->dl_lb, TRUE);
+    gtk_container_add(GTK_CONTAINER(grid), w);
+
+    /* upload */
+    w = ul_lb = gtk_label_new(NULL);
+    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD, NULL);
+    p->ul_lb = GTK_LABEL(w);
+    gtk_label_set_single_line_mode(p->ul_lb, TRUE);
+    gtk_container_add(GTK_CONTAINER(grid), w);
+
+    /* ratio */
+    w = gtk_label_new(NULL);
+    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD_BIG, NULL);
+    p->stats_lb = GTK_LABEL(w);
+    gtk_label_set_single_line_mode(p->stats_lb, TRUE);
+    gtk_container_add(GTK_CONTAINER(grid), w);
 
     /* ratio selector */
     w = gtk_button_new();
@@ -649,27 +675,8 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_icon_name("ratio", GTK_ICON_SIZE_MENU));
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     g_signal_connect(w, "clicked", G_CALLBACK(onYinYangReleased), p);
-    gtk_box_pack_end(h_box, w, false, false, 0);
+    gtk_container_add(GTK_CONTAINER(grid), w);
 
-    /* ratio */
-    w = gtk_label_new(NULL);
-    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD_BIG, NULL);
-    p->stats_lb = GTK_LABEL(w);
-    gtk_label_set_single_line_mode(p->stats_lb, TRUE);
-    gtk_box_pack_end(h_box, w, false, false, 0);
-
-    /* upload */
-    w = ul_lb = gtk_label_new(NULL);
-    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD, NULL);
-    p->ul_lb = GTK_LABEL(w);
-    gtk_label_set_single_line_mode(p->ul_lb, TRUE);
-    gtk_box_pack_end(h_box, w, false, false, 0);
-
-    /* download */
-    w = dl_lb = gtk_label_new(NULL);
-    p->dl_lb = GTK_LABEL(w);
-    gtk_label_set_single_line_mode(p->dl_lb, TRUE);
-    gtk_box_pack_end(h_box, w, false, false, 0);
 
     /**
     *** Workarea

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -628,7 +628,7 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
 
     /* gear */
     w = gtk_button_new();
-    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_stock("utilities", -1));
+    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_icon_name("utilities", GTK_ICON_SIZE_MENU));
     gtk_widget_set_tooltip_text(w, _("Options"));
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     p->options_menu = createOptionsMenu(p);
@@ -646,7 +646,7 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     /* ratio selector */
     w = gtk_button_new();
     gtk_widget_set_tooltip_text(w, _("Statistics"));
-    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_stock("ratio", -1));
+    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_icon_name("ratio", GTK_ICON_SIZE_MENU));
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     g_signal_connect(w, "clicked", G_CALLBACK(onYinYangReleased), p);
     gtk_box_pack_end(h_box, w, false, false, 0);

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -250,7 +250,7 @@ static void syncAltSpeedButton(PrivateData* p)
 
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), b);
     gtk_image_set_from_stock(GTK_IMAGE(p->alt_speed_image), stock, -1);
-    gtk_button_set_alignment(GTK_BUTTON(w), 0.5, 0.5);
+    g_object_set(w, "halign", GTK_ALIGN_CENTER, "valign", GTK_ALIGN_CENTER, NULL);
     gtk_widget_set_tooltip_text(w, str);
 
     g_free(str);

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -541,7 +541,6 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     char const* pch;
     char const* style;
     PrivateData* p;
-    GtkWidget* sibling = NULL;
     GtkWidget* ul_lb;
     GtkWidget* dl_lb;
     GtkWidget* mainmenu;
@@ -553,11 +552,11 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     GtkWidget* w;
     GtkWidget* self;
     GtkWidget* menu;
-    GtkWidget* grid_w;
+    GtkWidget* h;
+    GtkBox* h_box;
     GtkWindow* win;
     GtkCssProvider* css_provider;
     GSList* l;
-    GtkGrid* grid;
 
     p = g_new0(PrivateData, 1);
 
@@ -624,19 +623,18 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     *** Statusbar
     **/
 
-    grid_w = status = p->status = gtk_grid_new();
-    grid = GTK_GRID(grid_w);
-    gtk_container_set_border_width(GTK_CONTAINER(grid), GUI_PAD_SMALL);
+    h = status = p->status = gtk_hbox_new(FALSE, GUI_PAD);
+    h_box = GTK_BOX(h);
+    gtk_container_set_border_width(GTK_CONTAINER(h), GUI_PAD_SMALL);
 
     /* gear */
     w = gtk_button_new();
     gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_stock("utilities", -1));
     gtk_widget_set_tooltip_text(w, _("Options"));
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     p->options_menu = createOptionsMenu(p);
     g_signal_connect(w, "clicked", G_CALLBACK(onOptionsClicked), p);
-    sibling = w;
+    gtk_box_pack_start(h_box, w, false, false, 0);
 
     /* turtle */
     p->alt_speed_image = gtk_image_new();
@@ -644,46 +642,40 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_button_set_image(GTK_BUTTON(w), p->alt_speed_image);
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
     g_signal_connect(w, "toggled", G_CALLBACK(alt_speed_toggled_cb), p);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
+    gtk_box_pack_start(h_box, w, false, false, 0);
 
-    /* spacer */
-    w = gtk_alignment_new(0.0F, 0.0F, 0.0F, 0.0F);
-    gtk_widget_set_hexpand(w, TRUE);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
-
-    /* download */
-    w = dl_lb = gtk_label_new(NULL);
-    p->dl_lb = GTK_LABEL(w);
-    gtk_label_set_single_line_mode(p->dl_lb, TRUE);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
-
-    /* upload */
-    w = ul_lb = gtk_label_new(NULL);
-    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD, NULL);
-    p->ul_lb = GTK_LABEL(w);
-    gtk_label_set_single_line_mode(p->ul_lb, TRUE);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
+    /* ratio selector */
+    w = gtk_button_new();
+    gtk_widget_set_tooltip_text(w, _("Statistics"));
+    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_stock("ratio", -1));
+    gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
+    g_signal_connect(w, "clicked", G_CALLBACK(onYinYangReleased), p);
+    gtk_box_pack_end(h_box, w, false, false, 0);
 
     /* ratio */
     w = gtk_label_new(NULL);
     g_object_set(G_OBJECT(w), "margin-left", GUI_PAD_BIG, NULL);
     p->stats_lb = GTK_LABEL(w);
     gtk_label_set_single_line_mode(p->stats_lb, TRUE);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
-    w = gtk_button_new();
-    gtk_widget_set_tooltip_text(w, _("Statistics"));
-    gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_stock("ratio", -1));
-    gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
-    g_signal_connect(w, "clicked", G_CALLBACK(onYinYangReleased), p);
-    gtk_grid_attach_next_to(grid, w, sibling, GTK_POS_RIGHT, 1, 1);
-    sibling = w;
+    gtk_box_pack_end(h_box, w, false, false, 0);
 
-    /* workarea */
+    /* upload */
+    w = ul_lb = gtk_label_new(NULL);
+    g_object_set(G_OBJECT(w), "margin-left", GUI_PAD, NULL);
+    p->ul_lb = GTK_LABEL(w);
+    gtk_label_set_single_line_mode(p->ul_lb, TRUE);
+    gtk_box_pack_end(h_box, w, false, false, 0);
+
+    /* download */
+    w = dl_lb = gtk_label_new(NULL);
+    p->dl_lb = GTK_LABEL(w);
+    gtk_label_set_single_line_mode(p->dl_lb, TRUE);
+    gtk_box_pack_end(h_box, w, false, false, 0);
+
+    /**
+    *** Workarea
+    **/
+
     p->view = makeview(p);
     w = list = p->scroll = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(w), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -707,8 +707,8 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
         pango_layout_get_pixel_size(pango_layout, &w, &h);
         gtk_widget_set_size_request(ul_lb, w, h);
         gtk_widget_set_size_request(dl_lb, w, h);
-        gtk_misc_set_alignment(GTK_MISC(ul_lb), 1.0, 0.5);
-        gtk_misc_set_alignment(GTK_MISC(dl_lb), 1.0, 0.5);
+        g_object_set(ul_lb, "halign", GTK_ALIGN_END, "valign", GTK_ALIGN_CENTER, NULL);
+        g_object_set(dl_lb, "halign", GTK_ALIGN_END, "valign", GTK_ALIGN_CENTER, NULL);
         g_object_unref(G_OBJECT(pango_layout));
     }
 

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -132,7 +132,6 @@ static GtkWidget* makeview(PrivateData* p)
     gtk_tree_view_append_column(tree_view, col);
     g_object_set(r, "xpad", GUI_PAD_SMALL, "ypad", GUI_PAD_SMALL, NULL);
 
-    gtk_tree_view_set_rules_hint(tree_view, TRUE);
     sel = gtk_tree_view_get_selection(tree_view);
     gtk_tree_selection_set_mode(GTK_TREE_SELECTION(sel), GTK_SELECTION_MULTIPLE);
 

--- a/gtk/tr-window.c
+++ b/gtk/tr-window.c
@@ -79,7 +79,11 @@ static void on_popup_menu(GtkWidget* self UNUSED, GdkEventButton* event)
 {
     GtkWidget* menu = gtr_action_get_widget("/main-window-popup");
 
+#if GTK_CHECK_VERSION(3,22,0)
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
+#else
     gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event != NULL ? event->button : 0, event != NULL ? event->time : 0);
+#endif
 }
 
 static void view_row_activated(GtkTreeView* tree_view UNUSED, GtkTreePath* path UNUSED, GtkTreeViewColumn* column UNUSED,
@@ -200,11 +204,15 @@ static void privateFree(gpointer vprivate)
     g_free(p);
 }
 
-static void onYinYangReleased(GtkWidget* w UNUSED, gpointer vprivate)
+static void onYinYangClicked(GtkWidget* w UNUSED, gpointer vprivate)
 {
     PrivateData* p = vprivate;
 
+#if GTK_CHECK_VERSION(3,22,0)
+    gtk_menu_popup_at_widget(GTK_MENU(p->status_menu), GTK_WIDGET(w), GDK_GRAVITY_NORTH_EAST, GDK_GRAVITY_SOUTH_EAST, NULL);
+#else
     gtk_menu_popup(GTK_MENU(p->status_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 #define STATS_MODE "stats-mode"
@@ -497,7 +505,7 @@ static GtkWidget* createOptionsMenu(PrivateData* p)
     return top;
 }
 
-static void onOptionsClicked(GtkButton* button UNUSED, gpointer vp)
+static void onOptionsClicked(GtkButton* button, gpointer vp)
 {
     char buf1[512];
     char buf2[512];
@@ -528,7 +536,11 @@ static void onOptionsClicked(GtkButton* button UNUSED, gpointer vp)
     b = gtr_pref_flag_get(TR_KEY_ratio_limit_enabled);
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(b ? p->ratio_on_item : p->ratio_off_item), TRUE);
 
+#if GTK_CHECK_VERSION(3,22,0)
+    gtk_menu_popup_at_widget(GTK_MENU(p->options_menu), GTK_WIDGET(button), GDK_GRAVITY_NORTH_WEST, GDK_GRAVITY_SOUTH_WEST, NULL);
+#else
     gtk_menu_popup(GTK_MENU(p->options_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 /***
@@ -674,7 +686,7 @@ GtkWidget* gtr_window_new(GtkApplication* app, GtkUIManager* ui_mgr, TrCore* cor
     gtk_widget_set_tooltip_text(w, _("Statistics"));
     gtk_container_add(GTK_CONTAINER(w), gtk_image_new_from_icon_name("ratio", GTK_ICON_SIZE_MENU));
     gtk_button_set_relief(GTK_BUTTON(w), GTK_RELIEF_NONE);
-    g_signal_connect(w, "clicked", G_CALLBACK(onYinYangReleased), p);
+    g_signal_connect(w, "clicked", G_CALLBACK(onYinYangClicked), p);
     gtk_container_add(GTK_CONTAINER(grid), w);
 
 

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -398,7 +398,11 @@ void gtr_open_uri(char const* uri)
 
         if (!opened)
         {
+#if GTK_CHECK_VERSION(3,22,0)
+            opened = gtk_show_uri_on_window(NULL, uri, GDK_CURRENT_TIME, NULL);
+#else
             opened = gtk_show_uri(NULL, uri, GDK_CURRENT_TIME, NULL);
+#endif
         }
 
         if (!opened)

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -398,7 +398,7 @@ void gtr_open_uri(char const* uri)
 
         if (!opened)
         {
-#if GTK_CHECK_VERSION(3,22,0)
+#if GTK_CHECK_VERSION(3, 22, 0)
             opened = gtk_show_uri_on_window(NULL, uri, GDK_CURRENT_TIME, NULL);
 #else
             opened = gtk_show_uri(NULL, uri, GDK_CURRENT_TIME, NULL);


### PR DESCRIPTION
Fixes some of the smaller warnings, e.g. don't use `gtk_alignment_new()` or `gtk_menu_popup()`.

This is the low-hanging fruit -- it doesn't do anything to switch to GActions, or replace the use of GtkIconFactory and GtkUIManager.