### PR TITLE
Apply the configured peer socket TOS to UDP sockets, not just TCP.

### DIFF
--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -2279,6 +2279,8 @@ static void toggle_utp(void* data)
 
     tr_udpSetSocketBuffers(session);
 
+    tr_udpSetSocketTOS(session);
+
     /* But don't call tr_utpClose -- see reset_timer in tr-utp.c for an
        explanation. */
 }

--- a/libtransmission/tr-udp.c
+++ b/libtransmission/tr-udp.c
@@ -125,6 +125,24 @@ void tr_udpSetSocketBuffers(tr_session* session)
     }
 }
 
+void tr_udpSetSocketTOS(tr_session* session)
+{
+    if (session->peerSocketTOS == 0)
+    {
+        return;
+    }
+
+    if (session->udp_socket != TR_BAD_SOCKET)
+    {
+        tr_netSetTOS(session->udp_socket, session->peerSocketTOS, TR_AF_INET);
+    }
+
+    if (session->udp6_socket != TR_BAD_SOCKET)
+    {
+        tr_netSetTOS(session->udp6_socket, session->peerSocketTOS, TR_AF_INET6);
+    }
+}
+
 /* BEP-32 has a rather nice explanation of why we need to bind to one
    IPv6 address, if I may say so myself. */
 
@@ -362,6 +380,8 @@ ipv6:
     }
 
     tr_udpSetSocketBuffers(ss);
+
+    tr_udpSetSocketTOS(ss);
 
     if (ss->isDHTEnabled)
     {

--- a/libtransmission/tr-udp.h
+++ b/libtransmission/tr-udp.h
@@ -30,5 +30,6 @@ THE SOFTWARE.
 void tr_udpInit(tr_session*);
 void tr_udpUninit(tr_session*);
 void tr_udpSetSocketBuffers(tr_session*);
+void tr_udpSetSocketTOS(tr_session*);
 
 bool tau_handle_message(tr_session* session, uint8_t const* msg, size_t msglen);


### PR DESCRIPTION
OK, rebased against master (I never actually chose develop, must've been the default somehow?)

I think it's a pretty straightforward change and makes sense to do .. I policy route based on TOS, but without this have to disable uTP and DHT for it work.