### PR TITLE
refractor: simplify torrent model signal emissions

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -309,7 +309,6 @@ Application::Application(int& argc, char** argv) :
         refreshPref(key);
     }
 
-
     QTimer* timer = &myModelTimer;
     connect(timer, &QTimer::timeout, this, &Application::refreshTorrents);
     timer->setSingleShot(false);
@@ -407,6 +406,7 @@ QStringList Application::getNames(QSet<int> const& ids) const
     {
         names.push_back(myModel->getTorrentFromId(id)->name());
     }
+
     names.sort();
     return names;
 }

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -293,47 +293,37 @@ Application::Application(int& argc, char** argv) :
     myWindow = new MainWindow(*mySession, *myPrefs, *myModel, minimized);
     myWatchDir = new WatchDir(*myModel);
 
-    // when the session gets torrent info, update the model
-    connect(mySession, SIGNAL(torrentsUpdated(tr_variant*, bool)), myModel, SLOT(updateTorrents(tr_variant*, bool)));
-    connect(mySession, SIGNAL(torrentsUpdated(tr_variant*, bool)), myWindow, SLOT(refreshActionSensitivity()));
-    connect(mySession, SIGNAL(torrentsRemoved(tr_variant*)), myModel, SLOT(removeTorrents(tr_variant*)));
-    // when the session source gets changed, request a full refresh
-    connect(mySession, SIGNAL(sourceChanged()), this, SLOT(onSessionSourceChanged()));
-    // when the model sees a torrent for the first time, ask the session for full info on it
-    connect(myModel, SIGNAL(torrentsAdded(QSet<int>)), mySession, SLOT(initTorrents(QSet<int>)));
-    connect(myModel, SIGNAL(torrentsAdded(QSet<int>)), this, SLOT(onTorrentsAdded(QSet<int>)));
-
-    mySession->initTorrents();
-    mySession->refreshSessionStats();
-
-    // when torrents are added to the watch directory, tell the session
-    connect(myWatchDir, SIGNAL(torrentFileAdded(QString)), this, SLOT(addTorrent(QString)));
+    connect(myModel, &TorrentModel::torrentsAdded, this, &Application::onTorrentsAdded);
+    connect(myModel, &TorrentModel::torrentsChanged, myWindow, &MainWindow::refreshActionSensitivity);
+    connect(myModel, &TorrentModel::torrentsCompleted, this, &Application::onTorrentsCompleted);
+    connect(myModel, &TorrentModel::torrentsNeedInfo, this, &Application::onTorrentsNeedInfo);
+    connect(myPrefs, &Prefs::changed, this, &Application::refreshPref);
+    connect(mySession, &Session::sourceChanged, this, &Application::onSessionSourceChanged);
+    connect(mySession, &Session::torrentsRemoved, myModel, &TorrentModel::removeTorrents);
+    connect(mySession, &Session::torrentsUpdated, myModel, &TorrentModel::updateTorrents);
+    connect(myWatchDir, &WatchDir::torrentFileAdded, this, &Application::addTorrent);
 
     // init from preferences
-    QList<int> initKeys;
-    initKeys << Prefs::DIR_WATCH;
-
-    for (int const key : initKeys)
+    for (auto const key : { Prefs::DIR_WATCH })
     {
         refreshPref(key);
     }
 
-    connect(myPrefs, SIGNAL(changed(int)), this, SLOT(refreshPref(int const)));
 
     QTimer* timer = &myModelTimer;
-    connect(timer, SIGNAL(timeout()), this, SLOT(refreshTorrents()));
+    connect(timer, &QTimer::timeout, this, &Application::refreshTorrents);
     timer->setSingleShot(false);
     timer->setInterval(MODEL_REFRESH_INTERVAL_MSEC);
     timer->start();
 
     timer = &myStatsTimer;
-    connect(timer, SIGNAL(timeout()), mySession, SLOT(refreshSessionStats()));
+    connect(timer, &QTimer::timeout, mySession, &Session::refreshSessionStats);
     timer->setSingleShot(false);
     timer->setInterval(STATS_REFRESH_INTERVAL_MSEC);
     timer->start();
 
     timer = &mySessionTimer;
-    connect(timer, SIGNAL(timeout()), mySession, SLOT(refreshSessionInfo()));
+    connect(timer, &QTimer::timeout, mySession, &Session::refreshSessionInfo);
     timer->setSingleShot(false);
     timer->setInterval(SESSION_REFRESH_INTERVAL_MSEC);
     timer->start();
@@ -410,78 +400,51 @@ void Application::quitLater()
     QTimer::singleShot(0, this, SLOT(quit()));
 }
 
-/* these functions are for popping up desktop notifications */
-
-void Application::onTorrentsAdded(QSet<int> const& torrents)
+QStringList Application::getNames(QSet<int> const& ids) const
 {
-    if (!myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_ADD))
+    QStringList names;
+    for (auto const& id : ids)
     {
-        return;
+        names.push_back(myModel->getTorrentFromId(id)->name());
     }
+    names.sort();
+    return names;
+}
 
-    for (int const id : torrents)
+void Application::onTorrentsAdded(QSet<int> const& ids)
+{
+    if (myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_ADD))
     {
-        Torrent* tor = myModel->getTorrentFromId(id);
-
-        if (tor->name().isEmpty()) // wait until the torrent's INFO fields are loaded
-        {
-            connect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onNewTorrentChanged(int)));
-        }
-        else
-        {
-            onNewTorrentChanged(id);
-
-            if (!tor->isSeed())
-            {
-                connect(tor, SIGNAL(torrentCompleted(int)), this, SLOT(onTorrentCompleted(int)));
-            }
-        }
+        auto const title = tr("Torrent(s) Added", nullptr, ids.size());
+        auto const body = getNames(ids).join(QStringLiteral("\n"));
+        notifyApp(title, body);
     }
 }
 
-void Application::onTorrentCompleted(int id)
+void Application::onTorrentsCompleted(QSet<int> const& ids)
 {
-    Torrent* tor = myModel->getTorrentFromId(id);
-
-    if (tor != nullptr)
+    if (myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_COMPLETE))
     {
-        if (myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_COMPLETE))
-        {
-            notifyApp(tr("Torrent Completed"), tor->name());
-        }
+        auto const title = tr("Torrent Completed", nullptr, ids.size());
+        auto const body = getNames(ids).join(QStringLiteral("\n"));
+        notifyApp(title, body);
+    }
 
-        if (myPrefs->getBool(Prefs::COMPLETE_SOUND_ENABLED))
-        {
+    if (myPrefs->getBool(Prefs::COMPLETE_SOUND_ENABLED))
+    {
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-            beep();
+        beep();
 #else
-            QProcess::execute(myPrefs->getString(Prefs::COMPLETE_SOUND_COMMAND));
+        QProcess::execute(myPrefs->getString(Prefs::COMPLETE_SOUND_COMMAND));
 #endif
-        }
-
-        disconnect(tor, SIGNAL(torrentCompleted(int)), this, SLOT(onTorrentCompleted(int)));
     }
 }
 
-void Application::onNewTorrentChanged(int id)
+void Application::onTorrentsNeedInfo(QSet<int> const& ids)
 {
-    Torrent* tor = myModel->getTorrentFromId(id);
-
-    if (tor != nullptr && !tor->name().isEmpty())
+    if (!ids.isEmpty())
     {
-        int const age_secs = int(std::difftime(time(nullptr), tor->dateAdded()));
-
-        if (age_secs < 30)
-        {
-            notifyApp(tr("Torrent Added"), tor->name());
-        }
-
-        disconnect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onNewTorrentChanged(int)));
-
-        if (!tor->isSeed())
-        {
-            connect(tor, SIGNAL(torrentCompleted(int)), this, SLOT(onTorrentCompleted(int)));
-        }
+        mySession->initTorrents(ids);
     }
 }
 
@@ -592,25 +555,20 @@ void Application::refreshTorrents()
 ****
 ***/
 
-void Application::addTorrent(QString const& key)
-{
-    AddData const addme(key);
-
-    if (addme.type != addme.NONE)
-    {
-        addTorrent(addme);
-    }
-}
-
 void Application::addTorrent(AddData const& addme)
 {
+    if (addme.type == addme.NONE)
+    {
+        return;
+    }
+
     if (!myPrefs->getBool(Prefs::OPTIONS_PROMPT))
     {
         mySession->addTorrent(addme);
     }
     else
     {
-        OptionsDialog* o = new OptionsDialog(*mySession, *myPrefs, addme, myWindow);
+        auto o = new OptionsDialog(*mySession, *myPrefs, addme, myWindow);
         o->show();
     }
 

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -36,13 +36,7 @@ public:
     FaviconCache& faviconCache();
 
 public slots:
-    void addTorrent(QString const&);
     void addTorrent(AddData const&);
-
-private:
-    void maybeUpdateBlocklist();
-    void loadTranslations();
-    void quitLater();
 
 private slots:
     void consentGiven(int result);
@@ -50,8 +44,14 @@ private slots:
     void refreshPref(int key);
     void refreshTorrents();
     void onTorrentsAdded(QSet<int> const& torrents);
-    void onTorrentCompleted(int);
-    void onNewTorrentChanged(int);
+    void onTorrentsCompleted(QSet<int> const& torrents);
+    void onTorrentsNeedInfo(QSet<int> const& torrents);
+
+private:
+    void maybeUpdateBlocklist();
+    void loadTranslations();
+    void quitLater();
+    QStringList getNames(QSet<int> const& ids) const;
 
 private:
     Prefs* myPrefs;

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1445,7 +1445,9 @@ void DetailsDialog::initTrackerTab()
     connect(ui.removeTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onRemoveTrackerClicked);
     connect(ui.showBackupTrackersCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowBackupTrackersToggled);
     connect(ui.showTrackerScrapesCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowTrackerScrapesToggled);
-    connect(ui.trackersView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &DetailsDialog::onTrackerSelectionChanged);
+    connect(
+        ui.trackersView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+        &DetailsDialog::onTrackerSelectionChanged);
 
     onTrackerSelectionChanged();
 }

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -53,12 +53,13 @@ private:
     void getNewData();
 
     QIcon getStockIcon(QString const& freedesktop_name, int fallback);
+    void setEnabled(bool);
 
 private slots:
     void refresh();
     void refreshPref(int key);
 
-    void onTorrentChanged();
+    void onTorrentsChanged(QSet<int> const& ids);
     void onTimer();
 
     // Tracker tab

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -242,13 +242,13 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     connect(ui.action_DeselectAll, SIGNAL(triggered()), ui.listView, SLOT(clearSelection()));
     connect(ui.action_Quit, SIGNAL(triggered()), qApp, SLOT(quit()));
 
-    auto refreshActionSensitivitySoon = [this](){refreshSoon(REFRESH_ACTION_SENSITIVITY);};
+    auto refreshActionSensitivitySoon = [this]() { refreshSoon(REFRESH_ACTION_SENSITIVITY); };
     connect(&myFilterModel, &TorrentFilter::rowsInserted, refreshActionSensitivitySoon);
     connect(&myFilterModel, &TorrentFilter::rowsRemoved, refreshActionSensitivitySoon);
 
     // torrent view
     myFilterModel.setSourceModel(&myModel);
-    auto refreshSoonAdapter = [this](){refreshSoon();};
+    auto refreshSoonAdapter = [this]() { refreshSoon(); };
     connect(&myModel, &TorrentModel::modelReset, refreshSoonAdapter);
     connect(&myModel, &TorrentModel::rowsRemoved, refreshSoonAdapter);
     connect(&myModel, &TorrentModel::rowsInserted, refreshSoonAdapter);
@@ -312,7 +312,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     initStatusBar();
     ui.verticalLayout->insertWidget(0, myFilterBar = new FilterBar(myPrefs, myModel, myFilterModel));
 
-    auto refreshHeaderSoon = [this](){refreshSoon(REFRESH_TORRENT_VIEW_HEADER);};
+    auto refreshHeaderSoon = [this]() { refreshSoon(REFRESH_TORRENT_VIEW_HEADER); };
     connect(&myModel, &TorrentModel::rowsInserted, refreshHeaderSoon);
     connect(&myModel, &TorrentModel::rowsRemoved, refreshHeaderSoon);
     connect(&myFilterModel, &TorrentFilter::rowsInserted, refreshHeaderSoon);
@@ -702,19 +702,29 @@ void MainWindow::onRefreshTimer()
     std::swap(fields, myRefreshFields);
 
     if (fields & REFRESH_TITLE)
-      refreshTitle();
+    {
+        refreshTitle();
+    }
 
     if (fields & REFRESH_STATUS_BAR)
-      refreshStatusBar();
+    {
+        refreshStatusBar();
+    }
 
     if (fields & REFRESH_TRAY_ICON)
-      refreshTrayIcon();
+    {
+        refreshTrayIcon();
+    }
 
     if (fields & REFRESH_TORRENT_VIEW_HEADER)
-      refreshTorrentViewHeader();
+    {
+        refreshTorrentViewHeader();
+    }
 
     if (fields & REFRESH_ACTION_SENSITIVITY)
-      refreshActionSensitivity();
+    {
+        refreshActionSensitivity();
+    }
 }
 
 void MainWindow::refreshTitle()

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -176,12 +176,13 @@ private:
     QAction* myAltSpeedAction;
     QString myErrorMessage;
 
-    enum {
-        REFRESH_TITLE                = (1 << 0),
-        REFRESH_STATUS_BAR           = (1 << 1),
-        REFRESH_TRAY_ICON            = (1 << 2),
-        REFRESH_TORRENT_VIEW_HEADER  = (1 << 3),
-        REFRESH_ACTION_SENSITIVITY   = (1 << 4)
+    enum
+    {
+        REFRESH_TITLE = (1 << 0),
+        REFRESH_STATUS_BAR = (1 << 1),
+        REFRESH_TRAY_ICON = (1 << 2),
+        REFRESH_TORRENT_VIEW_HEADER = (1 << 3),
+        REFRESH_ACTION_SENSITIVITY = (1 << 4)
     };
     int myRefreshFields = 0;
     QTimer myRefreshTimer;

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -78,7 +78,6 @@ public slots:
     void setStatusbarVisible(bool);
     void setCompactView(bool);
     void refreshActionSensitivity();
-    void refreshActionSensitivitySoon();
     void wrongAuthentication();
 
     void openSession();
@@ -109,11 +108,8 @@ private:
 
 private slots:
     void openPreferences();
-    void refreshTitle();
-    void refreshStatusBar();
-    void refreshTrayIcon();
-    void refreshTrayIconSoon();
-    void refreshTorrentViewHeader();
+    void refreshSoon(int fields = ~0);
+    void onRefreshTimer();
     void openTorrent();
     void openURL();
     void newTorrent();
@@ -137,8 +133,6 @@ private slots:
     void onSetPrefs();
     void onSetPrefs(bool);
     void onSessionSourceChanged();
-    void onModelReset();
-
     void setSortAscendingPref(bool);
 
     void onStatsModeChanged(QAction* action);
@@ -171,8 +165,6 @@ private:
     time_t myLastReadTime;
     QTimer myNetworkTimer;
     bool myNetworkError;
-    QTimer myRefreshTrayIconTimer;
-    QTimer myRefreshActionSensitivityTimer;
     QAction* myDlimitOffAction;
     QAction* myDlimitOnAction;
     QAction* myUlimitOffAction;
@@ -183,4 +175,18 @@ private:
     QWidget* myFilterBar;
     QAction* myAltSpeedAction;
     QString myErrorMessage;
+
+    enum {
+        REFRESH_TITLE                = (1 << 0),
+        REFRESH_STATUS_BAR           = (1 << 1),
+        REFRESH_TRAY_ICON            = (1 << 2),
+        REFRESH_TORRENT_VIEW_HEADER  = (1 << 3),
+        REFRESH_ACTION_SENSITIVITY   = (1 << 4)
+    };
+    int myRefreshFields = 0;
+    QTimer myRefreshTimer;
+    void refreshTitle();
+    void refreshStatusBar();
+    void refreshTrayIcon();
+    void refreshTorrentViewHeader();
 };

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -107,36 +107,36 @@ private:
     virtual void showEvent(QShowEvent* event);
 
 private slots:
-    void openPreferences();
-    void refreshSoon(int fields = ~0);
-    void onRefreshTimer();
-    void openTorrent();
-    void openURL();
-    void newTorrent();
-    void trayActivated(QSystemTrayIcon::ActivationReason);
-    void refreshPref(int key);
     void addTorrents(QStringList const& filenames);
-    void removeTorrents(bool const deleteFiles);
-    void openStats();
-    void openDonate();
-    void openAbout();
-    void openHelp();
-    void openFolder();
     void copyMagnetLinkToClipboard();
-    void setLocation();
-    void openProperties();
-    void toggleSpeedMode();
     void dataReadProgress();
     void dataSendProgress();
+    void newTorrent();
     void onNetworkResponse(QNetworkReply::NetworkError code, QString const& message);
-    void toggleWindows(bool doShow);
+    void onRefreshTimer();
+    void onSessionSourceChanged();
     void onSetPrefs();
     void onSetPrefs(bool);
-    void onSessionSourceChanged();
-    void setSortAscendingPref(bool);
-
-    void onStatsModeChanged(QAction* action);
     void onSortModeChanged(QAction* action);
+    void onStatsModeChanged(QAction* action);
+    void openAbout();
+    void openDonate();
+    void openFolder();
+    void openHelp();
+    void openPreferences();
+    void openProperties();
+    void openStats();
+    void openTorrent();
+    void openURL();
+    void refreshPref(int key);
+    void refreshSoon(int fields = ~0);
+    void refreshStatusBar();
+    void removeTorrents(bool const deleteFiles);
+    void setLocation();
+    void setSortAscendingPref(bool);
+    void toggleSpeedMode();
+    void toggleWindows(bool doShow);
+    void trayActivated(QSystemTrayIcon::ActivationReason);
 
 private:
     Session& mySession;
@@ -186,7 +186,6 @@ private:
     int myRefreshFields = 0;
     QTimer myRefreshTimer;
     void refreshTitle();
-    void refreshStatusBar();
     void refreshTrayIcon();
     void refreshTorrentViewHeader();
 };

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -43,21 +43,6 @@ namespace
 
 typedef Torrent::KeyList KeyList;
 
-KeyList const& getInfoKeys()
-{
-    return Torrent::getInfoKeys();
-}
-
-KeyList const& getStatKeys()
-{
-    return Torrent::getStatKeys();
-}
-
-KeyList const& getExtraStatKeys()
-{
-    return Torrent::getExtraStatKeys();
-}
-
 void addList(tr_variant* list, KeyList const& keys)
 {
     tr_variantListReserve(list, keys.size());
@@ -598,9 +583,14 @@ void Session::refreshTorrents(QSet<int> const& ids, KeyList const& keys)
     q->run();
 }
 
+void Session::refreshDetailInfo(QSet<int> const& ids)
+{
+    refreshTorrents(ids, Torrent::detailInfoKeys);
+}
+
 void Session::refreshExtraStats(QSet<int> const& ids)
 {
-    refreshTorrents(ids, getStatKeys() + getExtraStatKeys());
+    refreshTorrents(ids, Torrent::mainStatKeys + Torrent::detailStatKeys);
 }
 
 void Session::sendTorrentRequest(char const* request, QSet<int> const& ids)
@@ -618,7 +608,7 @@ void Session::sendTorrentRequest(char const* request, QSet<int> const& ids)
 
     q->add([this, ids]()
         {
-            refreshTorrents(ids, getStatKeys());
+            refreshTorrents(ids, Torrent::mainStatKeys);
         });
 
     q->run();
@@ -661,17 +651,17 @@ void Session::queueMoveBottom(QSet<int> const& ids)
 
 void Session::refreshActiveTorrents()
 {
-    refreshTorrents(recentlyActiveIds, getStatKeys());
+    refreshTorrents(recentlyActiveIds, Torrent::mainStatKeys);
 }
 
 void Session::refreshAllTorrents()
 {
-    refreshTorrents(allIds, getStatKeys());
+    refreshTorrents(allIds, Torrent::mainStatKeys);
 }
 
 void Session::initTorrents(QSet<int> const& ids)
 {
-    refreshTorrents(ids, getStatKeys() + getInfoKeys());
+    refreshTorrents(ids, Torrent::allMainKeys);
 }
 
 void Session::refreshSessionStats()

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -86,30 +86,29 @@ public:
     void torrentSetLocation(QSet<int> const& ids, QString const& path, bool doMove);
     void torrentRenamePath(QSet<int> const& ids, QString const& oldpath, QString const& newname);
     void addTorrent(AddData const& addme, tr_variant* top, bool trashOriginal);
-
-public slots:
+    void initTorrents(QSet<int> const& ids = QSet<int>());
     void pauseTorrents(QSet<int> const& torrentIds = QSet<int>());
     void startTorrents(QSet<int> const& torrentIds = QSet<int>());
     void startTorrentsNow(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveTop(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveUp(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveDown(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveBottom(QSet<int> const& torrentIds = QSet<int>());
-    void refreshSessionInfo();
-    void refreshSessionStats();
+    void refreshDetailInfo(QSet<int> const& torrentIds);
     void refreshActiveTorrents();
     void refreshAllTorrents();
-    void initTorrents(QSet<int> const& ids = QSet<int>());
     void addNewlyCreatedTorrent(QString const& filename, QString const& localPath);
-    void addTorrent(AddData const& addme);
-    void removeTorrents(QSet<int> const& torrentIds, bool deleteFiles = false);
     void verifyTorrents(QSet<int> const& torrentIds);
     void reannounceTorrents(QSet<int> const& torrentIds);
-    void launchWebInterface();
-    void updatePref(int key);
-
-    /** request a refresh for statistics, including the ones only used by the properties dialog, for a specific torrent */
     void refreshExtraStats(QSet<int> const& ids);
+
+public slots:
+    void addTorrent(AddData const& addme);
+    void launchWebInterface();
+    void queueMoveBottom(QSet<int> const& torrentIds = QSet<int>());
+    void queueMoveDown(QSet<int> const& torrentIds = QSet<int>());
+    void queueMoveTop(QSet<int> const& torrentIds = QSet<int>());
+    void queueMoveUp(QSet<int> const& torrentIds = QSet<int>());
+    void refreshSessionInfo();
+    void refreshSessionStats();
+    void removeTorrents(QSet<int> const& torrentIds, bool deleteFiles = false);
+    void updatePref(int key);
 
 signals:
     void sourceChanged();

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -24,8 +24,8 @@
 #include "Utils.h"
 
 Torrent::Torrent(Prefs const& prefs, int id) :
-    myPrefs(prefs),
-    magnetTorrent(false)
+    myId(id),
+    myPrefs(prefs)
 {
 #ifndef NDEBUG
 
@@ -36,12 +36,7 @@ Torrent::Torrent(Prefs const& prefs, int id) :
 
 #endif
 
-    setInt(ID, id);
     setIcon(MIME_ICON, Utils::getFileIcon());
-}
-
-Torrent::~Torrent()
-{
 }
 
 /***
@@ -50,111 +45,146 @@ Torrent::~Torrent()
 
 Torrent::Property Torrent::myProperties[] =
 {
-    { ID, TR_KEY_id, QVariant::Int, INFO },
-    { UPLOAD_SPEED, TR_KEY_rateUpload, QVariant::ULongLong, STAT } /* Bps */,
-    { DOWNLOAD_SPEED, TR_KEY_rateDownload, QVariant::ULongLong, STAT }, /* Bps */
-    { DOWNLOAD_DIR, TR_KEY_downloadDir, QVariant::String, STAT },
-    { ACTIVITY, TR_KEY_status, QVariant::Int, STAT },
-    { NAME, TR_KEY_name, QVariant::String, INFO },
-    { ERROR, TR_KEY_error, QVariant::Int, STAT },
-    { ERROR_STRING, TR_KEY_errorString, QVariant::String, STAT },
-    { SIZE_WHEN_DONE, TR_KEY_sizeWhenDone, QVariant::ULongLong, STAT },
-    { LEFT_UNTIL_DONE, TR_KEY_leftUntilDone, QVariant::ULongLong, STAT },
-    { HAVE_UNCHECKED, TR_KEY_haveUnchecked, QVariant::ULongLong, STAT },
-    { HAVE_VERIFIED, TR_KEY_haveValid, QVariant::ULongLong, STAT },
-    { DESIRED_AVAILABLE, TR_KEY_desiredAvailable, QVariant::ULongLong, STAT },
-    { TOTAL_SIZE, TR_KEY_totalSize, QVariant::ULongLong, INFO },
-    { PIECE_SIZE, TR_KEY_pieceSize, QVariant::ULongLong, INFO },
-    { PIECE_COUNT, TR_KEY_pieceCount, QVariant::Int, INFO },
-    { PEERS_GETTING_FROM_US, TR_KEY_peersGettingFromUs, QVariant::Int, STAT },
-    { PEERS_SENDING_TO_US, TR_KEY_peersSendingToUs, QVariant::Int, STAT },
-    { WEBSEEDS_SENDING_TO_US, TR_KEY_webseedsSendingToUs, QVariant::Int, STAT_EXTRA },
-    { PERCENT_DONE, TR_KEY_percentDone, QVariant::Double, STAT },
-    { METADATA_PERCENT_DONE, TR_KEY_metadataPercentComplete, QVariant::Double, STAT },
-    { PERCENT_VERIFIED, TR_KEY_recheckProgress, QVariant::Double, STAT },
-    { DATE_ACTIVITY, TR_KEY_activityDate, QVariant::DateTime, STAT_EXTRA },
-    { DATE_ADDED, TR_KEY_addedDate, QVariant::DateTime, INFO },
-    { DATE_STARTED, TR_KEY_startDate, QVariant::DateTime, STAT_EXTRA },
-    { DATE_CREATED, TR_KEY_dateCreated, QVariant::DateTime, INFO },
-    { PEERS_CONNECTED, TR_KEY_peersConnected, QVariant::Int, STAT },
-    { ETA, TR_KEY_eta, QVariant::Int, STAT },
-    { RATIO, TR_KEY_uploadRatio, QVariant::Double, STAT },
-    { DOWNLOADED_EVER, TR_KEY_downloadedEver, QVariant::ULongLong, STAT },
-    { UPLOADED_EVER, TR_KEY_uploadedEver, QVariant::ULongLong, STAT },
-    { FAILED_EVER, TR_KEY_corruptEver, QVariant::ULongLong, STAT_EXTRA },
-    { TRACKERS, TR_KEY_trackers, QVariant::StringList, STAT },
-    { HOSTS, TR_KEY_NONE, QVariant::StringList, DERIVED },
-    { TRACKERSTATS, TR_KEY_trackerStats, CustomVariantType::TrackerStatsList, STAT_EXTRA },
-    { MIME_ICON, TR_KEY_NONE, QVariant::Icon, DERIVED },
-    { SEED_RATIO_LIMIT, TR_KEY_seedRatioLimit, QVariant::Double, STAT },
-    { SEED_RATIO_MODE, TR_KEY_seedRatioMode, QVariant::Int, STAT },
-    { SEED_IDLE_LIMIT, TR_KEY_seedIdleLimit, QVariant::Int, STAT_EXTRA },
-    { SEED_IDLE_MODE, TR_KEY_seedIdleMode, QVariant::Int, STAT_EXTRA },
-    { DOWN_LIMIT, TR_KEY_downloadLimit, QVariant::Int, STAT_EXTRA }, /* KB/s */
-    { DOWN_LIMITED, TR_KEY_downloadLimited, QVariant::Bool, STAT_EXTRA },
-    { UP_LIMIT, TR_KEY_uploadLimit, QVariant::Int, STAT_EXTRA }, /* KB/s */
-    { UP_LIMITED, TR_KEY_uploadLimited, QVariant::Bool, STAT_EXTRA },
-    { HONORS_SESSION_LIMITS, TR_KEY_honorsSessionLimits, QVariant::Bool, STAT_EXTRA },
-    { PEER_LIMIT, TR_KEY_peer_limit, QVariant::Int, STAT_EXTRA },
-    { HASH_STRING, TR_KEY_hashString, QVariant::String, INFO },
-    { IS_FINISHED, TR_KEY_isFinished, QVariant::Bool, STAT },
-    { IS_PRIVATE, TR_KEY_isPrivate, QVariant::Bool, INFO },
-    { IS_STALLED, TR_KEY_isStalled, QVariant::Bool, STAT },
-    { COMMENT, TR_KEY_comment, QVariant::String, INFO },
-    { CREATOR, TR_KEY_creator, QVariant::String, INFO },
-    { MANUAL_ANNOUNCE_TIME, TR_KEY_manualAnnounceTime, QVariant::DateTime, STAT_EXTRA },
-    { PEERS, TR_KEY_peers, CustomVariantType::PeerList, STAT_EXTRA },
-    { BANDWIDTH_PRIORITY, TR_KEY_bandwidthPriority, QVariant::Int, STAT_EXTRA },
-    { QUEUE_POSITION, TR_KEY_queuePosition, QVariant::Int, STAT },
+    { UPLOAD_SPEED, TR_KEY_rateUpload, QVariant::ULongLong } /* Bps */,
+    { DOWNLOAD_SPEED, TR_KEY_rateDownload, QVariant::ULongLong }, /* Bps */
+    { DOWNLOAD_DIR, TR_KEY_downloadDir, QVariant::String },
+    { ACTIVITY, TR_KEY_status, QVariant::Int },
+    { NAME, TR_KEY_name, QVariant::String },
+    { ERROR, TR_KEY_error, QVariant::Int },
+    { ERROR_STRING, TR_KEY_errorString, QVariant::String },
+    { SIZE_WHEN_DONE, TR_KEY_sizeWhenDone, QVariant::ULongLong },
+    { LEFT_UNTIL_DONE, TR_KEY_leftUntilDone, QVariant::ULongLong },
+    { HAVE_UNCHECKED, TR_KEY_haveUnchecked, QVariant::ULongLong },
+    { HAVE_VERIFIED, TR_KEY_haveValid, QVariant::ULongLong },
+    { DESIRED_AVAILABLE, TR_KEY_desiredAvailable, QVariant::ULongLong },
+    { TOTAL_SIZE, TR_KEY_totalSize, QVariant::ULongLong },
+    { PIECE_SIZE, TR_KEY_pieceSize, QVariant::ULongLong },
+    { PIECE_COUNT, TR_KEY_pieceCount, QVariant::Int },
+    { PEERS_GETTING_FROM_US, TR_KEY_peersGettingFromUs, QVariant::Int },
+    { PEERS_SENDING_TO_US, TR_KEY_peersSendingToUs, QVariant::Int },
+    { WEBSEEDS_SENDING_TO_US, TR_KEY_webseedsSendingToUs, QVariant::Int },
+    { PERCENT_DONE, TR_KEY_percentDone, QVariant::Double },
+    { METADATA_PERCENT_DONE, TR_KEY_metadataPercentComplete, QVariant::Double },
+    { PERCENT_VERIFIED, TR_KEY_recheckProgress, QVariant::Double },
+    { DATE_ACTIVITY, TR_KEY_activityDate, QVariant::DateTime },
+    { DATE_ADDED, TR_KEY_addedDate, QVariant::DateTime },
+    { DATE_STARTED, TR_KEY_startDate, QVariant::DateTime },
+    { DATE_CREATED, TR_KEY_dateCreated, QVariant::DateTime },
+    { PEERS_CONNECTED, TR_KEY_peersConnected, QVariant::Int },
+    { ETA, TR_KEY_eta, QVariant::Int },
+    { DOWNLOADED_EVER, TR_KEY_downloadedEver, QVariant::ULongLong },
+    { UPLOADED_EVER, TR_KEY_uploadedEver, QVariant::ULongLong },
+    { FAILED_EVER, TR_KEY_corruptEver, QVariant::ULongLong },
+    { TRACKERS, TR_KEY_trackers, QVariant::StringList },
+    { HOSTS, TR_KEY_NONE, QVariant::StringList },
+    { TRACKERSTATS, TR_KEY_trackerStats, CustomVariantType::TrackerStatsList },
+    { MIME_ICON, TR_KEY_NONE, QVariant::Icon },
+    { SEED_RATIO_LIMIT, TR_KEY_seedRatioLimit, QVariant::Double },
+    { SEED_RATIO_MODE, TR_KEY_seedRatioMode, QVariant::Int },
+    { SEED_IDLE_LIMIT, TR_KEY_seedIdleLimit, QVariant::Int },
+    { SEED_IDLE_MODE, TR_KEY_seedIdleMode, QVariant::Int },
+    { DOWN_LIMIT, TR_KEY_downloadLimit, QVariant::Int }, /* KB/s */
+    { DOWN_LIMITED, TR_KEY_downloadLimited, QVariant::Bool },
+    { UP_LIMIT, TR_KEY_uploadLimit, QVariant::Int }, /* KB/s */
+    { UP_LIMITED, TR_KEY_uploadLimited, QVariant::Bool },
+    { HONORS_SESSION_LIMITS, TR_KEY_honorsSessionLimits, QVariant::Bool },
+    { PEER_LIMIT, TR_KEY_peer_limit, QVariant::Int },
+    { HASH_STRING, TR_KEY_hashString, QVariant::String },
+    { IS_FINISHED, TR_KEY_isFinished, QVariant::Bool },
+    { IS_PRIVATE, TR_KEY_isPrivate, QVariant::Bool },
+    { IS_STALLED, TR_KEY_isStalled, QVariant::Bool },
+    { COMMENT, TR_KEY_comment, QVariant::String },
+    { CREATOR, TR_KEY_creator, QVariant::String },
+    { MANUAL_ANNOUNCE_TIME, TR_KEY_manualAnnounceTime, QVariant::DateTime },
+    { PEERS, TR_KEY_peers, CustomVariantType::PeerList },
+    { BANDWIDTH_PRIORITY, TR_KEY_bandwidthPriority, QVariant::Int },
+    { QUEUE_POSITION, TR_KEY_queuePosition, QVariant::Int },
 };
 
-Torrent::KeyList Torrent::buildKeyList(Group group)
-{
-    KeyList keys;
+/***
+****
+***/
 
-    if (keys.empty())
-    {
-        for (int i = 0; i < PROPERTY_COUNT; ++i)
-        {
-            if (myProperties[i].id == ID || myProperties[i].group == group)
-            {
-                keys << myProperties[i].key;
-            }
-        }
-    }
+// unchanging fields needed by the main window
+Torrent::KeyList const Torrent::mainInfoKeys{
+    TR_KEY_addedDate,
+    TR_KEY_downloadDir,
+    TR_KEY_hashString,
+    TR_KEY_id, // must be in every req
+    TR_KEY_name,
+    TR_KEY_totalSize,
+    TR_KEY_trackers,
+};
 
-    return keys;
-}
+// changing fields needed by the main window
+Torrent::KeyList const Torrent::mainStatKeys{
+    TR_KEY_downloadedEver,
+    TR_KEY_error,
+    TR_KEY_errorString,
+    TR_KEY_eta,
+    TR_KEY_haveUnchecked,
+    TR_KEY_haveValid,
+    TR_KEY_id, // must be in every req
+    TR_KEY_isFinished,
+    TR_KEY_leftUntilDone,
+    TR_KEY_manualAnnounceTime,
+    TR_KEY_metadataPercentComplete,
+    TR_KEY_peersConnected,
+    TR_KEY_peersGettingFromUs,
+    TR_KEY_peersSendingToUs,
+    TR_KEY_percentDone,
+    TR_KEY_queuePosition,
+    TR_KEY_rateDownload,
+    TR_KEY_rateUpload,
+    TR_KEY_recheckProgress,
+    TR_KEY_seedRatioLimit,
+    TR_KEY_seedRatioMode,
+    TR_KEY_sizeWhenDone,
+    TR_KEY_status,
+    TR_KEY_uploadedEver,
+    TR_KEY_webseedsSendingToUs
+};
 
-Torrent::KeyList const& Torrent::getInfoKeys()
-{
-    static KeyList keys;
+Torrent::KeyList const Torrent::allMainKeys = Torrent::mainInfoKeys + Torrent::mainStatKeys;
 
-    if (keys.isEmpty())
-    {
-        keys << buildKeyList(INFO) << TR_KEY_files;
-    }
+// unchanging fields needed by the details dialog
+Torrent::KeyList const Torrent::detailInfoKeys{
+    TR_KEY_comment,
+    TR_KEY_creator,
+    TR_KEY_dateCreated,
+    TR_KEY_files,
+    TR_KEY_id, // must be in every req
+    TR_KEY_isPrivate,
+    TR_KEY_pieceCount,
+    TR_KEY_pieceSize,
+    TR_KEY_trackers
+};
 
-    return keys;
-}
+// changing fields needed by the details dialog
+Torrent::KeyList const Torrent::detailStatKeys{
+    TR_KEY_activityDate,
+    TR_KEY_bandwidthPriority,
+    TR_KEY_corruptEver,
+    TR_KEY_desiredAvailable,
+    TR_KEY_downloadedEver,
+    TR_KEY_downloadLimit,
+    TR_KEY_downloadLimited,
+    TR_KEY_fileStats,
+    TR_KEY_honorsSessionLimits,
+    TR_KEY_id, // must be in every req
+    TR_KEY_peer_limit,
+    TR_KEY_peers,
+    TR_KEY_seedIdleLimit,
+    TR_KEY_seedIdleMode,
+    TR_KEY_startDate,
+    TR_KEY_trackerStats,
+    TR_KEY_uploadLimit,
+    TR_KEY_uploadLimited
+};
 
-Torrent::KeyList const& Torrent::getStatKeys()
-{
-    static KeyList keys(buildKeyList(STAT));
-    return keys;
-}
-
-Torrent::KeyList const& Torrent::getExtraStatKeys()
-{
-    static KeyList keys;
-
-    if (keys.isEmpty())
-    {
-        keys << buildKeyList(STAT_EXTRA) << TR_KEY_fileStats;
-    }
-
-    return keys;
-}
+/***
+****
+***/
 
 bool Torrent::setInt(int i, int value)
 {
@@ -239,16 +269,19 @@ bool Torrent::setSize(int i, qulonglong value)
     return changed;
 }
 
-bool Torrent::setString(int i, char const* value)
+bool Torrent::setString(int i, char const* value, size_t len)
 {
     bool changed = false;
 
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::String);
 
-    if (myValues[i].isNull() || myValues[i].toString() != QString::fromUtf8(value))
+    auto& oldval = myValues[i];
+    auto const newval = QString::fromUtf8(value, len);
+
+    if (oldval != newval)
     {
-        myValues[i].setValue(QString::fromUtf8(value));
+        oldval = newval;
         changed = true;
     }
 
@@ -268,6 +301,7 @@ int Torrent::getInt(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Int);
+    //assert(!myValues[i].isNull());
 
     return myValues[i].toInt();
 }
@@ -276,6 +310,7 @@ time_t Torrent::getTime(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::DateTime);
+    //assert((i == DATE_ADDED) || !myValues[i].isNull());
 
     return time_t(myValues[i].toLongLong());
 }
@@ -284,6 +319,7 @@ bool Torrent::getBool(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Bool);
+    //assert(!myValues[i].isNull());
 
     return myValues[i].toBool();
 }
@@ -292,6 +328,7 @@ qulonglong Torrent::getSize(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::ULongLong);
+    //assert(!myValues[i].isNull());
 
     return myValues[i].toULongLong();
 }
@@ -300,6 +337,7 @@ double Torrent::getDouble(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Double);
+    //assert(!myValues[i].isNull());
 
     return myValues[i].toDouble();
 }
@@ -308,6 +346,7 @@ QString Torrent::getString(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::String);
+    //assert((i == HASH_STRING) || !myValues[i].isNull());
 
     return myValues[i].toString();
 }
@@ -316,6 +355,7 @@ QIcon Torrent::getIcon(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Icon);
+    //assert(!myValues[i].isNull());
 
     return myValues[i].value<QIcon>();
 }
@@ -501,22 +541,11 @@ void Torrent::updateMimeIcon()
 ****
 ***/
 
-void Torrent::notifyComplete() const
-{
-    // if someone wants to implement notification, here's the hook.
-}
-
-/***
-****
-***/
-
-void Torrent::update(tr_variant* d)
+bool Torrent::update(tr_variant* d)
 {
     static bool lookup_initialized = false;
     static int key_to_property_index[TR_N_KEYS];
     bool changed = false;
-    bool const was_seed = isSeed();
-    uint64_t const old_verified_size = haveVerified();
 
     if (!lookup_initialized)
     {
@@ -577,10 +606,11 @@ void Torrent::update(tr_variant* d)
         case QVariant::String:
             {
                 char const* val;
+                size_t len;
 
-                if (tr_variantGetStr(child, &val, nullptr))
+                if (tr_variantGetStr(child, &val, &len))
                 {
-                    bool const field_changed = setString(property_index, val);
+                    bool const field_changed = setString(property_index, val, len);
                     changed |= field_changed;
 
                     if (field_changed && key == TR_KEY_name)
@@ -993,15 +1023,7 @@ void Torrent::update(tr_variant* d)
         changed = true;
     }
 
-    if (changed)
-    {
-        emit torrentChanged(id());
-    }
-
-    if (!was_seed && isSeed() && old_verified_size > 0)
-    {
-        emit torrentCompleted(id());
-    }
+    return changed;
 }
 
 QString Torrent::activityString() const

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -301,7 +301,7 @@ int Torrent::getInt(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Int);
-    //assert(!myValues[i].isNull());
+    // assert(!myValues[i].isNull());
 
     return myValues[i].toInt();
 }
@@ -310,7 +310,7 @@ time_t Torrent::getTime(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::DateTime);
-    //assert((i == DATE_ADDED) || !myValues[i].isNull());
+    // assert((i == DATE_ADDED) || !myValues[i].isNull());
 
     return time_t(myValues[i].toLongLong());
 }
@@ -319,7 +319,7 @@ bool Torrent::getBool(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Bool);
-    //assert(!myValues[i].isNull());
+    // assert(!myValues[i].isNull());
 
     return myValues[i].toBool();
 }
@@ -328,7 +328,7 @@ qulonglong Torrent::getSize(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::ULongLong);
-    //assert(!myValues[i].isNull());
+    // assert(!myValues[i].isNull());
 
     return myValues[i].toULongLong();
 }
@@ -337,7 +337,7 @@ double Torrent::getDouble(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Double);
-    //assert(!myValues[i].isNull());
+    // assert(!myValues[i].isNull());
 
     return myValues[i].toDouble();
 }
@@ -346,7 +346,7 @@ QString Torrent::getString(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::String);
-    //assert((i == HASH_STRING) || !myValues[i].isNull());
+    // assert((i == HASH_STRING) || !myValues[i].isNull());
 
     return myValues[i].toString();
 }
@@ -355,7 +355,7 @@ QIcon Torrent::getIcon(int i) const
 {
     assert(0 <= i && i < PROPERTY_COUNT);
     assert(myProperties[i].type == QVariant::Icon);
-    //assert(!myValues[i].isNull());
+    // assert(!myValues[i].isNull());
 
     return myValues[i].value<QIcon>();
 }

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -188,7 +188,8 @@ public:
 
 public:
     Torrent(Prefs const&, int id);
-    virtual ~Torrent() =default;;
+    virtual ~Torrent() = default;
+    ;
 
     int getBandwidthPriority() const
     {

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -178,7 +178,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_PROGRESS:
         if (val == 0)
         {
-            val = -compare(a->isMagnet(), b->isMagnet());
+            val = compare(a->metadataPercentDone(), b->metadataPercentDone());
         }
 
         if (val == 0)

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -44,7 +44,7 @@ struct TorrentIdLessThan
 };
 
 template<typename Iter>
-QSet<int> getIds (Iter it, Iter end)
+QSet<int> getIds(Iter it, Iter end)
 {
     QSet<int> ids;
 
@@ -161,11 +161,11 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
     auto processed = QSet<Torrent*>{};
 
     auto const now = time(nullptr);
-    auto const recently_added = [now](const auto& tor)
+    auto const recently_added = [now](>const< auto& tor)
         {
             static auto constexpr max_age = 60;
             auto const date = tor->dateAdded();
-            return (date != 0) && (difftime(now,date) < max_age);
+            return (date != 0) && (difftime(now, date) < max_age);
         };
 
     size_t i = 0;
@@ -222,7 +222,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
     {
         rowsAdd(instantiated);
     }
-    
+
     if (!changed.isEmpty())
     {
         rowsEmitChanged(changed);
@@ -276,7 +276,7 @@ std::optional<int> TorrentModel::getRow(int id) const
         row = std::distance(myTorrents.begin(), it.first);
         assert(myTorrents[*row]->id() == id);
     }
-    
+
     return row;
 }
 
@@ -314,6 +314,7 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) c
             rows.push_back(*row);
         }
     }
+
     std::sort(rows.begin(), rows.end());
 
     // rows -> spans
@@ -335,12 +336,14 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) c
                 in_span = false;
             }
         }
+
         if (!in_span)
         {
             span.first = span.second = row;
             in_span = true;
         }
     }
+
     if (in_span)
     {
         spans.push_back(span);
@@ -355,7 +358,7 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) c
 
 void TorrentModel::rowsEmitChanged(QSet<int> const& ids)
 {
-    for (const auto& span : getSpans(ids))
+    for (>const< auto& span : getSpans(ids))
     {
         emit dataChanged(index(span.first), index(span.second));
     }
@@ -372,14 +375,17 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
         std::sort(myTorrents.begin(), myTorrents.end(), TorrentIdLessThan());
         endInsertRows();
     }
-    else for (auto const& tor : torrents)
+    else
     {
-        auto const it = std::lower_bound(myTorrents.begin(), myTorrents.end(), tor, compare);
-        auto const row = std::distance(myTorrents.begin(), it);
+        for (auto const& tor : torrents)
+        {
+            auto const it = std::lower_bound(myTorrents.begin(), myTorrents.end(), tor, compare);
+            auto const row = std::distance(myTorrents.begin(), it);
 
-        beginInsertRows(QModelIndex(), row, row);
-        myTorrents.insert(it, tor);
-        endInsertRows();
+            beginInsertRows(QModelIndex(), row, row);
+            myTorrents.insert(it, tor);
+            endInsertRows();
+        }
     }
 }
 
@@ -429,6 +435,6 @@ void TorrentModel::getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount,
 
 bool TorrentModel::hasTorrent(QString const& hashString) const
 {
-    auto test = [hashString](auto const& tor){return tor->hashString() == hashString;};
+    auto test = [hashString](auto const& tor) { return tor->hashString() == hashString; };
     return std::any_of(myTorrents.cbegin(), myTorrents.cend(), test);
 }

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -6,7 +6,9 @@
  *
  */
 
+#include <algorithm>
 #include <iostream>
+#include <utility>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
@@ -15,6 +17,10 @@
 #include "Torrent.h"
 #include "TorrentDelegate.h"
 #include "TorrentModel.h"
+
+/***
+****
+***/
 
 namespace
 {
@@ -37,15 +43,40 @@ struct TorrentIdLessThan
     }
 };
 
+template<typename Iter>
+QSet<int> getIds (Iter it, Iter end)
+{
+    QSet<int> ids;
+
+    for ( ; it != end; ++it)
+    {
+        ids.insert((*it)->id());
+    }
+
+    return ids;
+}
+
 } // namespace
+
+/***
+****
+***/
+
+TorrentModel::TorrentModel(Prefs const& prefs) :
+    myPrefs(prefs)
+{
+}
+
+TorrentModel::~TorrentModel()
+{
+    clear();
+}
 
 void TorrentModel::clear()
 {
     beginResetModel();
-
     qDeleteAll(myTorrents);
     myTorrents.clear();
-
     endResetModel();
 }
 
@@ -91,199 +122,290 @@ QVariant TorrentModel::data(QModelIndex const& index, int role) const
 ****
 ***/
 
-void TorrentModel::addTorrent(Torrent* t)
-{
-    torrents_t::iterator const torrentIt = qLowerBound(myTorrents.begin(), myTorrents.end(), t, TorrentIdLessThan());
-    int const row = torrentIt == myTorrents.end() ? myTorrents.size() : torrentIt - myTorrents.begin();
-
-    beginInsertRows(QModelIndex(), row, row);
-    myTorrents.insert(torrentIt, t);
-    endInsertRows();
-}
-
-void TorrentModel::addTorrents(torrents_t&& torrents, QSet<int>& addIds)
-{
-    if (myTorrents.isEmpty())
-    {
-        qSort(torrents.begin(), torrents.end(), TorrentIdLessThan());
-
-        beginInsertRows(QModelIndex(), 0, torrents.size() - 1);
-        myTorrents.swap(torrents);
-        endInsertRows();
-
-        addIds += getIds();
-    }
-    else
-    {
-        for (Torrent* const tor : torrents)
-        {
-            addTorrent(tor);
-            addIds.insert(tor->id());
-        }
-    }
-}
-
-TorrentModel::TorrentModel(Prefs const& prefs) :
-    myPrefs(prefs)
-{
-}
-
-TorrentModel::~TorrentModel()
-{
-    clear();
-}
-
-/***
-****
-***/
-
-Torrent* TorrentModel::getTorrentFromId(int id)
-{
-    torrents_t::const_iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), id, TorrentIdLessThan());
-    return torrentIt == myTorrents.end() ? nullptr : *torrentIt;
-}
-
-Torrent const* TorrentModel::getTorrentFromId(int id) const
-{
-    torrents_t::const_iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), id, TorrentIdLessThan());
-    return torrentIt == myTorrents.end() ? nullptr : *torrentIt;
-}
-
-/***
-****
-***/
-
-void TorrentModel::onTorrentChanged(int torrentId)
-{
-    torrents_t::iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), torrentId, TorrentIdLessThan());
-
-    if (torrentIt == myTorrents.end())
-    {
-        return;
-    }
-
-    int const row = torrentIt - myTorrents.begin();
-    QModelIndex const qmi(index(row, 0));
-
-    emit dataChanged(qmi, qmi);
-}
-
-void TorrentModel::removeTorrents(tr_variant* torrents)
+void TorrentModel::removeTorrents(tr_variant* list)
 {
     int i = 0;
     tr_variant* child;
+    QSet<Torrent*> torrents;
 
-    while ((child = tr_variantListChild(torrents, i++)) != nullptr)
+    while ((child = tr_variantListChild(list, i++)) != nullptr)
     {
-        int64_t intVal;
+        int64_t id;
+        Torrent* torrent = nullptr;
 
-        if (tr_variantGetInt(child, &intVal))
+        if (tr_variantGetInt(child, &id))
         {
-            removeTorrent(intVal);
+            torrent = getTorrentFromId(id);
         }
+
+        if (torrent != nullptr)
+        {
+            torrents.insert(torrent);
+        }
+    }
+
+    if (!torrents.isEmpty())
+    {
+        rowsRemove(torrents);
     }
 }
 
 void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
 {
-    torrents_t newTorrents;
-    QSet<int> oldIds;
-    QSet<int> addIds;
-    QSet<int> newIds;
+    auto const old = QSet<Torrent*>::fromList(myTorrents.toList());
+    auto added = QSet<int>{};
+    auto changed = QSet<int>{};
+    auto completed = QSet<int>{};
+    auto instantiated = torrents_t{};
+    auto needinfo = QSet<int>{};
+    auto processed = QSet<Torrent*>{};
+
+    auto const now = time(nullptr);
+    auto const recently_added = [now](const auto& tor)
+        {
+            static auto constexpr max_age = 60;
+            auto const date = tor->dateAdded();
+            return (date != 0) && (difftime(now,date) < max_age);
+        };
+
+    size_t i = 0;
+    tr_variant* child;
+    while ((child = tr_variantListChild(torrents, i++)) != nullptr)
+    {
+        int64_t id;
+
+        if (!tr_variantDictFindInt(child, TR_KEY_id, &id))
+        {
+            continue;
+        }
+
+        Torrent* tor = getTorrentFromId(id);
+        std::optional<uint64_t> leftUntilDone;
+
+        if (tor == nullptr)
+        {
+            tor = new Torrent(myPrefs, id);
+            instantiated.push_back(tor);
+        }
+        else
+        {
+            leftUntilDone = tor->leftUntilDone();
+        }
+
+        if (tor->update(child))
+        {
+            changed.insert(id);
+        }
+
+        if (!tor->hasName() && !old.contains(tor))
+        {
+            needinfo.insert(id);
+        }
+
+        if (recently_added(tor) && tor->hasName() && !myAlreadyAdded.contains(id))
+        {
+            added.insert(id);
+            myAlreadyAdded.insert(id);
+        }
+
+        if (leftUntilDone && (*leftUntilDone > 0) && (tor->leftUntilDone() == 0) && (tor->downloadedEver() > 0))
+        {
+            completed.insert(id);
+        }
+
+        processed.insert(tor);
+    }
+
+    // model upkeep
+
+    if (!instantiated.isEmpty())
+    {
+        rowsAdd(instantiated);
+    }
+    
+    if (!changed.isEmpty())
+    {
+        rowsEmitChanged(changed);
+    }
+
+    // emit signals
+
+    if (!added.isEmpty())
+    {
+        emit torrentsAdded(added);
+    }
+
+    if (!needinfo.isEmpty())
+    {
+        emit torrentsNeedInfo(needinfo);
+    }
+
+    if (!changed.isEmpty())
+    {
+        emit torrentsChanged(changed);
+    }
+
+    if (!completed.isEmpty())
+    {
+        emit torrentsCompleted(completed);
+    }
+
+    // model upkeep
 
     if (isCompleteList)
     {
-        oldIds = getIds();
-    }
-
-    if (tr_variantIsList(torrents))
-    {
-        size_t i(0);
-        tr_variant* child;
-
-        while ((child = tr_variantListChild(torrents, i++)) != nullptr)
+        auto const removed = old - processed;
+        if (!removed.isEmpty())
         {
-            int64_t id;
+            rowsRemove(removed);
+        }
+    }
+}
 
-            if (tr_variantDictFindInt(child, TR_KEY_id, &id))
+/***
+****
+***/
+
+std::optional<int> TorrentModel::getRow(int id) const
+{
+    std::optional<int> row;
+
+    auto const it = std::equal_range(myTorrents.begin(), myTorrents.end(), id, TorrentIdLessThan());
+    if (it.first != it.second)
+    {
+        row = std::distance(myTorrents.begin(), it.first);
+        assert(myTorrents[*row]->id() == id);
+    }
+    
+    return row;
+}
+
+std::optional<int> TorrentModel::getRow(Torrent const* tor) const
+{
+    return getRow(tor->id());
+}
+
+Torrent* TorrentModel::getTorrentFromId(int id)
+{
+    auto const row = getRow(id);
+    return row ? myTorrents[*row] : nullptr;
+}
+
+Torrent const* TorrentModel::getTorrentFromId(int id) const
+{
+    auto const row = getRow(id);
+    return row ? myTorrents[*row] : nullptr;
+}
+
+/***
+****
+***/
+
+std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) const
+{
+    // ids -> rows
+    std::vector<int> rows;
+    rows.reserve(ids.size());
+    for (auto const& id : ids)
+    {
+        auto const row = getRow(id);
+        if (row)
+        {
+            rows.push_back(*row);
+        }
+    }
+    std::sort(rows.begin(), rows.end());
+
+    // rows -> spans
+    std::vector<span_t> spans;
+    spans.reserve(rows.size());
+    span_t span;
+    bool in_span = false;
+    for (auto const& row : rows)
+    {
+        if (in_span)
+        {
+            if (span.second + 1 == row)
             {
-                if (isCompleteList)
-                {
-                    newIds.insert(id);
-                }
-
-                Torrent* tor = getTorrentFromId(id);
-
-                if (tor == nullptr)
-                {
-                    tor = new Torrent(myPrefs, id);
-                    tor->update(child);
-
-                    if (!tor->hasMetadata())
-                    {
-                        tor->setMagnet(true);
-                    }
-
-                    newTorrents.append(tor);
-                    connect(tor, SIGNAL(torrentChanged(int)), this, SLOT(onTorrentChanged(int)));
-                }
-                else
-                {
-                    tor->update(child);
-
-                    if (tor->isMagnet() && tor->hasMetadata())
-                    {
-                        addIds.insert(tor->id());
-                        tor->setMagnet(false);
-                    }
-                }
+                span.second = row;
+            }
+            else
+            {
+                spans.push_back(span);
+                in_span = false;
             }
         }
-    }
-
-    if (!newTorrents.isEmpty())
-    {
-        addTorrents(std::move(newTorrents), addIds);
-    }
-
-    if (!addIds.isEmpty())
-    {
-        emit torrentsAdded(addIds);
-    }
-
-    if (isCompleteList)
-    {
-        QSet<int> removedIds(oldIds);
-        removedIds -= newIds;
-
-        for (int const id : removedIds)
+        if (!in_span)
         {
-            removeTorrent(id);
+            span.first = span.second = row;
+            in_span = true;
         }
     }
-}
-
-void TorrentModel::removeTorrent(int id)
-{
-    torrents_t::iterator const torrentIt = qBinaryFind(myTorrents.begin(), myTorrents.end(), id, TorrentIdLessThan());
-
-    if (torrentIt == myTorrents.end())
+    if (in_span)
     {
-        return;
+        spans.push_back(span);
     }
 
-    Torrent* const tor = *torrentIt;
-    int const row = torrentIt - myTorrents.begin();
-
-    beginRemoveRows(QModelIndex(), row, row);
-    myTorrents.remove(row);
-    endRemoveRows();
-
-    delete tor;
+    return spans;
 }
 
+/***
+****
+***/
+
+void TorrentModel::rowsEmitChanged(QSet<int> const& ids)
+{
+    for (const auto& span : getSpans(ids))
+    {
+        emit dataChanged(index(span.first), index(span.second));
+    }
+}
+
+void TorrentModel::rowsAdd(torrents_t const& torrents)
+{
+    auto const compare = TorrentIdLessThan();
+
+    if (myTorrents.isEmpty())
+    {
+        beginInsertRows(QModelIndex(), 0, torrents.size() - 1);
+        myTorrents = torrents;
+        std::sort(myTorrents.begin(), myTorrents.end(), TorrentIdLessThan());
+        endInsertRows();
+    }
+    else for (auto const& tor : torrents)
+    {
+        auto const it = std::lower_bound(myTorrents.begin(), myTorrents.end(), tor, compare);
+        auto const row = std::distance(myTorrents.begin(), it);
+
+        beginInsertRows(QModelIndex(), row, row);
+        myTorrents.insert(it, tor);
+        endInsertRows();
+    }
+}
+
+void TorrentModel::rowsRemove(QSet<Torrent*> const& torrents)
+{
+    // must walk in reverse to avoid invalidating row numbers
+    auto const& spans = getSpans(getIds(torrents.begin(), torrents.end()));
+    for (auto it = spans.rbegin(), end = spans.rend(); it != end; ++it)
+    {
+        auto const& span = *it;
+
+        beginRemoveRows(QModelIndex(), span.first, span.second);
+        auto const n = span.second + 1 - span.first;
+        myTorrents.remove(span.first, n);
+        endRemoveRows();
+    }
+
+    qDeleteAll(torrents);
+}
+
+/***
+****
+***/
+
 void TorrentModel::getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed,
-    size_t& downloadPeerCount)
+    size_t& downloadPeerCount) const
 {
     Speed upSpeed;
     Speed downSpeed;
@@ -305,29 +427,8 @@ void TorrentModel::getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount,
     downloadPeerCount = downCount;
 }
 
-QSet<int> TorrentModel::getIds() const
-{
-    QSet<int> ids;
-
-    ids.reserve(myTorrents.size());
-
-    for (Torrent const* const tor : myTorrents)
-    {
-        ids.insert(tor->id());
-    }
-
-    return ids;
-}
-
 bool TorrentModel::hasTorrent(QString const& hashString) const
 {
-    for (Torrent const* const tor : myTorrents)
-    {
-        if (tor->hashString() == hashString)
-        {
-            return true;
-        }
-    }
-
-    return false;
+    auto test = [hashString](auto const& tor){return tor->hashString() == hashString;};
+    return std::any_of(myTorrents.cbegin(), myTorrents.cend(), test);
 }

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -161,7 +161,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
     auto processed = QSet<Torrent*>{};
 
     auto const now = time(nullptr);
-    auto const recently_added = [now](>const< auto& tor)
+    auto const recently_added = [now](auto const& tor)
         {
             static auto constexpr max_age = 60;
             auto const date = tor->dateAdded();
@@ -358,7 +358,7 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) c
 
 void TorrentModel::rowsEmitChanged(QSet<int> const& ids)
 {
-    for (>const< auto& span : getSpans(ids))
+    for (auto const& span : getSpans(ids))
     {
         emit dataChanged(index(span.first), index(span.second));
     }

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -64,7 +64,7 @@ private:
 
     std::optional<int> getRow(int id) const;
     std::optional<int> getRow(Torrent const* tor) const;
-    using span_t = std::pair<int,int>;
+    using span_t = std::pair<int, int>;
     std::vector<span_t> getSpans(QSet<int> const& ids) const;
 
     Prefs const& myPrefs;

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -31,43 +31,43 @@ public:
         TorrentRole = Qt::UserRole
     };
 
-public:
-    TorrentModel(Prefs const& prefs);
+    explicit TorrentModel(Prefs const& prefs);
     virtual ~TorrentModel();
-
     void clear();
+
     bool hasTorrent(QString const& hashString) const;
 
     Torrent* getTorrentFromId(int id);
     Torrent const* getTorrentFromId(int id) const;
 
-    void getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed, size_t& downloadPeerCount);
+    void getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed, size_t& downloadPeerCount) const;
 
     // QAbstractItemModel
-    virtual int rowCount(QModelIndex const& parent = QModelIndex()) const;
-    virtual QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const;
+    int rowCount(QModelIndex const& parent = QModelIndex()) const override;
+    QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const override;
 
 public slots:
     void updateTorrents(tr_variant* torrentList, bool isCompleteList);
     void removeTorrents(tr_variant* torrentList);
-    void removeTorrent(int id);
 
 signals:
     void torrentsAdded(QSet<int>);
+    void torrentsChanged(QSet<int>);
+    void torrentsCompleted(QSet<int>);
+    void torrentsNeedInfo(QSet<int>);
 
 private:
-    typedef QVector<Torrent*> torrents_t;
+    using torrents_t = QVector<Torrent*>;
+    void rowsAdd(torrents_t const& torrents);
+    void rowsRemove(QSet<Torrent*> const& torrents);
+    void rowsEmitChanged(QSet<int> const& ids);
 
-private:
-    void addTorrent(Torrent*);
-    void addTorrents(torrents_t&& torrents, QSet<int>& addIds);
-    QSet<int> getIds() const;
+    std::optional<int> getRow(int id) const;
+    std::optional<int> getRow(Torrent const* tor) const;
+    using span_t = std::pair<int,int>;
+    std::vector<span_t> getSpans(QSet<int> const& ids) const;
 
-private slots:
-    void onTorrentChanged(int propertyId);
-
-private:
     Prefs const& myPrefs;
-
     torrents_t myTorrents;
+    QSet<int> myAlreadyAdded;
 };

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QAbstractListModel>
 #include <QSet>
 #include <QVector>


### PR DESCRIPTION
The Torrent->Application signal connections make up for about 5% of the app's memory use. Move this to the TorrentModel so that there are only a handful of signal connections.

Moving signals to TorrentModel means batch change signals can be emitted instead of per-change-per-torrent emissions and can be handled that way.