### PR TITLE
refactor: easy speedups

### DIFF
--- a/libtransmission/variant-json.c
+++ b/libtransmission/variant-json.c
@@ -118,9 +118,13 @@ static void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t action UNUSED, st
         int const depth = tr_ptrArraySize(&data->stack);
         size_t const n = depth < MAX_DEPTH ? data->preallocGuess[depth] : 0;
         if (state->type == JSONSL_T_LIST)
+        {
             tr_variantInitList(node, n);
+        }
         else
+        {
             tr_variantInitDict(node, n);
+        }
     }
 }
 

--- a/libtransmission/variant-json.c
+++ b/libtransmission/variant-json.c
@@ -45,6 +45,12 @@ struct json_wrapper_data
     struct evbuffer* strbuf;
     char const* source;
     tr_ptrArray stack;
+
+    /* A very common pattern is for a container's children to be similar,
+     * e.g. they may all be objects with the same set of keys. So when
+     * a container is popped off the stack, remember its size to use as
+     * a preallocation heuristic for the next container at that depth. */
+    size_t preallocGuess[MAX_DEPTH];
 };
 
 static tr_variant* get_node(struct jsonsl_st* jsn)
@@ -103,25 +109,18 @@ static void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t action UNUSED, st
     tr_variant* node;
     struct json_wrapper_data* data = jsn->data;
 
-    switch (state->type)
+    if ((state->type == JSONSL_T_LIST) || (state->type == JSONSL_T_OBJECT))
     {
-    case JSONSL_T_LIST:
         data->has_content = true;
         node = get_node(jsn);
-        tr_variantInitList(node, 0);
         tr_ptrArrayAppend(&data->stack, node);
-        break;
 
-    case JSONSL_T_OBJECT:
-        data->has_content = true;
-        node = get_node(jsn);
-        tr_variantInitDict(node, 0);
-        tr_ptrArrayAppend(&data->stack, node);
-        break;
-
-    default:
-        /* nothing else interesting on push */
-        break;
+        int const depth = tr_ptrArraySize(&data->stack);
+        size_t const n = depth < MAX_DEPTH ? data->preallocGuess[depth] : 0;
+        if (state->type == JSONSL_T_LIST)
+            tr_variantInitList(node, n);
+        else
+            tr_variantInitDict(node, n);
     }
 }
 
@@ -318,7 +317,12 @@ static void action_callback_POP(jsonsl_t jsn, jsonsl_action_t action UNUSED, str
     }
     else if (state->type == JSONSL_T_LIST || state->type == JSONSL_T_OBJECT)
     {
-        tr_ptrArrayPop(&data->stack);
+        int const depth = tr_ptrArraySize(&data->stack);
+        tr_variant const* v = tr_ptrArrayPop(&data->stack);
+        if (depth < MAX_DEPTH)
+        {
+            data->preallocGuess[depth] = v->val.l.count;
+        }
     }
     else if (state->type == JSONSL_T_SPECIAL)
     {
@@ -369,6 +373,10 @@ int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* s
     data.source = source;
     data.keybuf = evbuffer_new();
     data.strbuf = evbuffer_new();
+    for (int i = 0; i < MAX_DEPTH; ++i)
+    {
+        data.preallocGuess[i] = 0;
+    }
 
     /* parse it */
     jsonsl_feed(jsn, vbuf, len);

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -22,7 +22,6 @@ class AboutDialog : public BaseDialog
 
 public:
     AboutDialog(QWidget* parent = nullptr);
-    virtual ~AboutDialog() = default;
 
 private slots:
     void showCredits();

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -399,7 +399,7 @@ void Application::quitLater()
     QTimer::singleShot(0, this, SLOT(quit()));
 }
 
-QStringList Application::getNames(QSet<int> const& ids) const
+QStringList Application::getNames(torrent_ids_t const& ids) const
 {
     QStringList names;
     for (auto const& id : ids)
@@ -411,7 +411,7 @@ QStringList Application::getNames(QSet<int> const& ids) const
     return names;
 }
 
-void Application::onTorrentsAdded(QSet<int> const& ids)
+void Application::onTorrentsAdded(torrent_ids_t const& ids)
 {
     if (myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_ADD))
     {
@@ -421,7 +421,7 @@ void Application::onTorrentsAdded(QSet<int> const& ids)
     }
 }
 
-void Application::onTorrentsCompleted(QSet<int> const& ids)
+void Application::onTorrentsCompleted(torrent_ids_t const& ids)
 {
     if (myPrefs->getBool(Prefs::SHOW_NOTIFICATION_ON_COMPLETE))
     {
@@ -440,9 +440,9 @@ void Application::onTorrentsCompleted(QSet<int> const& ids)
     }
 }
 
-void Application::onTorrentsNeedInfo(QSet<int> const& ids)
+void Application::onTorrentsNeedInfo(torrent_ids_t const& ids)
 {
-    if (!ids.isEmpty())
+    if (!ids.empty())
     {
         mySession->initTorrents(ids);
     }

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <QApplication>
-#include <QSet>
 #include <QTimer>
 #include <QTranslator>
 
 #include "FaviconCache.h"
+#include "Typedefs.h"
 
 class AddData;
 class Prefs;
@@ -43,14 +43,14 @@ private slots:
     void onSessionSourceChanged();
     void refreshPref(int key);
     void refreshTorrents();
-    void onTorrentsAdded(QSet<int> const& torrents);
-    void onTorrentsCompleted(QSet<int> const& torrents);
-    void onTorrentsNeedInfo(QSet<int> const& torrents);
+    void onTorrentsAdded(torrent_ids_t const& torrents);
+    void onTorrentsCompleted(torrent_ids_t const& torrents);
+    void onTorrentsNeedInfo(torrent_ids_t const& torrents);
 
 private:
     void maybeUpdateBlocklist();
     void loadTranslations();
-    QStringList getNames(QSet<int> const& ids) const;
+    QStringList getNames(torrent_ids_t const& ids) const;
     void quitLater();
 
 private:

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -106,6 +106,7 @@ set(${PROJECT_NAME}_HEADERS
     TrackerDelegate.h
     TrackerModel.h
     TrackerModelFilter.h
+    Typedefs.h
     Utils.h
     WatchDir.h
 )

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -24,7 +24,7 @@ public:
     void addLayout(QGridLayout* layout);
 
     // QObject
-    virtual bool eventFilter(QObject* object, QEvent* event);
+    bool eventFilter(QObject* object, QEvent* event) override;
 
 public slots:
     void update();

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -312,7 +312,7 @@ void DetailsDialog::getNewData()
 
 void DetailsDialog::onTorrentsChanged(torrent_ids_t const& ids)
 {
-    if (!myHavePendingRefresh)
+    if (myHavePendingRefresh)
         return;
 
     if (!std::any_of(ids.begin(), ids.end(), [this](auto const& id){return myIds.count(id) != 0;}))

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -313,10 +313,14 @@ void DetailsDialog::getNewData()
 void DetailsDialog::onTorrentsChanged(torrent_ids_t const& ids)
 {
     if (myHavePendingRefresh)
+    {
         return;
+    }
 
-    if (!std::any_of(ids.begin(), ids.end(), [this](auto const& id){return myIds.count(id) != 0;}))
+    if (!std::any_of(ids.begin(), ids.end(), [this](auto const& id) { return myIds.count(id) != 0; }))
+    {
         return;
+    }
 
     myHavePendingRefresh = true;
     QTimer::singleShot(100, this, SLOT(refresh()));
@@ -1338,7 +1342,7 @@ void DetailsDialog::onEditTrackerClicked()
     }
     else
     {
-        torrent_ids_t ids { trackerInfo.torrentId };
+        torrent_ids_t ids{ trackerInfo.torrentId };
 
         QPair<int, QString> const idUrl = qMakePair(trackerInfo.st.id, newval);
 
@@ -1363,7 +1367,7 @@ void DetailsDialog::onRemoveTrackerClicked()
     // batch all of a tracker's torrents into one command
     for (int const id : torrentId_to_trackerIds.uniqueKeys())
     {
-        torrent_ids_t const ids { id };
+        torrent_ids_t const ids{ id };
         mySession.torrentSet(ids, TR_KEY_trackerRemove, torrentId_to_trackerIds.values(id));
     }
 

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -14,6 +14,7 @@
 #include <QTimer>
 
 #include "BaseDialog.h"
+#include "Typedefs.h"
 
 #include "ui_DetailsDialog.h"
 
@@ -35,7 +36,7 @@ public:
     DetailsDialog(Session&, Prefs&, TorrentModel const&, QWidget* parent = nullptr);
     virtual ~DetailsDialog();
 
-    void setIds(QSet<int> const& ids);
+    void setIds(torrent_ids_t const& ids);
 
     // QWidget
     QSize sizeHint() const override
@@ -59,7 +60,7 @@ private slots:
     void refresh();
     void refreshPref(int key);
 
-    void onTorrentsChanged(QSet<int> const& ids);
+    void onTorrentsChanged(torrent_ids_t const& ids);
     void onTimer();
 
     // Tracker tab
@@ -93,7 +94,7 @@ private:
 
     Ui::DetailsDialog ui;
 
-    QSet<int> myIds;
+    torrent_ids_t myIds;
     QTimer myTimer;
     bool myChangedTorrents;
     bool myHavePendingRefresh;

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -38,7 +38,7 @@ public:
     void setIds(QSet<int> const& ids);
 
     // QWidget
-    virtual QSize sizeHint() const
+    QSize sizeHint() const override
     {
         return QSize(440, 460);
     }

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -40,6 +40,15 @@ QString FaviconCache::getCacheDir()
     return QDir(base).absoluteFilePath(QLatin1String("favicons"));
 }
 
+namespace
+{
+
+QPixmap scale(QPixmap pixmap)
+{
+    return pixmap.scaled(FaviconCache::getIconSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+}
+
+}
 void FaviconCache::ensureCacheDirHasBeenScanned()
 {
     static bool hasBeenScanned = false;
@@ -60,24 +69,44 @@ void FaviconCache::ensureCacheDirHasBeenScanned()
 
             if (!pixmap.isNull())
             {
-                myPixmaps.insert(file, pixmap);
+                myPixmaps[file] = scale(pixmap);
             }
         }
     }
 }
 
-QString FaviconCache::getHost(QUrl const& url)
+/***
+****
+***/
+
+QString FaviconCache::getDisplayName(QUrl const& url)
 {
-    QString host = url.host();
-    int const first_dot = host.indexOf(QLatin1Char('.'));
-    int const last_dot = host.lastIndexOf(QLatin1Char('.'));
+    return getDisplayName(getKey(url));
+}
 
-    if (first_dot != -1 && last_dot != -1 && first_dot != last_dot)
-    {
-        host.remove(0, first_dot + 1);
-    }
+QString FaviconCache::getDisplayName(QString const& key)
+{
+    auto name = key;
+    name[0] = name.at(0).toTitleCase();
+    return name;
+}
 
-    return host;
+QString FaviconCache::getKey(QUrl const& url)
+{
+    auto host = url.host();
+
+    // remove tld
+    auto const suffix = url.topLevelDomain();
+    host.truncate(host.size() - suffix.size());
+
+    // remove subdomain
+    auto const pos = host.indexOf(QLatin1Char('.'));
+    return pos < 0 ? host : host.remove(0, pos + 1);
+}
+
+QString FaviconCache::getKey(QString const& displayName)
+{
+    return displayName.toLower();
 }
 
 QSize FaviconCache::getIconSize()
@@ -85,31 +114,26 @@ QSize FaviconCache::getIconSize()
     return QSize(16, 16);
 }
 
-QPixmap FaviconCache::find(QUrl const& url)
-{
-    return findFromHost(getHost(url));
-}
-
-QPixmap FaviconCache::findFromHost(QString const& host)
+QPixmap FaviconCache::find(QString const& key)
 {
     ensureCacheDirHasBeenScanned();
 
-    return myPixmaps[host];
+    return myPixmaps[key];
 }
 
-void FaviconCache::add(QUrl const& url)
+QString FaviconCache::add(QUrl const& url)
 {
     ensureCacheDirHasBeenScanned();
 
-    QString const host = getHost(url);
+    QString const key = getKey(url);
 
-    if (!myPixmaps.contains(host))
+    if (myPixmaps.count(key) == 0)
     {
         // add a placholder s.t. we only ping the server once per session
-        myPixmaps.insert(host, QPixmap());
+        myPixmaps[key] = QPixmap();
 
         // try to download the favicon
-        QString const path = QLatin1String("http://") + host + QLatin1String("/favicon.");
+        QString const path = QLatin1String("http://") + url.host() + QLatin1String("/favicon.");
         QStringList suffixes;
         suffixes << QLatin1String("ico") << QLatin1String("png") << QLatin1String("gif") << QLatin1String("jpg");
 
@@ -118,11 +142,13 @@ void FaviconCache::add(QUrl const& url)
             myNAM->get(QNetworkRequest(path + suffix));
         }
     }
+
+    return key;
 }
 
 void FaviconCache::onRequestFinished(QNetworkReply* reply)
 {
-    QString const host = reply->url().host();
+    auto const key = getKey(reply->url());
 
     QPixmap pixmap;
 
@@ -136,17 +162,17 @@ void FaviconCache::onRequestFinished(QNetworkReply* reply)
     if (!pixmap.isNull())
     {
         // save it in memory...
-        myPixmaps.insert(host, pixmap);
+        myPixmaps[key] = scale(pixmap);
 
         // save it on disk...
         QDir cacheDir(getCacheDir());
         cacheDir.mkpath(cacheDir.absolutePath());
-        QFile file(cacheDir.absoluteFilePath(host));
+        QFile file(cacheDir.absoluteFilePath(key));
         file.open(QIODevice::WriteOnly);
         file.write(content);
         file.close();
 
         // notify listeners
-        emit pixmapReady(host);
+        emit pixmapReady(key);
     }
 }

--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -10,7 +10,6 @@
 
 #include <unordered_map>
 
-#include <QMap>
 #include <QString>
 #include <QObject>
 #include <QPixmap>

--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -8,10 +8,14 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include <QMap>
 #include <QString>
 #include <QObject>
 #include <QPixmap>
+
+#include <Utils.h> // std::hash<QString>
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -26,19 +30,21 @@ public:
     virtual ~FaviconCache();
 
     // returns a cached pixmap, or a NULL pixmap if there's no match in the cache
-    QPixmap find(QUrl const& url);
+    QPixmap find(QString const& key);
+    QPixmap find(QUrl const& url) { return find(getKey(url)); }
 
-    // returns a cached pixmap, or a NULL pixmap if there's no match in the cache
-    QPixmap findFromHost(QString const& host);
+    // This will emit a signal when (if) the icon becomes ready.
+    // Returns the key.
+    QString add(QUrl const& url);
 
-    // this will emit a signal when (if) the icon becomes ready
-    void add(QUrl const& url);
-
-    static QString getHost(QUrl const& url);
+    static QString getDisplayName(QUrl const& url);
+    static QString getDisplayName(QString const& key);
+    static QString getKey(QUrl const& url);
+    static QString getKey(QString const& displayName);
     static QSize getIconSize();
 
 signals:
-    void pixmapReady(QString const& host);
+    void pixmapReady(QString const& key);
 
 private:
     QString getCacheDir();
@@ -49,5 +55,5 @@ private slots:
 
 private:
     QNetworkAccessManager* myNAM;
-    QMap<QString, QPixmap> myPixmaps;
+    std::unordered_map<QString, QPixmap> myPixmaps;
 };

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -20,12 +20,8 @@ public:
     {
     }
 
-    virtual ~FileTreeDelegate()
-    {
-    }
-
 public:
     // QAbstractItemDelegate
-    virtual QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const;
-    virtual void paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const;
+    QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const override;
+    void paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const override;
 };

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -292,7 +292,7 @@ int FileTreeModel::rowCount(QModelIndex const& parent) const
 
 int FileTreeModel::columnCount(QModelIndex const& parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
 
     return NUM_COLUMNS;
 }

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -43,7 +43,7 @@ public:
 
 public:
     FileTreeModel(QObject* parent = nullptr, bool isEditable = true);
-    virtual ~FileTreeModel();
+    ~FileTreeModel();
 
     void setEditable(bool editable);
 
@@ -62,14 +62,14 @@ public:
     QModelIndex parent(QModelIndex const& child, int column) const;
 
     // QAbstractItemModel
-    virtual QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const;
-    virtual Qt::ItemFlags flags(QModelIndex const& index) const;
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    virtual QModelIndex index(int row, int column, QModelIndex const& parent = QModelIndex()) const;
-    virtual QModelIndex parent(QModelIndex const& child) const;
-    virtual int rowCount(QModelIndex const& parent = QModelIndex()) const;
-    virtual int columnCount(QModelIndex const& parent = QModelIndex()) const;
-    virtual bool setData(QModelIndex const& index, QVariant const& value, int role = Qt::EditRole);
+    QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(QModelIndex const& index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column, QModelIndex const& parent = QModelIndex()) const override;
+    QModelIndex parent(QModelIndex const& child) const override;
+    int rowCount(QModelIndex const& parent = QModelIndex()) const override;
+    int columnCount(QModelIndex const& parent = QModelIndex()) const override;
+    bool setData(QModelIndex const& index, QVariant const& value, int role = Qt::EditRole) override;
 
 signals:
     void priorityChanged(QSet<int> const& fileIndices, int);

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -40,13 +40,13 @@ signals:
 
 protected:
     // QWidget
-    virtual void resizeEvent(QResizeEvent* event);
-    virtual void keyPressEvent(QKeyEvent* event);
-    virtual void mouseDoubleClickEvent(QMouseEvent* event);
-    virtual void contextMenuEvent(QContextMenuEvent* event);
+    void resizeEvent(QResizeEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
 
     // QAbstractItemView
-    virtual bool edit(QModelIndex const& index, EditTrigger trigger, QEvent* event);
+    bool edit(QModelIndex const& index, EditTrigger trigger, QEvent* event) override;
 
 private slots:
     void onClicked(QModelIndex const& index);

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -6,6 +6,9 @@
  *
  */
 
+#include <map>
+#include <unordered_map>
+
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -21,22 +24,13 @@
 #include "Torrent.h"
 #include "TorrentFilter.h"
 #include "TorrentModel.h"
+#include "Utils.h"
 
 enum
 {
     ActivityRole = FilterBarComboBox::UserRole,
     TrackerRole
 };
-
-namespace
-{
-
-QString readableHostName(QString const& host)
-{
-    return host.left(host.lastIndexOf(QLatin1Char('.')));
-}
-
-} // namespace
 
 /***
 ****
@@ -93,122 +87,81 @@ FilterBarComboBox* FilterBar::createActivityCombo()
 ****
 ***/
 
+namespace
+{
+
+QString getCountString(int n)
+{
+    return QString::fromLatin1("%L1").arg(n);
+}
+
+} // namespace
+
+
 void FilterBar::refreshTrackers()
 {
-    FaviconCache& favicons = qApp->faviconCache();
-    int const firstTrackerRow = 2; // skip over the "All" and separator...
+    enum { ROW_TOTALS = 0, ROW_SEPARATOR, ROW_FIRST_TRACKER };
 
-    // pull info from the tracker model...
-    QSet<QString> oldHosts;
-
-    for (int row = firstTrackerRow;; ++row)
-    {
-        QModelIndex index = myTrackerModel->index(row, 0);
-
-        if (!index.isValid())
-        {
-            break;
-        }
-
-        oldHosts << index.data(TrackerRole).toString();
-    }
-
-    // pull the new stats from the torrent model...
-    QSet<QString> newHosts;
-    QMap<QString, int> torrentsPerHost;
-
-    for (int row = 0;; ++row)
-    {
-        QModelIndex index = myTorrents.index(row, 0);
-
-        if (!index.isValid())
-        {
-            break;
-        }
-
-        Torrent const* tor = index.data(TorrentModel::TorrentRole).value<Torrent const*>();
-        QSet<QString> torrentNames;
-
-        for (QString const& host : tor->hosts())
-        {
-            newHosts.insert(host);
-            torrentNames.insert(readableHostName(host));
-        }
-
-        for (QString const& name : torrentNames)
-        {
-            ++torrentsPerHost[name];
-        }
-    }
+    auto torrentsPerHost = std::unordered_map<QString,int>{};
+    for (auto const& tor : myTorrents.torrents())
+        for (auto const& displayName : tor->trackerDisplayNames())
+            ++torrentsPerHost[displayName];
 
     // update the "All" row
-    myTrackerModel->setData(myTrackerModel->index(0, 0), myTorrents.rowCount(), FilterBarComboBox::CountRole);
-    myTrackerModel->setData(myTrackerModel->index(0, 0), getCountString(myTorrents.rowCount()),
-        FilterBarComboBox::CountStringRole);
+    auto const num_trackers = torrentsPerHost.size();
+    auto item = myTrackerModel->item(ROW_TOTALS);
+    item->setData(int(num_trackers), FilterBarComboBox::CountRole);
+    item->setData(getCountString(num_trackers), FilterBarComboBox::CountStringRole);
 
-    // rows to update
-    for (QString const& host : oldHosts & newHosts)
-    {
-        QString const name = readableHostName(host);
-        QStandardItem* row = myTrackerModel->findItems(name).front();
-        int const count = torrentsPerHost[name];
-        row->setData(count, FilterBarComboBox::CountRole);
-        row->setData(getCountString(count), FilterBarComboBox::CountStringRole);
-        row->setData(QIcon(favicons.findFromHost(host)), Qt::DecorationRole);
-    }
+    auto updateTrackerItem = [](QStandardItem* i, auto const& it) {
+        auto const& displayName = it->first;
+        auto const& count = it->second;
+        auto const icon = qApp->faviconCache().find(FaviconCache::getKey(displayName));
+        i->setData(displayName, Qt::DisplayRole);
+        i->setData(displayName, TrackerRole);
+        i->setData(getCountString(count), FilterBarComboBox::CountStringRole);
+        i->setData(icon, Qt::DecorationRole);
+        i->setData(int(count), FilterBarComboBox::CountRole);
+        return i;
+    };
 
-    // rows to remove
-    for (QString const& host : oldHosts - newHosts)
-    {
-        QString const name = readableHostName(host);
-        QStandardItem* item = myTrackerModel->findItems(name).front();
-
-        if (!item->data(TrackerRole).toString().isEmpty()) // don't remove "All"
-        {
-            myTrackerModel->removeRows(item->row(), 1);
-        }
-    }
-
-    // rows to add
+    auto newTrackers = std::map<QString, int>(torrentsPerHost.begin(), torrentsPerHost.end());
+    auto old_it = myTrackerCounts.cbegin();
+    auto new_it = newTrackers.cbegin();
+    auto const old_end = myTrackerCounts.cend();
+    auto const new_end = newTrackers.cend();
     bool anyAdded = false;
+    int row = ROW_FIRST_TRACKER;
 
-    for (QString const& host : newHosts - oldHosts)
+    while ((old_it != old_end) || (new_it != new_end))
     {
-        QString const name = readableHostName(host);
-
-        if (!myTrackerModel->findItems(name).isEmpty())
+        if ((old_it == old_end) || ((new_it != new_end) && (old_it->first > new_it->first)))
         {
-            continue;
+            myTrackerModel->insertRow(row, updateTrackerItem(new QStandardItem(1), new_it));
+            anyAdded = true;
+            ++new_it;
+            ++row;
         }
-
-        // find the sorted position to add this row
-        int i = firstTrackerRow;
-
-        for (int n = myTrackerModel->rowCount(); i < n; ++i)
+        else if ((new_it == new_end) || ((old_it != old_end) && (old_it->first < new_it->first)))
         {
-            QString const rowName = myTrackerModel->index(i, 0).data(Qt::DisplayRole).toString();
-
-            if (rowName >= name)
-            {
-                break;
-            }
+            myTrackerModel->removeRow(row);
+            ++old_it;
         }
-
-        // add the row
-        QStandardItem* row = new QStandardItem(favicons.findFromHost(host), name);
-        int const count = torrentsPerHost[host];
-        row->setData(count, FilterBarComboBox::CountRole);
-        row->setData(getCountString(count), FilterBarComboBox::CountStringRole);
-        row->setData(QIcon(favicons.findFromHost(host)), Qt::DecorationRole);
-        row->setData(host, TrackerRole);
-        myTrackerModel->insertRow(i, row);
-        anyAdded = true;
+        else // update
+        {
+            updateTrackerItem(myTrackerModel->item(row), new_it);
+            ++old_it;
+            ++new_it;
+            ++row;
+        }
     }
 
     if (anyAdded) // the one added might match our filter...
     {
         refreshPref(Prefs::FILTER_TRACKERS);
     }
+
+    myTrackerCounts.swap(newTrackers);
 }
 
 FilterBarComboBox* FilterBar::createTrackerCombo(QStandardItemModel* model)
@@ -280,10 +233,7 @@ FilterBar::FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter c
     myIsBootstrapping = false;
 
     // initialize our state
-    QList<int> initKeys;
-    initKeys << Prefs::FILTER_MODE << Prefs::FILTER_TRACKERS;
-
-    for (int const key : initKeys)
+    for (int const key : { Prefs::FILTER_MODE, Prefs::FILTER_TRACKERS })
     {
         refreshPref(key);
     }
@@ -324,10 +274,8 @@ void FilterBar::refreshPref(int key)
 
     case Prefs::FILTER_TRACKERS:
         {
-            QString const tracker = myPrefs.getString(key);
-            QString const name = readableHostName(tracker);
-            QList<QStandardItem*> rows = myTrackerModel->findItems(name);
-
+            auto const displayName = myPrefs.getString(key);
+            auto rows = myTrackerModel->findItems(displayName);
             if (!rows.isEmpty())
             {
                 myTrackerCombo->setCurrentIndex(rows.front()->row());
@@ -420,9 +368,4 @@ void FilterBar::recount()
     }
 
     refreshTrackers();
-}
-
-QString FilterBar::getCountString(int n) const
-{
-    return QString::fromLatin1("%L1").arg(n);
 }

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -97,15 +97,21 @@ QString getCountString(int n)
 
 } // namespace
 
-
 void FilterBar::refreshTrackers()
 {
-    enum { ROW_TOTALS = 0, ROW_SEPARATOR, ROW_FIRST_TRACKER };
+    enum
+    {
+        ROW_TOTALS = 0, ROW_SEPARATOR, ROW_FIRST_TRACKER
+    };
 
-    auto torrentsPerHost = std::unordered_map<QString,int>{};
+    auto torrentsPerHost = std::unordered_map<QString, int>{};
     for (auto const& tor : myTorrents.torrents())
-        for (auto const& displayName : tor->trackerDisplayNames())
+    {
+        for (auto const & displayName : tor->trackerDisplayNames())
+        {
             ++torrentsPerHost[displayName];
+        }
+    }
 
     // update the "All" row
     auto const num_trackers = torrentsPerHost.size();
@@ -113,17 +119,18 @@ void FilterBar::refreshTrackers()
     item->setData(int(num_trackers), FilterBarComboBox::CountRole);
     item->setData(getCountString(num_trackers), FilterBarComboBox::CountStringRole);
 
-    auto updateTrackerItem = [](QStandardItem* i, auto const& it) {
-        auto const& displayName = it->first;
-        auto const& count = it->second;
-        auto const icon = qApp->faviconCache().find(FaviconCache::getKey(displayName));
-        i->setData(displayName, Qt::DisplayRole);
-        i->setData(displayName, TrackerRole);
-        i->setData(getCountString(count), FilterBarComboBox::CountStringRole);
-        i->setData(icon, Qt::DecorationRole);
-        i->setData(int(count), FilterBarComboBox::CountRole);
-        return i;
-    };
+    auto updateTrackerItem = [](QStandardItem* i, auto const& it)
+        {
+            auto const& displayName = it->first;
+            auto const& count = it->second;
+            auto const icon = qApp->faviconCache().find(FaviconCache::getKey(displayName));
+            i->setData(displayName, Qt::DisplayRole);
+            i->setData(displayName, TrackerRole);
+            i->setData(getCountString(count), FilterBarComboBox::CountStringRole);
+            i->setData(icon, Qt::DecorationRole);
+            i->setData(int(count), FilterBarComboBox::CountRole);
+            return i;
+        };
 
     auto newTrackers = std::map<QString, int>(torrentsPerHost.begin(), torrentsPerHost.end());
     auto old_it = myTrackerCounts.cbegin();

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -107,7 +107,7 @@ void FilterBar::refreshTrackers()
     auto torrentsPerHost = std::unordered_map<QString, int>{};
     for (auto const& tor : myTorrents.torrents())
     {
-        for (auto const & displayName : tor->trackerDisplayNames())
+        for (auto const& displayName : tor->trackerDisplayNames())
         {
             ++torrentsPerHost[displayName];
         }

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -33,21 +33,7 @@ namespace
 
 QString readableHostName(QString const& host)
 {
-    // get the readable name...
-    QString name = host;
-    int const pos = name.lastIndexOf(QLatin1Char('.'));
-
-    if (pos >= 0)
-    {
-        name.truncate(pos);
-    }
-
-    if (!name.isEmpty())
-    {
-        name[0] = name[0].toUpper();
-    }
-
-    return name;
+    return host.left(host.lastIndexOf(QLatin1Char('.')));
 }
 
 } // namespace

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include <QWidget>
 
 class QLabel;
@@ -35,7 +37,6 @@ private:
     FilterBarComboBox* createTrackerCombo(QStandardItemModel*);
     FilterBarComboBox* createActivityCombo();
     void refreshTrackers();
-    QString getCountString(int n) const;
 
 private slots:
     void recountSoon();
@@ -57,4 +58,5 @@ private:
     QTimer* myRecountTimer;
     bool myIsBootstrapping;
     QLineEdit* myLineEdit;
+    std::map<QString, int> myTrackerCounts;
 };

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -89,7 +89,7 @@ QSize FilterBarComboBox::calculateSize(QSize const& textSize, QSize const& count
 
 void FilterBarComboBox::paintEvent(QPaintEvent* e)
 {
-    Q_UNUSED(e);
+    Q_UNUSED(e)
 
     QStylePainter painter(this);
     painter.setPen(palette().color(QPalette::Text));

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -28,12 +28,12 @@ public:
     int currentCount() const;
 
     // QWidget
-    virtual QSize minimumSizeHint() const;
-    virtual QSize sizeHint() const;
+    QSize minimumSizeHint() const override;
+    QSize sizeHint() const override;
 
 protected:
     // QWidget
-    virtual void paintEvent(QPaintEvent* e);
+    void paintEvent(QPaintEvent* e) override;
 
 private:
     QSize calculateSize(QSize const& textSize, QSize const& countSize) const;

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -25,8 +25,8 @@ public:
 
 protected:
     // QAbstractItemDelegate
-    virtual void paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const;
-    virtual QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const;
+    void paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const override;
+    QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const override;
 
 private:
     QComboBox* const myCombo;

--- a/qt/IconToolButton.h
+++ b/qt/IconToolButton.h
@@ -18,9 +18,9 @@ public:
     IconToolButton(QWidget* parent = nullptr);
 
     // QWidget
-    virtual QSize sizeHint() const;
+    QSize sizeHint() const override;
 
 protected:
     // QWidget
-    virtual void paintEvent(QPaintEvent* event);
+    void paintEvent(QPaintEvent* event) override;
 };

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -778,7 +778,8 @@ void MainWindow::refreshTrayIcon(TransferStats const& stats)
     }
     else if (stats.peersSending != 0)
     {
-        tip = Formatter::downloadSpeedToString(stats.speedDown) + QLatin1String("   ") + Formatter::uploadSpeedToString(stats.speedUp);
+        tip = Formatter::downloadSpeedToString(stats.speedDown) + QLatin1String("   ") + Formatter::uploadSpeedToString(
+            stats.speedUp);
     }
     else if (stats.peersReceiving != 0)
     {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -518,7 +518,7 @@ void MainWindow::setSortAscendingPref(bool b)
 
 void MainWindow::showEvent(QShowEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     ui.action_ShowMainWindow->setChecked(true);
 }
@@ -529,7 +529,7 @@ void MainWindow::showEvent(QShowEvent* event)
 
 void MainWindow::hideEvent(QHideEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
 
     if (!isVisible())
     {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -843,7 +843,6 @@ void MainWindow::refreshTorrentViewHeader()
 void MainWindow::refreshActionSensitivity()
 {
     int paused(0);
-    int queued(0);
     int selected(0);
     int selectedAndCanAnnounce(0);
     int selectedAndPaused(0);
@@ -864,12 +863,6 @@ void MainWindow::refreshActionSensitivity()
         {
             bool const isSelected(selectionModel->isSelected(modelIndex));
             bool const isPaused(tor->isPaused());
-            bool const isQueued(tor->isQueued());
-
-            if (isQueued)
-            {
-                ++queued;
-            }
 
             if (isPaused)
             {
@@ -885,7 +878,7 @@ void MainWindow::refreshActionSensitivity()
                     ++selectedAndPaused;
                 }
 
-                if (isQueued)
+                if (tor->isQueued())
                 {
                     ++selectedAndQueued;
                 }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -610,7 +610,7 @@ static void openSelect(QString const& path)
 
 void MainWindow::openFolder()
 {
-    QSet<int> const selectedTorrents = getSelectedTorrents();
+    auto const selectedTorrents = getSelectedTorrents();
 
     if (selectedTorrents.size() != 1)
     {
@@ -936,9 +936,9 @@ void MainWindow::clearSelection()
     ui.action_DeselectAll->trigger();
 }
 
-QSet<int> MainWindow::getSelectedTorrents(bool withMetadataOnly) const
+torrent_ids_t MainWindow::getSelectedTorrents(bool withMetadataOnly) const
 {
-    QSet<int> ids;
+    torrent_ids_t ids;
 
     for (QModelIndex const& index : ui.listView->selectionModel()->selectedRows())
     {
@@ -1340,7 +1340,7 @@ void MainWindow::addTorrent(AddData const& addMe, bool showOptions)
 
 void MainWindow::removeTorrents(bool const deleteFiles)
 {
-    QSet<int> ids;
+    torrent_ids_t ids;
     QMessageBox msgBox(this);
     QString primary_text;
     QString secondary_text;
@@ -1364,7 +1364,7 @@ void MainWindow::removeTorrents(bool const deleteFiles)
         }
     }
 
-    if (ids.isEmpty())
+    if (ids.empty())
     {
         return;
     }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -8,14 +8,14 @@
 
 #include <cassert>
 
-#include <QtGui>
 #include <QCheckBox>
+#include <QFileDialog>
 #include <QIcon>
+#include <QLabel>
+#include <QMessageBox>
 #include <QPainter>
 #include <QProxyStyle>
-#include <QLabel>
-#include <QFileDialog>
-#include <QMessageBox>
+#include <QtGui>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/version.h>
@@ -693,7 +693,7 @@ void MainWindow::refreshSoon(int fields)
     if (!myRefreshTimer.isActive())
     {
         myRefreshTimer.setSingleShot(true);
-        myRefreshTimer.start(100);
+        myRefreshTimer.start(200);
     }
 }
 

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -18,6 +18,7 @@
 #include <QWidgetList>
 
 #include "Filters.h"
+#include "Speed.h"
 #include "TorrentFilter.h"
 #include "Typedefs.h"
 
@@ -131,7 +132,6 @@ private slots:
     void openURL();
     void refreshPref(int key);
     void refreshSoon(int fields = ~0);
-    void refreshStatusBar();
     void removeTorrents(bool const deleteFiles);
     void setLocation();
     void setSortAscendingPref(bool);
@@ -177,6 +177,15 @@ private:
     QAction* myAltSpeedAction;
     QString myErrorMessage;
 
+    struct TransferStats
+    {
+        Speed speedUp;
+        Speed speedDown;
+        size_t peersSending = 0;
+        size_t peersReceiving = 0;
+    };
+    TransferStats getTransferStats() const;
+
     enum
     {
         REFRESH_TITLE = (1 << 0),
@@ -188,6 +197,7 @@ private:
     int myRefreshFields = 0;
     QTimer myRefreshTimer;
     void refreshTitle();
-    void refreshTrayIcon();
+    void refreshTrayIcon(const TransferStats&);
+    void refreshStatusBar(const TransferStats&);
     void refreshTorrentViewHeader();
 };

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -13,13 +13,14 @@
 #include <QMainWindow>
 #include <QNetworkReply>
 #include <QPointer>
-#include <QSet>
 #include <QSystemTrayIcon>
 #include <QTimer>
 #include <QWidgetList>
 
 #include "Filters.h"
 #include "TorrentFilter.h"
+#include "Typedefs.h"
+
 #include "ui_MainWindow.h"
 
 class QAction;
@@ -92,7 +93,7 @@ private:
     QIcon getStockIcon(QString const&, int fallback = -1);
     QIcon addEmblem(QIcon icon, QStringList const& emblemNames);
 
-    QSet<int> getSelectedTorrents(bool withMetadataOnly = false) const;
+    torrent_ids_t getSelectedTorrents(bool withMetadataOnly = false) const;
     void updateNetworkIcon();
 
     QMenu* createOptionsMenu();

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -84,9 +84,9 @@ public slots:
 
 protected:
     // QWidget
-    virtual void contextMenuEvent(QContextMenuEvent*);
-    virtual void dragEnterEvent(QDragEnterEvent*);
-    virtual void dropEvent(QDropEvent*);
+    void contextMenuEvent(QContextMenuEvent*) override;
+    void dragEnterEvent(QDragEnterEvent*) override;
+    void dropEvent(QDropEvent*) override;
 
 private:
     QIcon getStockIcon(QString const&, int fallback = -1);
@@ -103,8 +103,8 @@ private:
     void addTorrent(AddData const& addMe, bool showOptions);
 
     // QWidget
-    virtual void hideEvent(QHideEvent* event);
-    virtual void showEvent(QShowEvent* event);
+    void hideEvent(QHideEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private slots:
     void addTorrents(QStringList const& filenames);

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -197,7 +197,7 @@ private:
     int myRefreshFields = 0;
     QTimer myRefreshTimer;
     void refreshTitle();
-    void refreshTrayIcon(const TransferStats&);
-    void refreshStatusBar(const TransferStats&);
+    void refreshTrayIcon(TransferStats const&);
+    void refreshStatusBar(TransferStats const&);
     void refreshTorrentViewHeader();
 };

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -33,8 +33,8 @@ public:
 
 protected:
     // QWidget
-    virtual void dragEnterEvent(QDragEnterEvent*);
-    virtual void dropEvent(QDropEvent*);
+    void dragEnterEvent(QDragEnterEvent*) override;
+    void dropEvent(QDropEvent*) override;
 
 private:
     QString getSource() const;

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -32,14 +32,14 @@ public:
     QString const& path() const;
 
     // QWidget
-    virtual QSize sizeHint() const;
+    QSize sizeHint() const override;
 
 signals:
     void pathChanged(QString const& path);
 
 protected:
     // QWidget
-    virtual void paintEvent(QPaintEvent* event);
+    void paintEvent(QPaintEvent* event) override;
 
 private:
     void updateAppearance();

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -433,7 +433,7 @@ void PrefsDialog::initNetworkTab()
 
 void PrefsDialog::onBlocklistDialogDestroyed(QObject* o)
 {
-    Q_UNUSED(o);
+    Q_UNUSED(o)
 
     myBlocklistDialog = nullptr;
 }

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <QMap>
-#include <QSet>
 
 #include "BaseDialog.h"
 #include "Prefs.h"

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -26,7 +26,7 @@ void RelocateDialog::onMoveToggled(bool b)
     myMoveFlag = b;
 }
 
-RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, QSet<int> const& ids, QWidget* parent) :
+RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torrent_ids_t const& ids, QWidget* parent) :
     BaseDialog(parent),
     mySession(session),
     myIds(ids)

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -8,9 +8,8 @@
 
 #pragma once
 
-#include <QSet>
-
 #include "BaseDialog.h"
+#include "Typedefs.h"
 
 #include "ui_RelocateDialog.h"
 
@@ -22,7 +21,7 @@ class RelocateDialog : public BaseDialog
     Q_OBJECT
 
 public:
-    RelocateDialog(Session&, TorrentModel const&, QSet<int> const& ids, QWidget* parent = nullptr);
+    RelocateDialog(Session&, TorrentModel const&, torrent_ids_t const& ids, QWidget* parent = nullptr);
 
     virtual ~RelocateDialog()
     {
@@ -37,7 +36,7 @@ private slots:
 
 private:
     Session& mySession;
-    QSet<int> const myIds;
+    torrent_ids_t const myIds;
 
     Ui::RelocateDialog ui;
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -204,7 +204,7 @@ QNetworkAccessManager* RpcClient::networkAccessManager()
 
 void RpcClient::localSessionCallback(tr_session* s, tr_variant* response, void* vself)
 {
-    Q_UNUSED(s);
+    Q_UNUSED(s)
 
     RpcClient* self = static_cast<RpcClient*>(vself);
 

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -42,7 +42,7 @@ struct RpcResponse
     QNetworkReply::NetworkError networkError = QNetworkReply::NoError;
 };
 
-Q_DECLARE_METATYPE(QFutureInterface<RpcResponse>);
+Q_DECLARE_METATYPE(QFutureInterface<RpcResponse>)
 
 // The response future -- the RPC engine returns one for each request made.
 typedef QFuture<RpcResponse> RpcResponseFuture;

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -54,10 +54,10 @@ void addList(tr_variant* list, KeyList const& keys)
 }
 
 // If this object is passed as "ids" (compared by address), then recently active torrents are queried.
-auto const recentlyActiveIds = torrent_ids_t { -1 };
+auto const recentlyActiveIds = torrent_ids_t{ -1 };
 
 // If this object is passed as "ids" (compared by being empty), then all torrents are queried.
-auto const allIds = torrent_ids_t { };
+auto const allIds = torrent_ids_t{};
 
 } // namespace
 
@@ -538,7 +538,7 @@ void Session::torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath
 
     q->add([this, ids](RpcResponse const& /*r*/)
         {
-            refreshTorrents(ids,  {TR_KEY_fileStats, TR_KEY_files, TR_KEY_id, TR_KEY_name});
+            refreshTorrents(ids, { TR_KEY_fileStats, TR_KEY_files, TR_KEY_id, TR_KEY_name });
         });
 
     q->run();

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -54,10 +54,10 @@ void addList(tr_variant* list, KeyList const& keys)
 }
 
 // If this object is passed as "ids" (compared by address), then recently active torrents are queried.
-QSet<int> const recentlyActiveIds = QSet<int>() << -1;
+auto const recentlyActiveIds = torrent_ids_t { -1 };
 
 // If this object is passed as "ids" (compared by being empty), then all torrents are queried.
-QSet<int> const allIds;
+auto const allIds = torrent_ids_t { };
 
 } // namespace
 
@@ -405,13 +405,13 @@ bool Session::isLocal() const
 namespace
 {
 
-void addOptionalIds(tr_variant* args, QSet<int> const& ids)
+void addOptionalIds(tr_variant* args, torrent_ids_t const& ids)
 {
     if (&ids == &recentlyActiveIds)
     {
         tr_variantDictAddStr(args, TR_KEY_ids, "recently-active");
     }
-    else if (!ids.isEmpty())
+    else if (!ids.empty())
     {
         tr_variant* idList(tr_variantDictAddList(args, TR_KEY_ids, ids.size()));
 
@@ -424,7 +424,7 @@ void addOptionalIds(tr_variant* args, QSet<int> const& ids)
 
 } // namespace
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, double value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, double value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -434,7 +434,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, double value)
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, int value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, int value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -444,7 +444,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, int value)
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, bool value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, bool value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -454,7 +454,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, bool value)
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QStringList const& value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, QStringList const& value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -469,7 +469,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QStringList c
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QList<int> const& value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, QList<int> const& value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -484,7 +484,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QList<int> co
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QPair<int, QString> const& value)
+void Session::torrentSet(torrent_ids_t const& ids, tr_quark const key, QPair<int, QString> const& value)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -496,7 +496,7 @@ void Session::torrentSet(QSet<int> const& ids, tr_quark const key, QPair<int, QS
     exec(TR_KEY_torrent_set, &args);
 }
 
-void Session::torrentSetLocation(QSet<int> const& ids, QString const& location, bool doMove)
+void Session::torrentSetLocation(torrent_ids_t const& ids, QString const& location, bool doMove)
 {
     tr_variant args;
     tr_variantInitDict(&args, 3);
@@ -507,7 +507,7 @@ void Session::torrentSetLocation(QSet<int> const& ids, QString const& location, 
     exec(TR_KEY_torrent_set_location, &args);
 }
 
-void Session::torrentRenamePath(QSet<int> const& ids, QString const& oldpath, QString const& newname)
+void Session::torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath, QString const& newname)
 {
     tr_variant args;
     tr_variantInitDict(&args, 2);
@@ -536,20 +536,15 @@ void Session::torrentRenamePath(QSet<int> const& ids, QString const& oldpath, QS
             d->show();
         });
 
-    q->add([this](RpcResponse const& r)
+    q->add([this, ids](RpcResponse const& /*r*/)
         {
-            int64_t id = 0;
-
-            if (tr_variantDictFindInt(r.args.get(), TR_KEY_id, &id) && id != 0)
-            {
-                refreshTorrents(QSet<int>() << id, KeyList() << TR_KEY_fileStats << TR_KEY_files << TR_KEY_id << TR_KEY_name);
-            }
+            refreshTorrents(ids,  {TR_KEY_fileStats, TR_KEY_files, TR_KEY_id, TR_KEY_name});
         });
 
     q->run();
 }
 
-void Session::refreshTorrents(QSet<int> const& ids, KeyList const& keys)
+void Session::refreshTorrents(torrent_ids_t const& ids, KeyList const& keys)
 {
     tr_variant args;
     tr_variantInitDict(&args, 3);
@@ -584,17 +579,17 @@ void Session::refreshTorrents(QSet<int> const& ids, KeyList const& keys)
     q->run();
 }
 
-void Session::refreshDetailInfo(QSet<int> const& ids)
+void Session::refreshDetailInfo(torrent_ids_t const& ids)
 {
     refreshTorrents(ids, Torrent::detailInfoKeys);
 }
 
-void Session::refreshExtraStats(QSet<int> const& ids)
+void Session::refreshExtraStats(torrent_ids_t const& ids)
 {
     refreshTorrents(ids, Torrent::mainStatKeys + Torrent::detailStatKeys);
 }
 
-void Session::sendTorrentRequest(char const* request, QSet<int> const& ids)
+void Session::sendTorrentRequest(char const* request, torrent_ids_t const& ids)
 {
     tr_variant args;
     tr_variantInitDict(&args, 1);
@@ -615,37 +610,37 @@ void Session::sendTorrentRequest(char const* request, QSet<int> const& ids)
     q->run();
 }
 
-void Session::pauseTorrents(QSet<int> const& ids)
+void Session::pauseTorrents(torrent_ids_t const& ids)
 {
     sendTorrentRequest("torrent-stop", ids);
 }
 
-void Session::startTorrents(QSet<int> const& ids)
+void Session::startTorrents(torrent_ids_t const& ids)
 {
     sendTorrentRequest("torrent-start", ids);
 }
 
-void Session::startTorrentsNow(QSet<int> const& ids)
+void Session::startTorrentsNow(torrent_ids_t const& ids)
 {
     sendTorrentRequest("torrent-start-now", ids);
 }
 
-void Session::queueMoveTop(QSet<int> const& ids)
+void Session::queueMoveTop(torrent_ids_t const& ids)
 {
     sendTorrentRequest("queue-move-top", ids);
 }
 
-void Session::queueMoveUp(QSet<int> const& ids)
+void Session::queueMoveUp(torrent_ids_t const& ids)
 {
     sendTorrentRequest("queue-move-up", ids);
 }
 
-void Session::queueMoveDown(QSet<int> const& ids)
+void Session::queueMoveDown(torrent_ids_t const& ids)
 {
     sendTorrentRequest("queue-move-down", ids);
 }
 
-void Session::queueMoveBottom(QSet<int> const& ids)
+void Session::queueMoveBottom(torrent_ids_t const& ids)
 {
     sendTorrentRequest("queue-move-bottom", ids);
 }
@@ -660,7 +655,7 @@ void Session::refreshAllTorrents()
     refreshTorrents(allIds, Torrent::mainStatKeys);
 }
 
-void Session::initTorrents(QSet<int> const& ids)
+void Session::initTorrents(torrent_ids_t const& ids)
 {
     refreshTorrents(ids, Torrent::allMainKeys);
 }
@@ -1047,9 +1042,9 @@ void Session::addNewlyCreatedTorrent(QString const& filename, QString const& loc
     exec("torrent-add", &args);
 }
 
-void Session::removeTorrents(QSet<int> const& ids, bool deleteFiles)
+void Session::removeTorrents(torrent_ids_t const& ids, bool deleteFiles)
 {
-    if (!ids.isEmpty())
+    if (!ids.empty())
     {
         tr_variant args;
         tr_variantInitDict(&args, 2);
@@ -1060,9 +1055,9 @@ void Session::removeTorrents(QSet<int> const& ids, bool deleteFiles)
     }
 }
 
-void Session::verifyTorrents(QSet<int> const& ids)
+void Session::verifyTorrents(torrent_ids_t const& ids)
 {
-    if (!ids.isEmpty())
+    if (!ids.empty())
     {
         tr_variant args;
         tr_variantInitDict(&args, 1);
@@ -1072,9 +1067,9 @@ void Session::verifyTorrents(QSet<int> const& ids)
     }
 }
 
-void Session::reannounceTorrents(QSet<int> const& ids)
+void Session::reannounceTorrents(torrent_ids_t const& ids)
 {
-    if (!ids.isEmpty())
+    if (!ids.empty())
     {
         tr_variant args;
         tr_variantInitDict(&args, 1);

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <QObject>
-#include <QSet>
 #include <QString>
 #include <QStringList>
 
@@ -18,6 +17,7 @@
 
 #include "RpcClient.h"
 #include "Torrent.h"
+#include "Typedefs.h"
 
 class AddData;
 class Prefs;
@@ -77,37 +77,37 @@ public:
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
     RpcResponseFuture exec(char const* method, tr_variant* args);
 
-    void torrentSet(QSet<int> const& ids, tr_quark const key, bool val);
-    void torrentSet(QSet<int> const& ids, tr_quark const key, int val);
-    void torrentSet(QSet<int> const& ids, tr_quark const key, double val);
-    void torrentSet(QSet<int> const& ids, tr_quark const key, QList<int> const& val);
-    void torrentSet(QSet<int> const& ids, tr_quark const key, QStringList const& val);
-    void torrentSet(QSet<int> const& ids, tr_quark const key, QPair<int, QString> const& val);
-    void torrentSetLocation(QSet<int> const& ids, QString const& path, bool doMove);
-    void torrentRenamePath(QSet<int> const& ids, QString const& oldpath, QString const& newname);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, bool val);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, int val);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, double val);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, QList<int> const& val);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, QStringList const& val);
+    void torrentSet(torrent_ids_t const& ids, tr_quark const key, QPair<int, QString> const& val);
+    void torrentSetLocation(torrent_ids_t const& ids, QString const& path, bool doMove);
+    void torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath, QString const& newname);
     void addTorrent(AddData const& addme, tr_variant* top, bool trashOriginal);
-    void initTorrents(QSet<int> const& ids = QSet<int>());
-    void pauseTorrents(QSet<int> const& torrentIds = QSet<int>());
-    void startTorrents(QSet<int> const& torrentIds = QSet<int>());
-    void startTorrentsNow(QSet<int> const& torrentIds = QSet<int>());
-    void refreshDetailInfo(QSet<int> const& torrentIds);
+    void initTorrents(torrent_ids_t const& ids = {});
+    void pauseTorrents(torrent_ids_t const& torrentIds = {});
+    void startTorrents(torrent_ids_t const& torrentIds = {});
+    void startTorrentsNow(torrent_ids_t const& torrentIds = {});
+    void refreshDetailInfo(torrent_ids_t const& torrentIds);
     void refreshActiveTorrents();
     void refreshAllTorrents();
     void addNewlyCreatedTorrent(QString const& filename, QString const& localPath);
-    void verifyTorrents(QSet<int> const& torrentIds);
-    void reannounceTorrents(QSet<int> const& torrentIds);
-    void refreshExtraStats(QSet<int> const& ids);
+    void verifyTorrents(torrent_ids_t const& torrentIds);
+    void reannounceTorrents(torrent_ids_t const& torrentIds);
+    void refreshExtraStats(torrent_ids_t const& ids);
 
 public slots:
     void addTorrent(AddData const& addme);
     void launchWebInterface();
-    void queueMoveBottom(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveDown(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveTop(QSet<int> const& torrentIds = QSet<int>());
-    void queueMoveUp(QSet<int> const& torrentIds = QSet<int>());
+    void queueMoveBottom(torrent_ids_t const& torrentIds = {});
+    void queueMoveDown(torrent_ids_t const& torrentIds = {});
+    void queueMoveTop(torrent_ids_t const& torrentIds = {});
+    void queueMoveUp(torrent_ids_t const& torrentIds = {});
     void refreshSessionInfo();
     void refreshSessionStats();
-    void removeTorrents(QSet<int> const& torrentIds, bool deleteFiles = false);
+    void removeTorrents(torrent_ids_t const& torrentIds, bool deleteFiles = false);
     void updatePref(int key);
 
 signals:
@@ -131,8 +131,8 @@ private:
 
     void sessionSet(tr_quark const key, QVariant const& variant);
     void pumpRequests();
-    void sendTorrentRequest(char const* request, QSet<int> const& torrentIds);
-    void refreshTorrents(QSet<int> const& torrentIds, Torrent::KeyList const& keys);
+    void sendTorrentRequest(char const* request, torrent_ids_t const& torrentIds);
+    void refreshTorrents(torrent_ids_t const& torrentIds, Torrent::KeyList const& keys);
 
     static void updateStats(tr_variant* d, tr_session_stats* stats);
 

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -24,13 +24,9 @@ class SessionDialog : public BaseDialog
 public:
     SessionDialog(Session& session, Prefs& prefs, QWidget* parent = nullptr);
 
-    virtual ~SessionDialog()
-    {
-    }
-
 public slots:
     // QDialog
-    virtual void accept();
+    void accept() override;
 
 private slots:
     void resensitize();

--- a/qt/SqueezeLabel.h
+++ b/qt/SqueezeLabel.h
@@ -53,5 +53,5 @@ public:
 
 protected:
     // QWidget
-    virtual void paintEvent(QPaintEvent* paintEvent);
+    void paintEvent(QPaintEvent* paintEvent) override;
 };

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -22,10 +22,10 @@ class StatsDialog : public BaseDialog
 
 public:
     StatsDialog(Session&, QWidget* parent = nullptr);
-    ~StatsDialog();
+    ~StatsDialog() override;
 
     // QWidget
-    virtual void setVisible(bool visible);
+    void setVisible(bool visible) override;
 
 private slots:
     void updateStats();

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -755,19 +755,19 @@ bool Torrent::update(tr_quark const* keys, tr_variant** values, size_t n)
         // update the trackers
         if (trackers_ != trackers)
         {
-            QStringList hosts;
+            QStringList displayNames;
+            displayNames.reserve(trackers.size());
             for (auto const& tracker : trackers)
             {
                 auto const url = QUrl(tracker);
-                qApp->faviconCache().add(url);
-                hosts.append(FaviconCache::getHost(url));
+                auto const key = qApp->faviconCache().add(url);
+                displayNames.append(FaviconCache::getDisplayName(key));
             }
 
-            hosts.removeDuplicates();
-            hosts.removeOne(QString());
+            displayNames.removeDuplicates();
 
             trackers_.swap(trackers);
-            hosts_.swap(hosts);
+            trackerDisplayNames_.swap(displayNames);
             changed = true;
         }
     }
@@ -791,7 +791,6 @@ bool Torrent::update(tr_quark const* keys, tr_variant** values, size_t n)
             if (tr_variantDictFindStr(child, TR_KEY_announce, &str, &len))
             {
                 trackerStat.announce = QString::fromUtf8(str, len);
-                qApp->faviconCache().add(QUrl(trackerStat.announce));
             }
 
             if (tr_variantDictFindInt(child, TR_KEY_announceState, &i))

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -503,7 +503,7 @@ int Torrent::compareETA(Torrent const& that) const
 
 int Torrent::compareTracker(Torrent const& that) const
 {
-    Q_UNUSED(that);
+    Q_UNUSED(that)
 
     // FIXME
     return 0;

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -75,8 +75,6 @@ Torrent::Property Torrent::myProperties[] =
     { DOWNLOADED_EVER, TR_KEY_downloadedEver, QVariant::ULongLong },
     { UPLOADED_EVER, TR_KEY_uploadedEver, QVariant::ULongLong },
     { FAILED_EVER, TR_KEY_corruptEver, QVariant::ULongLong },
-    { TRACKERS, TR_KEY_trackers, QVariant::StringList },
-    { HOSTS, TR_KEY_NONE, QVariant::StringList },
     { TRACKERSTATS, TR_KEY_trackerStats, CustomVariantType::TrackerStatsList },
     { MIME_ICON, TR_KEY_NONE, QVariant::Icon },
     { SEED_RATIO_LIMIT, TR_KEY_seedRatioLimit, QVariant::Double },
@@ -406,7 +404,7 @@ bool Torrent::hasFileSubstring(QString const& substr) const
 
 bool Torrent::hasTrackerSubstring(QString const& substr) const
 {
-    for (QString const& s : myValues[TRACKERS].toStringList())
+    for (auto const& s : trackers())
     {
         if (s.contains(substr, Qt::CaseInsensitive))
         {
@@ -657,7 +655,6 @@ bool Torrent::update(tr_quark const* keys, tr_variant** values, size_t n)
                 break;
             }
 
-        case QVariant::StringList:
         case CustomVariantType::PeerList:
             // handled below
             break;
@@ -756,7 +753,7 @@ bool Torrent::update(tr_quark const* keys, tr_variant** values, size_t n)
         }
 
         // update the trackers
-        if (myValues[TRACKERS] != trackers)
+        if (trackers_ != trackers)
         {
             QStringList hosts;
             for (auto const& tracker : trackers)
@@ -769,8 +766,8 @@ bool Torrent::update(tr_quark const* keys, tr_variant** values, size_t n)
             hosts.removeDuplicates();
             hosts.removeOne(QString());
 
-            myValues[TRACKERS].setValue(trackers);
-            myValues[HOSTS].setValue(hosts);
+            trackers_.swap(trackers);
+            hosts_.swap(hosts);
             changed = true;
         }
     }

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -489,12 +489,12 @@ public:
         return myValues[TRACKERSTATS].value<TrackerStatsList>();
     }
 
-    const QStringList& trackers() const
+    QStringList const& trackers() const
     {
         return trackers_;
     }
 
-    const QStringList& trackerDisplayNames() const
+    QStringList const& trackerDisplayNames() const
     {
         return trackerDisplayNames_;
     }

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -231,7 +231,7 @@ public:
 
     bool hasError() const
     {
-        return !getError().isEmpty();
+        return getInt(ERROR) != TR_STAT_OK;
     }
 
     bool isDone() const

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -158,8 +158,6 @@ public:
         DOWNLOADED_EVER,
         UPLOADED_EVER,
         FAILED_EVER,
-        TRACKERS,
-        HOSTS,
         TRACKERSTATS,
         MIME_ICON,
         SEED_RATIO_LIMIT,
@@ -493,14 +491,14 @@ public:
         return myValues[TRACKERSTATS].value<TrackerStatsList>();
     }
 
-    QStringList trackers() const
+    const QStringList& trackers() const
     {
-        return myValues[TRACKERS].value<QStringList>();
+        return trackers_;
     }
 
-    QStringList hosts() const
+    const QStringList& hosts() const
     {
-        return myValues[HOSTS].value<QStringList>();
+        return hosts_;
     }
 
     PeerList peers() const
@@ -618,6 +616,9 @@ private:
     bool setString(int key, char const*, size_t len);
     bool setSize(int key, qulonglong);
     bool setTime(int key, time_t);
+
+    QStringList trackers_;
+    QStringList hosts_;
 
     char const* getMimeTypeString() const;
     void updateMimeIcon();

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -186,8 +186,6 @@ public:
 
 public:
     Torrent(Prefs const&, int id);
-    virtual ~Torrent() = default;
-    ;
 
     int getBandwidthPriority() const
     {

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -494,9 +494,9 @@ public:
         return trackers_;
     }
 
-    const QStringList& hosts() const
+    const QStringList& trackerDisplayNames() const
     {
-        return hosts_;
+        return trackerDisplayNames_;
     }
 
     PeerList peers() const
@@ -616,7 +616,7 @@ private:
     bool setTime(int key, time_t);
 
     QStringList trackers_;
-    QStringList hosts_;
+    QStringList trackerDisplayNames_;
 
     char const* getMimeTypeString() const;
     void updateMimeIcon();

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -424,7 +424,7 @@ QIcon& TorrentDelegate::getWarningEmblem() const
 {
     auto& icon = myWarningEmblem;
 
-    if (icon.isNull()) 
+    if (icon.isNull())
     {
         icon = QIcon::fromTheme(QLatin1String("emblem-important"));
     }

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -420,6 +420,23 @@ QSize TorrentDelegate::sizeHint(QStyleOptionViewItem const& option, QModelIndex 
     return QSize(option.rect.width(), *myHeightHint);
 }
 
+QIcon& TorrentDelegate::getWarningEmblem() const
+{
+    auto& icon = myWarningEmblem;
+
+    if (icon.isNull()) 
+    {
+        icon = QIcon::fromTheme(QLatin1String("emblem-important"));
+    }
+
+    if (icon.isNull())
+    {
+        icon = qApp->style()->standardIcon(QStyle::SP_MessageBoxWarning);
+    }
+
+    return icon;
+}
+
 void TorrentDelegate::paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const
 {
     Torrent const* tor(index.data(TorrentModel::TorrentRole).value<Torrent const*>());
@@ -531,8 +548,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     progressBarState |= QStyle::State_Small;
 
     QIcon::Mode const emblemIm = isItemSelected ? QIcon::Selected : QIcon::Normal;
-    QIcon const emblemIcon = tor.hasError() ? QIcon::fromTheme(QLatin1String("emblem-important"),
-        style->standardIcon(QStyle::SP_MessageBoxWarning)) : QIcon();
+    QIcon const emblemIcon = tor.hasError() ? getWarningEmblem() : QIcon();
 
     // layout
     QSize const m(margin(*style));

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -155,7 +155,7 @@ TorrentDelegate::~TorrentDelegate()
 
 QSize TorrentDelegate::margin(QStyle const& style) const
 {
-    Q_UNUSED(style);
+    Q_UNUSED(style)
 
     return QSize(4, 4);
 }

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -32,6 +32,7 @@ public:
 protected:
     QSize margin(QStyle const& style) const;
     void setProgressBarPercentDone(QStyleOptionViewItem const& option, Torrent const&) const;
+    QIcon& getWarningEmblem() const;
 
     // Our own overridables
     virtual QSize sizeHint(QStyleOptionViewItem const&, Torrent const&) const;
@@ -55,4 +56,5 @@ protected:
 private:
     mutable std::optional<int> myHeightHint;
     mutable QFont myHeightFont;
+    mutable QIcon myWarningEmblem;
 };

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -26,8 +26,8 @@ public:
     virtual ~TorrentDelegate();
 
     // QAbstractItemDelegate
-    virtual QSize sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const;
-    virtual void paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const;
+    QSize sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const override;
+    void paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const override;
 
 protected:
     QSize margin(QStyle const& style) const;

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -221,8 +221,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     progressBarState |= QStyle::State_Small;
 
     QIcon::Mode const emblemIm = isItemSelected ? QIcon::Selected : QIcon::Normal;
-    QIcon const emblemIcon = tor.hasError() ? QIcon::fromTheme(QLatin1String("emblem-important"),
-        style->standardIcon(QStyle::SP_MessageBoxWarning)) : QIcon();
+    QIcon const emblemIcon = tor.hasError() ? getWarningEmblem() : QIcon();
 
     // layout
     QSize const m(margin(*style));

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -20,12 +20,8 @@ public:
     {
     }
 
-    virtual ~TorrentDelegateMin()
-    {
-    }
-
 protected:
     // TorrentDelegate
-    virtual QSize sizeHint(QStyleOptionViewItem const&, Torrent const&) const;
-    virtual void drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const&) const;
+    QSize sizeHint(QStyleOptionViewItem const&, Torrent const&) const override;
+    void drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const&) const override;
 };

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -322,18 +322,9 @@ void TorrentFilter::countTorrentsPerMode(int* setmeCounts) const
 {
     std::fill_n(setmeCounts, static_cast<std::size_t>(FilterMode::NUM_MODES), 0);
 
-    for (int row(0);; ++row)
+    for (auto const& tor : dynamic_cast<TorrentModel*>(sourceModel())->torrents())
     {
-        QModelIndex index(sourceModel()->index(row, 0));
-
-        if (!index.isValid())
-        {
-            break;
-        }
-
-        Torrent const* tor(index.data(TorrentModel::TorrentRole).value<Torrent const*>());
-
-        for (int mode(0); mode < FilterMode::NUM_MODES; ++mode)
+        for (int mode = 0; mode < FilterMode::NUM_MODES; ++mode)
         {
             if (activityFilterAcceptsTorrent(tor, mode))
             {

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -39,8 +39,8 @@ public:
 
 protected:
     // QSortFilterProxyModel
-    virtual bool filterAcceptsRow(int, QModelIndex const&) const;
-    virtual bool lessThan(QModelIndex const&, QModelIndex const&) const;
+    bool filterAcceptsRow(int, QModelIndex const&) const override;
+    bool lessThan(QModelIndex const&, QModelIndex const&) const override;
 
 private:
     bool activityFilterAcceptsTorrent(Torrent const* tor, FilterMode const& mode) const;

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -478,29 +478,6 @@ void TorrentModel::rowsRemove(torrents_t const& torrents)
 ****
 ***/
 
-void TorrentModel::getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed,
-    size_t& downloadPeerCount) const
-{
-    Speed upSpeed;
-    Speed downSpeed;
-    size_t upCount = 0;
-    size_t downCount = 0;
-
-    for (Torrent const* const tor : myTorrents)
-    {
-        upSpeed += tor->uploadSpeed();
-        upCount += tor->peersWeAreUploadingTo();
-        downSpeed += tor->downloadSpeed();
-        downCount += tor->webseedsWeAreDownloadingFrom();
-        downCount += tor->peersWeAreDownloadingFrom();
-    }
-
-    uploadSpeed = upSpeed;
-    uploadPeerCount = upCount;
-    downloadSpeed = downSpeed;
-    downloadPeerCount = downCount;
-}
-
 bool TorrentModel::hasTorrent(QString const& hashString) const
 {
     auto test = [hashString](auto const& tor) { return tor->hashString() == hashString; };

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -46,7 +46,7 @@ struct TorrentIdLessThan
 template<typename Iter>
 auto getIds(Iter it, Iter end)
 {
-    std::unordered_set<int> ids;
+    torrent_ids_t ids;
 
     for ( ; it != end; ++it)
     {
@@ -154,11 +154,11 @@ void TorrentModel::removeTorrents(tr_variant* list)
 void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
 {
     auto const old = isCompleteList ? myTorrents : torrents_t{};
-    auto added = std::unordered_set<int>{};
-    auto changed = std::unordered_set<int>{};
-    auto completed = std::unordered_set<int>{};
+    auto added = torrent_ids_t{};
+    auto changed = torrent_ids_t{};
+    auto completed = torrent_ids_t{};
     auto instantiated = torrents_t{};
-    auto needinfo = std::unordered_set<int>{};
+    auto needinfo = torrent_ids_t{};
     auto processed = torrents_t{};
 
     auto const now = time(nullptr);
@@ -370,7 +370,7 @@ Torrent const* TorrentModel::getTorrentFromId(int id) const
 ****
 ***/
 
-std::vector<TorrentModel::span_t> TorrentModel::getSpans(std::unordered_set<int> const& ids) const
+std::vector<TorrentModel::span_t> TorrentModel::getSpans(torrent_ids_t const& ids) const
 {
     // ids -> rows
     std::vector<int> rows;

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -43,7 +43,8 @@ struct TorrentIdLessThan
     }
 };
 
-template<typename Iter> auto getIds(Iter it, Iter end)
+template<typename Iter>
+auto getIds(Iter it, Iter end)
 {
     std::unordered_set<int> ids;
 

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -43,10 +43,9 @@ struct TorrentIdLessThan
     }
 };
 
-template<typename Iter>
-QSet<int> getIds(Iter it, Iter end)
+template<typename Iter> auto getIds(Iter it, Iter end)
 {
-    QSet<int> ids;
+    std::unordered_set<int> ids;
 
     for ( ; it != end; ++it)
     {
@@ -145,7 +144,7 @@ void TorrentModel::removeTorrents(tr_variant* list)
         }
     }
 
-    if (!torrents.isEmpty())
+    if (!torrents.empty())
     {
         rowsRemove(torrents);
     }
@@ -154,11 +153,11 @@ void TorrentModel::removeTorrents(tr_variant* list)
 void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
 {
     auto const old = isCompleteList ? myTorrents : torrents_t{};
-    auto added = QSet<int>{};
-    auto changed = QSet<int>{};
-    auto completed = QSet<int>{};
+    auto added = std::unordered_set<int>{};
+    auto changed = std::unordered_set<int>{};
+    auto completed = std::unordered_set<int>{};
     auto instantiated = torrents_t{};
-    auto needinfo = QSet<int>{};
+    auto needinfo = std::unordered_set<int>{};
     auto processed = torrents_t{};
 
     auto const now = time(nullptr);
@@ -271,7 +270,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
             needinfo.insert(id);
         }
 
-        if (recently_added(tor) && tor->hasName() && !myAlreadyAdded.contains(id))
+        if (recently_added(tor) && tor->hasName() && !myAlreadyAdded.count(id))
         {
             added.insert(id);
             myAlreadyAdded.insert(id);
@@ -287,34 +286,34 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool isCompleteList)
 
     // model upkeep
 
-    if (!instantiated.isEmpty())
+    if (!instantiated.empty())
     {
         rowsAdd(instantiated);
     }
 
-    if (!changed.isEmpty())
+    if (!changed.empty())
     {
         rowsEmitChanged(changed);
     }
 
     // emit signals
 
-    if (!added.isEmpty())
+    if (!added.empty())
     {
         emit torrentsAdded(added);
     }
 
-    if (!needinfo.isEmpty())
+    if (!needinfo.empty())
     {
         emit torrentsNeedInfo(needinfo);
     }
 
-    if (!changed.isEmpty())
+    if (!changed.empty())
     {
         emit torrentsChanged(changed);
     }
 
-    if (!completed.isEmpty())
+    if (!completed.empty())
     {
         emit torrentsCompleted(completed);
     }
@@ -370,7 +369,7 @@ Torrent const* TorrentModel::getTorrentFromId(int id) const
 ****
 ***/
 
-std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) const
+std::vector<TorrentModel::span_t> TorrentModel::getSpans(std::unordered_set<int> const& ids) const
 {
     // ids -> rows
     std::vector<int> rows;
@@ -425,7 +424,7 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(QSet<int> const& ids) c
 ****
 ***/
 
-void TorrentModel::rowsEmitChanged(QSet<int> const& ids)
+void TorrentModel::rowsEmitChanged(torrent_ids_t const& ids)
 {
     for (auto const& span : getSpans(ids))
     {
@@ -437,7 +436,7 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
 {
     auto const compare = TorrentIdLessThan();
 
-    if (myTorrents.isEmpty())
+    if (myTorrents.empty())
     {
         beginInsertRows(QModelIndex(), 0, torrents.size() - 1);
         myTorrents = torrents;

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -82,7 +82,7 @@ void TorrentModel::clear()
 
 int TorrentModel::rowCount(QModelIndex const& parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
 
     return myTorrents.size();
 }

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -9,10 +9,12 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 
 #include <QAbstractListModel>
-#include <QSet>
-#include <QVector>
+//#include <QVector>
+
+#include <Typedefs.h>
 
 class Prefs;
 class Speed;
@@ -55,22 +57,22 @@ public slots:
     void removeTorrents(tr_variant* torrentList);
 
 signals:
-    void torrentsAdded(QSet<int>);
-    void torrentsChanged(QSet<int>);
-    void torrentsCompleted(QSet<int>);
-    void torrentsNeedInfo(QSet<int>);
+    void torrentsAdded(torrent_ids_t const&);
+    void torrentsChanged(torrent_ids_t const&);
+    void torrentsCompleted(torrent_ids_t const&);
+    void torrentsNeedInfo(torrent_ids_t const&);
 
 private:
     void rowsAdd(torrents_t const& torrents);
     void rowsRemove(torrents_t const& torrents);
-    void rowsEmitChanged(QSet<int> const& ids);
+    void rowsEmitChanged(torrent_ids_t const& ids);
 
     std::optional<int> getRow(int id) const;
     std::optional<int> getRow(Torrent const* tor) const;
     using span_t = std::pair<int, int>;
-    std::vector<span_t> getSpans(QSet<int> const& ids) const;
+    std::vector<span_t> getSpans(torrent_ids_t const& ids) const;
 
     Prefs const& myPrefs;
-    QSet<int> myAlreadyAdded;
+    torrent_ids_t myAlreadyAdded;
     torrents_t myTorrents;
 };

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <QAbstractListModel>
-//#include <QVector>
+// #include <QVector>
 
 #include <Typedefs.h>
 
@@ -45,7 +45,7 @@ public:
     Torrent const* getTorrentFromId(int id) const;
 
     using torrents_t = QVector<Torrent*>;
-    const torrents_t& torrents() const { return myTorrents; }
+    torrents_t const& torrents() const { return myTorrents; }
 
     // QAbstractItemModel
     int rowCount(QModelIndex const& parent = QModelIndex()) const override;

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -43,6 +43,8 @@ public:
     Torrent const* getTorrentFromId(int id) const;
 
     void getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed, size_t& downloadPeerCount) const;
+    using torrents_t = QVector<Torrent*>;
+    const torrents_t& torrents() const { return myTorrents; }
 
     // QAbstractItemModel
     int rowCount(QModelIndex const& parent = QModelIndex()) const override;
@@ -59,9 +61,8 @@ signals:
     void torrentsNeedInfo(QSet<int>);
 
 private:
-    using torrents_t = QVector<Torrent*>;
     void rowsAdd(torrents_t const& torrents);
-    void rowsRemove(QSet<Torrent*> const& torrents);
+    void rowsRemove(torrents_t const& torrents);
     void rowsEmitChanged(QSet<int> const& ids);
 
     std::optional<int> getRow(int id) const;
@@ -70,6 +71,6 @@ private:
     std::vector<span_t> getSpans(QSet<int> const& ids) const;
 
     Prefs const& myPrefs;
-    torrents_t myTorrents;
     QSet<int> myAlreadyAdded;
+    torrents_t myTorrents;
 };

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -34,7 +34,7 @@ public:
     };
 
     explicit TorrentModel(Prefs const& prefs);
-    virtual ~TorrentModel();
+    virtual ~TorrentModel() override;
     void clear();
 
     bool hasTorrent(QString const& hashString) const;

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -44,7 +44,6 @@ public:
     Torrent* getTorrentFromId(int id);
     Torrent const* getTorrentFromId(int id) const;
 
-    void getTransferSpeed(Speed& uploadSpeed, size_t& uploadPeerCount, Speed& downloadSpeed, size_t& downloadPeerCount) const;
     using torrents_t = QVector<Torrent*>;
     const torrents_t& torrents() const { return myTorrents; }
 

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -24,7 +24,7 @@ signals:
     void headerDoubleClicked();
 
 protected:
-    virtual void resizeEvent(QResizeEvent* event);
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     class HeaderWidget;

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -88,7 +88,7 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
 
 QSize TrackerDelegate::margin(QStyle const& style) const
 {
-    Q_UNUSED(style);
+    Q_UNUSED(style)
 
     return myMargin;
 }

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -26,15 +26,11 @@ public:
     {
     }
 
-    virtual ~TrackerDelegate()
-    {
-    }
-
     void setShowMore(bool b);
 
     // QAbstractItemDelegate
-    virtual QSize sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const;
-    virtual void paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const;
+    QSize sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const override;
+    void paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const override;
 
 protected:
     QString getText(TrackerInfo const&) const;

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -16,7 +16,7 @@
 
 int TrackerModel::rowCount(QModelIndex const& parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
 
     return parent.isValid() ? 0 : myRows.size();
 }

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -80,7 +80,7 @@ struct CompareTrackers
     }
 };
 
-void TrackerModel::refresh(TorrentModel const& torrentModel, QSet<int> const& ids)
+void TrackerModel::refresh(TorrentModel const& torrentModel, torrent_ids_t const& ids)
 {
     // build a list of the TrackerInfos
     QVector<TrackerInfo> trackers;

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <QAbstractListModel>
-#include <QSet>
 #include <QVector>
 
 #include "Torrent.h"
+#include "Typedefs.h"
 
 class TorrentModel;
 
@@ -37,7 +37,7 @@ public:
 public:
     TrackerModel() =default;
 
-    void refresh(TorrentModel const&, QSet<int> const& ids);
+    void refresh(TorrentModel const&, torrent_ids_t const& ids);
     int find(int torrentId, QString const& url) const;
 
     // QAbstractItemModel

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -35,7 +35,7 @@ public:
     };
 
 public:
-    TrackerModel() =default;
+    TrackerModel() = default;
 
     void refresh(TorrentModel const&, torrent_ids_t const& ids);
     int find(int torrentId, QString const& url) const;

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -35,20 +35,14 @@ public:
     };
 
 public:
-    TrackerModel()
-    {
-    }
-
-    virtual ~TrackerModel()
-    {
-    }
+    TrackerModel() =default;
 
     void refresh(TorrentModel const&, QSet<int> const& ids);
     int find(int torrentId, QString const& url) const;
 
     // QAbstractItemModel
-    virtual int rowCount(QModelIndex const& parent = QModelIndex()) const;
-    virtual QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const;
+    int rowCount(QModelIndex const& parent = QModelIndex()) const override;
+    QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const override;
 
 private:
     typedef QVector<TrackerInfo> rows_t;

--- a/qt/Typedefs.h
+++ b/qt/Typedefs.h
@@ -3,5 +3,3 @@
 #include <unordered_set>
 
 using torrent_ids_t = std::unordered_set<int>;
-
-

--- a/qt/Typedefs.h
+++ b/qt/Typedefs.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <unordered_set>
+
+using torrent_ids_t = std::unordered_set<int>;
+
+

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -6,8 +6,9 @@
  *
  */
 
-#include <map>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -109,12 +110,13 @@ QIcon fileIcon()
     return icon;
 }
 
-std::map<QString, QIcon> iconCache;
+std::unordered_map<QString, QIcon> iconCache;
+
 QIcon const getMimeIcon(QString const& filename)
 {
     // If the suffix doesn't match a mime type, treat it as a folder.
     // This heuristic is fast and yields good results for torrent names.
-    static std::set<QString> suffixes;
+    static std::unordered_set<QString> suffixes;
     if (suffixes.empty())
     {
         for (auto const& type : QMimeDatabase().allMimeTypes())

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -98,3 +98,17 @@ public:
                s.startsWith(QStringLiteral("https://"));
     }
 };
+
+namespace std
+{
+
+template<> struct hash<QString>
+{
+    std::size_t operator()(const QString& s) const
+    {
+        return qHash(s);
+    }
+};
+
+} // namespace std
+

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -80,7 +80,7 @@ public:
             return false;
         }
 
-        for (QChar const ch : s)
+        for (auto const& ch : s)
         {
             if (!isxdigit(ch.unicode()))
             {
@@ -93,9 +93,8 @@ public:
 
     static bool isUriWithSupportedScheme(QString const& s)
     {
-        static QString const ftp = QString::fromUtf8("ftp://");
-        static QString const http = QString::fromUtf8("http://");
-        static QString const https = QString::fromUtf8("https://");
-        return s.startsWith(http) || s.startsWith(https) || s.startsWith(ftp);
+        return s.startsWith(QStringLiteral("ftp://")) ||
+               s.startsWith(QStringLiteral("http://")) ||
+               s.startsWith(QStringLiteral("https://"));
     }
 };

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -94,21 +94,21 @@ public:
     static bool isUriWithSupportedScheme(QString const& s)
     {
         return s.startsWith(QStringLiteral("ftp://")) ||
-               s.startsWith(QStringLiteral("http://")) ||
-               s.startsWith(QStringLiteral("https://"));
+            s.startsWith(QStringLiteral("http://")) ||
+            s.startsWith(QStringLiteral("https://"));
     }
 };
 
 namespace std
 {
 
-template<> struct hash<QString>
+template<>
+struct hash<QString>
 {
-    std::size_t operator()(const QString& s) const
+    std::size_t operator ()(QString const& s) const
     {
         return qHash(s);
     }
 };
 
 } // namespace std
-

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -28,10 +28,6 @@ WatchDir::WatchDir(TorrentModel const& model) :
 {
 }
 
-WatchDir::~WatchDir()
-{
-}
-
 /***
 ****
 ***/

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -22,7 +22,6 @@ class WatchDir : public QObject
 
 public:
     WatchDir(TorrentModel const&);
-    virtual ~WatchDir();
 
     void setPath(QString const& path, bool isEnabled);
 

--- a/qt/qtr.pro
+++ b/qt/qtr.pro
@@ -121,6 +121,6 @@ SOURCES += AboutDialog.cc \
            Utils.cc \
            WatchDir.cc
 HEADERS += $$replace(SOURCES, .cc, .h)
-HEADERS += BaseDialog.h CustomVariantType.h Speed.h
+HEADERS += BaseDialog.h CustomVariantType.h Speed.h Typedefs.h
 
 win32:RC_FILE = qtr.rc


### PR DESCRIPTION
Methodology:

1. `$ perf record --call-graph dwarf qt/transmission-qt`
2. `$ hotspot perf.data`
3. find low-hanging fruit
4. repeat

What's New:

1. Use a better size heuristic when preallocating container nodes during JSON parsing in `libtransmission/variant-json.c`
2. Make `Torrent::hasError()` faster. Previously it was generating the error string as part of the process.
3. Use unordered containers where possible.
4. Generate a torrent's trackerDisplayNames once in `Torrent::update()`, instead of every time there's a filterbar update
5. Add a const torrent container accessor in TorrentModel so client code can call `for (auto const& tor : model.torrents())` instead of iterating through all of the model's QModelIndices
6. Scale the favicons once (when adding to cache) rather than each time used
7. Remove some unnecessary accessor calls in `MainWindow::refreshActionSensitivity()`
8. Two of the `MainWindow::refreshUIFoo()` functions needed to count the overall torrent speeds. Instead of calculating it twice, just do that once and pass the result to both of the UI refresh functions.
9. There are _many_ events that can trigger statusbar updates, so debounce the updates to 200 msec.
10. In TorrentDelegate, cache the warning emblem icon
