### PR TITLE
Don't bump upload activity on incomplete torrents

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -776,7 +776,10 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
 
             tor->uploadedCur += e->length;
             tr_announcerAddBytes(tor, TR_ANN_UP, e->length);
-            tor->setDateActive(now);
+            if (tor->isDone())
+            {
+                tor->setDateActive(now);
+            }
             tor->setDirty();
             tr_statsAddUploaded(tor->session, e->length);
 


### PR DESCRIPTION
Described in issue #995; retargetted version of #998.  With this, you have a way to spot dead torrents that are not going to ever complete, despite other people wanting to download them as well.