### PR TITLE
Fix musl build

### DIFF
--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -29,6 +29,7 @@ extern "C"
 #include <stddef.h> /* size_t */
 #include <stdint.h> /* uintN_t */
 #include <time.h> /* time_t */
+#include <sys/types.h>
 
 #include "tr-macros.h"
 


### PR DESCRIPTION
Downloaded from
https://cgit.gentoo.org/proj/musl.git/tree/net-p2p/transmission/files/transmission-2.84-musl-missing-header.patch

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

libtransmission/transmission.h: add missing <sys/types.h>

transmission.h and several files including it, like bitfield.c and fdlimits.h
make reference to ssize_t, off_t and other types defined in <sys/types.h> but
never include the header.  By including <sys/types.h> in transmission.h, the
required type definitions are propagated to all files that need them.

Not including <sys/types.h> on glibc and uClibc systems does not pose a problem
because of the way the headers stack in those C Standard Libraries, but on musl
excluding <sys/types.h> leads to compile time failure.

For the POSIX specs, see

http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html

Signed-of-by: Anthony G. Basile <blueness@gentoo.org>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/transmission/0002-musl-missing-header.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>