### PR TITLE
use metainfo folder instead of appdata

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -58,11 +58,11 @@ if(ENABLE_NLS)
         VERBATIM
     )
 
-    set(${PROJECT_NAME}_APPDATA_FILE "${PROJECT_BINARY_DIR}/${TR_NAME}-gtk.appdata.xml")
+    set(${PROJECT_NAME}_METAINFO_FILE "${PROJECT_BINARY_DIR}/${TR_NAME}-gtk.metainfo.xml")
     add_custom_command(
-        OUTPUT ${${PROJECT_NAME}_APPDATA_FILE}
-        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --xml -d ${CMAKE_SOURCE_DIR}/po --template ${PROJECT_SOURCE_DIR}/transmission-gtk.appdata.xml.in -o ${${PROJECT_NAME}_APPDATA_FILE}
-        DEPENDS ${PROJECT_SOURCE_DIR}/transmission-gtk.appdata.xml.in
+        OUTPUT ${${PROJECT_NAME}_METAINFO_FILE}
+        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --xml -d ${CMAKE_SOURCE_DIR}/po --template ${PROJECT_SOURCE_DIR}/transmission-gtk.metainfo.xml.in -o ${${PROJECT_NAME}_METAINFO_FILE}
+        DEPENDS ${PROJECT_SOURCE_DIR}/transmission-gtk.metainfo.xml.in
         VERBATIM
     )
 endif()
@@ -159,7 +159,7 @@ add_executable(${TR_NAME}-gtk WIN32
     ${${PROJECT_NAME}_SOURCES}
     ${${PROJECT_NAME}_HEADERS}
     ${${PROJECT_NAME}_DESKTOP_FILE}
-    ${${PROJECT_NAME}_APPDATA_FILE}
+    ${${PROJECT_NAME}_METAINFO_FILE}
     ${${PROJECT_NAME}_WIN32_RC_FILE}
 )
 
@@ -201,7 +201,7 @@ endif()
 
 if(ENABLE_NLS)
     install(FILES ${${PROJECT_NAME}_DESKTOP_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-    install(FILES ${${PROJECT_NAME}_APPDATA_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/appdata)
+    install(FILES ${${PROJECT_NAME}_METAINFO_FILE} DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 else()
     install(FILES transmission-gtk.desktop.in DESTINATION ${CMAKE_INSTALL_DATADIR}/applications RENAME ${TR_NAME}-gtk.desktop)
 endif()

--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -12,7 +12,7 @@ Copyright 2017 Endless Mobile, Inc.
   <summary>Download and share files over BitTorrent</summary>
 
   <description>
-    <!-- Translators: these are the application description paragraphs in the AppData file. -->
+    <!-- Translators: these are the application description paragraphs in the MetaInfo file. -->
     <p>
       BitTorrent is a peer-to-peer file-sharing protocol that is commonly used to
       distribute large amounts of data between multiple users.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -15,7 +15,7 @@ gtk/open-dialog.c
 gtk/relocate.c
 gtk/stats.c
 gtk/torrent-cell-renderer.c
-gtk/transmission-gtk.appdata.xml.in
+gtk/transmission-gtk.metainfo.xml.in
 gtk/transmission-gtk.desktop.in
 gtk/tr-core.c
 gtk/tr-icon.c


### PR DESCRIPTION
Lintian tag: appstream-metadata-in-legacy-location

AppStream metadata file was found in /usr/share/appdata/. The AppStream
XML files should be placed in /usr/share/metainfo/.

Refer to https://wiki.debian.org/AppStream/Guidelines for details.

Based-on work from: Pavel Rehak <pavel-rehak@email.cz>

Closes: https://github.com/transmission/transmission/pull/635
Closes: https://github.com/transmission/transmission/issues/1170
Fixes: 23d61b6457554203ea73951f3dd9f71a24be05ed

Signed-off-by: David Heidelberg <david@ixit.cz>