### PR TITLE
Fix incorrect Content-Type in Web UI javascript

### DIFF
--- a/web/javascript/remote.js
+++ b/web/javascript/remote.js
@@ -81,7 +81,7 @@ TransmissionRemote.prototype = {
         var ajaxSettings = {
             url: RPC._Root,
             type: 'POST',
-            contentType: 'json',
+            contentType: 'application/json',
             dataType: 'json',
             cache: false,
             data: JSON.stringify(data),


### PR DESCRIPTION
Content-Type in defined to be a media type holding the MIME type of the data, but 'json' isn't a valid MIME type, 'application/json' is