### PR TITLE
perf: omit tmp objects in countTorrentsPerMode()

### DIFF
--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -240,11 +240,11 @@ bool TorrentFilter::trackerFilterAcceptsTorrent(Torrent const* tor, QString cons
     return tracker.isEmpty() || tor->hasTrackerSubstring(tracker);
 }
 
-bool TorrentFilter::activityFilterAcceptsTorrent(Torrent const* tor, FilterMode const& m) const
+bool TorrentFilter::activityFilterAcceptsTorrent(Torrent const* tor, int filterMode) const
 {
     bool accepts;
 
-    switch (m.mode())
+    switch (filterMode)
     {
     case FilterMode::SHOW_ACTIVE:
         accepts = tor->peersWeAreUploadingTo() > 0 || tor->peersWeAreDownloadingFrom() > 0 || tor->isVerifying();
@@ -290,8 +290,8 @@ bool TorrentFilter::filterAcceptsRow(int sourceRow, QModelIndex const& sourcePar
 
     if (accepts)
     {
-        FilterMode const m = myPrefs.get<FilterMode>(Prefs::FILTER_MODE);
-        accepts = activityFilterAcceptsTorrent(tor, m);
+        auto const m = myPrefs.get<FilterMode>(Prefs::FILTER_MODE);
+        accepts = activityFilterAcceptsTorrent(tor, m.mode());
     }
 
     if (accepts)

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -43,7 +43,7 @@ protected:
     bool lessThan(QModelIndex const&, QModelIndex const&) const override;
 
 private:
-    bool activityFilterAcceptsTorrent(Torrent const* tor, FilterMode const& mode) const;
+    bool activityFilterAcceptsTorrent(Torrent const* tor, int filterMode) const;
     bool trackerFilterAcceptsTorrent(Torrent const* tor, QString const& tracker) const;
 
 private slots:


### PR DESCRIPTION
Avoid creating temporary FilterMode objects when looping through all [torrent x filterMode] pairs. This is a minor change, but it lowers the overall cost of `countTorrentsPerMode()` from 8.24% of runtime to 6.68%.