### PR TITLE
allow decimal values in seedRatioLimit input

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -99,7 +99,7 @@
 					<div class="prefs-section">
 						<div class="title">Seeding</div>
 						<div class="row"><div class="key"><input type="checkbox" id="seedRatioLimited"/><label for="seedRatioLimited">Stop seeding at ratio:</label></div>
-                                                                 <div class="value"><input type="number" min="0" id="seedRatioLimit"/></div></div>
+                                                                 <div class="value"><input type="number" min="0" step="any" id="seedRatioLimit"/></div></div>
 						<div class="row"><div class="key"><input type="checkbox" id="idle-seeding-limit-enabled"/><label for="idle-seeding-limit-enabled">Stop seeding if idle for (min):</label></div>
                                                                  <div class="value"><input type="number" min="1" max="40320" id="idle-seeding-limit"/></div></div>
 					</div>


### PR DESCRIPTION
On the web interface, attempting to enter a seed limit ratio consisting of a decimal number (e.g., 1.5) triggers a browser-generated validation error. Transmission still correctly validates and accepts the decimal value.

This patch simply adds a [step](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step) attribute to the input, telling browsers to recognize any numeric value as valid.

Chrome:
![ratio-chrome](https://user-images.githubusercontent.com/171487/80820851-e4e73600-8b94-11ea-8477-465046cffe2b.png)

Firefox:
![ratio-firefox](https://user-images.githubusercontent.com/171487/80820855-e6186300-8b94-11ea-808e-bee0c76e9da6.png)