### PR TITLE
Fixed showing popup menu on RMB at tray icon

### DIFF
--- a/gtk/tr-icon.c
+++ b/gtk/tr-icon.c
@@ -39,7 +39,7 @@ static void popup(GtkStatusIcon* self, guint button, guint when, gpointer data U
     GtkWidget* w = gtr_action_get_widget("/icon-popup");
 
 #if GTK_CHECK_VERSION(3, 22, 0)
-    gtk_menu_popup_at_widget(GTK_MENU(w), GTK_WIDGET(self), GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH, NULL);
+    gtk_menu_popup_at_pointer(GTK_MENU(w), NULL);
 #else
     gtk_menu_popup(GTK_MENU(w), NULL, NULL, gtk_status_icon_position_menu, self, button, when);
 #endif


### PR DESCRIPTION
Hello,
Context menu is not showing.
After right click at the tray icon I got errors in the log:
```
gtk_menu_popup_at_widget: assertion 'GTK_IS_WIDGET (widget)' failed
invalid cast from 'GtkStatusIcon' to 'GtkWidget'
```
I think we should use
`gtk_menu_popup_at_pointer(GTK_MENU(w), NULL);`

Tested, worked.
Thanks!