### PR TITLE
feat: fuzzing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,7 @@ function(tr_install_web DST_DIR)
         PATTERN *.scss EXCLUDE)
 endfunction()
 
+add_subdirectory(fuzz)
 add_subdirectory(libtransmission)
 
 set(MAC_PROJECT_DIR macosx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ tr_auto_option(ENABLE_MAC           "Build Mac client" AUTO)
         option(ENABLE_UTILS         "Build utils (create, edit, show)" ON)
         option(ENABLE_CLI           "Build command-line client" OFF)
         option(ENABLE_TESTS         "Build unit tests" ON)
+        option(ENABLE_FUZZ          "Build fuzz testing targets" OFF)
         option(ENABLE_LIGHTWEIGHT   "Optimize libtransmission for low-resource systems: smaller cache size, prefer unencrypted peer connections, etc." OFF)
         option(ENABLE_UTP           "Build µTP support" ON)
         option(ENABLE_NLS           "Enable native language support" ON)
@@ -527,6 +528,10 @@ if(ENABLE_TESTS)
     enable_testing()
 endif()
 
+if(ENABLE_FUZZ)
+    add_subdirectory(fuzz)
+endif()
+
 function(tr_install_web DST_DIR)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/web DESTINATION ${DST_DIR}
         PATTERN *.am EXCLUDE
@@ -534,7 +539,6 @@ function(tr_install_web DST_DIR)
         PATTERN *.scss EXCLUDE)
 endfunction()
 
-add_subdirectory(fuzz)
 add_subdirectory(libtransmission)
 
 set(MAC_PROJECT_DIR macosx)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(fuzz)
+
+include_directories(${CMAKE_SOURCE_DIR})
+
+foreach(P fuzz-magnet fuzz-torrent)
+    add_executable(${P} ${P}.cc ../libtransmission/magnet.c)
+    target_compile_options(${P} PRIVATE -g -fsanitize=fuzzer,address -D__TRANSMISSION__)
+    target_link_libraries(${P} PRIVATE -g -fsanitize=fuzzer,address ${TR_NAME})
+endforeach()

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -17,7 +17,7 @@ export CFLAGS="-g -O0"
 ```bash
 mkdir -p build
 cd build
-cmake ..
+cmake .. -DENABLE_FUZZ=ON
 
 # Magnet URI fuzzing
 make fuzz-magnet

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -29,6 +29,9 @@ make fuzz-torrent
 ## Running fuzzers
 
 ```bash
+# Run torrent fuzzer until a memory error occurs
+./fuzz/fuzz-torrent
+
 # Run magnet URI fuzzer until a memory error occurs
 ./fuzz/fuzz-magnet -max_len=2000 -only_ascii=1
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,37 @@
+# libtransmission Fuzz Targets
+
+## Requirements
+
+ - A modern version of LLVM / Clang with `libfuzzer` support.
+
+## Build setup
+
+```bash
+export CC=clang
+export CXX=clang++
+export CFLAGS="-g -O0"
+```
+
+## Build targets
+
+```bash
+mkdir -p build
+cd build
+cmake ..
+
+# Magnet URI fuzzing
+make fuzz-magnet
+
+# Torrent file fuzzing
+make fuzz-torrent
+```
+
+## Running fuzzers
+
+```bash
+# Run magnet URI fuzzer until a memory error occurs
+./fuzz/fuzz-magnet -max_len=2000 -only_ascii=1
+
+# Run two parallel jobs for the magnet URI fuzzer
+./fuzz/fuzz-magnet -max_len=2000 -only_ascii=1 -rss_limit_mb=8192 -jobs=2
+```

--- a/fuzz/fuzz-magnet.cc
+++ b/fuzz/fuzz-magnet.cc
@@ -4,33 +4,58 @@
 #include <string.h>
 #include <libtransmission/transmission.h>
 
-int isbanned(char c) {
-  if (c == ' ') return true;
-  if (c == '"') return true;
-  if (c == '<') return true;
-  if (c == '#') return true;
-  if (c == '|') return true;
+int isbanned(char c)
+{
+    if (c == ' ')
+    {
+        return true;
+    }
 
-  return false;
+    if (c == '"')
+    {
+        return true;
+    }
+
+    if (c == '<')
+    {
+        return true;
+    }
+
+    if (c == '#')
+    {
+        return true;
+    }
+
+    if (c == '|')
+    {
+        return true;
+    }
+
+    return false;
 }
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  for (size_t i = 0; i < Size; i++)
-    if (iscntrl(Data[i]) || isbanned(Data[i]))
-      return EXIT_FAILURE;
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    for (size_t i = 0; i < Size; i++)
+    {
+        if (iscntrl(Data[i]) || isbanned(Data[i]))
+        {
+            return EXIT_FAILURE;
+        }
+    }
 
-  char *uri = (char *)calloc(1, Size + 1);
-  strncpy(uri, (const char *)Data, Size);
+    char* uri = (char*)calloc(1, Size + 1);
+    strncpy(uri, (const char*)Data, Size);
 
-  tr_ctor *ctor = tr_ctorNew(NULL);
-  tr_ctorSetMetainfoFromMagnetLink(ctor, uri);
+    tr_ctor* ctor = tr_ctorNew(NULL);
+    tr_ctorSetMetainfoFromMagnetLink(ctor, uri);
 
-  tr_info inf;
-  tr_parse_result err = tr_torrentParse(ctor, &inf);
+    tr_info inf;
+    tr_parse_result err = tr_torrentParse(ctor, &inf);
 
-  free(uri);
-  tr_ctorFree(ctor);
-  tr_metainfoFree(&inf);
+    free(uri);
+    tr_ctorFree(ctor);
+    tr_metainfoFree(&inf);
 
-  return err;
+    return err;
 }

--- a/fuzz/fuzz-magnet.cc
+++ b/fuzz/fuzz-magnet.cc
@@ -1,0 +1,36 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libtransmission/transmission.h>
+
+int isbanned(char c) {
+  if (c == ' ') return true;
+  if (c == '"') return true;
+  if (c == '<') return true;
+  if (c == '#') return true;
+  if (c == '|') return true;
+
+  return false;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  for (size_t i = 0; i < Size; i++)
+    if (iscntrl(Data[i]) || isbanned(Data[i]))
+      return EXIT_FAILURE;
+
+  char *uri = (char *)calloc(1, Size + 1);
+  strncpy(uri, (const char *)Data, Size);
+
+  tr_ctor *ctor = tr_ctorNew(NULL);
+  tr_ctorSetMetainfoFromMagnetLink(ctor, uri);
+
+  tr_info inf;
+  tr_parse_result err = tr_torrentParse(ctor, &inf);
+
+  free(uri);
+  tr_ctorFree(ctor);
+  tr_metainfoFree(&inf);
+
+  return err;
+}

--- a/fuzz/fuzz-torrent.cc
+++ b/fuzz/fuzz-torrent.cc
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <libtransmission/transmission.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  tr_ctor *ctor = tr_ctorNew(NULL);
+  tr_ctorSetMetainfo(ctor, Data, Size);
+
+  tr_info inf;
+  tr_parse_result err = tr_torrentParse(ctor, &inf);
+
+  tr_ctorFree(ctor);
+  tr_metainfoFree(&inf);
+
+  return err;
+}

--- a/fuzz/fuzz-torrent.cc
+++ b/fuzz/fuzz-torrent.cc
@@ -2,15 +2,16 @@
 #include <stdlib.h>
 #include <libtransmission/transmission.h>
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  tr_ctor *ctor = tr_ctorNew(NULL);
-  tr_ctorSetMetainfo(ctor, Data, Size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    tr_ctor* ctor = tr_ctorNew(NULL);
+    tr_ctorSetMetainfo(ctor, Data, Size);
 
-  tr_info inf;
-  tr_parse_result err = tr_torrentParse(ctor, &inf);
+    tr_info inf;
+    tr_parse_result err = tr_torrentParse(ctor, &inf);
 
-  tr_ctorFree(ctor);
-  tr_metainfoFree(&inf);
+    tr_ctorFree(ctor);
+    tr_metainfoFree(&inf);
 
-  return err;
+    return err;
 }


### PR DESCRIPTION
This PR adds some [fuzzing](https://en.wikipedia.org/wiki/Fuzzing) targets to the project using [libFuzzer](https://llvm.org/docs/LibFuzzer.html). The goal is to surface crashes / memory leaks / memory errors so that they can be fixed. :smile:

For example, #1222 was discovered by running the `fuzz-magnet` target provided in this PR.

A modern version of LLVM / Clang with libFuzzer is required to build these development-only binaries.

Remaining questions:

 - [ ] While running `fuzz-torrent`, log output such as `Invalid metadata entry "info"` is slowing down the process. Is it possible to turn off these logs entirely?
 - [ ] Should the initial / generated corpus be kept in this repository, or somewhere else?
 - [ ] Any feedback on initializing a torrent's metainfo would be appreciated :) 