### PR TITLE
fix: memory leak in magnet parsing

### DIFF
--- a/libtransmission/magnet.c
+++ b/libtransmission/magnet.c
@@ -214,17 +214,18 @@ tr_magnet_info* tr_magnetParse(char const* uri)
     }
     else
     {
-        for (int i = 0; i < trCount; i++) {
+        for (int i = 0; i < trCount; i++)
+        {
             tr_free(tr[i]);
         }
 
-        for (int i = 0; i < wsCount; i++) {
+        for (int i = 0; i < wsCount; i++)
+        {
             tr_free(ws[i]);
         }
 
         tr_free(displayName);
     }
-
 
     return info;
 }

--- a/libtransmission/magnet.c
+++ b/libtransmission/magnet.c
@@ -174,7 +174,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 }
             }
 
-            if (vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0 && displayName == NULL)
+            if (displayName == NULL && vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0)
             {
                 displayName = tr_http_unescape(val, vallen);
             }

--- a/libtransmission/magnet.c
+++ b/libtransmission/magnet.c
@@ -174,7 +174,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 }
             }
 
-            if (vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0)
+            if (vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0 && displayName == NULL)
             {
                 displayName = tr_http_unescape(val, vallen);
             }
@@ -212,6 +212,19 @@ tr_magnet_info* tr_magnetParse(char const* uri)
         info->webseeds = tr_memdup(ws, sizeof(char*) * wsCount);
         memcpy(info->hash, sha1, sizeof(uint8_t) * SHA_DIGEST_LENGTH);
     }
+    else
+    {
+        for (int i = 0; i < trCount; i++) {
+            tr_free(tr[i]);
+        }
+
+        for (int i = 0; i < wsCount; i++) {
+            tr_free(ws[i]);
+        }
+
+        tr_free(displayName);
+    }
+
 
     return info;
 }


### PR DESCRIPTION
(discovered by libFuzzer, confirmed manually)

This PR fixes a small memory leak in `tr_magnetParse`. When a magnet URI is not successfully parsed, some memory allocations (created by `tr_http_unescape`) are not freed before `tr_magnetParse` returns.

To confirm the presence / fix of these leaks, the `fuzz-magnet` target from #1221 is used with [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html).

## Leak 0 (Before)

```sh-session
$ cat leaks/leak0
magnet:?dn=u

$ ./fuzz/fuzz-magnet ./leaks/leak0
INFO: Seed: 2668441529
INFO: Loaded 1 modules   (90 inline 8-bit counters): 90 [0x55aa055d6740, 0x55aa055d679a), 
INFO: Loaded 1 PC tables (90 PCs): 90 [0x55aa055d67a0,0x55aa055d6d40), 
./fuzz/fuzz-magnet: Running 1 inputs 1 time(s) each.
Running: ./leaks/leak0

=================================================================
==32679==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x55aa054a0b89 in malloc (/home/tom/transmission/build/fuzz/fuzz-magnet+0x128b89)
    #1 0x55aa054ecdaf in tr_malloc /home/tom/transmission/libtransmission/utils.c:128:24
    #2 0x55aa054edc61 in tr_strndup /home/tom/transmission/libtransmission/utils.c:417:15
    #3 0x55aa054edbfd in tr_strdup /home/tom/transmission/libtransmission/utils.c:404:12
    #4 0x55aa054fb79b in tr_http_unescape /home/tom/transmission/libtransmission/web.c:809:17
    #5 0x55aa054d9981 in tr_magnetParse /home/tom/transmission/libtransmission/magnet.c:179:31
    #6 0x55aa054e9cf8 in tr_ctorSetMetainfoFromMagnetLink /home/tom/transmission/libtransmission/torrent-ctor.c:101:35
    #7 0x55aa054d8fbd in LLVMFuzzerTestOneInput /home/tom/transmission/fuzz/fuzz-magnet.cc:51:5
    #8 0x55aa053d8d5e in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x60d5e)
    #9 0x55aa053bd084 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x45084)
    #10 0x55aa053c76c4 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x4f6c4)
    #11 0x55aa053b4e83 in main (/home/tom/transmission/build/fuzz/fuzz-magnet+0x3ce83)
    #12 0x7fc1b2e8d022 in __libc_start_main (/usr/lib/libc.so.6+0x27022)

SUMMARY: AddressSanitizer: 2 byte(s) leaked in 1 allocation(s).
```

## Leak 1 (Before)

```sh-session
$ cat leaks/leak1
magnet:?dn=u&dn=u

$ ./fuzz/fuzz-magnet ./leaks/leak1
INFO: Seed: 282678939
INFO: Loaded 1 modules   (90 inline 8-bit counters): 90 [0x55a6fff38740, 0x55a6fff3879a), 
INFO: Loaded 1 PC tables (90 PCs): 90 [0x55a6fff387a0,0x55a6fff38d40), 
./fuzz/fuzz-magnet: Running 1 inputs 1 time(s) each.
Running: ./leaks/leak1

=================================================================
==32852==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 2 object(s) allocated from:
    #0 0x55a6ffe02b89 in malloc (/home/tom/transmission/build/fuzz/fuzz-magnet+0x128b89)
    #1 0x55a6ffe4edaf in tr_malloc /home/tom/transmission/libtransmission/utils.c:128:24
    #2 0x55a6ffe4fc61 in tr_strndup /home/tom/transmission/libtransmission/utils.c:417:15
    #3 0x55a6ffe4fbfd in tr_strdup /home/tom/transmission/libtransmission/utils.c:404:12
    #4 0x55a6ffe5d79b in tr_http_unescape /home/tom/transmission/libtransmission/web.c:809:17
    #5 0x55a6ffe3b981 in tr_magnetParse /home/tom/transmission/libtransmission/magnet.c:179:31
    #6 0x55a6ffe4bcf8 in tr_ctorSetMetainfoFromMagnetLink /home/tom/transmission/libtransmission/torrent-ctor.c:101:35
    #7 0x55a6ffe3afbd in LLVMFuzzerTestOneInput /home/tom/transmission/fuzz/fuzz-magnet.cc:51:5
    #8 0x55a6ffd3ad5e in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x60d5e)
    #9 0x55a6ffd1f084 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x45084)
    #10 0x55a6ffd296c4 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/tom/transmission/build/fuzz/fuzz-magnet+0x4f6c4)
    #11 0x55a6ffd16e83 in main (/home/tom/transmission/build/fuzz/fuzz-magnet+0x3ce83)
    #12 0x7f7a8c050022 in __libc_start_main (/usr/lib/libc.so.6+0x27022)

SUMMARY: AddressSanitizer: 4 byte(s) leaked in 2 allocation(s).
```

## Both leaks (after this patch)

```sh-session
$ ./fuzz/fuzz-magnet leaks/leak0
INFO: Seed: 794977013
INFO: Loaded 1 modules   (93 inline 8-bit counters): 93 [0x563ceefa0740, 0x563ceefa079d), 
INFO: Loaded 1 PC tables (93 PCs): 93 [0x563ceefa07a0,0x563ceefa0d70), 
./fuzz/fuzz-magnet: Running 1 inputs 1 time(s) each.
Running: leaks/leak0
Executed leaks/leak0 in 0 ms

$ ./fuzz/fuzz-magnet leaks/leak1
INFO: Seed: 3041774648
INFO: Loaded 1 modules   (93 inline 8-bit counters): 93 [0x56235d29e740, 0x56235d29e79d), 
INFO: Loaded 1 PC tables (93 PCs): 93 [0x56235d29e7a0,0x56235d29ed70), 
./fuzz/fuzz-magnet: Running 1 inputs 1 time(s) each.
Running: leaks/leak1
Executed leaks/leak1 in 0 ms
```