### PR TITLE
chore: replace myFoo naming idiom with snake_case_

### DIFF
--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -47,5 +47,5 @@ void AboutDialog::showCredits()
 
 void AboutDialog::showLicense()
 {
-    Utils::openDialog(myLicenseDialog, this);
+    Utils::openDialog(license_dialog_, this);
 }

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -30,5 +30,5 @@ private slots:
 private:
     Ui::AboutDialog ui;
 
-    QPointer<LicenseDialog> myLicenseDialog;
+    QPointer<LicenseDialog> license_dialog_;
 };

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -56,18 +56,18 @@ private:
     void quitLater();
 
 private:
-    Prefs* myPrefs;
-    Session* mySession;
-    TorrentModel* myModel;
-    MainWindow* myWindow;
-    WatchDir* myWatchDir;
-    QTimer myModelTimer;
-    QTimer myStatsTimer;
-    QTimer mySessionTimer;
-    time_t myLastFullUpdateTime;
-    QTranslator myQtTranslator;
-    QTranslator myAppTranslator;
-    FaviconCache myFavicons;
+    Prefs* prefs_;
+    Session* session_;
+    TorrentModel* model_;
+    MainWindow* window_;
+    WatchDir* watch_dir_;
+    QTimer model_timer_;
+    QTimer stats_timer_;
+    QTimer session_timer_;
+    time_t last_full_update_time_;
+    QTranslator qt_translator_;
+    QTranslator app_translator_;
+    FaviconCache favicons_;
 };
 
 #undef qApp

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -36,15 +36,15 @@ int itemColumnSpan(QGridLayout* layout, QLayoutItem const* item)
 
 ColumnResizer::ColumnResizer(QObject* parent) :
     QObject(parent),
-    myTimer(new QTimer(this))
+    timer_(new QTimer(this))
 {
-    myTimer->setSingleShot(true);
-    connect(myTimer, SIGNAL(timeout()), SLOT(update()));
+    timer_->setSingleShot(true);
+    connect(timer_, SIGNAL(timeout()), SLOT(update()));
 }
 
 void ColumnResizer::addLayout(QGridLayout* layout)
 {
-    myLayouts << layout;
+    layouts_ << layout;
     scheduleUpdate();
 }
 
@@ -62,7 +62,7 @@ void ColumnResizer::update()
 {
     int maxWidth = 0;
 
-    for (QGridLayout* const layout : myLayouts)
+    for (QGridLayout* const layout : layouts_)
     {
         for (int i = 0, count = layout->rowCount(); i < count; ++i)
         {
@@ -77,7 +77,7 @@ void ColumnResizer::update()
         }
     }
 
-    for (QGridLayout* const layout : myLayouts)
+    for (QGridLayout* const layout : layouts_)
     {
         layout->setColumnMinimumWidth(0, maxWidth);
     }
@@ -85,5 +85,5 @@ void ColumnResizer::update()
 
 void ColumnResizer::scheduleUpdate()
 {
-    myTimer->start(0);
+    timer_->start(0);
 }

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -33,6 +33,6 @@ private:
     void scheduleUpdate();
 
 private:
-    QTimer* myTimer;
-    QSet<QGridLayout*> myLayouts;
+    QTimer* timer_;
+    QSet<QGridLayout*> layouts_;
 };

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -212,7 +212,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     changed_torrents_(false),
     have_pending_refresh_(false)
 {
-    ui.setupUi(this);
+    ui_.setupUi(this);
 
     initInfoTab();
     initPeersTab();
@@ -221,7 +221,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     initOptionsTab();
 
     adjustSize();
-    ui.commentBrowser->setMaximumHeight(QWIDGETSIZE_MAX);
+    ui_.commentBrowser->setMaximumHeight(QWIDGETSIZE_MAX);
 
     QList<int> initKeys;
     initKeys << Prefs::SHOW_TRACKER_SCRAPES << Prefs::SHOW_BACKUP_TRACKERS;
@@ -252,7 +252,7 @@ void DetailsDialog::setIds(torrent_ids_t const& ids)
     if (ids != ids_)
     {
         setEnabled(false);
-        ui.filesView->clear();
+        ui_.filesView->clear();
 
         ids_ = ids;
         session_.refreshDetailInfo(ids_);
@@ -270,12 +270,12 @@ void DetailsDialog::refreshPref(int key)
     {
     case Prefs::SHOW_TRACKER_SCRAPES:
         {
-            QItemSelectionModel* selectionModel(ui.trackersView->selectionModel());
+            QItemSelectionModel* selectionModel(ui_.trackersView->selectionModel());
             QItemSelection const selection(selectionModel->selection());
             QModelIndex const currentIndex(selectionModel->currentIndex());
             tracker_delegate_->setShowMore(prefs_.getBool(key));
             selectionModel->clear();
-            ui.trackersView->reset();
+            ui_.trackersView->reset();
             selectionModel->select(selection, QItemSelectionModel::Select);
             selectionModel->setCurrentIndex(currentIndex, QItemSelectionModel::NoUpdate);
             break;
@@ -441,7 +441,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.stateValueLabel->setText(string);
+    ui_.stateValueLabel->setText(string);
     QString const stateString = string;
 
     // have_label_
@@ -510,7 +510,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.haveValueLabel->setText(string);
+    ui_.haveValueLabel->setText(string);
 
     // availability_label_
     if (torrents.empty() || sizeWhenDone == 0)
@@ -522,7 +522,7 @@ void DetailsDialog::refresh()
         string = QString::fromLatin1("%1%").arg(Formatter::percentToString((100.0 * available) / sizeWhenDone));
     }
 
-    ui.availabilityValueLabel->setText(string);
+    ui_.availabilityValueLabel->setText(string);
 
     // downloaded_label_
     if (torrents.empty())
@@ -553,7 +553,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.downloadedValueLabel->setText(string);
+    ui_.downloadedValueLabel->setText(string);
 
     //  uploaded_label_
     if (torrents.empty())
@@ -574,7 +574,7 @@ void DetailsDialog::refresh()
         string = tr("%1 (Ratio: %2)").arg(Formatter::sizeToString(u)).arg(Formatter::ratioToString(tr_getRatio(u, d)));
     }
 
-    ui.uploadedValueLabel->setText(string);
+    ui_.uploadedValueLabel->setText(string);
 
     // run_time_label_
     if (torrents.empty())
@@ -615,7 +615,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.runningTimeValueLabel->setText(string);
+    ui_.runningTimeValueLabel->setText(string);
 
     // eta_label_
     string.clear();
@@ -650,7 +650,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.remainingTimeValueLabel->setText(string);
+    ui_.remainingTimeValueLabel->setText(string);
 
     // last_activity_label_
     if (torrents.empty())
@@ -688,7 +688,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.lastActivityValueLabel->setText(string);
+    ui_.lastActivityValueLabel->setText(string);
 
     if (torrents.empty())
     {
@@ -713,7 +713,7 @@ void DetailsDialog::refresh()
         string = none;
     }
 
-    ui.errorValueLabel->setText(string);
+    ui_.errorValueLabel->setText(string);
 
     ///
     /// information tab
@@ -756,7 +756,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.sizeValueLabel->setText(string);
+    ui_.sizeValueLabel->setText(string);
 
     // hash_label_
     string = none;
@@ -775,7 +775,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.hashValueLabel->setText(string);
+    ui_.hashValueLabel->setText(string);
 
     // privacy_label_
     string = none;
@@ -795,7 +795,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.privacyValueLabel->setText(string);
+    ui_.privacyValueLabel->setText(string);
 
     // comment_browser_
     string = none;
@@ -816,12 +816,12 @@ void DetailsDialog::refresh()
         }
     }
 
-    if (ui.commentBrowser->toPlainText() != string)
+    if (ui_.commentBrowser->toPlainText() != string)
     {
-        ui.commentBrowser->setText(string);
+        ui_.commentBrowser->setText(string);
     }
 
-    ui.commentBrowser->setEnabled(!isCommentMixed && !string.isEmpty());
+    ui_.commentBrowser->setEnabled(!isCommentMixed && !string.isEmpty());
 
     // origin_label_
     string = none;
@@ -866,7 +866,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.originValueLabel->setText(string);
+    ui_.originValueLabel->setText(string);
 
     // location_label_
     string = none;
@@ -885,7 +885,7 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.locationValueLabel->setText(string);
+    ui_.locationValueLabel->setText(string);
 
     ///
     ///  Options Tab
@@ -912,7 +912,7 @@ void DetailsDialog::refresh()
             }
         }
 
-        ui.sessionLimitCheck->setChecked(uniform && baselineFlag);
+        ui_.sessionLimitCheck->setChecked(uniform && baselineFlag);
 
         // single_down_check_
         uniform = true;
@@ -927,7 +927,7 @@ void DetailsDialog::refresh()
             }
         }
 
-        ui.singleDownCheck->setChecked(uniform && baselineFlag);
+        ui_.singleDownCheck->setChecked(uniform && baselineFlag);
 
         // single_up_check_
         uniform = true;
@@ -942,7 +942,7 @@ void DetailsDialog::refresh()
             }
         }
 
-        ui.singleUpCheck->setChecked(uniform && baselineFlag);
+        ui_.singleUpCheck->setChecked(uniform && baselineFlag);
 
         // bandwidth_priority_combo_
         uniform = true;
@@ -959,18 +959,18 @@ void DetailsDialog::refresh()
 
         if (uniform)
         {
-            i = ui.bandwidthPriorityCombo->findData(baselineInt);
+            i = ui_.bandwidthPriorityCombo->findData(baselineInt);
         }
         else
         {
             i = -1;
         }
 
-        setIfIdle(ui.bandwidthPriorityCombo, i);
+        setIfIdle(ui_.bandwidthPriorityCombo, i);
 
-        setIfIdle(ui.singleDownSpin, int(baseline.downloadLimit().KBps()));
-        setIfIdle(ui.singleUpSpin, int(baseline.uploadLimit().KBps()));
-        setIfIdle(ui.peerLimitSpin, baseline.peerLimit());
+        setIfIdle(ui_.singleDownSpin, int(baseline.downloadLimit().KBps()));
+        setIfIdle(ui_.singleUpSpin, int(baseline.uploadLimit().KBps()));
+        setIfIdle(ui_.peerLimitSpin, baseline.peerLimit());
     }
 
     if (!torrents.empty())
@@ -990,10 +990,10 @@ void DetailsDialog::refresh()
             }
         }
 
-        setIfIdle(ui.ratioCombo, uniform ? ui.ratioCombo->findData(baselineInt) : -1);
-        ui.ratioSpin->setVisible(uniform && baselineInt == TR_RATIOLIMIT_SINGLE);
+        setIfIdle(ui_.ratioCombo, uniform ? ui_.ratioCombo->findData(baselineInt) : -1);
+        ui_.ratioSpin->setVisible(uniform && baselineInt == TR_RATIOLIMIT_SINGLE);
 
-        setIfIdle(ui.ratioSpin, baseline.seedRatioLimit());
+        setIfIdle(ui_.ratioSpin, baseline.seedRatioLimit());
 
         // idle
         uniform = true;
@@ -1008,10 +1008,10 @@ void DetailsDialog::refresh()
             }
         }
 
-        setIfIdle(ui.idleCombo, uniform ? ui.idleCombo->findData(baselineInt) : -1);
-        ui.idleSpin->setVisible(uniform && baselineInt == TR_RATIOLIMIT_SINGLE);
+        setIfIdle(ui_.idleCombo, uniform ? ui_.idleCombo->findData(baselineInt) : -1);
+        ui_.idleSpin->setVisible(uniform && baselineInt == TR_RATIOLIMIT_SINGLE);
 
-        setIfIdle(ui.idleSpin, baseline.seedIdleLimit());
+        setIfIdle(ui_.idleSpin, baseline.seedIdleLimit());
         onIdleLimitChanged();
     }
 
@@ -1136,14 +1136,14 @@ void DetailsDialog::refresh()
         }
     }
 
-    ui.peersView->addTopLevelItems(newItems);
+    ui_.peersView->addTopLevelItems(newItems);
 
     for (QString const& key : peers_.keys())
     {
         if (!peers2.contains(key)) // old peer has disconnected
         {
             QTreeWidgetItem* item = peers_.value(key, nullptr);
-            ui.peersView->takeTopLevelItem(ui.peersView->indexOfTopLevelItem(item));
+            ui_.peersView->takeTopLevelItem(ui_.peersView->indexOfTopLevelItem(item));
             delete item;
         }
     }
@@ -1152,12 +1152,12 @@ void DetailsDialog::refresh()
 
     if (!single)
     {
-        ui.filesView->clear();
+        ui_.filesView->clear();
     }
 
     if (single)
     {
-        ui.filesView->update(torrents[0]->files(), changed_torrents_);
+        ui_.filesView->update(torrents[0]->files(), changed_torrents_);
     }
 
     changed_torrents_ = false;
@@ -1167,9 +1167,9 @@ void DetailsDialog::refresh()
 
 void DetailsDialog::setEnabled(bool enabled)
 {
-    for (int i = 0; i < ui.tabs->count(); ++i)
+    for (int i = 0; i < ui_.tabs->count(); ++i)
     {
-        ui.tabs->widget(i)->setEnabled(enabled);
+        ui_.tabs->widget(i)->setEnabled(enabled);
     }
 }
 
@@ -1179,12 +1179,12 @@ void DetailsDialog::setEnabled(bool enabled)
 
 void DetailsDialog::initInfoTab()
 {
-    int const h = QFontMetrics(ui.commentBrowser->font()).lineSpacing() * 4;
-    ui.commentBrowser->setFixedHeight(h);
+    int const h = QFontMetrics(ui_.commentBrowser->font()).lineSpacing() * 4;
+    ui_.commentBrowser->setFixedHeight(h);
 
     auto* cr = new ColumnResizer(this);
-    cr->addLayout(ui.activitySectionLayout);
-    cr->addLayout(ui.detailsSectionLayout);
+    cr->addLayout(ui_.activitySectionLayout);
+    cr->addLayout(ui_.detailsSectionLayout);
     cr->update();
 }
 
@@ -1240,7 +1240,7 @@ void DetailsDialog::onUploadLimitedToggled(bool val)
 
 void DetailsDialog::onIdleModeChanged(int index)
 {
-    int const val = ui.idleCombo->itemData(index).toInt();
+    int const val = ui_.idleCombo->itemData(index).toInt();
     session_.torrentSet(ids_, TR_KEY_seedIdleMode, val);
     getNewData();
 }
@@ -1248,17 +1248,17 @@ void DetailsDialog::onIdleModeChanged(int index)
 void DetailsDialog::onIdleLimitChanged()
 {
     //: Spin box suffix, "Stop seeding if idle for: [ 5 minutes ]" (includes leading space after the number, if needed)
-    QString const unitsSuffix = tr(" minute(s)", nullptr, ui.idleSpin->value());
+    QString const unitsSuffix = tr(" minute(s)", nullptr, ui_.idleSpin->value());
 
-    if (ui.idleSpin->suffix() != unitsSuffix)
+    if (ui_.idleSpin->suffix() != unitsSuffix)
     {
-        ui.idleSpin->setSuffix(unitsSuffix);
+        ui_.idleSpin->setSuffix(unitsSuffix);
     }
 }
 
 void DetailsDialog::onRatioModeChanged(int index)
 {
-    int const val = ui.ratioCombo->itemData(index).toInt();
+    int const val = ui_.ratioCombo->itemData(index).toInt();
     session_.torrentSet(ids_, TR_KEY_seedRatioMode, val);
 }
 
@@ -1266,7 +1266,7 @@ void DetailsDialog::onBandwidthPriorityChanged(int index)
 {
     if (index != -1)
     {
-        int const priority = ui.bandwidthPriorityCombo->itemData(index).toInt();
+        int const priority = ui_.bandwidthPriorityCombo->itemData(index).toInt();
         session_.torrentSet(ids_, TR_KEY_bandwidthPriority, priority);
         getNewData();
     }
@@ -1274,9 +1274,9 @@ void DetailsDialog::onBandwidthPriorityChanged(int index)
 
 void DetailsDialog::onTrackerSelectionChanged()
 {
-    int const selectionCount = ui.trackersView->selectionModel()->selectedRows().size();
-    ui.editTrackerButton->setEnabled(selectionCount == 1);
-    ui.removeTrackerButton->setEnabled(selectionCount > 0);
+    int const selectionCount = ui_.trackersView->selectionModel()->selectedRows().size();
+    ui_.editTrackerButton->setEnabled(selectionCount == 1);
+    ui_.removeTrackerButton->setEnabled(selectionCount > 0);
 }
 
 void DetailsDialog::onAddTrackerClicked()
@@ -1321,11 +1321,11 @@ void DetailsDialog::onAddTrackerClicked()
 
 void DetailsDialog::onEditTrackerClicked()
 {
-    QItemSelectionModel* selectionModel = ui.trackersView->selectionModel();
+    QItemSelectionModel* selectionModel = ui_.trackersView->selectionModel();
     QModelIndexList selectedRows = selectionModel->selectedRows();
     assert(selectedRows.size() == 1);
     QModelIndex i = selectionModel->currentIndex();
-    auto const trackerInfo = ui.trackersView->model()->data(i, TrackerModel::TrackerRole).value<TrackerInfo>();
+    auto const trackerInfo = ui_.trackersView->model()->data(i, TrackerModel::TrackerRole).value<TrackerInfo>();
 
     bool ok = false;
     QString const newval = QInputDialog::getText(this, tr("Edit URL "), tr("Edit tracker announce URL:"), QLineEdit::Normal,
@@ -1353,13 +1353,13 @@ void DetailsDialog::onEditTrackerClicked()
 void DetailsDialog::onRemoveTrackerClicked()
 {
     // make a map of torrentIds to announce URLs to remove
-    QItemSelectionModel* selectionModel = ui.trackersView->selectionModel();
+    QItemSelectionModel* selectionModel = ui_.trackersView->selectionModel();
     QModelIndexList selectedRows = selectionModel->selectedRows();
     QMap<int, int> torrentId_to_trackerIds;
 
     for (QModelIndex const& i : selectedRows)
     {
-        auto const inf = ui.trackersView->model()->data(i, TrackerModel::TrackerRole).value<TrackerInfo>();
+        auto const inf = ui_.trackersView->model()->data(i, TrackerModel::TrackerRole).value<TrackerInfo>();
         torrentId_to_trackerIds.insertMulti(inf.torrentId, inf.st.id);
     }
 
@@ -1378,48 +1378,48 @@ void DetailsDialog::initOptionsTab()
 {
     QString const speed_K_str = Formatter::unitStr(Formatter::SPEED, Formatter::KB);
 
-    ui.singleDownSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
-    ui.singleUpSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
+    ui_.singleDownSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
+    ui_.singleUpSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
 
-    ui.singleDownSpin->setProperty(PREF_KEY, TR_KEY_downloadLimit);
-    ui.singleUpSpin->setProperty(PREF_KEY, TR_KEY_uploadLimit);
-    ui.ratioSpin->setProperty(PREF_KEY, TR_KEY_seedRatioLimit);
-    ui.idleSpin->setProperty(PREF_KEY, TR_KEY_seedIdleLimit);
-    ui.peerLimitSpin->setProperty(PREF_KEY, TR_KEY_peer_limit);
+    ui_.singleDownSpin->setProperty(PREF_KEY, TR_KEY_downloadLimit);
+    ui_.singleUpSpin->setProperty(PREF_KEY, TR_KEY_uploadLimit);
+    ui_.ratioSpin->setProperty(PREF_KEY, TR_KEY_seedRatioLimit);
+    ui_.idleSpin->setProperty(PREF_KEY, TR_KEY_seedIdleLimit);
+    ui_.peerLimitSpin->setProperty(PREF_KEY, TR_KEY_peer_limit);
 
-    ui.bandwidthPriorityCombo->addItem(tr("High"), TR_PRI_HIGH);
-    ui.bandwidthPriorityCombo->addItem(tr("Normal"), TR_PRI_NORMAL);
-    ui.bandwidthPriorityCombo->addItem(tr("Low"), TR_PRI_LOW);
+    ui_.bandwidthPriorityCombo->addItem(tr("High"), TR_PRI_HIGH);
+    ui_.bandwidthPriorityCombo->addItem(tr("Normal"), TR_PRI_NORMAL);
+    ui_.bandwidthPriorityCombo->addItem(tr("Low"), TR_PRI_LOW);
 
-    ui.ratioCombo->addItem(tr("Use Global Settings"), TR_RATIOLIMIT_GLOBAL);
-    ui.ratioCombo->addItem(tr("Seed regardless of ratio"), TR_RATIOLIMIT_UNLIMITED);
-    ui.ratioCombo->addItem(tr("Stop seeding at ratio:"), TR_RATIOLIMIT_SINGLE);
+    ui_.ratioCombo->addItem(tr("Use Global Settings"), TR_RATIOLIMIT_GLOBAL);
+    ui_.ratioCombo->addItem(tr("Seed regardless of ratio"), TR_RATIOLIMIT_UNLIMITED);
+    ui_.ratioCombo->addItem(tr("Stop seeding at ratio:"), TR_RATIOLIMIT_SINGLE);
 
-    ui.idleCombo->addItem(tr("Use Global Settings"), TR_IDLELIMIT_GLOBAL);
-    ui.idleCombo->addItem(tr("Seed regardless of activity"), TR_IDLELIMIT_UNLIMITED);
-    ui.idleCombo->addItem(tr("Stop seeding if idle for:"), TR_IDLELIMIT_SINGLE);
+    ui_.idleCombo->addItem(tr("Use Global Settings"), TR_IDLELIMIT_GLOBAL);
+    ui_.idleCombo->addItem(tr("Seed regardless of activity"), TR_IDLELIMIT_UNLIMITED);
+    ui_.idleCombo->addItem(tr("Stop seeding if idle for:"), TR_IDLELIMIT_SINGLE);
 
     auto* cr = new ColumnResizer(this);
-    cr->addLayout(ui.speedSectionLayout);
-    cr->addLayout(ui.seedingLimitsSectionRatioLayout);
-    cr->addLayout(ui.seedingLimitsSectionIdleLayout);
-    cr->addLayout(ui.peerConnectionsSectionLayout);
+    cr->addLayout(ui_.speedSectionLayout);
+    cr->addLayout(ui_.seedingLimitsSectionRatioLayout);
+    cr->addLayout(ui_.seedingLimitsSectionIdleLayout);
+    cr->addLayout(ui_.peerConnectionsSectionLayout);
     cr->update();
 
     void (QComboBox::* comboIndexChanged)(int) = &QComboBox::currentIndexChanged;
     void (QSpinBox::* spinValueChanged)(int) = &QSpinBox::valueChanged;
-    connect(ui.bandwidthPriorityCombo, comboIndexChanged, this, &DetailsDialog::onBandwidthPriorityChanged);
-    connect(ui.idleCombo, comboIndexChanged, this, &DetailsDialog::onIdleModeChanged);
-    connect(ui.idleSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
-    connect(ui.idleSpin, spinValueChanged, this, &DetailsDialog::onIdleLimitChanged);
-    connect(ui.peerLimitSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
-    connect(ui.ratioCombo, comboIndexChanged, this, &DetailsDialog::onRatioModeChanged);
-    connect(ui.ratioSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
-    connect(ui.sessionLimitCheck, &QCheckBox::clicked, this, &DetailsDialog::onHonorsSessionLimitsToggled);
-    connect(ui.singleDownCheck, &QCheckBox::clicked, this, &DetailsDialog::onDownloadLimitedToggled);
-    connect(ui.singleDownSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
-    connect(ui.singleUpCheck, &QCheckBox::clicked, this, &DetailsDialog::onUploadLimitedToggled);
-    connect(ui.singleUpSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
+    connect(ui_.bandwidthPriorityCombo, comboIndexChanged, this, &DetailsDialog::onBandwidthPriorityChanged);
+    connect(ui_.idleCombo, comboIndexChanged, this, &DetailsDialog::onIdleModeChanged);
+    connect(ui_.idleSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
+    connect(ui_.idleSpin, spinValueChanged, this, &DetailsDialog::onIdleLimitChanged);
+    connect(ui_.peerLimitSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
+    connect(ui_.ratioCombo, comboIndexChanged, this, &DetailsDialog::onRatioModeChanged);
+    connect(ui_.ratioSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
+    connect(ui_.sessionLimitCheck, &QCheckBox::clicked, this, &DetailsDialog::onHonorsSessionLimitsToggled);
+    connect(ui_.singleDownCheck, &QCheckBox::clicked, this, &DetailsDialog::onDownloadLimitedToggled);
+    connect(ui_.singleDownSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
+    connect(ui_.singleUpCheck, &QCheckBox::clicked, this, &DetailsDialog::onUploadLimitedToggled);
+    connect(ui_.singleUpSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);
 }
 
 /***
@@ -1433,23 +1433,23 @@ void DetailsDialog::initTrackerTab()
     tracker_filter_->setSourceModel(tracker_model_);
     tracker_delegate_ = new TrackerDelegate();
 
-    ui.trackersView->setModel(tracker_filter_);
-    ui.trackersView->setItemDelegate(tracker_delegate_);
+    ui_.trackersView->setModel(tracker_filter_);
+    ui_.trackersView->setItemDelegate(tracker_delegate_);
 
-    ui.addTrackerButton->setIcon(getStockIcon(QLatin1String("list-add"), QStyle::SP_DialogOpenButton));
-    ui.editTrackerButton->setIcon(getStockIcon(QLatin1String("document-properties"), QStyle::SP_DesktopIcon));
-    ui.removeTrackerButton->setIcon(getStockIcon(QLatin1String("list-remove"), QStyle::SP_TrashIcon));
+    ui_.addTrackerButton->setIcon(getStockIcon(QLatin1String("list-add"), QStyle::SP_DialogOpenButton));
+    ui_.editTrackerButton->setIcon(getStockIcon(QLatin1String("document-properties"), QStyle::SP_DesktopIcon));
+    ui_.removeTrackerButton->setIcon(getStockIcon(QLatin1String("list-remove"), QStyle::SP_TrashIcon));
 
-    ui.showTrackerScrapesCheck->setChecked(prefs_.getBool(Prefs::SHOW_TRACKER_SCRAPES));
-    ui.showBackupTrackersCheck->setChecked(prefs_.getBool(Prefs::SHOW_BACKUP_TRACKERS));
+    ui_.showTrackerScrapesCheck->setChecked(prefs_.getBool(Prefs::SHOW_TRACKER_SCRAPES));
+    ui_.showBackupTrackersCheck->setChecked(prefs_.getBool(Prefs::SHOW_BACKUP_TRACKERS));
 
-    connect(ui.addTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onAddTrackerClicked);
-    connect(ui.editTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onEditTrackerClicked);
-    connect(ui.removeTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onRemoveTrackerClicked);
-    connect(ui.showBackupTrackersCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowBackupTrackersToggled);
-    connect(ui.showTrackerScrapesCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowTrackerScrapesToggled);
+    connect(ui_.addTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onAddTrackerClicked);
+    connect(ui_.editTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onEditTrackerClicked);
+    connect(ui_.removeTrackerButton, &QAbstractButton::clicked, this, &DetailsDialog::onRemoveTrackerClicked);
+    connect(ui_.showBackupTrackersCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowBackupTrackersToggled);
+    connect(ui_.showTrackerScrapesCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowTrackerScrapesToggled);
     connect(
-        ui.trackersView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+        ui_.trackersView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
         &DetailsDialog::onTrackerSelectionChanged);
 
     onTrackerSelectionChanged();
@@ -1461,15 +1461,15 @@ void DetailsDialog::initTrackerTab()
 
 void DetailsDialog::initPeersTab()
 {
-    ui.peersView->setHeaderLabels({ QString(), tr("Up"), tr("Down"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
-    ui.peersView->sortByColumn(COL_ADDRESS, Qt::AscendingOrder);
+    ui_.peersView->setHeaderLabels({ QString(), tr("Up"), tr("Down"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
+    ui_.peersView->sortByColumn(COL_ADDRESS, Qt::AscendingOrder);
 
-    ui.peersView->setColumnWidth(COL_LOCK, 20);
-    ui.peersView->setColumnWidth(COL_UP, measureViewItem(ui.peersView, COL_UP, QLatin1String("1024 MiB/s")));
-    ui.peersView->setColumnWidth(COL_DOWN, measureViewItem(ui.peersView, COL_DOWN, QLatin1String("1024 MiB/s")));
-    ui.peersView->setColumnWidth(COL_PERCENT, measureViewItem(ui.peersView, COL_PERCENT, QLatin1String("100%")));
-    ui.peersView->setColumnWidth(COL_STATUS, measureViewItem(ui.peersView, COL_STATUS, QLatin1String("ODUK?EXI")));
-    ui.peersView->setColumnWidth(COL_ADDRESS, measureViewItem(ui.peersView, COL_ADDRESS, QLatin1String("888.888.888.888")));
+    ui_.peersView->setColumnWidth(COL_LOCK, 20);
+    ui_.peersView->setColumnWidth(COL_UP, measureViewItem(ui_.peersView, COL_UP, QLatin1String("1024 MiB/s")));
+    ui_.peersView->setColumnWidth(COL_DOWN, measureViewItem(ui_.peersView, COL_DOWN, QLatin1String("1024 MiB/s")));
+    ui_.peersView->setColumnWidth(COL_PERCENT, measureViewItem(ui_.peersView, COL_PERCENT, QLatin1String("100%")));
+    ui_.peersView->setColumnWidth(COL_STATUS, measureViewItem(ui_.peersView, COL_STATUS, QLatin1String("ODUK?EXI")));
+    ui_.peersView->setColumnWidth(COL_ADDRESS, measureViewItem(ui_.peersView, COL_ADDRESS, QLatin1String("888.888.888.888")));
 }
 
 /***
@@ -1478,10 +1478,10 @@ void DetailsDialog::initPeersTab()
 
 void DetailsDialog::initFilesTab()
 {
-    connect(ui.filesView, &FileTreeView::openRequested, this, &DetailsDialog::onOpenRequested);
-    connect(ui.filesView, &FileTreeView::pathEdited, this, &DetailsDialog::onPathEdited);
-    connect(ui.filesView, &FileTreeView::priorityChanged, this, &DetailsDialog::onFilePriorityChanged);
-    connect(ui.filesView, &FileTreeView::wantedChanged, this, &DetailsDialog::onFileWantedChanged);
+    connect(ui_.filesView, &FileTreeView::openRequested, this, &DetailsDialog::onOpenRequested);
+    connect(ui_.filesView, &FileTreeView::pathEdited, this, &DetailsDialog::onPathEdited);
+    connect(ui_.filesView, &FileTreeView::priorityChanged, this, &DetailsDialog::onFilePriorityChanged);
+    connect(ui_.filesView, &FileTreeView::wantedChanged, this, &DetailsDialog::onFileWantedChanged);
 }
 
 void DetailsDialog::onFilePriorityChanged(QSet<int> const& indices, int priority)

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -89,20 +89,20 @@ private slots:
     void onIdleLimitChanged();
 
 private:
-    Session& mySession;
-    Prefs& myPrefs;
-    TorrentModel const& myModel;
+    Session& session_;
+    Prefs& prefs_;
+    TorrentModel const& model_;
 
     Ui::DetailsDialog ui;
 
-    torrent_ids_t myIds;
-    QTimer myTimer;
-    bool myChangedTorrents;
-    bool myHavePendingRefresh;
+    torrent_ids_t ids_;
+    QTimer timer_;
+    bool changed_torrents_;
+    bool have_pending_refresh_;
 
-    TrackerModel* myTrackerModel;
-    TrackerModelFilter* myTrackerFilter;
-    TrackerDelegate* myTrackerDelegate;
+    TrackerModel* tracker_model_;
+    TrackerModelFilter* tracker_filter_;
+    TrackerDelegate* tracker_delegate_;
 
-    QMap<QString, QTreeWidgetItem*> myPeers;
+    QMap<QString, QTreeWidgetItem*> peers_;
 };

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -93,7 +93,7 @@ private:
     Prefs& prefs_;
     TorrentModel const& model_;
 
-    Ui::DetailsDialog ui;
+    Ui::DetailsDialog ui_;
 
     torrent_ids_t ids_;
     QTimer timer_;

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -20,13 +20,13 @@
 
 FaviconCache::FaviconCache()
 {
-    myNAM = new QNetworkAccessManager();
-    connect(myNAM, SIGNAL(finished(QNetworkReply*)), this, SLOT(onRequestFinished(QNetworkReply*)));
+    nam_ = new QNetworkAccessManager();
+    connect(nam_, SIGNAL(finished(QNetworkReply*)), this, SLOT(onRequestFinished(QNetworkReply*)));
 }
 
 FaviconCache::~FaviconCache()
 {
-    delete myNAM;
+    delete nam_;
 }
 
 /***
@@ -69,7 +69,7 @@ void FaviconCache::ensureCacheDirHasBeenScanned()
 
             if (!pixmap.isNull())
             {
-                myPixmaps[file] = scale(pixmap);
+                pixmaps_[file] = scale(pixmap);
             }
         }
     }
@@ -113,7 +113,7 @@ QPixmap FaviconCache::find(QString const& key)
 {
     ensureCacheDirHasBeenScanned();
 
-    return myPixmaps[key];
+    return pixmaps_[key];
 }
 
 QString FaviconCache::add(QUrl const& url)
@@ -122,10 +122,10 @@ QString FaviconCache::add(QUrl const& url)
 
     QString const key = getKey(url);
 
-    if (myPixmaps.count(key) == 0)
+    if (pixmaps_.count(key) == 0)
     {
         // add a placholder s.t. we only ping the server once per session
-        myPixmaps[key] = QPixmap();
+        pixmaps_[key] = QPixmap();
 
         // try to download the favicon
         QString const path = QLatin1String("http://") + url.host() + QLatin1String("/favicon.");
@@ -134,7 +134,7 @@ QString FaviconCache::add(QUrl const& url)
 
         for (QString const& suffix : suffixes)
         {
-            myNAM->get(QNetworkRequest(path + suffix));
+            nam_->get(QNetworkRequest(path + suffix));
         }
     }
 
@@ -157,7 +157,7 @@ void FaviconCache::onRequestFinished(QNetworkReply* reply)
     if (!pixmap.isNull())
     {
         // save it in memory...
-        myPixmaps[key] = scale(pixmap);
+        pixmaps_[key] = scale(pixmap);
 
         // save it on disk...
         QDir cacheDir(getCacheDir());

--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -52,6 +52,6 @@ private slots:
     void onRequestFinished(QNetworkReply* reply);
 
 private:
-    QNetworkAccessManager* myNAM;
-    std::unordered_map<QString, QPixmap> myPixmaps;
+    QNetworkAccessManager* nam_;
+    std::unordered_map<QString, QPixmap> pixmaps_;
 };

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -34,14 +34,14 @@ public:
 
 public:
     FileTreeItem(QString const& name = QString(), int fileIndex = -1, uint64_t size = 0) :
-        myName(name),
-        myFileIndex(fileIndex),
-        myTotalSize(size),
-        myParent(nullptr),
-        myPriority(0),
-        myIsWanted(false),
-        myHaveSize(0),
-        myFirstUnhashedRow(0)
+        name_(name),
+        file_index_(fileIndex),
+        total_size_(size),
+        parent_(nullptr),
+        priority_(0),
+        is_wanted_(false),
+        have_size_(0),
+        first_unhashed_row_(0)
     {
     }
 
@@ -53,29 +53,29 @@ public:
 
     FileTreeItem* child(int row)
     {
-        return myChildren.at(row);
+        return children_.at(row);
     }
 
     int childCount() const
     {
-        return myChildren.size();
+        return children_.size();
     }
 
     FileTreeItem* parent()
     {
-        return myParent;
+        return parent_;
     }
 
     FileTreeItem const* parent() const
     {
-        return myParent;
+        return parent_;
     }
 
     int row() const;
 
     QString const& name() const
     {
-        return myName;
+        return name_;
     }
 
     QVariant data(int column, int role) const;
@@ -85,12 +85,12 @@ public:
 
     int fileIndex() const
     {
-        return myFileIndex;
+        return file_index_;
     }
 
     uint64_t totalSize() const
     {
-        return myTotalSize;
+        return total_size_;
     }
 
     QString path() const;
@@ -107,15 +107,15 @@ private:
     QHash<QString, int> const& getMyChildRows();
 
 private:
-    QString myName;
-    int const myFileIndex;
-    uint64_t const myTotalSize;
+    QString name_;
+    int const file_index_;
+    uint64_t const total_size_;
 
-    FileTreeItem* myParent;
-    QList<FileTreeItem*> myChildren;
-    QHash<QString, int> myChildRows;
-    int myPriority;
-    bool myIsWanted;
-    uint64_t myHaveSize;
-    size_t myFirstUnhashedRow;
+    FileTreeItem* parent_;
+    QList<FileTreeItem*> children_;
+    QHash<QString, int> child_rows_;
+    int priority_;
+    bool is_wanted_;
+    uint64_t have_size_;
+    size_t first_unhashed_row_;
 };

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -88,8 +88,8 @@ private:
     QModelIndexList getOrphanIndices(QModelIndexList const& indices) const;
 
 private:
-    bool myIsEditable;
+    bool is_editable_;
 
-    FileTreeItem* myRootItem;
-    QMap<int, FileTreeItem*> myIndexCache;
+    FileTreeItem* root_item_;
+    QMap<int, FileTreeItem*> index_cache_;
 };

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -67,18 +67,18 @@ private:
     static Qt::CheckState getCumulativeCheckState(QModelIndexList const& indices);
 
 private:
-    FileTreeModel* myModel;
-    QSortFilterProxyModel* myProxy;
-    FileTreeDelegate* myDelegate;
+    FileTreeModel* model_;
+    QSortFilterProxyModel* proxy_;
+    FileTreeDelegate* delegate_;
 
-    QMenu* myContextMenu = nullptr;
-    QMenu* myPriorityMenu = nullptr;
-    QAction* myCheckSelectedAction = nullptr;
-    QAction* myUncheckSelectedAction = nullptr;
-    QAction* myOnlyCheckSelectedAction = nullptr;
-    QAction* myHighPriorityAction = nullptr;
-    QAction* myNormalPriorityAction = nullptr;
-    QAction* myLowPriorityAction = nullptr;
-    QAction* myOpenAction = nullptr;
-    QAction* myRenameAction = nullptr;
+    QMenu* context_menu_ = nullptr;
+    QMenu* priority_menu_ = nullptr;
+    QAction* check_selected_action_ = nullptr;
+    QAction* uncheck_selected_action_ = nullptr;
+    QAction* only_check_selected_action_ = nullptr;
+    QAction* high_priority_action_ = nullptr;
+    QAction* normal_priority_action_ = nullptr;
+    QAction* low_priority_action_ = nullptr;
+    QAction* open_action_ = nullptr;
+    QAction* rename_action_ = nullptr;
 };

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -47,16 +47,16 @@ private slots:
     void onTextChanged(QString const&);
 
 private:
-    Prefs& myPrefs;
-    TorrentModel const& myTorrents;
-    TorrentFilter const& myFilter;
+    Prefs& prefs_;
+    TorrentModel const& torrents_;
+    TorrentFilter const& filter_;
 
-    FilterBarComboBox* myActivityCombo;
-    FilterBarComboBox* myTrackerCombo;
-    QLabel* myCountLabel;
-    QStandardItemModel* myTrackerModel;
-    QTimer* myRecountTimer;
-    bool myIsBootstrapping;
-    QLineEdit* myLineEdit;
-    std::map<QString, int> myTrackerCounts;
+    FilterBarComboBox* activity_combo_;
+    FilterBarComboBox* tracker_combo_;
+    QLabel* count_label_;
+    QStandardItemModel* tracker_model_;
+    QTimer* recount_timer_;
+    bool is_bootstrapping_;
+    QLineEdit* line_edit_;
+    std::map<QString, int> tracker_counts_;
 };

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -28,7 +28,7 @@ int getHSpacing(QWidget const* w)
 
 FilterBarComboBoxDelegate::FilterBarComboBoxDelegate(QObject* parent, QComboBox* combo) :
     QItemDelegate(parent),
-    myCombo(combo)
+    combo_(combo)
 {
 }
 
@@ -63,7 +63,7 @@ void FilterBarComboBoxDelegate::paint(QPainter* painter, QStyleOptionViewItem co
 
         QStyleOption opt;
         opt.rect = rect;
-        myCombo->style()->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, &opt, painter, myCombo);
+        combo_->style()->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, &opt, painter, combo_);
     }
     else
     {
@@ -75,11 +75,11 @@ void FilterBarComboBoxDelegate::paint(QPainter* painter, QStyleOptionViewItem co
 
         QRect boundingBox = option.rect;
 
-        int const hmargin = getHSpacing(myCombo);
+        int const hmargin = getHSpacing(combo_);
         boundingBox.adjust(hmargin, 0, -hmargin, 0);
 
         QRect decorationRect = rect(option, index, Qt::DecorationRole);
-        decorationRect.setSize(myCombo->iconSize());
+        decorationRect.setSize(combo_->iconSize());
         decorationRect = QStyle::alignedRect(option.direction, Qt::AlignLeft | Qt::AlignVCenter, decorationRect.size(),
             boundingBox);
         Utils::narrowRect(boundingBox, decorationRect.width() + hmargin, 0, option.direction);
@@ -103,16 +103,16 @@ QSize FilterBarComboBoxDelegate::sizeHint(QStyleOptionViewItem const& option, QM
 {
     if (isSeparator(index))
     {
-        int const pm = myCombo->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, myCombo);
+        int const pm = combo_->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, combo_);
         return QSize(pm, pm + 10);
     }
 
-    QStyle* s = myCombo->style();
-    int const hmargin = getHSpacing(myCombo);
+    QStyle* s = combo_->style();
+    int const hmargin = getHSpacing(combo_);
 
     QSize size = QItemDelegate::sizeHint(option, index);
-    size.setHeight(qMax(size.height(), myCombo->iconSize().height() + 6));
-    size.rwidth() += s->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, myCombo);
+    size.setHeight(qMax(size.height(), combo_->iconSize().height() + 6));
+    size.rwidth() += s->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, combo_);
     size.rwidth() += rect(option, index, FilterBarComboBox::CountStringRole).width();
     size.rwidth() += hmargin * 4;
     return size;

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -29,5 +29,5 @@ protected:
     QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const override;
 
 private:
-    QComboBox* const myCombo;
+    QComboBox* const combo_;
 };

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -30,23 +30,23 @@ public:
 
 public:
     FilterMode(int mode = SHOW_ALL) :
-        myMode(mode)
+        mode_(mode)
     {
     }
 
     FilterMode(QString const& name) :
-        myMode(modeFromName(name))
+        mode_(modeFromName(name))
     {
     }
 
     int mode() const
     {
-        return myMode;
+        return mode_;
     }
 
     QString const& name() const
     {
-        return names[myMode];
+        return names[mode_];
     }
 
     static int modeFromName(QString const& name);
@@ -57,7 +57,7 @@ public:
     }
 
 private:
-    int myMode;
+    int mode_;
 
     static QString const names[];
 };
@@ -84,30 +84,30 @@ public:
 
 public:
     SortMode(int mode = SORT_BY_ID) :
-        myMode(mode)
+        mode_(mode)
     {
     }
 
     SortMode(QString const& name) :
-        myMode(modeFromName(name))
+        mode_(modeFromName(name))
     {
     }
 
     int mode() const
     {
-        return myMode;
+        return mode_;
     }
 
     QString const& name() const
     {
-        return names[myMode];
+        return names[mode_];
     }
 
     static int modeFromName(QString const& name);
     static QString const& nameFromMode(int mode);
 
 private:
-    int myMode;
+    int mode_;
 
     static QString const names[];
 };

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -25,54 +25,54 @@ int const INTERVAL_MSEC = 15000;
 
 FreeSpaceLabel::FreeSpaceLabel(QWidget* parent) :
     QLabel(parent),
-    mySession(nullptr),
-    myTimer(this)
+    session_(nullptr),
+    timer_(this)
 {
-    myTimer.setSingleShot(true);
-    myTimer.setInterval(INTERVAL_MSEC);
+    timer_.setSingleShot(true);
+    timer_.setInterval(INTERVAL_MSEC);
 
-    connect(&myTimer, SIGNAL(timeout()), this, SLOT(onTimer()));
+    connect(&timer_, SIGNAL(timeout()), this, SLOT(onTimer()));
 }
 
 void FreeSpaceLabel::setSession(Session& session)
 {
-    if (mySession == &session)
+    if (session_ == &session)
     {
         return;
     }
 
-    mySession = &session;
+    session_ = &session;
     onTimer();
 }
 
 void FreeSpaceLabel::setPath(QString const& path)
 {
-    if (myPath != path)
+    if (path_ != path)
     {
         setText(tr("<i>Calculating Free Space...</i>"));
-        myPath = path;
+        path_ = path;
         onTimer();
     }
 }
 
 void FreeSpaceLabel::onTimer()
 {
-    myTimer.stop();
+    timer_.stop();
 
-    if (mySession == nullptr || myPath.isEmpty())
+    if (session_ == nullptr || path_.isEmpty())
     {
         return;
     }
 
     tr_variant args;
     tr_variantInitDict(&args, 1);
-    tr_variantDictAddStr(&args, TR_KEY_path, myPath.toUtf8().constData());
+    tr_variantDictAddStr(&args, TR_KEY_path, path_.toUtf8().constData());
 
     auto* q = new RpcQueue();
 
     q->add([this, &args]()
         {
-            return mySession->exec("free-space", &args);
+            return session_->exec("free-space", &args);
         });
 
     q->add([this](RpcResponse const& r)
@@ -98,7 +98,7 @@ void FreeSpaceLabel::onTimer()
             str = QString::fromUtf8(path, len);
             setToolTip(QDir::toNativeSeparators(str));
 
-            myTimer.start();
+            timer_.start();
         });
 
     q->run();

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -37,7 +37,7 @@ private slots:
     void onTimer();
 
 private:
-    Session* mySession;
-    QString myPath;
-    QTimer myTimer;
+    Session* session_;
+    QString path_;
+    QTimer timer_;
 };

--- a/qt/InteropHelper.cc
+++ b/qt/InteropHelper.cc
@@ -14,7 +14,7 @@ bool InteropHelper::isConnected() const
 {
 #ifdef ENABLE_DBUS_INTEROP
 
-    if (myDbusClient.isConnected())
+    if (dbus_client_.isConnected())
     {
         return true;
     }
@@ -23,7 +23,7 @@ bool InteropHelper::isConnected() const
 
 #ifdef ENABLE_COM_INTEROP
 
-    if (myComClient.isConnected())
+    if (com_client_.isConnected())
     {
         return true;
     }
@@ -38,7 +38,7 @@ bool InteropHelper::addMetainfo(QString const& metainfo)
 #ifdef ENABLE_DBUS_INTEROP
 
     {
-        QVariant const response = myDbusClient.addMetainfo(metainfo);
+        QVariant const response = dbus_client_.addMetainfo(metainfo);
 
         if (response.isValid() && response.toBool())
         {
@@ -51,7 +51,7 @@ bool InteropHelper::addMetainfo(QString const& metainfo)
 #ifdef ENABLE_COM_INTEROP
 
     {
-        QVariant const response = myComClient.addMetainfo(metainfo);
+        QVariant const response = com_client_.addMetainfo(metainfo);
 
         if (response.isValid() && response.toBool())
         {

--- a/qt/InteropHelper.h
+++ b/qt/InteropHelper.h
@@ -31,9 +31,9 @@ public:
 
 private:
 #ifdef ENABLE_DBUS_INTEROP
-    DBusInteropHelper myDbusClient;
+    DBusInteropHelper dbus_client_;
 #endif
 #ifdef ENABLE_COM_INTEROP
-    ComInteropHelper myComClient;
+    ComInteropHelper com_client_;
 #endif
 };

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -56,7 +56,7 @@ public:
 
     QSystemTrayIcon& trayIcon()
     {
-        return myTrayIcon;
+        return tray_icon_;
     }
 
 public slots:
@@ -139,42 +139,42 @@ private slots:
     void trayActivated(QSystemTrayIcon::ActivationReason);
 
 private:
-    Session& mySession;
-    Prefs& myPrefs;
-    TorrentModel& myModel;
+    Session& session_;
+    Prefs& prefs_;
+    TorrentModel& model_;
 
-    QPixmap myPixmapNetworkError;
-    QPixmap myPixmapNetworkIdle;
-    QPixmap myPixmapNetworkReceive;
-    QPixmap myPixmapNetworkTransmit;
-    QPixmap myPixmapNetworkTransmitReceive;
+    QPixmap pixmap_network_error_;
+    QPixmap pixmap_network_idle_;
+    QPixmap pixmap_network_receive_;
+    QPixmap pixmap_network_transmit_;
+    QPixmap pixmap_network_transmit_receive_;
 
     Ui_MainWindow ui;
 
-    time_t myLastFullUpdateTime;
-    QPointer<SessionDialog> mySessionDialog;
-    QPointer<PrefsDialog> myPrefsDialog;
-    QPointer<AboutDialog> myAboutDialog;
-    QPointer<StatsDialog> myStatsDialog;
-    QPointer<DetailsDialog> myDetailsDialog;
-    QSystemTrayIcon myTrayIcon;
-    TorrentFilter myFilterModel;
-    TorrentDelegate* myTorrentDelegate;
-    TorrentDelegateMin* myTorrentDelegateMin;
-    time_t myLastSendTime;
-    time_t myLastReadTime;
-    QTimer myNetworkTimer;
-    bool myNetworkError;
-    QAction* myDlimitOffAction;
-    QAction* myDlimitOnAction;
-    QAction* myUlimitOffAction;
-    QAction* myUlimitOnAction;
-    QAction* myRatioOffAction;
-    QAction* myRatioOnAction;
-    QWidgetList myHidden;
-    QWidget* myFilterBar;
-    QAction* myAltSpeedAction;
-    QString myErrorMessage;
+    time_t last_full_update_time_;
+    QPointer<SessionDialog> session_dialog_;
+    QPointer<PrefsDialog> prefs_dialog_;
+    QPointer<AboutDialog> about_dialog_;
+    QPointer<StatsDialog> stats_dialog_;
+    QPointer<DetailsDialog> details_dialog_;
+    QSystemTrayIcon tray_icon_;
+    TorrentFilter filter_model_;
+    TorrentDelegate* torrent_delegate_;
+    TorrentDelegateMin* torrent_delegate_min_;
+    time_t last_send_time_;
+    time_t last_read_time_;
+    QTimer network_timer_;
+    bool network_error_;
+    QAction* dlimit_off_action_;
+    QAction* dlimit_on_action_;
+    QAction* ulimit_off_action_;
+    QAction* ulimit_on_action_;
+    QAction* ratio_off_action_;
+    QAction* ratio_on_action_;
+    QWidgetList hidden_;
+    QWidget* filter_bar_;
+    QAction* alt_speed_action_;
+    QString error_message_;
 
     struct TransferStats
     {
@@ -193,8 +193,8 @@ private:
         REFRESH_TORRENT_VIEW_HEADER = (1 << 3),
         REFRESH_ACTION_SENSITIVITY = (1 << 4)
     };
-    int myRefreshFields = 0;
-    QTimer myRefreshTimer;
+    int refresh_fields_ = 0;
+    QTimer refresh_timer_;
     void refreshActionSensitivity();
     void refreshStatusBar(TransferStats const&);
     void refreshTitle();

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -44,9 +44,9 @@ private slots:
     void makeTorrent();
 
 private:
-    Session& mySession;
+    Session& session_;
 
     Ui::MakeDialog ui;
 
-    std::unique_ptr<tr_metainfo_builder, void (*)(tr_metainfo_builder*)> myBuilder;
+    std::unique_ptr<tr_metainfo_builder, void (*)(tr_metainfo_builder*)> builder_;
 };

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -60,29 +60,29 @@ private slots:
     void onSessionUpdated();
 
 private:
-    Session& mySession;
-    AddData myAdd;
+    Session& session_;
+    AddData add_;
 
     Ui::OptionsDialog ui;
 
-    bool myIsLocal;
-    QDir myLocalDestination;
-    bool myHaveInfo;
-    tr_info myInfo;
-    QPushButton* myVerifyButton;
-    QVector<int> myPriorities;
-    QVector<bool> myWanted;
-    FileList myFiles;
+    bool is_local_;
+    QDir local_destination_;
+    bool have_info_;
+    tr_info info_;
+    QPushButton* verify_button_;
+    QVector<int> priorities_;
+    QVector<bool> wanted_;
+    FileList files_;
 
-    QTimer myVerifyTimer;
-    char myVerifyBuf[2048 * 4];
-    QFile myVerifyFile;
-    uint64_t myVerifyFilePos;
-    int myVerifyFileIndex;
-    uint32_t myVerifyPieceIndex;
-    uint32_t myVerifyPiecePos;
-    QVector<bool> myVerifyFlags;
-    QCryptographicHash myVerifyHash;
-    mybins_t myVerifyBins;
-    QTimer myEditTimer;
+    QTimer verify_timer_;
+    char verify_buf_[2048 * 4];
+    QFile verify_file_;
+    uint64_t verify_file_pos_;
+    int verify_file_index_;
+    uint32_t verify_piece_index_;
+    uint32_t verify_piece_pos_;
+    QVector<bool> verify_flags_;
+    QCryptographicHash verify_hash_;
+    mybins_t verify_bins_;
+    QTimer edit_timer_;
 };

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -20,10 +20,10 @@
 
 PathButton::PathButton(QWidget* parent) :
     QToolButton(parent),
-    myMode(DirectoryMode),
-    myTitle(),
-    myNameFilter(),
-    myPath()
+    mode_(DirectoryMode),
+    title_(),
+    name_filter_(),
+    path_()
 {
     setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed));
     setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
@@ -36,43 +36,43 @@ PathButton::PathButton(QWidget* parent) :
 
 void PathButton::setMode(Mode mode)
 {
-    if (myMode == mode)
+    if (mode_ == mode)
     {
         return;
     }
 
-    myMode = mode;
+    mode_ = mode;
 
     updateAppearance();
 }
 
 void PathButton::setTitle(QString const& title)
 {
-    myTitle = title;
+    title_ = title;
 }
 
 void PathButton::setNameFilter(QString const& nameFilter)
 {
-    myNameFilter = nameFilter;
+    name_filter_ = nameFilter;
 }
 
 void PathButton::setPath(QString const& path)
 {
-    if (myPath == path)
+    if (path_ == path)
     {
         return;
     }
 
-    myPath = QDir::toNativeSeparators(Utils::removeTrailingDirSeparator(path));
+    path_ = QDir::toNativeSeparators(Utils::removeTrailingDirSeparator(path));
 
     updateAppearance();
 
-    emit pathChanged(myPath);
+    emit pathChanged(path_);
 }
 
 QString const& PathButton::path() const
 {
-    return myPath;
+    return path_;
 }
 
 QSize PathButton::sizeHint() const
@@ -97,8 +97,8 @@ void PathButton::paintEvent(QPaintEvent* /*event*/)
         textWidth -= style()->pixelMetric(QStyle::PM_MenuButtonIndicator, &option, this);
     }
 
-    QFileInfo const pathInfo(myPath);
-    option.text = myPath.isEmpty() ? tr("(None)") : (pathInfo.fileName().isEmpty() ? myPath : pathInfo.fileName());
+    QFileInfo const pathInfo(path_);
+    option.text = path_.isEmpty() ? tr("(None)") : (pathInfo.fileName().isEmpty() ? path_ : pathInfo.fileName());
     option.text = fontMetrics().elidedText(option.text, Qt::ElideMiddle, textWidth);
 
     painter.drawComplexControl(QStyle::CC_ToolButton, option);
@@ -114,14 +114,14 @@ void PathButton::onClicked()
         dialog->setOption(QFileDialog::ShowDirsOnly);
     }
 
-    if (!myNameFilter.isEmpty())
+    if (!name_filter_.isEmpty())
     {
-        dialog->setNameFilter(myNameFilter);
+        dialog->setNameFilter(name_filter_);
     }
 
-    QFileInfo const pathInfo(myPath);
+    QFileInfo const pathInfo(path_);
 
-    if (!myPath.isEmpty() && pathInfo.exists())
+    if (!path_.isEmpty() && pathInfo.exists())
     {
         if (pathInfo.isDir())
         {
@@ -150,16 +150,16 @@ void PathButton::onFileSelected(QString const& path)
 
 void PathButton::updateAppearance()
 {
-    QFileInfo const pathInfo(myPath);
+    QFileInfo const pathInfo(path_);
 
     int const iconSize(style()->pixelMetric(QStyle::PM_SmallIconSize));
     QFileIconProvider const iconProvider;
 
     QIcon icon;
 
-    if (!myPath.isEmpty() && pathInfo.exists())
+    if (!path_.isEmpty() && pathInfo.exists())
     {
-        icon = iconProvider.icon(myPath);
+        icon = iconProvider.icon(path_);
     }
 
     if (icon.isNull())
@@ -169,21 +169,21 @@ void PathButton::updateAppearance()
 
     setIconSize(QSize(iconSize, iconSize));
     setIcon(icon);
-    setToolTip(myPath == text() ? QString() : myPath);
+    setToolTip(path_ == text() ? QString() : path_);
 
     update();
 }
 
 bool PathButton::isDirMode() const
 {
-    return myMode == DirectoryMode;
+    return mode_ == DirectoryMode;
 }
 
 QString PathButton::effectiveTitle() const
 {
-    if (!myTitle.isEmpty())
+    if (!title_.isEmpty())
     {
-        return myTitle;
+        return title_;
     }
 
     return isDirMode() ? tr("Select Folder") : tr("Select File");

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -52,8 +52,8 @@ private slots:
     void onFileSelected(QString const& path);
 
 private:
-    Mode myMode;
-    QString myTitle;
-    QString myNameFilter;
-    QString myPath;
+    Mode mode_;
+    QString title_;
+    QString name_filter_;
+    QString path_;
 };

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -25,7 +25,7 @@
 ****
 ***/
 
-Prefs::PrefItem Prefs::myItems[] =
+Prefs::PrefItem Prefs::items_[] =
 {
     /* gui settings */
     { OPTIONS_PROMPT, TR_KEY_show_options_window, QVariant::Bool },
@@ -126,27 +126,27 @@ Prefs::PrefItem Prefs::myItems[] =
 ***/
 
 Prefs::Prefs(QString const& configDir) :
-    myConfigDir(configDir)
+    config_dir_(configDir)
 {
-    assert(sizeof(myItems) / sizeof(myItems[0]) == PREFS_COUNT);
+    assert(sizeof(items_) / sizeof(items_[0]) == PREFS_COUNT);
 
 #ifndef NDEBUG
 
     for (int i = 0; i < PREFS_COUNT; ++i)
     {
-        assert(myItems[i].id == i);
+        assert(items_[i].id == i);
     }
 
 #endif
 
     // these are the prefs that don't get saved to settings.json
     // when the application exits.
-    myTemporaryPrefs << FILTER_TEXT;
+    temporary_prefs_ << FILTER_TEXT;
 
     tr_variant top;
     tr_variantInitDict(&top, 0);
     initDefaults(&top);
-    tr_sessionLoadSettings(&top, myConfigDir.toUtf8().constData(), nullptr);
+    tr_sessionLoadSettings(&top, config_dir_.toUtf8().constData(), nullptr);
 
     for (int i = 0; i < PREFS_COUNT; ++i)
     {
@@ -155,14 +155,14 @@ Prefs::Prefs(QString const& configDir) :
         int64_t intVal;
         char const* str;
         size_t strLen;
-        tr_variant* b(tr_variantDictFind(&top, myItems[i].key));
+        tr_variant* b(tr_variantDictFind(&top, items_[i].key));
 
-        switch (myItems[i].type)
+        switch (items_[i].type)
         {
         case QVariant::Int:
             if (tr_variantGetInt(b, &intVal))
             {
-                myValues[i].setValue(static_cast<qlonglong>(intVal));
+                values_[i].setValue(static_cast<qlonglong>(intVal));
             }
 
             break;
@@ -170,7 +170,7 @@ Prefs::Prefs(QString const& configDir) :
         case CustomVariantType::SortModeType:
             if (tr_variantGetStr(b, &str, nullptr))
             {
-                myValues[i] = QVariant::fromValue(SortMode(QString::fromUtf8(str)));
+                values_[i] = QVariant::fromValue(SortMode(QString::fromUtf8(str)));
             }
 
             break;
@@ -178,7 +178,7 @@ Prefs::Prefs(QString const& configDir) :
         case CustomVariantType::FilterModeType:
             if (tr_variantGetStr(b, &str, nullptr))
             {
-                myValues[i] = QVariant::fromValue(FilterMode(QString::fromUtf8(str)));
+                values_[i] = QVariant::fromValue(FilterMode(QString::fromUtf8(str)));
             }
 
             break;
@@ -186,7 +186,7 @@ Prefs::Prefs(QString const& configDir) :
         case QVariant::String:
             if (tr_variantGetStr(b, &str, &strLen))
             {
-                myValues[i].setValue(QString::fromUtf8(str, strLen));
+                values_[i].setValue(QString::fromUtf8(str, strLen));
             }
 
             break;
@@ -194,7 +194,7 @@ Prefs::Prefs(QString const& configDir) :
         case QVariant::Bool:
             if (tr_variantGetBool(b, &boolVal))
             {
-                myValues[i].setValue(static_cast<bool>(boolVal));
+                values_[i].setValue(static_cast<bool>(boolVal));
             }
 
             break;
@@ -202,7 +202,7 @@ Prefs::Prefs(QString const& configDir) :
         case QVariant::Double:
             if (tr_variantGetReal(b, &d))
             {
-                myValues[i].setValue(d);
+                values_[i].setValue(d);
             }
 
             break;
@@ -210,7 +210,7 @@ Prefs::Prefs(QString const& configDir) :
         case QVariant::DateTime:
             if (tr_variantGetInt(b, &intVal))
             {
-                myValues[i].setValue(QDateTime::fromTime_t(intVal));
+                values_[i].setValue(QDateTime::fromTime_t(intVal));
             }
 
             break;
@@ -232,15 +232,15 @@ Prefs::~Prefs()
 
     for (int i = 0; i < PREFS_COUNT; ++i)
     {
-        if (myTemporaryPrefs.contains(i))
+        if (temporary_prefs_.contains(i))
         {
             continue;
         }
 
-        tr_quark const key = myItems[i].key;
-        QVariant const& val = myValues[i];
+        tr_quark const key = items_[i].key;
+        QVariant const& val = values_[i];
 
-        switch (myItems[i].type)
+        switch (items_[i].type)
         {
         case QVariant::Int:
             tr_variantDictAddInt(&current_settings, key, val.toInt());
@@ -291,7 +291,7 @@ Prefs::~Prefs()
 
     // update settings.json with our settings
     tr_variant file_settings;
-    QFile const file(QDir(myConfigDir).absoluteFilePath(QLatin1String("settings.json")));
+    QFile const file(QDir(config_dir_).absoluteFilePath(QLatin1String("settings.json")));
 
     if (!tr_variantFromFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toUtf8().constData(), nullptr))
     {
@@ -360,39 +360,39 @@ void Prefs::initDefaults(tr_variant* d)
 
 bool Prefs::getBool(int key) const
 {
-    assert(myItems[key].type == QVariant::Bool);
-    return myValues[key].toBool();
+    assert(items_[key].type == QVariant::Bool);
+    return values_[key].toBool();
 }
 
 QString Prefs::getString(int key) const
 {
-    assert(myItems[key].type == QVariant::String);
-    QByteArray const b = myValues[key].toByteArray();
+    assert(items_[key].type == QVariant::String);
+    QByteArray const b = values_[key].toByteArray();
 
     if (Utils::isValidUtf8(b.constData()))
     {
-        myValues[key].setValue(QString::fromUtf8(b.constData()));
+        values_[key].setValue(QString::fromUtf8(b.constData()));
     }
 
-    return myValues[key].toString();
+    return values_[key].toString();
 }
 
 int Prefs::getInt(int key) const
 {
-    assert(myItems[key].type == QVariant::Int);
-    return myValues[key].toInt();
+    assert(items_[key].type == QVariant::Int);
+    return values_[key].toInt();
 }
 
 double Prefs::getDouble(int key) const
 {
-    assert(myItems[key].type == QVariant::Double);
-    return myValues[key].toDouble();
+    assert(items_[key].type == QVariant::Double);
+    return values_[key].toDouble();
 }
 
 QDateTime Prefs::getDateTime(int key) const
 {
-    assert(myItems[key].type == QVariant::DateTime);
-    return myValues[key].toDateTime();
+    assert(items_[key].type == QVariant::DateTime);
+    return values_[key].toDateTime();
 }
 
 /***

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -144,22 +144,22 @@ public:
 
     char const* keyStr(int i) const
     {
-        return tr_quark_get_string(myItems[i].key, nullptr);
+        return tr_quark_get_string(items_[i].key, nullptr);
     }
 
     tr_quark getKey(int i) const
     {
-        return myItems[i].key;
+        return items_[i].key;
     }
 
     int type(int i) const
     {
-        return myItems[i].type;
+        return items_[i].type;
     }
 
     QVariant const& variant(int i) const
     {
-        return myValues[i];
+        return values_[i];
     }
 
     int getInt(int key) const;
@@ -171,13 +171,13 @@ public:
     template<typename T>
     T get(int key) const
     {
-        return myValues[key].value<T>();
+        return values_[key].value<T>();
     }
 
     template<typename T>
     void set(int key, T const& value)
     {
-        QVariant& v(myValues[key]);
+        QVariant& v(values_[key]);
         QVariant const tmp = QVariant::fromValue(value);
 
         if (v.isNull() || v != tmp)
@@ -207,10 +207,10 @@ private:
     void set(int key, char const* value);
 
 private:
-    QString const myConfigDir;
+    QString const config_dir_;
 
-    QSet<int> myTemporaryPrefs;
-    QVariant mutable myValues[PREFS_COUNT];
+    QSet<int> temporary_prefs_;
+    QVariant mutable values_[PREFS_COUNT];
 
-    static PrefItem myItems[];
+    static PrefItem items_[];
 };

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -167,31 +167,31 @@ bool PrefsDialog::updateWidgetValue(QWidget* widget, int prefKey)
 
     if (prefWidget.is<QCheckBox>())
     {
-        prefWidget.as<QCheckBox>()->setChecked(myPrefs.getBool(prefKey));
+        prefWidget.as<QCheckBox>()->setChecked(prefs_.getBool(prefKey));
     }
     else if (prefWidget.is<QSpinBox>())
     {
-        prefWidget.as<QSpinBox>()->setValue(myPrefs.getInt(prefKey));
+        prefWidget.as<QSpinBox>()->setValue(prefs_.getInt(prefKey));
     }
     else if (prefWidget.is<QDoubleSpinBox>())
     {
-        prefWidget.as<QDoubleSpinBox>()->setValue(myPrefs.getDouble(prefKey));
+        prefWidget.as<QDoubleSpinBox>()->setValue(prefs_.getDouble(prefKey));
     }
     else if (prefWidget.is<QTimeEdit>())
     {
-        prefWidget.as<QTimeEdit>()->setTime(QTime(0, 0).addSecs(myPrefs.getInt(prefKey) * 60));
+        prefWidget.as<QTimeEdit>()->setTime(QTime(0, 0).addSecs(prefs_.getInt(prefKey) * 60));
     }
     else if (prefWidget.is<QLineEdit>())
     {
-        prefWidget.as<QLineEdit>()->setText(myPrefs.getString(prefKey));
+        prefWidget.as<QLineEdit>()->setText(prefs_.getString(prefKey));
     }
     else if (prefWidget.is<PathButton>())
     {
-        prefWidget.as<PathButton>()->setPath(myPrefs.getString(prefKey));
+        prefWidget.as<PathButton>()->setPath(prefs_.getString(prefKey));
     }
     else if (prefWidget.is<FreeSpaceLabel>())
     {
-        prefWidget.as<FreeSpaceLabel>()->setPath(myPrefs.getString(prefKey));
+        prefWidget.as<FreeSpaceLabel>()->setPath(prefs_.getString(prefKey));
     }
     else
     {
@@ -207,7 +207,7 @@ void PrefsDialog::linkWidgetToPref(QWidget* widget, int prefKey)
 
     prefWidget.setPrefKey(prefKey);
     updateWidgetValue(widget, prefKey);
-    myWidgets.insert(prefKey, widget);
+    widgets_.insert(prefKey, widget);
 
     if (prefWidget.is<QCheckBox>())
     {
@@ -304,12 +304,12 @@ void PrefsDialog::initRemoteTab()
     linkWidgetToPref(ui.enableRpcWhitelistCheck, Prefs::RPC_WHITELIST_ENABLED);
     linkWidgetToPref(ui.rpcWhitelistEdit, Prefs::RPC_WHITELIST);
 
-    myWebWidgets << ui.rpcPortLabel << ui.rpcPortSpin << ui.requireRpcAuthCheck << ui.enableRpcWhitelistCheck;
-    myWebAuthWidgets << ui.rpcUsernameLabel << ui.rpcUsernameEdit << ui.rpcPasswordLabel << ui.rpcPasswordEdit;
-    myWebWhitelistWidgets << ui.rpcWhitelistLabel << ui.rpcWhitelistEdit;
-    myUnsupportedWhenRemote << ui.enableRpcCheck << myWebWidgets << myWebAuthWidgets << myWebWhitelistWidgets;
+    web_widgets_ << ui.rpcPortLabel << ui.rpcPortSpin << ui.requireRpcAuthCheck << ui.enableRpcWhitelistCheck;
+    web_auth_widgets_ << ui.rpcUsernameLabel << ui.rpcUsernameEdit << ui.rpcPasswordLabel << ui.rpcPasswordEdit;
+    web_whitelist_widgets_ << ui.rpcWhitelistLabel << ui.rpcWhitelistEdit;
+    unsupported_when_remote_ << ui.enableRpcCheck << web_widgets_ << web_auth_widgets_ << web_whitelist_widgets_;
 
-    connect(ui.openWebClientButton, SIGNAL(clicked()), &mySession, SLOT(launchWebInterface()));
+    connect(ui.openWebClientButton, SIGNAL(clicked()), &session_, SLOT(launchWebInterface()));
 }
 
 /***
@@ -347,7 +347,7 @@ void PrefsDialog::initSpeedTab()
         ui.altSpeedLimitDaysCombo->addItem(qtDayName(i), qtDayToTrDay(i));
     }
 
-    ui.altSpeedLimitDaysCombo->setCurrentIndex(ui.altSpeedLimitDaysCombo->findData(myPrefs.getInt(
+    ui.altSpeedLimitDaysCombo->setCurrentIndex(ui.altSpeedLimitDaysCombo->findData(prefs_.getInt(
         Prefs::ALT_SPEED_LIMIT_TIME_DAY)));
 
     linkWidgetToPref(ui.uploadSpeedLimitCheck, Prefs::USPEED_ENABLED);
@@ -360,7 +360,7 @@ void PrefsDialog::initSpeedTab()
     linkWidgetToPref(ui.altSpeedLimitStartTimeEdit, Prefs::ALT_SPEED_LIMIT_TIME_BEGIN);
     linkWidgetToPref(ui.altSpeedLimitEndTimeEdit, Prefs::ALT_SPEED_LIMIT_TIME_END);
 
-    mySchedWidgets << ui.altSpeedLimitStartTimeEdit << ui.altSpeedLimitToLabel << ui.altSpeedLimitEndTimeEdit <<
+    sched_widgets_ << ui.altSpeedLimitStartTimeEdit << ui.altSpeedLimitToLabel << ui.altSpeedLimitEndTimeEdit <<
         ui.altSpeedLimitDaysLabel << ui.altSpeedLimitDaysCombo;
 
     auto* cr = new ColumnResizer(this);
@@ -391,7 +391,7 @@ void PrefsDialog::initDesktopTab()
 void PrefsDialog::onPortTested(bool isOpen)
 {
     ui.testPeerPortButton->setEnabled(true);
-    myWidgets[Prefs::PEER_PORT]->setEnabled(true);
+    widgets_[Prefs::PEER_PORT]->setEnabled(true);
     ui.peerPortStatusLabel->setText(isOpen ? tr("Port is <b>open</b>") : tr("Port is <b>closed</b>"));
 }
 
@@ -399,8 +399,8 @@ void PrefsDialog::onPortTest()
 {
     ui.peerPortStatusLabel->setText(tr("Testing TCP Port..."));
     ui.testPeerPortButton->setEnabled(false);
-    myWidgets[Prefs::PEER_PORT]->setEnabled(false);
-    mySession.portTest();
+    widgets_[Prefs::PEER_PORT]->setEnabled(false);
+    session_.portTest();
 }
 
 void PrefsDialog::initNetworkTab()
@@ -424,7 +424,7 @@ void PrefsDialog::initNetworkTab()
     cr->update();
 
     connect(ui.testPeerPortButton, SIGNAL(clicked()), SLOT(onPortTest()));
-    connect(&mySession, SIGNAL(portTested(bool)), SLOT(onPortTested(bool)));
+    connect(&session_, SIGNAL(portTested(bool)), SLOT(onPortTested(bool)));
 }
 
 /***
@@ -435,29 +435,29 @@ void PrefsDialog::onBlocklistDialogDestroyed(QObject* o)
 {
     Q_UNUSED(o)
 
-    myBlocklistDialog = nullptr;
+    blocklist_dialog_ = nullptr;
 }
 
 void PrefsDialog::onUpdateBlocklistCancelled()
 {
-    disconnect(&mySession, SIGNAL(blocklistUpdated(int)), this, SLOT(onBlocklistUpdated(int)));
-    myBlocklistDialog->deleteLater();
+    disconnect(&session_, SIGNAL(blocklistUpdated(int)), this, SLOT(onBlocklistUpdated(int)));
+    blocklist_dialog_->deleteLater();
 }
 
 void PrefsDialog::onBlocklistUpdated(int n)
 {
-    myBlocklistDialog->setText(tr("<b>Update succeeded!</b><p>Blocklist now has %Ln rule(s).", nullptr, n));
-    myBlocklistDialog->setTextFormat(Qt::RichText);
+    blocklist_dialog_->setText(tr("<b>Update succeeded!</b><p>Blocklist now has %Ln rule(s).", nullptr, n));
+    blocklist_dialog_->setTextFormat(Qt::RichText);
 }
 
 void PrefsDialog::onUpdateBlocklistClicked()
 {
-    myBlocklistDialog = new QMessageBox(QMessageBox::Information, QString(),
+    blocklist_dialog_ = new QMessageBox(QMessageBox::Information, QString(),
         tr("<b>Update Blocklist</b><p>Getting new blocklist..."), QMessageBox::Close, this);
-    connect(myBlocklistDialog, SIGNAL(rejected()), this, SLOT(onUpdateBlocklistCancelled()));
-    connect(&mySession, SIGNAL(blocklistUpdated(int)), this, SLOT(onBlocklistUpdated(int)));
-    myBlocklistDialog->show();
-    mySession.updateBlocklist();
+    connect(blocklist_dialog_, SIGNAL(rejected()), this, SLOT(onUpdateBlocklistCancelled()));
+    connect(&session_, SIGNAL(blocklistUpdated(int)), this, SLOT(onBlocklistUpdated(int)));
+    blocklist_dialog_->show();
+    session_.updateBlocklist();
 }
 
 void PrefsDialog::encryptionEdited(int i)
@@ -477,7 +477,7 @@ void PrefsDialog::initPrivacyTab()
     linkWidgetToPref(ui.blocklistEdit, Prefs::BLOCKLIST_URL);
     linkWidgetToPref(ui.autoUpdateBlocklistCheck, Prefs::BLOCKLIST_UPDATES_ENABLED);
 
-    myBlockWidgets << ui.blocklistEdit << ui.blocklistStatusLabel << ui.updateBlocklistButton << ui.autoUpdateBlocklistCheck;
+    block_widgets_ << ui.blocklistEdit << ui.blocklistStatusLabel << ui.updateBlocklistButton << ui.autoUpdateBlocklistCheck;
 
     auto* cr = new ColumnResizer(this);
     cr->addLayout(ui.encryptionSectionLayout);
@@ -542,8 +542,8 @@ void PrefsDialog::initDownloadingTab()
 
     ui.watchDirStack->setMinimumWidth(200);
 
-    ui.downloadDirFreeSpaceLabel->setSession(mySession);
-    ui.downloadDirFreeSpaceLabel->setPath(myPrefs.getString(Prefs::DOWNLOAD_DIR));
+    ui.downloadDirFreeSpaceLabel->setSession(session_);
+    ui.downloadDirFreeSpaceLabel->setPath(prefs_.getString(Prefs::DOWNLOAD_DIR));
 
     linkWidgetToPref(ui.watchDirCheck, Prefs::DIR_WATCH_ENABLED);
     linkWidgetToPref(ui.watchDirButton, Prefs::DIR_WATCH);
@@ -578,10 +578,10 @@ void PrefsDialog::initDownloadingTab()
 
 void PrefsDialog::updateDownloadingWidgetsLocality()
 {
-    ui.watchDirStack->setCurrentWidget(myIsLocal ? static_cast<QWidget*>(ui.watchDirButton) : ui.watchDirEdit);
-    ui.downloadDirStack->setCurrentWidget(myIsLocal ? static_cast<QWidget*>(ui.downloadDirButton) : ui.downloadDirEdit);
-    ui.incompleteDirStack->setCurrentWidget(myIsLocal ? static_cast<QWidget*>(ui.incompleteDirButton) : ui.incompleteDirEdit);
-    ui.completionScriptStack->setCurrentWidget(myIsLocal ? static_cast<QWidget*>(ui.completionScriptButton) :
+    ui.watchDirStack->setCurrentWidget(is_local_ ? static_cast<QWidget*>(ui.watchDirButton) : ui.watchDirEdit);
+    ui.downloadDirStack->setCurrentWidget(is_local_ ? static_cast<QWidget*>(ui.downloadDirButton) : ui.downloadDirEdit);
+    ui.incompleteDirStack->setCurrentWidget(is_local_ ? static_cast<QWidget*>(ui.incompleteDirButton) : ui.incompleteDirEdit);
+    ui.completionScriptStack->setCurrentWidget(is_local_ ? static_cast<QWidget*>(ui.completionScriptButton) :
         ui.completionScriptEdit);
 
     ui.watchDirStack->setFixedHeight(ui.watchDirStack->currentWidget()->sizeHint().height());
@@ -598,10 +598,10 @@ void PrefsDialog::updateDownloadingWidgetsLocality()
 
 PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent) :
     BaseDialog(parent),
-    mySession(session),
-    myPrefs(prefs),
-    myIsServer(session.isServer()),
-    myIsLocal(mySession.isLocal())
+    session_(session),
+    prefs_(prefs),
+    is_server_(session.isServer()),
+    is_local_(session_.isLocal())
 {
     ui.setupUi(this);
 
@@ -613,7 +613,7 @@ PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent) :
     initDesktopTab();
     initRemoteTab();
 
-    connect(&mySession, SIGNAL(sessionUpdated()), SLOT(sessionUpdated()));
+    connect(&session_, SIGNAL(sessionUpdated()), SLOT(sessionUpdated()));
 
     QList<int> keys;
     keys << Prefs::RPC_ENABLED << Prefs::ALT_SPEED_LIMIT_ENABLED << Prefs::ALT_SPEED_LIMIT_TIME_ENABLED << Prefs::ENCRYPTION <<
@@ -627,9 +627,9 @@ PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent) :
 
     // if it's a remote session, disable the preferences
     // that don't work in remote sessions
-    if (!myIsServer)
+    if (!is_server_)
     {
-        for (QWidget* const w : myUnsupportedWhenRemote)
+        for (QWidget* const w : unsupported_when_remote_)
         {
             w->setToolTip(tr("Not supported by remote sessions"));
             w->setEnabled(false);
@@ -643,7 +643,7 @@ PrefsDialog::~PrefsDialog() = default;
 
 void PrefsDialog::setPref(int key, QVariant const& v)
 {
-    myPrefs.set(key, v);
+    prefs_.set(key, v);
     refreshPref(key);
 }
 
@@ -653,11 +653,11 @@ void PrefsDialog::setPref(int key, QVariant const& v)
 
 void PrefsDialog::sessionUpdated()
 {
-    bool const isLocal = mySession.isLocal();
+    bool const isLocal = session_.isLocal();
 
-    if (myIsLocal != isLocal)
+    if (is_local_ != isLocal)
     {
-        myIsLocal = isLocal;
+        is_local_ = isLocal;
         updateDownloadingWidgetsLocality();
     }
 
@@ -666,7 +666,7 @@ void PrefsDialog::sessionUpdated()
 
 void PrefsDialog::updateBlocklistLabel()
 {
-    int const n = mySession.blocklistSize();
+    int const n = session_.blocklistSize();
     ui.blocklistStatusLabel->setText(tr("<i>Blocklist contains %Ln rule(s)</i>", nullptr, n));
 }
 
@@ -678,21 +678,21 @@ void PrefsDialog::refreshPref(int key)
     case Prefs::RPC_WHITELIST_ENABLED:
     case Prefs::RPC_AUTH_REQUIRED:
         {
-            bool const enabled(myPrefs.getBool(Prefs::RPC_ENABLED));
-            bool const whitelist(myPrefs.getBool(Prefs::RPC_WHITELIST_ENABLED));
-            bool const auth(myPrefs.getBool(Prefs::RPC_AUTH_REQUIRED));
+            bool const enabled(prefs_.getBool(Prefs::RPC_ENABLED));
+            bool const whitelist(prefs_.getBool(Prefs::RPC_WHITELIST_ENABLED));
+            bool const auth(prefs_.getBool(Prefs::RPC_AUTH_REQUIRED));
 
-            for (QWidget* const w : myWebWhitelistWidgets)
+            for (QWidget* const w : web_whitelist_widgets_)
             {
                 w->setEnabled(enabled && whitelist);
             }
 
-            for (QWidget* const w : myWebAuthWidgets)
+            for (QWidget* const w : web_auth_widgets_)
             {
                 w->setEnabled(enabled && auth);
             }
 
-            for (QWidget* const w : myWebWidgets)
+            for (QWidget* const w : web_widgets_)
             {
                 w->setEnabled(enabled);
             }
@@ -702,9 +702,9 @@ void PrefsDialog::refreshPref(int key)
 
     case Prefs::ALT_SPEED_LIMIT_TIME_ENABLED:
         {
-            bool const enabled = myPrefs.getBool(key);
+            bool const enabled = prefs_.getBool(key);
 
-            for (QWidget* const w : mySchedWidgets)
+            for (QWidget* const w : sched_widgets_)
             {
                 w->setEnabled(enabled);
             }
@@ -714,9 +714,9 @@ void PrefsDialog::refreshPref(int key)
 
     case Prefs::BLOCKLIST_ENABLED:
         {
-            bool const enabled = myPrefs.getBool(key);
+            bool const enabled = prefs_.getBool(key);
 
-            for (QWidget* const w : myBlockWidgets)
+            for (QWidget* const w : block_widgets_)
             {
                 w->setEnabled(enabled);
             }
@@ -733,9 +733,9 @@ void PrefsDialog::refreshPref(int key)
         break;
     }
 
-    key2widget_t::iterator it(myWidgets.find(key));
+    key2widget_t::iterator it(widgets_.find(key));
 
-    if (it != myWidgets.end())
+    if (it != widgets_.end())
     {
         QWidget* w(it.value());
 
@@ -744,7 +744,7 @@ void PrefsDialog::refreshPref(int key)
             if (key == Prefs::ENCRYPTION)
             {
                 auto* comboBox = qobject_cast<QComboBox*>(w);
-                int const index = comboBox->findData(myPrefs.getInt(key));
+                int const index = comboBox->findData(prefs_.getInt(key));
                 comboBox->setCurrentIndex(index);
             }
         }

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -70,25 +70,25 @@ private slots:
     void onBlocklistUpdated(int n);
 
 private:
-    Session& mySession;
-    Prefs& myPrefs;
+    Session& session_;
+    Prefs& prefs_;
 
     Ui::PrefsDialog ui;
 
-    bool const myIsServer;
-    bool myIsLocal;
+    bool const is_server_;
+    bool is_local_;
 
-    key2widget_t myWidgets;
-    QWidgetList myWebWidgets;
-    QWidgetList myWebAuthWidgets;
-    QWidgetList myWebWhitelistWidgets;
-    QWidgetList myProxyWidgets;
-    QWidgetList myProxyAuthWidgets;
-    QWidgetList mySchedWidgets;
-    QWidgetList myBlockWidgets;
-    QWidgetList myUnsupportedWhenRemote;
+    key2widget_t widgets_;
+    QWidgetList web_widgets_;
+    QWidgetList web_auth_widgets_;
+    QWidgetList web_whitelist_widgets_;
+    QWidgetList proxy_widgets_;
+    QWidgetList proxy_auth_widgets_;
+    QWidgetList sched_widgets_;
+    QWidgetList block_widgets_;
+    QWidgetList unsupported_when_remote_;
 
-    int myBlocklistHttpTag;
-    QHttp* myBlocklistHttp;
-    QMessageBox* myBlocklistDialog;
+    int blocklist_http_tag_;
+    QHttp* blocklist_http_;
+    QMessageBox* blocklist_dialog_;
 };

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -13,29 +13,29 @@
 #include "Torrent.h"
 #include "TorrentModel.h"
 
-bool RelocateDialog::myMoveFlag = true;
+bool RelocateDialog::move_flag_ = true;
 
 void RelocateDialog::onSetLocation()
 {
-    mySession.torrentSetLocation(myIds, newLocation(), myMoveFlag);
+    session_.torrentSetLocation(ids_, newLocation(), move_flag_);
     close();
 }
 
 void RelocateDialog::onMoveToggled(bool b)
 {
-    myMoveFlag = b;
+    move_flag_ = b;
 }
 
 RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torrent_ids_t const& ids, QWidget* parent) :
     BaseDialog(parent),
-    mySession(session),
-    myIds(ids)
+    session_(session),
+    ids_(ids)
 {
     ui.setupUi(this);
 
     QString path;
 
-    for (int const id : myIds)
+    for (int const id : ids_)
     {
         Torrent const* tor = model.getTorrentFromId(id);
 
@@ -45,7 +45,7 @@ RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torr
         }
         else if (path != tor->getPath())
         {
-            if (mySession.isServer())
+            if (session_.isServer())
             {
                 path = QDir::homePath();
             }
@@ -58,7 +58,7 @@ RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torr
         }
     }
 
-    if (mySession.isServer())
+    if (session_.isServer())
     {
         ui.newLocationStack->setCurrentWidget(ui.newLocationButton);
         ui.newLocationButton->setMode(PathButton::DirectoryMode);
@@ -75,7 +75,7 @@ RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torr
     ui.newLocationStack->setFixedHeight(ui.newLocationStack->currentWidget()->sizeHint().height());
     ui.newLocationLabel->setBuddy(ui.newLocationStack->currentWidget());
 
-    if (myMoveFlag)
+    if (move_flag_)
     {
         ui.moveDataRadio->setChecked(true);
     }

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -35,10 +35,10 @@ private slots:
     void onMoveToggled(bool);
 
 private:
-    Session& mySession;
-    torrent_ids_t const myIds;
+    Session& session_;
+    torrent_ids_t const ids_;
 
     Ui::RelocateDialog ui;
 
-    static bool myMoveFlag;
+    static bool move_flag_;
 };

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -91,10 +91,10 @@ private slots:
     void localRequestFinished(TrVariantPtr response);
 
 private:
-    tr_session* mySession;
-    QString mySessionId;
-    QUrl myUrl;
-    QNetworkAccessManager* myNAM;
-    QHash<int64_t, QFutureInterface<RpcResponse>> myLocalRequests;
-    int64_t myNextTag;
+    tr_session* session_;
+    QString session_id_;
+    QUrl url_;
+    QNetworkAccessManager* nam_;
+    QHash<int64_t, QFutureInterface<RpcResponse>> local_requests_;
+    int64_t next_tag_;
 };

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -12,38 +12,38 @@
 
 RpcQueue::RpcQueue(QObject* parent) :
     QObject(parent),
-    myTolerateErrors(false)
+    tolerate_errors_(false)
 {
-    connect(&myFutureWatcher, SIGNAL(finished()), SLOT(stepFinished()));
+    connect(&future_watcher_, SIGNAL(finished()), SLOT(stepFinished()));
 }
 
 void RpcQueue::stepFinished()
 {
     RpcResponse result;
 
-    if (myFutureWatcher.future().isResultReadyAt(0))
+    if (future_watcher_.future().isResultReadyAt(0))
     {
-        result = myFutureWatcher.result();
-        RpcResponseFuture future = myFutureWatcher.future();
+        result = future_watcher_.result();
+        RpcResponseFuture future = future_watcher_.future();
 
         // we can't handle network errors, abort queue and pass the error upwards
         if (result.networkError != QNetworkReply::NoError)
         {
             assert(!result.success);
 
-            myPromise.reportFinished(&result);
+            promise_.reportFinished(&result);
             deleteLater();
             return;
         }
 
         // call user-handler for ordinary errors
-        if (!result.success && myNextErrorHandler)
+        if (!result.success && next_error_handler_)
         {
-            myNextErrorHandler(future);
+            next_error_handler_(future);
         }
 
         // run next request, if we have one to run and there was no error (or if we tolerate errors)
-        if ((result.success || myTolerateErrors) && !myQueue.isEmpty())
+        if ((result.success || tolerate_errors_) && !queue_.isEmpty())
         {
             runNext(future);
             return;
@@ -51,36 +51,36 @@ void RpcQueue::stepFinished()
     }
     else
     {
-        assert(!myNextErrorHandler);
-        assert(myQueue.isEmpty());
+        assert(!next_error_handler_);
+        assert(queue_.isEmpty());
 
         // one way or another, the last step returned nothing.
         // assume it is OK and ensure that we're not going to give an empty response object to any of the next steps.
         result.success = true;
     }
 
-    myPromise.reportFinished(&result);
+    promise_.reportFinished(&result);
     deleteLater();
 }
 
 void RpcQueue::runNext(RpcResponseFuture const& response)
 {
-    assert(!myQueue.isEmpty());
+    assert(!queue_.isEmpty());
 
-    RpcResponseFuture const oldFuture = myFutureWatcher.future();
+    RpcResponseFuture const oldFuture = future_watcher_.future();
 
     while (true)
     {
-        auto next = myQueue.dequeue();
-        myNextErrorHandler = next.second;
-        myFutureWatcher.setFuture((next.first)(response));
+        auto next = queue_.dequeue();
+        next_error_handler_ = next.second;
+        future_watcher_.setFuture((next.first)(response));
 
-        if (oldFuture != myFutureWatcher.future())
+        if (oldFuture != future_watcher_.future())
         {
             break;
         }
 
-        if (myQueue.isEmpty())
+        if (queue_.isEmpty())
         {
             deleteLater();
             break;

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -28,19 +28,19 @@ public:
 
     void setTolerateErrors(bool tolerateErrors = true)
     {
-        myTolerateErrors = tolerateErrors;
+        tolerate_errors_ = tolerateErrors;
     }
 
     template<typename Func>
     void add(Func func)
     {
-        myQueue.enqueue(qMakePair(normalizeFunc(func), ErrorHandlerFunction()));
+        queue_.enqueue(qMakePair(normalizeFunc(func), ErrorHandlerFunction()));
     }
 
     template<typename Func, typename ErrorHandler>
     void add(Func func, ErrorHandler errorHandler)
     {
-        myQueue.enqueue(qMakePair(normalizeFunc(func), normalizeErrorHandler(errorHandler)));
+        queue_.enqueue(qMakePair(normalizeFunc(func), normalizeErrorHandler(errorHandler)));
     }
 
     // The first function in queue is ran synchronously
@@ -138,9 +138,9 @@ private:
     }
 
 private:
-    bool myTolerateErrors;
-    QFutureInterface<RpcResponse> myPromise;
-    QQueue<QPair<QueuedFunction, ErrorHandlerFunction>> myQueue;
-    ErrorHandlerFunction myNextErrorHandler;
-    QFutureWatcher<RpcResponse> myFutureWatcher;
+    bool tolerate_errors_;
+    QFutureInterface<RpcResponse> promise_;
+    QQueue<QPair<QueuedFunction, ErrorHandlerFunction>> queue_;
+    ErrorHandlerFunction next_error_handler_;
+    QFutureWatcher<RpcResponse> future_watcher_;
 };

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -40,27 +40,27 @@ public:
 
     QUrl const& getRemoteUrl() const
     {
-        return myRpc.url();
+        return rpc_.url();
     }
 
     tr_session_stats const& getStats() const
     {
-        return myStats;
+        return stats_;
     }
 
     tr_session_stats const& getCumulativeStats() const
     {
-        return myCumulativeStats;
+        return cumulative_stats_;
     }
 
     QString const& sessionVersion() const
     {
-        return mySessionVersion;
+        return session_version_;
     }
 
     int64_t blocklistSize() const
     {
-        return myBlocklistSize;
+        return blocklist_size_;
     }
 
     void setBlocklistSize(int64_t i);
@@ -137,16 +137,16 @@ private:
     static void updateStats(tr_variant* d, tr_session_stats* stats);
 
 private:
-    QString const myConfigDir;
-    Prefs& myPrefs;
+    QString const config_dir_;
+    Prefs& prefs_;
 
-    int64_t myBlocklistSize;
-    tr_session* mySession;
-    QStringList myIdleJSON;
-    tr_session_stats myStats;
-    tr_session_stats myCumulativeStats;
-    QString mySessionVersion;
-    QString mySessionId;
-    bool myIsDefinitelyLocalSession;
-    RpcClient myRpc;
+    int64_t blocklist_size_;
+    tr_session* session_;
+    QStringList idle_json_;
+    tr_session_stats stats_;
+    tr_session_stats cumulative_stats_;
+    QString session_version_;
+    QString session_id_;
+    bool is_definitely_local_session_;
+    RpcClient rpc_;
 };

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -16,13 +16,13 @@
 
 void SessionDialog::accept()
 {
-    myPrefs.set(Prefs::SESSION_IS_REMOTE, ui.remoteSessionRadio->isChecked());
-    myPrefs.set(Prefs::SESSION_REMOTE_HOST, ui.hostEdit->text());
-    myPrefs.set(Prefs::SESSION_REMOTE_PORT, ui.portSpin->value());
-    myPrefs.set(Prefs::SESSION_REMOTE_AUTH, ui.authCheck->isChecked());
-    myPrefs.set(Prefs::SESSION_REMOTE_USERNAME, ui.usernameEdit->text());
-    myPrefs.set(Prefs::SESSION_REMOTE_PASSWORD, ui.passwordEdit->text());
-    mySession.restart();
+    prefs_.set(Prefs::SESSION_IS_REMOTE, ui.remoteSessionRadio->isChecked());
+    prefs_.set(Prefs::SESSION_REMOTE_HOST, ui.hostEdit->text());
+    prefs_.set(Prefs::SESSION_REMOTE_PORT, ui.portSpin->value());
+    prefs_.set(Prefs::SESSION_REMOTE_AUTH, ui.authCheck->isChecked());
+    prefs_.set(Prefs::SESSION_REMOTE_USERNAME, ui.usernameEdit->text());
+    prefs_.set(Prefs::SESSION_REMOTE_PASSWORD, ui.passwordEdit->text());
+    session_.restart();
     BaseDialog::accept();
 }
 
@@ -31,12 +31,12 @@ void SessionDialog::resensitize()
     bool const isRemote = ui.remoteSessionRadio->isChecked();
     bool const useAuth = ui.authCheck->isChecked();
 
-    for (QWidget* const w : myRemoteWidgets)
+    for (QWidget* const w : remote_widgets_)
     {
         w->setEnabled(isRemote);
     }
 
-    for (QWidget* const w : myAuthWidgets)
+    for (QWidget* const w : auth_widgets_)
     {
         w->setEnabled(isRemote && useAuth);
     }
@@ -48,8 +48,8 @@ void SessionDialog::resensitize()
 
 SessionDialog::SessionDialog(Session& session, Prefs& prefs, QWidget* parent) :
     BaseDialog(parent),
-    mySession(session),
-    myPrefs(prefs)
+    session_(session),
+    prefs_(prefs)
 {
     ui.setupUi(this);
 
@@ -60,20 +60,20 @@ SessionDialog::SessionDialog(Session& session, Prefs& prefs, QWidget* parent) :
     connect(ui.remoteSessionRadio, SIGNAL(toggled(bool)), this, SLOT(resensitize()));
 
     ui.hostEdit->setText(prefs.get<QString>(Prefs::SESSION_REMOTE_HOST));
-    myRemoteWidgets << ui.hostLabel << ui.hostEdit;
+    remote_widgets_ << ui.hostLabel << ui.hostEdit;
 
     ui.portSpin->setValue(prefs.get<int>(Prefs::SESSION_REMOTE_PORT));
-    myRemoteWidgets << ui.portLabel << ui.portSpin;
+    remote_widgets_ << ui.portLabel << ui.portSpin;
 
     ui.authCheck->setChecked(prefs.get<bool>(Prefs::SESSION_REMOTE_AUTH));
     connect(ui.authCheck, SIGNAL(toggled(bool)), this, SLOT(resensitize()));
-    myRemoteWidgets << ui.authCheck;
+    remote_widgets_ << ui.authCheck;
 
     ui.usernameEdit->setText(prefs.get<QString>(Prefs::SESSION_REMOTE_USERNAME));
-    myAuthWidgets << ui.usernameLabel << ui.usernameEdit;
+    auth_widgets_ << ui.usernameLabel << ui.usernameEdit;
 
     ui.passwordEdit->setText(prefs.get<QString>(Prefs::SESSION_REMOTE_PASSWORD));
-    myAuthWidgets << ui.passwordLabel << ui.passwordEdit;
+    auth_widgets_ << ui.passwordLabel << ui.passwordEdit;
 
     resensitize();
 }

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -32,11 +32,11 @@ private slots:
     void resensitize();
 
 private:
-    Session& mySession;
-    Prefs& myPrefs;
+    Session& session_;
+    Prefs& prefs_;
 
     Ui::SessionDialog ui;
 
-    QWidgetList myRemoteWidgets;
-    QWidgetList myAuthWidgets;
+    QWidgetList remote_widgets_;
+    QWidgetList auth_widgets_;
 };

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -20,8 +20,8 @@ enum
 
 StatsDialog::StatsDialog(Session& session, QWidget* parent) :
     BaseDialog(parent),
-    mySession(session),
-    myTimer(new QTimer(this))
+    session_(session),
+    timer_(new QTimer(this))
 {
     ui.setupUi(this);
 
@@ -30,23 +30,23 @@ StatsDialog::StatsDialog(Session& session, QWidget* parent) :
     cr->addLayout(ui.totalSectionLayout);
     cr->update();
 
-    myTimer->setSingleShot(false);
-    connect(myTimer, SIGNAL(timeout()), &mySession, SLOT(refreshSessionStats()));
+    timer_->setSingleShot(false);
+    connect(timer_, SIGNAL(timeout()), &session_, SLOT(refreshSessionStats()));
 
-    connect(&mySession, SIGNAL(statsUpdated()), this, SLOT(updateStats()));
+    connect(&session_, SIGNAL(statsUpdated()), this, SLOT(updateStats()));
     updateStats();
-    mySession.refreshSessionStats();
+    session_.refreshSessionStats();
 }
 
 StatsDialog::~StatsDialog() = default;
 
 void StatsDialog::setVisible(bool visible)
 {
-    myTimer->stop();
+    timer_->stop();
 
     if (visible)
     {
-        myTimer->start(REFRESH_INTERVAL_MSEC);
+        timer_->start(REFRESH_INTERVAL_MSEC);
     }
 
     BaseDialog::setVisible(visible);
@@ -54,8 +54,8 @@ void StatsDialog::setVisible(bool visible)
 
 void StatsDialog::updateStats()
 {
-    tr_session_stats const& current(mySession.getStats());
-    tr_session_stats const& total(mySession.getCumulativeStats());
+    tr_session_stats const& current(session_.getStats());
+    tr_session_stats const& total(session_.getCumulativeStats());
 
     ui.currentUploadedValueLabel->setText(Formatter::sizeToString(current.uploadedBytes));
     ui.currentDownloadedValueLabel->setText(Formatter::sizeToString(current.downloadedBytes));

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -31,9 +31,9 @@ private slots:
     void updateStats();
 
 private:
-    Session& mySession;
+    Session& session_;
 
     Ui::StatsDialog ui;
 
-    QTimer* myTimer;
+    QTimer* timer_;
 };

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -44,7 +44,7 @@ protected:
     static QString shortTransferString(Torrent const& tor);
 
 protected:
-    QStyleOptionProgressBar* myProgressBarStyle;
+    QStyleOptionProgressBar* progress_bar_style_;
 
     static QColor blueBrush;
     static QColor greenBrush;
@@ -54,7 +54,7 @@ protected:
     static QColor silverBack;
 
 private:
-    mutable std::optional<int> myHeightHint;
-    mutable QFont myHeightFont;
-    mutable QIcon myWarningEmblem;
+    mutable std::optional<int> height_hint_;
+    mutable QFont height_font_;
+    mutable QIcon warning_emblem_;
 };

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -49,8 +49,8 @@ namespace
 class ItemLayout
 {
 private:
-    QString myNameText;
-    QString myStatusText;
+    QString name_text_;
+    QString status_text_;
 
 public:
     QFont nameFont;
@@ -72,12 +72,12 @@ public:
 
     QString nameText() const
     {
-        return elidedText(nameFont, myNameText, nameRect.width());
+        return elidedText(nameFont, name_text_, nameRect.width());
     }
 
     QString statusText() const
     {
-        return myStatusText;
+        return status_text_;
     }
 
 private:
@@ -89,8 +89,8 @@ private:
 
 ItemLayout::ItemLayout(QString const& nameText, QString const& statusText, QIcon const& emblemIcon, QFont const& baseFont,
     Qt::LayoutDirection direction, QPoint const& topLeft, int width) :
-    myNameText(nameText),
-    myStatusText(statusText),
+    name_text_(nameText),
+    status_text_(statusText),
     nameFont(baseFont),
     statusFont(baseFont)
 {
@@ -98,11 +98,11 @@ ItemLayout::ItemLayout(QString const& nameText, QString const& statusText, QIcon
     int const iconSize(style->pixelMetric(QStyle::PM_SmallIconSize));
 
     QFontMetrics const nameFM(nameFont);
-    QSize const nameSize(nameFM.size(0, myNameText));
+    QSize const nameSize(nameFM.size(0, name_text_));
 
     statusFont.setPointSize(static_cast<int>(statusFont.pointSize() * 0.85));
     QFontMetrics const statusFM(statusFont);
-    QSize const statusSize(statusFM.size(0, myStatusText));
+    QSize const statusSize(statusFM.size(0, status_text_));
 
     QStyleOptionProgressBar barStyle;
     barStyle.rect = QRect(0, 0, BAR_WIDTH, BAR_HEIGHT);
@@ -249,33 +249,33 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     painter->drawText(layout.nameRect, Qt::AlignLeft | Qt::AlignVCenter, layout.nameText());
     painter->setFont(layout.statusFont);
     painter->drawText(layout.statusRect, Qt::AlignLeft | Qt::AlignVCenter, layout.statusText());
-    myProgressBarStyle->rect = layout.barRect;
+    progress_bar_style_->rect = layout.barRect;
 
     if (tor.isDownloading())
     {
-        myProgressBarStyle->palette.setBrush(QPalette::Highlight, blueBrush);
-        myProgressBarStyle->palette.setColor(QPalette::Base, blueBack);
-        myProgressBarStyle->palette.setColor(QPalette::Window, blueBack);
+        progress_bar_style_->palette.setBrush(QPalette::Highlight, blueBrush);
+        progress_bar_style_->palette.setColor(QPalette::Base, blueBack);
+        progress_bar_style_->palette.setColor(QPalette::Window, blueBack);
     }
     else if (tor.isSeeding())
     {
-        myProgressBarStyle->palette.setBrush(QPalette::Highlight, greenBrush);
-        myProgressBarStyle->palette.setColor(QPalette::Base, greenBack);
-        myProgressBarStyle->palette.setColor(QPalette::Window, greenBack);
+        progress_bar_style_->palette.setBrush(QPalette::Highlight, greenBrush);
+        progress_bar_style_->palette.setColor(QPalette::Base, greenBack);
+        progress_bar_style_->palette.setColor(QPalette::Window, greenBack);
     }
     else
     {
-        myProgressBarStyle->palette.setBrush(QPalette::Highlight, silverBrush);
-        myProgressBarStyle->palette.setColor(QPalette::Base, silverBack);
-        myProgressBarStyle->palette.setColor(QPalette::Window, silverBack);
+        progress_bar_style_->palette.setBrush(QPalette::Highlight, silverBrush);
+        progress_bar_style_->palette.setColor(QPalette::Base, silverBack);
+        progress_bar_style_->palette.setColor(QPalette::Window, silverBack);
     }
 
-    myProgressBarStyle->state = progressBarState;
-    myProgressBarStyle->text = QString::fromLatin1("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
-    myProgressBarStyle->textVisible = true;
-    myProgressBarStyle->textAlignment = Qt::AlignCenter;
+    progress_bar_style_->state = progressBarState;
+    progress_bar_style_->text = QString::fromLatin1("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
+    progress_bar_style_->textVisible = true;
+    progress_bar_style_->textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);
-    style->drawControl(QStyle::CE_ProgressBar, myProgressBarStyle, painter);
+    style->drawControl(QStyle::CE_ProgressBar, progress_bar_style_, painter);
 
     painter->restore();
 }

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -49,6 +49,6 @@ private slots:
     void refilter();
 
 private:
-    QTimer myRefilterTimer;
-    Prefs const& myPrefs;
+    QTimer refilter_timer_;
+    Prefs const& prefs_;
 };

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -45,7 +45,7 @@ public:
     Torrent const* getTorrentFromId(int id) const;
 
     using torrents_t = QVector<Torrent*>;
-    torrents_t const& torrents() const { return myTorrents; }
+    torrents_t const& torrents() const { return torrents_; }
 
     // QAbstractItemModel
     int rowCount(QModelIndex const& parent = QModelIndex()) const override;
@@ -71,7 +71,7 @@ private:
     using span_t = std::pair<int, int>;
     std::vector<span_t> getSpans(torrent_ids_t const& ids) const;
 
-    Prefs const& myPrefs;
-    torrent_ids_t myAlreadyAdded;
-    torrents_t myTorrents;
+    Prefs const& prefs_;
+    torrent_ids_t already_added_;
+    torrents_t torrents_;
 };

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -17,14 +17,14 @@ class TorrentView::HeaderWidget : public QWidget
 public:
     HeaderWidget(TorrentView* parent) :
         QWidget(parent),
-        myText()
+        text_()
     {
         setFont(qApp->font("QMiniFont"));
     }
 
     void setText(QString const& text)
     {
-        myText = text;
+        text_ = text;
         update();
     }
 
@@ -52,7 +52,7 @@ protected:
         painter.drawControl(QStyle::CE_HeaderSection, option);
 
         option.rect = style()->subElementRect(QStyle::SE_HeaderLabel, &option, this);
-        painter.drawItemText(option.rect, Qt::AlignCenter, option.palette, true, myText, QPalette::ButtonText);
+        painter.drawItemText(option.rect, Qt::AlignCenter, option.palette, true, text_, QPalette::ButtonText);
     }
 
     void mouseDoubleClickEvent(QMouseEvent* /*event*/) override
@@ -61,12 +61,12 @@ protected:
     }
 
 private:
-    QString myText;
+    QString text_;
 };
 
 TorrentView::TorrentView(QWidget* parent) :
     QListView(parent),
-    myHeaderWidget(new HeaderWidget(this))
+    header_widget_(new HeaderWidget(this))
 {
 }
 
@@ -74,22 +74,22 @@ void TorrentView::setHeaderText(QString const& text)
 {
     bool const headerVisible = !text.isEmpty();
 
-    myHeaderWidget->setText(text);
-    myHeaderWidget->setVisible(headerVisible);
+    header_widget_->setText(text);
+    header_widget_->setVisible(headerVisible);
 
     if (headerVisible)
     {
         adjustHeaderPosition();
     }
 
-    setViewportMargins(0, headerVisible ? myHeaderWidget->height() : 0, 0, 0);
+    setViewportMargins(0, headerVisible ? header_widget_->height() : 0, 0, 0);
 }
 
 void TorrentView::resizeEvent(QResizeEvent* event)
 {
     QListView::resizeEvent(event);
 
-    if (myHeaderWidget->isVisible())
+    if (header_widget_->isVisible())
     {
         adjustHeaderPosition();
     }
@@ -99,6 +99,6 @@ void TorrentView::adjustHeaderPosition()
 {
     QRect headerWidgetRect = contentsRect();
     headerWidgetRect.setWidth(viewport()->width());
-    headerWidgetRect.setHeight(myHeaderWidget->sizeHint().height());
-    myHeaderWidget->setGeometry(headerWidgetRect);
+    headerWidgetRect.setHeight(header_widget_->sizeHint().height());
+    header_widget_->setGeometry(headerWidgetRect);
 }

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -33,5 +33,5 @@ private:
     void adjustHeaderPosition();
 
 private:
-    HeaderWidget* const myHeaderWidget;
+    HeaderWidget* const header_widget_;
 };

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -29,8 +29,8 @@
 namespace
 {
 
-int const spacing_ = 6;
-QSize const margin_(10, 10);
+int const spacing = 6;
+QSize const margin(10, 10);
 
 class ItemLayout
 {
@@ -63,7 +63,7 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
     QRect baseRect(topLeft, QSize(width, 0));
 
     iconRect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignTop, iconSize, baseRect);
-    Utils::narrowRect(baseRect, iconSize.width() + spacing_, 0, direction);
+    Utils::narrowRect(baseRect, iconSize.width() + spacing, 0, direction);
 
     text_document_.setDocumentMargin(0);
     text_document_.setTextWidth(baseRect.width());
@@ -91,8 +91,8 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, TrackerInfo const& info) const
 {
-    ItemLayout const layout(getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - margin_.width() * 2);
-    return layout.size() + margin_ * 2;
+    ItemLayout const layout(getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - margin.width() * 2);
+    return layout.size() + margin * 2;
 }
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const
@@ -120,7 +120,7 @@ void TrackerDelegate::drawTracker(QPainter* painter, QStyleOptionViewItem const&
 
     QIcon trackerIcon(inf.st.getFavicon());
 
-    QRect const contentRect(option.rect.adjusted(margin_.width(), margin_.height(), -margin_.width(), -margin_.height()));
+    QRect const contentRect(option.rect.adjusted(margin.width(), margin.height(), -margin.width(), -margin.height()));
     ItemLayout const layout(getText(inf), isItemSelected, option.direction, contentRect.topLeft(), contentRect.width());
 
     painter->save();

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -29,13 +29,13 @@
 namespace
 {
 
-int const mySpacing = 6;
-QSize const myMargin(10, 10);
+int const spacing_ = 6;
+QSize const margin_(10, 10);
 
 class ItemLayout
 {
 private:
-    QTextDocument myTextDocument;
+    QTextDocument text_document_;
 
 public:
     QRect iconRect;
@@ -50,7 +50,7 @@ public:
 
     QAbstractTextDocumentLayout* textLayout() const
     {
-        return myTextDocument.documentLayout();
+        return text_document_.documentLayout();
     }
 };
 
@@ -63,10 +63,10 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
     QRect baseRect(topLeft, QSize(width, 0));
 
     iconRect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignTop, iconSize, baseRect);
-    Utils::narrowRect(baseRect, iconSize.width() + mySpacing, 0, direction);
+    Utils::narrowRect(baseRect, iconSize.width() + spacing_, 0, direction);
 
-    myTextDocument.setDocumentMargin(0);
-    myTextDocument.setTextWidth(baseRect.width());
+    text_document_.setDocumentMargin(0);
+    text_document_.setTextWidth(baseRect.width());
 
     QTextOption textOption;
     textOption.setTextDirection(direction);
@@ -76,11 +76,11 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
         textOption.setFlags(QTextOption::SuppressColors);
     }
 
-    myTextDocument.setDefaultTextOption(textOption);
-    myTextDocument.setHtml(text);
+    text_document_.setDefaultTextOption(textOption);
+    text_document_.setHtml(text);
 
     textRect = baseRect;
-    textRect.setSize(myTextDocument.size().toSize());
+    textRect.setSize(text_document_.size().toSize());
 }
 
 } // namespace
@@ -91,8 +91,8 @@ ItemLayout::ItemLayout(QString const& text, bool suppressColors, Qt::LayoutDirec
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, TrackerInfo const& info) const
 {
-    ItemLayout const layout(getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - myMargin.width() * 2);
-    return layout.size() + myMargin * 2;
+    ItemLayout const layout(getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - margin_.width() * 2);
+    return layout.size() + margin_ * 2;
 }
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const
@@ -120,7 +120,7 @@ void TrackerDelegate::drawTracker(QPainter* painter, QStyleOptionViewItem const&
 
     QIcon trackerIcon(inf.st.getFavicon());
 
-    QRect const contentRect(option.rect.adjusted(myMargin.width(), myMargin.height(), -myMargin.width(), -myMargin.height()));
+    QRect const contentRect(option.rect.adjusted(margin_.width(), margin_.height(), -margin_.width(), -margin_.height()));
     ItemLayout const layout(getText(inf), isItemSelected, option.direction, contentRect.topLeft(), contentRect.width());
 
     painter->save();
@@ -151,7 +151,7 @@ void TrackerDelegate::drawTracker(QPainter* painter, QStyleOptionViewItem const&
 
 void TrackerDelegate::setShowMore(bool b)
 {
-    myShowMore = b;
+    show_more_ = b;
 }
 
 namespace
@@ -255,7 +255,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
             }
         }
 
-        if (myShowMore)
+        if (show_more_)
         {
             if (inf.st.hasScraped)
             {

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -22,7 +22,7 @@ class TrackerDelegate : public QItemDelegate
 public:
     TrackerDelegate(QObject* parent = nullptr) :
         QItemDelegate(parent),
-        myShowMore(false)
+        show_more_(false)
     {
     }
 
@@ -39,5 +39,5 @@ protected:
     void drawTracker(QPainter*, QStyleOptionViewItem const&, TrackerInfo const&) const;
 
 private:
-    bool myShowMore;
+    bool show_more_;
 };

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -18,7 +18,7 @@ int TrackerModel::rowCount(QModelIndex const& parent) const
 {
     Q_UNUSED(parent)
 
-    return parent.isValid() ? 0 : myRows.size();
+    return parent.isValid() ? 0 : rows_.size();
 }
 
 QVariant TrackerModel::data(QModelIndex const& index, int role) const
@@ -27,9 +27,9 @@ QVariant TrackerModel::data(QModelIndex const& index, int role) const
 
     int const row = index.row();
 
-    if (0 <= row && row < myRows.size())
+    if (0 <= row && row < rows_.size())
     {
-        TrackerInfo const& trackerInfo = myRows.at(row);
+        TrackerInfo const& trackerInfo = rows_.at(row);
 
         switch (role)
         {
@@ -111,30 +111,30 @@ void TrackerModel::refresh(TorrentModel const& torrentModel, torrent_ids_t const
     int oldIndex = 0;
     int newIndex = 0;
 
-    while (oldIndex < myRows.size() || newIndex < trackers.size())
+    while (oldIndex < rows_.size() || newIndex < trackers.size())
     {
-        bool const isEndOfOld = oldIndex == myRows.size();
+        bool const isEndOfOld = oldIndex == rows_.size();
         bool const isEndOfNew = newIndex == trackers.size();
 
-        if (isEndOfOld || (!isEndOfNew && comp(trackers.at(newIndex), myRows.at(oldIndex))))
+        if (isEndOfOld || (!isEndOfNew && comp(trackers.at(newIndex), rows_.at(oldIndex))))
         {
             // add this new row
             beginInsertRows(QModelIndex(), oldIndex, oldIndex);
-            myRows.insert(oldIndex, trackers.at(newIndex));
+            rows_.insert(oldIndex, trackers.at(newIndex));
             endInsertRows();
             ++oldIndex;
             ++newIndex;
         }
-        else if (isEndOfNew || (!isEndOfOld && comp(myRows.at(oldIndex), trackers.at(newIndex))))
+        else if (isEndOfNew || (!isEndOfOld && comp(rows_.at(oldIndex), trackers.at(newIndex))))
         {
             // remove this old row
             beginRemoveRows(QModelIndex(), oldIndex, oldIndex);
-            myRows.remove(oldIndex);
+            rows_.remove(oldIndex);
             endRemoveRows();
         }
         else // update existing row
         {
-            myRows[oldIndex].st = trackers.at(newIndex).st;
+            rows_[oldIndex].st = trackers.at(newIndex).st;
             emit dataChanged(index(oldIndex, 0), index(oldIndex, 0));
             ++oldIndex;
             ++newIndex;
@@ -144,9 +144,9 @@ void TrackerModel::refresh(TorrentModel const& torrentModel, torrent_ids_t const
 
 int TrackerModel::find(int torrentId, QString const& url) const
 {
-    for (int i = 0, n = myRows.size(); i < n; ++i)
+    for (int i = 0, n = rows_.size(); i < n; ++i)
     {
-        TrackerInfo const& inf = myRows.at(i);
+        TrackerInfo const& inf = rows_.at(i);
 
         if (inf.torrentId == torrentId && url == inf.st.announce)
         {

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -48,5 +48,5 @@ private:
     using rows_t = QVector<TrackerInfo>;
 
 private:
-    rows_t myRows;
+    rows_t rows_;
 };

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -11,13 +11,13 @@
 
 TrackerModelFilter::TrackerModelFilter(QObject* parent) :
     QSortFilterProxyModel(parent),
-    myShowBackups(false)
+    show_backups_(false)
 {
 }
 
 void TrackerModelFilter::setShowBackupTrackers(bool b)
 {
-    myShowBackups = b;
+    show_backups_ = b;
     invalidateFilter();
 }
 
@@ -25,5 +25,5 @@ bool TrackerModelFilter::filterAcceptsRow(int sourceRow, QModelIndex const& sour
 {
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
     auto const trackerInfo = index.data(TrackerModel::TrackerRole).value<TrackerInfo>();
-    return myShowBackups || !trackerInfo.st.isBackup;
+    return show_backups_ || !trackerInfo.st.isBackup;
 }

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -21,7 +21,7 @@ public:
 
     bool showBackupTrackers() const
     {
-        return myShowBackups;
+        return show_backups_;
     }
 
 protected:
@@ -29,5 +29,5 @@ protected:
     virtual bool filterAcceptsRow(int sourceRow, QModelIndex const& sourceParent) const;
 
 private:
-    bool myShowBackups;
+    bool show_backups_;
 };

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -46,8 +46,8 @@ private slots:
     void rescanAllWatchedDirectories();
 
 private:
-    TorrentModel const& myModel;
+    TorrentModel const& model_;
 
-    QSet<QString> myWatchDirFiles;
-    QFileSystemWatcher* myWatcher;
+    QSet<QString> watch_dir_files_;
+    QFileSystemWatcher* watcher_;
 };


### PR DESCRIPTION
This comes out of the discussion at https://github.com/transmission/transmission/pull/1234#discussion_r427630467 to replace the `myFoo` member variable naming idiom with `foo_`.

Here's how it was done. I'm kind of happy about getting something this ugly to work, but I wouldn't say I'm proud of it... :smiling_imp: : 

```sh
$ grep --no-filename --only-matching --perl-regexp "my[A-Z][A-Za-z]+\w*" *\.h *\.cc | sort | uniq > oldvars
$ # process longer variable names first so that shorter names don't partially rename longer ones 
$ cat oldvars | awk '{ print length, $0 }' | sort --reverse --numeric-sort --stable | cut -d" " -f2- > oldvars
$ cat oldvars | sed --expression 's/\([A-Z]\)/_\L\1/g' --expression 's/$/_/' --expression 's/^my_//' > newvars
$ paste -d '/' oldvars newvars | sed --expression 's/^/"s\//' --expression 's/$/\/g"/' > expressions
$ # ... manually copyedit `expressions` to fix any edge cases ...
$ xargs -L1 -I '{}' perl -p -i -e '{}' *.cc *h < expressions
$ rm oldvars newvars expressions
```