### PR TITLE
fix(rpc-spec): fix typo in `editDate` arg description

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -807,7 +807,7 @@
          |         | yes       | session-get          | new arg "session-id"
          |         | yes       | torrent-get          | new arg "labels"
          |         | yes       | torrent-set          | new arg "labels"
-         |         | yes       | torrent-set          | new arg "editDate"
+         |         | yes       | torrent-get          | new arg "editDate"
          |         | yes       | torrent-get          | new arg "format"
 
 


### PR DESCRIPTION
The argument is actually valid for `torrent-get` only.