### PR TITLE
chore: prefer QStringLiteral

### DIFF
--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -24,7 +24,7 @@ AboutDialog::AboutDialog(QWidget* parent) :
     ui_.setupUi(this);
 
     ui_.iconLabel->setPixmap(qApp->windowIcon().pixmap(48));
-    ui_.titleLabel->setText(tr("<b style='font-size:x-large'>Transmission %1</b>").arg(QString::fromUtf8(LONG_VERSION_STRING)));
+    ui_.titleLabel->setText(tr("<b style='font-size:x-large'>Transmission %1</b>").arg(QStringLiteral(LONG_VERSION_STRING)));
 
     QPushButton* b;
 

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -39,7 +39,7 @@ int AddData::set(QString const& key)
     }
     else if (Utils::isHexHashcode(key))
     {
-        magnet = QString::fromUtf8("magnet:?xt=urn:btih:") + key;
+        magnet = QStringLiteral("magnet:?xt=urn:btih:") + key;
         type = MAGNET;
     }
     else

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -41,8 +41,8 @@
 namespace
 {
 
-QLatin1String const MY_CONFIG_NAME("transmission");
-QLatin1String const MY_READABLE_NAME("transmission-qt");
+auto const MY_CONFIG_NAME = QStringLiteral("transmission");
+auto const MY_READABLE_NAME = QStringLiteral("transmission-qt");
 
 tr_option const opts[] =
 {
@@ -73,7 +73,7 @@ bool loadTranslation(QTranslator& translator, QString const& name, QLocale const
 {
     for (QString const& directory : search_directories)
     {
-        if (translator.load(locale, name, QLatin1String("_"), directory))
+        if (translator.load(locale, name, QStringLiteral("_"), directory))
         {
             return true;
         }
@@ -96,13 +96,13 @@ Application::Application(int& argc, char** argv) :
 
     if (QIcon::themeName().isEmpty())
     {
-        QIcon::setThemeName(QLatin1String("Faenza"));
+        QIcon::setThemeName(QStringLiteral("Faenza"));
     }
 
 #endif
 
     // set the default icon
-    QIcon icon = QIcon::fromTheme(QLatin1String("transmission"));
+    QIcon icon = QIcon::fromTheme(QStringLiteral("transmission"));
 
     if (icon.isNull())
     {
@@ -111,7 +111,7 @@ Application::Application(int& argc, char** argv) :
 
         for (int const size : sizes)
         {
-            icon.addPixmap(QPixmap(QString::fromLatin1(":/icons/transmission-%1.png").arg(size)));
+            icon.addPixmap(QPixmap(QStringLiteral(":/icons/transmission-%1.png").arg(size)));
         }
     }
 
@@ -161,13 +161,13 @@ Application::Application(int& argc, char** argv) :
             break;
 
         case 'v':
-            std::cerr << MY_READABLE_NAME.latin1() << ' ' << LONG_VERSION_STRING << std::endl;
+            std::cerr << qPrintable(MY_READABLE_NAME) << ' ' << LONG_VERSION_STRING << std::endl;
             quitLater();
             return;
 
         case TR_OPT_ERR:
             std::cerr << qPrintable(QObject::tr("Invalid option")) << std::endl;
-            tr_getopt_usage(MY_READABLE_NAME.latin1(), getUsage(), opts);
+            tr_getopt_usage(qPrintable(MY_READABLE_NAME), getUsage(), opts);
             quitLater();
             return;
 
@@ -203,7 +203,7 @@ Application::Application(int& argc, char** argv) :
 
             case AddData::FILENAME:
             case AddData::METAINFO:
-                metainfo = QString::fromLatin1(a.toBase64());
+                metainfo = QString::fromUtf8(a.toBase64());
                 break;
 
             default:
@@ -238,7 +238,7 @@ Application::Application(int& argc, char** argv) :
     }
 
     // is this the first time we've run transmission?
-    bool const first_time = !dir.exists(QLatin1String("settings.json"));
+    bool const first_time = !dir.exists(QStringLiteral("settings.json"));
 
     // initialize the prefs
     prefs_ = new Prefs(config_dir);
@@ -356,17 +356,17 @@ void Application::loadTranslations()
 {
     QStringList const qt_qm_dirs = QStringList() << QLibraryInfo::location(QLibraryInfo::TranslationsPath) <<
 #ifdef TRANSLATIONS_DIR
-        QString::fromUtf8(TRANSLATIONS_DIR) <<
+        QStringLiteral(TRANSLATIONS_DIR) <<
 #endif
-        (applicationDirPath() + QLatin1String("/translations"));
+        (applicationDirPath() + QStringLiteral("/translations"));
 
     QStringList const app_qm_dirs = QStringList() <<
 #ifdef TRANSLATIONS_DIR
-        QString::fromUtf8(TRANSLATIONS_DIR) <<
+        QStringLiteral(TRANSLATIONS_DIR) <<
 #endif
-        (applicationDirPath() + QLatin1String("/translations"));
+        (applicationDirPath() + QStringLiteral("/translations"));
 
-    QString const qt_file_name = QLatin1String("qtbase");
+    auto const qt_file_name = QStringLiteral("qtbase");
 
     QLocale const locale;
     QLocale const english_locale(QLocale::English, QLocale::UnitedStates);
@@ -584,20 +584,20 @@ bool Application::notifyApp(QString const& title, QString const& body) const
 {
 #ifdef QT_DBUS_LIB
 
-    QLatin1String const dbus_service_name("org.freedesktop.Notifications");
-    QLatin1String const dbus_interface_name("org.freedesktop.Notifications");
-    QLatin1String const dbus_path("/org/freedesktop/Notifications");
+    auto const DBUS_SERVICE_NAME = QStringLiteral("org.freedesktop.Notifications");
+    auto const DBUS_INTERFACE_NAME = QStringLiteral("org.freedesktop.Notifications");
+    auto const DBUS_PATH = QStringLiteral("/org/freedesktop/Notifications");
 
     QDBusConnection bus = QDBusConnection::sessionBus();
 
     if (bus.isConnected())
     {
         QDBusMessage m =
-            QDBusMessage::createMethodCall(dbus_service_name, dbus_path, dbus_interface_name, QLatin1String("Notify"));
+            QDBusMessage::createMethodCall(DBUS_SERVICE_NAME, DBUS_PATH, DBUS_INTERFACE_NAME, QStringLiteral("Notify"));
         QVariantList args;
-        args.append(QLatin1String("Transmission")); // app_name
+        args.append(QStringLiteral("Transmission")); // app_name
         args.append(0U); // replaces_id
-        args.append(QLatin1String("transmission")); // icon
+        args.append(QStringLiteral("transmission")); // icon
         args.append(title); // summary
         args.append(body); // body
         args.append(QStringList()); // actions - unused for plain passive popups

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -28,7 +28,7 @@ extern wchar_t qAxModuleFilename[MAX_PATH];
 extern QString qAxInit();
 
 ComInteropHelper::ComInteropHelper() :
-    client_(new QAxObject(QLatin1String("Transmission.QtClient")))
+    client_(new QAxObject(QStringLiteral("Transmission.QtClient")))
 {
 }
 

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -20,9 +20,9 @@
 namespace
 {
 
-QLatin1String const DBUS_SERVICE("com.transmissionbt.Transmission");
-QLatin1String const DBUS_OBJECT_PATH("/com/transmissionbt/Transmission");
-QLatin1String const DBUS_INTERFACE("com.transmissionbt.Transmission");
+auto const DBUS_SERVICE = QStringLiteral("com.transmissionbt.Transmission");
+auto const DBUS_OBJECT_PATH = QStringLiteral("/com/transmissionbt/Transmission");
+auto const DBUS_INTERFACE = QStringLiteral("com.transmissionbt.Transmission");
 
 } // namespace
 
@@ -34,7 +34,7 @@ bool DBusInteropHelper::isConnected() const
 QVariant DBusInteropHelper::addMetainfo(QString const& metainfo)
 {
     QDBusMessage request = QDBusMessage::createMethodCall(DBUS_SERVICE, DBUS_OBJECT_PATH, DBUS_INTERFACE,
-        QLatin1String("AddMetainfo"));
+        QStringLiteral("AddMetainfo"));
     request.setArguments(QVariantList() << metainfo);
 
     QDBusReply<bool> const response = QDBusConnection::sessionBus().call(request);

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -161,7 +161,7 @@ private:
                 if (ip_address.protocol() == QAbstractSocket::IPv4Protocol)
                 {
                     quint32 const ipv4_address = ip_address.toIPv4Address();
-                    collated_address = QLatin1String("1-") + QString::fromLatin1(QByteArray::number(ipv4_address, 16).
+                    collated_address = QStringLiteral("1-") + QString::fromUtf8(QByteArray::number(ipv4_address, 16).
                         rightJustified(8, '0'));
                 }
                 else if (ip_address.protocol() == QAbstractSocket::IPv6Protocol)
@@ -174,13 +174,13 @@ private:
                         tmp[i] = ipv6_address[i];
                     }
 
-                    collated_address = QLatin1String("2-") + QString::fromLatin1(tmp.toHex());
+                    collated_address = QStringLiteral("2-") + QString::fromUtf8(tmp.toHex());
                 }
             }
 
             if (collated_address.isEmpty())
             {
-                collated_address = QLatin1String("3-") + peer.address.toLower();
+                collated_address = QStringLiteral("3-") + peer.address.toLower();
             }
         }
 
@@ -518,7 +518,7 @@ void DetailsDialog::refresh()
     }
     else
     {
-        string = QString::fromLatin1("%1%").arg(Formatter::percentToString((100.0 * available) / size_when_done));
+        string = QStringLiteral("%1%").arg(Formatter::percentToString((100.0 * available) / size_when_done));
     }
 
     ui_.availabilityValueLabel->setText(string);
@@ -1039,7 +1039,7 @@ void DetailsDialog::refresh()
 
             if (item == nullptr) // new peer has connected
             {
-                static QIcon const ENCRYPTION_ICON(QLatin1String(":/icons/encrypted.png"));
+                static QIcon const ENCRYPTION_ICON(QStringLiteral(":/icons/encrypted.png"));
                 static QIcon const EMPTY_ICON;
                 item = new PeerItem(peer);
                 item->setTextAlignment(COL_UP, Qt::AlignRight | Qt::AlignVCenter);
@@ -1115,7 +1115,7 @@ void DetailsDialog::refresh()
 
                 if (!txt.isEmpty())
                 {
-                    code_tip += QString::fromLatin1("%1: %2\n").arg(ch).arg(txt);
+                    code_tip += QStringLiteral("%1: %2\n").arg(ch).arg(txt);
                 }
             }
 
@@ -1126,7 +1126,7 @@ void DetailsDialog::refresh()
 
             item->setText(COL_UP, peer.rate_to_peer.isZero() ? QString() : Formatter::speedToString(peer.rate_to_peer));
             item->setText(COL_DOWN, peer.rate_to_client.isZero() ? QString() : Formatter::speedToString(peer.rate_to_client));
-            item->setText(COL_PERCENT, peer.progress > 0 ? QString::fromLatin1("%1%").arg(int(peer.progress * 100.0)) :
+            item->setText(COL_PERCENT, peer.progress > 0 ? QStringLiteral("%1%").arg(int(peer.progress * 100.0)) :
                 QString());
             item->setText(COL_STATUS, code);
             item->setToolTip(COL_STATUS, code_tip);
@@ -1376,8 +1376,8 @@ void DetailsDialog::initOptionsTab()
 {
     QString const speed_K_str = Formatter::unitStr(Formatter::SPEED, Formatter::KB);
 
-    ui_.singleDownSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
-    ui_.singleUpSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
+    ui_.singleDownSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
+    ui_.singleUpSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
 
     ui_.singleDownSpin->setProperty(PREF_KEY, TR_KEY_downloadLimit);
     ui_.singleUpSpin->setProperty(PREF_KEY, TR_KEY_uploadLimit);
@@ -1434,9 +1434,9 @@ void DetailsDialog::initTrackerTab()
     ui_.trackersView->setModel(tracker_filter_);
     ui_.trackersView->setItemDelegate(tracker_delegate_);
 
-    ui_.addTrackerButton->setIcon(getStockIcon(QLatin1String("list-add"), QStyle::SP_DialogOpenButton));
-    ui_.editTrackerButton->setIcon(getStockIcon(QLatin1String("document-properties"), QStyle::SP_DesktopIcon));
-    ui_.removeTrackerButton->setIcon(getStockIcon(QLatin1String("list-remove"), QStyle::SP_TrashIcon));
+    ui_.addTrackerButton->setIcon(getStockIcon(QStringLiteral("list-add"), QStyle::SP_DialogOpenButton));
+    ui_.editTrackerButton->setIcon(getStockIcon(QStringLiteral("document-properties"), QStyle::SP_DesktopIcon));
+    ui_.removeTrackerButton->setIcon(getStockIcon(QStringLiteral("list-remove"), QStyle::SP_TrashIcon));
 
     ui_.showTrackerScrapesCheck->setChecked(prefs_.getBool(Prefs::SHOW_TRACKER_SCRAPES));
     ui_.showBackupTrackersCheck->setChecked(prefs_.getBool(Prefs::SHOW_BACKUP_TRACKERS));
@@ -1463,11 +1463,11 @@ void DetailsDialog::initPeersTab()
     ui_.peersView->sortByColumn(COL_ADDRESS, Qt::AscendingOrder);
 
     ui_.peersView->setColumnWidth(COL_LOCK, 20);
-    ui_.peersView->setColumnWidth(COL_UP, measureViewItem(ui_.peersView, COL_UP, QLatin1String("1024 MiB/s")));
-    ui_.peersView->setColumnWidth(COL_DOWN, measureViewItem(ui_.peersView, COL_DOWN, QLatin1String("1024 MiB/s")));
-    ui_.peersView->setColumnWidth(COL_PERCENT, measureViewItem(ui_.peersView, COL_PERCENT, QLatin1String("100%")));
-    ui_.peersView->setColumnWidth(COL_STATUS, measureViewItem(ui_.peersView, COL_STATUS, QLatin1String("ODUK?EXI")));
-    ui_.peersView->setColumnWidth(COL_ADDRESS, measureViewItem(ui_.peersView, COL_ADDRESS, QLatin1String("888.888.888.888")));
+    ui_.peersView->setColumnWidth(COL_UP, measureViewItem(ui_.peersView, COL_UP, QStringLiteral("1024 MiB/s")));
+    ui_.peersView->setColumnWidth(COL_DOWN, measureViewItem(ui_.peersView, COL_DOWN, QStringLiteral("1024 MiB/s")));
+    ui_.peersView->setColumnWidth(COL_PERCENT, measureViewItem(ui_.peersView, COL_PERCENT, QStringLiteral("100%")));
+    ui_.peersView->setColumnWidth(COL_STATUS, measureViewItem(ui_.peersView, COL_STATUS, QStringLiteral("ODUK?EXI")));
+    ui_.peersView->setColumnWidth(COL_ADDRESS, measureViewItem(ui_.peersView, COL_ADDRESS, QStringLiteral("888.888.888.888")));
 }
 
 /***

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -37,7 +37,7 @@ QString FaviconCache::getCacheDir()
 {
     QString const base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 
-    return QDir(base).absoluteFilePath(QLatin1String("favicons"));
+    return QDir(base).absoluteFilePath(QStringLiteral("favicons"));
 }
 
 namespace
@@ -128,9 +128,9 @@ QString FaviconCache::add(QUrl const& url)
         pixmaps_[key] = QPixmap();
 
         // try to download the favicon
-        QString const path = QLatin1String("http://") + url.host() + QLatin1String("/favicon.");
+        QString const path = QStringLiteral("http://") + url.host() + QStringLiteral("/favicon.");
         QStringList suffixes;
-        suffixes << QLatin1String("ico") << QLatin1String("png") << QLatin1String("gif") << QLatin1String("jpg");
+        suffixes << QStringLiteral("ico") << QStringLiteral("png") << QStringLiteral("gif") << QStringLiteral("jpg");
 
         for (QString const& suffix : suffixes)
         {

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -60,7 +60,7 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
         p.textAlignment = Qt::AlignCenter;
         p.textVisible = true;
         p.progress = int(100.0 * index.data().toDouble());
-        p.text = QString::fromLatin1("%1%").arg(p.progress);
+        p.text = QStringLiteral("%1%").arg(p.progress);
         style->drawControl(QStyle::CE_ProgressBar, &p, painter);
     }
     else if (column == FileTreeModel::COL_WANTED)

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -91,13 +91,13 @@ void FileTreeView::resizeEvent(QResizeEvent* event)
         case FileTreeModel::COL_SIZE:
             for (int s = Formatter::B; s <= Formatter::TB; ++s)
             {
-                item_texts << QLatin1String("999.9 ") + Formatter::unitStr(Formatter::MEM, static_cast<Formatter::Size>(s));
+                item_texts << QStringLiteral("999.9 ") + Formatter::unitStr(Formatter::MEM, static_cast<Formatter::Size>(s));
             }
 
             break;
 
         case FileTreeModel::COL_PROGRESS:
-            item_texts << QLatin1String("  100%  ");
+            item_texts << QStringLiteral("  100%  ");
             break;
 
         case FileTreeModel::COL_WANTED:

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -51,31 +51,31 @@ FilterBarComboBox* FilterBar::createActivityCombo()
     model->appendRow(new QStandardItem); // separator
     delegate->setSeparator(model, model->index(1, 0));
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("system-run")), tr("Active"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("system-run")), tr("Active"));
     row->setData(FilterMode::SHOW_ACTIVE, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("go-down")), tr("Downloading"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("go-down")), tr("Downloading"));
     row->setData(FilterMode::SHOW_DOWNLOADING, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("go-up")), tr("Seeding"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("go-up")), tr("Seeding"));
     row->setData(FilterMode::SHOW_SEEDING, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("media-playback-pause")), tr("Paused"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("media-playback-pause")), tr("Paused"));
     row->setData(FilterMode::SHOW_PAUSED, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("dialog-ok")), tr("Finished"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("dialog-ok")), tr("Finished"));
     row->setData(FilterMode::SHOW_FINISHED, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("view-refresh")), tr("Verifying"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("view-refresh")), tr("Verifying"));
     row->setData(FilterMode::SHOW_VERIFYING, ActivityRole);
     model->appendRow(row);
 
-    row = new QStandardItem(QIcon::fromTheme(QLatin1String("process-stop")), tr("Error"));
+    row = new QStandardItem(QIcon::fromTheme(QStringLiteral("process-stop")), tr("Error"));
     row->setData(FilterMode::SHOW_ERROR, ActivityRole);
     model->appendRow(row);
 
@@ -92,7 +92,7 @@ namespace
 
 QString getCountString(int n)
 {
-    return QString::fromLatin1("%L1").arg(n);
+    return QStringLiteral("%L1").arg(n);
 }
 
 } // namespace

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -34,12 +34,12 @@ FilterBarComboBoxDelegate::FilterBarComboBoxDelegate(QObject* parent, QComboBox*
 
 bool FilterBarComboBoxDelegate::isSeparator(QModelIndex const& index)
 {
-    return index.data(Qt::AccessibleDescriptionRole).toString() == QLatin1String("separator");
+    return index.data(Qt::AccessibleDescriptionRole).toString() == QStringLiteral("separator");
 }
 
 void FilterBarComboBoxDelegate::setSeparator(QAbstractItemModel* model, QModelIndex const& index)
 {
-    model->setData(index, QString::fromLatin1("separator"), Qt::AccessibleDescriptionRole);
+    model->setData(index, QStringLiteral("separator"), Qt::AccessibleDescriptionRole);
 
     if (auto* m = qobject_cast<QStandardItemModel*>(model))
     {

--- a/qt/Filters.cc
+++ b/qt/Filters.cc
@@ -10,14 +10,14 @@
 
 QString const FilterMode::names_[NUM_MODES] =
 {
-    QLatin1String("show-all"),
-    QLatin1String("show-active"),
-    QLatin1String("show-downloading"),
-    QLatin1String("show-seeding"),
-    QLatin1String("show-paused"),
-    QLatin1String("show-finished"),
-    QLatin1String("show-verifying"),
-    QLatin1String("show-error")
+    QStringLiteral("show-all"),
+    QStringLiteral("show-active"),
+    QStringLiteral("show-downloading"),
+    QStringLiteral("show-seeding"),
+    QStringLiteral("show-paused"),
+    QStringLiteral("show-finished"),
+    QStringLiteral("show-verifying"),
+    QStringLiteral("show-error")
 };
 
 int FilterMode::modeFromName(QString const& name)
@@ -35,16 +35,16 @@ int FilterMode::modeFromName(QString const& name)
 
 QString const SortMode::names_[NUM_MODES] =
 {
-    QLatin1String("sort-by-activity"),
-    QLatin1String("sort-by-age"),
-    QLatin1String("sort-by-eta"),
-    QLatin1String("sort-by-name"),
-    QLatin1String("sort-by-progress"),
-    QLatin1String("sort-by-queue"),
-    QLatin1String("sort-by-ratio"),
-    QLatin1String("sort-by-size"),
-    QLatin1String("sort-by-state"),
-    QLatin1String("sort-by-id")
+    QStringLiteral("sort-by-activity"),
+    QStringLiteral("sort-by-age"),
+    QStringLiteral("sort-by-eta"),
+    QStringLiteral("sort-by-name"),
+    QStringLiteral("sort-by-progress"),
+    QStringLiteral("sort-by-queue"),
+    QStringLiteral("sort-by-ratio"),
+    QStringLiteral("sort-by-size"),
+    QStringLiteral("sort-by-state"),
+    QStringLiteral("sort-by-id")
 };
 
 int SortMode::modeFromName(QString const& name)

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -50,10 +50,10 @@
 namespace
 {
 
-QLatin1String const TotalRatioStatsModeName("total-ratio");
-QLatin1String const TotalTransferStatsModeName("total-transfer");
-QLatin1String const SessionRatioStatsModeName("session-ratio");
-QLatin1String const SessionTransferStatsModeName("session-transfer");
+auto const TOTAL_RATIO_STATS_MODE_NAME = QStringLiteral("total-ratio");
+auto const TOTAL_TRANSFER_STATS_MODE_NAME = QStringLiteral("total-transfer");
+auto const SESSION_RATIO_STATS_MODE_NAME = QStringLiteral("session-ratio");
+auto const SESSION_TRANSFER_STATS_MODE_NAME = QStringLiteral("session-transfer");
 
 } // namespace
 
@@ -156,37 +156,37 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     ui_.listView->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     // icons
-    QIcon const icon_play = getStockIcon(QLatin1String("media-playback-start"), QStyle::SP_MediaPlay);
-    QIcon const icon_pause = getStockIcon(QLatin1String("media-playback-pause"), QStyle::SP_MediaPause);
-    QIcon const icon_open = getStockIcon(QLatin1String("document-open"), QStyle::SP_DialogOpenButton);
+    QIcon const icon_play = getStockIcon(QStringLiteral("media-playback-start"), QStyle::SP_MediaPlay);
+    QIcon const icon_pause = getStockIcon(QStringLiteral("media-playback-pause"), QStyle::SP_MediaPause);
+    QIcon const icon_open = getStockIcon(QStringLiteral("document-open"), QStyle::SP_DialogOpenButton);
     ui_.action_OpenFile->setIcon(icon_open);
     ui_.action_AddURL->setIcon(addEmblem(icon_open,
-        QStringList() << QLatin1String("emblem-web") << QLatin1String("applications-internet")));
-    ui_.action_New->setIcon(getStockIcon(QLatin1String("document-new"), QStyle::SP_DesktopIcon));
-    ui_.action_Properties->setIcon(getStockIcon(QLatin1String("document-properties"), QStyle::SP_DesktopIcon));
-    ui_.action_OpenFolder->setIcon(getStockIcon(QLatin1String("folder-open"), QStyle::SP_DirOpenIcon));
+        QStringList() << QStringLiteral("emblem-web") << QStringLiteral("applications-internet")));
+    ui_.action_New->setIcon(getStockIcon(QStringLiteral("document-new"), QStyle::SP_DesktopIcon));
+    ui_.action_Properties->setIcon(getStockIcon(QStringLiteral("document-properties"), QStyle::SP_DesktopIcon));
+    ui_.action_OpenFolder->setIcon(getStockIcon(QStringLiteral("folder-open"), QStyle::SP_DirOpenIcon));
     ui_.action_Start->setIcon(icon_play);
     ui_.action_StartNow->setIcon(icon_play);
-    ui_.action_Announce->setIcon(getStockIcon(QLatin1String("network-transmit-receive")));
+    ui_.action_Announce->setIcon(getStockIcon(QStringLiteral("network-transmit-receive")));
     ui_.action_Pause->setIcon(icon_pause);
-    ui_.action_Remove->setIcon(getStockIcon(QLatin1String("list-remove"), QStyle::SP_TrashIcon));
-    ui_.action_Delete->setIcon(getStockIcon(QLatin1String("edit-delete"), QStyle::SP_TrashIcon));
+    ui_.action_Remove->setIcon(getStockIcon(QStringLiteral("list-remove"), QStyle::SP_TrashIcon));
+    ui_.action_Delete->setIcon(getStockIcon(QStringLiteral("edit-delete"), QStyle::SP_TrashIcon));
     ui_.action_StartAll->setIcon(icon_play);
     ui_.action_PauseAll->setIcon(icon_pause);
-    ui_.action_Quit->setIcon(getStockIcon(QLatin1String("application-exit")));
-    ui_.action_SelectAll->setIcon(getStockIcon(QLatin1String("edit-select-all")));
-    ui_.action_ReverseSortOrder->setIcon(getStockIcon(QLatin1String("view-sort-ascending"), QStyle::SP_ArrowDown));
-    ui_.action_Preferences->setIcon(getStockIcon(QLatin1String("preferences-system")));
-    ui_.action_Contents->setIcon(getStockIcon(QLatin1String("help-contents"), QStyle::SP_DialogHelpButton));
-    ui_.action_About->setIcon(getStockIcon(QLatin1String("help-about")));
-    ui_.action_QueueMoveTop->setIcon(getStockIcon(QLatin1String("go-top")));
-    ui_.action_QueueMoveUp->setIcon(getStockIcon(QLatin1String("go-up"), QStyle::SP_ArrowUp));
-    ui_.action_QueueMoveDown->setIcon(getStockIcon(QLatin1String("go-down"), QStyle::SP_ArrowDown));
-    ui_.action_QueueMoveBottom->setIcon(getStockIcon(QLatin1String("go-bottom")));
+    ui_.action_Quit->setIcon(getStockIcon(QStringLiteral("application-exit")));
+    ui_.action_SelectAll->setIcon(getStockIcon(QStringLiteral("edit-select-all")));
+    ui_.action_ReverseSortOrder->setIcon(getStockIcon(QStringLiteral("view-sort-ascending"), QStyle::SP_ArrowDown));
+    ui_.action_Preferences->setIcon(getStockIcon(QStringLiteral("preferences-system")));
+    ui_.action_Contents->setIcon(getStockIcon(QStringLiteral("help-contents"), QStyle::SP_DialogHelpButton));
+    ui_.action_About->setIcon(getStockIcon(QStringLiteral("help-about")));
+    ui_.action_QueueMoveTop->setIcon(getStockIcon(QStringLiteral("go-top")));
+    ui_.action_QueueMoveUp->setIcon(getStockIcon(QStringLiteral("go-up"), QStyle::SP_ArrowUp));
+    ui_.action_QueueMoveDown->setIcon(getStockIcon(QStringLiteral("go-down"), QStyle::SP_ArrowDown));
+    ui_.action_QueueMoveBottom->setIcon(getStockIcon(QStringLiteral("go-bottom")));
 
     auto makeNetworkPixmap = [this](char const* name_in, QSize size = QSize(16, 16))
         {
-            QString const name = QLatin1String(name_in);
+            auto const name = QString::fromUtf8(name_in);
             QIcon const icon = getStockIcon(name, QStyle::SP_DriveNetIcon);
             return icon.pixmap(size);
         };
@@ -291,7 +291,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     menu->addSeparator();
     menu->addAction(ui_.action_Quit);
     tray_icon_.setContextMenu(menu);
-    tray_icon_.setIcon(QIcon::fromTheme(QLatin1String("transmission-tray-icon"), qApp->windowIcon()));
+    tray_icon_.setIcon(QIcon::fromTheme(QStringLiteral("transmission-tray-icon"), qApp->windowIcon()));
 
     connect(&prefs_, SIGNAL(changed(int)), this, SLOT(refreshPref(int)));
     connect(ui_.action_ShowMainWindow, SIGNAL(triggered(bool)), this, SLOT(toggleWindows(bool)));
@@ -467,12 +467,12 @@ QMenu* MainWindow::createOptionsMenu()
 
 QMenu* MainWindow::createStatsModeMenu()
 {
-    QPair<QAction*, QLatin1String> const stats_modes[] =
+    QPair<QAction*, QString> const stats_modes[] =
     {
-        qMakePair(ui_.action_TotalRatio, TotalRatioStatsModeName),
-        qMakePair(ui_.action_TotalTransfer, TotalTransferStatsModeName),
-        qMakePair(ui_.action_SessionRatio, SessionRatioStatsModeName),
-        qMakePair(ui_.action_SessionTransfer, SessionTransferStatsModeName)
+        qMakePair(ui_.action_TotalRatio, TOTAL_RATIO_STATS_MODE_NAME),
+        qMakePair(ui_.action_TotalTransfer, TOTAL_TRANSFER_STATS_MODE_NAME),
+        qMakePair(ui_.action_SessionRatio, SESSION_RATIO_STATS_MODE_NAME),
+        qMakePair(ui_.action_SessionTransfer, SESSION_TRANSFER_STATS_MODE_NAME)
     };
 
     auto* actionGroup = new QActionGroup(this);
@@ -568,12 +568,12 @@ namespace
 
 static void openSelect(QString const& path)
 {
-    QString const explorer = QLatin1String("explorer");
+    auto const explorer = QStringLiteral("explorer");
     QString param;
 
     if (!QFileInfo(path).isDir())
     {
-        param = QLatin1String("/select,");
+        param = QStringLiteral("/select,");
     }
 
     param += QDir::toNativeSeparators(path);
@@ -587,13 +587,13 @@ static void openSelect(QString const& path)
 static void openSelect(QString const& path)
 {
     QStringList script_args;
-    script_args << QLatin1String("-e") <<
-        QString::fromLatin1("tell application \"Finder\" to reveal POSIX file \"%1\"").arg(path);
-    QProcess::execute(QLatin1String("/usr/bin/osascript"), script_args);
+    script_args << QStringLiteral("-e") <<
+        QStringLiteral("tell application \"Finder\" to reveal POSIX file \"%1\"").arg(path);
+    QProcess::execute(QStringLiteral("/usr/bin/osascript"), script_args);
 
     script_args.clear();
-    script_args << QLatin1String("-e") << QLatin1String("tell application \"Finder\" to activate");
-    QProcess::execute(QLatin1String("/usr/bin/osascript"), script_args);
+    script_args << QStringLiteral("-e") << QStringLiteral("tell application \"Finder\" to activate");
+    QProcess::execute(QStringLiteral("/usr/bin/osascript"), script_args);
 }
 
 #endif
@@ -659,7 +659,7 @@ void MainWindow::openStats()
 
 void MainWindow::openDonate()
 {
-    QDesktopServices::openUrl(QUrl(QLatin1String("https://transmissionbt.com/donate/")));
+    QDesktopServices::openUrl(QUrl(QStringLiteral("https://transmissionbt.com/donate/")));
 }
 
 void MainWindow::openAbout()
@@ -669,7 +669,7 @@ void MainWindow::openAbout()
 
 void MainWindow::openHelp()
 {
-    QDesktopServices::openUrl(QUrl(QString::fromLatin1("https://transmissionbt.com/help/gtk/%1.%2x").arg(MAJOR_VERSION).
+    QDesktopServices::openUrl(QUrl(QStringLiteral("https://transmissionbt.com/help/gtk/%1.%2x").arg(MAJOR_VERSION).
         arg(MINOR_VERSION / 10)));
 }
 
@@ -742,7 +742,7 @@ void MainWindow::onRefreshTimer()
 
 void MainWindow::refreshTitle()
 {
-    QString title(QLatin1String("Transmission"));
+    QString title(QStringLiteral("Transmission"));
     QUrl const url(session_.getRemoteUrl());
 
     if (!url.isEmpty())
@@ -769,7 +769,7 @@ void MainWindow::refreshTrayIcon(TransferStats const& stats)
     }
     else if (stats.peers_sending != 0)
     {
-        tip = Formatter::downloadSpeedToString(stats.speed_down) + QLatin1String("   ") + Formatter::uploadSpeedToString(
+        tip = Formatter::downloadSpeedToString(stats.speed_down) + QStringLiteral("   ") + Formatter::uploadSpeedToString(
             stats.speed_up);
     }
     else if (stats.peers_receiving != 0)
@@ -792,17 +792,17 @@ void MainWindow::refreshStatusBar(TransferStats const& stats)
     QString const mode(prefs_.getString(Prefs::STATUSBAR_STATS));
     QString str;
 
-    if (mode == SessionRatioStatsModeName)
+    if (mode == SESSION_RATIO_STATS_MODE_NAME)
     {
         str = tr("Ratio: %1").arg(Formatter::ratioToString(session_.getStats().ratio));
     }
-    else if (mode == SessionTransferStatsModeName)
+    else if (mode == SESSION_TRANSFER_STATS_MODE_NAME)
     {
         tr_session_stats const& stats(session_.getStats());
         str = tr("Down: %1, Up: %2").arg(Formatter::sizeToString(stats.downloadedBytes)).
             arg(Formatter::sizeToString(stats.uploadedBytes));
     }
-    else if (mode == TotalTransferStatsModeName)
+    else if (mode == TOTAL_TRANSFER_STATS_MODE_NAME)
     {
         tr_session_stats const& stats(session_.getCumulativeStats());
         str = tr("Down: %1, Up: %2").arg(Formatter::sizeToString(stats.downloadedBytes)).
@@ -810,7 +810,7 @@ void MainWindow::refreshStatusBar(TransferStats const& stats)
     }
     else // default is "total-ratio"
     {
-        assert(mode == TotalRatioStatsModeName);
+        assert(mode == TOTAL_RATIO_STATS_MODE_NAME);
         str = tr("Ratio: %1").arg(Formatter::ratioToString(session_.getCumulativeStats().ratio));
     }
 
@@ -1245,7 +1245,7 @@ void MainWindow::refreshPref(int key)
 namespace
 {
 
-QLatin1String const SHOW_OPTIONS_CHECKBOX_NAME("show-options-checkbox");
+auto const SHOW_OPTIONS_CHECKBOX_NAME = QStringLiteral("show-options-checkbox");
 
 } // namespace
 
@@ -1412,8 +1412,8 @@ void MainWindow::removeTorrents(bool const delete_files)
         }
     }
 
-    msg_box.setWindowTitle(QLatin1String(" "));
-    msg_box.setText(QString::fromLatin1("<big><b>%1</big></b>").arg(primary_text));
+    msg_box.setWindowTitle(QStringLiteral(" "));
+    msg_box.setText(QStringLiteral("<big><b>%1</big></b>").arg(primary_text));
     msg_box.setInformativeText(secondary_text);
     msg_box.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
     msg_box.setDefaultButton(QMessageBox::Cancel);
@@ -1550,9 +1550,9 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 {
     QMimeData const* mime = event->mimeData();
 
-    if (mime->hasFormat(QLatin1String("application/x-bittorrent")) || mime->hasUrls() ||
-        mime->text().trimmed().endsWith(QLatin1String(".torrent"), Qt::CaseInsensitive) ||
-        mime->text().startsWith(QLatin1String("magnet:"), Qt::CaseInsensitive))
+    if (mime->hasFormat(QStringLiteral("application/x-bittorrent")) || mime->hasUrls() ||
+        mime->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
+        mime->text().startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
     {
         event->acceptProposedAction();
     }

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -113,12 +113,12 @@ void MakeProgressDialog::onProgress()
     else if (b.result == TR_MAKEMETA_IO_READ)
     {
         str = tr("Error reading \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
-            arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
+            arg(QString::fromUtf8(tr_strerror(b.my_errno)));
     }
     else if (b.result == TR_MAKEMETA_IO_WRITE)
     {
         str = tr("Error writing \"%1\": %2").arg(QString::fromUtf8(b.errfile)).
-            arg(QString::fromLocal8Bit(tr_strerror(b.my_errno)));
+            arg(QString::fromUtf8(tr_strerror(b.my_errno)));
     }
 
     ui_.progressLabel->setText(str);
@@ -165,7 +165,7 @@ void MakeDialog::makeTorrent()
 
     // the file to create
     QString const path = QString::fromUtf8(builder_->top);
-    QString const torrent_name = QFileInfo(path).completeBaseName() + QLatin1String(".torrent");
+    auto const torrent_name = QFileInfo(path).completeBaseName() + QStringLiteral(".torrent");
     QString const target = QDir(ui_.destinationButton->path()).filePath(torrent_name);
 
     // comment

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -74,7 +74,7 @@ OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData const
     ui_.sourceLabel->setBuddy(ui_.sourceStack->currentWidget());
 
     QFontMetrics const fontMetrics(font());
-    int const width = fontMetrics.size(0, QString::fromUtf8("This is a pretty long torrent filename indeed.torrent")).width();
+    int const width = fontMetrics.size(0, QStringLiteral("This is a pretty long torrent filename indeed.torrent")).width();
     ui_.sourceStack->setMinimumWidth(width);
 
     QString const download_dir(Utils::removeTrailingDirSeparator(prefs.getString(Prefs::DOWNLOAD_DIR)));

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -291,7 +291,7 @@ Prefs::~Prefs()
 
     // update settings.json with our settings
     tr_variant file_settings;
-    QFile const file(QDir(config_dir_).absoluteFilePath(QLatin1String("settings.json")));
+    QFile const file(QDir(config_dir_).absoluteFilePath(QStringLiteral("settings.json")));
 
     if (!tr_variantFromFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toUtf8().constData(), nullptr))
     {

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -327,10 +327,10 @@ void PrefsDialog::initSpeedTab()
     QString const speed_K_str = Formatter::unitStr(Formatter::SPEED, Formatter::KB);
     QLocale const locale;
 
-    ui_.uploadSpeedLimitSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
-    ui_.downloadSpeedLimitSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
-    ui_.altUploadSpeedLimitSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
-    ui_.altDownloadSpeedLimitSpin->setSuffix(QString::fromLatin1(" %1").arg(speed_K_str));
+    ui_.uploadSpeedLimitSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
+    ui_.downloadSpeedLimitSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
+    ui_.altUploadSpeedLimitSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
+    ui_.altDownloadSpeedLimitSpin->setSuffix(QStringLiteral(" %1").arg(speed_K_str));
 
     ui_.altSpeedLimitDaysCombo->addItem(tr("Every Day"), QVariant(TR_SCHED_ALL));
     ui_.altSpeedLimitDaysCombo->addItem(tr("Weekdays"), QVariant(TR_SCHED_WEEKDAY));

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -216,15 +216,15 @@ void Session::updatePref(int key)
                 switch (i)
                 {
                 case 0:
-                    sessionSet(prefs_.getKey(key), QLatin1String("tolerated"));
+                    sessionSet(prefs_.getKey(key), QStringLiteral("tolerated"));
                     break;
 
                 case 1:
-                    sessionSet(prefs_.getKey(key), QLatin1String("preferred"));
+                    sessionSet(prefs_.getKey(key), QStringLiteral("preferred"));
                     break;
 
                 case 2:
-                    sessionSet(prefs_.getKey(key), QLatin1String("required"));
+                    sessionSet(prefs_.getKey(key), QStringLiteral("required"));
                     break;
                 }
 
@@ -348,10 +348,10 @@ void Session::start()
     if (prefs_.get<bool>(Prefs::SESSION_IS_REMOTE))
     {
         QUrl url;
-        url.setScheme(QLatin1String("http"));
+        url.setScheme(QStringLiteral("http"));
         url.setHost(prefs_.get<QString>(Prefs::SESSION_REMOTE_HOST));
         url.setPort(prefs_.get<int>(Prefs::SESSION_REMOTE_PORT));
-        url.setPath(QLatin1String("/transmission/rpc"));
+        url.setPath(QStringLiteral("/transmission/rpc"));
 
         if (prefs_.get<bool>(Prefs::SESSION_REMOTE_AUTH))
         {
@@ -978,7 +978,7 @@ void Session::addTorrent(AddData const& add_me, tr_variant* args, bool trash_ori
         [add_me](RpcResponse const& r)
         {
             auto* d = new QMessageBox(QMessageBox::Warning, tr("Error Adding Torrent"),
-                QString::fromLatin1("<p><b>%1</b></p><p>%2</p>").arg(r.result).arg(add_me.readableName()), QMessageBox::Close,
+                QStringLiteral("<p><b>%1</b></p><p>%2</p>").arg(r.result).arg(add_me.readableName()), QMessageBox::Close,
                 qApp->activeWindow());
             QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
             d->show();
@@ -1088,12 +1088,12 @@ void Session::launchWebInterface()
     if (session_ == nullptr) // remote session
     {
         url = rpc_.url();
-        url.setPath(QLatin1String("/transmission/web/"));
+        url.setPath(QStringLiteral("/transmission/web/"));
     }
     else // local session
     {
-        url.setScheme(QLatin1String("http"));
-        url.setHost(QLatin1String("localhost"));
+        url.setScheme(QStringLiteral("http"));
+        url.setHost(QStringLiteral("localhost"));
         url.setPort(prefs_.getInt(Prefs::RPC_PORT));
     }
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -271,7 +271,7 @@ QString TorrentDelegate::shortTransferString(Torrent const& tor)
 
     if (have_down)
     {
-        str = Formatter::downloadSpeedToString(tor.downloadSpeed()) + QLatin1String("   ") +
+        str = Formatter::downloadSpeedToString(tor.downloadSpeed()) + QStringLiteral("   ") +
             Formatter::uploadSpeedToString(tor.uploadSpeed());
     }
     else if (have_up)
@@ -294,7 +294,7 @@ QString TorrentDelegate::shortStatusString(Torrent const& tor)
 
     case TR_STATUS_DOWNLOAD:
     case TR_STATUS_SEED:
-        str = shortTransferString(tor) + QLatin1String("    ") + tr("Ratio: %1").arg(Formatter::ratioToString(tor.ratio()));
+        str = shortTransferString(tor) + QStringLiteral("    ") + tr("Ratio: %1").arg(Formatter::ratioToString(tor.ratio()));
         break;
 
     default:
@@ -426,7 +426,7 @@ QIcon& TorrentDelegate::getWarningEmblem() const
 
     if (icon.isNull())
     {
-        icon = QIcon::fromTheme(QLatin1String("emblem-important"));
+        icon = QIcon::fromTheme(QStringLiteral("emblem-important"));
     }
 
     if (icon.isNull())

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -273,7 +273,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     }
 
     progress_bar_style_->state = progress_bar_state;
-    progress_bar_style_->text = QString::fromLatin1("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
+    progress_bar_style_->text = QStringLiteral("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
     progress_bar_style_->textVisible = true;
     progress_bar_style_->textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -175,27 +175,27 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
     QString key;
     QString str;
     time_t const now(time(nullptr));
-    QString const err_markup_begin = QLatin1String("<span style=\"color:red\">");
-    QString const err_markup_end = QLatin1String("</span>");
-    QString const timeout_markup_begin = QLatin1String("<span style=\"color:#224466\">");
-    QString const timeout_markup_end = QLatin1String("</span>");
-    QString const success_markup_begin = QLatin1String("<span style=\"color:#008B00\">");
-    QString const success_markup_end = QLatin1String("</span>");
+    auto const err_markup_begin = QStringLiteral("<span style=\"color:red\">");
+    auto const err_markup_end = QStringLiteral("</span>");
+    auto const timeout_markup_begin = QStringLiteral("<span style=\"color:#224466\">");
+    auto const timeout_markup_end = QStringLiteral("</span>");
+    auto const success_markup_begin = QStringLiteral("<span style=\"color:#008B00\">");
+    auto const success_markup_end = QStringLiteral("</span>");
 
     // hostname
-    str += inf.st.is_backup ? QLatin1String("<i>") : QLatin1String("<b>");
+    str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
     char* host = nullptr;
     int port = 0;
     tr_urlParse(inf.st.announce.toUtf8().constData(), TR_BAD_SIZE, nullptr, &host, &port, nullptr);
-    str += QString::fromLatin1("%1:%2").arg(QString::fromUtf8(host)).arg(port);
+    str += QStringLiteral("%1:%2").arg(QString::fromUtf8(host)).arg(port);
     tr_free(host);
 
     if (!key.isEmpty())
     {
-        str += QLatin1String(" - ") + key;
+        str += QStringLiteral(" - ") + key;
     }
 
-    str += inf.st.is_backup ? QLatin1String("</i>") : QLatin1String("</b>");
+    str += inf.st.is_backup ? QStringLiteral("</i>") : QStringLiteral("</b>");
 
     // announce & scrape info
     if (!inf.st.is_backup)
@@ -203,7 +203,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
         if (inf.st.has_announced && inf.st.announce_state != TR_TRACKER_INACTIVE)
         {
             QString const tstr(timeToStringRounded(now - inf.st.last_announce_time));
-            str += QLatin1String("<br/>\n");
+            str += QStringLiteral("<br/>\n");
 
             if (inf.st.last_announce_succeeded)
             {
@@ -228,28 +228,28 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
         switch (inf.st.announce_state)
         {
         case TR_TRACKER_INACTIVE:
-            str += QLatin1String("<br/>\n");
+            str += QStringLiteral("<br/>\n");
             str += tr("No updates scheduled");
             break;
 
         case TR_TRACKER_WAITING:
             {
                 QString const tstr(timeToStringRounded(inf.st.next_announce_time - now));
-                str += QLatin1String("<br/>\n");
+                str += QStringLiteral("<br/>\n");
                 //: %1 is duration
                 str += tr("Asking for more peers in %1").arg(tstr);
                 break;
             }
 
         case TR_TRACKER_QUEUED:
-            str += QLatin1String("<br/>\n");
+            str += QStringLiteral("<br/>\n");
             str += tr("Queued to ask for more peers");
             break;
 
         case TR_TRACKER_ACTIVE:
             {
                 QString const tstr(timeToStringRounded(now - inf.st.last_announce_start_time));
-                str += QLatin1String("<br/>\n");
+                str += QStringLiteral("<br/>\n");
                 //: %1 is duration
                 str += tr("Asking for more peers now... <small>%1</small>").arg(tstr);
                 break;
@@ -260,7 +260,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
         {
             if (inf.st.has_scraped)
             {
-                str += QLatin1String("<br/>\n");
+                str += QStringLiteral("<br/>\n");
                 QString const tstr(timeToStringRounded(now - inf.st.last_scrape_time));
 
                 if (inf.st.last_scrape_succeeded)
@@ -299,7 +299,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
 
             case TR_TRACKER_WAITING:
                 {
-                    str += QLatin1String("<br/>\n");
+                    str += QStringLiteral("<br/>\n");
                     QString const tstr(timeToStringRounded(inf.st.next_scrape_time - now));
                     //: %1 is duration
                     str += tr("Asking for peer counts in %1").arg(tstr);
@@ -308,14 +308,14 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
 
             case TR_TRACKER_QUEUED:
                 {
-                    str += QLatin1String("<br/>\n");
+                    str += QStringLiteral("<br/>\n");
                     str += tr("Queued to ask for peer counts");
                     break;
                 }
 
             case TR_TRACKER_ACTIVE:
                 {
-                    str += QLatin1String("<br/>\n");
+                    str += QStringLiteral("<br/>\n");
                     QString const tstr(timeToStringRounded(now - inf.st.last_scrape_start_time));
                     //: %1 is duration
                     str += tr("Asking for peer counts now... <small>%1</small>").arg(tstr);

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -51,7 +51,7 @@ namespace
 
 void addAssociatedFileIcon(QFileInfo const& file_info, UINT icon_size, QIcon& icon)
 {
-    QString const pixmap_cache_key = QLatin1String("tr_file_ext_") + QString::number(icon_size) + QLatin1Char('_') +
+    QString const pixmap_cache_key = QStringLiteral("tr_file_ext_") + QString::number(icon_size) + QLatin1Char('_') +
         file_info.suffix();
 
     QPixmap pixmap;

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -70,7 +70,7 @@ public:
 
     static bool isMagnetLink(QString const& s)
     {
-        return s.startsWith(QString::fromUtf8("magnet:?"));
+        return s.startsWith(QStringLiteral("magnet:?"));
     }
 
     static bool isHexHashcode(QString const& s)

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -113,7 +113,7 @@ void WatchDir::watcherActivated(QString const& path)
 
     // try to add any new files which end in .torrent
     QSet<QString> const new_files(files - watch_dir_files_);
-    QString const torrent_suffix = QString::fromUtf8(".torrent");
+    auto const torrent_suffix = QStringLiteral(".torrent");
 
     for (QString const& name : new_files)
     {


### PR DESCRIPTION
Further reading:
* https://forum.qt.io/topic/78540/qstringliteral-vs-qlatin1string/2
* https://woboq.com/blog/qstringliteral.html
* https://www.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral

tl;dr: QLatin1Literal uses less memory than QStringLiteral; however, since most Qt APIs require a QString argument, there's extra runtime cost of converting QLatin1Strings to QStrings. QStringLiteral uses a little more memory but constructs its QStrings at compile time.

ok, the previous [`prefer-qstringliteral` branch](https://github.com/transmission/transmission/pull/1274) is getting out of control: the secondary goal of fixing a .clang-tidy issue is causing more diffs than the primary goal. So, I'm breaking it into two separate PRs.