### PR TITLE
fix: Fix magnet link parsing for empty values.

### DIFF
--- a/libtransmission/magnet-test.c
+++ b/libtransmission/magnet-test.c
@@ -63,6 +63,52 @@ static int test1(void)
     tr_magnetFree(info);
     info = NULL;
 
+    /* uri with an empty value parameter */
+    uri =
+        "magnet:?xt=urn:btih:"
+        "2I2UAEFDZJFN4W3UE65QSOTCUOEZ744B"
+        "&empty"
+        "&dn=Display%20Name"
+        "&tr=http%3A%2F%2Ftracker.openbittorrent.com%2Fannounce"
+        "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"
+        "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce";
+    info = tr_magnetParse(uri);
+    check(info != NULL);
+    check_int(info->trackerCount, ==, 2);
+    check_str(info->trackers[0], ==, "http://tracker.openbittorrent.com/announce");
+    check_str(info->trackers[1], ==, "http://tracker.opentracker.org/announce");
+    check_int(info->webseedCount, ==, 1);
+    check_str(info->webseeds[0], ==, "http://server.webseed.org/path/to/file");
+    check_str(info->displayName, ==, "Display Name");
+    check_mem(info->hash, ==, dec, 20);
+
+    tr_magnetFree(info);
+    info = NULL;
+
+    /* uri with junk values */
+    uri =
+        "magnet:?xt=urn:btih:"
+        "2I2UAEFDZJFN4W3UE65QSOTCUOEZ744B"
+        "&empty"
+        "&empty_again"
+        "&dn=Display%20Name"
+        "&&=&tr=http%3A%2F%2Ftracker.openbittorrent.com%2Fannounce"
+        "&empty_again"
+        "&=&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"
+        "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce&=&=&&";
+    info = tr_magnetParse(uri);
+    check(info != NULL);
+    check_int(info->trackerCount, ==, 2);
+    check_str(info->trackers[0], ==, "http://tracker.openbittorrent.com/announce");
+    check_str(info->trackers[1], ==, "http://tracker.opentracker.org/announce");
+    check_int(info->webseedCount, ==, 1);
+    check_str(info->webseeds[0], ==, "http://server.webseed.org/path/to/file");
+    check_str(info->displayName, ==, "Display Name");
+    check_mem(info->hash, ==, dec, 20);
+
+    tr_magnetFree(info);
+    info = NULL;
+
     return 0;
 }
 

--- a/libtransmission/magnet.c
+++ b/libtransmission/magnet.c
@@ -124,36 +124,28 @@ tr_magnet_info* tr_magnetParse(char const* uri)
     {
         for (char const* walk = uri + 8; !tr_str_is_empty(walk);)
         {
+            char const* next = strchr(walk, '&');
             char const* key = walk;
-            char const* delim = strchr(key, '=');
-            char const* val = delim == NULL ? NULL : delim + 1;
-            char const* next = strchr(delim == NULL ? key : val, '&');
-            size_t keylen;
-            size_t vallen;
+            char const* val = strchr(key, '=');
 
-            if (delim != NULL)
+            size_t keylen = 0;
+            size_t vallen = 0;
+
+            if (next != NULL && val != NULL && val <= next)
             {
-                keylen = (size_t)(delim - key);
+                keylen = (size_t)(val - key);
+                val++;
+                vallen = (size_t)(next - val);
             }
             else if (next != NULL)
             {
                 keylen = (size_t)(next - key);
-            }
-            else
-            {
-                keylen = strlen(key);
-            }
-
-            if (val == NULL)
-            {
                 vallen = 0;
             }
-            else if (next != NULL)
+            else if (val != NULL)
             {
-                vallen = (size_t)(next - val);
-            }
-            else
-            {
+                keylen = (size_t)(val - key);
+                val++;
                 vallen = strlen(val);
             }
 


### PR DESCRIPTION
Updates `tr_magnetParse` to properly parse links where some parameters might have empty values.

Fixes: #1113.