### PR TITLE
fix: ensure details dialog is updated on selection

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -256,9 +256,15 @@ void DetailsDialog::setIds(torrent_ids_t const& ids)
         ui_.filesView->clear();
 
         ids_ = ids;
-        session_.refreshDetailInfo(ids_);
+
+        // refresh the UI with the info we have
         changed_torrents_ = true;
+        refresh();
         tracker_model_->refresh(model_, ids_);
+
+        // ask the backend for updated info
+        changed_torrents_ = true;
+        session_.refreshDetailInfo(ids_);
         onTimer();
     }
 }


### PR DESCRIPTION
Fixes #1296.

In addition to updating the UI when a torrent's information changes, also update it with the current information when the torrent selection changes.

This patch is still a little warty due to the double-assignment of the `changed_torrents_` flag because it's coupled with `DetailsDialog::refresh()`. That flag is used to determine whether the editable fields, e.g. file priority and the do-not-download flag, should be updated.