### PR TITLE
feat: add 'edit-date' support to qt client

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -285,6 +285,7 @@ Application::Application(int& argc, char** argv) :
 
     connect(model_, &TorrentModel::torrentsAdded, this, &Application::onTorrentsAdded);
     connect(model_, &TorrentModel::torrentsCompleted, this, &Application::onTorrentsCompleted);
+    connect(model_, &TorrentModel::torrentsEdited, this, &Application::onTorrentsEdited);
     connect(model_, &TorrentModel::torrentsNeedInfo, this, &Application::onTorrentsNeedInfo);
     connect(prefs_, &Prefs::changed, this, &Application::refreshPref);
     connect(session_, &Session::sourceChanged, this, &Application::onSessionSourceChanged);

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -6,9 +6,8 @@
  *
  */
 
-#include <algorithm> // std::any_of
+#include <algorithm>
 #include <cassert>
-#include <climits> /* INT_MAX */
 #include <ctime>
 
 #include <QDateTime>
@@ -231,6 +230,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     }
 
     connect(&model_, &TorrentModel::torrentsChanged, this, &DetailsDialog::onTorrentsChanged);
+    connect(&model_, &TorrentModel::torrentsEdited, this, &DetailsDialog::onTorrentsEdited);
     connect(&prefs_, &Prefs::changed, this, &DetailsDialog::refreshPref);
     connect(&timer_, &QTimer::timeout, this, &DetailsDialog::onTimer);
 
@@ -306,10 +306,24 @@ void DetailsDialog::getNewData()
     }
 }
 
-void DetailsDialog::onTorrentEdited(torrent_ids_t const& /*ids*/)
+void DetailsDialog::onTorrentsEdited(torrent_ids_t const& ids)
 {
-    // FIXME
-    // refreshDetailInfo({ tor.id() });
+    // std::set_intersection requires sorted inputs
+    auto a = std::vector<int>{ ids.begin(), ids.end() };
+    std::sort(std::begin(a), std::end(a));
+    auto b = std::vector<int>{ ids_.begin(), ids_.end() };
+    std::sort(std::begin(b), std::end(b));
+
+    // are any of the edited torrents on display here?
+    torrent_ids_t interesting_ids;
+    std::set_intersection(std::begin(a), std::end(a),
+        std::begin(b), std::end(b),
+        std::inserter(interesting_ids, std::begin(interesting_ids)));
+
+    if (!interesting_ids.empty())
+    {
+        session_.refreshDetailInfo(interesting_ids);
+    }
 }
 
 void DetailsDialog::onTorrentsChanged(torrent_ids_t const& ids)

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -61,7 +61,7 @@ private slots:
     void refreshPref(int key);
     void onTimer();
 
-    void onTorrentEdited(torrent_ids_t const& ids);
+    void onTorrentsEdited(torrent_ids_t const& ids);
     void onTorrentsChanged(torrent_ids_t const& ids);
 
     // Tracker tab

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -40,6 +40,7 @@ Torrent::KeyList const Torrent::MainInfoKeys{
 // changing fields needed by the main window
 Torrent::KeyList const Torrent::MainStatKeys{
     TR_KEY_downloadedEver,
+    TR_KEY_editDate,
     TR_KEY_error,
     TR_KEY_errorString,
     TR_KEY_eta,

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -295,6 +295,11 @@ public:
         return date_created_;
     }
 
+    time_t dateEdited() const
+    {
+        return edit_date_;
+    }
+
     time_t manualAnnounceTime() const
     {
         return manual_announce_time_;

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -157,6 +157,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
     auto added = torrent_ids_t{};
     auto changed = torrent_ids_t{};
     auto completed = torrent_ids_t{};
+    auto edited = torrent_ids_t{};
     auto instantiated = torrents_t{};
     auto needinfo = torrent_ids_t{};
     auto processed = torrents_t{};
@@ -261,9 +262,16 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
             left_until_done = tor->leftUntilDone();
         }
 
+        auto const old_edit_date = tor->dateEdited();
+
         if (tor->update(keys.data(), values.data(), keys.size()))
         {
             changed.insert(id);
+        }
+
+        if (old_edit_date != tor->dateEdited())
+        {
+            edited.insert(id);
         }
 
         if (is_new && !tor->hasName())
@@ -290,6 +298,11 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
     if (!instantiated.empty())
     {
         rowsAdd(instantiated);
+    }
+
+    if (!edited.empty())
+    {
+        emit torrentsEdited(edited);
     }
 
     if (!changed.empty())


### PR DESCRIPTION
edit-date got added to the backend in 3.00, but I never finished adding
it properly to the Qt client. This PR rectifies that. When a torrent is
edited, the Application and DetailsDialogs will re-query the backend to
update the torrent properties that are needed.