### PR TITLE
Fix typo in rpc-spec.txt

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -808,7 +808,7 @@
          |         | yes       | torrent-get          | new arg "labels"
          |         | yes       | torrent-set          | new arg "labels"
          |         | yes       | torrent-get          | new arg "editDate"
-         |         | yes       | torrent-get          | new arg "format"
+         |         | yes       | torrent-get          | new request arg "format"
 
 
 5.1.  Upcoming Breakage


### PR DESCRIPTION
The "format" is a request arg, not part of the torrent-get payload.