### PR TITLE
refactor: compute string lengths at compile time

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -56,7 +56,7 @@ namespace
 
 int constexpr RefreshIntervalMSec = 4000;
 
-char const constexpr* const PrefKey = "pref_key";
+char const constexpr* const PrefKey { "pref_key" };
 
 enum // peer columns
 {

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -24,7 +24,12 @@
 #include "Formatter.h"
 #include "Utils.h"
 
-#define PRIORITY_KEY "priority"
+namespace
+{
+
+char const constexpr* const PriorityKey { "priority" };
+
+}
 
 FileTreeView::FileTreeView(QWidget* parent, bool is_editable) :
     QTreeView(parent),
@@ -346,7 +351,7 @@ void FileTreeView::setSelectedItemsPriority()
 {
     auto* action = qobject_cast<QAction*>(sender());
     assert(action != nullptr);
-    model_->setPriority(selectedSourceRows(), action->property(PRIORITY_KEY).toInt());
+    model_->setPriority(selectedSourceRows(), action->property(PriorityKey).toInt());
 }
 
 bool FileTreeView::openSelectedItem()
@@ -395,9 +400,9 @@ void FileTreeView::initContextMenu()
     normal_priority_action_ = priority_menu_->addAction(FileTreeItem::tr("Normal"), this, SLOT(setSelectedItemsPriority()));
     low_priority_action_ = priority_menu_->addAction(FileTreeItem::tr("Low"), this, SLOT(setSelectedItemsPriority()));
 
-    high_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_HIGH);
-    normal_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_NORMAL);
-    low_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_LOW);
+    high_priority_action_->setProperty(PriorityKey, TR_PRI_HIGH);
+    normal_priority_action_->setProperty(PriorityKey, TR_PRI_NORMAL);
+    low_priority_action_->setProperty(PriorityKey, TR_PRI_LOW);
 
     context_menu_->addSeparator();
 

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -46,12 +46,12 @@
 #include "TorrentModel.h"
 #include "Utils.h"
 
-#define PREF_VARIANTS_KEY "pref-variants-list"
-#define STATS_MODE_KEY "stats-mode"
-#define SORT_MODE_KEY "sort-mode"
-
 namespace
 {
+
+char const constexpr* const PrefVariantsKey { "pref-variants-list" };
+char const constexpr* const StatsModeKey { "stats-mode" };
+char const constexpr* const SortModeKey { "sort-mode" };
 
 auto const TotalRatioStatsModeName = QStringLiteral("total-ratio");
 auto const TotalTransferStatsModeName = QStringLiteral("total-transfer");
@@ -164,7 +164,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     QIcon const icon_open = getStockIcon(QStringLiteral("document-open"), QStyle::SP_DialogOpenButton);
     ui_.action_OpenFile->setIcon(icon_open);
     ui_.action_AddURL->setIcon(addEmblem(icon_open,
-        QStringList() << QStringLiteral("emblem-web") << QStringLiteral("applications-internet")));
+        QStringList{ QStringLiteral("emblem-web"), QStringLiteral("applications-internet") }));
     ui_.action_New->setIcon(getStockIcon(QStringLiteral("document-new"), QStyle::SP_DesktopIcon));
     ui_.action_Properties->setIcon(getStockIcon(QStringLiteral("document-properties"), QStyle::SP_DesktopIcon));
     ui_.action_OpenFolder->setIcon(getStockIcon(QStringLiteral("folder-open"), QStyle::SP_DirOpenIcon));
@@ -268,7 +268,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
 
     for (auto const& mode : sort_modes)
     {
-        mode.first->setProperty(SORT_MODE_KEY, mode.second);
+        mode.first->setProperty(SortModeKey, mode.second);
         action_group->addAction(mode.first);
     }
 
@@ -372,7 +372,7 @@ void MainWindow::onSessionSourceChanged()
 
 void MainWindow::onSetPrefs()
 {
-    QVariantList const p = sender()->property(PREF_VARIANTS_KEY).toList();
+    QVariantList const p = sender()->property(PrefVariantsKey).toList();
     assert(p.size() % 2 == 0);
 
     for (int i = 0, n = p.size(); i < n; i += 2)
@@ -415,13 +415,13 @@ QMenu* MainWindow::createOptionsMenu()
 
             off_action = menu->addAction(tr("Unlimited"));
             off_action->setCheckable(true);
-            off_action->setProperty(PREF_VARIANTS_KEY, QVariantList() << enabled_pref << false);
+            off_action->setProperty(PrefVariantsKey, QVariantList{ enabled_pref, false });
             action_group->addAction(off_action);
             connect(off_action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs(bool)));
 
             on_action = menu->addAction(tr("Limited at %1").arg(Formatter::speedToString(Speed::fromKBps(current_value))));
             on_action->setCheckable(true);
-            on_action->setProperty(PREF_VARIANTS_KEY, QVariantList() << pref << current_value << enabled_pref << true);
+            on_action->setProperty(PrefVariantsKey, QVariantList{ pref, current_value, enabled_pref, true });
             action_group->addAction(on_action);
             connect(on_action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs(bool)));
 
@@ -430,7 +430,7 @@ QMenu* MainWindow::createOptionsMenu()
             for (int const i : stock_speeds)
             {
                 QAction* action = menu->addAction(Formatter::speedToString(Speed::fromKBps(i)));
-                action->setProperty(PREF_VARIANTS_KEY, QVariantList() << pref << i << enabled_pref << true);
+                action->setProperty(PrefVariantsKey, QVariantList{ pref, i, enabled_pref, true });
                 connect(action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs()));
             }
         };
@@ -445,13 +445,13 @@ QMenu* MainWindow::createOptionsMenu()
 
             off_action = menu->addAction(tr("Seed Forever"));
             off_action->setCheckable(true);
-            off_action->setProperty(PREF_VARIANTS_KEY, QVariantList() << enabled_pref << false);
+            off_action->setProperty(PrefVariantsKey, QVariantList{ enabled_pref, false });
             action_group->addAction(off_action);
             connect(off_action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs(bool)));
 
             on_action = menu->addAction(tr("Stop at Ratio (%1)").arg(Formatter::ratioToString(current_value)));
             on_action->setCheckable(true);
-            on_action->setProperty(PREF_VARIANTS_KEY, QVariantList() << pref << current_value << enabled_pref << true);
+            on_action->setProperty(PrefVariantsKey, QVariantList{ pref, current_value, enabled_pref, true });
             action_group->addAction(on_action);
             connect(on_action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs(bool)));
 
@@ -460,7 +460,7 @@ QMenu* MainWindow::createOptionsMenu()
             for (double const i : stock_ratios)
             {
                 QAction* action = menu->addAction(Formatter::ratioToString(i));
-                action->setProperty(PREF_VARIANTS_KEY, QVariantList() << pref << i << enabled_pref << true);
+                action->setProperty(PrefVariantsKey, QVariantList{ pref, i, enabled_pref, true });
                 connect(action, SIGNAL(triggered(bool)), this, SLOT(onSetPrefs()));
             }
         };
@@ -495,7 +495,7 @@ QMenu* MainWindow::createStatsModeMenu()
 
     for (auto const& mode : stats_modes)
     {
-        mode.first->setProperty(STATS_MODE_KEY, QString(mode.second));
+        mode.first->setProperty(StatsModeKey, mode.second);
         action_group->addAction(mode.first);
         menu->addAction(mode.first);
     }
@@ -512,7 +512,7 @@ QMenu* MainWindow::createStatsModeMenu()
 
 void MainWindow::onSortModeChanged(QAction* action)
 {
-    prefs_.set(Prefs::SORT_MODE, SortMode(action->property(SORT_MODE_KEY).toInt()));
+    prefs_.set(Prefs::SORT_MODE, SortMode(action->property(SortModeKey).toInt()));
 }
 
 void MainWindow::setSortAscendingPref(bool b)
@@ -1024,7 +1024,7 @@ void MainWindow::reannounceSelected()
 
 void MainWindow::onStatsModeChanged(QAction* action)
 {
-    prefs_.set(Prefs::STATUSBAR_STATS, action->property(STATS_MODE_KEY).toString());
+    prefs_.set(Prefs::STATUSBAR_STATS, action->property(StatsModeKey).toString());
 }
 
 /**
@@ -1117,7 +1117,7 @@ void MainWindow::refreshPref(int key)
 
         for (QAction* action : action_group->actions())
         {
-            action->setChecked(str == action->property(STATS_MODE_KEY).toString());
+            action->setChecked(str == action->property(StatsModeKey).toString());
         }
 
         refreshSoon(REFRESH_STATUS_BAR);
@@ -1134,7 +1134,7 @@ void MainWindow::refreshPref(int key)
 
         for (QAction* action : action_group->actions())
         {
-            action->setChecked(i == action->property(SORT_MODE_KEY).toInt());
+            action->setChecked(i == action->property(SortModeKey).toInt());
         }
 
         break;

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -312,6 +312,18 @@ Prefs::~Prefs()
  */
 void Prefs::initDefaults(tr_variant* d)
 {
+    auto constexpr FilterMode = std::string_view{ "all" };
+    auto constexpr SessionHost = std::string_view{ "localhost" };
+    auto constexpr SessionPassword = std::string_view{ "" };
+    auto constexpr SessionUsername = std::string_view{ "" };
+    auto constexpr SortMode = std::string_view{ "sort-by-name" };
+    auto constexpr SoundCommand =
+        std::string_view{ "canberra-gtk-play -i complete-download -d 'transmission torrent downloaded'" };
+    auto constexpr StatsMode = std::string_view{ "total-ratio" };
+    auto constexpr WindowLayout = std::string_view{ "menu,toolbar,filter,list,statusbar" };
+
+    auto const download_dir = std::string_view{ tr_getDefaultDownloadDir() };
+
     tr_variantDictReserve(d, 38);
     dictAdd(d, TR_KEY_blocklist_updates_enabled, true);
     dictAdd(d, TR_KEY_compact_view, false);
@@ -331,8 +343,7 @@ void Prefs::initDefaults(tr_variant* d)
     dictAdd(d, TR_KEY_sort_reversed, false);
     dictAdd(d, TR_KEY_torrent_added_notification_enabled, true);
     dictAdd(d, TR_KEY_torrent_complete_notification_enabled, true);
-    dictAdd(d, TR_KEY_torrent_complete_sound_command,
-        "canberra-gtk-play -i complete-download -d 'transmission torrent downloaded'");
+    dictAdd(d, TR_KEY_torrent_complete_sound_command, SoundCommand);
     dictAdd(d, TR_KEY_torrent_complete_sound_enabled, true);
     dictAdd(d, TR_KEY_user_has_given_informed_consent, false);
     dictAdd(d, TR_KEY_watch_dir_enabled, false);
@@ -342,16 +353,16 @@ void Prefs::initDefaults(tr_variant* d)
     dictAdd(d, TR_KEY_main_window_x, 50);
     dictAdd(d, TR_KEY_main_window_y, 50);
     dictAdd(d, TR_KEY_remote_session_port, TR_DEFAULT_RPC_PORT);
-    dictAdd(d, TR_KEY_download_dir, tr_getDefaultDownloadDir());
-    dictAdd(d, TR_KEY_filter_mode, "all");
-    dictAdd(d, TR_KEY_main_window_layout_order, "menu,toolbar,filter,list,statusbar");
-    dictAdd(d, TR_KEY_open_dialog_dir, QDir::home().absolutePath().toUtf8());
-    dictAdd(d, TR_KEY_remote_session_host, "localhost");
-    dictAdd(d, TR_KEY_remote_session_password, "");
-    dictAdd(d, TR_KEY_remote_session_username, "");
-    dictAdd(d, TR_KEY_sort_mode, "sort-by-name");
-    dictAdd(d, TR_KEY_statusbar_stats, "total-ratio");
-    dictAdd(d, TR_KEY_watch_dir, tr_getDefaultDownloadDir());
+    dictAdd(d, TR_KEY_download_dir, download_dir);
+    dictAdd(d, TR_KEY_filter_mode, FilterMode);
+    dictAdd(d, TR_KEY_main_window_layout_order, WindowLayout);
+    dictAdd(d, TR_KEY_open_dialog_dir, QDir::home().absolutePath());
+    dictAdd(d, TR_KEY_remote_session_host, SessionHost);
+    dictAdd(d, TR_KEY_remote_session_password, SessionPassword);
+    dictAdd(d, TR_KEY_remote_session_username, SessionUsername);
+    dictAdd(d, TR_KEY_sort_mode, SortMode);
+    dictAdd(d, TR_KEY_statusbar_stats, StatsMode);
+    dictAdd(d, TR_KEY_watch_dir, download_dir);
 }
 
 /***
@@ -367,14 +378,16 @@ bool Prefs::getBool(int key) const
 QString Prefs::getString(int key) const
 {
     assert(Items[key].type == QVariant::String);
-    QByteArray const b = values_[key].toByteArray();
+    auto& value = values_[key];
+
+    QByteArray const b = value.toByteArray();
 
     if (Utils::isValidUtf8(b.constData()))
     {
-        values_[key].setValue(QString::fromUtf8(b.constData()));
+        value.setValue(QString::fromUtf8(b.constData(), b.size()));
     }
 
-    return values_[key].toString();
+    return value.toString();
 }
 
 int Prefs::getInt(int key) const

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include <QFuture>
 #include <QFutureInterface>
 #include <QHash>
+#include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QObject>
 #include <QString>
@@ -86,6 +88,8 @@ private:
     RpcResponse parseResponseData(tr_variant& response);
 
     static void localSessionCallback(tr_session* s, tr_variant* response, void* vself);
+
+    std::optional<QNetworkRequest> request_;
 
     tr_session* session_ = {};
     QString session_id_;

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -118,10 +118,12 @@ void Session::portTest()
 
 void Session::copyMagnetLinkToClipboard(int torrent_id)
 {
+    auto constexpr MagnetLinkKey = std::string_view { "magnetLink" };
+
     tr_variant args;
     tr_variantInitDict(&args, 2);
     dictAdd(&args, TR_KEY_ids, std::array<int, 1>{ torrent_id });
-    dictAdd(&args, TR_KEY_fields, std::array<std::string_view, 1>{ "magnetLink" });
+    dictAdd(&args, TR_KEY_fields, std::array<std::string_view, 1>{ MagnetLinkKey });
 
     auto* q = new RpcQueue();
 
@@ -407,9 +409,11 @@ namespace
 
 void addOptionalIds(tr_variant* args, torrent_ids_t const& ids)
 {
+    auto constexpr RecentlyActiveKey = std::string_view{ "recently-active" };
+
     if (&ids == &RecentlyActiveIDs)
     {
-        dictAdd(args, TR_KEY_ids, "recently-active");
+        dictAdd(args, TR_KEY_ids, RecentlyActiveKey);
     }
     else if (!ids.empty())
     {
@@ -531,9 +535,11 @@ void Session::torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath
 
 void Session::refreshTorrents(torrent_ids_t const& ids, KeyList const& keys)
 {
+    auto constexpr TableKey = std::string_view{ "table" };
+
     tr_variant args;
     tr_variantInitDict(&args, 3);
-    dictAdd(&args, TR_KEY_format, "table");
+    dictAdd(&args, TR_KEY_format, TableKey);
 
     std::vector<std::string_view> keystrs;
     keystrs.reserve(keys.size());

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -159,6 +159,7 @@ void variantInit(tr_variant* init_me, double value);
 void variantInit(tr_variant* init_me, QByteArray const& value);
 void variantInit(tr_variant* init_me, QString const& value);
 void variantInit(tr_variant* init_me, std::string_view value);
+void variantInit(tr_variant* init_me, char const* value) = delete; // use string_view
 
 template<typename C, typename T = typename C::value_type>
 void variantInit(tr_variant* init_me, C const& value)


### PR DESCRIPTION
Fixes a 00be8d0 regression that was caused by inferring a string literal to be a bool. Add a safeguard so that it can't happen again.

Replace string literals with constexpr std::string_views so their string lengths will be computed at compile time.

In RpcClient, cache the QNetworkRequest so that we don't have to rebuild it every time we need to post a request.