### PR TITLE
fix: type deduction error introduced in 00be8d0

### DIFF
--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -312,6 +312,18 @@ Prefs::~Prefs()
  */
 void Prefs::initDefaults(tr_variant* d)
 {
+    auto constexpr FilterMode = std::string_view { "all" };
+    auto constexpr SessionHost = std::string_view { "localhost" };
+    auto constexpr SessionPassword = std::string_view { "" };
+    auto constexpr SessionUsername = std::string_view { "" };
+    auto constexpr SortMode = std::string_view { "sort-by-name" };
+    auto constexpr SoundCommand =
+        std::string_view { "canberra-gtk-play -i complete-download -d 'transmission torrent downloaded'" };
+    auto constexpr StatsMode = std::string_view { "total-ratio" };
+    auto constexpr WindowLayout = std::string_view { "menu,toolbar,filter,list,statusbar" };
+
+    auto const download_dir = std::string_view { tr_getDefaultDownloadDir() };
+
     tr_variantDictReserve(d, 38);
     dictAdd(d, TR_KEY_blocklist_updates_enabled, true);
     dictAdd(d, TR_KEY_compact_view, false);
@@ -331,8 +343,7 @@ void Prefs::initDefaults(tr_variant* d)
     dictAdd(d, TR_KEY_sort_reversed, false);
     dictAdd(d, TR_KEY_torrent_added_notification_enabled, true);
     dictAdd(d, TR_KEY_torrent_complete_notification_enabled, true);
-    dictAdd(d, TR_KEY_torrent_complete_sound_command,
-        "canberra-gtk-play -i complete-download -d 'transmission torrent downloaded'");
+    dictAdd(d, TR_KEY_torrent_complete_sound_command, SoundCommand);
     dictAdd(d, TR_KEY_torrent_complete_sound_enabled, true);
     dictAdd(d, TR_KEY_user_has_given_informed_consent, false);
     dictAdd(d, TR_KEY_watch_dir_enabled, false);
@@ -342,16 +353,16 @@ void Prefs::initDefaults(tr_variant* d)
     dictAdd(d, TR_KEY_main_window_x, 50);
     dictAdd(d, TR_KEY_main_window_y, 50);
     dictAdd(d, TR_KEY_remote_session_port, TR_DEFAULT_RPC_PORT);
-    dictAdd(d, TR_KEY_download_dir, tr_getDefaultDownloadDir());
-    dictAdd(d, TR_KEY_filter_mode, "all");
-    dictAdd(d, TR_KEY_main_window_layout_order, "menu,toolbar,filter,list,statusbar");
-    dictAdd(d, TR_KEY_open_dialog_dir, QDir::home().absolutePath().toUtf8());
-    dictAdd(d, TR_KEY_remote_session_host, "localhost");
-    dictAdd(d, TR_KEY_remote_session_password, "");
-    dictAdd(d, TR_KEY_remote_session_username, "");
-    dictAdd(d, TR_KEY_sort_mode, "sort-by-name");
-    dictAdd(d, TR_KEY_statusbar_stats, "total-ratio");
-    dictAdd(d, TR_KEY_watch_dir, tr_getDefaultDownloadDir());
+    dictAdd(d, TR_KEY_download_dir, download_dir);
+    dictAdd(d, TR_KEY_filter_mode, FilterMode);
+    dictAdd(d, TR_KEY_main_window_layout_order, WindowLayout);
+    dictAdd(d, TR_KEY_open_dialog_dir, QDir::home().absolutePath());
+    dictAdd(d, TR_KEY_remote_session_host, SessionHost);
+    dictAdd(d, TR_KEY_remote_session_password, SessionPassword);
+    dictAdd(d, TR_KEY_remote_session_username, SessionUsername);
+    dictAdd(d, TR_KEY_sort_mode, SortMode);
+    dictAdd(d, TR_KEY_statusbar_stats, StatsMode);
+    dictAdd(d, TR_KEY_watch_dir, download_dir);
 }
 
 /***

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -118,10 +118,12 @@ void Session::portTest()
 
 void Session::copyMagnetLinkToClipboard(int torrent_id)
 {
+    auto constexpr MagnetLinkKey = std::string_view { "magnetLink" };
+
     tr_variant args;
     tr_variantInitDict(&args, 2);
     dictAdd(&args, TR_KEY_ids, std::array<int, 1>{ torrent_id });
-    dictAdd(&args, TR_KEY_fields, std::array<std::string_view, 1>{ "magnetLink" });
+    dictAdd(&args, TR_KEY_fields, std::array<std::string_view, 1>{ MagnetLinkKey });
 
     auto* q = new RpcQueue();
 
@@ -407,9 +409,11 @@ namespace
 
 void addOptionalIds(tr_variant* args, torrent_ids_t const& ids)
 {
+    auto constexpr RecentlyActiveKey = std::string_view { "recently-active" };
+
     if (&ids == &RecentlyActiveIDs)
     {
-        dictAdd(args, TR_KEY_ids, "recently-active");
+        dictAdd(args, TR_KEY_ids, RecentlyActiveKey);
     }
     else if (!ids.empty())
     {
@@ -531,9 +535,11 @@ void Session::torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath
 
 void Session::refreshTorrents(torrent_ids_t const& ids, KeyList const& keys)
 {
+    auto constexpr TableKey = std::string_view { "table" };
+
     tr_variant args;
     tr_variantInitDict(&args, 3);
-    dictAdd(&args, TR_KEY_format, "table");
+    dictAdd(&args, TR_KEY_format, TableKey);
 
     std::vector<std::string_view> keystrs;
     keystrs.reserve(keys.size());

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -159,6 +159,7 @@ void variantInit(tr_variant* init_me, double value);
 void variantInit(tr_variant* init_me, QByteArray const& value);
 void variantInit(tr_variant* init_me, QString const& value);
 void variantInit(tr_variant* init_me, std::string_view value);
+void variantInit(tr_variant* init_me, char const* value) = delete; // use string_view
 
 template<typename C, typename T = typename C::value_type>
 void variantInit(tr_variant* init_me, C const& value)


### PR DESCRIPTION
Explicitly delete the implied function to ensure we don't get bitten by this again in the future.

Mark the string_views constexpr where possible so that we can avoid some strlen() calls at runtime.