### PR TITLE
feat: add 'transfer.complete' notification hint on XDG desktop notifications

### DIFF
--- a/gtk/actions.c
+++ b/gtk/actions.c
@@ -95,7 +95,7 @@ static GtkActionEntry entries[] =
     { "pause-all-torrents", "media-playback-pause", N_("_Pause All"), NULL, N_("Pause all torrents"), G_CALLBACK(action_cb) },
     { "start-all-torrents", "media-playback-start", N_("_Start All"), NULL, N_("Start all torrents"), G_CALLBACK(action_cb) },
     { "relocate-torrent", NULL, N_("Set _Location…"), NULL, NULL, G_CALLBACK(action_cb) },
-    { "remove-torrent", "list-remove", NULL, "Delete", N_("Remove torrent"), G_CALLBACK(action_cb) },
+    { "remove-torrent", "list-remove", N_("Remove torrent"), "Delete", G_CALLBACK(action_cb) },
     { "delete-torrent", "edit-delete", N_("_Delete Files and Remove"), "<shift>Delete", NULL, G_CALLBACK(action_cb) },
     { "new-torrent", "document-new", N_("_New…"), NULL, N_("Create a torrent"), G_CALLBACK(action_cb) },
     { "quit", "application-exit", N_("_Quit"), NULL, NULL, G_CALLBACK(action_cb) },

--- a/gtk/notify.c
+++ b/gtk/notify.c
@@ -171,7 +171,6 @@ static void notify_callback(GObject* source, GAsyncResult* res, gpointer user_da
 
 void gtr_notify_torrent_completed(TrCore* core, int torrent_id)
 {
-    GVariantBuilder actions_builder;
     TrNotification* n;
     tr_torrent* tor;
     char const* cmd = gtr_pref_string_get(TR_KEY_torrent_complete_sound_command);
@@ -195,8 +194,8 @@ void gtr_notify_torrent_completed(TrCore* core, int torrent_id)
     n->core = core;
     n->torrent_id = torrent_id;
 
+    GVariantBuilder actions_builder;
     g_variant_builder_init(&actions_builder, G_VARIANT_TYPE("as"));
-
     if (server_supports_actions)
     {
         tr_info const* inf = tr_torrentInfo(tor);
@@ -213,8 +212,12 @@ void gtr_notify_torrent_completed(TrCore* core, int torrent_id)
         }
     }
 
+    GVariantBuilder hints_builder;
+    g_variant_builder_init(&hints_builder, G_VARIANT_TYPE("a{sv}"));
+    g_variant_builder_add(&hints_builder, "{sv}", "category", g_variant_new_string("transfer.complete"));
+
     g_dbus_proxy_call(proxy, "Notify", g_variant_new("(susssasa{sv}i)", "Transmission", n->id, "transmission",
-        _("Torrent Complete"), tr_torrentName(tor), &actions_builder, NULL, -1), G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+        _("Torrent Complete"), tr_torrentName(tor), &actions_builder, &hints_builder, -1), G_DBUS_CALL_FLAGS_NONE, -1, NULL,
         notify_callback, n);
 }
 

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -601,7 +601,9 @@ bool Application::notifyApp(QString const& title, QString const& body) const
         args.append(title); // summary
         args.append(body); // body
         args.append(QStringList()); // actions - unused for plain passive popups
-        args.append(QVariantMap()); // hints - unused atm
+        args.append(QVariantMap({
+            std::make_pair(QStringLiteral("category"), QVariant(QStringLiteral("transfer.complete")))
+        })); // hints
         args.append(static_cast<int32_t>(-1)); // use the default timeout period
         m.setArguments(args);
         QDBusReply<quint32> const reply_msg = bus.call(m);


### PR DESCRIPTION
Described at https://developer.gnome.org/notification-spec/#categories, this is for a file transfer or download complete notification.