### PR TITLE
fix: qt client memory leaks

### DIFF
--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -142,6 +142,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     session_(session),
     prefs_(prefs),
     model_(model),
+    lvp_style_(new ListViewProxyStyle{}),
     filter_model_(prefs),
     torrent_delegate_(new TorrentDelegate(this)),
     torrent_delegate_min_(new TorrentDelegateMin(this)),
@@ -155,7 +156,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
 
     ui_.setupUi(this);
 
-    ui_.listView->setStyle(new ListViewProxyStyle);
+    ui_.listView->setStyle(lvp_style_.get());
     ui_.listView->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     // icons

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ctime>
+#include <memory>
 
 #include <QMainWindow>
 #include <QNetworkReply>
@@ -32,6 +33,7 @@ class QStringList;
 class AboutDialog;
 class AddData;
 class DetailsDialog;
+class ListViewProxyStyle;
 class Prefs;
 class PrefsDialog;
 class Session;
@@ -141,6 +143,8 @@ private:
     Session& session_;
     Prefs& prefs_;
     TorrentModel& model_;
+
+    std::shared_ptr<ListViewProxyStyle> lvp_style_;
 
     QPixmap pixmap_network_error_;
     QPixmap pixmap_network_idle_;

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -81,20 +81,13 @@ void WatchDir::setPath(QString const& path, bool is_enabled)
 {
     // clear out any remnants of the previous watcher, if any
     watch_dir_files_.clear();
-
-    if (watcher_ != nullptr)
-    {
-        delete watcher_;
-        watcher_ = nullptr;
-    }
+    watcher_.reset();
 
     // maybe create a new watcher
     if (is_enabled)
     {
-        watcher_ = new QFileSystemWatcher();
-        watcher_->addPath(path);
-        connect(watcher_, SIGNAL(directoryChanged(QString)), this, SLOT(watcherActivated(QString)));
-        // std::cerr << "watching " << qPrintable(path) << " for new .torrent files" << std::endl;
+        watcher_ = std::make_unique<QFileSystemWatcher>(QStringList{path});
+        connect(watcher_.get(), SIGNAL(directoryChanged(QString)), this, SLOT(watcherActivated(QString)));
         QTimer::singleShot(0, this, SLOT(rescanAllWatchedDirectories())); // trigger the watchdir for .torrent files in there already
     }
 }
@@ -150,12 +143,12 @@ void WatchDir::watcherActivated(QString const& path)
 
 void WatchDir::rescanAllWatchedDirectories()
 {
-    if (watcher_ == nullptr)
+    if (!watcher_)
     {
         return;
     }
 
-    for (QString const& path : watcher_->directories())
+    for (auto const& path : watcher_->directories())
     {
         watcherActivated(path);
     }

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -86,7 +86,7 @@ void WatchDir::setPath(QString const& path, bool is_enabled)
     // maybe create a new watcher
     if (is_enabled)
     {
-        watcher_ = std::make_unique<QFileSystemWatcher>(QStringList{path});
+        watcher_ = std::make_unique<QFileSystemWatcher>(QStringList{ path });
         connect(watcher_.get(), SIGNAL(directoryChanged(QString)), this, SLOT(watcherActivated(QString)));
         QTimer::singleShot(0, this, SLOT(rescanAllWatchedDirectories())); // trigger the watchdir for .torrent files in there already
     }

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -8,11 +8,12 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QObject>
+#include <QFileSystemWatcher>
 #include <QSet>
 #include <QString>
-
-class QFileSystemWatcher;
 
 class TorrentModel;
 
@@ -49,5 +50,5 @@ private:
     TorrentModel const& model_;
 
     QSet<QString> watch_dir_files_;
-    QFileSystemWatcher* watcher_ = {};
+    std::unique_ptr<QFileSystemWatcher> watcher_;
 };


### PR DESCRIPTION
Over the weekend I ran the Qt client in valgrind and found a couple of leaks -- WatchDir's QFileSystemWatcher, and the QStyle that we pass to TorrentView.setStyle() in the main window. This PR fixes both of those leaks.