### PR TITLE
Fix or silence gtk warnings

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -167,6 +167,7 @@ target_link_libraries(${TR_NAME}-gtk
 )
 
 if(NOT MSVC)
+    # https://github.com/transmission/transmission/issues/1381 patches welcome
     target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-deprecated-declarations)
 endif()
 

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -166,6 +166,10 @@ target_link_libraries(${TR_NAME}-gtk
     ${EVENT2_LIBRARIES}
 )
 
+if(NOT MSVC)
+    target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-deprecated-declarations)
+endif()
+
 if(MSVC)
     tr_append_target_property(${TR_NAME}-gtk LINK_FLAGS "/ENTRY:mainCRTStartup")
 endif()

--- a/gtk/actions.c
+++ b/gtk/actions.c
@@ -95,7 +95,7 @@ static GtkActionEntry entries[] =
     { "pause-all-torrents", "media-playback-pause", N_("_Pause All"), NULL, N_("Pause all torrents"), G_CALLBACK(action_cb) },
     { "start-all-torrents", "media-playback-start", N_("_Start All"), NULL, N_("Start all torrents"), G_CALLBACK(action_cb) },
     { "relocate-torrent", NULL, N_("Set _Location…"), NULL, NULL, G_CALLBACK(action_cb) },
-    { "remove-torrent", "list-remove", N_("Remove torrent"), "Delete", G_CALLBACK(action_cb) },
+    { "remove-torrent", "list-remove", N_("Remove torrent"), "Delete", NULL, G_CALLBACK(action_cb) },
     { "delete-torrent", "edit-delete", N_("_Delete Files and Remove"), "<shift>Delete", NULL, G_CALLBACK(action_cb) },
     { "new-torrent", "document-new", N_("_New…"), NULL, N_("Create a torrent"), G_CALLBACK(action_cb) },
     { "quit", "application-exit", N_("_Quit"), NULL, NULL, G_CALLBACK(action_cb) },

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2923,8 +2923,7 @@ static void details_free(gpointer gdata)
 GtkWidget* gtr_torrent_details_dialog_new(GtkWindow* parent, TrCore* core)
 {
     GtkWidget* d;
-    GtkWidget* n;
-    GtkWidget* v;
+    GtkWidget* n; GtkWidget* v;
     GtkWidget* w;
     GtkWidget* l;
     struct DetailsImpl* di = g_new0(struct DetailsImpl, 1);
@@ -2949,7 +2948,9 @@ GtkWidget* gtr_torrent_details_dialog_new(GtkWindow* parent, TrCore* core)
     gtk_window_set_role(GTK_WINDOW(d), "tr-info");
 
     /* return saved window size */
-    gtk_window_resize(d, gtr_pref_int_get(TR_KEY_details_window_width), gtr_pref_int_get(TR_KEY_details_window_height));
+    gtk_window_resize(GTK_WINDOW(d),
+        gtr_pref_int_get(TR_KEY_details_window_width),
+        gtr_pref_int_get(TR_KEY_details_window_height));
     g_signal_connect(d, "size-allocate", G_CALLBACK(on_details_window_size_allocated), NULL);
 
     g_signal_connect_swapped(d, "response", G_CALLBACK(gtk_widget_destroy), d);

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -2923,7 +2923,8 @@ static void details_free(gpointer gdata)
 GtkWidget* gtr_torrent_details_dialog_new(GtkWindow* parent, TrCore* core)
 {
     GtkWidget* d;
-    GtkWidget* n; GtkWidget* v;
+    GtkWidget* n;
+    GtkWidget* v;
     GtkWidget* w;
     GtkWidget* l;
     struct DetailsImpl* di = g_new0(struct DetailsImpl, 1);

--- a/gtk/file-list.c
+++ b/gtk/file-list.c
@@ -593,7 +593,7 @@ void gtr_file_list_set_torrent(GtkWidget* w, int torrentId)
     gtk_tree_view_set_model(GTK_TREE_VIEW(data->view), data->model);
 
     /* set default sort by label */
-    gtk_tree_sortable_set_sort_column_id(data->model, FC_LABEL, GTK_SORT_ASCENDING);
+    gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(data->store), FC_LABEL, GTK_SORT_ASCENDING);
 
     gtk_tree_view_expand_all(GTK_TREE_VIEW(data->view));
     g_object_unref(data->model);


### PR DESCRIPTION
* Disable deprecation warnings in GTK client. Yes, updating the codebase is still a goal. (help welcomed!) But there's a deluge of deprecation warnings that drown out everythign else, so turn off the deprecation warnings for now.

* Fix a regression introduced a few days ago with 47501a4 when an argument got removed.

* Fix a couple of type warnings by casting gobjects to the correct type for the functions being called.