### PR TITLE
Web: add "Never" and "Mixed" values for "Last Activity"

### DIFF
--- a/web/javascript/inspector.js
+++ b/web/javascript/inspector.js
@@ -301,6 +301,7 @@ function Inspector(controller) {
             // last activity
             //
 
+            str = '';
             latest = -1;
             if (torrents.length < 1) {
                 str = none;
@@ -308,17 +309,26 @@ function Inspector(controller) {
                 baseline = torrents[0].getLastActivity();
                 for (i = 0; t = torrents[i]; ++i) {
                     d = t.getLastActivity();
-                    if (latest < d) {
+                    if (baseline != d) {
+                        str = mixed;
+                        break;
+                    } else if (latest < d) {
                         latest = d;
                     };
                 };
-                d = now / 1000 - latest; // seconds since last activity
-                if (d < 0) {
-                    str = none;
-                } else if (d < 5) {
-                    str = 'Active now';
-                } else {
-                    str = fmt.timeInterval(d) + ' ago';
+                if (!str.length) {
+                    if (!latest) {
+                        str = 'Never';
+                    } else {
+                        d = now / 1000 - latest; // seconds since last activity
+                        if (d < 0) {
+                            str = none;
+                        } else if (d < 5) {
+                            str = 'Active now';
+                        } else {
+                            str = fmt.timeInterval(d) + ' ago';
+                        };
+                    };
                 };
             };
             setTextContent(e.last_activity_lb, str);


### PR DESCRIPTION
In web interface when data for certain torrent was never received, it last activity shows the number of days since 01.01.1970, which is not really useful. This PR changes this to display text "Never" instead. Also last activity field did not show a "Mixed" value (like other fields) when selecting multiple torrents. This is now fixed too.

Fixes #658