### PR TITLE
feat: nicer add-torrent workflow in the qt client.

### DIFF
--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -121,7 +121,7 @@ QString AddData::readableShortName() const
     switch (type)
     {
     case FILENAME:
-        return QFileInfo(filename).fileName();
+        return QFileInfo(filename).baseName();
 
     case URL:
         return url.path().split(QLatin1Char('/')).last();

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -15,6 +15,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/quark.h>
@@ -24,6 +25,7 @@
 #include "RpcQueue.h"
 #include "Torrent.h"
 #include "Typedefs.h"
+#include "Utils.h" // std::hash<QString>
 
 class AddData;
 class Prefs;
@@ -120,6 +122,7 @@ public:
 public slots:
     void addTorrent(AddData const& addme);
     void launchWebInterface();
+    void onDuplicatesTimer();
     void queueMoveBottom(torrent_ids_t const& torrentIds = {});
     void queueMoveDown(torrent_ids_t const& torrentIds = {});
     void queueMoveTop(torrent_ids_t const& torrentIds = {});
@@ -176,4 +179,7 @@ private:
     bool is_definitely_local_session_ = true;
     RpcClient rpc_;
     torrent_ids_t const RecentlyActiveIDs = { -1 };
+
+    std::map<QString, QString> duplicates_;
+    QTimer duplicates_timer_;
 };

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -253,7 +253,9 @@ bool TorrentFilter::filterAcceptsRow(int source_row, QModelIndex const& source_p
     if (accepts)
     {
         auto const text = prefs_.getString(Prefs::FILTER_TEXT);
-        accepts = text.isEmpty() || tor.name().contains(text, Qt::CaseInsensitive);
+        accepts = text.isEmpty() ||
+            tor.name().contains(text, Qt::CaseInsensitive) ||
+            tor.hashString().contains(text, Qt::CaseInsensitive);
     }
 
     return accepts;


### PR DESCRIPTION
* If you accidentally try to add a lot of duplicates -- for example, by starting up with a lot of duplicate torrents in the watchdir -- then coalesce all of them into a single error dialog instead of spamming the desktop with a different dialog for every duplicate.

* Make the duplicate torrent dialog's error message slightly terser to make it accommodate a long list of torrents: omit the ".torrent" file suffixes and show an abbreviated form of the existing torrent's hash.

* Support searching by torrent hash in the filterbar's text entry. This is useful when copy/pasting the hash from the duplicate torrent error dialog and is also consistent with the GTK client behavior.

* Copy the GTK client's behavior of appending ".added" to the end of .torrent files after they've been added to the session.