### PR TITLE
refactor: avoid unnecessary QString duplication

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,9 +46,7 @@ EXTRA_DIST += \
   libtransmission/CMakeLists.txt \
   libtransmission/version.h.in \
   po/CMakeLists.txt \
-  qt/CMakeLists.txt \
   tests/CMakeLists.txt \
-  tests/helpers/CMakeLists.txt \
   tests/libtransmission/CMakeLists.txt \
   tests/qt/CMakeLists.txt \
   utils/CMakeLists.txt

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,10 @@ EXTRA_DIST += \
   libtransmission/version.h.in \
   po/CMakeLists.txt \
   qt/CMakeLists.txt \
+  tests/CMakeLists.txt \
+  tests/helpers/CMakeLists.txt \
+  tests/libtransmission/CMakeLists.txt \
+  tests/qt/CMakeLists.txt \
   utils/CMakeLists.txt
 
 if HAVE_REVISION_FILE

--- a/configure.ac
+++ b/configure.ac
@@ -677,7 +677,9 @@ AC_CONFIG_FILES([Makefile
                  web/javascript/jquery/Makefile
                  tests/Makefile
                  tests/gtest/Makefile
+                 tests/helpers/Makefile
                  tests/libtransmission/Makefile
+                 tests/qt/Makefile
                  po/Makefile.in])
 
 AC_OUTPUT

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -623,21 +623,3 @@ FaviconCache& Application::faviconCache()
 {
     return favicons_;
 }
-
-/***
-****
-***/
-
-int tr_main(int argc, char** argv)
-{
-    InteropHelper::initialize();
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    Application::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
-    Application::setAttribute(Qt::AA_UseHighDpiPixmaps);
-
-    Application app(argc, argv);
-    return app.exec();
-}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -220,7 +220,9 @@ if(ENABLE_QT_COM_INTEROP)
     set_source_files_properties(transmission-qt.idl ${CMAKE_CURRENT_BINARY_DIR}/transmission-qt.tlb PROPERTIES HEADER_FILE_ONLY ON)
 endif()
 
-add_executable(${TR_NAME}-qt WIN32
+set(LIB_NAME ${PROJECT_NAME})
+
+add_library(${LIB_NAME} STATIC
     ${${PROJECT_NAME}_SOURCES}
     ${${PROJECT_NAME}_UI_SOURCES}
     ${${PROJECT_NAME}_QRC_SOURCES}
@@ -229,35 +231,51 @@ add_executable(${TR_NAME}-qt WIN32
     ${${PROJECT_NAME}_WIN32_RC_FILE}
 )
 
-target_link_libraries(${TR_NAME}-qt
+target_link_libraries(${LIB_NAME}
     ${TR_NAME}
     ${QT_TARGETS}
-    ${CURL_LIBRARIES}
-    ${EVENT2_LIBRARIES}
 )
 
-target_compile_definitions(${TR_NAME}-qt PRIVATE
-    "TRANSLATIONS_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}/${TR_NAME}/translations\""
+set_target_properties(${LIB_NAME}
+    PROPERTIES
+    AUTOMOC TRUE
+)
+
+set(INSTALL_TRANSLATIONS_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${TR_NAME}/translations")
+
+target_compile_definitions(${LIB_NAME} PRIVATE
+    "TRANSLATIONS_DIR=\"${INSTALL_TRANSLATIONS_DIR}\""
     QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
     $<$<BOOL:${ENABLE_QT_COM_INTEROP}>:ENABLE_COM_INTEROP>
-    $<$<BOOL:${ENABLE_QT_DBUS_INTEROP}>:ENABLE_DBUS_INTEROP>)
+    $<$<BOOL:${ENABLE_QT_DBUS_INTEROP}>:ENABLE_DBUS_INTEROP>
+)
+
+set(EXE_NAME ${TR_NAME}-qt)
+
+add_executable(${EXE_NAME} WIN32
+    Main.cc
+)
+
+target_link_libraries(${EXE_NAME}
+    ${LIB_NAME}
+    ${QT_TARGETS}
+)
 
 if(MSVC)
-    tr_append_target_property(${TR_NAME}-qt LINK_FLAGS "/ENTRY:mainCRTStartup")
+    tr_append_target_property(${EXE_NAME} LINK_FLAGS "/ENTRY:mainCRTStartup")
 endif()
 
-set_target_properties(${TR_NAME}-qt PROPERTIES AUTOMOC TRUE)
-
-install(TARGETS ${TR_NAME}-qt DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${EXE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if(INSTALL_DOC)
-    install(FILES ${TR_NAME}-qt.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+    install(FILES ${EXE_NAME}.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 endif()
 
 install(FILES transmission-qt.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 
 if(ENABLE_NLS)
-    install(FILES ${${PROJECT_NAME}_QM_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${TR_NAME}/translations)
+    install(FILES ${${PROJECT_NAME}_QM_FILES} DESTINATION "${INSTALL_TRANSLATIONS_DIR}")
 endif()
 
 if(WIN32)

--- a/qt/Main.cc
+++ b/qt/Main.cc
@@ -1,0 +1,29 @@
+/*
+ * This file Copyright (C) 2009-2015 Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#include "libtransmission/transmission.h"
+#include "libtransmission/utils.h"
+
+#include "qt/Application.h"
+#include "qt/InteropHelper.h"
+
+#include <QtGlobal>
+
+int tr_main(int argc, char** argv)
+{
+    InteropHelper::initialize();
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    Application::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
+    Application::setAttribute(Qt::AA_UseHighDpiPixmaps);
+
+    Application app(argc, argv);
+    return app.exec();
+}

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -417,13 +417,6 @@ bool Prefs::getBool(int key) const
 QString Prefs::getString(int key) const
 {
     assert(Items[key].type == QVariant::String);
-    QByteArray const b = values_[key].toByteArray();
-
-    if (Utils::isValidUtf8(b.constData()))
-    {
-        values_[key].setValue(QString::fromUtf8(b.constData()));
-    }
-
     return values_[key].toString();
 }
 

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -179,7 +179,7 @@ public:
         QVariant& v(values_[key]);
         QVariant const tmp = QVariant::fromValue(value);
 
-        if (v.isNull() || v != tmp)
+        if (!v.isValid() || v != tmp)
         {
             v = tmp;
             emit changed(key);

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -468,8 +468,6 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     bool const is_item_enabled((option.state & QStyle::State_Enabled) != 0);
     bool const is_item_active((option.state & QStyle::State_Active) != 0);
 
-    painter->save();
-
     if (is_item_selected)
     {
         QPalette::ColorGroup cg = is_item_enabled ? QPalette::Normal : QPalette::Disabled;
@@ -597,6 +595,4 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     setProgressBarPercentDone(option, tor);
 
     style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
-
-    painter->restore();
 }

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -149,8 +149,6 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     bool const is_item_enabled((option.state & QStyle::State_Enabled) != 0);
     bool const is_item_active((option.state & QStyle::State_Active) != 0);
 
-    painter->save();
-
     if (is_item_selected)
     {
         QPalette::ColorGroup cg = is_item_enabled ? QPalette::Normal : QPalette::Disabled;
@@ -278,6 +276,4 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);
     style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
-
-    painter->restore();
 }

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -13,6 +13,7 @@
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
+#include "FaviconCache.h"
 #include "Filters.h"
 #include "Macros.h"
 
@@ -51,4 +52,6 @@ private slots:
 private:
     QTimer refilter_timer_;
     Prefs const& prefs_;
+    FaviconCache::Key tracker_key_;
+    FilterMode filter_mode_;
 };

--- a/qt/qtr.pro
+++ b/qt/qtr.pro
@@ -96,6 +96,7 @@ SOURCES += AboutDialog.cc \
            InteropHelper.cc \
            InteropObject.cc \
            LicenseDialog.cc \
+           Main.cc \
            MainWindow.cc \
            MakeDialog.cc \
            OptionsDialog.cc \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,7 @@ include_directories(
 
 add_subdirectory(gtest)
 add_subdirectory(libtransmission)
+
+if(ENABLE_QT)
+  add_subdirectory(qt)
+endif()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,8 @@
 SUBDIRS = \
   gtest \
-  libtransmission
+  helpers \
+  libtransmission \
+  qt
 
 EXTRA_DIST = \
   CMakeLists.txt

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = \
   gtest \
+  helpers \
   libtransmission \
   qt

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,9 +1,4 @@
 SUBDIRS = \
   gtest \
-  helpers \
   libtransmission \
   qt
-
-EXTRA_DIST = \
-  CMakeLists.txt
-

--- a/tests/helpers/Makefile.am
+++ b/tests/helpers/Makefile.am
@@ -1,0 +1,4 @@
+EXTRA_DIST = \
+  sandbox.h \
+  session.h \
+  utils.h

--- a/tests/helpers/sandbox.h
+++ b/tests/helpers/sandbox.h
@@ -1,0 +1,230 @@
+/*
+ * This file Copyright (C) 2020 Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#pragma once
+
+#include "libtransmission/error.h"
+#include "libtransmission/file.h" // tr_sys_file_*()
+
+#include "tests/helpers/utils.h" // makeString()
+
+#include <cstdlib> // getenv()
+#include <cstring> // strlen()
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace transmission
+{
+
+namespace tests
+{
+
+namespace helpers
+{
+
+class Sandbox
+{
+public:
+    Sandbox() :
+        parent_dir_{get_default_parent_dir()},
+        sandbox_dir_{create_sandbox(parent_dir_, "transmission-test-XXXXXX")}
+    {
+    }
+
+    ~Sandbox()
+    {
+        rimraf(sandbox_dir_);
+    }
+
+    std::string const& path() const
+    {
+        return sandbox_dir_;
+    }
+
+protected:
+    static std::string get_default_parent_dir()
+    {
+        auto* path = getenv("TMPDIR");
+        if (path != NULL)
+        {
+            return path;
+        }
+
+        tr_error* error = nullptr;
+        path = tr_sys_dir_get_current(&error);
+        if (path != nullptr)
+        {
+            std::string const ret = path;
+            tr_free(path);
+            return ret;
+        }
+
+        std::cerr << "tr_sys_dir_get_current error: '" << error->message << "'" << std::endl;
+        tr_error_free(error);
+        return {};
+    }
+
+    static std::string create_sandbox(std::string const& parent_dir, std::string const& tmpl)
+    {
+        std::string path = makeString(tr_buildPath(parent_dir.data(), tmpl.data(), nullptr));
+        tr_sys_dir_create_temp(&path.front(), nullptr);
+        tr_sys_path_native_separators(&path.front());
+        return path;
+    }
+
+    static auto get_folder_files(std::string const& path)
+    {
+        std::vector<std::string> ret;
+
+        tr_sys_path_info info;
+        if (tr_sys_path_get_info(path.data(), 0, &info, nullptr) &&
+            (info.type == TR_SYS_PATH_IS_DIRECTORY))
+        {
+            auto const odir = tr_sys_dir_open(path.data(), nullptr);
+            if (odir != TR_BAD_SYS_DIR)
+            {
+                char const* name;
+                while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
+                {
+                    if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
+                    {
+                        ret.push_back(makeString(tr_buildPath(path.data(), name, nullptr)));
+                    }
+                }
+
+                tr_sys_dir_close(odir, nullptr);
+            }
+        }
+
+        return ret;
+    }
+
+    static void rimraf(std::string const& path, bool verbose = false)
+    {
+        for (auto const& child : get_folder_files(path))
+        {
+            rimraf(child, verbose);
+        }
+
+        if (verbose)
+        {
+            std::cerr << "cleanup: removing '" << path << "'" << std::endl;
+        }
+
+        tr_sys_path_remove(path.data(), nullptr);
+    }
+
+private:
+    std::string const parent_dir_;
+    std::string const sandbox_dir_;
+};
+
+class SandboxedTest : public ::testing::Test
+{
+protected:
+    std::string sandboxDir() const { return sandbox_.path(); }
+
+    auto currentTestName() const
+    {
+        auto const* i = ::testing::UnitTest::GetInstance()->current_test_info();
+        auto child = std::string(i->test_suite_name());
+        child += '_';
+        child += i->name();
+        return child;
+    }
+
+    void buildParentDir(std::string const& path) const
+    {
+        auto const tmperr = errno;
+
+        auto const dir = makeString(tr_sys_path_dirname(path.c_str(), nullptr));
+        tr_error* error = nullptr;
+        tr_sys_dir_create(dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700, &error);
+        EXPECT_EQ(nullptr, error) << "path[" << path << "] dir[" << dir << "] " << error->code << ", " << error->message;
+
+        errno = tmperr;
+    }
+
+    static void blockingFileWrite(tr_sys_file_t fd, void const* data, size_t data_len)
+    {
+        uint64_t n_left = data_len;
+        auto const* left = static_cast<uint8_t const*>(data);
+
+        while (n_left > 0)
+        {
+            uint64_t n = {};
+            tr_error* error = nullptr;
+            if (!tr_sys_file_write(fd, left, n_left, &n, &error))
+            {
+                fprintf(stderr, "Error writing file: '%s'\n", error->message);
+                tr_error_free(error);
+                break;
+            }
+
+            left += n;
+            n_left -= n;
+        }
+    }
+
+    void createTmpfileWithContents(std::string& tmpl, void const* payload, size_t n) const
+    {
+        auto const tmperr = errno;
+
+        buildParentDir(tmpl);
+
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.InnerPointer)
+        auto const fd = tr_sys_file_open_temp(&tmpl.front(), nullptr);
+        blockingFileWrite(fd, payload, n);
+        tr_sys_file_close(fd, nullptr);
+        sync();
+
+        errno = tmperr;
+    }
+
+    void createFileWithContents(std::string const& path, void const* payload, size_t n) const
+    {
+        auto const tmperr = errno;
+
+        buildParentDir(path);
+
+        auto const fd = tr_sys_file_open(path.c_str(),
+            TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
+            0600, nullptr);
+        blockingFileWrite(fd, payload, n);
+        tr_sys_file_close(fd, nullptr);
+        sync();
+
+        errno = tmperr;
+    }
+
+    void createFileWithContents(std::string const& path, void const* payload) const
+    {
+        createFileWithContents(path, payload, strlen(static_cast<char const*>(payload)));
+    }
+
+    bool verbose = false;
+
+    void sync() const
+    {
+#ifndef _WIN32
+        ::sync();
+#endif
+    }
+
+private:
+    Sandbox sandbox_;
+};
+
+} // namespace helpers
+
+} // namespace tests
+
+} // namespace transmission

--- a/tests/helpers/utils.h
+++ b/tests/helpers/utils.h
@@ -1,0 +1,58 @@
+/*
+ * This file Copyright (C) 2020 Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#pragma once
+
+#include "libtransmission/utils.h" // tr_free(), tr_wait_msec()
+
+#include <chrono>
+#include <functional>
+#include <string>
+
+namespace transmission
+{
+
+namespace tests
+{
+
+namespace helpers
+{
+
+auto const makeString = [](char*&& s)
+    {
+        auto const ret = std::string(s != nullptr ? s : "");
+        tr_free(s);
+        return ret;
+    };
+
+bool waitFor(std::function<bool()> const& test, int msec)
+{
+    auto const deadline = std::chrono::milliseconds { msec };
+    auto const begin = std::chrono::steady_clock::now();
+
+    for (;;)
+    {
+        if (test())
+        {
+            return true;
+        }
+
+        if ((std::chrono::steady_clock::now() - begin) >= deadline)
+        {
+            return false;
+        }
+
+        tr_wait_msec(10);
+    }
+}
+
+} // namespace helpers
+
+} // namespace tests
+
+} // namespace transmission

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -15,6 +15,7 @@ add_definitions(
 )
 
 include_directories(
+  ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/libtransmission
   ${CMAKE_SOURCE_DIR}/tests/libtransmission
   ${CMAKE_BINARY_DIR}/libtransmission

--- a/tests/libtransmission/Makefile.am
+++ b/tests/libtransmission/Makefile.am
@@ -15,7 +15,7 @@ AM_CPPFLAGS = \
   @LIBEVENT_CFLAGS@ \
   @LIBCURL_CFLAGS@ \
   -I$(top_srcdir)/third-party/googletest/googletest/include \
-  -I$(top_srcdir)/libtransmission \
+  -I$(top_srcdir) \
   -I$(srcdir) \
   -pthread
 

--- a/tests/libtransmission/Makefile.am
+++ b/tests/libtransmission/Makefile.am
@@ -89,5 +89,4 @@ test_watchdir_SOURCES = watchdir-test.cc
 EXTRA_DIST = \
   CMakeLists.txt \
   subprocess-test.cmd \
-  crypto-test-ref.h \
-  test-fixtures.h
+  crypto-test-ref.h

--- a/tests/libtransmission/Makefile.am
+++ b/tests/libtransmission/Makefile.am
@@ -87,6 +87,5 @@ test_variant_SOURCES = variant-test.cc
 test_watchdir_SOURCES = watchdir-test.cc
 
 EXTRA_DIST = \
-  CMakeLists.txt \
   subprocess-test.cmd \
   crypto-test-ref.h

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -6,10 +6,10 @@
  *
  */
 
-#include "transmission.h"
-#include "crypto-utils.h"
-#include "bitfield.h"
-#include "utils.h" /* tr_free */
+#include "libtransmission/transmission.h"
+#include "libtransmission/crypto-utils.h"
+#include "libtransmission/bitfield.h"
+#include "libtransmission/utils.h" /* tr_free */
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -10,23 +10,25 @@
 #include <cstring> // strlen()
 // #include <unistd.h> // sync()
 
-#include "transmission.h"
-#include "blocklist.h"
-#include "file.h"
-#include "peer-socket.h"
-#include "net.h"
-#include "session.h" // tr_sessionIsAddressBlocked()
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/blocklist.h"
+#include "libtransmission/file.h"
+#include "libtransmission/peer-socket.h"
+#include "libtransmission/net.h"
+#include "libtransmission/session.h" // tr_sessionIsAddressBlocked()
+#include "libtransmission/utils.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/session.h"
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
-class BlocklistTest : public SessionTest
+using helpers::makeString;
+
+class BlocklistTest : public helpers::SessionTest
 {
 protected:
     static char const constexpr* const Contents1 =
@@ -141,6 +143,6 @@ TEST_F(BlocklistTest, updating)
     tr_free(path);
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -8,8 +8,8 @@
 
 #include <array>
 
-#include "transmission.h"
-#include "clients.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/clients.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -6,10 +6,10 @@
  *
  */
 
-#include "transmission.h"
-#include "crypto.h"
-#include "crypto-utils.h"
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/crypto.h"
+#include "libtransmission/crypto-utils.h"
+#include "libtransmission/utils.h"
 
 #include "crypto-test-ref.h"
 

--- a/tests/libtransmission/error-test.cc
+++ b/tests/libtransmission/error-test.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include "transmission.h"
-#include "error.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/error.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -6,12 +6,12 @@
  *
  */
 
-#include "transmission.h"
-#include "error.h"
-#include "file.h"
-#include "tr-macros.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/error.h"
+#include "libtransmission/file.h"
+#include "libtransmission/tr-macros.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/session.h"
 
 #include <array>
 #include <cstring>
@@ -35,13 +35,15 @@
 #define NATIVE_PATH_SEP "\\"
 #endif
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
-class FileTest : public SessionTest
+using helpers::makeString;
+
+class FileTest : public helpers::SessionTest
 {
 protected:
     auto createTestDir(std::string const& child_name)
@@ -1494,6 +1496,6 @@ TEST_F(FileTest, dirRead)
     tr_free(path1);
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/getopt-test.cc
+++ b/tests/libtransmission/getopt-test.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include "transmission.h"
-#include "tr-getopt.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/tr-getopt.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/history-test.cc
+++ b/tests/libtransmission/history-test.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include "transmission.h"
-#include "history.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/history.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -8,10 +8,10 @@
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 
-#include "transmission.h"
-#include "utils.h" // tr_free()
-#include "variant.h"
-#include "variant-common.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/utils.h" // tr_free()
+#include "libtransmission/variant.h"
+#include "libtransmission/variant-common.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/magnet-test.cc
+++ b/tests/libtransmission/magnet-test.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include "transmission.h"
-#include "magnet.h"
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/magnet.h"
+#include "libtransmission/utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -6,26 +6,29 @@
  *
  */
 
-#include "transmission.h"
-#include "crypto-utils.h"
-#include "file.h"
-#include "makemeta.h"
-#include "utils.h" // tr_free()
+#include "libtransmission/transmission.h"
+#include "libtransmission/crypto-utils.h"
+#include "libtransmission/file.h"
+#include "libtransmission/makemeta.h"
+#include "libtransmission/utils.h" // tr_free()
 
-#include "test-fixtures.h"
+#include "tests/helpers/sandbox.h"
 
 #include <array>
 #include <cstdlib> // mktemp()
 #include <cstring> // strlen()
 #include <string>
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
-class MakemetaTest : public SandboxedTest
+using helpers::makeString;
+using helpers::waitFor;
+
+class MakemetaTest : public helpers::SandboxedTest
 {
 protected:
     void testSingleFileImpl(tr_tracker_info const* trackers, int const trackerCount, void const* payload,
@@ -241,6 +244,6 @@ TEST_F(MakemetaTest, singleDirectoryRandomPayload)
     }
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/metainfo-test.cc
+++ b/tests/libtransmission/metainfo-test.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include "transmission.h"
-#include "metainfo.h"
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/metainfo.h"
+#include "libtransmission/utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -8,24 +8,27 @@
 
 #include <event2/buffer.h>
 
-#include "transmission.h"
-#include "cache.h" // tr_cacheWriteBlock()
-#include "file.h" // tr_sys_path_*()
-#include "variant.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/cache.h" // tr_cacheWriteBlock()
+#include "libtransmission/file.h" // tr_sys_path_*()
+#include "libtransmission/variant.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/session.h"
 
 #include <string>
 #include <utility>
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
+
+using helpers::makeString;
+using helpers::waitFor;
 
 class IncompleteDirTest :
-    public SessionTest,
+    public helpers::SessionTest,
     public ::testing::WithParamInterface<std::pair<std::string, std::string>>
 {
 protected:
@@ -149,7 +152,7 @@ INSTANTIATE_TEST_SUITE_P(
 ****
 ***/
 
-using MoveTest = SessionTest;
+using MoveTest = helpers::SessionTest;
 
 TEST_F(MoveTest, setLocation)
 {
@@ -185,6 +188,6 @@ TEST_F(MoveTest, setLocation)
     tr_torrentRemove(tor, true, tr_sys_path_remove);
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/peer-msgs-test.cc
+++ b/tests/libtransmission/peer-msgs-test.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include "transmission.h"
-#include "peer-msgs.h"
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/peer-msgs.h"
+#include "libtransmission/utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/quark-test.cc
+++ b/tests/libtransmission/quark-test.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include "transmission.h"
-#include "quark.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/quark.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -6,15 +6,15 @@
  *
  */
 
-#include "transmission.h"
-#include "crypto-utils.h"
-#include "file.h"
-#include "resume.h"
-#include "torrent.h" // tr_isTorrent()
-#include "tr-assert.h"
-#include "variant.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/crypto-utils.h"
+#include "libtransmission/file.h"
+#include "libtransmission/resume.h"
+#include "libtransmission/torrent.h" // tr_isTorrent()
+#include "libtransmission/tr-assert.h"
+#include "libtransmission/variant.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/session.h"
 
 #include <array>
 #include <cerrno>
@@ -22,13 +22,16 @@
 #include <cstring> // strcmp()
 #include <string>
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
-class RenameTest : public SessionTest
+using helpers::makeString;
+using helpers::waitFor;
+
+class RenameTest : public helpers::SessionTest
 {
     static auto constexpr MaxWaitMsec = 3000;
 
@@ -531,6 +534,6 @@ TEST_F(RenameTest, partialFile)
     torrentRemoveAndWait(tor, 0);
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -6,25 +6,25 @@
  *
  */
 
-#include "transmission.h"
-#include "rpcimpl.h"
-#include "utils.h"
-#include "variant.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/rpcimpl.h"
+#include "libtransmission/utils.h"
+#include "libtransmission/variant.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/session.h"
 
 #include <algorithm>
 #include <array>
 #include <set>
 #include <vector>
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
-using RpcTest = SessionTest;
+using RpcTest = helpers::SessionTest;
 
 TEST_F(RpcTest, list)
 {
@@ -182,6 +182,6 @@ TEST_F(RpcTest, sessionGet)
     tr_torrentRemove(tor, false, nullptr);
 }
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -6,11 +6,11 @@
  *
  */
 
-#include "transmission.h"
-#include "session.h"
-#include "session-id.h"
-#include "utils.h"
-#include "version.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/session.h"
+#include "libtransmission/session-id.h"
+#include "libtransmission/utils.h"
+#include "libtransmission/version.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -6,15 +6,17 @@
  *
  */
 
-#include "transmission.h"
-#include "error.h"
-#include "file.h"
-#include "subprocess.h"
-#include "utils.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/error.h"
+#include "libtransmission/file.h"
+#include "libtransmission/platform.h" // TR_PATH_DELIMITER
+#include "libtransmission/subprocess.h"
+#include "libtransmission/utils.h"
+
+#include "tests/helpers/utils.h"
+#include "tests/helpers/sandbox.h"
 
 #include "gtest/internal/gtest-port.h" // GetArgvs()
-
-#include "test-fixtures.h"
 
 #include <array>
 #include <cstdlib>
@@ -25,11 +27,14 @@
 #define setenv(key, value, unused) SetEnvironmentVariableA(key, value)
 #endif
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
+
+using helpers::makeString;
+using helpers::waitFor;
 
 std::string getSelfPath()
 {
@@ -52,7 +57,7 @@ class SubprocessTest :
     public testing::WithParamInterface<std::string>
 {
 protected:
-    Sandbox sandbox_;
+    helpers::Sandbox sandbox_;
 
     [[nodiscard]] std::string buildSandboxPath(std::string const& filename) const
     {
@@ -403,6 +408,6 @@ INSTANTIATE_TEST_SUITE_P(
     );
 #endif
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -12,14 +12,16 @@
 #define unsetenv(key) SetEnvironmentVariableA(key, nullptr)
 #endif
 
-#include "transmission.h"
-#include "ConvertUTF.h" // tr_utf8_validate()
-#include "platform.h"
-#include "crypto-utils.h" // tr_rand_int_weak()
-#include "utils.h"
-#include "web.h" // tr_http_unescape()
+#include "libtransmission/transmission.h"
+#include "libtransmission/ConvertUTF.h" // tr_utf8_validate()
+#include "libtransmission/platform.h"
+#include "libtransmission/crypto-utils.h" // tr_rand_int_weak()
+#include "libtransmission/utils.h"
+#include "libtransmission/web.h" // tr_http_unescape()
 
-#include "test-fixtures.h"
+#include "tests/helpers/utils.h" // makeString()
+
+#include "gtest/gtest.h"
 
 #include <algorithm>
 #include <array>
@@ -27,7 +29,7 @@
 #include <cstdlib> // setenv(), unsetenv()
 #include <string>
 
-using ::libtransmission::test::makeString;
+using ::transmission::tests::helpers::makeString;
 
 using UtilsTest = ::testing::Test;
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -8,10 +8,10 @@
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 
-#include "transmission.h"
-#include "utils.h" /* tr_free */
-#include "variant-common.h"
-#include "variant.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/utils.h" /* tr_free */
+#include "libtransmission/variant-common.h"
+#include "libtransmission/variant.h"
 
 #include <algorithm>
 #include <array>

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -6,13 +6,14 @@
  *
  */
 
-#include "transmission.h"
-#include "file.h"
-#include "net.h"
-#include "utils.h"
-#include "watchdir.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/file.h"
+#include "libtransmission/net.h"
+#include "libtransmission/platform.h"
+#include "libtransmission/utils.h"
+#include "libtransmission/watchdir.h"
 
-#include "test-fixtures.h"
+#include "tests/helpers/sandbox.h"
 
 #include <event2/event.h>
 
@@ -40,10 +41,10 @@ auto constexpr TwoHundredMsec = timeval { 0, 200000 };
 
 }
 
-namespace libtransmission
+namespace transmission
 {
 
-namespace test
+namespace tests
 {
 
 enum class WatchMode
@@ -53,7 +54,7 @@ enum class WatchMode
 };
 
 class WatchDirTest :
-    public SandboxedTest,
+    public helpers::SandboxedTest,
     public ::testing::WithParamInterface<WatchMode>
 {
 private:
@@ -369,6 +370,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(WatchMode::NATIVE, WatchMode::GENERIC)
     );
 
-} // namespace test
+} // namespace tests
 
-} // namespace libtransmission
+} // namespace transmission

--- a/tests/qt/.clang-tidy
+++ b/tests/qt/.clang-tidy
@@ -1,0 +1,78 @@
+---
+# Many of these checks are disabled only because the code hasn't been
+# cleaned up yet. Pull requests welcomed.
+Checks: >
+  bugprone-*,
+  -bugprone-branch-clone,
+  -bugprone-narrowing-conversions,
+  cert-*,
+  -cert-dcl50-cpp,
+  -cert-err58-cpp,
+  clang-analyzer-optin*,
+  -clang-diagnostic-c++98*,
+  -clang-diagnostic-global-constructors,
+  -clang-diagnostic-missing-prototypes,
+  -clang-diagnostic-nonportable-system-include-path,
+  -clang-diagnostic-old-style-cast,
+  -clang-diagnostic-shorten-64-to-32,
+  -clang-diagnostic-sign-compare,
+  -clang-diagnostic-sign-conversion,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-special-member-functions,
+  google-readability-*,
+  google-runtime-operator,
+  hicpp-*,
+  -hicpp-multiway-paths-covered,
+  -hicpp-no-array-decay,
+  -hicpp-signed-bitwise,
+  -hicpp-special-member-functions,
+  -hicpp-vararg,
+  misc-*,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  modernize-*,
+  -modernize-raw-string-literal,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+  -readability-convert-member-functions-to-static,
+  -readability-implicit-bool-conversion,
+  -readability-inconsistent-declaration-parameter-name,
+  -readability-magic-numbers,
+  -readability-qualified-auto,
+  -readability-redundant-access-specifiers,
+  -readability-static-accessed-through-instance
+
+WarningsAsErrors: >
+  *
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase,             value: camelBack  }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,            value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,      value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,               value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,    value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,             value: lower_case }

--- a/tests/qt/CMakeLists.txt
+++ b/tests/qt/CMakeLists.txt
@@ -1,0 +1,26 @@
+set_directory_properties(
+  PROPERTIES
+  FOLDER "UnitTests"
+  MSVC_RUNTIME_LIBRARY "MultiThreaded"
+)
+
+add_compile_options(
+  ${CXX_WARNING_FLAGS}
+)
+
+include_directories(
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+)
+
+include_directories(
+  SYSTEM
+  ${EVENT2_INCLUDE_DIRS}
+)
+
+foreach(T prefs)
+  set(TP trqt-test-${T})
+  add_executable(${TP} ${T}-test.cc)
+  target_link_libraries(${TP} gtestall trqt)
+  add_test(NAME ${TP} COMMAND ${TP})
+endforeach()

--- a/tests/qt/Makefile.am
+++ b/tests/qt/Makefile.am
@@ -1,0 +1,2 @@
+EXTRA_DIST = \
+  prefs-test.cc

--- a/tests/qt/prefs-test.cc
+++ b/tests/qt/prefs-test.cc
@@ -53,10 +53,10 @@ TEST_F(PrefsTest, emitsChanged)
     auto constexpr Key = Prefs::DOWNLOAD_DIR;
     using collection = std::set<int>;
     auto changed_properties = collection{};
-    auto const expected_pre = collection{}; 
-    auto const expected_post = collection{ Key }; 
+    auto const expected_pre = collection{};
+    auto const expected_post = collection{ Key };
 
-    auto on_received = [&](int id){ changed_properties.insert(id); };
+    auto on_received = [&](int id) { changed_properties.insert(id); };
     QObject::connect(prefs_.get(), &Prefs::changed, on_received);
 
     EXPECT_EQ(expected_pre, changed_properties);

--- a/tests/qt/prefs-test.cc
+++ b/tests/qt/prefs-test.cc
@@ -1,0 +1,69 @@
+/*
+ * This file Copyright (C) 2020 Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#include "qt/Prefs.h"
+
+#include "tests/helpers/sandbox.h"
+
+#include "gtest/gtest.h"
+
+#include <set>
+
+namespace transmission
+{
+
+namespace tests
+{
+
+class PrefsTest : public helpers::SandboxedTest
+{
+protected:
+    void SetUp() override
+    {
+        SandboxedTest::SetUp();
+        prefs_ = std::make_unique<Prefs>(sandboxDir().c_str());
+    }
+
+    void TearDown() override
+    {
+        prefs_.reset();
+        SandboxedTest::TearDown();
+    }
+
+    std::unique_ptr<Prefs> prefs_;
+};
+
+TEST_F(PrefsTest, canSetString)
+{
+    auto constexpr Key = Prefs::DOWNLOAD_DIR;
+    auto const expected = QStringLiteral("/home/ilyak/Загрузки");
+    prefs_->set(Key, expected);
+
+    auto const actual = prefs_->getString(Key);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(PrefsTest, emitsChanged)
+{
+    auto constexpr Key = Prefs::DOWNLOAD_DIR;
+    using collection = std::set<int>;
+    auto changed_properties = collection{};
+    auto const expected_pre = collection{}; 
+    auto const expected_post = collection{ Key }; 
+
+    auto on_received = [&](int id){ changed_properties.insert(id); };
+    QObject::connect(prefs_.get(), &Prefs::changed, on_received);
+
+    EXPECT_EQ(expected_pre, changed_properties);
+    prefs_->set(Key, QStringLiteral("/some/path"));
+    EXPECT_EQ(expected_post, changed_properties);
+}
+
+} // namespace tests
+
+} // namespace transmission


### PR DESCRIPTION
* Don't re-assign the preferences string when calling Prefs::getString(). This was originally needed for https://trac.transmissionbt.com/ticket/4760 which is no longer reproducible

* Update the build config s.t. transmission-qt can be tested in the Google Tests directory. Add a test to confirm that assigning and then extracting a Prefs string does not corrupt the string.

* In filterbar, don't ping prefs for the filter string every time that `filterAcceptsRow()` is called. Instead, cache the filter string in filterbar and update it whenever the prefs change.

