### PR TITLE
fixup: qt client nicer torrent add handling

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1159,11 +1159,18 @@ void Session::onDuplicatesTimer()
     if (!lines.empty())
     {
         lines.sort(Qt::CaseInsensitive);
-        auto* d = new QMessageBox(QMessageBox::Warning,
-            tr("Unable to add Duplicate Torrent(s)", "", lines.size()),
-            lines.join(QStringLiteral("\n")),
-            QMessageBox::Close,
-            qApp->activeWindow());
+        auto const title = tr("Duplicate Torrent(s)", "", lines.size());
+        auto const detail = lines.join(QStringLiteral("\n"));
+        auto const detail_text = tr("Unable to add %1 duplicate torrents", "", lines.size()).arg(lines.size());
+        auto const use_detail = lines.size() > 1;
+        auto const text = use_detail ? detail_text : detail;
+
+        auto* d = new QMessageBox(QMessageBox::Warning, title, text, QMessageBox::Close, qApp->activeWindow());
+        if (use_detail)
+        {
+            d->setDetailedText(detail);
+        }
+
         QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
         d->show();
     }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1149,7 +1149,7 @@ void Session::onDuplicatesTimer()
     duplicates.swap(duplicates_);
 
     QStringList lines;
-    for (auto it : duplicates_)
+    for (auto it : duplicates)
     {
         lines.push_back(tr("%1 (copy of %2)")
             .arg(it.first)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1161,7 +1161,7 @@ void Session::onDuplicatesTimer()
         lines.sort(Qt::CaseInsensitive);
         auto const title = tr("Duplicate Torrent(s)", "", lines.size());
         auto const detail = lines.join(QStringLiteral("\n"));
-        auto const detail_text = tr("Unable to add %1 duplicate torrents", "", lines.size()).arg(lines.size());
+        auto const detail_text = tr("Unable to add %n duplicate torrent(s)", "", lines.size());
         auto const use_detail = lines.size() > 1;
         auto const text = use_detail ? detail_text : detail;
 

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -121,7 +121,6 @@ public:
 public slots:
     void addTorrent(AddData const& addme);
     void launchWebInterface();
-    void onDuplicatesTimer();
     void queueMoveBottom(torrent_ids_t const& torrentIds = {});
     void queueMoveDown(torrent_ids_t const& torrentIds = {});
     void queueMoveTop(torrent_ids_t const& torrentIds = {});
@@ -181,4 +180,7 @@ private:
 
     std::map<QString, QString> duplicates_;
     QTimer duplicates_timer_;
+
+private slots:
+    void onDuplicatesTimer();
 };

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -25,7 +25,6 @@
 #include "RpcQueue.h"
 #include "Torrent.h"
 #include "Typedefs.h"
-#include "Utils.h" // std::hash<QString>
 
 class AddData;
 class Prefs;


### PR DESCRIPTION
Tweak the display of the "unable to add duplicate torrents" dialog in the Qt client.

This PR is a followup to [this PR](https://github.com/transmission/transmission/pull/1410) where @mikedld had some comments that I didn't see until after it had been merged.