### PR TITLE
refactor: work around msvc constxpr std::array bug

### DIFF
--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -21,7 +21,7 @@ TEST(Client, clientForId)
         char const* expected_client;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 24>{
+    auto const tests = std::array<LocalTest, 24>{
         LocalTest{ "-BT791B-", "BitTorrent 7.9.1 (Beta)" },
         { "-BT791\0-", "BitTorrent 7.9.1" },
         { "-FC1013-", "FileCroc 1.0.1.3" },
@@ -63,7 +63,7 @@ TEST(Client, clientForId)
         { "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28", "BitLord 0.56" }
     };
 
-    for (auto const& test : Tests)
+    for (auto const& test : tests)
     {
         auto buf = std::array<char, 128>{};
         tr_clientForId(buf.data(), buf.size(), test.peer_id);

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -128,14 +128,14 @@ TEST(Crypto, ssha1)
         char const* const ssha1;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 2>{
+    auto const tests = std::array<LocalTest, 2>{
         LocalTest{ "test", "{15ad0621b259a84d24dcd4e75b09004e98a3627bAMbyRHJy" },
         { "QNY)(*#$B)!_X$B !_B#($^!)*&$%CV!#)&$C!@$(P*)", "{10e2d7acbb104d970514a147cd16d51dfa40fb3c0OSwJtOL" }
     };
 
     auto constexpr HashCount = size_t{ 4 * 1024 };
 
-    for (auto const& test : Tests)
+    for (auto const& test : tests)
     {
         std::unordered_set<std::string> hashes;
         hashes.reserve(HashCount);

--- a/tests/libtransmission/getopt-test.cc
+++ b/tests/libtransmission/getopt-test.cc
@@ -16,7 +16,7 @@
 namespace
 {
 
-auto constexpr Options = std::array<tr_option, 8>{
+auto const Options = std::array<tr_option, 8>{
     tr_option{ 'p', "private", "Allow this torrent to only be used with the specified tracker(s)", "p", false, nullptr },
     { 'o', "outfile", "Save the generated .torrent to this filename", "o", true, "<file>" },
     { 's', "piecesize", "Set how many KiB each piece should be, overriding the preferred default", "s", true, "<size in KiB>" },
@@ -54,101 +54,101 @@ protected:
 
 TEST_F(GetoptTest, noOptions)
 {
-    auto constexpr Args = std::array<char const*, 1>{ "/some/path/tr-getopt-test" };
+    auto const args = std::array<char const*, 1>{ "/some/path/tr-getopt-test" };
     auto constexpr ExpectedN = 0;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{};
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{};
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{};
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{};
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, shortNoarg)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-p" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-p" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'p' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'p' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ nullptr };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, longNoarg)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--private" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--private" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'p' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'p' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ nullptr };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, shortWithArg)
 {
-    auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-o", "/tmp/outfile" };
+    auto const args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-o", "/tmp/outfile" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'o' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, longWithArg)
 {
-    auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "--outfile", "/tmp/outfile" };
+    auto const args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "--outfile", "/tmp/outfile" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'o' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, shortWithArgAfterEq)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o=/tmp/outfile" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o=/tmp/outfile" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'o' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, longWithArgAfterEq)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--outfile=/tmp/outfile" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--outfile=/tmp/outfile" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'o' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, unknownOption)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-z" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-z" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ TR_OPT_UNK };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "-z" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ TR_OPT_UNK };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "-z" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, missingArg)
 {
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ TR_OPT_ERR };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ TR_OPT_ERR };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ nullptr };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, lotsOfOptions)
 {
-    auto constexpr Args =
+    auto const args =
         std::array<char const*, 6>{ "/some/path/tr-getopt-test", "--piecesize=4", "-c", "hello world", "-p", "--tracker=foo" };
     auto constexpr ExpectedN = 4;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 's', 'c', 'p', 't' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "4", "hello world", nullptr, "foo" };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 's', 'c', 'p', 't' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ "4", "hello world", nullptr, "foo" };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }
 
 TEST_F(GetoptTest, matchLongerKey)
 {
     // confirm that this resolves to 'q' and not 'p'
-    auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-pk" };
+    auto const args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-pk" };
     auto constexpr ExpectedN = 1;
-    auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'q' };
-    auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
-    runTest(Args.size(), Args.data(), ExpectedN, ExpectedC.data(), ExpectedOptArg.data());
+    auto const expected_c = std::array<int, ExpectedN>{ 'q' };
+    auto const expected_opt_arg = std::array<char const*, ExpectedN>{ nullptr };
+    runTest(args.size(), args.data(), ExpectedN, expected_c.data(), expected_opt_arg.data());
 }

--- a/tests/libtransmission/magnet-test.cc
+++ b/tests/libtransmission/magnet-test.cc
@@ -16,7 +16,7 @@
 
 TEST(Magnet, magnetParse)
 {
-    auto constexpr ExpectedHash = std::array<uint8_t, SHA_DIGEST_LENGTH>{
+    auto const expected_hash = std::array<uint8_t, SHA_DIGEST_LENGTH>{
         210, 53, 64, 16, 163, 202, 74, 222, 91, 116,
         39, 187, 9, 58, 98, 163, 137, 159, 243, 129
     };
@@ -47,8 +47,8 @@ TEST(Magnet, magnetParse)
         EXPECT_EQ(1, info->webseedCount);
         EXPECT_STREQ("http://server.webseed.org/path/to/file", info->webseeds[0]);
         EXPECT_STREQ("Display Name", info->displayName);
-        EXPECT_EQ(ExpectedHash.size(), sizeof(info->hash));
-        EXPECT_EQ(0, memcmp(info->hash, ExpectedHash.data(), ExpectedHash.size()));
+        EXPECT_EQ(expected_hash.size(), sizeof(info->hash));
+        EXPECT_EQ(0, memcmp(info->hash, expected_hash.data(), expected_hash.size()));
         tr_magnetFree(info);
     }
 }

--- a/tests/libtransmission/metainfo-test.cc
+++ b/tests/libtransmission/metainfo-test.cc
@@ -59,7 +59,7 @@ TEST(Metainfo, bucket)
         void const* benc;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 9>{
+    auto const tests = std::array<LocalTest, 9>{
         LocalTest{ 0, TR_PARSE_OK, BEFORE_PATH "5:a.txt" AFTER_PATH },
 
         /* allow empty components, but not =all= empty components, see bug #5517 */
@@ -83,7 +83,7 @@ TEST(Metainfo, bucket)
 
     tr_logSetLevel(TR_LOG_SILENT);
 
-    for (auto const& test : Tests)
+    for (auto const& test : tests)
     {
         auto* ctor = tr_ctorNew(nullptr);
         int const err = tr_ctorSetMetainfo(ctor, test.benc, strlen(static_cast<char const*>(test.benc)));
@@ -109,7 +109,7 @@ TEST(Metainfo, sanitize)
         bool expected_is_adjusted;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 29>{
+    auto const tests = std::array<LocalTest, 29>{
         // skipped
         LocalTest{ "", 0, nullptr, false },
         { ".", 1, nullptr, false },
@@ -146,7 +146,7 @@ TEST(Metainfo, sanitize)
         { "compass", 7, "compass", false }
     };
 
-    for (auto const& test : Tests)
+    for (auto const& test : tests)
     {
         bool is_adjusted;
         char* const result = tr_metainfo_sanitize_path_component(test.str, test.len, &is_adjusted);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -476,15 +476,15 @@ TEST_F(RenameTest, partialFile)
 {
     auto constexpr PieceCount = uint32_t { 33 };
     auto constexpr PieceSize = uint32_t { 32768 };
-    auto constexpr Length = std::array<uint32_t, 3>{ 1048576, 4096, 512 };
-    auto constexpr TotalSize = uint64_t(Length[0]) + Length[1] + Length[2];
+    auto const length = std::array<uint32_t, 3>{ 1048576, 4096, 512 };
+    auto const total_size = uint64_t(length[0]) + length[1] + length[2];
 
     /***
     ****  create our test torrent with an incomplete .part file
     ***/
 
     auto* tor = zeroTorrentInit();
-    EXPECT_EQ(TotalSize, tor->info.totalSize);
+    EXPECT_EQ(total_size, tor->info.totalSize);
     EXPECT_EQ(PieceSize, tor->info.pieceSize);
     EXPECT_EQ(PieceCount, tor->info.pieceCount);
     EXPECT_STREQ("files-filled-with-zeroes/1048576", tor->info.files[0].name);
@@ -493,12 +493,12 @@ TEST_F(RenameTest, partialFile)
 
     zeroTorrentPopulate(tor, false);
     auto* fst = tr_torrentFiles(tor, nullptr);
-    EXPECT_EQ(Length[0] - PieceSize, fst[0].bytesCompleted);
-    EXPECT_EQ(Length[1], fst[1].bytesCompleted);
-    EXPECT_EQ(Length[2], fst[2].bytesCompleted);
+    EXPECT_EQ(length[0] - PieceSize, fst[0].bytesCompleted);
+    EXPECT_EQ(length[1], fst[1].bytesCompleted);
+    EXPECT_EQ(length[2], fst[2].bytesCompleted);
     tr_torrentFilesFree(fst, tor->info.fileCount);
     auto const* st = tr_torrentStat(tor);
-    EXPECT_EQ(TotalSize, st->sizeWhenDone);
+    EXPECT_EQ(total_size, st->sizeWhenDone);
     EXPECT_EQ(PieceSize, st->leftUntilDone);
 
     /***

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -102,7 +102,7 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 
     // what we expected
-    auto constexpr ExpectedKeys = std::array<tr_quark, 50>{
+    auto const expected_keys = std::array<tr_quark, 50>{
         TR_KEY_alt_speed_down,
         TR_KEY_alt_speed_enabled,
         TR_KEY_alt_speed_time_begin,
@@ -166,14 +166,14 @@ TEST_F(RpcTest, sessionGet)
     }
 
     auto missing_keys = std::vector<tr_quark>{};
-    std::set_difference(std::begin(ExpectedKeys), std::end(ExpectedKeys),
+    std::set_difference(std::begin(expected_keys), std::end(expected_keys),
         std::begin(actual_keys), std::end(actual_keys),
         std::inserter(missing_keys, std::begin(missing_keys)));
     EXPECT_EQ(decltype(missing_keys) {}, missing_keys);
 
     auto unexpected_keys = std::vector<tr_quark>{};
     std::set_difference(std::begin(actual_keys), std::end(actual_keys),
-        std::begin(ExpectedKeys), std::end(ExpectedKeys),
+        std::begin(expected_keys), std::end(expected_keys),
         std::inserter(unexpected_keys, std::begin(unexpected_keys)));
     EXPECT_EQ(decltype(unexpected_keys) {}, unexpected_keys);
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -184,14 +184,14 @@ int compareInts(void const* va, void const* vb) noexcept
 
 TEST_F(UtilsTest, lowerbound)
 {
-    auto constexpr A = std::array<int, 7>{ 1, 2, 3, 3, 3, 5, 8 };
+    auto const a = std::array<int, 7>{ 1, 2, 3, 3, 3, 5, 8 };
     auto const expected_pos = std::array<int, 10>{ 0, 1, 2, 5, 5, 6, 6, 6, 7, 7 };
     auto const expected_exact = std::array<bool, 10>{ true, true, true, false, true, false, false, true, false, false };
 
     for (int i = 1; i <= 10; i++)
     {
         bool exact;
-        auto const pos = tr_lowerBound(&i, A.data(), A.size(), sizeof(int), compareInts, &exact);
+        auto const pos = tr_lowerBound(&i, a.data(), a.size(), sizeof(int), compareInts, &exact);
         EXPECT_EQ(expected_pos[i - 1], pos);
         EXPECT_EQ(expected_exact[i - 1], exact);
     }


### PR DESCRIPTION
The tests FTBFS on the latest version of MSVC because it has a regression that crashes the compiler when it sees a constexpr std::array. This commit can be reverted when MSVC releases a fix.

https://developercommunity.visualstudio.com/content/problem/1139953/167-regression-auto-constexpr-with-deduced-array-i.html