### PR TITLE
refactor: use a vector for FavIcon cache keys

### DIFF
--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <unordered_map>
-#include <unordered_set>
+#include <vector>
 
-#include <QString>
 #include <QObject>
 #include <QPixmap>
+#include <QString>
 
 #include "Macros.h"
 #include "Utils.h" // std::hash<QString>
@@ -31,7 +31,7 @@ public:
     FaviconCache();
 
     using Key = QString;
-    using Keys = std::unordered_set<Key>;
+    using Keys = std::vector<Key>;
 
     // returns a cached pixmap, or a NULL pixmap if there's no match in the cache
     QPixmap find(Key const& key);

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -68,7 +68,7 @@ bool Torrent::getSeedRatio(double& setmeRatio) const
 
 bool Torrent::includesTracker(FaviconCache::Key const& key) const
 {
-    return tracker_keys_.count(key) != 0;
+    return std::binary_search(std::begin(tracker_keys_), std::end(tracker_keys_), key);
 }
 
 int Torrent::compareSeedRatio(Torrent const& that) const
@@ -300,11 +300,12 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
 
             case TR_KEY_trackers:
                 {
-                    FaviconCache::Keys tmp;
-                    std::transform(std::cbegin(tracker_stats_), std::cend(tracker_stats_),
-                        std::inserter(tmp, std::end(tmp)),
-                        [](auto const& ts) { return ts.favicon_key; });
-                    std::swap(tracker_keys_, tmp);
+                    std::set<FaviconCache::Key> tmp;
+                    for (auto const& ts : tracker_stats_)
+                    {
+                        tmp.insert(ts.favicon_key);
+                    }
+                    tracker_keys_ = FaviconCache::Keys(std::begin(tmp), std::end(tmp));
                     break;
                 }
             }

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -305,6 +305,7 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
                     {
                         tmp.insert(ts.favicon_key);
                     }
+
                     tracker_keys_ = FaviconCache::Keys(std::begin(tmp), std::end(tmp));
                     break;
                 }


### PR DESCRIPTION
Third of three PRs focused on small memory wins in transmission-qt. This one saves 1-2 M off RES in my 15K torrent testbed. Not a major improvement, but nice enough.

Previously we held the torrent's tracker keys in an `std::unordered_set`. That container type is overkill for this field: the list is usually short and almost never changes, so we don't need fast insertion time. We can keep the same log N lookup by using a sorted `std::vector` and avoid the excess container size & memory allocations of a `std::unordered_set`.