### PR TITLE
refactor: make torrents' mime icons lazy-loaded.

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -349,7 +349,6 @@ Application::Application(int& argc, char** argv) :
     }
 
     InteropHelper::registerObject(this);
-    QTimer::singleShot(1000 * 60 * 10, this, SLOT(quit()));
 }
 
 void Application::loadTranslations()

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -349,6 +349,7 @@ Application::Application(int& argc, char** argv) :
     }
 
     InteropHelper::registerObject(this);
+    QTimer::singleShot(1000 * 60 * 10, this, SLOT(quit()));
 }
 
 void Application::loadTranslations()

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -152,14 +152,12 @@ QModelIndexList FileTreeModel::getOrphanIndices(QModelIndexList const& indices) 
 
 QVariant FileTreeModel::data(QModelIndex const& index, int role) const
 {
-    QVariant value;
-
     if (index.isValid())
     {
-        value = itemFromIndex(index)->data(index.column(), role);
+        return itemFromIndex(index)->data(index.column(), role);
     }
 
-    return value;
+    return {};
 }
 
 Qt::ItemFlags FileTreeModel::flags(QModelIndex const& index) const
@@ -193,30 +191,28 @@ bool FileTreeModel::setData(QModelIndex const& index, QVariant const& newname, i
 
 QVariant FileTreeModel::headerData(int column, Qt::Orientation orientation, int role) const
 {
-    QVariant data;
-
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole)
     {
         switch (column)
         {
         case COL_NAME:
-            data.setValue(tr("File"));
+            return tr("File");
             break;
 
         case COL_SIZE:
-            data.setValue(tr("Size"));
+            return tr("Size");
             break;
 
         case COL_PROGRESS:
-            data.setValue(tr("Progress"));
+            return tr("Progress");
             break;
 
         case COL_WANTED:
-            data.setValue(tr("Download"));
+            return tr("Download");
             break;
 
         case COL_PRIORITY:
-            data.setValue(tr("Priority"));
+            return tr("Priority");
             break;
 
         default:
@@ -224,7 +220,7 @@ QVariant FileTreeModel::headerData(int column, Qt::Orientation orientation, int 
         }
     }
 
-    return data;
+    return {};
 }
 
 QModelIndex FileTreeModel::index(int row, int column, QModelIndex const& parent) const

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -161,27 +161,28 @@ int Torrent::compareETA(Torrent const& that) const
 ****
 ***/
 
-void Torrent::updateMimeIcon()
+QIcon Torrent::getMimeTypeIcon() const
 {
-    auto const& files = files_;
-    auto const& icon_cache = IconCache::get();
-
-    QIcon icon;
-
-    if (files.size() > 1)
+    if (icon_.isNull())
     {
-        icon = icon_cache.folderIcon();
-    }
-    else if (files.size() == 1)
-    {
-        icon = icon_cache.guessMimeIcon(files.at(0).filename, icon_cache.fileIcon());
-    }
-    else
-    {
-        icon = icon_cache.guessMimeIcon(name(), icon_cache.folderIcon());
+        auto const& files = files_;
+        auto const& icon_cache = IconCache::get();
+
+        if (files.size() > 1)
+        {
+            icon_ = icon_cache.folderIcon();
+        }
+        else if (files.size() == 1)
+        {
+            icon_ = icon_cache.guessMimeIcon(files.at(0).filename, icon_cache.fileIcon());
+        }
+        else
+        {
+            icon_ = icon_cache.guessMimeIcon(name(), icon_cache.folderIcon());
+        }
     }
 
-    icon_ = icon;
+    return icon_;
 }
 
 /***
@@ -283,13 +284,13 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
             {
             case TR_KEY_name:
                 {
-                    updateMimeIcon();
+                    icon_ = {};
                     break;
                 }
 
             case TR_KEY_files:
                 {
-                    updateMimeIcon();
+                    icon_ = {};
                     for (int i = 0; i < files_.size(); ++i)
                     {
                         files_[i].index = i;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -540,10 +540,7 @@ public:
         return isWaitingToDownload() || isWaitingToSeed();
     }
 
-    QIcon getMimeTypeIcon() const
-    {
-        return icon_;
-    }
+    QIcon getMimeTypeIcon() const;
 
     enum Field
     {
@@ -666,7 +663,8 @@ private:
     QString error_string_;
     QString name_;
 
-    QIcon icon_;
+    // mutable because it's a lazy lookup
+    mutable QIcon icon_;
 
     PeerList peers_;
     FileList files_;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -606,8 +606,6 @@ public:
     fields_t update(tr_quark const* keys, tr_variant const* const* values, size_t n);
 
 private:
-    void updateMimeIcon();
-
     int const id_;
 
     bool download_limited_ = {};

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -93,8 +93,6 @@ int TorrentModel::rowCount(QModelIndex const& parent) const
 
 QVariant TorrentModel::data(QModelIndex const& index, int role) const
 {
-    QVariant var;
-
     Torrent const* t = torrents_.value(index.row(), nullptr);
 
     if (t != nullptr)
@@ -102,15 +100,15 @@ QVariant TorrentModel::data(QModelIndex const& index, int role) const
         switch (role)
         {
         case Qt::DisplayRole:
-            var.setValue(t->name());
+            return t->name();
             break;
 
         case Qt::DecorationRole:
-            var.setValue(t->getMimeTypeIcon());
+            return t->getMimeTypeIcon();
             break;
 
         case TorrentRole:
-            var = QVariant::fromValue(t);
+            return QVariant::fromValue(t);
             break;
 
         default:
@@ -119,7 +117,7 @@ QVariant TorrentModel::data(QModelIndex const& index, int role) const
         }
     }
 
-    return var;
+    return {};
 }
 
 /***


### PR DESCRIPTION
Another "small wins" patch, this time for startup load: icon loading is expensive, so calculating them for every torrent all at once on startup isn't great. By lazy-loading them, the work is spread out over time.