### PR TITLE
feat: add 'TR_RPC_VERBOSE' env variable in Qt app.

### DIFF
--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -24,8 +24,6 @@
 
 #include "VariantHelpers.h"
 
-// #define DEBUG_HTTP
-
 using ::trqt::variant_helpers::dictAdd;
 using ::trqt::variant_helpers::dictFind;
 using ::trqt::variant_helpers::variantInit;
@@ -35,6 +33,8 @@ namespace
 
 char const constexpr* const RequestDataPropertyKey { "requestData" };
 char const constexpr* const RequestFutureinterfacePropertyKey { "requestReplyFutureInterface" };
+
+bool const Verbose = tr_env_key_exists("TR_RPC_VERBOSE");
 
 void destroyVariant(tr_variant* json)
 {
@@ -155,16 +155,17 @@ void RpcClient::sendNetworkRequest(TrVariantPtr json, QFutureInterface<RpcRespon
     connect(reply, SIGNAL(downloadProgress(qint64, qint64)), this, SIGNAL(dataReadProgress()));
     connect(reply, SIGNAL(uploadProgress(qint64, qint64)), this, SIGNAL(dataSendProgress()));
 
-#ifdef DEBUG_HTTP
-    std::cerr << "sending " << "POST " << qPrintable(url_.path()) << std::endl;
-
-    for (QByteArray const& b : request.rawHeaderList())
+    if (Verbose)
     {
-        std::cerr << b.constData() << ": " << request.rawHeader(b).constData() << std::endl;
-    }
+        std::cerr << "sending " << "POST " << qPrintable(url_.path()) << std::endl;
 
-    std::cerr << "Body:\n" << json_data.constData() << std::endl;
-#endif
+        for (QByteArray const& b : request_->rawHeaderList())
+        {
+            std::cerr << b.constData() << ": " << request_->rawHeader(b).constData() << std::endl;
+        }
+
+        std::cerr << "Body:\n" << json_data.constData() << std::endl;
+    }
 }
 
 void RpcClient::sendLocalRequest(TrVariantPtr json, QFutureInterface<RpcResponse> const& promise, int64_t tag)
@@ -233,16 +234,17 @@ void RpcClient::networkRequestFinished(QNetworkReply* reply)
     auto promise = reply->property(RequestFutureinterfacePropertyKey).
         value<QFutureInterface<RpcResponse>>();
 
-#ifdef DEBUG_HTTP
-    std::cerr << "http response header: " << std::endl;
-
-    for (QByteArray const& b : reply->rawHeaderList())
+    if (Verbose)
     {
-        std::cerr << b.constData() << ": " << reply->rawHeader(b).constData() << std::endl;
-    }
+        std::cerr << "http response header: " << std::endl;
 
-    std::cerr << "json:\n" << reply->peek(reply->bytesAvailable()).constData() << std::endl;
-#endif
+        for (QByteArray const& b : reply->rawHeaderList())
+        {
+            std::cerr << b.constData() << ": " << reply->rawHeader(b).constData() << std::endl;
+        }
+
+        std::cerr << "json:\n" << reply->peek(reply->bytesAvailable()).constData() << std::endl;
+    }
 
     if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 409 &&
         reply->hasRawHeader(TR_RPC_SESSION_ID_HEADER))


### PR DESCRIPTION
Final PR from the Labor Day hack session. :slightly_smiling_face: 

When set, this will log the RPC messages sent between the GUI and the
backend. This replaces the old `#ifdef DEBUG_HTTP` as a more flexible
option that can be enabled without rebuilding the app.