### PR TITLE
chore: fix clang-tidy-11 warnings

### DIFF
--- a/qt/Application.h
+++ b/qt/Application.h
@@ -34,7 +34,7 @@ class Application : public QApplication
 
 public:
     Application(int& argc, char** argv);
-    virtual ~Application();
+    ~Application() override;
 
     void raise();
     bool notifyApp(QString const& title, QString const& body) const;

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -37,7 +37,7 @@ class DetailsDialog : public BaseDialog
 
 public:
     DetailsDialog(Session&, Prefs&, TorrentModel const&, QWidget* parent = nullptr);
-    virtual ~DetailsDialog();
+    ~DetailsDialog() override;
 
     void setIds(torrent_ids_t const& ids);
 

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -45,7 +45,7 @@ public:
 
 public:
     FileTreeModel(QObject* parent = nullptr, bool is_editable = true);
-    ~FileTreeModel();
+    ~FileTreeModel() override;
 
     void setEditable(bool editable);
 

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -17,6 +17,7 @@
 
 Formatter& Formatter::get()
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static auto& singleton = *new Formatter();
     return singleton;
 }

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -35,6 +35,7 @@
 
 IconCache& IconCache::get()
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static auto& singleton = *new IconCache();
     return singleton;
 }

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -37,7 +37,7 @@ class OptionsDialog : public BaseDialog
 
 public:
     OptionsDialog(Session& session, Prefs const& prefs, AddData addme, QWidget* parent = nullptr);
-    virtual ~OptionsDialog();
+    ~OptionsDialog() override;
 
 private:
     using mybins_t = QMap<uint32_t, int32_t>;

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -315,7 +315,7 @@ Prefs::~Prefs()
                 auto const test = [&mode](auto const& item) { return item.first == mode; };
                 // NOLINTNEXTLINE(readability-qualified-auto)
                 auto const it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
-                auto const& pair = it == std::end(FilterModes) ? FilterModes.front(): *it;
+                auto const& pair = it == std::end(FilterModes) ? FilterModes.front() : *it;
                 dictAdd(&current_settings, key, pair.second);
                 break;
             }

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <string_view>
 
 #include <QDateTime>
 #include <QDir>
@@ -125,34 +126,43 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items
     { UPLOAD_SLOTS_PER_TORRENT, TR_KEY_upload_slots_per_torrent, QVariant::Int }
 };
 
+namespace
+{
+
+auto const FilterModes = std::array<std::pair<int, std::string_view>, FilterMode::NUM_MODES>
+{{
+    { FilterMode::SHOW_ALL, "show-all" },
+    { FilterMode::SHOW_ACTIVE, "show-active" },
+    { FilterMode::SHOW_DOWNLOADING, "show-downloading" },
+    { FilterMode::SHOW_SEEDING, "show-seeding" },
+    { FilterMode::SHOW_PAUSED, "show-paused" },
+    { FilterMode::SHOW_FINISHED, "show-finished" },
+    { FilterMode::SHOW_VERIFYING, "show-verifying" },
+    { FilterMode::SHOW_ERROR, "show-error" }
+}};
+
+auto const SortModes = std::array<std::pair<int, std::string_view>, SortMode::NUM_MODES>
+{{
+    { SortMode::SORT_BY_NAME, "sort-by-name" },
+    { SortMode::SORT_BY_ACTIVITY, "sort-by-activity" },
+    { SortMode::SORT_BY_AGE, "sort-by-age" },
+    { SortMode::SORT_BY_ETA, "sort-by-eta" },
+    { SortMode::SORT_BY_PROGRESS, "sort-by-progress" },
+    { SortMode::SORT_BY_QUEUE, "sort-by-queue" },
+    { SortMode::SORT_BY_RATIO, "sort-by-ratio" },
+    { SortMode::SORT_BY_SIZE, "sort-by-size" },
+    { SortMode::SORT_BY_STATE, "sort-by-state" },
+    { SortMode::SORT_BY_ID, "sort-by-id" }
+}};
+
+} // namespace
+
 /***
 ****
 ***/
 
 Prefs::Prefs(QString config_dir) :
-    config_dir_(std::move(config_dir)),
-    FilterModes{
-        std::make_pair(FilterMode::SHOW_ALL, QStringLiteral("show-all")),
-        std::make_pair(FilterMode::SHOW_ACTIVE, QStringLiteral("show-active")),
-        std::make_pair(FilterMode::SHOW_DOWNLOADING, QStringLiteral("show-downloading")),
-        std::make_pair(FilterMode::SHOW_SEEDING, QStringLiteral("show-seeding")),
-        std::make_pair(FilterMode::SHOW_PAUSED, QStringLiteral("show-paused")),
-        std::make_pair(FilterMode::SHOW_FINISHED, QStringLiteral("show-finished")),
-        std::make_pair(FilterMode::SHOW_VERIFYING, QStringLiteral("show-verifying")),
-        std::make_pair(FilterMode::SHOW_ERROR, QStringLiteral("show-error"))
-        },
-    SortModes{
-        std::make_pair(SortMode::SORT_BY_NAME, QStringLiteral("sort-by-name")),
-        std::make_pair(SortMode::SORT_BY_ACTIVITY, QStringLiteral("sort-by-activity")),
-        std::make_pair(SortMode::SORT_BY_AGE, QStringLiteral("sort-by-age")),
-        std::make_pair(SortMode::SORT_BY_ETA, QStringLiteral("sort-by-eta")),
-        std::make_pair(SortMode::SORT_BY_PROGRESS, QStringLiteral("sort-by-progress")),
-        std::make_pair(SortMode::SORT_BY_QUEUE, QStringLiteral("sort-by-queue")),
-        std::make_pair(SortMode::SORT_BY_RATIO, QStringLiteral("sort-by-ratio")),
-        std::make_pair(SortMode::SORT_BY_SIZE, QStringLiteral("sort-by-size")),
-        std::make_pair(SortMode::SORT_BY_STATE, QStringLiteral("sort-by-state")),
-        std::make_pair(SortMode::SORT_BY_ID, QStringLiteral("sort-by-id"))
-        }
+    config_dir_(std::move(config_dir))
 {
     static_assert(sizeof(Items) / sizeof(Items[0]) == PREFS_COUNT);
 
@@ -191,12 +201,13 @@ Prefs::Prefs(QString config_dir) :
 
         case CustomVariantType::SortModeType:
             {
-                auto const value = getValue<QString>(b);
+                auto const value = getValue<std::string_view>(b);
                 if (value)
                 {
-                    auto test = [&value](auto const& item) { return item.second == *value; };
-                    auto const* it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
-                    auto const& pair = it == std::end(SortModes) ? SortModes[0] : *it;
+                    auto const test = [&value](auto const& item) { return item.second == *value; };
+                    // NOLINTNEXTLINE(readability-qualified-auto)
+                    auto const it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
+                    auto const& pair = it == std::end(SortModes) ? SortModes.front() : *it;
                     values_[i] = QVariant::fromValue(SortMode(pair.first));
                 }
             }
@@ -204,12 +215,13 @@ Prefs::Prefs(QString config_dir) :
 
         case CustomVariantType::FilterModeType:
             {
-                auto const value = getValue<QString>(b);
+                auto const value = getValue<std::string_view>(b);
                 if (value)
                 {
-                    auto test = [&value](auto const& item) { return item.second == *value; };
-                    auto const* it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
-                    auto const& pair = it == std::end(FilterModes) ? FilterModes[0] : *it;
+                    auto const test = [&value](auto const& item) { return item.second == *value; };
+                    // NOLINTNEXTLINE(readability-qualified-auto)
+                    auto const it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
+                    auto const& pair = it == std::end(FilterModes) ? FilterModes.front() : *it;
                     values_[i] = QVariant::fromValue(FilterMode(pair.first));
                 }
             }
@@ -289,9 +301,10 @@ Prefs::~Prefs()
         case CustomVariantType::SortModeType:
             {
                 auto const mode = val.value<SortMode>().mode();
-                auto test = [&mode](auto const& item) { return item.first == mode; };
-                auto const* it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
-                auto const& pair = it == std::end(SortModes) ? SortModes[0] : *it;
+                auto const test = [&mode](auto const& item) { return item.first == mode; };
+                // NOLINTNEXTLINE(readability-qualified-auto)
+                auto const it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
+                auto const& pair = it == std::end(SortModes) ? SortModes.front() : *it;
                 dictAdd(&current_settings, key, pair.second);
                 break;
             }
@@ -299,9 +312,10 @@ Prefs::~Prefs()
         case CustomVariantType::FilterModeType:
             {
                 auto const mode = val.value<FilterMode>().mode();
-                auto test = [&mode](auto const& item) { return item.first == mode; };
-                auto const* it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
-                auto const& pair = it == std::end(FilterModes) ? FilterModes[0] : *it;
+                auto const test = [&mode](auto const& item) { return item.first == mode; };
+                // NOLINTNEXTLINE(readability-qualified-auto)
+                auto const it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
+                auto const& pair = it == std::end(FilterModes) ? FilterModes.front(): *it;
                 dictAdd(&current_settings, key, pair.second);
                 break;
             }

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -195,7 +195,7 @@ Prefs::Prefs(QString config_dir) :
                 if (value)
                 {
                     auto test = [&value](auto const& item) { return item.second == *value; };
-                    auto it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
+                    auto const* it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
                     auto const& pair = it == std::end(SortModes) ? SortModes[0] : *it;
                     values_[i] = QVariant::fromValue(SortMode(pair.first));
                 }
@@ -208,7 +208,7 @@ Prefs::Prefs(QString config_dir) :
                 if (value)
                 {
                     auto test = [&value](auto const& item) { return item.second == *value; };
-                    auto it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
+                    auto const* it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
                     auto const& pair = it == std::end(FilterModes) ? FilterModes[0] : *it;
                     values_[i] = QVariant::fromValue(FilterMode(pair.first));
                 }
@@ -290,7 +290,7 @@ Prefs::~Prefs()
             {
                 auto const mode = val.value<SortMode>().mode();
                 auto test = [&mode](auto const& item) { return item.first == mode; };
-                auto it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
+                auto const* it = std::find_if(std::cbegin(SortModes), std::cend(SortModes), test);
                 auto const& pair = it == std::end(SortModes) ? SortModes[0] : *it;
                 dictAdd(&current_settings, key, pair.second);
                 break;
@@ -300,7 +300,7 @@ Prefs::~Prefs()
             {
                 auto const mode = val.value<FilterMode>().mode();
                 auto test = [&mode](auto const& item) { return item.first == mode; };
-                auto it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
+                auto const* it = std::find_if(std::cbegin(FilterModes), std::cend(FilterModes), test);
                 auto const& pair = it == std::end(FilterModes) ? FilterModes[0] : *it;
                 dictAdd(&current_settings, key, pair.second);
                 break;

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -134,7 +134,7 @@ public:
 
 public:
     Prefs(QString config_dir);
-    virtual ~Prefs();
+    ~Prefs() override;
 
     bool isCore(int key) const
     {

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -204,8 +204,6 @@ private:
     void set(int key, char const* value) = delete;
 
     QString const config_dir_;
-    std::array<std::pair<int, QString>, FilterMode::NUM_MODES> const FilterModes;
-    std::array<std::pair<int, QString>, SortMode::NUM_MODES> const SortModes;
 
     QSet<int> temporary_prefs_;
     QVariant mutable values_[PREFS_COUNT];

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -13,6 +13,7 @@
 #include "Torrent.h"
 #include "TorrentModel.h"
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool RelocateDialog::move_flag = true;
 
 void RelocateDialog::onSetLocation()

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -144,7 +144,7 @@ void RpcClient::sendNetworkRequest(TrVariantPtr json, QFutureInterface<RpcRespon
     }
 
     size_t raw_json_data_length;
-    char* raw_json_data = tr_variantToStr(json.get(), TR_VARIANT_FMT_JSON_LEAN, &raw_json_data_length);
+    auto* raw_json_data = tr_variantToStr(json.get(), TR_VARIANT_FMT_JSON_LEAN, &raw_json_data_length);
     QByteArray json_data(raw_json_data, raw_json_data_length);
     tr_free(raw_json_data);
 

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -10,12 +10,8 @@
 
 #include "RpcQueue.h"
 
-namespace
-{
-
-auto next_tag = RpcQueue::Tag {};
-
-}
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+RpcQueue::Tag RpcQueue::next_tag = {};
 
 RpcQueue::RpcQueue(QObject* parent) :
     QObject(parent),

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -145,6 +145,7 @@ private:
 
 private:
     Tag const tag_;
+    static Tag next_tag;
     bool tolerate_errors_ = {};
     QFutureInterface<RpcResponse> promise_;
     QQueue<QPair<QueuedFunction, ErrorHandlerFunction>> queue_;

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -41,7 +41,7 @@ class Session : public QObject
 
 public:
     Session(QString config_dir, Prefs& prefs);
-    virtual ~Session();
+    ~Session() override;
 
     void stop();
     void restart();

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -28,13 +28,6 @@ enum
     BAR_HEIGHT = 12
 };
 
-QColor TorrentDelegate::green_brush;
-QColor TorrentDelegate::blue_brush;
-QColor TorrentDelegate::silver_brush;
-QColor TorrentDelegate::green_back;
-QColor TorrentDelegate::blue_back;
-QColor TorrentDelegate::silver_back;
-
 namespace
 {
 
@@ -127,19 +120,16 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QString progress_
 } // namespace
 
 TorrentDelegate::TorrentDelegate(QObject* parent) :
-    QStyledItemDelegate(parent)
+    QStyledItemDelegate{parent},
+    blue_back{"lightgrey"},
+    blue_brush{"steelblue"},
+    green_back{"darkseagreen"},
+    green_brush{"forestgreen"},
+    silver_back{"grey"},
+    silver_brush{"silver"}
 {
     progress_bar_style_.minimum = 0;
     progress_bar_style_.maximum = 1000;
-
-    green_brush = QColor("forestgreen");
-    green_back = QColor("darkseagreen");
-
-    blue_brush = QColor("steelblue");
-    blue_back = QColor("lightgrey");
-
-    silver_brush = QColor("silver");
-    silver_back = QColor("grey");
 }
 
 /***

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -45,12 +45,12 @@ protected:
     static QString shortStatusString(Torrent const& tor);
     static QString shortTransferString(Torrent const& tor);
 
-    static QColor blue_brush;
-    static QColor green_brush;
-    static QColor silver_brush;
-    static QColor blue_back;
-    static QColor green_back;
-    static QColor silver_back;
+    QColor const blue_back;
+    QColor const blue_brush;
+    QColor const green_back;
+    QColor const green_brush;
+    QColor const silver_back;
+    QColor const silver_brush;
 
     mutable QStyleOptionProgressBar progress_bar_style_ = {};
 

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -38,7 +38,7 @@ public:
     };
 
     explicit TorrentModel(Prefs const& prefs);
-    virtual ~TorrentModel() override;
+    ~TorrentModel() override;
     void clear();
 
     bool hasTorrent(TorrentHash const& hash) const;

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -185,11 +185,8 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
 
     // hostname
     str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
-    char* host = nullptr;
-    int port = 0;
-    tr_urlParse(inf.st.announce.toUtf8().constData(), TR_BAD_SIZE, nullptr, &host, &port, nullptr);
-    str += QStringLiteral("%1:%2").arg(QString::fromUtf8(host)).arg(port);
-    tr_free(host);
+    auto const url = QUrl(inf.st.announce);
+    str += QStringLiteral("%1:%2").arg(url.host()).arg(url.port(80));
 
     if (!key.isEmpty())
     {

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -19,6 +19,7 @@ Checks: >
   -clang-diagnostic-sign-conversion,
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-narrowing-conversions,


### PR DESCRIPTION
This PR fixes some warnings that I found when test-driving clang-tidy-11 on Transmission.