### PR TITLE
feat: filter textfield now understands regexes

### DIFF
--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
+#include <QRegExp>
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
@@ -49,6 +51,7 @@ private slots:
     void refilter();
 
 private:
+    std::optional<QRegExp> regex_;
     QTimer refilter_timer_;
     Prefs const& prefs_;
 };

--- a/web/javascript/dialog.js
+++ b/web/javascript/dialog.js
@@ -87,7 +87,9 @@ Dialog.prototype = {
         this._callback = callback;
         $('body').addClass('dialog_showing');
         this._container.show();
-        transmission.updateButtonStates();
+        if (transmission) {
+            transmission.updateButtonStates();
+        }
         if (isMobileDevice) {
             transmission.hideMobileAddressbar();
         };

--- a/web/javascript/torrent.js
+++ b/web/javascript/torrent.js
@@ -461,13 +461,13 @@ Torrent.prototype = {
      * @param search substring to look for, or null
      * @return true if it passes the test, false if it fails
      */
-    test: function (state, search, tracker) {
+    test: function (state, regex, tracker) {
         // flter by state...
         var pass = this.testState(state);
 
         // maybe filter by text...
-        if (pass && search && search.length) {
-            pass = this.getCollatedName().indexOf(search.toLowerCase()) !== -1;
+        if (pass && regex) {
+            pass = regex.test(this.getCollatedName());
         };
 
         // maybe filter by tracker...


### PR DESCRIPTION
The Qt, GTK, and web clients now support filtering torrent names with regular expressions.