### PR TITLE
fix: Coverity warnings

### DIFF
--- a/libtransmission/announcer-udp.c
+++ b/libtransmission/announcer-udp.c
@@ -530,7 +530,7 @@ static void tau_tracker_send_request(struct tau_tracker* tracker, void const* pa
     dbgmsg(tracker->key, "sending request w/connection id %" PRIu64 "\n", tracker->connection_id);
     evbuffer_add_hton_64(buf, tracker->connection_id);
     evbuffer_add_reference(buf, payload, payload_len, NULL, NULL);
-    (void) tau_sendto(tracker->session, tracker->addr, tracker->port, evbuffer_pullup(buf, -1), evbuffer_get_length(buf));
+    (void)tau_sendto(tracker->session, tracker->addr, tracker->port, evbuffer_pullup(buf, -1), evbuffer_get_length(buf));
     evbuffer_free(buf);
 }
 

--- a/libtransmission/announcer-udp.c
+++ b/libtransmission/announcer-udp.c
@@ -530,7 +530,7 @@ static void tau_tracker_send_request(struct tau_tracker* tracker, void const* pa
     dbgmsg(tracker->key, "sending request w/connection id %" PRIu64 "\n", tracker->connection_id);
     evbuffer_add_hton_64(buf, tracker->connection_id);
     evbuffer_add_reference(buf, payload, payload_len, NULL, NULL);
-    tau_sendto(tracker->session, tracker->addr, tracker->port, evbuffer_pullup(buf, -1), evbuffer_get_length(buf));
+    (void) tau_sendto(tracker->session, tracker->addr, tracker->port, evbuffer_pullup(buf, -1), evbuffer_get_length(buf));
     evbuffer_free(buf);
 }
 

--- a/libtransmission/bitfield.c
+++ b/libtransmission/bitfield.c
@@ -410,8 +410,13 @@ void tr_bitfieldAdd(tr_bitfield* b, size_t nth)
 {
     if (!tr_bitfieldHas(b, nth) && tr_bitfieldEnsureNthBitAlloced(b, nth))
     {
-        b->bits[nth >> 3U] |= 0x80 >> (nth & 7U);
-        tr_bitfieldIncTrueCount(b, 1);
+        size_t const offset = nth >> 3U;
+
+        if ((b->bits != NULL) && (offset < b->alloc_count))
+        {
+            b->bits[offset] |= 0x80 >> (nth & 7U);
+            tr_bitfieldIncTrueCount(b, 1);
+        }
     }
 }
 

--- a/libtransmission/makemeta.c
+++ b/libtransmission/makemeta.c
@@ -292,7 +292,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
         {
             uint64_t const n_this_pass = MIN(b->files[fileIndex].size - off, leftInPiece);
             uint64_t n_read = 0;
-            tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, NULL);
+            (void) tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, NULL);
             bufptr += n_read;
             off += n_read;
             leftInPiece -= n_read;

--- a/libtransmission/makemeta.c
+++ b/libtransmission/makemeta.c
@@ -292,7 +292,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
         {
             uint64_t const n_this_pass = MIN(b->files[fileIndex].size - off, leftInPiece);
             uint64_t n_read = 0;
-            (void) tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, NULL);
+            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, NULL);
             bufptr += n_read;
             off += n_read;
             leftInPiece -= n_read;

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -3124,8 +3124,13 @@ static void rechokeDownloads(tr_swarm* s)
         tr_free(piece_is_interesting);
     }
 
+    if ((rechoke != NULL) && (rechoke_count > 0))
+    {
+        qsort(rechoke, rechoke_count, sizeof(struct tr_rechoke_info), compare_rechoke_info);
+    }
+
     /* now that we know which & how many peers to be interested in... update the peer interest */
-    qsort(rechoke, rechoke_count, sizeof(struct tr_rechoke_info), compare_rechoke_info);
+
     s->interestedCount = MIN(maxPeers, rechoke_count);
 
     for (int i = 0; i < rechoke_count; ++i)

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -996,14 +996,17 @@ static void pieceListSort(tr_swarm* s, enum piece_sort_state state)
 {
     TR_ASSERT(state == PIECES_SORTED_BY_INDEX || state == PIECES_SORTED_BY_WEIGHT);
 
-    if (state == PIECES_SORTED_BY_WEIGHT)
+    if ((s->pieceCount > 0) && (s->pieces != NULL))
     {
-        setComparePieceByWeightTorrent(s);
-        qsort(s->pieces, s->pieceCount, sizeof(struct weighted_piece), comparePieceByWeight);
-    }
-    else
-    {
-        qsort(s->pieces, s->pieceCount, sizeof(struct weighted_piece), comparePieceByIndex);
+        if (state == PIECES_SORTED_BY_WEIGHT)
+        {
+            setComparePieceByWeightTorrent(s);
+            qsort(s->pieces, s->pieceCount, sizeof(struct weighted_piece), comparePieceByWeight);
+        }
+        else
+        {
+            qsort(s->pieces, s->pieceCount, sizeof(struct weighted_piece), comparePieceByIndex);
+        }
     }
 
     s->pieceSortState = state;

--- a/libtransmission/platform.c
+++ b/libtransmission/platform.c
@@ -595,10 +595,10 @@ char const* tr_getWebClientDir(tr_session const* session)
 
             /* XDG_DATA_DIRS are the backup directories */
             {
-                char const* pkg = PACKAGE_DATA_DIR;
+                char const* const pkg = PACKAGE_DATA_DIR;
                 char* xdg = tr_env_get_string("XDG_DATA_DIRS", NULL);
                 char const* fallback = "/usr/local/share:/usr/share";
-                char* buf = tr_strdup_printf("%s:%s:%s", pkg != NULL ? pkg : "", xdg != NULL ? xdg : "", fallback);
+                char* buf = tr_strdup_printf("%s:%s:%s", pkg, xdg != NULL ? xdg : "", fallback);
                 tr_free(xdg);
                 tmp = buf;
 

--- a/libtransmission/ptrarray.c
+++ b/libtransmission/ptrarray.c
@@ -171,7 +171,11 @@ int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, tr_voidptr_comp
 
 static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, tr_voidptr_compare_func compare)
 {
-    for (int i = 0; i < t->n_items - 2; ++i)
+    if (t->items == NULL)
+    {
+        TR_ASSERT(t->n_items == 0);
+    }
+    else for (int i = 0; i < t->n_items - 2; ++i)
     {
         TR_ASSERT(compare(t->items[i], t->items[i + 1]) < 0);
     }

--- a/libtransmission/ptrarray.c
+++ b/libtransmission/ptrarray.c
@@ -175,9 +175,12 @@ static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, tr_voidptr_compar
     {
         TR_ASSERT(t->n_items == 0);
     }
-    else for (int i = 0; i < t->n_items - 2; ++i)
+    else
     {
-        TR_ASSERT(compare(t->items[i], t->items[i + 1]) < 0);
+        for (int i = 0; i < t->n_items - 2; ++i)
+        {
+            TR_ASSERT(compare(t->items[i], t->items[i + 1]) < 0);
+        }
     }
 }
 

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -1583,16 +1583,15 @@ static char const* torrentRenamePath(tr_session* session, tr_variant* args_in, t
 {
     TR_UNUSED(args_out);
 
-    int torrentCount;
-    tr_torrent** torrents;
-    char const* oldpath = NULL;
-    char const* newname = NULL;
     char const* errmsg = NULL;
 
-    tr_variantDictFindStr(args_in, TR_KEY_path, &oldpath, NULL);
-    tr_variantDictFindStr(args_in, TR_KEY_name, &newname, NULL);
-    torrents = getTorrents(session, args_in, &torrentCount);
+    char const* oldpath = NULL;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_path, &oldpath, NULL);
+    char const* newname = NULL;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_name, &newname, NULL);
 
+    int torrentCount = 0;
+    tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
     if (torrentCount == 1)
     {
         tr_torrentRenamePath(torrents[0], oldpath, newname, torrentRenamePathDone, idle_data);
@@ -1897,10 +1896,10 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
     TR_ASSERT(idle_data != NULL);
 
     char const* filename = NULL;
-    char const* metainfo_base64 = NULL;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_filename, &filename, NULL);
 
-    tr_variantDictFindStr(args_in, TR_KEY_filename, &filename, NULL);
-    tr_variantDictFindStr(args_in, TR_KEY_metainfo, &metainfo_base64, NULL);
+    char const* metainfo_base64 = NULL;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_metainfo, &metainfo_base64, NULL);
 
     if (filename == NULL && metainfo_base64 == NULL)
     {
@@ -1920,12 +1919,12 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
     int64_t i;
     bool boolVal;
     tr_variant* l;
-    char const* cookies = NULL;
     tr_ctor* ctor = tr_ctorNew(session);
 
     /* set the optional arguments */
 
-    tr_variantDictFindStr(args_in, TR_KEY_cookies, &cookies, NULL);
+    char const* cookies = NULL;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_cookies, &cookies, NULL);
 
     if (download_dir != NULL)
     {

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -981,9 +981,9 @@ static void sessionSetImpl(void* vdata)
 
     free_incoming_peer_port(session);
 
-    tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, NULL);
-
-    if (!tr_address_from_string(&b.addr, str) || b.addr.type != TR_AF_INET)
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, NULL) ||
+        !tr_address_from_string(&b.addr, str) ||
+        b.addr.type != TR_AF_INET)
     {
         b.addr = tr_inaddr_any;
     }
@@ -991,9 +991,9 @@ static void sessionSetImpl(void* vdata)
     b.socket = TR_BAD_SOCKET;
     session->public_ipv4 = tr_memdup(&b, sizeof(struct tr_bindinfo));
 
-    tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, NULL);
-
-    if (!tr_address_from_string(&b.addr, str) || b.addr.type != TR_AF_INET6)
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, NULL) ||
+        !tr_address_from_string(&b.addr, str) ||
+        b.addr.type != TR_AF_INET6)
     {
         b.addr = tr_in6addr_any;
     }
@@ -2692,15 +2692,13 @@ static void metainfoLookupInit(tr_session* session)
 
 char const* tr_sessionFindTorrentFile(tr_session const* session, char const* hashString)
 {
-    char const* filename = NULL;
-
     if (session->metainfoLookup == NULL)
     {
         metainfoLookupInit((tr_session*)session);
     }
 
-    tr_variantDictFindStr(session->metainfoLookup, tr_quark_new(hashString, TR_BAD_SIZE), &filename, NULL);
-
+    char const* filename = NULL;
+    (void)tr_variantDictFindStr(session->metainfoLookup, tr_quark_new(hashString, TR_BAD_SIZE), &filename, NULL);
     return filename;
 }
 

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -13,8 +13,6 @@
 
 #include <event2/buffer.h>
 
-#include "ConvertUTF.h"
-
 #define LIBTRANSMISSION_VARIANT_MODULE
 
 #include "transmission.h"

--- a/libtransmission/variant-json.c
+++ b/libtransmission/variant-json.c
@@ -560,12 +560,12 @@ static void jsonStringFunc(tr_variant const* val, void* vdata)
     char* outend;
     struct evbuffer_iovec vec[1];
     struct jsonWalk* data = vdata;
-    char const* str;
-    size_t len;
     unsigned char const* it;
     unsigned char const* end;
 
-    tr_variantGetStr(val, &str, &len);
+    char const* str = NULL;
+    size_t len = 0;
+    (void) tr_variantGetStr(val, &str, &len);
     it = (unsigned char const*)str;
     end = it + len;
 

--- a/libtransmission/variant-json.c
+++ b/libtransmission/variant-json.c
@@ -565,7 +565,7 @@ static void jsonStringFunc(tr_variant const* val, void* vdata)
 
     char const* str = NULL;
     size_t len = 0;
-    (void) tr_variantGetStr(val, &str, &len);
+    (void)tr_variantGetStr(val, &str, &len);
     it = (unsigned char const*)str;
     end = it + len;
 

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -34,7 +34,6 @@
 #define LIBTRANSMISSION_VARIANT_MODULE
 
 #include "transmission.h"
-#include "ConvertUTF.h"
 #include "error.h"
 #include "file.h"
 #include "log.h"

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -1007,7 +1007,7 @@ static void tr_variantListCopy(tr_variant* target, tr_variant const* src)
         {
             size_t len = 0;
             char const* str = NULL;
-            (void) tr_variantGetStr(val, &str, &len);
+            (void)tr_variantGetStr(val, &str, &len);
             tr_variantListAddRaw(target, str, len);
         }
         else if (tr_variantIsDict(val))
@@ -1087,7 +1087,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             {
                 size_t len = 0;
                 char const* str = NULL;
-                (void) tr_variantGetStr(val, &str, &len);
+                (void)tr_variantGetStr(val, &str, &len);
                 tr_variantDictAddRaw(target, key, str, len);
             }
             else if (tr_variantIsDict(val) && tr_variantDictFindDict(target, key, &t))

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -1006,9 +1006,9 @@ static void tr_variantListCopy(tr_variant* target, tr_variant const* src)
         }
         else if (tr_variantIsString(val))
         {
-            size_t len;
-            char const* str;
-            tr_variantGetStr(val, &str, &len);
+            size_t len = 0;
+            char const* str = NULL;
+            (void) tr_variantGetStr(val, &str, &len);
             tr_variantListAddRaw(target, str, len);
         }
         else if (tr_variantIsDict(val))
@@ -1086,9 +1086,9 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             }
             else if (tr_variantIsString(val))
             {
-                size_t len;
-                char const* str;
-                tr_variantGetStr(val, &str, &len);
+                size_t len = 0;
+                char const* str = NULL;
+                (void) tr_variantGetStr(val, &str, &len);
                 tr_variantDictAddRaw(target, key, str, len);
             }
             else if (tr_variantIsDict(val) && tr_variantDictFindDict(target, key, &t))


### PR DESCRIPTION
A handful of small changes to address some Coverity warnings.

Common threads:

* Cast return values of called functions to `(void)` to explicitly ignore return value
* Add extra `NULL` safeguards before calling `qsort()`
* Ensure variables are always initialized in a way that can be understood by static analysis