### PR TITLE
Sonarcloud warnings 3

### DIFF
--- a/macosx/TransmissionHelp/html/Index2.html
+++ b/macosx/TransmissionHelp/html/Index2.html
@@ -6,6 +6,10 @@
 	<meta name="keywords" content="index">
 	<meta name="description" content="Index">
 	<link href="../styles/indexpage.css" type="text/css" rel="stylesheet" media="all">
+	<style>
+		li { padding: 10px; }
+		ul { list-style: none; padding-inline-start: 0; }
+	</style>
 </head>
 
 <body>
@@ -21,94 +25,22 @@
 	</div>
 
 	<div id="terms">
-		<table style="width: 100%; border-width: 0; padding: 0">
-			<tr>
-                        	<th style="font: Lucida grande, arial, sans-serif"><strong>Index</strong></th>
-			</tr>
-			<tr>
-				<td class="blue">
-					<p><a href="pffirewall.html">Firewall</a></p>
-				</td>
-			</tr>
-			
-			<tr>
-				<td class="blue">
-					<p><a href="FAQ.html">Frequently Asked Questions</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="gettingstarted.html">Getting Started</a></p>
-				</td>
-			</tr>
-			
-			<tr>
-				<td class="blue">
-					<p><a href="usingt.html">Managing your transfers</a></p>
-				</td>
-			</tr>
-			<tr>
-				<td class="blue">
-					<p><a href="check.html">Manual torrent verification</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="Speed.html">Maximizing download speed</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="network.html">Network preferences</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="peers.html">Peer preferences</a></p>
-				</td>
-			</tr>
-			
-			<tr>
-				<td class="blue">
-					<p><a href="portforward.html">Port Forwarding FAQ</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="remote.html">Remote</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="scripts.html">Running Scripts</a></p>
-				</td>
-			</tr>
-			
-			<tr>
-				<td class="blue">
-					<p><a href="pfrouter.html">Router</a></p>
-				</td>
-			</tr>
-
-			<tr>
-				<td class="blue">
-					<p><a href="tracker.html">Tracker information</a></p>
-				</td>
-			</tr>
-			
-			<tr>
-				<td class="blue">
-					<p><a href="troubleshoot.html">Troubleshooting port issues</a></p>
-				</td>
-			</tr>
-			
-		</table>
+		<ul>
+			<li><a href="pffirewall.html">Firewall</a></li>
+			<li><a href="FAQ.html">Frequently Asked Questions</a></li>
+			<li><a href="gettingstarted.html">Getting Started</a></li>
+			<li><a href="usingt.html">Managing your transfers</a></li>
+			<li><a href="check.html">Manual torrent verification</a></li>
+			<li><a href="Speed.html">Maximizing download speed</a></li>
+			<li><a href="network.html">Network preferences</a></li>
+			<li><a href="peers.html">Peer preferences</a></li>
+			<li><a href="portforward.html">Port Forwarding FAQ</a></li>
+			<li><a href="remote.html">Remote</a></li>
+			<li><a href="scripts.html">Running Scripts</a></li>
+			<li><a href="pfrouter.html">Router</a></li>
+			<li><a href="tracker.html">Tracker information</a></li>
+			<li><a href="troubleshoot.html">Troubleshooting port issues</a></li>
+		</ul>
 	</div>
 </body>
 </html>

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -23,12 +23,10 @@ AboutDialog::AboutDialog(QWidget* parent) :
 {
     ui_.setupUi(this);
 
-    ui_.iconLabel->setPixmap(qApp->windowIcon().pixmap(48));
+    ui_.iconLabel->setPixmap(QApplication::windowIcon().pixmap(48));
     ui_.titleLabel->setText(tr("<b style='font-size:x-large'>Transmission %1</b>").arg(QStringLiteral(LONG_VERSION_STRING)));
 
-    QPushButton* b;
-
-    b = ui_.dialogButtons->addButton(tr("C&redits"), QDialogButtonBox::ActionRole);
+    QPushButton const* b = ui_.dialogButtons->addButton(tr("C&redits"), QDialogButtonBox::ActionRole);
     connect(b, &QAbstractButton::clicked, this, &AboutDialog::showCredits);
 
     b = ui_.dialogButtons->addButton(tr("&License"), QDialogButtonBox::ActionRole);

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -15,6 +15,29 @@
 #include "AddData.h"
 #include "Utils.h"
 
+namespace
+{
+
+QString getNameFromMetainfo(QByteArray const& metainfo)
+{
+    QString name;
+
+    tr_ctor* ctor = tr_ctorNew(nullptr);
+    tr_ctorSetMetainfo(ctor, metainfo.constData(), metainfo.size());
+
+    tr_info inf;
+    if (tr_torrentParse(ctor, &inf) == TR_PARSE_OK)
+    {
+        name = QString::fromUtf8(inf.name); // metainfo is required to be UTF-8
+        tr_metainfoFree(&inf);
+    }
+
+    tr_ctorFree(ctor);
+    return name;
+}
+
+} // anonymous namespace
+
 int AddData::set(QString const& key)
 {
     if (Utils::isMagnetLink(key))
@@ -79,41 +102,23 @@ QByteArray AddData::toBase64() const
 
 QString AddData::readableName() const
 {
-    QString ret;
-
     switch (type)
     {
     case FILENAME:
-        ret = filename;
-        break;
+        return filename;
 
     case MAGNET:
-        ret = magnet;
-        break;
+        return magnet;
 
     case URL:
-        ret = url.toString();
-        break;
+        return url.toString();
 
     case METAINFO:
-        {
-            tr_info inf;
-            tr_ctor* ctor = tr_ctorNew(nullptr);
+        return getNameFromMetainfo(metainfo);
 
-            tr_ctorSetMetainfo(ctor, metainfo.constData(), metainfo.size());
-
-            if (tr_torrentParse(ctor, &inf) == TR_PARSE_OK)
-            {
-                ret = QString::fromUtf8(inf.name); // metainfo is required to be UTF-8
-                tr_metainfoFree(&inf);
-            }
-
-            tr_ctorFree(ctor);
-            break;
-        }
+    default: // NONE
+        return {};
     }
-
-    return ret;
 }
 
 QString AddData::readableShortName() const

--- a/qt/AddData.h
+++ b/qt/AddData.h
@@ -24,7 +24,6 @@ public:
         METAINFO
     };
 
-public:
     AddData() = default;
 
     explicit AddData(QString const& str)

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -640,5 +640,5 @@ int tr_main(int argc, char** argv)
     Application::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     Application app(argc, argv);
-    return app.exec();
+    return QApplication::exec();
 }

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -382,7 +382,7 @@ void Application::loadTranslations()
     }
 }
 
-void Application::quitLater()
+void Application::quitLater() const
 {
     QTimer::singleShot(0, this, SLOT(quit()));
 }
@@ -405,21 +405,21 @@ QStringList Application::getNames(torrent_ids_t const& ids) const
     return names;
 }
 
-void Application::onTorrentsAdded(torrent_ids_t const& ids)
+void Application::onTorrentsAdded(torrent_ids_t const& ids) const
 {
     if (prefs_->getBool(Prefs::SHOW_NOTIFICATION_ON_ADD))
     {
-        auto const title = tr("Torrent(s) Added", nullptr, ids.size());
+        auto const title = tr("Torrent(s) Added", nullptr, static_cast<int>(ids.size()));
         auto const body = getNames(ids).join(QStringLiteral("\n"));
         notifyApp(title, body);
     }
 }
 
-void Application::onTorrentsCompleted(torrent_ids_t const& ids)
+void Application::onTorrentsCompleted(torrent_ids_t const& ids) const
 {
     if (prefs_->getBool(Prefs::SHOW_NOTIFICATION_ON_COMPLETE))
     {
-        auto const title = tr("Torrent Completed", nullptr, ids.size());
+        auto const title = tr("Torrent Completed", nullptr, static_cast<int>(ids.size()));
         auto const body = getNames(ids).join(QStringLiteral("\n"));
         notifyApp(title, body);
     }
@@ -490,12 +490,9 @@ void Application::refreshPref(int key)
 
     case Prefs::DIR_WATCH:
     case Prefs::DIR_WATCH_ENABLED:
-        {
-            QString const path(prefs_->getString(Prefs::DIR_WATCH));
-            bool const is_enabled(prefs_->getBool(Prefs::DIR_WATCH_ENABLED));
-            watch_dir_->setPath(path, is_enabled);
-            break;
-        }
+        watch_dir_->setPath(prefs_->getString(Prefs::DIR_WATCH),
+            prefs_->getBool(Prefs::DIR_WATCH_ENABLED));
+        break;
 
     default:
         break;

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -49,8 +49,8 @@ public slots:
 private slots:
     void consentGiven(int result);
     void onSessionSourceChanged();
-    void onTorrentsAdded(torrent_ids_t const& torrents);
-    void onTorrentsCompleted(torrent_ids_t const& torrents);
+    void onTorrentsAdded(torrent_ids_t const& torrents) const;
+    void onTorrentsCompleted(torrent_ids_t const& torrents) const;
     void onTorrentsEdited(torrent_ids_t const& torrents);
     void onTorrentsNeedInfo(torrent_ids_t const& torrents);
     void refreshPref(int key);
@@ -60,7 +60,7 @@ private:
     void maybeUpdateBlocklist();
     void loadTranslations();
     QStringList getNames(torrent_ids_t const& ids) const;
-    void quitLater();
+    void quitLater() const;
 
     Prefs* prefs_ = {};
     Session* session_ = {};
@@ -75,8 +75,8 @@ private:
     QTranslator app_translator_;
     FaviconCache favicons_;
 
-    QString const config_name_;
-    QString const display_name_;
+    QString const config_name_ = QStringLiteral("transmission");
+    QString const display_name_ = QStringLiteral("transmission-qt");
 
     std::unordered_set<QString> interned_strings_;
 };

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -14,7 +14,7 @@
 namespace
 {
 
-int itemColumnSpan(QGridLayout* layout, QLayoutItem const* item)
+int itemColumnSpan(QGridLayout const* layout, QLayoutItem const* item)
 {
     for (int i = 0, count = layout->count(); i < count; ++i)
     {
@@ -59,15 +59,15 @@ bool ColumnResizer::eventFilter(QObject* object, QEvent* event)
     return QObject::eventFilter(object, event);
 }
 
-void ColumnResizer::update()
+void ColumnResizer::update() const
 {
     int max_width = 0;
 
-    for (QGridLayout* const layout : layouts_)
+    for (QGridLayout const* const layout : layouts_)
     {
         for (int i = 0, count = layout->rowCount(); i < count; ++i)
         {
-            QLayoutItem* item = layout->itemAtPosition(i, 0);
+            QLayoutItem const* const item = layout->itemAtPosition(i, 0);
 
             if (item == nullptr || itemColumnSpan(layout, item) > 1)
             {

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -30,7 +30,7 @@ public:
     bool eventFilter(QObject* object, QEvent* event) override;
 
 public slots:
-    void update();
+    void update() const;
 
 private:
     void scheduleUpdate();

--- a/qt/CustomVariantType.h
+++ b/qt/CustomVariantType.h
@@ -16,7 +16,7 @@ public:
     enum
     {
         TrackerStatsList = QVariant::UserType,
-        PeerList = QVariant::UserType,
+        PeerList,
         FileList,
         FilterModeType,
         SortModeType

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -410,7 +410,7 @@ void DetailsDialog::refreshUI()
     QString const none = tr("None");
     QString const mixed = tr("Mixed");
     QString const unknown = tr("Unknown");
-    auto const now = time_t(nullptr);
+    auto const now = time(nullptr);
 
     // build a list of torrents
     for (int const id : ids_)

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -71,7 +71,7 @@ enum // peer columns
     N_COLUMNS
 };
 
-int measureViewItem(QTreeWidget* view, int column, QString const& text)
+int measureViewItem(QTreeWidget const* view, int column, QString const& text)
 {
     QTreeWidgetItem const* header_item = view->headerItem();
 
@@ -79,6 +79,41 @@ int measureViewItem(QTreeWidget* view, int column, QString const& text)
     int const header_width = Utils::measureHeaderItem(view->header(), header_item->text(column));
 
     return std::max(item_width, header_width);
+}
+
+QString collateAddress(QString const& address)
+{
+    QString collated;
+
+    QHostAddress ip_address;
+    if (ip_address.setAddress(address))
+    {
+        if (ip_address.protocol() == QAbstractSocket::IPv4Protocol)
+        {
+            quint32 const ipv4_address = ip_address.toIPv4Address();
+            collated = QStringLiteral("1-") +
+                QString::fromUtf8(QByteArray::number(ipv4_address, 16).rightJustified(8, '0'));
+        }
+        else if (ip_address.protocol() == QAbstractSocket::IPv6Protocol)
+        {
+            Q_IPV6ADDR const ipv6_address = ip_address.toIPv6Address();
+            QByteArray tmp(16, '\0');
+
+            for (int i = 0; i < 16; ++i)
+            {
+                tmp[i] = ipv6_address[i];
+            }
+
+            collated = QStringLiteral("2-") + QString::fromUtf8(tmp.toHex());
+        }
+    }
+
+    if (collated.isEmpty())
+    {
+        collated = QStringLiteral("3-") + address.toLower();
+    }
+
+    return collated;
 }
 
 } // namespace
@@ -117,7 +152,7 @@ public:
     bool operator <(QTreeWidgetItem const& other) const override
     {
         auto const* i = dynamic_cast<PeerItem const*>(&other);
-        QTreeWidget* tw(treeWidget());
+        auto const* tw = treeWidget();
         int const column = tw != nullptr ? tw->sortColumn() : 0;
 
         assert(i != nullptr);
@@ -152,34 +187,7 @@ private:
     {
         if (collated_address_.isEmpty())
         {
-            QHostAddress ip_address;
-
-            if (ip_address.setAddress(peer_.address))
-            {
-                if (ip_address.protocol() == QAbstractSocket::IPv4Protocol)
-                {
-                    quint32 const ipv4_address = ip_address.toIPv4Address();
-                    collated_address_ = QStringLiteral("1-") + QString::fromUtf8(QByteArray::number(ipv4_address, 16).
-                        rightJustified(8, '0'));
-                }
-                else if (ip_address.protocol() == QAbstractSocket::IPv6Protocol)
-                {
-                    Q_IPV6ADDR const ipv6_address = ip_address.toIPv6Address();
-                    QByteArray tmp(16, '\0');
-
-                    for (int i = 0; i < 16; ++i)
-                    {
-                        tmp[i] = ipv6_address[i];
-                    }
-
-                    collated_address_ = QStringLiteral("2-") + QString::fromUtf8(tmp.toHex());
-                }
-            }
-
-            if (collated_address_.isEmpty())
-            {
-                collated_address_ = QStringLiteral("3-") + peer_.address.toLower();
-            }
+            collated_address_ = collateAddress(peer_.address);
         }
 
         return collated_address_;
@@ -190,7 +198,7 @@ private:
 ****
 ***/
 
-QIcon DetailsDialog::getStockIcon(QString const& freedesktop_name, int fallback)
+QIcon DetailsDialog::getStockIcon(QString const& freedesktop_name, int fallback) const
 {
     QIcon icon = QIcon::fromTheme(freedesktop_name);
 
@@ -206,9 +214,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     BaseDialog(parent),
     session_(session),
     prefs_(prefs),
-    model_(model),
-    icon_encrypted_(QStringLiteral(":/icons/encrypted.png")),
-    icon_unencrypted_()
+    model_(model)
 {
     ui_.setupUi(this);
 
@@ -396,8 +402,7 @@ void setIfIdle(QSpinBox* spin, int value)
 
 void DetailsDialog::refreshUI()
 {
-    int const n = ids_.size();
-    bool const single = n == 1;
+    bool const single = ids_.size() == 1;
     QString const blank;
     QFontMetrics const fm(fontMetrics());
     QList<Torrent const*> torrents;
@@ -405,6 +410,7 @@ void DetailsDialog::refreshUI()
     QString const none = tr("None");
     QString const mixed = tr("Mixed");
     QString const unknown = tr("Unknown");
+    auto const now = time_t(nullptr);
 
     // build a list of torrents
     for (int const id : ids_)
@@ -644,7 +650,6 @@ void DetailsDialog::refreshUI()
         }
         else
         {
-            auto const now = time(nullptr);
             auto const seconds = int(std::difftime(now, baseline));
             string = Formatter::get().timeToString(seconds);
         }
@@ -706,7 +711,6 @@ void DetailsDialog::refreshUI()
             }
         }
 
-        auto const now = time(nullptr);
         auto const seconds = int(std::difftime(now, latest));
 
         if (seconds < 0)
@@ -1141,6 +1145,9 @@ void DetailsDialog::refreshUI()
 
                 case 'T':
                     txt = tr("Peer is connected over uTP");
+                    break;
+
+                default:
                     break;
                 }
 

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -54,7 +54,7 @@ private:
     void initFilesTab();
     void initOptionsTab();
 
-    QIcon getStockIcon(QString const& freedesktop_name, int fallback);
+    QIcon getStockIcon(QString const& freedesktop_name, int fallback) const;
     void setEnabled(bool);
 
 private slots:
@@ -133,6 +133,6 @@ private:
 
     QMap<QString, QTreeWidgetItem*> peers_;
 
-    QIcon const icon_encrypted_;
-    QIcon const icon_unencrypted_;
+    QIcon const icon_encrypted_ = QIcon(QStringLiteral(":/icons/encrypted.png"));
+    QIcon const icon_unencrypted_ = {};
 };

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -41,7 +41,7 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
         return;
     }
 
-    QStyle* style(qApp->style());
+    QStyle* style = QApplication::style();
 
     painter->save();
     QItemDelegate::drawBackground(painter, option, index);
@@ -50,11 +50,11 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
     {
         QStyleOptionProgressBar p;
         p.state = option.state | QStyle::State_Small;
-        p.direction = qApp->layoutDirection();
+        p.direction = QApplication::layoutDirection();
         p.rect = option.rect;
         p.rect.setSize(QSize(option.rect.width() - 4, option.rect.height() - 8));
         p.rect.moveCenter(option.rect.center());
-        p.fontMetrics = qApp->fontMetrics();
+        p.fontMetrics = QApplication::fontMetrics();
         p.minimum = 0;
         p.maximum = 100;
         p.textAlignment = Qt::AlignCenter;

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -167,7 +167,7 @@ QVariant FileTreeItem::data(int column, int role) const
         {
             if (file_index_ < 0)
             {
-                value = qApp->style()->standardIcon(QStyle::SP_DirOpenIcon);
+                value = QApplication::style()->standardIcon(QStyle::SP_DirOpenIcon);
             }
             else
             {

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -34,7 +34,6 @@ public:
     };
 /* *INDENT-ON* */
 
-public:
     FileTreeItem(QString const& name = QString(), int file_index = -1, uint64_t size = 0) :
         name_(name),
         total_size_(size),

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -24,7 +24,12 @@
 #include "Formatter.h"
 #include "Utils.h"
 
-#define PRIORITY_KEY "priority"
+namespace
+{
+
+char const* const PriorityKey = "priority";
+
+}
 
 FileTreeView::FileTreeView(QWidget* parent, bool is_editable) :
     QTreeView(parent),
@@ -341,7 +346,7 @@ void FileTreeView::setSelectedItemsPriority()
 {
     auto* action = qobject_cast<QAction*>(sender());
     assert(action != nullptr);
-    model_->setPriority(selectedSourceRows(), action->property(PRIORITY_KEY).toInt());
+    model_->setPriority(selectedSourceRows(), action->property(PriorityKey).toInt());
 }
 
 bool FileTreeView::openSelectedItem()
@@ -390,9 +395,9 @@ void FileTreeView::initContextMenu()
     normal_priority_action_ = priority_menu_->addAction(FileTreeItem::tr("Normal"), this, SLOT(setSelectedItemsPriority()));
     low_priority_action_ = priority_menu_->addAction(FileTreeItem::tr("Low"), this, SLOT(setSelectedItemsPriority()));
 
-    high_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_HIGH);
-    normal_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_NORMAL);
-    low_priority_action_->setProperty(PRIORITY_KEY, TR_PRI_LOW);
+    high_priority_action_->setProperty(PriorityKey, TR_PRI_HIGH);
+    normal_priority_action_->setProperty(PriorityKey, TR_PRI_NORMAL);
+    low_priority_action_->setProperty(PriorityKey, TR_PRI_LOW);
 
     context_menu_->addSeparator();
 

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -51,7 +51,7 @@ FilterBarComboBox* FilterBar::createActivityCombo()
     model->appendRow(row);
 
     model->appendRow(new QStandardItem); // separator
-    delegate->setSeparator(model, model->index(1, 0));
+    FilterBarComboBoxDelegate::setSeparator(model, model->index(1, 0));
 
     row = new QStandardItem(QIcon::fromTheme(QStringLiteral("system-run")), tr("Active"));
     row->setData(FilterMode::SHOW_ACTIVE, ACTIVITY_ROLE);
@@ -196,7 +196,7 @@ FilterBarComboBox* FilterBar::createTrackerCombo(QStandardItemModel* model)
     model->appendRow(row);
 
     model->appendRow(new QStandardItem); // separator
-    delegate->setSeparator(model, model->index(1, 0));
+    FilterBarComboBoxDelegate::setSeparator(model, model->index(1, 0));
 
     c->setModel(model);
     return c;

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -70,7 +70,7 @@ QSize FilterBarComboBox::calculateSize(QSize const& text_size, QSize const& coun
     content_size.rwidth() += hmargin + text_size.width();
     content_size.rwidth() += hmargin + count_size.width();
 
-    return style()->sizeFromContents(QStyle::CT_ComboBox, &option, content_size, this).expandedTo(qApp->globalStrut());
+    return style()->sizeFromContents(QStyle::CT_ComboBox, &option, content_size, this).expandedTo(QApplication::globalStrut());
 }
 
 void FilterBarComboBox::paintEvent(QPaintEvent* e)

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -40,12 +40,6 @@ IconCache& IconCache::get()
     return singleton;
 }
 
-IconCache::IconCache() :
-    folder_icon_(QFileIconProvider().icon(QFileIconProvider::Folder)),
-    file_icon_(QFileIconProvider().icon(QFileIconProvider::File))
-{
-}
-
 QIcon IconCache::guessMimeIcon(QString const& filename, QIcon fallback) const
 {
     QIcon icon;

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -14,6 +14,7 @@
 
 #include <unordered_map>
 
+#include <QFileIconProvider>
 #include <QIcon>
 #include <QString>
 
@@ -36,11 +37,11 @@ public:
     QIcon getMimeTypeIcon(QString const& mime_type, bool multifile) const;
 
 protected:
-    IconCache();
+    IconCache() = default;
 
 private:
-    QIcon const folder_icon_;
-    QIcon const file_icon_;
+    QIcon const folder_icon_ = QFileIconProvider().icon(QFileIconProvider::Folder);
+    QIcon const file_icon_ = QFileIconProvider().icon(QFileIconProvider::File);
 
     mutable std::unordered_map<QString, QIcon> name_to_icon_;
     mutable std::unordered_map<QString, QIcon> name_to_emblem_icon_;

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -46,9 +46,14 @@
 #include "TorrentModel.h"
 #include "Utils.h"
 
-#define PREF_VARIANTS_KEY "pref-variants-list"
-#define STATS_MODE_KEY "stats-mode"
-#define SORT_MODE_KEY "sort-mode"
+namespace
+{
+
+char const* const PrefVariantsKey = "submenu";
+char const* const StatsModeKey = "stats-mode";
+char const* const SortModeKey = "sort-mode";
+
+}
 
 /**
  * This is a proxy-style for that forces it to be always disabled.
@@ -264,7 +269,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
 
     for (auto const& mode : sort_modes)
     {
-        mode.first->setProperty(SORT_MODE_KEY, mode.second);
+        mode.first->setProperty(SortModeKey, mode.second);
         action_group->addAction(mode.first);
     }
 
@@ -368,7 +373,7 @@ void MainWindow::onSessionSourceChanged()
 
 void MainWindow::onSetPrefs()
 {
-    QVariantList const p = sender()->property(PREF_VARIANTS_KEY).toList();
+    QVariantList const p = sender()->property(PrefVariantsKey).toList();
     assert(p.size() % 2 == 0);
 
     for (int i = 0, n = p.size(); i < n; i += 2)
@@ -411,14 +416,14 @@ QMenu* MainWindow::createOptionsMenu()
 
             off_action = menu->addAction(tr("Unlimited"));
             off_action->setCheckable(true);
-            off_action->setProperty(PREF_VARIANTS_KEY, QVariantList{ enabled_pref, false });
+            off_action->setProperty(PrefVariantsKey, QVariantList{ enabled_pref, false });
             action_group->addAction(off_action);
             connect(off_action, &QAction::triggered, this, qOverload<bool>(&MainWindow::onSetPrefs));
 
             on_action =
                 menu->addAction(tr("Limited at %1").arg(Formatter::get().speedToString(Speed::fromKBps(current_value))));
             on_action->setCheckable(true);
-            on_action->setProperty(PREF_VARIANTS_KEY, QVariantList{ pref, current_value, enabled_pref, true });
+            on_action->setProperty(PrefVariantsKey, QVariantList{ pref, current_value, enabled_pref, true });
             action_group->addAction(on_action);
             connect(on_action, &QAction::triggered, this, qOverload<bool>(&MainWindow::onSetPrefs));
 
@@ -427,7 +432,7 @@ QMenu* MainWindow::createOptionsMenu()
             for (int const i : stock_speeds)
             {
                 QAction* action = menu->addAction(Formatter::get().speedToString(Speed::fromKBps(i)));
-                action->setProperty(PREF_VARIANTS_KEY, QVariantList{ pref, i, enabled_pref, true });
+                action->setProperty(PrefVariantsKey, QVariantList{ pref, i, enabled_pref, true });
                 connect(action, &QAction::triggered, this, qOverload<>(&MainWindow::onSetPrefs));
             }
         };
@@ -442,13 +447,13 @@ QMenu* MainWindow::createOptionsMenu()
 
             off_action = menu->addAction(tr("Seed Forever"));
             off_action->setCheckable(true);
-            off_action->setProperty(PREF_VARIANTS_KEY, QVariantList{ enabled_pref, false });
+            off_action->setProperty(PrefVariantsKey, QVariantList{ enabled_pref, false });
             action_group->addAction(off_action);
             connect(off_action, &QAction::triggered, this, qOverload<bool>(&MainWindow::onSetPrefs));
 
             on_action = menu->addAction(tr("Stop at Ratio (%1)").arg(Formatter::get().ratioToString(current_value)));
             on_action->setCheckable(true);
-            on_action->setProperty(PREF_VARIANTS_KEY, QVariantList{ pref, current_value, enabled_pref, true });
+            on_action->setProperty(PrefVariantsKey, QVariantList{ pref, current_value, enabled_pref, true });
             action_group->addAction(on_action);
             connect(on_action, &QAction::triggered, this, qOverload<bool>(&MainWindow::onSetPrefs));
 
@@ -457,7 +462,7 @@ QMenu* MainWindow::createOptionsMenu()
             for (double const i : stock_ratios)
             {
                 QAction* action = menu->addAction(Formatter::get().ratioToString(i));
-                action->setProperty(PREF_VARIANTS_KEY, QVariantList{ pref, i, enabled_pref, true });
+                action->setProperty(PrefVariantsKey, QVariantList{ pref, i, enabled_pref, true });
                 connect(action, &QAction::triggered, this, qOverload<>(&MainWindow::onSetPrefs));
             }
         };
@@ -492,7 +497,7 @@ QMenu* MainWindow::createStatsModeMenu()
 
     for (auto const& mode : stats_modes)
     {
-        mode.first->setProperty(STATS_MODE_KEY, QString(mode.second));
+        mode.first->setProperty(StatsModeKey, QString(mode.second));
         action_group->addAction(mode.first);
         menu->addAction(mode.first);
     }
@@ -509,7 +514,7 @@ QMenu* MainWindow::createStatsModeMenu()
 
 void MainWindow::onSortModeChanged(QAction* action)
 {
-    prefs_.set(Prefs::SORT_MODE, SortMode(action->property(SORT_MODE_KEY).toInt()));
+    prefs_.set(Prefs::SORT_MODE, SortMode(action->property(SortModeKey).toInt()));
 }
 
 void MainWindow::setSortAscendingPref(bool b)
@@ -1026,7 +1031,7 @@ void MainWindow::reannounceSelected()
 
 void MainWindow::onStatsModeChanged(QAction* action)
 {
-    prefs_.set(Prefs::STATUSBAR_STATS, action->property(STATS_MODE_KEY).toString());
+    prefs_.set(Prefs::STATUSBAR_STATS, action->property(StatsModeKey).toString());
 }
 
 /**
@@ -1119,7 +1124,7 @@ void MainWindow::refreshPref(int key)
 
         for (QAction* action : action_group->actions())
         {
-            action->setChecked(str == action->property(STATS_MODE_KEY).toString());
+            action->setChecked(str == action->property(StatsModeKey).toString());
         }
 
         refreshSoon(REFRESH_STATUS_BAR);
@@ -1136,7 +1141,7 @@ void MainWindow::refreshPref(int key)
 
         for (QAction* action : action_group->actions())
         {
-            action->setChecked(i == action->property(SORT_MODE_KEY).toInt());
+            action->setChecked(i == action->property(SortModeKey).toInt());
         }
 
         break;

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -295,7 +295,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     menu->addSeparator();
     menu->addAction(ui_.action_Quit);
     tray_icon_.setContextMenu(menu);
-    tray_icon_.setIcon(QIcon::fromTheme(QStringLiteral("transmission-tray-icon"), qApp->windowIcon()));
+    tray_icon_.setIcon(QIcon::fromTheme(QStringLiteral("transmission-tray-icon"), QApplication::windowIcon()));
 
     connect(&prefs_, &Prefs::changed, this, &MainWindow::refreshPref);
     connect(ui_.action_ShowMainWindow, &QAction::triggered, this, &MainWindow::toggleWindows);
@@ -1089,7 +1089,7 @@ void MainWindow::toggleWindows(bool do_show)
 
         // activateWindow ();
         raise();
-        qApp->setActiveWindow(this);
+        QApplication::setActiveWindow(this);
     }
 }
 
@@ -1194,7 +1194,7 @@ void MainWindow::refreshPref(int key)
         b = prefs_.getBool(key);
         ui_.action_TrayIcon->setChecked(b);
         tray_icon_.setVisible(b);
-        qApp->setQuitOnLastWindowClosed(!b);
+        QApplication::setQuitOnLastWindowClosed(!b);
         refreshSoon(REFRESH_TRAY_ICON);
         break;
 
@@ -1288,11 +1288,11 @@ void MainWindow::openTorrent()
 
 void MainWindow::openURL()
 {
-    QString str = qApp->clipboard()->text(QClipboard::Selection);
+    QString str = QApplication::clipboard()->text(QClipboard::Selection);
 
     if (!AddData::isSupported(str))
     {
-        str = qApp->clipboard()->text(QClipboard::Clipboard);
+        str = QApplication::clipboard()->text(QClipboard::Clipboard);
     }
 
     if (!AddData::isSupported(str))
@@ -1331,12 +1331,12 @@ void MainWindow::addTorrent(AddData const& addMe, bool show_options)
     {
         auto* o = new OptionsDialog(session_, prefs_, addMe, this);
         o->show();
-        qApp->alert(o);
+        QApplication::alert(o);
     }
     else
     {
         session_.addTorrent(addMe);
-        qApp->alert(this);
+        QApplication::alert(this);
     }
 }
 

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -142,11 +142,6 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     torrent_delegate_(new TorrentDelegate(this)),
     torrent_delegate_min_(new TorrentDelegateMin(this)),
     network_timer_(this),
-    total_ratio_stats_mode_name_(QStringLiteral("total-ratio")),
-    total_transfer_stats_mode_name_(QStringLiteral("total-transfer")),
-    session_ratio_stats_mode_name_(QStringLiteral("session-ratio")),
-    session_transfer_stats_mode_name_(QStringLiteral("session-transfer")),
-    show_options_checkbox_name_(QStringLiteral("show-options-checkbox")),
     refresh_timer_(this)
 {
     setAcceptDrops(true);

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -180,12 +180,11 @@ private:
     QAction* alt_speed_action_ = {};
     QString error_message_;
 
-    QString const total_ratio_stats_mode_name_;
-    QString const total_transfer_stats_mode_name_;
-    QString const session_ratio_stats_mode_name_;
-    QString const session_transfer_stats_mode_name_;
-
-    QString const show_options_checkbox_name_;
+    QString const total_ratio_stats_mode_name_ = QStringLiteral("total-ratio");
+    QString const total_transfer_stats_mode_name_ = QStringLiteral("total-transfer");
+    QString const session_ratio_stats_mode_name_ = QStringLiteral("session-ratio");
+    QString const session_transfer_stats_mode_name_ = QStringLiteral("session-transfer");
+    QString const show_options_checkbox_name_ = QStringLiteral("show-options-checkbox");
 
     struct TransferStats
     {

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -32,7 +32,6 @@ using ::trqt::variant_helpers::listAdd;
 OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme, QWidget* parent) :
     BaseDialog(parent),
     add_(std::move(addme)),
-    verify_hash_(QCryptographicHash::Sha1),
     verify_button_(new QPushButton(tr("&Verify Local Data"), this)),
     session_(session),
     is_local_(session_.isLocal())

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -63,7 +63,8 @@ private slots:
 private:
     AddData add_;
     FileList files_;
-    QCryptographicHash verify_hash_;
+    QCryptographicHash verify_hash_ = QCryptographicHash(QCryptographicHash::Sha1);
+
     QDir local_destination_;
     QFile verify_file_;
     QPushButton* verify_button_ = {};

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -84,7 +84,8 @@ void PathButton::paintEvent(QPaintEvent* /*event*/)
     QStyleOptionToolButton option;
     initStyleOption(&option);
 
-    QSize const fake_content_size(qMax(100, qApp->globalStrut().width()), qMax(100, qApp->globalStrut().height()));
+    auto const& strut = QApplication::globalStrut();
+    QSize const fake_content_size(qMax(100, strut.width()), qMax(100, strut.height()));
     QSize const fake_size_hint = style()->sizeFromContents(QStyle::CT_ToolButton, &option, fake_content_size, this);
 
     int text_width = width() - (fake_size_hint.width() - fake_content_size.width()) - iconSize().width() - 6;

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -19,8 +19,7 @@
 #include "Utils.h"
 
 PathButton::PathButton(QWidget* parent) :
-    QToolButton(parent),
-    mode_(DirectoryMode)
+    QToolButton(parent)
 {
     setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed));
     setToolButtonStyle(Qt::ToolButtonTextBesideIcon);

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -57,5 +57,5 @@ private:
     QString name_filter_;
     QString path_;
     QString title_;
-    Mode mode_;
+    Mode mode_ = DirectoryMode;
 };

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -185,7 +185,7 @@ Prefs::Prefs(QString config_dir) :
 
     for (int i = 0; i < PREFS_COUNT; ++i)
     {
-        tr_variant* b(tr_variantDictFind(&top, Items[i].key));
+        tr_variant const* b = tr_variantDictFind(&top, Items[i].key);
 
         switch (Items[i].type)
         {

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -132,7 +132,6 @@ public:
         PREFS_COUNT
     };
 
-public:
     explicit Prefs(QString config_dir);
     ~Prefs() override;
 
@@ -206,7 +205,7 @@ private:
     QString const config_dir_;
 
     QSet<int> temporary_prefs_;
-    QVariant mutable values_[PREFS_COUNT];
+    std::array<QVariant, PREFS_COUNT> mutable values_;
 
     static std::array<PrefItem, PREFS_COUNT> const Items;
 };

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -133,7 +133,7 @@ void RpcClient::sendNetworkRequest(TrVariantPtr json, QFutureInterface<RpcRespon
     {
         QNetworkRequest request;
         request.setUrl(url_);
-        request.setRawHeader("User-Agent", (qApp->applicationName() + QLatin1Char('/') + QString::fromUtf8(
+        request.setRawHeader("User-Agent", (QApplication::applicationName() + QLatin1Char('/') + QString::fromUtf8(
             LONG_VERSION_STRING)).toUtf8());
         request.setRawHeader("Content-Type", "application/json; charset=UTF-8");
         if (!session_id_.isEmpty())

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -72,7 +72,7 @@ void RpcQueue::runNext(RpcResponseFuture const& response)
 
     RpcResponseFuture const old_future = future_watcher_.future();
 
-    while (true)
+    for (;;)
     {
         auto next = queue_.dequeue();
         next_error_handler_ = next.second;

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -61,10 +61,6 @@ private:
     // Internally stored error handler function. Takes the last response future and returns nothing.
     using ErrorHandlerFunction = std::function<void (RpcResponseFuture const&)>;
 
-private slots:
-    void stepFinished();
-
-private:
     void runNext(RpcResponseFuture const& response);
 
     // These overloads convert various forms of input closures to what we store internally.
@@ -143,7 +139,6 @@ private:
             };
     }
 
-private:
     Tag const tag_;
     static Tag next_tag;
     bool tolerate_errors_ = {};
@@ -151,4 +146,7 @@ private:
     QQueue<QPair<QueuedFunction, ErrorHandlerFunction>> queue_;
     ErrorHandlerFunction next_error_handler_;
     QFutureWatcher<RpcResponse> future_watcher_;
+
+private slots:
+    void stepFinished();
 };

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1167,7 +1167,7 @@ void Session::onDuplicatesTimer()
             d->setDetailedText(detail);
         }
 
-        d->connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
+        QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
         d->show();
     }
 }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -139,7 +139,7 @@ void Session::copyMagnetLinkToClipboard(int torrent_id)
                 auto const link = dictFind<QString>(child, TR_KEY_magnetLink);
                 if (link)
                 {
-                    qApp->clipboard()->setText(*link);
+                    QApplication::clipboard()->setText(*link);
                 }
             }
         });
@@ -518,8 +518,8 @@ void Session::torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath
             auto* d = new QMessageBox(QMessageBox::Information, tr("Error Renaming Path"),
                 tr(R"(<p><b>Unable to rename "%1" as "%2": %3.</b></p><p>Please correct the errors and try again.</p>)").
                     arg(path).arg(name).arg(r.result), QMessageBox::Close,
-                qApp->activeWindow());
-            d->connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
+                QApplication::activeWindow());
+            QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
             d->show();
         });
 
@@ -1042,7 +1042,6 @@ void Session::updateInfo(tr_variant* d)
         session_id_.clear();
     }
 
-    // std::cerr << "Session::updateInfo end" << std::endl;
     connect(&prefs_, &Prefs::changed, this, &Session::updatePref);
 
     emit sessionUpdated();
@@ -1095,8 +1094,8 @@ void Session::addTorrent(AddData const& add_me, tr_variant* args, bool trash_ori
         {
             auto* d = new QMessageBox(QMessageBox::Warning, tr("Error Adding Torrent"),
                 QStringLiteral("<p><b>%1</b></p><p>%2</p>").arg(r.result).arg(add_me.readableName()), QMessageBox::Close,
-                qApp->activeWindow());
-            d->connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
+                QApplication::activeWindow());
+            QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
             d->show();
         });
 
@@ -1162,7 +1161,7 @@ void Session::onDuplicatesTimer()
         auto const use_detail = lines.size() > 1;
         auto const text = use_detail ? detail_text : detail;
 
-        auto* d = new QMessageBox(QMessageBox::Warning, title, text, QMessageBox::Close, qApp->activeWindow());
+        auto* d = new QMessageBox(QMessageBox::Warning, title, text, QMessageBox::Close, QApplication::activeWindow());
         if (use_detail)
         {
             d->setDetailedText(detail);

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -30,7 +30,6 @@ using ::trqt::variant_helpers::change;
 
 Torrent::Torrent(Prefs const& prefs, int id) :
     id_(id),
-    icon_(IconCache::get().fileIcon()),
     prefs_(prefs)
 {
 }

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -22,6 +22,7 @@
 #include <libtransmission/quark.h>
 
 #include "FaviconCache.h"
+#include "IconCache.h"
 #include "Macros.h"
 #include "Speed.h"
 
@@ -666,7 +667,7 @@ private:
     QString name_;
 
     // mutable because it's a lazy lookup
-    mutable QIcon icon_;
+    mutable QIcon icon_ = IconCache::get().fileIcon();
 
     PeerList peers_;
     FileList files_;

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -89,7 +89,7 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QString progress_
     status_font(base_font),
     progress_font(base_font)
 {
-    QStyle const* style(qApp->style());
+    QStyle const* style = QApplication::style();
     int const icon_size(style->pixelMetric(QStyle::PM_LargeIconSize));
 
     name_font.setWeight(QFont::Bold);
@@ -377,8 +377,9 @@ QString TorrentDelegate::statusString(Torrent const& tor)
 
 QSize TorrentDelegate::sizeHint(QStyleOptionViewItem const& option, Torrent const& tor) const
 {
-    QSize const m(margin(*qApp->style()));
-    ItemLayout const layout(tor.name(), progressString(tor), statusString(tor), QIcon(), option.font, option.direction,
+    auto const m = QSize(margin(*QApplication::style()));
+    auto const layout = ItemLayout(tor.name(), progressString(tor), statusString(tor),
+        QIcon(), option.font, option.direction,
         QPoint(0, 0), option.rect.width() - m.width() * 2);
     return layout.size() + m * 2;
 }
@@ -413,7 +414,7 @@ QIcon& TorrentDelegate::getWarningEmblem() const
 
     if (icon.isNull())
     {
-        icon = qApp->style()->standardIcon(QStyle::SP_MessageBoxWarning);
+        icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
     }
 
     return icon;
@@ -450,7 +451,7 @@ void TorrentDelegate::setProgressBarPercentDone(QStyleOptionViewItem const& opti
 
 void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const& tor) const
 {
-    QStyle const* style(qApp->style());
+    auto const* style = QApplication::style();
 
     bool const is_paused(tor.isPaused());
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -120,13 +120,7 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QString progress_
 } // namespace
 
 TorrentDelegate::TorrentDelegate(QObject* parent) :
-    QStyledItemDelegate{parent},
-    blue_back{"lightgrey"},
-    blue_brush{"steelblue"},
-    green_back{"darkseagreen"},
-    green_brush{"forestgreen"},
-    silver_back{"grey"},
-    silver_brush{"silver"}
+    QStyledItemDelegate{parent}
 {
     progress_bar_style_.minimum = 0;
     progress_bar_style_.maximum = 1000;
@@ -567,21 +561,21 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     if (tor.isDownloading())
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, blue_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, blue_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, blue_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, BlueBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, BlueBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, BlueBack);
     }
     else if (tor.isSeeding())
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, green_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, green_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, green_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, GreenBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, GreenBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, GreenBack);
     }
     else
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, silver_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, silver_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, silver_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, SilverBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, SilverBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, SilverBack);
     }
 
     progress_bar_style_.state = progress_bar_state;

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -111,9 +111,9 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QString progress_
     status_rect = name_rect.adjusted(0, name_rect.height() + 1, 0, status_size.height() + 1);
     bar_rect = status_rect.adjusted(0, status_rect.height() + 1, 0, BAR_HEIGHT + 1);
     progress_rect = bar_rect.adjusted(0, bar_rect.height() + 1, 0, progress_size.height() + 1);
-    icon_rect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(icon_size, icon_size),
+    icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(icon_size, icon_size),
         QRect(top_left, QSize(width, progress_rect.bottom() - name_rect.top())));
-    emblem_rect = style->alignedRect(direction, Qt::AlignRight | Qt::AlignBottom,
+    emblem_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignBottom,
         emblem_icon.actualSize(icon_rect.size() / 2, QIcon::Normal, QIcon::On), icon_rect);
 }
 

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -45,12 +45,12 @@ protected:
     static QString shortStatusString(Torrent const& tor);
     static QString shortTransferString(Torrent const& tor);
 
-    QColor const blue_back;
-    QColor const blue_brush;
-    QColor const green_back;
-    QColor const green_brush;
-    QColor const silver_back;
-    QColor const silver_brush;
+    QColor const BlueBack{ "lightgrey" };
+    QColor const BlueBrush{ "steelblue" };
+    QColor const GreenBack{ "darkseagreen" };
+    QColor const GreenBrush{ "forestgreen" };
+    QColor const SilverBack{ "grey" };
+    QColor const SilverBrush{ "silver" };
 
     mutable QStyleOptionProgressBar progress_bar_style_ = {};
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -48,10 +48,6 @@ namespace
 
 class ItemLayout
 {
-private:
-    QString name_text_;
-    QString status_text_;
-
 public:
     QFont name_font;
     QFont status_font;
@@ -81,6 +77,9 @@ public:
     }
 
 private:
+    QString name_text_;
+    QString status_text_;
+
     [[nodiscard]] QString elidedText(QFont const& font, QString const& text, int width) const
     {
         return QFontMetrics(font).elidedText(text, Qt::ElideRight, width);
@@ -89,16 +88,16 @@ private:
 
 ItemLayout::ItemLayout(QString name_text, QString status_text, QIcon const& emblem_icon, QFont const& base_font,
     Qt::LayoutDirection direction, QPoint const& top_left, int width) :
-    name_text_(std::move(name_text)),
-    status_text_(std::move(status_text)),
     name_font(base_font),
-    status_font(base_font)
+    status_font(base_font),
+    name_text_(std::move(name_text)),
+    status_text_(std::move(status_text))
 {
-    QStyle const* style(qApp->style());
-    int const icon_size(style->pixelMetric(QStyle::PM_SmallIconSize));
+    auto const* style = QApplication::style();
+    int const icon_size = style->pixelMetric(QStyle::PM_SmallIconSize);
 
-    QFontMetrics const name_fm(name_font);
-    QSize const name_size(name_fm.size(0, name_text_));
+    auto const name_fm = QFontMetrics(name_font);
+    auto const name_size = QSize(name_fm.size(0, name_text_));
 
     status_font.setPointSize(static_cast<int>(status_font.pointSize() * 0.85));
     QFontMetrics const status_fm(status_font);
@@ -115,12 +114,12 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QIcon const& embl
     QRect base_rect(top_left,
         QSize(width, std::max({ icon_size, name_size.height(), status_size.height(), bar_size.height() })));
 
-    icon_rect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(icon_size, icon_size), base_rect);
-    emblem_rect = style->alignedRect(direction, Qt::AlignRight | Qt::AlignBottom, emblem_icon.actualSize(icon_rect.size() / 2,
+    icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(icon_size, icon_size), base_rect);
+    emblem_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignBottom, emblem_icon.actualSize(icon_rect.size() / 2,
         QIcon::Normal, QIcon::On), icon_rect);
-    bar_rect = style->alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, bar_size, base_rect);
+    bar_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, bar_size, base_rect);
     Utils::narrowRect(base_rect, icon_rect.width() + GUI_PAD, bar_rect.width() + GUI_PAD, direction);
-    status_rect = style->alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, QSize(status_size.width(),
+    status_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, QSize(status_size.width(),
         base_rect.height()),
         base_rect);
     Utils::narrowRect(base_rect, 0, status_rect.width() + GUI_PAD, direction);
@@ -131,16 +130,16 @@ ItemLayout::ItemLayout(QString name_text, QString status_text, QIcon const& embl
 
 QSize TorrentDelegateMin::sizeHint(QStyleOptionViewItem const& option, Torrent const& tor) const
 {
-    bool const is_magnet(!tor.hasMetadata());
-    QSize const m(margin(*qApp->style()));
-    ItemLayout const layout(is_magnet ? progressString(tor) : tor.name(), shortStatusString(tor), QIcon(), option.font,
+    auto const is_magnet = bool(!tor.hasMetadata());
+    auto const m = QSize(margin(*QApplication::style()));
+    auto const layout = ItemLayout(is_magnet ? progressString(tor) : tor.name(), shortStatusString(tor), QIcon(), option.font,
         option.direction, QPoint(0, 0), option.rect.width() - m.width() * 2);
     return layout.size() + m * 2;
 }
 
 void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem const& option, Torrent const& tor) const
 {
-    QStyle const* style(qApp->style());
+    auto const* style = QApplication::style();
 
     bool const is_paused(tor.isPaused());
     bool const is_magnet(!tor.hasMetadata());

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -254,21 +254,21 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
 
     if (tor.isDownloading())
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, blue_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, blue_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, blue_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, BlueBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, BlueBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, BlueBack);
     }
     else if (tor.isSeeding())
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, green_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, green_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, green_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, GreenBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, GreenBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, GreenBack);
     }
     else
     {
-        progress_bar_style_.palette.setBrush(QPalette::Highlight, silver_brush);
-        progress_bar_style_.palette.setColor(QPalette::Base, silver_back);
-        progress_bar_style_.palette.setColor(QPalette::Window, silver_back);
+        progress_bar_style_.palette.setBrush(QPalette::Highlight, SilverBrush);
+        progress_bar_style_.palette.setColor(QPalette::Base, SilverBack);
+        progress_bar_style_.palette.setColor(QPalette::Window, SilverBack);
     }
 
     progress_bar_style_.state = progress_bar_state;

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -35,7 +35,6 @@ public:
         FILTER_BY_TRACKER
     };
 
-public:
     explicit TorrentFilter(Prefs const& prefs);
     [[nodiscard]] std::array<int, FilterMode::NUM_MODES> countTorrentsPerMode() const;
 

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -452,7 +452,7 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
         for (auto const& tor : torrents)
         {
             auto* const it = std::lower_bound(torrents_.begin(), torrents_.end(), tor, compare);
-            auto const row = std::distance(torrents_.begin(), it);
+            int const row = std::distance(torrents_.begin(), it);
 
             beginInsertRows(QModelIndex(), row, row);
             torrents_.insert(it, tor);

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -31,17 +31,17 @@ namespace
 
 struct TorrentIdLessThan
 {
-    bool operator ()(Torrent* left, Torrent* right) const
+    bool operator ()(Torrent const* left, Torrent const* right) const
     {
         return left->id() < right->id();
     }
 
-    bool operator ()(int left_id, Torrent* right) const
+    bool operator ()(int left_id, Torrent const* right) const
     {
         return left_id < right->id();
     }
 
-    bool operator ()(Torrent* left, int right_id) const
+    bool operator ()(Torrent const* left, int right_id) const
     {
         return left->id() < right_id;
     }
@@ -112,7 +112,6 @@ QVariant TorrentModel::data(QModelIndex const& index, int role) const
             break;
 
         default:
-            // std::cerr << "Unhandled role: " << role << std::endl;
             break;
         }
     }
@@ -163,7 +162,7 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
     auto changed_fields = Torrent::fields_t{};
 
     auto const now = time(nullptr);
-    auto const recently_added = [now](auto const& tor)
+    auto const recently_added = [&now](auto const& tor)
         {
             static auto constexpr MaxAge = 60;
             auto const date = tor->dateAdded();

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -19,7 +19,7 @@ public:
         QWidget(parent),
         text_()
     {
-        setFont(qApp->font("QMiniFont"));
+        setFont(QApplication::font("QMiniFont"));
     }
 
     void setText(QString const& text)

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -16,8 +16,7 @@ class TorrentView::HeaderWidget : public QWidget
 {
 public:
     explicit HeaderWidget(TorrentView* parent) :
-        QWidget(parent),
-        text_()
+        QWidget(parent)
     {
         setFont(QApplication::font("QMiniFont"));
     }

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -35,9 +35,6 @@ auto constexpr Margin = QSize{ 10, 10 };
 
 class ItemLayout
 {
-private:
-    QTextDocument text_document_;
-
 public:
     QRect icon_rect;
     QRect text_rect;
@@ -53,17 +50,19 @@ public:
     {
         return text_document_.documentLayout();
     }
+
+private:
+    QTextDocument text_document_;
 };
 
 ItemLayout::ItemLayout(QString const& text, bool suppress_colors, Qt::LayoutDirection direction, QPoint const& top_left,
     int width)
 {
-    QStyle const* style(qApp->style());
     QSize const icon_size = FaviconCache::getIconSize();
 
     QRect base_rect(top_left, QSize(width, 0));
 
-    icon_rect = style->alignedRect(direction, Qt::AlignLeft | Qt::AlignTop, icon_size, base_rect);
+    icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignTop, icon_size, base_rect);
     Utils::narrowRect(base_rect, icon_size.width() + Spacing, 0, direction);
 
     text_document_.setDocumentMargin(0);
@@ -175,13 +174,16 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
 {
     QString key;
     QString str;
-    time_t const now(time(nullptr));
     auto const err_markup_begin = QStringLiteral("<span style=\"color:red\">");
     auto const err_markup_end = QStringLiteral("</span>");
     auto const timeout_markup_begin = QStringLiteral("<span style=\"color:#224466\">");
     auto const timeout_markup_end = QStringLiteral("</span>");
     auto const success_markup_begin = QStringLiteral("<span style=\"color:#008B00\">");
     auto const success_markup_end = QStringLiteral("</span>");
+
+    auto const now = time(nullptr);
+    auto const time_until = [&now](auto t) { return timeToStringRounded(static_cast<int>(t - now)); };
+    auto const time_since = [&now](auto t) { return timeToStringRounded(static_cast<int>(now - t)); };
 
     // hostname
     str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
@@ -200,7 +202,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
     {
         if (inf.st.has_announced && inf.st.announce_state != TR_TRACKER_INACTIVE)
         {
-            QString const tstr(timeToStringRounded(now - inf.st.last_announce_time));
+            auto const tstr = time_since(inf.st.last_announce_time);
             str += QStringLiteral("<br/>\n");
 
             if (inf.st.last_announce_succeeded)
@@ -231,13 +233,10 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
             break;
 
         case TR_TRACKER_WAITING:
-            {
-                QString const tstr(timeToStringRounded(inf.st.next_announce_time - now));
-                str += QStringLiteral("<br/>\n");
-                //: %1 is duration
-                str += tr("Asking for more peers in %1").arg(tstr);
-                break;
-            }
+            str += QStringLiteral("<br/>\n");
+            //: %1 is duration
+            str += tr("Asking for more peers in %1").arg(time_until(inf.st.next_announce_time));
+            break;
 
         case TR_TRACKER_QUEUED:
             str += QStringLiteral("<br/>\n");
@@ -245,81 +244,69 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
             break;
 
         case TR_TRACKER_ACTIVE:
+            str += QStringLiteral("<br/>\n");
+            //: %1 is duration
+            str += tr("Asking for more peers now... <small>%1</small>").arg(time_since(inf.st.last_announce_start_time));
+            break;
+        }
+
+        if (!show_more_)
+        {
+            return str;
+        }
+
+        if (inf.st.has_scraped)
+        {
+            str += QStringLiteral("<br/>\n");
+            auto const tstr = time_since(inf.st.last_scrape_time);
+
+            if (!inf.st.last_scrape_succeeded)
             {
-                QString const tstr(timeToStringRounded(now - inf.st.last_announce_start_time));
-                str += QStringLiteral("<br/>\n");
-                //: %1 is duration
-                str += tr("Asking for more peers now... <small>%1</small>").arg(tstr);
-                break;
+                //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
+                str += tr("Got a scrape error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.last_scrape_result).
+                    arg(err_markup_end).arg(tstr);
+            }
+            else if (inf.st.seeder_count >= 0 && inf.st.leecher_count >= 0)
+            {
+                //: First part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
+                //: %1 and %2 are replaced with HTML markup
+                str += tr("Tracker had%1 %Ln seeder(s)%2", nullptr, inf.st.seeder_count).arg(success_markup_begin).
+                    arg(success_markup_end);
+                //: Second part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
+                //: %1 and %2 are replaced with HTML markup, %3 is duration;
+                //: notice that leading space (before "and") is included here
+                str += tr(" and%1 %Ln leecher(s)%2 %3 ago", nullptr, inf.st.leecher_count).arg(success_markup_begin).
+                    arg(success_markup_end).arg(tstr);
+            }
+            else
+            {
+                //: %1 and %2 are replaced with HTML markup, %3 is duration
+                str += tr("Tracker had %1no information%2 on peer counts %3 ago").arg(success_markup_begin).
+                    arg(success_markup_end).arg(tstr);
             }
         }
 
-        if (show_more_)
+        switch (inf.st.scrape_state)
         {
-            if (inf.st.has_scraped)
-            {
-                str += QStringLiteral("<br/>\n");
-                QString const tstr(timeToStringRounded(now - inf.st.last_scrape_time));
+        case TR_TRACKER_INACTIVE:
+            break;
 
-                if (inf.st.last_scrape_succeeded)
-                {
-                    if (inf.st.seeder_count >= 0 && inf.st.leecher_count >= 0)
-                    {
-                        //: First part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
-                        //: %1 and %2 are replaced with HTML markup
-                        str += tr("Tracker had%1 %Ln seeder(s)%2", nullptr, inf.st.seeder_count).arg(success_markup_begin).
-                            arg(success_markup_end);
-                        //: Second part of phrase "Tracker had ... seeder(s) and ... leecher(s) ... ago";
-                        //: %1 and %2 are replaced with HTML markup, %3 is duration;
-                        //: notice that leading space (before "and") is included here
-                        str += tr(" and%1 %Ln leecher(s)%2 %3 ago", nullptr, inf.st.leecher_count).arg(success_markup_begin).
-                            arg(success_markup_end).arg(tstr);
-                    }
-                    else
-                    {
-                        //: %1 and %2 are replaced with HTML markup, %3 is duration
-                        str += tr("Tracker had %1no information%2 on peer counts %3 ago").arg(success_markup_begin).
-                            arg(success_markup_end).arg(tstr);
-                    }
-                }
-                else
-                {
-                    //: %1 and %3 are replaced with HTML markup, %2 is error message, %4 is duration
-                    str += tr("Got a scrape error %1\"%2\"%3 %4 ago").arg(err_markup_begin).arg(inf.st.last_scrape_result).
-                        arg(err_markup_end).arg(tstr);
-                }
-            }
+        case TR_TRACKER_WAITING:
+            str += QStringLiteral("<br/>\n");
+            //: %1 is duration
+            str += tr("Asking for peer counts in %1").arg(time_until(inf.st.next_scrape_time));
+            break;
 
-            switch (inf.st.scrape_state)
-            {
-            case TR_TRACKER_INACTIVE:
-                break;
+        case TR_TRACKER_QUEUED:
+            str += QStringLiteral("<br/>\n");
+            str += tr("Queued to ask for peer counts");
+            break;
 
-            case TR_TRACKER_WAITING:
-                {
-                    str += QStringLiteral("<br/>\n");
-                    QString const tstr(timeToStringRounded(inf.st.next_scrape_time - now));
-                    //: %1 is duration
-                    str += tr("Asking for peer counts in %1").arg(tstr);
-                    break;
-                }
-
-            case TR_TRACKER_QUEUED:
-                {
-                    str += QStringLiteral("<br/>\n");
-                    str += tr("Queued to ask for peer counts");
-                    break;
-                }
-
-            case TR_TRACKER_ACTIVE:
-                {
-                    str += QStringLiteral("<br/>\n");
-                    QString const tstr(timeToStringRounded(now - inf.st.last_scrape_start_time));
-                    //: %1 is duration
-                    str += tr("Asking for peer counts now... <small>%1</small>").arg(tstr);
-                    break;
-                }
-            }
+        case TR_TRACKER_ACTIVE:
+            str += QStringLiteral("<br/>\n");
+            //: %1 is duration
+            str += tr("Asking for peer counts now... <small>%1</small>").arg(time_since(inf.st.last_scrape_start_time));
+            break;
         }
     }
 

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -18,7 +18,7 @@ class TrackerModelFilter : public QSortFilterProxyModel
     TR_DISABLE_COPY_MOVE(TrackerModelFilter)
 
 public:
-    TrackerModelFilter(QObject* parent = nullptr);
+    explicit TrackerModelFilter(QObject* parent = nullptr);
 
     void setShowBackupTrackers(bool);
 

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -134,7 +134,7 @@ QString Utils::removeTrailingDirSeparator(QString const& path)
     return path.left(i);
 }
 
-int Utils::measureViewItem(QAbstractItemView* view, QString const& text)
+int Utils::measureViewItem(QAbstractItemView const* view, QString const& text)
 {
     QStyleOptionViewItem option;
     option.initFrom(view);
@@ -147,7 +147,7 @@ int Utils::measureViewItem(QAbstractItemView* view, QString const& text)
         width();
 }
 
-int Utils::measureHeaderItem(QHeaderView* view, QString const& text)
+int Utils::measureHeaderItem(QHeaderView const* view, QString const& text)
 {
     QStyleOptionHeader option;
     option.initFrom(view);

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -60,8 +60,8 @@ public:
         rect.adjust(dx1, 0, -dx2, 0);
     }
 
-    static int measureViewItem(QAbstractItemView* view, QString const& text);
-    static int measureHeaderItem(QHeaderView* view, QString const& text);
+    static int measureViewItem(QAbstractItemView const* view, QString const& text);
+    static int measureHeaderItem(QHeaderView const* view, QString const& text);
 
     static QColor getFadedColor(QColor const& color);
 


### PR DESCRIPTION
No functional changes.

More low-hanging fruit changes to improve Transmission's sonarcloud score:

* prefer initializing member data in class initializers
* don't use instance references when invoking static methods (e.g. use `QApplication::style()` instead of `qApp->style()`)