### PR TITLE
chore(web): get rid of webpack-dev-server warning

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/transmission/transmission",
   "license": "MIT",
   "scripts": {
-    "dev": "WEBPACK_MODE=development webpack-dev-server --config webpack.config.js",
+    "dev": "WEBPACK_MODE=development webpack-dev-server -d --config webpack.config.js",
     "build": "webpack --config webpack.config.js",
     "css": "sass --no-source-map style/",
     "css:map": "sass style/",


### PR DESCRIPTION
To get rid of the warning msg 'WARNING in Conflict: Multiple assets emit different content to the same filename ...',
option -d added to webpack-dev-server