### PR TITLE
Improve the "Stalled" French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1359,7 +1359,7 @@ msgstr "%1$s  %2$s"
 
 #: ../gtk/torrent-cell-renderer.c:175
 msgid "Stalled"
-msgstr "Bloqué"
+msgstr "À l’arrêt"
 
 #: ../gtk/torrent-cell-renderer.c:207
 #, c-format


### PR DESCRIPTION
"Bloqué" implies something is blocking the transfer which is misleading and has lead to confusion for multiple users (see https://forum.transmissionbt.com/viewtopic.php?t=13666).
"Inactif" would work but  conflicts with the translation for "Idle". Another translation for "Idle" would be "Pause" but that would in turn conflict with the translation for "paused torrents". That means the "Idle" translation should stay as is.
Then what we need is to convey that "Stalled" is a long pause with no clear prospect or starting again soon which "À l’arrêt" does.