### PR TITLE
chore: fix more sonarcloud warnings

### DIFF
--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -329,7 +329,6 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
     TR_ASSERT(path != NULL);
 
     char* ret = NULL;
-    char* tmp = NULL;
 
 #if defined(HAVE_CANONICALIZE_FILE_NAME)
 
@@ -337,21 +336,9 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
 
 #endif
 
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L
-
-    /* Better safe than sorry: realpath() officially supports NULL as destination
-       starting off POSIX.1-2008. */
-
     if (ret == NULL)
     {
-        ret = realpath(path, NULL);
-    }
-
-#endif
-
-    if (ret == NULL)
-    {
-        tmp = tr_new(char, PATH_MAX);
+        char tmp[PATH_MAX];
         ret = realpath(path, tmp);
 
         if (ret != NULL)
@@ -364,8 +351,6 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
     {
         set_system_error(error, errno);
     }
-
-    tr_free(tmp);
 
     return ret;
 }

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -147,15 +147,15 @@ bool tr_address_from_string(tr_address* dst, char const* src)
  */
 int tr_address_compare(tr_address const* a, tr_address const* b)
 {
-    static int const sizes[2] = { sizeof(struct in_addr), sizeof(struct in6_addr) };
-
-    /* IPv6 addresses are always "greater than" IPv4 */
+    // IPv6 addresses are always "greater than" IPv4
     if (a->type != b->type)
     {
         return a->type == TR_AF_INET ? 1 : -1;
     }
 
-    return memcmp(&a->addr, &b->addr, sizes[a->type]);
+    return a->type == TR_AF_INET ?
+        memcmp(&a->addr.addr4, &b->addr.addr4, sizeof(a->addr.addr4)) :
+        memcmp(&a->addr.addr6, &b->addr.addr6, sizeof(a->addr.addr6));
 }
 
 /***********************************************************************

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -155,7 +155,7 @@ int tr_address_compare(tr_address const* a, tr_address const* b)
 
     return a->type == TR_AF_INET ?
         memcmp(&a->addr.addr4, &b->addr.addr4, sizeof(a->addr.addr4)) :
-        memcmp(&a->addr.addr6, &b->addr.addr6, sizeof(a->addr.addr6));
+        memcmp(&a->addr.addr6.s6_addr, &b->addr.addr6.s6_addr, sizeof(a->addr.addr6.s6_addr));
 }
 
 /***********************************************************************

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -188,6 +188,11 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
     tr_ptrArray stack = TR_PTR_ARRAY_INIT;
     tr_quark key = 0;
 
+    if ((buf_in == NULL) || (bufend_in == NULL) || (top == NULL))
+    {
+        return EINVAL;
+    }
+
     tr_variantInit(top, 0);
 
     while (buf != bufend)

--- a/utils/remote.c
+++ b/utils/remote.c
@@ -3016,7 +3016,7 @@ static void getHostAndPortAndRpcUrl(int* argc, char** argv, char** host, int* po
         char const* const first_colon = strchr(s, ':');
         char const* const last_colon = strrchr(s, ':');
 
-        if (last_colon != NULL && ((*s == '[' && *(last_colon - 1) == ']') || first_colon == last_colon))
+        if (last_colon != NULL && ((*s == '[' && (last_colon > s) && *(last_colon - 1) == ']') || first_colon == last_colon))
         {
             /* user passed in both host and port */
             *host = tr_strndup(s, last_colon - s);

--- a/utils/remote.c
+++ b/utils/remote.c
@@ -3016,7 +3016,7 @@ static void getHostAndPortAndRpcUrl(int* argc, char** argv, char** host, int* po
         char const* const first_colon = strchr(s, ':');
         char const* const last_colon = strrchr(s, ':');
 
-        if (last_colon != NULL && ((*s == '[' && (last_colon > s) && *(last_colon - 1) == ']') || first_colon == last_colon))
+        if (last_colon != NULL && ((*s == '[' && (last_colon > s) && (last_colon[-1] == ']')) || first_colon == last_colon))
         {
             /* user passed in both host and port */
             *host = tr_strndup(s, last_colon - s);


### PR DESCRIPTION
most of the changes in this set are to silence nullptr dereference warnings by adding `(foo != NULL)` style safeguards.

The `tr_address` comparison function is a fair call: this revision compares the struct's fields directly to avoid accidentally including padding in the `memcmp()` comparison.

The change to how `realpath()` is invoked fixes the warning but is mainly to ensure that the calling function always returns memory that's been allocated with `tr_malloc()` instead of mixing that with `realpath()`'s call to `malloc()`.