### PR TITLE
refactor: fix more sonarcloud warnings

### DIFF
--- a/gtk/details.c
+++ b/gtk/details.c
@@ -1657,7 +1657,7 @@ static void refreshWebseedList(struct DetailsImpl* di, tr_torrent** torrents, in
     /* step 3: update the webseeds */
     for (int i = 0; i < n; ++i)
     {
-        tr_torrent* tor = torrents[i];
+        tr_torrent const* tor = torrents[i];
         tr_info const* inf = tr_torrentInfo(tor);
         double* speeds_KBps = tr_torrentWebSpeeds_KBps(tor);
 
@@ -2583,7 +2583,7 @@ static void get_editable_tracker_list(GString* gstr, tr_torrent const* tor)
 static void on_edit_trackers(GtkButton* button, gpointer data)
 {
     struct DetailsImpl* di = data;
-    tr_torrent* tor = tracker_list_get_current_torrent(di);
+    tr_torrent const* tor = tracker_list_get_current_torrent(di);
 
     if (tor != NULL)
     {
@@ -2642,7 +2642,7 @@ static void on_tracker_list_selection_changed(GtkTreeSelection* sel, gpointer gd
 {
     struct DetailsImpl* di = gdi;
     int const n = gtk_tree_selection_count_selected_rows(sel);
-    tr_torrent* tor = tracker_list_get_current_torrent(di);
+    tr_torrent const* tor = tracker_list_get_current_torrent(di);
 
     gtk_widget_set_sensitive(di->remove_tracker_button, n > 0);
     gtk_widget_set_sensitive(di->add_tracker_button, tor != NULL);
@@ -2697,12 +2697,12 @@ static void on_add_tracker_response(GtkDialog* dialog, int response, gpointer gd
     }
 }
 
-static void on_tracker_list_add_button_clicked(GtkButton* button, gpointer gdi)
+static void on_tracker_list_add_button_clicked(GtkButton const* button, gpointer gdi)
 {
     TR_UNUSED(button);
 
     struct DetailsImpl* di = gdi;
-    tr_torrent* tor = tracker_list_get_current_torrent(di);
+    tr_torrent const* tor = tracker_list_get_current_torrent(di);
 
     if (tor != NULL)
     {
@@ -2734,7 +2734,7 @@ static void on_tracker_list_add_button_clicked(GtkButton* button, gpointer gdi)
     }
 }
 
-static void on_tracker_list_remove_button_clicked(GtkButton* button, gpointer gdi)
+static void on_tracker_list_remove_button_clicked(GtkButton const* button, gpointer gdi)
 {
     TR_UNUSED(button);
 
@@ -2903,7 +2903,7 @@ static gboolean periodic_refresh(gpointer data)
     return G_SOURCE_CONTINUE;
 }
 
-static void on_details_window_size_allocated(GtkWidget* gtk_window, GtkAllocation* alloc, gpointer gdata)
+static void on_details_window_size_allocated(GtkWidget* gtk_window, GtkAllocation const* alloc, gconstpointer gdata)
 {
     TR_UNUSED(alloc);
     TR_UNUSED(gdata);
@@ -3010,7 +3010,7 @@ void gtr_torrent_details_dialog_set_torrents(GtkWidget* w, GSList* ids)
     if (len == 1)
     {
         int const id = GPOINTER_TO_INT(ids->data);
-        tr_torrent* tor = gtr_core_find_torrent(di->core, id);
+        tr_torrent const* tor = gtr_core_find_torrent(di->core, id);
         tr_info const* inf = tr_torrentInfo(tor);
         g_snprintf(title, sizeof(title), _("%s Properties"), inf->name);
 

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -1109,7 +1109,7 @@ static void refreshInfo(struct DetailsImpl* di, tr_torrent** torrents, int n)
         }
         else
         {
-            int const period = time(NULL) - latest;
+            time_t const period = time(NULL) - latest;
 
             if (period < 5)
             {

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -455,7 +455,7 @@ static void ratio_spun_cb(GtkSpinButton* s, struct DetailsImpl* di)
 
 static void max_peers_spun_cb(GtkSpinButton* s, struct DetailsImpl* di)
 {
-    torrent_set_int(di, TR_KEY_peer_limit, gtk_spin_button_get_value(s));
+    torrent_set_int(di, TR_KEY_peer_limit, gtk_spin_button_get_value_as_int(s));
 }
 
 static void onPriorityChanged(GtkComboBox* combo_box, struct DetailsImpl* di)

--- a/gtk/details.c
+++ b/gtk/details.c
@@ -358,14 +358,12 @@ static void refreshOptions(struct DetailsImpl* di, tr_torrent** torrents, int n)
 static void torrent_set_bool(struct DetailsImpl* di, tr_quark const key, gboolean value)
 {
     tr_variant top;
-    tr_variant* args;
-    tr_variant* ids;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStr(&top, TR_KEY_method, "torrent-set");
-    args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
+    tr_variant* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
     tr_variantDictAddBool(args, key, value);
-    ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
+    tr_variant* const ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
 
     for (GSList* l = di->ids; l != NULL; l = l->next)
     {
@@ -379,14 +377,12 @@ static void torrent_set_bool(struct DetailsImpl* di, tr_quark const key, gboolea
 static void torrent_set_int(struct DetailsImpl* di, tr_quark const key, int value)
 {
     tr_variant top;
-    tr_variant* args;
-    tr_variant* ids;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStr(&top, TR_KEY_method, "torrent-set");
-    args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
+    tr_variant* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
     tr_variantDictAddInt(args, key, value);
-    ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
+    tr_variant* const ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
 
     for (GSList* l = di->ids; l != NULL; l = l->next)
     {
@@ -400,14 +396,12 @@ static void torrent_set_int(struct DetailsImpl* di, tr_quark const key, int valu
 static void torrent_set_real(struct DetailsImpl* di, tr_quark const key, double value)
 {
     tr_variant top;
-    tr_variant* args;
-    tr_variant* ids;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStr(&top, TR_KEY_method, "torrent-set");
-    args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
+    tr_variant* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
     tr_variantDictAddReal(args, key, value);
-    ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
+    tr_variant* const ids = tr_variantDictAddList(args, TR_KEY_ids, g_slist_length(di->ids));
 
     for (GSList* l = di->ids; l != NULL; l = l->next)
     {
@@ -623,17 +617,15 @@ static char const* activityString(int activity, bool finished)
  * This way if the user has text selected, refreshing won't deselect it */
 static void gtr_text_buffer_set_text(GtkTextBuffer* b, char const* str)
 {
-    char* old_str;
-    GtkTextIter start;
-    GtkTextIter end;
-
     if (str == NULL)
     {
         str = "";
     }
 
+    GtkTextIter start;
+    GtkTextIter end;
     gtk_text_buffer_get_bounds(b, &start, &end);
-    old_str = gtk_text_buffer_get_text(b, &start, &end, FALSE);
+    char* old_str = gtk_text_buffer_get_text(b, &start, &end, FALSE);
 
     if (old_str == NULL || g_strcmp0(old_str, str) != 0)
     {
@@ -1497,16 +1489,13 @@ static void refreshPeerRow(GtkListStore* store, GtkTreeIter* iter, tr_peer_stat 
 
 static void refreshPeerList(struct DetailsImpl* di, tr_torrent** torrents, int n)
 {
-    int* peerCount;
     GtkTreeIter iter;
-    GtkTreeModel* model;
     GHashTable* hash = di->peer_hash;
     GtkListStore* store = di->peer_store;
-    struct tr_peer_stat** peers;
 
     /* step 1: get all the peers */
-    peers = g_new(struct tr_peer_stat*, n);
-    peerCount = g_new(int, n);
+    struct tr_peer_stat** peers = g_new(struct tr_peer_stat*, n);
+    int* peerCount = g_new(int, n);
 
     for (int i = 0; i < n; ++i)
     {
@@ -1514,7 +1503,7 @@ static void refreshPeerList(struct DetailsImpl* di, tr_torrent** torrents, int n
     }
 
     /* step 2: mark all the peers in the list as not-updated */
-    model = GTK_TREE_MODEL(store);
+    GtkTreeModel* const model = GTK_TREE_MODEL(store);
 
     if (gtk_tree_model_iter_nth_child(model, &iter, NULL, 0))
     {
@@ -1571,8 +1560,6 @@ static void refreshPeerList(struct DetailsImpl* di, tr_torrent** torrents, int n
     }
 
     /* step 5: remove peers that have disappeared */
-    model = GTK_TREE_MODEL(store);
-
     if (gtk_tree_model_iter_nth_child(model, &iter, NULL, 0))
     {
         gboolean more = TRUE;
@@ -1665,13 +1652,11 @@ static void refreshWebseedList(struct DetailsImpl* di, tr_torrent** torrents, in
         {
             char buf[128];
             char key[256];
-            GtkTreePath* p;
-            GtkTreeRowReference* ref;
             char const* url = inf->webseeds[j];
 
             g_snprintf(key, sizeof(key), "%d.%s", tr_torrentId(tor), url);
-            ref = g_hash_table_lookup(hash, key);
-            p = gtk_tree_row_reference_get_path(ref);
+            GtkTreeRowReference* const ref = g_hash_table_lookup(hash, key);
+            GtkTreePath* const p = gtk_tree_row_reference_get_path(ref);
             gtk_tree_model_get_iter(model, &iter, p);
 
             if (speeds_KBps[j] > 0)
@@ -1747,7 +1732,6 @@ static gboolean onPeerViewQueryTooltip(GtkWidget* widget, gint x, gint y, gboole
     {
         char* name = NULL;
         char* addr = NULL;
-        char* markup = NULL;
         char* flagstr = NULL;
         struct DetailsImpl* di = gdi;
         GString* gstr = di->gstr;
@@ -1759,7 +1743,7 @@ static gboolean onPeerViewQueryTooltip(GtkWidget* widget, gint x, gint y, gboole
             -1);
 
         g_string_truncate(gstr, 0);
-        markup = g_markup_escape_text(name, -1);
+        char* const markup = g_markup_escape_text(name, -1);
         g_string_append_printf(gstr, "<b>%s</b>\n%s\n \n", markup, addr);
         g_free(markup);
 
@@ -2308,8 +2292,8 @@ static void favicon_ready_cb(gpointer pixbuf, gpointer vreference)
 
     if (pixbuf != NULL)
     {
-        GtkTreePath* path = gtk_tree_row_reference_get_path(reference);
-        GtkTreeModel* model = gtk_tree_row_reference_get_model(reference);
+        GtkTreePath* const path = gtk_tree_row_reference_get_path(reference);
+        GtkTreeModel* const model = gtk_tree_row_reference_get_model(reference);
 
         if (gtk_tree_model_get_iter(model, &iter, path))
         {
@@ -2325,10 +2309,7 @@ static void favicon_ready_cb(gpointer pixbuf, gpointer vreference)
 
 static void refreshTracker(struct DetailsImpl* di, tr_torrent** torrents, int n)
 {
-    int* statCount;
-    tr_tracker_stat** stats;
     GtkTreeIter iter;
-    GtkTreeModel* model;
     GString* gstr = di->gstr; /* buffer for temporary strings */
     GHashTable* hash = di->tracker_hash;
     GtkListStore* store = di->tracker_store;
@@ -2336,8 +2317,8 @@ static void refreshTracker(struct DetailsImpl* di, tr_torrent** torrents, int n)
     gboolean const showScrape = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(di->scrape_check));
 
     /* step 1: get all the trackers */
-    statCount = g_new0(int, n);
-    stats = g_new0(tr_tracker_stat*, n);
+    int* const statCount = g_new0(int, n);
+    tr_tracker_stat** const stats = g_new0(tr_tracker_stat*, n);
 
     for (int i = 0; i < n; ++i)
     {
@@ -2345,7 +2326,7 @@ static void refreshTracker(struct DetailsImpl* di, tr_torrent** torrents, int n)
     }
 
     /* step 2: mark all the trackers in the list as not-updated */
-    model = GTK_TREE_MODEL(store);
+    GtkTreeModel* const model = GTK_TREE_MODEL(store);
 
     if (gtk_tree_model_iter_nth_child(model, &iter, NULL, 0))
     {
@@ -2496,16 +2477,12 @@ static void on_edit_trackers_response(GtkDialog* dialog, int response, gpointer 
 
         if (tor != NULL)
         {
-            tr_tracker_info* trackers;
-            char** tracker_strings;
-            char* tracker_text;
-
             /* build the array of trackers */
             gtk_text_buffer_get_bounds(text_buffer, &start, &end);
-            tracker_text = gtk_text_buffer_get_text(text_buffer, &start, &end, FALSE);
-            tracker_strings = g_strsplit(tracker_text, "\n", 0);
+            char* const tracker_text = gtk_text_buffer_get_text(text_buffer, &start, &end, FALSE);
+            char** const tracker_strings = g_strsplit(tracker_text, "\n", 0);
 
-            trackers = g_new0(tr_tracker_info, g_strv_length(tracker_strings));
+            tr_tracker_info* const trackers = g_new0(tr_tracker_info, g_strv_length(tracker_strings));
             n = 0;
             tier = 0;
 
@@ -2532,9 +2509,9 @@ static void on_edit_trackers_response(GtkDialog* dialog, int response, gpointer 
             }
             else
             {
-                GtkWidget* w;
                 char const* text = _("List contains invalid URLs");
-                w = gtk_message_dialog_new(GTK_WINDOW(dialog), GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s",
+                GtkWidget* w = gtk_message_dialog_new(GTK_WINDOW(
+                    dialog), GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "%s",
                     text);
                 gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(w), "%s",
                     _("Please correct the errors and try again."));

--- a/gtk/file-list.c
+++ b/gtk/file-list.c
@@ -116,7 +116,7 @@ static gboolean refreshFilesForeach(GtkTreeModel* model, GtkTreePath* path, GtkT
 
     if (is_file)
     {
-        tr_torrent* tor = refresh_data->tor;
+        tr_torrent const* tor = refresh_data->tor;
         tr_info const* inf = tr_torrentInfo(tor);
         int const enabled = inf->files[index].dnd ? 0 : 1;
         int const priority = inf->files[index].priority;
@@ -648,9 +648,8 @@ static void renderPriority(GtkTreeViewColumn* column, GtkCellRenderer* renderer,
 }
 
 /* build a filename from tr_torrentGetCurrentDir() + the model's FC_LABELs */
-static char* buildFilename(tr_torrent* tor, GtkTreeModel* model, GtkTreePath* path, GtkTreeIter* iter)
+static char* buildFilename(tr_torrent const* tor, GtkTreeModel* model, GtkTreePath* path, GtkTreeIter const* iter)
 {
-    char* ret;
     GtkTreeIter child;
     GtkTreeIter parent = *iter;
     int n = gtk_tree_path_get_depth(path);
@@ -664,7 +663,7 @@ static char* buildFilename(tr_torrent* tor, GtkTreeModel* model, GtkTreePath* pa
     }
     while (gtk_tree_model_iter_parent(model, &parent, &child));
 
-    ret = g_build_filenamev(tokens);
+    char* const ret = g_build_filenamev(tokens);
     g_strfreev(tokens);
     return ret;
 }
@@ -675,7 +674,7 @@ static gboolean onRowActivated(GtkTreeView* view, GtkTreePath* path, GtkTreeView
 
     gboolean handled = FALSE;
     FileData* data = gdata;
-    tr_torrent* tor = gtr_core_find_torrent(data->core, data->torrentId);
+    tr_torrent const* tor = gtr_core_find_torrent(data->core, data->torrentId);
 
     if (tor != NULL)
     {
@@ -776,7 +775,8 @@ static gboolean onViewPathToggled(GtkTreeView* view, GtkTreeViewColumn* col, Gtk
 /**
  * @note 'col' and 'path' are assumed not to be NULL.
  */
-static gboolean getAndSelectEventPath(GtkTreeView* treeview, GdkEventButton* event, GtkTreeViewColumn** col, GtkTreePath** path)
+static gboolean getAndSelectEventPath(GtkTreeView* treeview, GdkEventButton const* event, GtkTreeViewColumn** col,
+    GtkTreePath** path)
 {
     GtkTreeSelection* sel;
 
@@ -796,7 +796,7 @@ static gboolean getAndSelectEventPath(GtkTreeView* treeview, GdkEventButton* eve
     return FALSE;
 }
 
-static gboolean onViewButtonPressed(GtkWidget* w, GdkEventButton* event, gpointer gdata)
+static gboolean onViewButtonPressed(GtkWidget* w, GdkEventButton const* event, gpointer gdata)
 {
     GtkTreeViewColumn* col;
     GtkTreePath* path = NULL;
@@ -865,34 +865,31 @@ static int on_rename_done_idle(struct rename_data* data)
     return G_SOURCE_REMOVE;
 }
 
-static void on_rename_done(tr_torrent* tor G_GNUC_UNUSED, char const* oldpath G_GNUC_UNUSED, char const* newname G_GNUC_UNUSED,
-    int error, struct rename_data* rename_data)
+static void on_rename_done(tr_torrent const* tor G_GNUC_UNUSED, char const* oldpath G_GNUC_UNUSED,
+    char const* newname G_GNUC_UNUSED, int error, struct rename_data* rename_data)
 {
     rename_data->error = error;
     gdk_threads_add_idle((GSourceFunc)on_rename_done_idle, rename_data);
 }
 
-static void cell_edited_callback(GtkCellRendererText* cell G_GNUC_UNUSED, gchar* path_string, gchar* newname, FileData* data)
+static void cell_edited_callback(GtkCellRendererText const* cell G_GNUC_UNUSED, gchar const* path_string, gchar const* newname,
+    FileData* data)
 {
-    tr_torrent* tor;
-    GString* oldpath;
-    GtkTreeIter iter;
-    struct rename_data* rename_data;
-
-    tor = gtr_core_find_torrent(data->core, data->torrentId);
+    tr_torrent* const tor = gtr_core_find_torrent(data->core, data->torrentId);
 
     if (tor == NULL)
     {
         return;
     }
 
+    GtkTreeIter iter;
     if (!gtk_tree_model_get_iter_from_string(data->model, &iter, path_string))
     {
         return;
     }
 
     /* build oldpath */
-    oldpath = g_string_new(NULL);
+    GString* oldpath = g_string_new(NULL);
 
     for (;;)
     {
@@ -913,7 +910,7 @@ static void cell_edited_callback(GtkCellRendererText* cell G_GNUC_UNUSED, gchar*
     }
 
     /* do the renaming */
-    rename_data = g_new0(struct rename_data, 1);
+    struct rename_data* rename_data = g_new0(struct rename_data, 1);
     rename_data->newname = g_strdup(newname);
     rename_data->file_data = data;
     rename_data->path_string = g_strdup(path_string);

--- a/gtk/filter.c
+++ b/gtk/filter.c
@@ -424,7 +424,7 @@ static GtkWidget* tracker_combo_box_new(GtkTreeModel* tmodel)
     return c;
 }
 
-static gboolean test_tracker(tr_torrent* tor, int active_tracker_type, char const* host)
+static gboolean test_tracker(tr_torrent const* tor, int active_tracker_type, char const* host)
 {
     gboolean matches = TRUE;
 

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -75,7 +75,7 @@ static char const* LICENSE =
 
 struct cbdata
 {
-    char* config_dir;
+    char const* config_dir;
     gboolean start_paused;
     gboolean is_iconified;
     gboolean is_closing;
@@ -634,7 +634,7 @@ int main(int argc, char** argv)
 
     /* default settings */
     memset(&cbdata, 0, sizeof(struct cbdata));
-    cbdata.config_dir = (char*)tr_getDefaultConfigDir(MY_CONFIG_NAME);
+    cbdata.config_dir = tr_getDefaultConfigDir(MY_CONFIG_NAME);
 
     /* init i18n */
     setlocale(LC_ALL, "");

--- a/gtk/makemeta-ui.c
+++ b/gtk/makemeta-ui.c
@@ -386,8 +386,8 @@ static char const* getDefaultSavePath(void)
     return g_get_user_special_dir(G_USER_DIRECTORY_DESKTOP);
 }
 
-static void on_drag_data_received(GtkWidget* widget, GdkDragContext* drag_context, gint x, gint y,
-    GtkSelectionData* selection_data, guint info, guint time_, gpointer user_data)
+static void on_drag_data_received(GtkWidget const* widget, GdkDragContext* drag_context, gint x, gint y,
+    GtkSelectionData const* selection_data, guint info, guint time_, gpointer user_data)
 {
     TR_UNUSED(widget);
     TR_UNUSED(x);

--- a/gtk/notify.c
+++ b/gtk/notify.c
@@ -76,8 +76,8 @@ static void get_capabilities_callback(GObject* source, GAsyncResult* res, gpoint
     g_variant_unref(result);
 }
 
-static void g_signal_callback(GDBusProxy* dbus_proxy, char* sender_name, char* signal_name, GVariant* params,
-    gpointer user_data)
+static void g_signal_callback(GDBusProxy const* dbus_proxy, char const* sender_name, char const* signal_name, GVariant* params,
+    gconstpointer user_data)
 {
     TR_UNUSED(dbus_proxy);
     TR_UNUSED(sender_name);

--- a/gtk/relocate.c
+++ b/gtk/relocate.c
@@ -92,7 +92,7 @@ static gboolean onTimer(gpointer gdata)
     return G_SOURCE_CONTINUE;
 }
 
-static void onResponse(GtkDialog* dialog, int response, gpointer user_data)
+static void onResponse(GtkDialog* dialog, int response, gconstpointer user_data)
 {
     TR_UNUSED(user_data);
 

--- a/gtk/tr-core.c
+++ b/gtk/tr-core.c
@@ -801,8 +801,8 @@ static void core_watchdir_monitor_file(TrCore* core, GFile* file)
 }
 
 /* GFileMonitor noticed a file was created */
-static void on_file_changed_in_watchdir(GFileMonitor* monitor, GFile* file, GFile* other_type, GFileMonitorEvent event_type,
-    gpointer core)
+static void on_file_changed_in_watchdir(GFileMonitor const* monitor, GFile* file, GFile const* other_type,
+    GFileMonitorEvent event_type, gpointer core)
 {
     TR_UNUSED(monitor);
     TR_UNUSED(other_type);

--- a/gtk/tr-prefs.c
+++ b/gtk/tr-prefs.c
@@ -636,7 +636,7 @@ static void refreshWhitelist(struct remote_page* page)
     g_string_free(gstr, TRUE);
 }
 
-static void onAddressEdited(GtkCellRendererText* r, gchar* path_string, gchar* address, gpointer gpage)
+static void onAddressEdited(GtkCellRendererText const* r, gchar const* path_string, gchar* address, gpointer gpage)
 {
     TR_UNUSED(r);
 
@@ -654,7 +654,7 @@ static void onAddressEdited(GtkCellRendererText* r, gchar* path_string, gchar* a
     refreshWhitelist(page);
 }
 
-static void onAddWhitelistClicked(GtkButton* b, gpointer gpage)
+static void onAddWhitelistClicked(GtkButton const* b, gpointer gpage)
 {
     TR_UNUSED(b);
 
@@ -670,7 +670,7 @@ static void onAddWhitelistClicked(GtkButton* b, gpointer gpage)
     gtk_tree_path_free(path);
 }
 
-static void onRemoveWhitelistClicked(GtkButton* b, gpointer gpage)
+static void onRemoveWhitelistClicked(GtkButton const* b, gpointer gpage)
 {
     TR_UNUSED(b);
 

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -99,11 +99,8 @@ char* tr_strlsize(char* buf, guint64 bytes, size_t buflen)
     return buf;
 }
 
-char* tr_strltime(char* buf, int seconds, size_t buflen)
+char* tr_strltime(char* buf, time_t seconds, size_t buflen)
 {
-    int days;
-    int hours;
-    int minutes;
     char d[128];
     char h[128];
     char m[128];
@@ -114,15 +111,15 @@ char* tr_strltime(char* buf, int seconds, size_t buflen)
         seconds = 0;
     }
 
-    days = seconds / 86400;
-    hours = (seconds % 86400) / 3600;
-    minutes = (seconds % 3600) / 60;
+    int const days = seconds / 86400;
+    int const hours = (seconds % 86400) / 3600;
+    int const minutes = (seconds % 3600) / 60;
     seconds = (seconds % 3600) % 60;
 
     g_snprintf(d, sizeof(d), ngettext("%'d day", "%'d days", days), days);
     g_snprintf(h, sizeof(h), ngettext("%'d hour", "%'d hours", hours), hours);
     g_snprintf(m, sizeof(m), ngettext("%'d minute", "%'d minutes", minutes), minutes);
-    g_snprintf(s, sizeof(s), ngettext("%'d second", "%'d seconds", seconds), seconds);
+    g_snprintf(s, sizeof(s), ngettext("%'d second", "%'d seconds", (int)seconds), (int)seconds);
 
     if (days != 0)
     {

--- a/gtk/util.c
+++ b/gtk/util.c
@@ -111,7 +111,7 @@ char* tr_strltime(char* buf, time_t seconds, size_t buflen)
         seconds = 0;
     }
 
-    int const days = seconds / 86400;
+    int const days = (int)(seconds / 86400);
     int const hours = (seconds % 86400) / 3600;
     int const minutes = (seconds % 3600) / 60;
     seconds = (seconds % 3600) % 60;

--- a/gtk/util.h
+++ b/gtk/util.h
@@ -73,7 +73,7 @@ char* tr_strlsize(char* buf, guint64 size, size_t buflen);
 char* tr_strlratio(char* buf, double ratio, size_t buflen);
 
 /* return a human-readable string for the time given in seconds. */
-char* tr_strltime(char* buf, int secs, size_t buflen);
+char* tr_strltime(char* buf, time_t secs, size_t buflen);
 
 /***
 ****

--- a/libtransmission/announcer-udp.c
+++ b/libtransmission/announcer-udp.c
@@ -45,7 +45,7 @@ static void tau_sockaddr_setport(struct sockaddr* sa, tr_port port)
     }
 }
 
-static int tau_sendto(tr_session* session, struct evutil_addrinfo* ai, tr_port port, void const* buf, size_t buflen)
+static int tau_sendto(tr_session const* session, struct evutil_addrinfo* ai, tr_port port, void const* buf, size_t buflen)
 {
     tr_socket_t sockfd;
 

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -548,7 +548,7 @@ static void publishError(tr_tier* tier, char const* msg)
     publishMessage(tier, msg, TR_TRACKER_ERROR);
 }
 
-static int8_t getSeedProbability(tr_tier* tier, int seeds, int leechers, int pex_count)
+static int8_t getSeedProbability(tr_tier const* tier, int seeds, int leechers, int pex_count)
 {
     /* special case optimization:
        ocelot omits seeds from peer lists sent to seeds on private trackers.
@@ -613,7 +613,7 @@ static int filter_trackers_compare_func(void const* va, void const* vb)
 /**
  * Massages the incoming list of trackers into something we can use.
  */
-static tr_tracker_info* filter_trackers(tr_tracker_info* input, int input_count, int* setme_count)
+static tr_tracker_info* filter_trackers(tr_tracker_info const* input, int input_count, int* setme_count)
 {
     int n = 0;
     struct tr_tracker_info* ret;
@@ -1363,7 +1363,7 @@ static bool multiscrape_too_big(char const* errmsg)
     return false;
 }
 
-static void on_scrape_error(tr_session* session, tr_tier* tier, char const* errmsg)
+static void on_scrape_error(tr_session const* session, tr_tier* tier, char const* errmsg)
 {
     int interval;
 
@@ -1921,7 +1921,7 @@ static void copy_tier_attributes(struct tr_torrent_tiers* tt, tr_tier const* src
     {
         for (int j = 0; !found && j < tt->tiers[i].tracker_count; ++j)
         {
-            if ((tr_strcmp0(src->currentTracker->announce, tt->tiers[i].trackers[j].announce) == 0))
+            if (tr_strcmp0(src->currentTracker->announce, tt->tiers[i].trackers[j].announce) == 0)
             {
                 found = true;
                 copy_tier_attributes_impl(&tt->tiers[i], j, src);

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1159,7 +1159,6 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
             int scrape_fields = 0;
             int seeders = 0;
             int leechers = 0;
-            int downloads = 0;
             bool const isStopped = event == TR_ANNOUNCE_EVENT_STOPPED;
 
             publishErrorClear(tier);
@@ -1182,7 +1181,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
                 if (response->downloads >= 0)
                 {
-                    tracker->downloadCount = downloads = response->downloads;
+                    tracker->downloadCount = response->downloads;
                     ++scrape_fields;
                 }
 
@@ -1644,8 +1643,8 @@ static bool tierNeedsToScrape(tr_tier const* tier, time_t const now)
 static int compareTiers(void const* va, void const* vb)
 {
     int ret;
-    tr_tier const* a = *(tr_tier const**)va;
-    tr_tier const* b = *(tr_tier const**)vb;
+    tr_tier const* a = *(tr_tier const* const*)va;
+    tr_tier const* b = *(tr_tier const* const*)vb;
 
     /* primary key: larger stats come before smaller */
     ret = compareTransfer(a->byteCounts[TR_ANN_UP], a->byteCounts[TR_ANN_DOWN], b->byteCounts[TR_ANN_UP],

--- a/libtransmission/bandwidth.c
+++ b/libtransmission/bandwidth.c
@@ -183,7 +183,7 @@ static void allocateBandwidth(tr_bandwidth* b, tr_priority_t parent_priority, tr
     }
 }
 
-static void phaseOne(tr_ptrArray* peerArray, tr_direction dir)
+static void phaseOne(tr_ptrArray const* peerArray, tr_direction dir)
 {
     int n;
     int peerCount = tr_ptrArraySize(peerArray);

--- a/libtransmission/cache.c
+++ b/libtransmission/cache.c
@@ -125,7 +125,7 @@ enum
  *   - Stale runs, runs sitting in cache for a long time or runs not growing, get priority.
  *     Returns number of runs.
  */
-static int calcRuns(tr_cache* cache, struct run_info* runs)
+static int calcRuns(tr_cache const* cache, struct run_info* runs)
 {
     int const n = tr_ptrArraySize(&cache->blocks);
     int i = 0;
@@ -376,7 +376,7 @@ int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t
 ****
 ***/
 
-static int findBlockPos(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t block)
+static int findBlockPos(tr_cache const* cache, tr_torrent* torrent, tr_piece_index_t block)
 {
     struct cache_block key;
     key.tor = torrent;

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -138,7 +138,7 @@ static bool isMainlineStyle(uint8_t const* peer_id)
 
 static bool decodeBitCometClient(char* buf, size_t buflen, uint8_t const* id)
 {
-    char const* chid = (char*)id;
+    char const* chid = (char const*)id;
     bool is_bitlord;
     int major;
     int minor;
@@ -186,7 +186,7 @@ static bool decodeBitCometClient(char* buf, size_t buflen, uint8_t const* id)
 char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
 {
     uint8_t const* id = id_in;
-    char const* chid = (char*)id;
+    char const* chid = (char const*)id;
 
     *buf = '\0';
 

--- a/libtransmission/crypto-utils-openssl.c
+++ b/libtransmission/crypto-utils-openssl.c
@@ -83,7 +83,7 @@ static bool check_openssl_result(int result, int expected_result, bool expected_
 #define check_result(result) check_openssl_result((result), 1, true, __FILE__, __LINE__)
 #define check_result_neq(result, x_result) check_openssl_result((result), (x_result), false, __FILE__, __LINE__)
 
-static bool check_openssl_pointer(void* pointer, char const* file, int line)
+static bool check_openssl_pointer(void const* pointer, char const* file, int line)
 {
     bool const ret = pointer != NULL;
 

--- a/libtransmission/crypto.c
+++ b/libtransmission/crypto.c
@@ -90,7 +90,7 @@ uint8_t const* tr_cryptoGetMyPublicKey(tr_crypto const* crypto, int* setme_len)
 ***
 **/
 
-static void initRC4(tr_crypto* crypto, tr_rc4_ctx_t* setme, char const* key)
+static void initRC4(tr_crypto const* crypto, tr_rc4_ctx_t* setme, char const* key)
 {
     TR_ASSERT(crypto->torrentHashIsSet);
 

--- a/libtransmission/fdlimit.c
+++ b/libtransmission/fdlimit.c
@@ -164,14 +164,14 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
         if (dir == NULL)
         {
             tr_logAddError(_("Couldn't get directory for \"%1$s\": %2$s"), filename, error->message);
-            goto fail;
+            goto FAIL;
         }
 
         if (!tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
         {
             tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), dir, error->message);
             tr_free(dir);
-            goto fail;
+            goto FAIL;
         }
 
         tr_free(dir);
@@ -191,7 +191,7 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddError(_("Couldn't open \"%1$s\": %2$s"), filename, error->message);
-        goto fail;
+        goto FAIL;
     }
 
     if (writable && !already_existed && allocation != TR_PREALLOCATE_NONE)
@@ -216,7 +216,7 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
         {
             tr_logAddError(_("Couldn't preallocate file \"%1$s\" (%2$s, size: %3$" PRIu64 "): %4$s"),
                 filename, type, file_size, error->message);
-            goto fail;
+            goto FAIL;
         }
 
         tr_logAddDebug(_("Preallocated file \"%1$s\" (%2$s, size: %3$" PRIu64 ")"), filename, type, file_size);
@@ -231,13 +231,13 @@ static int cached_file_open(struct tr_cached_file* o, char const* filename, bool
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
         tr_logAddError(_("Couldn't truncate \"%1$s\": %2$s"), filename, error->message);
-        goto fail;
+        goto FAIL;
     }
 
     o->fd = fd;
     return 0;
 
-fail:
+FAIL:
     {
         int const err = error->code;
         tr_error_free(error);

--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -202,19 +202,19 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
                 break;
             }
 
-            goto failure;
+            goto FAILURE;
         }
 
         if (errno != ENOENT)
         {
             set_system_error(&my_error, errno);
-            goto failure;
+            goto FAILURE;
         }
     }
 
     if (ret && pp == path_end)
     {
-        goto cleanup;
+        goto CLEANUP;
     }
 
     /* Go one level down on each iteration and attempt to create */
@@ -232,10 +232,10 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
 
     if (ret)
     {
-        goto cleanup;
+        goto CLEANUP;
     }
 
-failure:
+FAILURE:
 
     TR_ASSERT(!ret);
     TR_ASSERT(my_error != NULL);
@@ -243,7 +243,7 @@ failure:
     tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), path, my_error->message);
     tr_error_propagate(error, &my_error);
 
-cleanup:
+CLEANUP:
 
     TR_ASSERT(my_error == NULL);
 
@@ -844,7 +844,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 
     if (ret || errno == ENOSPC)
     {
-        goto out;
+        goto OUT;
     }
 
 #endif
@@ -874,7 +874,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 
             if (ret || code == ENOSPC)
             {
-                goto non_sparse_out;
+                goto NON_SPARSE_OUT;
             }
         }
 
@@ -902,7 +902,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 
             if (ret || code == ENOSPC)
             {
-                goto non_sparse_out;
+                goto NON_SPARSE_OUT;
             }
         }
 
@@ -916,13 +916,13 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 #endif
 
 #if defined(HAVE_XFS_XFS_H) || defined(__APPLE__)
-non_sparse_out:
+NON_SPARSE_OUT:
 #endif
         errno = code;
     }
 
 #ifdef HAVE_FALLOCATE64
-out:
+OUT:
 #endif
 
     if (!ret)

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -883,7 +883,7 @@ static ReadState readPadC(tr_handshake* handshake, struct evbuffer* inbuf)
     return READ_NOW;
 }
 
-static ReadState readIA(tr_handshake* handshake, struct evbuffer* inbuf)
+static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
 {
     size_t const needlen = handshake->ia_len;
     struct evbuffer* outbuf;

--- a/libtransmission/log.c
+++ b/libtransmission/log.c
@@ -138,7 +138,7 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
     struct timeval tv;
     tr_gettimeofday(&tv);
     time_t const seconds = tv.tv_sec;
-    int const milliseconds = tv.tv_usec / 1000;
+    int const milliseconds = (int)(tv.tv_usec / 1000);
     char msec_str[8];
     tr_snprintf(msec_str, sizeof msec_str, "%03d", milliseconds);
 

--- a/libtransmission/log.c
+++ b/libtransmission/log.c
@@ -224,7 +224,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 
     if (buf_len < 0)
     {
-        goto finish;
+        goto FINISH;
     }
 
 #ifdef _WIN32
@@ -298,7 +298,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
         }
     }
 
-finish:
+FINISH:
     tr_lockUnlock(getMessageLock());
     errno = err;
 }

--- a/libtransmission/log.c
+++ b/libtransmission/log.c
@@ -135,20 +135,19 @@ void tr_logFreeQueue(tr_log_message* list)
 
 char* tr_logGetTimeStr(char* buf, size_t buflen)
 {
-    char tmp[64];
-    struct tm now_tm;
     struct timeval tv;
-    time_t seconds;
-    int milliseconds;
-
     tr_gettimeofday(&tv);
+    time_t const seconds = tv.tv_sec;
+    int const milliseconds = tv.tv_usec / 1000;
+    char msec_str[8];
+    tr_snprintf(msec_str, sizeof msec_str, "%03d", milliseconds);
 
-    seconds = tv.tv_sec;
+    struct tm now_tm;
     tr_localtime_r(&seconds, &now_tm);
-    strftime(tmp, sizeof(tmp), "%Y-%m-%d %H:%M:%S.%%03d", &now_tm);
-    milliseconds = tv.tv_usec / 1000;
-    tr_snprintf(buf, buflen, tmp, milliseconds);
+    char date_str[32];
+    strftime(date_str, sizeof(date_str), "%Y-%m-%d %H:%M:%S", &now_tm);
 
+    tr_snprintf(buf, buflen, "%s.%s", date_str, msec_str);
     return buf;
 }
 

--- a/libtransmission/natpmp.c
+++ b/libtransmission/natpmp.c
@@ -231,7 +231,6 @@ int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled,
     case TR_NATPMP_IDLE:
         *public_port = nat->public_port;
         return nat->is_mapped ? TR_PORT_MAPPED : TR_PORT_UNMAPPED;
-        break;
 
     case TR_NATPMP_DISCOVER:
         ret = TR_PORT_UNMAPPED;

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -573,7 +573,7 @@ static int get_source_address(struct sockaddr const* dst, socklen_t dst_len, str
 
     if (s == TR_BAD_SOCKET)
     {
-        goto fail;
+        goto FAIL;
     }
 
     /* Since it's a UDP socket, this doesn't actually send any packets. */
@@ -581,21 +581,21 @@ static int get_source_address(struct sockaddr const* dst, socklen_t dst_len, str
 
     if (rc == -1)
     {
-        goto fail;
+        goto FAIL;
     }
 
     rc = getsockname(s, src, src_len);
 
     if (rc == -1)
     {
-        goto fail;
+        goto FAIL;
     }
 
     evutil_closesocket(s);
 
     return rc;
 
-fail:
+FAIL:
     save = errno;
     evutil_closesocket(s);
     errno = save;

--- a/libtransmission/net.c
+++ b/libtransmission/net.c
@@ -229,7 +229,7 @@ bool tr_address_from_sockaddr_storage(tr_address* setme_addr, tr_port* setme_por
 {
     if (from->ss_family == AF_INET)
     {
-        struct sockaddr_in* sin = (struct sockaddr_in*)from;
+        struct sockaddr_in const* sin = (struct sockaddr_in const*)from;
         setme_addr->type = TR_AF_INET;
         setme_addr->addr.addr4.s_addr = sin->sin_addr.s_addr;
         *setme_port = sin->sin_port;
@@ -238,7 +238,7 @@ bool tr_address_from_sockaddr_storage(tr_address* setme_addr, tr_port* setme_por
 
     if (from->ss_family == AF_INET6)
     {
-        struct sockaddr_in6* sin6 = (struct sockaddr_in6*)from;
+        struct sockaddr_in6 const* sin6 = (struct sockaddr_in6 const*)from;
         setme_addr->type = TR_AF_INET6;
         setme_addr->addr.addr6 = sin6->sin6_addr;
         *setme_port = sin6->sin6_port;

--- a/libtransmission/peer-io.c
+++ b/libtransmission/peer-io.c
@@ -406,7 +406,7 @@ static void event_write_cb(evutil_socket_t fd, short event, void* vio)
 
     if (res <= 0)
     {
-        goto ERROR;
+        goto FAIL;
     }
 
     if (evbuffer_get_length(io->outbuf) != 0)
@@ -425,7 +425,7 @@ RESCHEDULE:
 
     return;
 
-ERROR:
+FAIL:
     tr_net_strerror(errstr, sizeof(errstr), e);
     dbgmsg(io, "event_write_cb got an error. res is %d, what is %hd, errno is %d (%s)", res, what, e, errstr);
 

--- a/libtransmission/peer-io.c
+++ b/libtransmission/peer-io.c
@@ -392,7 +392,7 @@ static void event_write_cb(evutil_socket_t fd, short event, void* vio)
     {
         if (e == 0 || e == EAGAIN || e == EINTR || e == EINPROGRESS)
         {
-            goto reschedule;
+            goto RESCHEDULE;
         }
 
         /* error case */
@@ -406,7 +406,7 @@ static void event_write_cb(evutil_socket_t fd, short event, void* vio)
 
     if (res <= 0)
     {
-        goto error;
+        goto ERROR;
     }
 
     if (evbuffer_get_length(io->outbuf) != 0)
@@ -417,7 +417,7 @@ static void event_write_cb(evutil_socket_t fd, short event, void* vio)
     didWriteWrapper(io, res);
     return;
 
-reschedule:
+RESCHEDULE:
     if (evbuffer_get_length(io->outbuf) != 0)
     {
         tr_peerIoSetEnabled(io, dir, true);
@@ -425,7 +425,7 @@ reschedule:
 
     return;
 
-error:
+ERROR:
     tr_net_strerror(errstr, sizeof(errstr), e);
     dbgmsg(io, "event_write_cb got an error. res is %d, what is %hd, errno is %d (%s)", res, what, e, errstr);
 

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -2355,7 +2355,7 @@ static bool isAtomInteresting(tr_torrent const* tor, struct peer_atom* atom)
     return true;
 }
 
-int tr_peerMgrGetPeers(tr_torrent* tor, tr_pex** setme_pex, uint8_t af, uint8_t list_mode, int maxCount)
+int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, uint8_t list_mode, int maxCount)
 {
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(setme_pex != NULL);

--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -318,12 +318,12 @@ static inline void managerUnlock(struct tr_peerMgr const* manager)
     tr_sessionUnlock(manager->session);
 }
 
-static inline void swarmLock(tr_swarm* swarm)
+static inline void swarmLock(tr_swarm const* swarm)
 {
     managerLock(swarm->manager);
 }
 
-static inline void swarmUnlock(tr_swarm* swarm)
+static inline void swarmUnlock(tr_swarm const* swarm)
 {
     managerUnlock(swarm->manager);
 }
@@ -585,7 +585,7 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
     }
 }
 
-static bool isAtomBlocklisted(tr_session* session, struct peer_atom* atom)
+static bool isAtomBlocklisted(tr_session const* session, struct peer_atom* atom)
 {
     if (atom->blocklisted < 0)
     {

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -107,7 +107,8 @@ enum
     TR_PEERS_INTERESTING
 };
 
-int tr_peerMgrGetPeers(tr_torrent* tor, tr_pex** setme_pex, uint8_t address_type, uint8_t peer_list_mode, int max_peer_count);
+int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t address_type, uint8_t peer_list_mode,
+    int max_peer_count);
 
 void tr_peerMgrStartTorrent(tr_torrent* tor);
 

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -2276,10 +2276,10 @@ typedef struct
 }
 PexDiffs;
 
-static void pexAddedCb(void* vpex, void* userData)
+static void pexAddedCb(void const* vpex, void* userData)
 {
     PexDiffs* diffs = userData;
-    tr_pex* pex = vpex;
+    tr_pex const* pex = vpex;
 
     if (diffs->addedCount < MAX_PEX_ADDED)
     {
@@ -2288,10 +2288,10 @@ static void pexAddedCb(void* vpex, void* userData)
     }
 }
 
-static inline void pexDroppedCb(void* vpex, void* userData)
+static inline void pexDroppedCb(void const* vpex, void* userData)
 {
     PexDiffs* diffs = userData;
-    tr_pex* pex = vpex;
+    tr_pex const* pex = vpex;
 
     if (diffs->droppedCount < MAX_PEX_DROPPED)
     {
@@ -2299,15 +2299,15 @@ static inline void pexDroppedCb(void* vpex, void* userData)
     }
 }
 
-static inline void pexElementCb(void* vpex, void* userData)
+static inline void pexElementCb(void const* vpex, void* userData)
 {
     PexDiffs* diffs = userData;
-    tr_pex* pex = vpex;
+    tr_pex const* pex = vpex;
 
     diffs->elements[diffs->elementCount++] = *pex;
 }
 
-typedef void (* tr_set_func)(void* element, void* userData);
+typedef void (* tr_set_func)(void const* element, void* userData);
 
 /**
  * @brief find the differences and commonalities in two sorted sets
@@ -2334,12 +2334,12 @@ static void tr_set_compare(void const* va, size_t aCount, void const* vb, size_t
     {
         if (a == aend)
         {
-            (*in_b_cb)((void*)b, userData);
+            (*in_b_cb)(b, userData);
             b += elementSize;
         }
         else if (b == bend)
         {
-            (*in_a_cb)((void*)a, userData);
+            (*in_a_cb)(a, userData);
             a += elementSize;
         }
         else
@@ -2348,18 +2348,18 @@ static void tr_set_compare(void const* va, size_t aCount, void const* vb, size_t
 
             if (val == 0)
             {
-                (*in_both_cb)((void*)a, userData);
+                (*in_both_cb)(a, userData);
                 a += elementSize;
                 b += elementSize;
             }
             else if (val < 0)
             {
-                (*in_a_cb)((void*)a, userData);
+                (*in_a_cb)(a, userData);
                 a += elementSize;
             }
             else if (val > 0)
             {
-                (*in_b_cb)((void*)b, userData);
+                (*in_b_cb)(b, userData);
                 b += elementSize;
             }
         }

--- a/libtransmission/peer-msgs.c
+++ b/libtransmission/peer-msgs.c
@@ -2686,7 +2686,7 @@ bool tr_peerMsgsIsIncomingConnection(tr_peerMsgs const* msgs)
 
 bool tr_isPeerMsgs(void const* msgs)
 {
-    return msgs != NULL && ((struct tr_peerMsgs*)msgs)->magic_number == MAGIC_NUMBER;
+    return msgs != NULL && ((struct tr_peerMsgs const*)msgs)->magic_number == MAGIC_NUMBER;
 }
 
 tr_peerMsgs* tr_peerMsgsCast(void* vm)

--- a/libtransmission/platform.c
+++ b/libtransmission/platform.c
@@ -270,10 +270,10 @@ static char const* getHomeDir(void)
             struct passwd pwent;
             struct passwd* pw = NULL;
             char buf[4096];
-
-            if (!getpwuid_r(getuid(), &pwent, buf, sizeof buf, &pw))
+            getpwuid_r(getuid(), &pwent, buf, sizeof buf, &pw);
+            if (pw != NULL)
             {
-                home = tr_strdup(pwent.pw_dir);
+                home = tr_strdup(pw->pw_dir);
             }
 
 #endif

--- a/libtransmission/platform.c
+++ b/libtransmission/platform.c
@@ -267,14 +267,14 @@ static char const* getHomeDir(void)
 
 #else
 
-            struct passwd* pw = getpwuid(getuid());
+            struct passwd pwent;
+            struct passwd* pw = NULL;
+            char buf[4096];
 
-            if (pw != NULL)
+            if (!getpwuid_r(getuid(), &pwent, buf, sizeof buf, &pw))
             {
-                home = tr_strdup(pw->pw_dir);
+                home = tr_strdup(pwent.pw_dir);
             }
-
-            endpwent();
 
 #endif
         }

--- a/libtransmission/quark.c
+++ b/libtransmission/quark.c
@@ -491,22 +491,19 @@ tr_quark tr_quark_new(void const* str, size_t len)
 {
     tr_quark ret = TR_KEY_NONE;
 
-    if (str == NULL)
+    if (str != NULL)
     {
-        goto finish;
+        if (len == TR_BAD_SIZE)
+        {
+            len = strlen(str);
+        }
+
+        if (!tr_quark_lookup(str, len, &ret))
+        {
+            ret = append_new_quark(str, len);
+        }
     }
 
-    if (len == TR_BAD_SIZE)
-    {
-        len = strlen(str);
-    }
-
-    if (!tr_quark_lookup(str, len, &ret))
-    {
-        ret = append_new_quark(str, len);
-    }
-
-finish:
     return ret;
 }
 

--- a/libtransmission/resume.c
+++ b/libtransmission/resume.c
@@ -64,12 +64,12 @@ static void savePeers(tr_variant* dict, tr_torrent const* tor)
     tr_free(pex);
 }
 
-static int addPeers(tr_torrent* tor, uint8_t const* buf, int buflen)
+static int addPeers(tr_torrent* tor, uint8_t const* buf, size_t buflen)
 {
     int numAdded = 0;
-    int const count = buflen / sizeof(tr_pex);
+    size_t const count = buflen / sizeof(tr_pex);
 
-    for (int i = 0; i < count && numAdded < MAX_REMEMBERED_PEERS; ++i)
+    for (size_t i = 0; i < count && numAdded < MAX_REMEMBERED_PEERS; ++i)
     {
         tr_pex pex;
         memcpy(&pex, buf + i * sizeof(tr_pex), sizeof(tr_pex));
@@ -113,10 +113,10 @@ static uint64_t loadPeers(tr_variant* dict, tr_torrent* tor)
 
 static void saveLabels(tr_variant* dict, tr_torrent const* tor)
 {
-    int const n = tr_ptrArraySize(&tor->labels);
+    size_t const n = tr_ptrArraySize(&tor->labels);
     tr_variant* list = tr_variantDictAddList(dict, TR_KEY_labels, n);
     char const* const* labels = (char const* const*)tr_ptrArrayBase(&tor->labels);
-    for (int i = 0; i < n; ++i)
+    for (size_t i = 0; i < n; ++i)
     {
         tr_variantListAddStr(list, labels[i]);
     }

--- a/libtransmission/resume.c
+++ b/libtransmission/resume.c
@@ -45,7 +45,7 @@ static void savePeers(tr_variant* dict, tr_torrent const* tor)
     int count;
     tr_pex* pex;
 
-    count = tr_peerMgrGetPeers((tr_torrent*)tor, &pex, TR_AF_INET, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
+    count = tr_peerMgrGetPeers(tor, &pex, TR_AF_INET, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
 
     if (count > 0)
     {
@@ -54,7 +54,7 @@ static void savePeers(tr_variant* dict, tr_torrent const* tor)
 
     tr_free(pex);
 
-    count = tr_peerMgrGetPeers((tr_torrent*)tor, &pex, TR_AF_INET6, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
+    count = tr_peerMgrGetPeers(tor, &pex, TR_AF_INET6, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
 
     if (count > 0)
     {

--- a/libtransmission/rpc-server.c
+++ b/libtransmission/rpc-server.c
@@ -182,7 +182,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
         /* first look for the session id */
         for (int i = 0; i < n; ++i)
         {
-            struct tr_mimepart* p = tr_ptrArrayNth(&parts, i);
+            struct tr_mimepart const* p = tr_ptrArrayNth(&parts, i);
 
             if (tr_strcasestr(p->headers, TR_RPC_SESSION_ID_HEADER) != NULL)
             {
@@ -206,13 +206,13 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
         {
             for (int i = 0; i < n; ++i)
             {
-                struct tr_mimepart* p = tr_ptrArrayNth(&parts, i);
+                struct tr_mimepart const* p = tr_ptrArrayNth(&parts, i);
                 size_t body_len = p->body_len;
                 tr_variant top;
                 tr_variant* args;
                 tr_variant test;
                 bool have_source = false;
-                char* body = p->body;
+                char const* body = p->body;
 
                 if (body_len >= 2 && memcmp(&body[body_len - 2], "\r\n", 2) == 0)
                 {
@@ -819,7 +819,7 @@ static void startServer(void* vserver)
 
     char const* address = tr_rpcGetBindAddress(server);
 
-    int const port = server->port;
+    tr_port const port = server->port;
 
     if (evhttp_bind_socket(httpd, address, port) == -1)
     {
@@ -1137,7 +1137,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
     }
     else
     {
-        s->port = i;
+        s->port = (tr_port)i;
     }
 
     key = TR_KEY_rpc_url;

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -115,11 +115,11 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
 
     if (tr_variantDictFindList(args, TR_KEY_ids, &ids))
     {
-        int const n = tr_variantListSize(ids);
+        size_t const n = tr_variantListSize(ids);
 
         torrents = tr_new0(tr_torrent*, n);
 
-        for (int i = 0; i < n; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             tr_torrent* tor;
             tr_variant const* const node = tr_variantListChild(ids, i);
@@ -1037,11 +1037,11 @@ static char const* torrentGet(tr_session* session, tr_variant* args_in, tr_varia
 
 static char const* setLabels(tr_torrent* tor, tr_variant* list)
 {
-    int const n = tr_variantListSize(list);
+    size_t const n = tr_variantListSize(list);
     char const* errmsg = NULL;
     tr_ptrArray labels = TR_PTR_ARRAY_INIT;
     int labelcount = 0;
-    for (int i = 0; i < n; i++)
+    for (size_t i = 0; i < n; ++i)
     {
         char const* str;
         size_t str_len;
@@ -1100,13 +1100,13 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
 {
     int64_t tmp;
     int fileCount = 0;
-    int const n = tr_variantListSize(list);
+    size_t const n = tr_variantListSize(list);
     char const* errmsg = NULL;
     tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
 
     if (n != 0)
     {
-        for (int i = 0; i < n; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             if (tr_variantGetInt(tr_variantListChild(list, i), &tmp))
             {
@@ -1142,13 +1142,13 @@ static char const* setFileDLs(tr_torrent* tor, bool do_download, tr_variant* lis
 {
     int64_t tmp;
     int fileCount = 0;
-    int const n = tr_variantListSize(list);
+    size_t const n = tr_variantListSize(list);
     char const* errmsg = NULL;
     tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
 
     if (n != 0) /* if argument list, process them */
     {
-        for (int i = 0; i < n; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             if (tr_variantGetInt(tr_variantListChild(list, i), &tmp))
             {
@@ -1335,7 +1335,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
 
         if (tr_variantGetInt(val, &pos) && 0 <= pos && pos < n)
         {
-            tids[t++] = pos;
+            tids[t++] = (int)pos;
         }
 
         ++i;
@@ -1471,12 +1471,12 @@ static char const* torrentSet(tr_session* session, tr_variant* args_in, tr_varia
 
         if (tr_variantDictFindInt(args_in, TR_KEY_seedIdleLimit, &tmp))
         {
-            tr_torrentSetIdleLimit(tor, tmp);
+            tr_torrentSetIdleLimit(tor, (uint16_t)tmp);
         }
 
         if (tr_variantDictFindInt(args_in, TR_KEY_seedIdleMode, &tmp))
         {
-            tr_torrentSetIdleMode(tor, tmp);
+            tr_torrentSetIdleMode(tor, (tr_idlelimit)tmp);
         }
 
         if (tr_variantDictFindReal(args_in, TR_KEY_seedRatioLimit, &d))
@@ -1486,12 +1486,12 @@ static char const* torrentSet(tr_session* session, tr_variant* args_in, tr_varia
 
         if (tr_variantDictFindInt(args_in, TR_KEY_seedRatioMode, &tmp))
         {
-            tr_torrentSetRatioMode(tor, tmp);
+            tr_torrentSetRatioMode(tor, (tr_ratiolimit)tmp);
         }
 
         if (tr_variantDictFindInt(args_in, TR_KEY_queuePosition, &tmp))
         {
-            tr_torrentSetQueuePosition(tor, tmp);
+            tr_torrentSetQueuePosition(tor, (int)tmp);
         }
 
         if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_trackerAdd, &tmp_variant))
@@ -1631,7 +1631,7 @@ static void portTested(tr_session* session, bool did_connect, bool did_timeout, 
     }
     else /* success */
     {
-        bool const isOpen = response_byte_count != 0 && *(char*)response == '1';
+        bool const isOpen = response_byte_count != 0 && *(char const*)response == '1';
         tr_variantDictAddBool(data->args_out, TR_KEY_port_is_open, isOpen);
         tr_snprintf(result, sizeof(result), "success");
     }
@@ -1936,12 +1936,12 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
 
     if (tr_variantDictFindInt(args_in, TR_KEY_peer_limit, &i))
     {
-        tr_ctorSetPeerLimit(ctor, TR_FORCE, i);
+        tr_ctorSetPeerLimit(ctor, TR_FORCE, (uint16_t)i);
     }
 
     if (tr_variantDictFindInt(args_in, TR_KEY_bandwidthPriority, &i))
     {
-        tr_ctorSetBandwidthPriority(ctor, i);
+        tr_ctorSetBandwidthPriority(ctor, (tr_priority_t)i);
     }
 
     if (tr_variantDictFindList(args_in, TR_KEY_files_unwanted, &l))
@@ -2120,7 +2120,7 @@ static char const* sessionSet(tr_session* session, tr_variant* args_in, tr_varia
 
     if (tr_variantDictFindInt(args_in, TR_KEY_download_queue_size, &i))
     {
-        tr_sessionSetQueueSize(session, TR_DOWN, i);
+        tr_sessionSetQueueSize(session, TR_DOWN, (int)i);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_download_queue_enabled, &boolVal))
@@ -2220,7 +2220,7 @@ static char const* sessionSet(tr_session* session, tr_variant* args_in, tr_varia
 
     if (tr_variantDictFindInt(args_in, TR_KEY_seed_queue_size, &i))
     {
-        tr_sessionSetQueueSize(session, TR_UP, i);
+        tr_sessionSetQueueSize(session, TR_UP, (int)i);
     }
 
     if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_done_filename, &str, NULL))
@@ -2705,7 +2705,7 @@ void tr_rpc_request_exec_json(tr_session* session, tr_variant const* request, tr
     tr_variant* const mutable_request = (tr_variant*)request;
     tr_variant* args_in = tr_variantDictFind(mutable_request, TR_KEY_arguments);
     char const* result = NULL;
-    struct method* method = NULL;
+    struct method const* method = NULL;
 
     if (callback == NULL)
     {

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -259,8 +259,8 @@ static char const* queueMoveBottom(tr_session* session, tr_variant* args_in, tr_
 
 static int compareTorrentByQueuePosition(void const* va, void const* vb)
 {
-    tr_torrent const* a = *(tr_torrent const**)va;
-    tr_torrent const* b = *(tr_torrent const**)vb;
+    tr_torrent const* a = *(tr_torrent const* const*)va;
+    tr_torrent const* b = *(tr_torrent const* const*)vb;
 
     return a->queuePosition - b->queuePosition;
 }

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -11,6 +11,9 @@
 #include <stdlib.h> /* strtol */
 #include <string.h> /* strcmp */
 
+#ifndef ZLIB_CONST
+#define ZLIB_CONST
+#endif
 #include <zlib.h>
 
 #include <event2/buffer.h>
@@ -1689,7 +1692,7 @@ static void gotNewBlocklist(tr_session* session, bool did_connect, bool did_time
         stream.zalloc = (alloc_func)Z_NULL;
         stream.zfree = (free_func)Z_NULL;
         stream.opaque = (voidpf)Z_NULL;
-        stream.next_in = (void*)response;
+        stream.next_in = response;
         stream.avail_in = response_byte_count;
         inflateInit2(&stream, windowBits);
 

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -1905,8 +1905,8 @@ tr_torrent** tr_sessionGetTorrents(tr_session* session, int* setme_n)
 
 static int compareTorrentByCur(void const* va, void const* vb)
 {
-    tr_torrent const* a = *(tr_torrent const**)va;
-    tr_torrent const* b = *(tr_torrent const**)vb;
+    tr_torrent const* a = *(tr_torrent const* const*)va;
+    tr_torrent const* b = *(tr_torrent const* const*)vb;
     uint64_t const aCur = a->downloadedCur + a->uploadedCur;
     uint64_t const bCur = b->downloadedCur + b->uploadedCur;
 

--- a/libtransmission/subprocess-posix.c
+++ b/libtransmission/subprocess-posix.c
@@ -63,24 +63,24 @@ static bool tr_spawn_async_in_child(char* const* cmd, char* const* env, char con
         {
             if (putenv(env[i]) != 0)
             {
-                goto fail;
+                goto FAIL;
             }
         }
     }
 
     if (work_dir != NULL && chdir(work_dir) == -1)
     {
-        goto fail;
+        goto FAIL;
     }
 
     if (execvp(cmd[0], cmd) == -1)
     {
-        goto fail;
+        goto FAIL;
     }
 
     return true;
 
-fail:
+FAIL:
     (void)write(pipe_fd, &errno, sizeof(errno));
     return false;
 }

--- a/libtransmission/torrent.c
+++ b/libtransmission/torrent.c
@@ -1874,28 +1874,25 @@ static void onVerifyDoneThreadFunc(void* vdata)
     struct verify_data* data = vdata;
     tr_torrent* tor = data->tor;
 
-    if (tor->isDeleting)
+    if (!tor->isDeleting)
     {
-        goto cleanup;
+        if (!data->aborted)
+        {
+            tr_torrentRecheckCompleteness(tor);
+        }
+
+        if (data->callback_func != NULL)
+        {
+            (*data->callback_func)(tor, data->aborted, data->callback_data);
+        }
+
+        if (!data->aborted && tor->startAfterVerify)
+        {
+            tor->startAfterVerify = false;
+            torrentStart(tor, false);
+        }
     }
 
-    if (!data->aborted)
-    {
-        tr_torrentRecheckCompleteness(tor);
-    }
-
-    if (data->callback_func != NULL)
-    {
-        (*data->callback_func)(tor, data->aborted, data->callback_data);
-    }
-
-    if (!data->aborted && tor->startAfterVerify)
-    {
-        tor->startAfterVerify = false;
-        torrentStart(tor, false);
-    }
-
-cleanup:
     tr_free(data);
 }
 

--- a/libtransmission/tr-lpd.c
+++ b/libtransmission/tr-lpd.c
@@ -265,15 +265,11 @@ static bool lpd_extractParam(char const* const str, char const* const name, int 
         char const* const new_line = strstr(beg, CRLF);
 
         /* the value is delimited by the next CRLF */
-        int len = new_line - beg;
+        int const len = new_line - beg;
 
         /* if value string hits the length limit n,
          * leave space for a trailing '\0' character */
-        if (len < n--)
-        {
-            n = len;
-        }
-
+        n = MIN(len, n - 1);
         strncpy(val, beg, n);
         val[n] = 0;
     }

--- a/libtransmission/tr-udp.c
+++ b/libtransmission/tr-udp.c
@@ -161,7 +161,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
     if (s == TR_BAD_SOCKET)
     {
-        goto fail;
+        goto FAIL;
     }
 
 #ifdef IPV6_V6ONLY
@@ -190,7 +190,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
     if (rc == -1)
     {
-        goto fail;
+        goto FAIL;
     }
 
     if (ss->udp6_socket == TR_BAD_SOCKET)
@@ -204,7 +204,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
         if (rc == -1)
         {
-            goto fail;
+            goto FAIL;
         }
 
         tr_netCloseSocket(s);
@@ -222,7 +222,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
     return;
 
-fail:
+FAIL:
     /* Something went wrong.  It's difficult to recover, so let's simply
        set things up so that we try again next time. */
     tr_logAddNamedError("UDP", "Couldn't rebind IPv6 socket");
@@ -318,7 +318,7 @@ void tr_udpInit(tr_session* ss)
     if (ss->udp_socket == TR_BAD_SOCKET)
     {
         tr_logAddNamedError("UDP", "Couldn't create IPv4 socket");
-        goto ipv6;
+        goto IPV6;
     }
 
     memset(&sin, 0, sizeof(sin));
@@ -338,7 +338,7 @@ void tr_udpInit(tr_session* ss)
         tr_logAddNamedError("UDP", "Couldn't bind IPv4 socket");
         tr_netCloseSocket(ss->udp_socket);
         ss->udp_socket = TR_BAD_SOCKET;
-        goto ipv6;
+        goto IPV6;
     }
 
     ss->udp_event = event_new(ss->event_base, ss->udp_socket, EV_READ | EV_PERSIST, event_callback, ss);
@@ -348,7 +348,7 @@ void tr_udpInit(tr_session* ss)
         tr_logAddNamedError("UDP", "Couldn't allocate IPv4 event");
     }
 
-ipv6:
+IPV6:
     if (tr_globalIPv6() != NULL)
     {
         rebind_ipv6(ss, true);

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -2217,19 +2217,14 @@ char* tr_env_get_string(char const* key, char const* default_value)
 
 #else
 
-    char* value = getenv(key);
+    char const* value = getenv(key);
 
     if (value == NULL)
     {
-        value = (char*)default_value;
+        value = default_value;
     }
 
-    if (value != NULL)
-    {
-        value = tr_strdup(value);
-    }
-
-    return value;
+    return value != NULL ? tr_strdup(value) : NULL;
 
 #endif
 }

--- a/libtransmission/variant-benc.c
+++ b/libtransmission/variant-benc.c
@@ -102,19 +102,19 @@ int tr_bencParseStr(void const* vbuf, void const* vbufend, uint8_t const** setme
 
     if (buf >= bufend)
     {
-        goto err;
+        goto ERR;
     }
 
     if (!isdigit(*buf))
     {
-        goto err;
+        goto ERR;
     }
 
     end = memchr(buf, ':', bufend - buf);
 
     if (end == NULL)
     {
-        goto err;
+        goto ERR;
     }
 
     errno = 0;
@@ -122,7 +122,7 @@ int tr_bencParseStr(void const* vbuf, void const* vbufend, uint8_t const** setme
 
     if (errno != 0 || ulend != end || len > MAX_BENC_STR_LENGTH)
     {
-        goto err;
+        goto ERR;
     }
 
     strbegin = (uint8_t const*)end + 1;
@@ -130,7 +130,7 @@ int tr_bencParseStr(void const* vbuf, void const* vbufend, uint8_t const** setme
 
     if (strend < strbegin || strend > bufend)
     {
-        goto err;
+        goto ERR;
     }
 
     *setme_end = (uint8_t const*)end + 1 + len;
@@ -138,7 +138,7 @@ int tr_bencParseStr(void const* vbuf, void const* vbufend, uint8_t const** setme
     *setme_strlen = len;
     return 0;
 
-err:
+ERR:
     *setme_end = NULL;
     *setme_str = NULL;
     *setme_strlen = 0;

--- a/libtransmission/variant.c
+++ b/libtransmission/variant.c
@@ -339,7 +339,7 @@ bool tr_variantGetRaw(tr_variant const* v, uint8_t const** setme_raw, size_t* se
 
     if (success)
     {
-        *setme_raw = (uint8_t*)getStr(v);
+        *setme_raw = (uint8_t const*)getStr(v);
         *setme_len = v->val.s.len;
     }
 
@@ -388,7 +388,7 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
 
     if (!success && tr_variantIsInt(v))
     {
-        *setme = v->val.i;
+        *setme = (double)v->val.i;
         success = true;
     }
 
@@ -415,19 +415,19 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
 
 bool tr_variantDictFindInt(tr_variant* dict, tr_quark const key, int64_t* setme)
 {
-    tr_variant* child = tr_variantDictFind(dict, key);
+    tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetInt(child, setme);
 }
 
 bool tr_variantDictFindBool(tr_variant* dict, tr_quark const key, bool* setme)
 {
-    tr_variant* child = tr_variantDictFind(dict, key);
+    tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetBool(child, setme);
 }
 
 bool tr_variantDictFindReal(tr_variant* dict, tr_quark const key, double* setme)
 {
-    tr_variant* child = tr_variantDictFind(dict, key);
+    tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetReal(child, setme);
 }
 
@@ -449,7 +449,7 @@ bool tr_variantDictFindDict(tr_variant* dict, tr_quark const key, tr_variant** s
 
 bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const** setme_raw, size_t* setme_len)
 {
-    tr_variant* child = tr_variantDictFind(dict, key);
+    tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetRaw(child, setme_raw, setme_len);
 }
 
@@ -721,7 +721,7 @@ bool tr_variantDictRemove(tr_variant* dict, tr_quark const key)
 
     if (i >= 0)
     {
-        int const last = dict->val.l.count - 1;
+        int const last = (int)dict->val.l.count - 1;
 
         tr_variantFree(&dict->val.l.vals[i]);
 
@@ -842,7 +842,7 @@ void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkF
         }
         else if (tr_variantIsContainer(node->v) && node->childIndex < node->v->val.l.count)
         {
-            int const index = node->childIndex;
+            size_t const index = node->childIndex;
             ++node->childIndex;
 
             v = node->v->val.l.vals + index;
@@ -1165,55 +1165,55 @@ char* tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt, size_t* len)
     return evbuffer_free_to_str(buf, len);
 }
 
+static int writeVariantToFd(tr_variant const* v, tr_variant_fmt fmt, tr_sys_file_t fd, tr_error** error)
+{
+    int err = 0;
+    struct evbuffer* buf = tr_variantToBuf(v, fmt);
+    char const* walk = (char const*)evbuffer_pullup(buf, -1);
+    uint64_t nleft = evbuffer_get_length(buf);
+
+    while (nleft > 0)
+    {
+        uint64_t n = 0;
+
+        tr_error* tmperr = NULL;
+        if (!tr_sys_file_write(fd, walk, nleft, &n, &tmperr))
+        {
+            err = tmperr->code;
+            tr_error_propagate(error, &tmperr);
+            break;
+        }
+
+        nleft -= n;
+        walk += n;
+    }
+
+    evbuffer_free(buf);
+    return err;
+}
+
 int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filename)
 {
-    char* tmp;
-    tr_sys_file_t fd;
-    int err = 0;
-    char* real_filename;
-    tr_error* error = NULL;
-
     /* follow symlinks to find the "real" file, to make sure the temporary
      * we build with tr_sys_file_open_temp() is created on the right partition */
-    if ((real_filename = tr_sys_path_resolve(filename, NULL)) != NULL)
+    char* real_filename = tr_sys_path_resolve(filename, NULL);
+    if (real_filename != NULL)
     {
         filename = real_filename;
     }
 
     /* if the file already exists, try to move it out of the way & keep it as a backup */
-    tmp = tr_strdup_printf("%s.tmp.XXXXXX", filename);
-    fd = tr_sys_file_open_temp(tmp, &error);
+    char* const tmp = tr_strdup_printf("%s.tmp.XXXXXX", filename);
+    tr_error* error = NULL;
+    tr_sys_file_t const fd = tr_sys_file_open_temp(tmp, &error);
 
+    int err = 0;
     if (fd != TR_BAD_SYS_FILE)
     {
-        uint64_t nleft;
-
-        /* save the variant to a temporary file */
-        {
-            struct evbuffer* buf = tr_variantToBuf(v, fmt);
-            char const* walk = (char const*)evbuffer_pullup(buf, -1);
-            nleft = evbuffer_get_length(buf);
-
-            while (nleft > 0)
-            {
-                uint64_t n;
-
-                if (!tr_sys_file_write(fd, walk, nleft, &n, &error))
-                {
-                    err = error->code;
-                    break;
-                }
-
-                nleft -= n;
-                walk += n;
-            }
-
-            evbuffer_free(buf);
-        }
-
+        err = writeVariantToFd(v, fmt, fd, &error);
         tr_sys_file_close(fd, NULL);
 
-        if (nleft > 0)
+        if (err)
         {
             tr_logAddError(_("Couldn't save temporary file \"%1$s\": %2$s"), tmp, error->message);
             tr_sys_path_remove(tmp, NULL);

--- a/libtransmission/watchdir-generic.c
+++ b/libtransmission/watchdir-generic.c
@@ -93,13 +93,13 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
         handle)) == NULL)
     {
         log_error("Failed to create event: %s", tr_strerror(errno));
-        goto fail;
+        goto FAIL;
     }
 
     if (event_add(backend->event, &tr_watchdir_generic_interval) == -1)
     {
         log_error("Failed to add event: %s", tr_strerror(errno));
-        goto fail;
+        goto FAIL;
     }
 
     /* Run initial scan on startup */
@@ -107,7 +107,7 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
 
     return BACKEND_DOWNCAST(backend);
 
-fail:
+FAIL:
     tr_watchdir_generic_free(BACKEND_DOWNCAST(backend));
     return NULL;
 }

--- a/libtransmission/watchdir-inotify.c
+++ b/libtransmission/watchdir-inotify.c
@@ -166,19 +166,19 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
     if ((backend->infd = inotify_init()) == -1)
     {
         log_error("Unable to inotify_init: %s", tr_strerror(errno));
-        goto fail;
+        goto FAIL;
     }
 
     if ((backend->inwd = inotify_add_watch(backend->infd, path, INOTIFY_WATCH_MASK | IN_ONLYDIR)) == -1)
     {
         log_error("Failed to setup watchdir \"%s\": %s (%d)", path, tr_strerror(errno), errno);
-        goto fail;
+        goto FAIL;
     }
 
     if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->infd, 0)) == NULL)
     {
         log_error("Failed to create event buffer: %s", tr_strerror(errno));
-        goto fail;
+        goto FAIL;
     }
 
     /* Guarantees at least the sizeof an inotify event will be available in the
@@ -196,7 +196,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
 
     return BACKEND_DOWNCAST(backend);
 
-fail:
+FAIL:
     tr_watchdir_inotify_free(BACKEND_DOWNCAST(backend));
     return NULL;
 }

--- a/libtransmission/watchdir.c
+++ b/libtransmission/watchdir.c
@@ -136,7 +136,7 @@ struct timeval tr_watchdir_retry_max_interval = { .tv_sec = 10, .tv_usec = 0 };
 
 static int compare_retry_names(void const* a, void const* b)
 {
-    return strcmp(((tr_watchdir_retry*)a)->name, ((tr_watchdir_retry*)b)->name);
+    return strcmp(((tr_watchdir_retry const*)a)->name, ((tr_watchdir_retry const*)b)->name);
 }
 
 static void tr_watchdir_retry_free(tr_watchdir_retry* retry);

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -68,7 +68,6 @@ private:
 
     static Qt::CheckState getCumulativeCheckState(QModelIndexList const& indices);
 
-private:
     FileTreeModel* model_ = {};
     QSortFilterProxyModel* proxy_ = {};
     FileTreeDelegate* delegate_ = {};

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -98,7 +98,7 @@ QString getCountString(int n)
 }
 
 Torrent::fields_t constexpr TrackerFields = {
-    (uint64_t(1) << Torrent::TRACKER_STATS)
+    uint64_t(1) << Torrent::TRACKER_STATS
     };
 
 auto constexpr ActivityFields = FilterMode::TorrentFields;

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -25,7 +25,6 @@ public:
         UserRole
     };
 
-public:
     explicit FilterBarComboBox(QWidget* parent = nullptr);
 
     // QWidget

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -28,7 +28,6 @@ public:
         NUM_MODES
     };
 
-public:
     explicit FilterMode(int mode = SHOW_ALL) :
         mode_(mode)
     {
@@ -76,7 +75,6 @@ public:
         NUM_MODES
     };
 
-public:
     explicit SortMode(int mode = SORT_BY_ID) :
         mode_(mode)
     {

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -27,7 +27,7 @@ class FreeSpaceLabel : public QLabel
     TR_DISABLE_COPY_MOVE(FreeSpaceLabel)
 
 public:
-    FreeSpaceLabel(QWidget* parent = nullptr);
+    explicit FreeSpaceLabel(QWidget* parent = nullptr);
 
     void setSession(Session& session);
     void setPath(QString const& folder);

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -137,7 +137,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     session_(session),
     prefs_(prefs),
     model_(model),
-    lvp_style_(new ListViewProxyStyle{}),
+    lvp_style_(std::make_shared<ListViewProxyStyle>()),
     filter_model_(prefs),
     torrent_delegate_(new TorrentDelegate(this)),
     torrent_delegate_min_(new TorrentDelegateMin(this)),

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -573,7 +573,10 @@ namespace
 {
 
 // Open Folder & select torrent's file or top folder
+
+#ifdef HAVE_OPEN_SELECT
 #undef HAVE_OPEN_SELECT
+#endif
 
 #if defined(Q_OS_WIN)
 

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -91,24 +91,6 @@ protected:
     void dragEnterEvent(QDragEnterEvent*) override;
     void dropEvent(QDropEvent*) override;
 
-private:
-    QIcon getStockIcon(QString const&, int fallback = -1);
-    QIcon addEmblem(QIcon icon, QStringList const& emblem_names);
-
-    torrent_ids_t getSelectedTorrents(bool withMetadataOnly = false) const;
-    void updateNetworkIcon();
-
-    QMenu* createOptionsMenu();
-    QMenu* createStatsModeMenu();
-    void initStatusBar();
-
-    void clearSelection();
-    void addTorrent(AddData const& add_me, bool show_options);
-
-    // QWidget
-    void hideEvent(QHideEvent* event) override;
-    void showEvent(QShowEvent* event) override;
-
 private slots:
     void addTorrents(QStringList const& filenames);
     void copyMagnetLinkToClipboard();
@@ -141,6 +123,23 @@ private slots:
     void trayActivated(QSystemTrayIcon::ActivationReason);
 
 private:
+    QIcon getStockIcon(QString const&, int fallback = -1);
+    QIcon addEmblem(QIcon icon, QStringList const& emblem_names);
+
+    torrent_ids_t getSelectedTorrents(bool withMetadataOnly = false) const;
+    void updateNetworkIcon();
+
+    QMenu* createOptionsMenu();
+    QMenu* createStatsModeMenu();
+    void initStatusBar();
+
+    void clearSelection();
+    void addTorrent(AddData const& add_me, bool show_options);
+
+    // QWidget
+    void hideEvent(QHideEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+
     Session& session_;
     Prefs& prefs_;
     TorrentModel& model_;

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -36,14 +36,13 @@ protected:
     void dragEnterEvent(QDragEnterEvent*) override;
     void dropEvent(QDropEvent*) override;
 
-private:
-    QString getSource() const;
-
 private slots:
     void onSourceChanged();
     void makeTorrent();
 
 private:
+    QString getSource() const;
+
     Session& session_;
 
     Ui::MakeDialog ui_ = {};

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -39,15 +39,6 @@ public:
     OptionsDialog(Session& session, Prefs const& prefs, AddData addme, QWidget* parent = nullptr);
     ~OptionsDialog() override;
 
-private:
-    using mybins_t = QMap<uint32_t, int32_t>;
-
-private:
-    void reload();
-    void updateWidgetsLocality();
-    void clearInfo();
-    void clearVerify();
-
 private slots:
     void onAccepted();
     void onPriorityChanged(QSet<int> const& file_indices, int);
@@ -61,6 +52,13 @@ private slots:
     void onSessionUpdated();
 
 private:
+    using mybins_t = QMap<uint32_t, int32_t>;
+
+    void reload();
+    void updateWidgetsLocality();
+    void clearInfo();
+    void clearVerify();
+
     AddData add_;
     FileList files_;
     QCryptographicHash verify_hash_ = QCryptographicHash(QCryptographicHash::Sha1);

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -24,7 +24,6 @@ public:
         FileMode
     };
 
-public:
     explicit PathButton(QWidget* parent = nullptr);
 
     void setMode(Mode mode);

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -30,25 +30,6 @@ class PrefsDialog : public BaseDialog
 public:
     PrefsDialog(Session&, Prefs&, QWidget* parent = nullptr);
 
-private:
-    using key2widget_t = QMap<int, QWidget*>;
-
-private:
-    bool updateWidgetValue(QWidget* widget, int pref_key);
-    void linkWidgetToPref(QWidget* widget, int pref_key);
-    void updateBlocklistLabel();
-    void updateDownloadingWidgetsLocality();
-
-    void setPref(int key, QVariant const& v);
-
-    void initDownloadingTab();
-    void initSeedingTab();
-    void initSpeedTab();
-    void initPrivacyTab();
-    void initNetworkTab();
-    void initDesktopTab();
-    void initRemoteTab();
-
 private slots:
     void checkBoxToggled(bool checked);
     void spinBoxEditingFinished();
@@ -70,6 +51,23 @@ private slots:
     void onBlocklistUpdated(int n);
 
 private:
+    using key2widget_t = QMap<int, QWidget*>;
+
+    bool updateWidgetValue(QWidget* widget, int pref_key);
+    void linkWidgetToPref(QWidget* widget, int pref_key);
+    void updateBlocklistLabel();
+    void updateDownloadingWidgetsLocality();
+
+    void setPref(int key, QVariant const& v);
+
+    void initDownloadingTab();
+    void initSeedingTab();
+    void initSpeedTab();
+    void initPrivacyTab();
+    void initNetworkTab();
+    void initDesktopTab();
+    void initRemoteTab();
+
     Session& session_;
     Prefs& prefs_;
 

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -24,14 +24,13 @@ class RelocateDialog : public BaseDialog
 public:
     RelocateDialog(Session&, TorrentModel const&, torrent_ids_t ids, QWidget* parent = nullptr);
 
-private:
-    QString newLocation() const;
-
 private slots:
     void onSetLocation();
     void onMoveToggled(bool);
 
 private:
+    QString newLocation() const;
+
     Session& session_;
     torrent_ids_t const ids_;
 

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -144,6 +144,9 @@ signals:
     void networkResponse(QNetworkReply::NetworkError code, QString const& message);
     void httpAuthenticationRequired();
 
+private slots:
+    void onDuplicatesTimer();
+
 private:
     void start();
 
@@ -161,7 +164,6 @@ private:
 
     void addOptionalIds(tr_variant* args, torrent_ids_t const& ids);
 
-private:
     QString const config_dir_;
     Prefs& prefs_;
 
@@ -180,7 +182,4 @@ private:
 
     std::map<QString, QString> duplicates_;
     QTimer duplicates_timer_;
-
-private slots:
-    void onDuplicatesTimer();
 };

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -69,6 +69,5 @@ private:
     {
     }
 
-private:
     int bytes_per_second_ = {};
 };

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -185,13 +185,12 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
             keys.push_back(tr_quark_new(str, len));
         }
     }
-    else
+    else if (first_child != nullptr)
     {
         // In 'object' format, every entry is an object with the same set of properties
-        size_t i = 0;
         tr_quark key;
         tr_variant* value;
-        while (first_child && tr_variantDictChild(first_child, i++, &key, &value))
+        for (size_t i = 0; tr_variantDictChild(first_child, i, &key, &value); ++i)
         {
             keys.push_back(key);
         }

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -36,7 +36,6 @@ public:
         TrackerRole = Qt::UserRole
     };
 
-public:
     TrackerModel() = default;
 
     void refresh(TorrentModel const&, torrent_ids_t const& ids);
@@ -49,6 +48,5 @@ public:
 private:
     using rows_t = QVector<TrackerInfo>;
 
-private:
     rows_t rows_;
 };

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -32,6 +32,12 @@ public:
 signals:
     void torrentFileAdded(QString const& filename);
 
+private slots:
+    void watcherActivated(QString const& path);
+    void onTimeout();
+
+    void rescanAllWatchedDirectories();
+
 private:
     enum
     {
@@ -40,16 +46,8 @@ private:
         ERROR
     };
 
-private:
     int metainfoTest(QString const& filename) const;
 
-private slots:
-    void watcherActivated(QString const& path);
-    void onTimeout();
-
-    void rescanAllWatchedDirectories();
-
-private:
     TorrentModel const& model_;
 
     QSet<QString> watch_dir_files_;


### PR DESCRIPTION
This time around:

* replace use of `getpwuid()` with `getpwuid_r()`

* easy const correctness changes

* a dead store removal

* ensure log.c's printf() calls get literal fmt strings

* remove some redundant access specifiers in trqt headers