### PR TITLE
fix: Add unrecognized client names

### DIFF
--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -234,6 +234,12 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
             tr_snprintf(buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1),
                 strint(id + 5, 1), getMnemonicEnd(id[6]));
         }
+        else if (strncmp(chid + 1, "UW", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "\xc2\xb5Torrent Web %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5,
+                1), getMnemonicEnd(
+                id[6]));
+        }
         /* */
         else if (strncmp(chid + 1, "AZ", 2) == 0)
         {
@@ -290,6 +296,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "BH", 2) == 0)
         {
             four_digits(buf, buflen, "BitZilla", id + 3);
+        }
+        else if (strncmp(chid + 1, "BI", 2) == 0)
+        {
+            four_digits(buf, buflen, "BiglyBT", id + 3);
         }
         else if (strncmp(chid + 1, "BM", 2) == 0)
         {
@@ -499,6 +509,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "ES", 2) == 0)
         {
             three_digits(buf, buflen, "Electric Sheep", id + 3);
+        }
+        else if (strncmp(chid + 1, "FW", 2) == 0)
+        {
+            three_digits(buf, buflen, "FrostWire", id + 3);
         }
         else if (strncmp(chid + 1, "HL", 2) == 0)
         {

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -21,7 +21,7 @@ TEST(Client, clientForId)
         char const* expected_client;
     };
 
-    auto const tests = std::array<LocalTest, 24>{
+    auto const tests = std::array<LocalTest, 27>{
         LocalTest{ "-BT791B-", "BitTorrent 7.9.1 (Beta)" },
         { "-BT791\0-", "BitTorrent 7.9.1" },
         { "-FC1013-", "FileCroc 1.0.1.3" },
@@ -60,7 +60,11 @@ TEST(Client, clientForId)
         { "-I\05O\x08\x03\x01-", "-I%05O%08%03%01-" },
 
         { "\x65\x78\x62\x63\x00\x38\x7A\x44\x63\x10\x2D\x6E\x9A\xD6\x72\x3B\x33\x9F\x35\xA9", "BitComet 0.56" },
-        { "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28", "BitLord 0.56" }
+        { "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28", "BitLord 0.56" },
+
+        { "-UW110Q-", "\xc2\xb5Torrent Web 1.1.0" },
+        { "-FW6830-", "FrostWire 6.8.3" },
+        { "-BI2300-", "BiglyBT 2.3.0.0" }
     };
 
     for (auto const& test : tests)


### PR DESCRIPTION
Fixes issue #1363 

Add ability to recognize uTorrent Web, FrostWire, and BiglyBT