### PR TITLE
Create fail early

### DIFF
--- a/libtransmission/makemeta.c
+++ b/libtransmission/makemeta.c
@@ -433,6 +433,14 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
 {
     tr_variant top;
 
+    /* fail early if we can't write the torrent file */
+    if (!tr_canWriteFile(builder->outputFile))
+    {
+        builder->my_errno = errno;
+        tr_strlcpy(builder->errfile, builder->outputFile, sizeof(builder->errfile));
+        builder->result = TR_MAKEMETA_IO_WRITE;
+    }
+
     /* allow an empty set, but if URLs *are* listed, verify them. #814, #971 */
     for (int i = 0; i < builder->trackerCount && builder->result == TR_MAKEMETA_OK; ++i)
     {

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -15,11 +15,10 @@
 #include <float.h> /* DBL_DIG */
 #include <locale.h> /* localeconv() */
 #include <math.h> /* fabs(), floor() */
-#include <stdio.h>
+#include <stdio.h> /* fopen() */
 #include <stdlib.h> /* getenv() */
 #include <string.h> /* strerror(), memset(), memmem() */
 #include <time.h> /* nanosleep() */
-#include <fcntl.h> /* open() */
 
 #ifdef _WIN32
 #include <ws2tcpip.h> /* WSAStartup() */
@@ -406,17 +405,17 @@ int64_t tr_getDirFreeSpace(char const* dir)
 
 bool tr_canWriteFile(char const* path)
 {
-    int fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0644);
-    int open_error = errno;
+    FILE* file = fopen(path, "wb+");
+    int fopen_error = errno;
 
-    if (fd > 0)
+    if (file != NULL)
     {
-        close(fd);
+        fclose(file);
         return 1;
     }
 
     /* if the file exists don't treat as error */
-    return open_error == EEXIST;
+    return fopen_error == EEXIST;
 }
 
 /****

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -19,6 +19,7 @@
 #include <stdlib.h> /* getenv() */
 #include <string.h> /* strerror(), memset(), memmem() */
 #include <time.h> /* nanosleep() */
+#include <fcntl.h> /* open() */
 
 #ifdef _WIN32
 #include <ws2tcpip.h> /* WSAStartup() */
@@ -401,6 +402,21 @@ int64_t tr_getDirFreeSpace(char const* dir)
     }
 
     return free_space;
+}
+
+bool tr_canWriteFile(char const* path)
+{
+    int fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0644);
+    int open_error = errno;
+
+    if (fd > 0)
+    {
+        close(fd);
+        return 1;
+    }
+
+    /* if the file exists don't treat as error */
+    return open_error == EEXIST;
 }
 
 /****

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -85,6 +85,12 @@ char* tr_buildPath(char const* first_element, ...) TR_GNUC_NULL_TERMINATED TR_GN
 int64_t tr_getDirFreeSpace(char const* path);
 
 /**
+ * @brief Returns wethter we can or not write on a file
+ * @return 1 if can write on file, 0 if we can't
+ */
+bool tr_canWriteFile(char const* path);
+
+/**
  * @brief Convenience wrapper around timer_add() to have a timer wake up in a number of seconds and microseconds
  * @param timer         the timer to set
  * @param seconds       seconds to wait


### PR DESCRIPTION
The output torrent file is not checked for write permission before the heavy work of creating all the metadata of the torrent.
When you create a big torrent file (several giga bytes) you can loose several minutes before the error shows out.

Implementing an early failing behavior is time and resource saving.