### PR TITLE
NAT-PMP private/public port and lifetime fix

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -2988,6 +2988,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = S6RRCN7583;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = macosx;
 				GCC_PREFIX_HEADER = macosx/Transmission_Prefix.pch;
@@ -3178,6 +3179,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = S6RRCN7583;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = macosx;
 				GCC_PREFIX_HEADER = macosx/Transmission_Prefix.pch;
@@ -3335,6 +3337,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = S6RRCN7583;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = macosx;
 				GCC_PREFIX_HEADER = macosx/Transmission_Prefix.pch;

--- a/libtransmission/natpmp.c
+++ b/libtransmission/natpmp.c
@@ -30,8 +30,6 @@ static char const* getKey(void)
     return _("Port Forwarding (NAT-PMP)");
 }
 
-
-
 /**
 ***
 **/
@@ -85,7 +83,8 @@ static void setCommandTime(struct tr_natpmp* nat)
     nat->command_time = tr_time() + COMMAND_WAIT_SECS;
 }
 
-int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port, tr_port *real_private_port)
+int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port,
+    tr_port* real_private_port)
 {
     int ret;
 

--- a/libtransmission/natpmp.c
+++ b/libtransmission/natpmp.c
@@ -30,32 +30,7 @@ static char const* getKey(void)
     return _("Port Forwarding (NAT-PMP)");
 }
 
-typedef enum
-{
-    TR_NATPMP_IDLE,
-    TR_NATPMP_ERR,
-    TR_NATPMP_DISCOVER,
-    TR_NATPMP_RECV_PUB,
-    TR_NATPMP_SEND_MAP,
-    TR_NATPMP_RECV_MAP,
-    TR_NATPMP_SEND_UNMAP,
-    TR_NATPMP_RECV_UNMAP
-}
-tr_natpmp_state;
 
-struct tr_natpmp
-{
-    bool has_discovered;
-    bool is_mapped;
-
-    tr_port public_port;
-    tr_port private_port;
-
-    time_t renew_time;
-    time_t command_time;
-    tr_natpmp_state state;
-    natpmp_t natpmp;
-};
 
 /**
 ***
@@ -110,7 +85,7 @@ static void setCommandTime(struct tr_natpmp* nat)
     nat->command_time = tr_time() + COMMAND_WAIT_SECS;
 }
 
-int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port)
+int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port, tr_port *real_private_port)
 {
     int ret;
 
@@ -230,6 +205,7 @@ int tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled,
     {
     case TR_NATPMP_IDLE:
         *public_port = nat->public_port;
+        *real_private_port = nat->private_port;
         return nat->is_mapped ? TR_PORT_MAPPED : TR_PORT_UNMAPPED;
 
     case TR_NATPMP_DISCOVER:

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -17,12 +17,40 @@
  * @{
  */
 
+#include "natpmp.h"
 typedef struct tr_natpmp tr_natpmp;
 
 tr_natpmp* tr_natpmpInit(void);
 
 void tr_natpmpClose(tr_natpmp*);
 
-int tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port);
+int tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port, tr_port * real_private_port);
+
+typedef enum
+{
+    TR_NATPMP_IDLE,
+    TR_NATPMP_ERR,
+    TR_NATPMP_DISCOVER,
+    TR_NATPMP_RECV_PUB,
+    TR_NATPMP_SEND_MAP,
+    TR_NATPMP_RECV_MAP,
+    TR_NATPMP_SEND_UNMAP,
+    TR_NATPMP_RECV_UNMAP
+}
+tr_natpmp_state;
+
+struct tr_natpmp
+{
+    bool has_discovered;
+    bool is_mapped;
+
+    tr_port public_port;
+    tr_port private_port;
+
+    time_t renew_time;
+    time_t command_time;
+    tr_natpmp_state state;
+    natpmp_t natpmp;
+};
 
 /* @} */

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -24,7 +24,7 @@ tr_natpmp* tr_natpmpInit(void);
 
 void tr_natpmpClose(tr_natpmp*);
 
-int tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port, tr_port * real_private_port);
+int tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port, tr_port* real_private_port);
 
 typedef enum
 {

--- a/libtransmission/port-forwarding.c
+++ b/libtransmission/port-forwarding.c
@@ -91,7 +91,7 @@ static void natPulse(tr_shared* s, bool do_check)
 
     oldStatus = tr_sharedTraversalStatus(s);
 
-    s->natpmpStatus = tr_natpmpPulse(s->natpmp, private_peer_port, is_enabled, &public_peer_port,&received_private_port);
+    s->natpmpStatus = tr_natpmpPulse(s->natpmp, private_peer_port, is_enabled, &public_peer_port, &received_private_port);
 
     if (s->natpmpStatus == TR_PORT_MAPPED)
     {

--- a/libtransmission/port-forwarding.c
+++ b/libtransmission/port-forwarding.c
@@ -97,7 +97,8 @@ static void natPulse(tr_shared* s, bool do_check)
     {
         s->session->public_peer_port = public_peer_port;
         s->session->private_peer_port = received_private_port;
-        tr_logAddNamedInfo(getKey(), "public peer port %d (private %d) ", s->session->public_peer_port, s->session->private_peer_port);
+        tr_logAddNamedInfo(
+            getKey(), "public peer port %d (private %d) ", s->session->public_peer_port, s->session->private_peer_port);
     }
 
     s->upnpStatus = tr_upnpPulse(s->upnp, private_peer_port, is_enabled, do_check);
@@ -123,7 +124,7 @@ static void set_evtimer_from_status(tr_shared* s)
         /* if we're mapped, everything is fine... check back in 20 minutes
          * to renew the port forwarding if it's expired */
         s->doPortCheck = true;
-        sec = s->natpmp->renew_time-time(NULL);
+        sec = s->natpmp->renew_time - time(NULL);
 
         break;
 

--- a/libtransmission/port-forwarding.c
+++ b/libtransmission/port-forwarding.c
@@ -75,6 +75,7 @@ static void natPulse(tr_shared* s, bool do_check)
     int oldStatus;
     int newStatus;
     tr_port public_peer_port;
+    tr_port received_private_port;
     tr_port const private_peer_port = s->session->private_peer_port;
     bool const is_enabled = s->isEnabled && !s->isShuttingDown;
 
@@ -90,11 +91,13 @@ static void natPulse(tr_shared* s, bool do_check)
 
     oldStatus = tr_sharedTraversalStatus(s);
 
-    s->natpmpStatus = tr_natpmpPulse(s->natpmp, private_peer_port, is_enabled, &public_peer_port);
+    s->natpmpStatus = tr_natpmpPulse(s->natpmp, private_peer_port, is_enabled, &public_peer_port,&received_private_port);
 
     if (s->natpmpStatus == TR_PORT_MAPPED)
     {
         s->session->public_peer_port = public_peer_port;
+        s->session->private_peer_port = received_private_port;
+        tr_logAddNamedInfo(getKey(), "public peer port %d (private %d) ", s->session->public_peer_port, s->session->private_peer_port);
     }
 
     s->upnpStatus = tr_upnpPulse(s->upnp, private_peer_port, is_enabled, do_check);
@@ -120,7 +123,8 @@ static void set_evtimer_from_status(tr_shared* s)
         /* if we're mapped, everything is fine... check back in 20 minutes
          * to renew the port forwarding if it's expired */
         s->doPortCheck = true;
-        sec = 60 * 20;
+        sec = s->natpmp->renew_time-time(NULL);
+
         break;
 
     case TR_PORT_ERROR:

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -1346,7 +1346,7 @@ void tr_sessionSetPeerPort(tr_session* session, tr_port port)
 
 tr_port tr_sessionGetPeerPort(tr_session const* session)
 {
-    return tr_isSession(session) ? session->private_peer_port : 0;
+    return tr_isSession(session) ? session->public_peer_port : 0;
 }
 
 tr_port tr_sessionSetPeerPortRandom(tr_session* session)


### PR DESCRIPTION
Hello,

I wrote this little patch to fix NAT-PMP behavior on my VPN. There were two issues :
1. The default hard-coded lifetime on transmission of a nat-pmp entry is 20 min. This create an issue if the NAT-PMP service offers a lifetime which is less than that. I patched the code to reflect the lifetime from the nat-pmp messages and trigger a periodic update from transmission reflecting that time.
2. There was a bug in the private-port/public port values, which prevented the "Test Port" RPC to work .