### PR TITLE
NAT-PMP private/public port and lifetime fix

### DIFF
--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -27,7 +27,6 @@ static char const* getKey(void)
     return _("Port Forwarding (NAT-PMP)");
 }
 
-
 /**
 ***
 **/
@@ -85,7 +84,12 @@ static void setCommandTime(struct tr_natpmp* nat)
     nat->command_time = tr_time() + CommandWaitSecs;
 }
 
-tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port, tr_port* real_private_port)
+tr_port_forwarding tr_natpmpPulse(
+    struct tr_natpmp* nat,
+    tr_port private_port,
+    bool is_enabled,
+    tr_port* public_port,
+    tr_port* real_private_port)
 {
     if (is_enabled && nat->state == TR_NATPMP_DISCOVER)
     {

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -27,31 +27,6 @@ static char const* getKey(void)
     return _("Port Forwarding (NAT-PMP)");
 }
 
-enum tr_natpmp_state
-{
-    TR_NATPMP_IDLE,
-    TR_NATPMP_ERR,
-    TR_NATPMP_DISCOVER,
-    TR_NATPMP_RECV_PUB,
-    TR_NATPMP_SEND_MAP,
-    TR_NATPMP_RECV_MAP,
-    TR_NATPMP_SEND_UNMAP,
-    TR_NATPMP_RECV_UNMAP
-};
-
-struct tr_natpmp
-{
-    bool has_discovered;
-    bool is_mapped;
-
-    tr_port public_port;
-    tr_port private_port;
-
-    time_t renew_time;
-    time_t command_time;
-    tr_natpmp_state state;
-    natpmp_t natpmp;
-};
 
 /**
 ***
@@ -110,7 +85,7 @@ static void setCommandTime(struct tr_natpmp* nat)
     nat->command_time = tr_time() + CommandWaitSecs;
 }
 
-tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port)
+tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port, tr_port* real_private_port)
 {
     if (is_enabled && nat->state == TR_NATPMP_DISCOVER)
     {
@@ -227,6 +202,7 @@ tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, b
     {
     case TR_NATPMP_IDLE:
         *public_port = nat->public_port;
+        *real_private_port = nat->private_port;
         return nat->is_mapped ? TR_PORT_MAPPED : TR_PORT_UNMAPPED;
 
     case TR_NATPMP_DISCOVER:

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -14,12 +14,38 @@
  * @{
  */
 
-struct tr_natpmp;
+#include "natpmp.h"
+
+enum tr_natpmp_state
+{
+    TR_NATPMP_IDLE,
+    TR_NATPMP_ERR,
+    TR_NATPMP_DISCOVER,
+    TR_NATPMP_RECV_PUB,
+    TR_NATPMP_SEND_MAP,
+    TR_NATPMP_RECV_MAP,
+    TR_NATPMP_SEND_UNMAP,
+    TR_NATPMP_RECV_UNMAP
+};
+
+struct tr_natpmp
+{
+    bool has_discovered;
+    bool is_mapped;
+
+    tr_port public_port;
+    tr_port private_port;
+
+    time_t renew_time;
+    time_t command_time;
+    tr_natpmp_state state;
+    natpmp_t natpmp;
+};
 
 tr_natpmp* tr_natpmpInit(void);
 
 void tr_natpmpClose(tr_natpmp*);
 
-tr_port_forwarding tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port);
+tr_port_forwarding tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port, tr_port* real_private_port);
 
 /* @} */

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -68,8 +68,6 @@ static char const* getNatStateStr(int state)
 
 static void natPulse(tr_shared* s, bool do_check)
 {
-    int oldStatus;
-    int newStatus;
     tr_port received_private_port;
     tr_port const private_peer_port = s->session->private_peer_port;
     bool const is_enabled = s->isEnabled && !s->isShuttingDown;
@@ -94,7 +92,10 @@ static void natPulse(tr_shared* s, bool do_check)
         s->session->public_peer_port = public_peer_port;
         s->session->private_peer_port = received_private_port;
         tr_logAddNamedInfo(
-            getKey(), "public peer port %d (private %d) ", s->session->public_peer_port, s->session->private_peer_port);
+            getKey(),
+            "public peer port %d (private %d) ",
+            s->session->public_peer_port,
+            s->session->private_peer_port);
     }
 
     s->upnpStatus = tr_upnpPulse(s->upnp, private_peer_port, is_enabled, do_check);
@@ -123,8 +124,7 @@ static void set_evtimer_from_status(tr_shared* s)
         /* if we're mapped, everything is fine... check back in 20 minutes
          * to renew the port forwarding if it's expired */
         s->doPortCheck = true;
-        sec = s->natpmp->renew_time - time(NULL);
-
+        sec = (int)(s->natpmp->renew_time - time(NULL));
         break;
 
     case TR_PORT_ERROR:

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -121,10 +121,10 @@ static void set_evtimer_from_status(tr_shared* s)
     switch (tr_sharedTraversalStatus(s))
     {
     case TR_PORT_MAPPED:
-        /* if we're mapped, everything is fine... check back in 20 minutes
+        /* if we're mapped, everything is fine... check back at renew_time
          * to renew the port forwarding if it's expired */
         s->doPortCheck = true;
-        sec = (int)(s->natpmp->renew_time - time(NULL));
+        sec = int(s->natpmp->renew_time - tr_time());
         break;
 
     case TR_PORT_ERROR:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1247,7 +1247,7 @@ void tr_sessionSetPeerPort(tr_session* session, tr_port port)
 
 tr_port tr_sessionGetPeerPort(tr_session const* session)
 {
-    return tr_isSession(session) ? session->private_peer_port : 0;
+    return tr_isSession(session) ? session->public_peer_port : 0;
 }
 
 tr_port tr_sessionSetPeerPortRandom(tr_session* session)


### PR DESCRIPTION
Hello,

I wrote this little patch to fix NAT-PMP behavior on my VPN. There were two issues :
    - The default hard-coded lifetime on transmission of a nat-pmp entry is 20 min. This create an issue if the NAT-PMP service offers a lifetime which is less than that. I patched the code to reflect the lifetime from the nat-pmp messages and trigger a periodic update from transmission reflecting that time.
    - There was a bug in the private-port/public port values, which prevented the "Test Port" RPC to work .
