### PR TITLE
fix: dangling reference crash in FreeSpaceLabel

### DIFF
--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -73,29 +73,37 @@ void FreeSpaceLabel::onTimer()
 
     auto* q = new RpcQueue();
 
+    auto* alive = new bool(true);
+    connect(this, &QObject::destroyed, [alive] { *alive = false; });
+
     q->add([this, &args]()
         {
             return session_->exec("free-space", &args);
         });
 
-    q->add([this](RpcResponse const& r)
+    q->add([this, alive](RpcResponse const& r)
         {
-            // update the label
-            auto const bytes = dictFind<int64_t>(r.args.get(), TR_KEY_size_bytes);
-            if (bytes && *bytes > 1)
+            if (*alive)
             {
-                setText(tr("%1 free").arg(Formatter::get().sizeToString(*bytes)));
-            }
-            else
-            {
-                setText(QString());
+                // update the label
+                auto const bytes = dictFind<int64_t>(r.args.get(), TR_KEY_size_bytes);
+                if (bytes && *bytes > 1)
+                {
+                    setText(tr("%1 free").arg(Formatter::get().sizeToString(*bytes)));
+                }
+                else
+                {
+                    clear();
+                }
+
+                // update the tooltip
+                auto const path = dictFind<QString>(r.args.get(), TR_KEY_path);
+                setToolTip(QDir::toNativeSeparators(path ? *path : QString()));
+
+                timer_.start();
             }
 
-            // update the tooltip
-            auto const path = dictFind<QString>(r.args.get(), TR_KEY_path);
-            setToolTip(QDir::toNativeSeparators(path ? *path : QString()));
-
-            timer_.start();
+            delete alive;
         });
 
     q->run();


### PR DESCRIPTION
Fixes a crash that could happen if a FreeSpaceLabel was destroyed while an RPC request was in-flight.