### PR TITLE
Properly parse dht_search()

### DIFF
--- a/libtransmission/tr-dht.c
+++ b/libtransmission/tr-dht.c
@@ -729,7 +729,7 @@ static int tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
     {
         rc = dht_search(tor->info.hash, announce ? tr_sessionGetPeerPort(session_) : 0, af, callback, NULL);
 
-        if (rc >= 1)
+        if (rc >= 0)
         {
             tr_logAddTorInfo(tor, "Starting %s DHT announce (%s, %d nodes)", af == AF_INET6 ? "IPv6" : "IPv4",
                 tr_dhtPrintableStatus(status), numnodes);


### PR DESCRIPTION
Per analysis by cfpp2p
(https://github.com/transmission/transmission/issues/564#issuecomment-377612224),
a duplicate search is not an error.