### PR TITLE
Add the option of automatically picking up URLs from the clipboard on window focus

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -21,7 +21,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr my_static = std::array<std::string_view, 389>{ ""sv,
+auto constexpr my_static = std::array<std::string_view, 390>{ ""sv,
                                                               "activeTorrentCount"sv,
                                                               "activity-date"sv,
                                                               "activityDate"sv,
@@ -274,6 +274,7 @@ auto constexpr my_static = std::array<std::string_view, 389>{ ""sv,
                                                               "ratio-limit"sv,
                                                               "ratio-limit-enabled"sv,
                                                               "ratio-mode"sv,
+                                                              "read-clipboard"sv,
                                                               "recent-download-dir-1"sv,
                                                               "recent-download-dir-2"sv,
                                                               "recent-download-dir-3"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -276,6 +276,7 @@ enum
     TR_KEY_ratio_limit,
     TR_KEY_ratio_limit_enabled,
     TR_KEY_ratio_mode,
+    TR_KEY_read_clipboard,
     TR_KEY_recent_download_dir_1,
     TR_KEY_recent_download_dir_2,
     TR_KEY_recent_download_dir_3,

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1212,12 +1212,10 @@ void MainWindow::refreshPref(int key)
         break;
 
     case Prefs::COMPACT_VIEW:
-        {
-            b = prefs_.getBool(key);
-            ui_.action_CompactView->setChecked(b);
-            ui_.listView->setItemDelegate(b ? torrent_delegate_min_ : torrent_delegate_);
-            break;
-        }
+        b = prefs_.getBool(key);
+        ui_.action_CompactView->setChecked(b);
+        ui_.listView->setItemDelegate(b ? torrent_delegate_min_ : torrent_delegate_);
+        break;
 
     case Prefs::MAIN_WINDOW_X:
     case Prefs::MAIN_WINDOW_Y:
@@ -1246,10 +1244,8 @@ void MainWindow::refreshPref(int key)
         }
 
     case Prefs::READ_CLIPBOARD:
-        {
-            b = prefs_.getBool(Prefs::READ_CLIPBOARD);
-            read_from_clipboard_ = b;
-        }
+        read_from_clipboard_ = prefs_.getBool(Prefs::READ_CLIPBOARD);
+        break;
 
     default:
         break;
@@ -1612,11 +1608,11 @@ bool MainWindow::event(QEvent* e)
         return QMainWindow::event(e);
     }
 
-    QClipboard const* clipboard = QGuiApplication::clipboard();
-    if (clipboard->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
-        clipboard->text().startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
+    QString const text = QGuiApplication::clipboard()->text().trimmed();
+    if (text.endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
+        text.startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
     {
-        QStringList list = clipboard->text().trimmed().split(QLatin1Char('\n'));
+        QStringList list = text.split(QLatin1Char('\n'));
 
         for (QString const& entry : list)
         {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1633,7 +1633,7 @@ bool MainWindow::event(QEvent* e)
         }
     }
 
-    return QWidget::event(e);
+    return QMainWindow::event(e);
 }
 
 /***

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1612,7 +1612,7 @@ bool MainWindow::event(QEvent* e)
         return QMainWindow::event(e);
     }
 
-    QClipboard* const clipboard = QGuiApplication::clipboard();
+    QClipboard const* clipboard = QGuiApplication::clipboard();
     if (clipboard->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
         clipboard->text().startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
     {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1598,6 +1598,44 @@ void MainWindow::dropEvent(QDropEvent* event)
     }
 }
 
+bool MainWindow::event(QEvent* e)
+{
+    if (e->type() == QEvent::WindowActivate)
+    {
+        QClipboard* clipboard = QGuiApplication::clipboard();
+        if (clipboard->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||
+            clipboard->text().startsWith(QStringLiteral("magnet:"), Qt::CaseInsensitive))
+        {
+            QStringList list = clipboard->text().trimmed().split(QLatin1Char('\n'));
+
+            for (QString const& entry : list)
+            {
+                QString key = entry.trimmed();
+
+                if (!key.isEmpty())
+                {
+                    QUrl const url(key);
+
+                    if (url.isLocalFile())
+                    {
+                        key = url.toLocalFile();
+                    }
+
+                    static QStringList processed;
+
+                    if (!processed.contains(key))
+                    {
+                        processed.append(key);
+                        trApp->addTorrent(AddData(key));
+                    }
+                }
+            }
+        }
+    }
+
+    return QWidget::event(e);
+}
+
 /***
 ****
 ***/

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -317,7 +317,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     connect(&filter_model_, &TorrentFilter::rowsRemoved, this, refresh_header_soon);
     connect(ui_.listView, &TorrentView::headerDoubleClicked, filter_bar, &FilterBar::clear);
 
-    static std::array<int, 16> constexpr InitKeys = {
+    static std::array<int, 17> constexpr InitKeys = {
         Prefs::ALT_SPEED_LIMIT_ENABLED, //
         Prefs::COMPACT_VIEW, //
         Prefs::DSPEED, //
@@ -326,6 +326,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
         Prefs::MAIN_WINDOW_X, //
         Prefs::RATIO, //
         Prefs::RATIO_ENABLED, //
+        Prefs::READ_CLIPBOARD, //
         Prefs::SHOW_TRAY_ICON, //
         Prefs::SORT_MODE, //
         Prefs::SORT_REVERSED, //
@@ -1244,6 +1245,12 @@ void MainWindow::refreshPref(int key)
             break;
         }
 
+    case Prefs::READ_CLIPBOARD:
+        {
+            b = prefs_.getBool(Prefs::READ_CLIPBOARD);
+            read_from_clipboard_ = b;
+        }
+
     default:
         break;
     }
@@ -1600,7 +1607,7 @@ void MainWindow::dropEvent(QDropEvent* event)
 
 bool MainWindow::event(QEvent* e)
 {
-    if (e->type() == QEvent::WindowActivate)
+    if (e->type() == QEvent::WindowActivate && read_from_clipboard_)
     {
         QClipboard* clipboard = QGuiApplication::clipboard();
         if (clipboard->text().trimmed().endsWith(QStringLiteral(".torrent"), Qt::CaseInsensitive) ||

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -179,6 +179,7 @@ private:
     QWidget* filter_bar_ = {};
     QAction* alt_speed_action_ = {};
     QString error_message_;
+    bool read_from_clipboard_ = {};
 
     QString const total_ratio_stats_mode_name_ = QStringLiteral("total-ratio");
     QString const total_transfer_stats_mode_name_ = QStringLiteral("total-transfer");

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -91,6 +91,7 @@ protected:
     void contextMenuEvent(QContextMenuEvent*) override;
     void dragEnterEvent(QDragEnterEvent*) override;
     void dropEvent(QDropEvent*) override;
+    bool event(QEvent*) override;
 
 private slots:
     void addTorrents(QStringList const& filenames);

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -179,7 +179,8 @@ private:
     QWidget* filter_bar_ = {};
     QAction* alt_speed_action_ = {};
     QString error_message_;
-    bool read_from_clipboard_ = {};
+    bool auto_add_clipboard_links = {};
+    QStringList clipboard_processed_keys_ = {};
 
     QString const total_ratio_stats_mode_name_ = QStringLiteral("total-ratio");
     QString const total_transfer_stats_mode_name_ = QStringLiteral("total-transfer");

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -100,6 +100,7 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items{
     { COMPLETE_SOUND_COMMAND, TR_KEY_torrent_complete_sound_command, QVariant::StringList },
     { COMPLETE_SOUND_ENABLED, TR_KEY_torrent_complete_sound_enabled, QVariant::Bool },
     { USER_HAS_GIVEN_INFORMED_CONSENT, TR_KEY_user_has_given_informed_consent, QVariant::Bool },
+    { READ_CLIPBOARD, TR_KEY_read_clipboard, QVariant::Bool },
 
     /* libtransmission settings */
     { ALT_SPEED_LIMIT_UP, TR_KEY_alt_speed_up, QVariant::Int },
@@ -493,6 +494,7 @@ void Prefs::initDefaults(tr_variant* d) const
     dictAdd(d, TR_KEY_sort_mode, SortMode);
     dictAdd(d, TR_KEY_statusbar_stats, StatsMode);
     dictAdd(d, TR_KEY_watch_dir, download_dir);
+    dictAdd(d, TR_KEY_read_clipboard, false);
 }
 
 /***

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -74,6 +74,7 @@ public:
         COMPLETE_SOUND_COMMAND,
         COMPLETE_SOUND_ENABLED,
         USER_HAS_GIVEN_INFORMED_CONSENT,
+        READ_CLIPBOARD,
         /* core prefs */
         FIRST_CORE_PREF,
         ALT_SPEED_LIMIT_UP = FIRST_CORE_PREF,

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -569,6 +569,7 @@ void PrefsDialog::initDownloadingTab()
     linkWidgetToPref(ui_.watchDirEdit, Prefs::DIR_WATCH);
     linkWidgetToPref(ui_.showTorrentOptionsDialogCheck, Prefs::OPTIONS_PROMPT);
     linkWidgetToPref(ui_.startAddedTorrentsCheck, Prefs::START);
+    linkWidgetToPref(ui_.detectTorrentFromClipboard, Prefs::READ_CLIPBOARD);
     linkWidgetToPref(ui_.trashTorrentFileCheck, Prefs::TRASH_ORIGINAL);
     linkWidgetToPref(ui_.downloadDirButton, Prefs::DOWNLOAD_DIR);
     linkWidgetToPref(ui_.downloadDirEdit, Prefs::DOWNLOAD_DIR);

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>545</width>
+    <width>601</width>
     <height>547</height>
    </rect>
   </property>
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="elideMode">
       <enum>Qt::ElideNone</enum>
@@ -273,6 +273,13 @@
          <property name="leftMargin">
           <number>18</number>
          </property>
+         <item row="5" column="0">
+          <widget class="QLabel" name="downloadDirLabel">
+           <property name="text">
+            <string>Save to &amp;Location:</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="0">
           <widget class="QCheckBox" name="watchDirCheck">
            <property name="text">
@@ -280,6 +287,37 @@
            </property>
            <property name="checked">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="startAddedTorrentsCheck">
+           <property name="text">
+            <string>&amp;Start added torrents</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="FreeSpaceLabel" name="downloadDirFreeSpaceLabel">
+           <property name="text">
+            <string notr="true">...</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QCheckBox" name="showTorrentOptionsDialogCheck">
+           <property name="text">
+            <string>Show the Torrent Options &amp;dialog</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="trashTorrentFileCheck">
+           <property name="text">
+            <string>Mo&amp;ve the .torrent file to the trash</string>
            </property>
           </widget>
          </item>
@@ -295,35 +333,7 @@
            <widget class="QLineEdit" name="watchDirEdit"/>
           </widget>
          </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QCheckBox" name="showTorrentOptionsDialogCheck">
-           <property name="text">
-            <string>Show the Torrent Options &amp;dialog</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QCheckBox" name="startAddedTorrentsCheck">
-           <property name="text">
-            <string>&amp;Start added torrents</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QCheckBox" name="trashTorrentFileCheck">
-           <property name="text">
-            <string>Mo&amp;ve the .torrent file to the trash</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="downloadDirLabel">
-           <property name="text">
-            <string>Save to &amp;Location:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QStackedWidget" name="downloadDirStack">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -335,13 +345,10 @@
            <widget class="QLineEdit" name="downloadDirEdit"/>
           </widget>
          </item>
-         <item row="5" column="1">
-          <widget class="FreeSpaceLabel" name="downloadDirFreeSpaceLabel">
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="PasteTorrentFromClipboard">
            <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <string>Paste torrent from clipboard</string>
            </property>
           </widget>
          </item>

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -347,6 +347,9 @@
          </item>
          <item row="3" column="0">
           <widget class="QCheckBox" name="detectTorrentFromClipboard">
+           <property name="toolTip">
+            <string>Reads user clipboard content for torrents</string>
+           </property>
            <property name="text">
             <string>Detect new torrents from clipboard</string>
            </property>

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -346,9 +346,9 @@
           </widget>
          </item>
          <item row="3" column="0">
-          <widget class="QCheckBox" name="PasteTorrentFromClipboard">
+          <widget class="QCheckBox" name="detectTorrentFromClipboard">
            <property name="text">
-            <string>Paste torrent from clipboard</string>
+            <string>Detect new torrents from clipboard</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This PR aims to implement #1515 for the Qt frontend

When the window is focused, if the user has opted in to the functionality in the preferences, the clipboard will be searched for URLs.

(FYI: This has been implemented as part of a university course)