### PR TITLE
fix: don't follow symlinks when removing junk files

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2125,7 +2125,7 @@ static void removeEmptyFoldersAndJunkFiles(char const* folder)
             auto const filename = tr_strvPath(folder, name);
 
             auto info = tr_sys_path_info{};
-            if (tr_sys_path_get_info(filename.c_str(), 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY)
+            if (tr_sys_path_get_info(filename.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY)
             {
                 removeEmptyFoldersAndJunkFiles(filename.c_str());
             }


### PR DESCRIPTION
This prevents accidentally following a symlink that points outside of
the torrent's folder and crawling the rest of the drive for junk files
to remove.

This also prevents symlinks that point to a folder from being treated as
real directories, which would cause them to be removed even if the folder
they point to is not actually empty.

Both issues are especially bad when combined: a symlink to / inside the
torrent folder caused transmission to crawl the entire drive and delete
every single folder symlink it could find. Oops.