### PR TITLE
Use different User-Agent deppending on the interface type.

### DIFF
--- a/cli/cli.c
+++ b/cli/cli.c
@@ -275,7 +275,7 @@ int tr_main(int argc, char* argv[])
         }
     }
 
-    h = tr_sessionInit(configDir, false, &settings);
+    h = tr_sessionInit(configDir, false, &settings, "CLI");
 
     ctor = tr_ctorNew(h);
 

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -658,7 +658,7 @@ static int daemon_start(void* raw_arg, bool foreground)
     tr_formatter_mem_init(MEM_K, MEM_K_STR, MEM_M_STR, MEM_G_STR, MEM_T_STR);
     tr_formatter_size_init(DISK_K, DISK_K_STR, DISK_M_STR, DISK_G_STR, DISK_T_STR);
     tr_formatter_speed_init(SPEED_K, SPEED_K_STR, SPEED_M_STR, SPEED_G_STR, SPEED_T_STR);
-    session = tr_sessionInit(configDir, true, settings);
+    session = tr_sessionInit(configDir, true, settings, "daemon");
     tr_sessionSetRPCCallback(session, on_rpc_callback, NULL);
     tr_logAddNamedInfo(NULL, "Using settings from \"%s\"", configDir);
     tr_sessionSaveSettings(session, configDir, settings);

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -524,7 +524,7 @@ static void on_startup(GApplication* application, gpointer user_data)
     }
 
     /* initialize the libtransmission session */
-    session = tr_sessionInit(cbdata->config_dir, TRUE, gtr_pref_get_all());
+    session = tr_sessionInit(cbdata->config_dir, TRUE, gtr_pref_get_all(), "GTK");
 
     gtr_pref_flag_set(TR_KEY_alt_speed_enabled, tr_sessionUsesAltSpeed(session));
     gtr_pref_int_set(TR_KEY_peer_port, tr_sessionGetPeerPort(session));

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -189,6 +189,8 @@ struct tr_session
 
     char* blocklist_url;
 
+    char const* http_user_agent;
+
     struct tr_device_info* downloadDir;
 
     struct tr_list* blocklists;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -199,11 +199,13 @@ void tr_sessionSaveSettings(tr_session* session, char const* configDir, struct t
  * @param configDir where Transmission will look for resume files, blocklists, etc.
  * @param messageQueueingEnabled if false, messages will be dumped to stderr
  * @param settings libtransmission settings
+ * @param userAgentComment comment to be appended to the User-Agent in HTTP requests
  * @see tr_sessionGetDefaultSettings()
  * @see tr_sessionLoadSettings()
  * @see tr_getDefaultConfigDir()
  */
-tr_session* tr_sessionInit(char const* configDir, bool messageQueueingEnabled, struct tr_variant* settings);
+tr_session* tr_sessionInit(char const* configDir, bool messageQueueingEnabled, struct tr_variant* settings,
+    char const* userAgentComment);
 
 /** @brief Update a session's settings from a benc dictionary
            like to the one used in tr_sessionInit() */

--- a/libtransmission/web.c
+++ b/libtransmission/web.c
@@ -280,7 +280,7 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
 
     curl_easy_setopt(e, CURLOPT_TIMEOUT, task->timeout_secs);
     curl_easy_setopt(e, CURLOPT_URL, task->url);
-    curl_easy_setopt(e, CURLOPT_USERAGENT, TR_NAME "/" SHORT_VERSION_STRING);
+    curl_easy_setopt(e, CURLOPT_USERAGENT, s->http_user_agent);
     curl_easy_setopt(e, CURLOPT_VERBOSE, (long)(web->curl_verbose ? 1 : 0));
     curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
     curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -461,7 +461,7 @@ static void removeKeRangerRansomware()
                                     [tbString UTF8String]);
 
         const char * configDir = tr_getDefaultConfigDir("Transmission");
-        fLib = tr_sessionInit(configDir, YES, &settings);
+        fLib = tr_sessionInit(configDir, YES, &settings, "macOS");
         tr_variantFree(&settings);
 
         fConfigDirectory = [[NSString alloc] initWithUTF8String: configDir];

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -360,7 +360,7 @@ void Session::start()
         tr_variant settings;
         tr_variantInitDict(&settings, 0);
         tr_sessionLoadSettings(&settings, config_dir_.toUtf8().constData(), "qt");
-        session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings);
+        session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings, "Qt");
         tr_variantFree(&settings);
 
         rpc_.start(session_);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -332,7 +332,7 @@ private:
             tr_variantDictAddInt(settings, q, verbose ? TR_LOG_DEBUG : TR_LOG_ERROR);
         }
 
-        return tr_sessionInit(sandboxDir().data(), !verbose, settings);
+        return tr_sessionInit(sandboxDir().data(), !verbose, settings, nullptr);
     }
 
     void sessionClose(tr_session* session)


### PR DESCRIPTION
Improves upon issue #1649, because now private trackers can differentiate between Transmission variants they find problematic.