### PR TITLE
Update platform.h

### DIFF
--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -12,8 +12,13 @@
 #error only libtransmission should #include this header.
 #endif
 
-#define TR_PATH_DELIMITER '/'
-#define TR_PATH_DELIMITER_STR "/"
+#ifdef _WIN32
+    #define TR_PATH_DELIMITER '\\'
+    #define TR_PATH_DELIMITER_STR "\\"
+#else
+    #define TR_PATH_DELIMITER '/'
+    #define TR_PATH_DELIMITER_STR "/"
+#endif
 
 /**
  * @addtogroup tr_session Session


### PR DESCRIPTION
How is it possible in 2021? If I add torrent into folder with backslash at the end (like D:\Torrents\) then it leads to fail, because transmission make result path something like C:\Torrents\/file.txt