### PR TITLE
Use reflink-copy for moving files over filesystems fast

### DIFF
--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -406,6 +406,16 @@ bool tr_sys_path_rename(char const* src_path, char const* dst_path, tr_error** e
     TR_ASSERT(dst_path != NULL);
 
     bool ret = rename(src_path, dst_path) != -1;
+    int errsv = errno;
+
+    // Use system mv's copy-on-write mechanism for move
+    // from a filesystem to another:
+    if (errsv == EXDEV)
+    {
+        char base[500] = "mv ";
+        char const* cmd = strcat(strcat(strcat(base, src_path), " "), dst_path);
+        ret = system(cmd) != -1;
+    }
 
     if (!ret)
     {


### PR DESCRIPTION
Discussed in #1060 .

Syscall rename(2) fails for moving files between filesystems, so instead of fall-backing into full copy-and-write, use mv, which uses reflinks internally.