### PR TITLE
WIP: Support binding the RPC to a Unix socket

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -82,6 +82,7 @@ typedef enum tr_address_type
 {
     TR_AF_INET,
     TR_AF_INET6,
+    TR_AF_UNIX,
     NUM_TR_AF_INET_TYPES
 }
 tr_address_type;
@@ -93,6 +94,7 @@ typedef struct tr_address
     {
         struct in6_addr addr6;
         struct in_addr addr4;
+        char unixSocketPath[TR_UNIX_ADDRSTRLEN];
     }
     addr;
 }
@@ -115,9 +117,14 @@ int tr_address_compare(tr_address const* a, tr_address const* b);
 
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);
 
-static inline bool tr_address_is_valid(tr_address const* a)
+static inline bool tr_address_is_valid_inet(tr_address const* a)
 {
     return a != NULL && (a->type == TR_AF_INET || a->type == TR_AF_INET6);
+}
+
+static inline bool tr_address_is_valid(tr_address const* a)
+{
+    return tr_address_is_valid_inet(a) || a->type == TR_AF_UNIX;
 }
 
 /***********************************************************************

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -164,7 +164,13 @@
 
 #define TR_INET6_ADDRSTRLEN 46
 
+#define TR_UNIX_ADDRSTRLEN 108
+
 #define TR_ADDRSTRLEN 64
+
+#define TR_UNIX_SOCKET_PREFIX "unix:"
+
+#define TR_UNIX_LISTEN_BACKLOG 10
 
 #define TR_BAD_SIZE ((size_t)-1)
 


### PR DESCRIPTION
Resolves #441 

The RPC can now listen on a Unix socket like this: `transmission-daemon -r unix:/tmp/mysocket.sock`

I've marked the PR as WIP because it likely needs porting to Windows. I don't know anything about Windows so someone else will have to do that. Additionally, I haven't done anything with curl yet so the web interface is probably broken.