### PR TITLE
Fix typo in transmission_hu.ts

### DIFF
--- a/qt/translations/transmission_hu.ts
+++ b/qt/translations/transmission_hu.ts
@@ -2242,7 +2242,7 @@ Másik elsődleges URL-t új sorba írva adhatsz hozzá.</translation>
     <message>
         <location line="+7"/>
         <source>Connect to &amp;Remote Session</source>
-        <translation>Csatalkozás &amp;távoli munkamenethez</translation>
+        <translation>Csatlakozás &amp;távoli munkamenethez</translation>
     </message>
     <message>
         <location line="+7"/>


### PR DESCRIPTION
Original word does not exist in Hungarian language, swap two letters to fix it.