### PR TITLE
Add unrecognized client names #1363

### DIFF
--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -826,7 +826,7 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
     }
     else if (strncmp(chid, "-BL", 3) == 0)
     {
-        tr_snprintf(buf, buflen, "BitLord %c.%c.%c-%c%c", id[3], id[4], id[5], id[6], id[7]);
+        tr_snprintf(buf, buflen, "BitLord %c.%c.%c-%c%c%c", id[3], id[4], id[5], id[6], id[7], id[8]);
     }
 
     /* Shad0w-style */

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -234,6 +234,11 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
             tr_snprintf(buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1),
                 strint(id + 5, 1), getMnemonicEnd(id[6]));
         }
+        else if (strncmp(chid + 1, "UW", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "\xc2\xb5Torrent Web %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5,
+                1), getMnemonicEnd(id[6]));
+        }
         /* */
         else if (strncmp(chid + 1, "AZ", 2) == 0)
         {
@@ -666,7 +671,7 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "UW", 2) == 0)
         {
             tr_snprintf(buf, buflen, "\xc2\xb5Torrent Web %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5,
-                1), getMnemonicEnd(id[6]));
+                2), getMnemonicEnd(id[7]));
         }
 
         if (!tr_str_is_empty(buf))

--- a/libtransmission/clients.c
+++ b/libtransmission/clients.c
@@ -291,6 +291,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             four_digits(buf, buflen, "BitZilla", id + 3);
         }
+        else if (strncmp(chid + 1, "BI", 2) == 0)
+        {
+            four_digits(buf, buflen, "BiglyBT", id + 3);
+        }
         else if (strncmp(chid + 1, "BM", 2) == 0)
         {
             four_digits(buf, buflen, "BitMagnet", id + 3);
@@ -467,6 +471,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             four_digits(buf, buflen, "FireTorrent", id + 3);
         }
+        else if (strncmp(chid + 1, "WW", 2) == 0)
+        {
+            four_digits(buf, buflen, "WebTorrent", id + 3);
+        }
         else if (strncmp(chid + 1, "XL", 2) == 0)
         {
             four_digits(buf, buflen, "Xunlei", id + 3);
@@ -499,6 +507,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         else if (strncmp(chid + 1, "ES", 2) == 0)
         {
             three_digits(buf, buflen, "Electric Sheep", id + 3);
+        }
+        else if (strncmp(chid + 1, "FW", 2) == 0)
+        {
+            three_digits(buf, buflen, "FrostWire", id + 3);
         }
         else if (strncmp(chid + 1, "HL", 2) == 0)
         {
@@ -622,6 +634,10 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             tr_snprintf(buf, buflen, "Baidu Netdisk");
         }
+        else if (strncmp(chid + 1, "WS", 2) == 0)
+        {
+            no_version(buf, buflen, "HTTP Seed");
+        }
 
         if (!tr_str_is_empty(buf))
         {
@@ -646,6 +662,11 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         {
             tr_snprintf(buf, buflen, "\xc2\xb5Torrent Embedded %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1),
                 strint(id + 5, 2), getMnemonicEnd(id[7]));
+        }
+        else if (strncmp(chid + 1, "UW", 2) == 0)
+        {
+            tr_snprintf(buf, buflen, "\xc2\xb5Torrent Web %d.%d.%d%s", strint(id + 3, 1), strint(id + 4, 1), strint(id + 5,
+                1), getMnemonicEnd(id[6]));
         }
 
         if (!tr_str_is_empty(buf))
@@ -787,6 +808,25 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
     else if (strncmp(chid, "TIX", 3) == 0)
     {
         two_major_two_minor(buf, buflen, "Tixati", id + 3);
+    }
+    else if (strncmp(chid, "A2", 2) == 0)
+    {
+        if (id[4] == '-' && id[6] == '-' && id[8] == '-')
+        {
+            tr_snprintf(buf, buflen, "aria2 %c.%c.%c", id[3], id[5], id[7]);
+        }
+        else if (id[4] == '-' && id[7] == '-' && id[9] == '-')
+        {
+            tr_snprintf(buf, buflen, "aria2 %c.%c%c.%c", id[3], id[5], id[6], id[8]);
+        }
+        else
+        {
+            no_version(buf, buflen, "aria2");
+        }
+    }
+    else if (strncmp(chid, "-BL", 3) == 0)
+    {
+        tr_snprintf(buf, buflen, "BitLord %c.%c.%c-%c%c", id[3], id[4], id[5], id[6], id[7]);
     }
 
     /* Shad0w-style */

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -67,7 +67,7 @@ TEST(Client, clientForId)
         { "-BI2300-", "BiglyBT 2.3.0.0" },
         { "A2-1-18-8-", "aria2 1.18.8" },
         { "A2-1-2-0-", "aria2 1.2.0" },
-        { "-BL24632", "BitLord 2.4.6-32" },
+        { "-BL246326", "BitLord 2.4.6-326" }, // Style used after BitLord 0.59
         { "-WW0007-", "WebTorrent 0.0.0.7" },
         { "-WS1000-", "HTTP Seed" }
     };

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -21,7 +21,7 @@ TEST(Client, clientForId)
         char const* expected_client;
     };
 
-    auto const tests = std::array<LocalTest, 24>{
+    auto const tests = std::array<LocalTest, 32>{
         LocalTest{ "-BT791B-", "BitTorrent 7.9.1 (Beta)" },
         { "-BT791\0-", "BitTorrent 7.9.1" },
         { "-FC1013-", "FileCroc 1.0.1.3" },
@@ -60,7 +60,16 @@ TEST(Client, clientForId)
         { "-I\05O\x08\x03\x01-", "-I%05O%08%03%01-" },
 
         { "\x65\x78\x62\x63\x00\x38\x7A\x44\x63\x10\x2D\x6E\x9A\xD6\x72\x3B\x33\x9F\x35\xA9", "BitComet 0.56" },
-        { "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28", "BitLord 0.56" }
+        { "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28", "BitLord 0.56" },
+
+        { "-UW110Q-", "\xc2\xb5Torrent Web 1.1.0" },
+        { "-FW6830-", "FrostWire 6.8.3" },
+        { "-BI2300-", "BiglyBT 2.3.0.0" },
+        { "A2-1-18-8-", "aria2 1.18.8" },
+        { "A2-1-2-0-", "aria2 1.2.0" },
+        { "-BL24632", "BitLord 2.4.6-32" },
+        { "-WW0007-", "WebTorrent 0.0.0.7" },
+        { "-WS1000-", "HTTP Seed" }
     };
 
     for (auto const& test : tests)


### PR DESCRIPTION
This is based off of PR #1526 by azy5030 to add in: Torrent Web, BiglyBT, and FrostWire. I made the additional change requested by livings124.

In addition this also adds support for: HTTP Seed, aria2 (#532), and BitLord. Further testing revealed the BitLord -32 is not the 32 bit version as I thought, but instead part of a 3 digit build number. I've fixed this in my second commit.

This is my first PR so if there are any more changes required let me know and I'll make them.