### PR TITLE
Add total disk space to free-space RPC request

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -658,7 +658,7 @@
    -------------+----------------------------------------------------------
    "path"       | string  same as the Request argument
    "size-bytes" | number  the size, in bytes, of the free space in that directory
-   "total-bytes"| number  the total size, in bytes, that exists in that directory
+   "total_size" | number  the total size, in bytes, that exists in that directory
 
 
 5.0.  Protocol Versions

--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -654,10 +654,11 @@
 
    Response arguments:
 
-   string      | value type & description
-   ------------+----------------------------------------------------------
-   "path"      | string  same as the Request argument
-   "size-bytes"| number  the size, in bytes, of the free space in that directory
+   string       | value type & description
+   -------------+----------------------------------------------------------
+   "path"       | string  same as the Request argument
+   "size-bytes" | number  the size, in bytes, of the free space in that directory
+   "total-bytes"| number  the total size, in bytes, that exists in that directory
 
 
 5.0.  Protocol Versions

--- a/libtransmission/platform-quota.c
+++ b/libtransmission/platform-quota.c
@@ -265,20 +265,19 @@ static char const* getblkdev(char const* path)
 
 #include <quota.h>
 
-static int64_t getquota(char const* device)
+struct tr_disk_space getquota(char const* device)
 {
     struct quotahandle* qh;
     struct quotakey qk;
     struct quotaval qv;
-    int64_t limit;
-    int64_t freespace;
+    struct tr_disk_space disk_space;
     int64_t spaceused;
 
     qh = quota_open(device);
 
     if (qh == NULL)
     {
-        return -1;
+        return { -1, -1 };
     }
 
     qk.qk_idtype = QUOTA_IDTYPE_USER;
@@ -288,7 +287,7 @@ static int64_t getquota(char const* device)
     if (quota_get(qh, &qk, &qv) == -1)
     {
         quota_close(qh);
-        return -1;
+        return { -1, -1 };
     }
 
     if (qv.qv_softlimit > 0)
@@ -302,19 +301,21 @@ static int64_t getquota(char const* device)
     else
     {
         quota_close(qh);
-        return -1;
+        return { -1, -1 };
     }
 
     spaceused = qv.qv_usage;
     quota_close(qh);
 
     freespace = limit - spaceused;
-    return freespace < 0 ? 0 : freespace;
+    disk_space.free = freespace < 0 ? 0 : freespace;
+    disk_space.limit = limit < 0 ? 0 : limit;
+    return disk_space;
 }
 
 #else
 
-static int64_t getquota(char const* device)
+static struct tr_disk_space getquota(char const* device)
 {
 #if defined(__DragonFly__)
     struct ufs_dqblk dq;
@@ -323,6 +324,7 @@ static int64_t getquota(char const* device)
 #endif
     int64_t limit;
     int64_t freespace;
+    struct tr_disk_space disk_space = { -1, -1 };
     int64_t spaceused;
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
@@ -334,7 +336,7 @@ static int64_t getquota(char const* device)
 
     if (fd < 0)
     {
-        return -1;
+        return disk_space;
     }
 
     op.op = Q_GETQUOTA;
@@ -360,7 +362,7 @@ static int64_t getquota(char const* device)
         else
         {
             /* No quota enabled for this user */
-            return -1;
+            return disk_space;
         }
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
@@ -378,9 +380,13 @@ static int64_t getquota(char const* device)
         freespace = limit - spaceused;
 
 #ifdef __APPLE__
-        return freespace < 0 ? 0 : freespace;
+        disk_space.free = freespace < 0 ? 0 : freespace;
+        disk_space.total = limit < 0 ? 0 : limit;
+        return disk_space;
 #else
-        return freespace < 0 ? 0 : (freespace * 1024);
+        disk_space.free = freespace < 0 ? 0 : (freespace * 1024);
+        disk_space.total = limit < 0 ? 0 : (limit * 1024);
+        return disk_space;
 #endif
     }
 
@@ -389,17 +395,16 @@ static int64_t getquota(char const* device)
 #endif
 
     /* something went wrong */
-    return -1;
+    return disk_space;
 }
 
 #endif
 
 #ifdef HAVE_XQM
 
-static int64_t getxfsquota(char* device)
+static struct tr_disk_space getxfsquota(char* device)
 {
-    int64_t limit;
-    int64_t freespace;
+    struct tr_disk_space disk_space = { -1, -1 }
     struct fs_disk_quota dq;
 
     if (quotactl(QCMD(Q_XGETQUOTA, USRQUOTA), device, getuid(), (caddr_t)&dq) == 0)
@@ -416,24 +421,28 @@ static int64_t getxfsquota(char* device)
         else
         {
             /* No quota enabled for this user */
-            return -1;
+            return disk_space;
         }
 
         freespace = limit - (dq.d_bcount >> 1);
-        return freespace < 0 ? 0 : (freespace * 1024);
+        freespace = freespace < 0 ? 0 : (freespace * 1024);
+        limit = limit < 0 ? 0 : (limit * 1024)
+        disk_space.free = freespace;
+        disk_space.total = limit;
+        return disk_space
     }
 
     /* something went wrong */
-    return -1;
+    return disk_space;
 }
 
 #endif /* HAVE_XQM */
 
 #endif /* _WIN32 */
 
-static int64_t tr_getQuotaFreeSpace(struct tr_device_info const* info)
+static struct tr_disk_space tr_getQuotaSpace(struct tr_device_info const* info)
 {
-    int64_t ret = -1;
+    struct tr_disk_space ret = { -1, -1 };
 
 #ifndef _WIN32
 
@@ -457,11 +466,11 @@ static int64_t tr_getQuotaFreeSpace(struct tr_device_info const* info)
     return ret;
 }
 
-static int64_t tr_getDiskFreeSpace(char const* path)
+static struct tr_disk_space tr_getDiskSpace(char const* path)
 {
 #ifdef _WIN32
 
-    int64_t ret = -1;
+    struct tr_disk_space ret = { -1, -1 };
     wchar_t* wide_path;
 
     wide_path = tr_win32_utf8_to_native(path, -1);
@@ -469,10 +478,12 @@ static int64_t tr_getDiskFreeSpace(char const* path)
     if (wide_path != NULL)
     {
         ULARGE_INTEGER freeBytesAvailable;
+        ULARGE_INTEGER totalBytesAvailable;
 
-        if (GetDiskFreeSpaceExW(wide_path, &freeBytesAvailable, NULL, NULL))
+        if (GetDiskFreeSpaceExW(wide_path, &freeBytesAvailable, &totalBytesAvailable, NULL))
         {
-            ret = freeBytesAvailable.QuadPart;
+            ret.free = freeBytesAvailable.QuadPart;
+            ret.total = totalBytesAvailable.QuadPart;
         }
 
         tr_free(wide_path);
@@ -483,13 +494,13 @@ static int64_t tr_getDiskFreeSpace(char const* path)
 #elif defined(HAVE_STATVFS)
 
     struct statvfs buf;
-    return statvfs(path, &buf) ? -1 : (int64_t)buf.f_bavail * (int64_t)buf.f_frsize;
+    return statvfs(path, &buf) ? (struct tr_disk_space){ -1, -1 } : (struct tr_disk_space){ (int64_t)buf.f_bavail * (int64_t)buf.f_frsize, (int64_t)buf.f_blocks * (int64_t)buf.f_frsize };
 
 #else
 
 #warning FIXME: not implemented
 
-    return -1;
+    return { -1, -1 };
 
 #endif
 }
@@ -520,26 +531,27 @@ void tr_device_info_free(struct tr_device_info* info)
     }
 }
 
-int64_t tr_device_info_get_free_space(struct tr_device_info const* info)
+struct tr_disk_space tr_device_info_get_disk_space(struct tr_device_info const* info)
 {
-    int64_t free_space;
+    struct tr_disk_space space;
 
     if (info == NULL || info->path == NULL)
     {
         errno = EINVAL;
-        free_space = -1;
+        space.free = -1;
+        space.total = -1;
     }
     else
     {
-        free_space = tr_getQuotaFreeSpace(info);
+        space = tr_getQuotaSpace(info);
 
-        if (free_space < 0)
+        if (space.free < 0 || space.total < 0)
         {
-            free_space = tr_getDiskFreeSpace(info->path);
+            space = tr_getDiskSpace(info->path);
         }
     }
 
-    return free_space;
+    return space;
 }
 
 /***

--- a/libtransmission/platform-quota.h
+++ b/libtransmission/platform-quota.h
@@ -24,11 +24,17 @@ struct tr_device_info
     char* fstype;
 };
 
+struct tr_disk_space {
+   int64_t  free;
+   int64_t  total;
+};
+
 struct tr_device_info* tr_device_info_create(char const* path);
 
-/** If the disk quota is enabled and readable, this returns how much is available in the quota.
-    Otherwise, it returns how much is available on the disk, or -1 on error. */
-int64_t tr_device_info_get_free_space(struct tr_device_info const* info);
+/** This returns an array where the zeroth value represents the free space available and the second value represents the total space on disk.
+    If the disk quota (free space) is enabled and readable, this returns how much is available in the quota.
+    Otherwise, it returns how much is available on the disk, or { -1, -1 } on error. */
+struct tr_disk_space tr_device_info_get_disk_space(struct tr_device_info const* info);
 
 void tr_device_info_free(struct tr_device_info* info);
 

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -2640,7 +2640,7 @@ static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_varian
     errno = 0;
     disk_space = tr_getDirFreeSpace(path);
 
-    if (disk_space.free < 0)
+    if (disk_space.free < 0 || disk_space.total < 0)
     {
         err = tr_strerror(errno);
     }

--- a/libtransmission/session.c
+++ b/libtransmission/session.c
@@ -1220,11 +1220,11 @@ int64_t tr_sessionGetDirFreeSpace(tr_session* session, char const* dir)
 
     if (tr_strcmp0(dir, tr_sessionGetDownloadDir(session)) == 0)
     {
-        free_space = tr_device_info_get_free_space(session->downloadDir);
+        free_space = tr_device_info_get_disk_space(session->downloadDir).free;
     }
     else
     {
-        free_space = tr_getDirFreeSpace(dir);
+        free_space = tr_getDirFreeSpace(dir).free;
     }
 
     return free_space;

--- a/libtransmission/utils.c
+++ b/libtransmission/utils.c
@@ -47,7 +47,7 @@
 #include "mime-types.h"
 #include "net.h"
 #include "platform.h" /* tr_lockLock() */
-#include "platform-quota.h" /* tr_device_info_create(), tr_device_info_get_free_space(), tr_device_info_free() */
+#include "platform-quota.h" /* tr_device_info_create(), tr_device_info_get_disk_space(), tr_device_info_free() */
 #include "tr-assert.h"
 #include "utils.h"
 #include "variant.h"
@@ -383,24 +383,21 @@ char* tr_buildPath(char const* first_element, ...)
     return buf;
 }
 
-int64_t tr_getDirFreeSpace(char const* dir)
+struct tr_disk_space tr_getDirFreeSpace(char const* dir)
 {
-    int64_t free_space;
+    struct tr_disk_space disk_space = { -1, -1 };
 
     if (tr_str_is_empty(dir))
     {
         errno = EINVAL;
-        free_space = -1;
-    }
-    else
-    {
-        struct tr_device_info* info;
-        info = tr_device_info_create(dir);
-        free_space = tr_device_info_get_free_space(info);
-        tr_device_info_free(info);
+        return disk_space;
     }
 
-    return free_space;
+    struct tr_device_info* info;
+    info = tr_device_info_create(dir);
+    disk_space = tr_device_info_get_disk_space(info);
+    tr_device_info_free(info);
+    return disk_space;
 }
 
 /****

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -82,7 +82,7 @@ char* tr_buildPath(char const* first_element, ...) TR_GNUC_NULL_TERMINATED TR_GN
  * @brief Get available disk space (in bytes) for the specified folder.
  * @return zero or positive integer on success, -1 in case of error.
  */
-int64_t tr_getDirFreeSpace(char const* path);
+struct tr_disk_space tr_getDirFreeSpace(char const* path);
 
 /**
  * @brief Convenience wrapper around timer_add() to have a timer wake up in a number of seconds and microseconds


### PR DESCRIPTION
Hi! I'm the creator of [Flood for Transmission](https://github.com/johman10/flood-for-transmission) and I was working on a little detail panel that shows the available space. In that panel I was hoping to show user configured paths and how much space is available with a progress bar kind of representation.

However as of today Transmission doesn't let me know how much space is available in total. For this purpose I made this PR. It basically also returns the amount of bytes that the disk has in total (along side the untouched free space).

To do this I had to dig through some layers all the way to the deepest native call and pass it back up, which I used a struct for. Please review carefully as this is my first ever work in any form of C so I may have done somethings a bit different than conventional. But if so, please do let me know and I can look at it, or feel free to update the PR yourself if you feel like it.

I tested this on Linux (via Windows subsystem) with a Postman request see below:
![image](https://user-images.githubusercontent.com/5371454/116358096-eda13500-a805-11eb-8623-90040e068a82.png)

I don't know how else to test this so let me know if something is off.