### PR TITLE
fix: Qt download URL in build-qt.ps1

### DIFF
--- a/release/windows/build-qt.ps1
+++ b/release/windows/build-qt.ps1
@@ -10,7 +10,7 @@ $global:QtDeps = @(
 
 function global:Build-Qt([string] $PrefixDir, [string] $Arch, [string] $DepsPrefixDir) {
     $Filename = "qt-everywhere-src-${QtVersion}.zip" # tar.xz has some names truncated (e.g. .../double-conversion.h -> .../double-conv)
-    $Url = "http://download.qt.io/archive/qt/$($QtVersion -replace '\.\d+$', '')/${QtVersion}/single/${Filename}"
+    $Url = "http://qt.mirror.constant.com/archive/qt/$($QtVersion -replace '\.\d+$', '')/${QtVersion}/single/${Filename}"
 
     $ArchiveBase = "qt-everywhere-src-${QtVersion}"
     $UnpackFlags = @(


### PR DESCRIPTION
The previous URL returns a 302 error, which causes Invoke-WebRequest to error out. This PR changes the URL to the redirected location.

Example of CI failure: https://ci.appveyor.com/project/transmissionbt/transmission/builds/39088944/job/wy2w6jn6y8cgkjlv#L349