### PR TITLE
chore: bump imagemagick version in choco install on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ for:
       choco install ActivePerl
       choco install nasm
       choco install jom
-      choco install imagemagick.tool --version 7.0.10.29
+      choco install imagemagick.tool --version 7.0.11.12
       choco install wixtoolset --version 3.11.2
 
       Remove-Item -Path (Join-Path $Env:SystemDrive OpenSSL-Win32) -Recurse


### PR DESCRIPTION
The old version number is erroring out.

Sample failed run: https://ci.appveyor.com/project/transmissionbt/transmission/builds/39214635/job/43mfddhi9s5l85mn