### PR TITLE
chore: silence readability-function-cognitive-complexity

### DIFF
--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -49,6 +49,7 @@ Checks: >
   performance-*,
   readability-*,
   -readability-convert-member-functions-to-static,
+  -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -readability-inconsistent-declaration-parameter-name,
   -readability-magic-numbers,

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -52,6 +52,7 @@ Checks: >
   performance-*,
   readability-*,
   -readability-convert-member-functions-to-static,
+  -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -readability-inconsistent-declaration-parameter-name,
   -readability-magic-numbers,


### PR DESCRIPTION
GTest's macros are triggering `readability-function-cognitive-complexity`, so disable the warning.