### PR TITLE
refactor: qt deprecations, pt 1

### DIFF
--- a/qt/BaseDialog.h
+++ b/qt/BaseDialog.h
@@ -13,7 +13,7 @@
 class BaseDialog : public QDialog
 {
 public:
-    BaseDialog(QWidget* parent = nullptr, Qt::WindowFlags flags = 0) :
+    BaseDialog(QWidget* parent = nullptr, Qt::WindowFlags flags = {}) :
         QDialog(parent, flags)
     {
         setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1368,12 +1368,12 @@ void DetailsDialog::onRemoveTrackerClicked()
     // make a map of torrentIds to announce URLs to remove
     QItemSelectionModel* selection_model = ui_.trackersView->selectionModel();
     QModelIndexList selected_rows = selection_model->selectedRows();
-    QMap<int, int> torrent_id_to_tracker_ids;
+    QMultiMap<int, int> torrent_id_to_tracker_ids;
 
     for (QModelIndex const& i : selected_rows)
     {
         auto const inf = ui_.trackersView->model()->data(i, TrackerModel::TrackerRole).value<TrackerInfo>();
-        torrent_id_to_tracker_ids.insertMulti(inf.torrent_id, inf.st.id);
+        torrent_id_to_tracker_ids.insert(inf.torrent_id, inf.st.id);
     }
 
     // batch all of a tracker's torrents into one command

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -375,8 +375,8 @@ void Prefs::initDefaults(tr_variant* d) const
 {
     auto constexpr FilterMode = std::string_view { "all" };
     auto constexpr SessionHost = std::string_view { "localhost" };
-    auto constexpr SessionPassword = std::string_view { "" };
-    auto constexpr SessionUsername = std::string_view { "" };
+    auto constexpr SessionPassword = std::string_view {};
+    auto constexpr SessionUsername = std::string_view {};
     auto constexpr SortMode = std::string_view { "sort-by-name" };
     auto constexpr SoundCommand =
         std::string_view { "canberra-gtk-play -i complete-download -d 'transmission torrent downloaded'" };


### PR DESCRIPTION
I recently upgraded to Ubuntu 21.04 and the new versions of clang-tidy and Qt had a few new warnings for the codebase. This PR fixes the easy warnings.

There are still two remaining changes that will be a little more intrusive, so I've filed issues to discuss them first: https://github.com/transmission/transmission/issues/1704 and https://github.com/transmission/transmission/issues/1706