### PR TITLE
libtransmission: open files O_DIRECT to read pieces.

### DIFF
--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -487,6 +487,7 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
         ((flags & TR_SYS_FILE_APPEND) != 0 ? O_APPEND : 0) |
         ((flags & TR_SYS_FILE_TRUNCATE) != 0 ? O_TRUNC : 0) |
         ((flags & TR_SYS_FILE_SEQUENTIAL) != 0 ? O_SEQUENTIAL : 0) |
+        ((flags & TR_SYS_FILE_O_DIRECT) != 0 ? O_DIRECT : 0) |
         O_BINARY | O_LARGEFILE | O_CLOEXEC;
 
     ret = open(path, native_flags, permissions);

--- a/libtransmission/file-posix.c
+++ b/libtransmission/file-posix.c
@@ -487,7 +487,9 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
         ((flags & TR_SYS_FILE_APPEND) != 0 ? O_APPEND : 0) |
         ((flags & TR_SYS_FILE_TRUNCATE) != 0 ? O_TRUNC : 0) |
         ((flags & TR_SYS_FILE_SEQUENTIAL) != 0 ? O_SEQUENTIAL : 0) |
+#ifdef O_DIRECT
         ((flags & TR_SYS_FILE_O_DIRECT) != 0 ? O_DIRECT : 0) |
+#endif
         O_BINARY | O_LARGEFILE | O_CLOEXEC;
 
     ret = open(path, native_flags, permissions);

--- a/libtransmission/file-win32.c
+++ b/libtransmission/file-win32.c
@@ -859,6 +859,8 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
         native_flags |= FILE_FLAG_SEQUENTIAL_SCAN;
     }
 
+    /* if ((flags & TR_SYS_FILE_O_DIRECT) != 0)  // ignore for now */
+
     ret = open_file(path, native_access, native_disposition, native_flags, error);
 
     success = ret != TR_BAD_SYS_FILE;

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -68,7 +68,8 @@ typedef enum
     TR_SYS_FILE_CREATE_NEW = (1 << 3),
     TR_SYS_FILE_APPEND = (1 << 4),
     TR_SYS_FILE_TRUNCATE = (1 << 5),
-    TR_SYS_FILE_SEQUENTIAL = (1 << 6)
+    TR_SYS_FILE_SEQUENTIAL = (1 << 6),
+    TR_SYS_FILE_O_DIRECT = (1 << 7),
 }
 tr_sys_file_open_flags_t;
 

--- a/libtransmission/torrent-magnet.c
+++ b/libtransmission/torrent-magnet.c
@@ -171,7 +171,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 
         TR_ASSERT(tor->infoDictLength > 0);
 
-        fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, NULL);
+        fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ | TR_SYS_FILE_O_DIRECT, 0, NULL);
 
         if (fd != TR_BAD_SYS_FILE)
         {


### PR DESCRIPTION
When reading chunks from files to serve, open the file
with O_DIRECT so that it does not SPAM the buffer cache
and slow down everything else on the machine.

There is little value in caching pieces, in general, even
when we are the only seed with many clients, because once
a piece is served, the clients will take up the load of
distributing it. Thus, it will be rare to serve the same
piece soon after, so we should take care not to displace
what might be more immediately useful data.

Without this patch, serving from the same machine where
I develop often makes git operations very slow.