### PR TITLE
qt: Fix open folder menu option

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -538,10 +538,11 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
     if (names.empty())
     {
         // unchanging fields needed by the main window
-        static auto constexpr MainInfoKeys = std::array<tr_quark, 8>{
+        static auto constexpr MainInfoKeys = std::array<tr_quark, 9>{
             TR_KEY_addedDate,
             TR_KEY_downloadDir,
             TR_KEY_file_count,
+            TR_KEY_files,
             TR_KEY_hashString,
             TR_KEY_name,
             TR_KEY_primary_mime_type,


### PR DESCRIPTION
In openFolder function for qt, the torrent files are checked if they are
empty. Since we have never updated TR_KEY_files, the torrent files are
empty and openFolder fails.
As mentioned in #1095, opening the torrent properties fixes this
issue as the torrent details are refreshed when the properties window is
opened. This commit adds TR_KEY_files to MainInfoKeys, so that the files
are refreshed during torrentInit.

I'm not sure if this PR should fix, #1095 as there are two issues mentioned in there.