### PR TITLE
Correct closing </i> tag in german translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1831,7 +1831,7 @@ msgstr "Port ist <b>offen</b>"
 
 #: ../gtk/tr-prefs.c:1129
 msgid "<i>Testing TCP port…</i>"
-msgstr "<i>TCP-Port wird getestet …<i>"
+msgstr "<i>TCP-Port wird getestet …</i>"
 
 #: ../gtk/tr-prefs.c:1155
 msgid "Listening Port"


### PR DESCRIPTION
Corrects a closing tag in the german translation that leads to console warnings