### PR TITLE
Restore support for the INSTALL_LIB option

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -294,3 +294,8 @@ endif()
 if(WIN32)
     target_link_libraries(${TR_NAME} crypt32 shlwapi)
 endif()
+
+if(INSTALL_LIB)
+    install(TARGETS ${TR_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${${PROJECT_NAME}_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${TR_NAME})
+endif()


### PR DESCRIPTION
It appears this was removed by accident.

Fixes: 677dc73eac3efa769eefb1c7ec4eda232a35977a