### PR TITLE
skip verify option

### DIFF
--- a/cli/cli.c
+++ b/cli/cli.c
@@ -91,6 +91,7 @@ static struct tr_option const options[] =
     { 'u', "uplimit", "Set max upload speed in "SPEED_K_STR, "u", true, "<speed>" },
     { 'U', "no-uplimit", "Don't limit the upload speed", "U", false, NULL },
     { 'v', "verify", "Verify the specified torrent", "v", false, NULL },
+    { 'T', "skip-verify", "Skip verifying specified first-added torrent", "T", false, NULL },
     { 'V', "version", "Show version number and exit", "V", false, NULL },
     { 'w', "download-dir", "Where to save downloaded data", "w", true, "<path>" },
     { 0, NULL, NULL, NULL, false, NULL }
@@ -460,6 +461,11 @@ static int parseCommandLine(tr_variant* d, int argc, char const** argv)
         case 'v':
             verify = true;
             break;
+
+        case 'T':
+	        verify = false;
+	        torrentSkipVerify();
+	    break;
 
         case 'V':
             showVersion = true;

--- a/libtransmission/rpcimpl.c
+++ b/libtransmission/rpcimpl.c
@@ -425,7 +425,28 @@ static char const* torrentVerify(tr_session* session, tr_variant* args_in, tr_va
     for (int i = 0; i < torrentCount; ++i)
     {
         tr_torrent* tor = torrents[i];
-        tr_torrentVerify(tor, NULL, NULL);
+        tr_torrentVerify(tor, NULL, NULL); 
+        notify(session, TR_RPC_TORRENT_CHANGED, tor);
+    }
+
+    tr_free(torrents);
+    return NULL;
+}
+
+static char const* torrentSkipVerify(tr_session* session, tr_variant* args_in, tr_variant* args_out,
+    struct tr_rpc_idle_data* idle_data)
+{
+    TR_UNUSED(args_out);
+    TR_UNUSED(idle_data);
+    TR_ASSERT(idle_data == NULL);
+
+    int torrentCount;
+    tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
+
+    for (int i = 0; i < torrentCount; ++i)
+    {
+        tr_torrent* tor = torrents[i];
+        tr_torrentSetFilesVerified( tor );
         notify(session, TR_RPC_TORRENT_CHANGED, tor);
     }
 
@@ -2703,6 +2724,7 @@ methods[] =
     { "torrent-start-now", true, torrentStartNow },
     { "torrent-stop", true, torrentStop },
     { "torrent-verify", true, torrentVerify },
+    { "torrent-skip-verify", true, torrentSkipVerify },
     { "torrent-reannounce", true, torrentReannounce },
     { "queue-move-top", true, queueMoveTop },
     { "queue-move-up", true, queueMoveUp },

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1571,6 +1571,8 @@ typedef void (* tr_verify_done_func)(tr_torrent* torrent, bool aborted, void* us
  */
 void tr_torrentVerify(tr_torrent* torrent, tr_verify_done_func callback_func_or_NULL, void* callback_data_or_NULL);
 
+void tr_torrentSetFilesVerified( tr_torrent * tor );
+
 /***********************************************************************
  * tr_info
  **********************************************************************/

--- a/utils/remote.c
+++ b/utils/remote.c
@@ -338,6 +338,7 @@ static tr_option opts[] =
     { 830, "utp", "Enable uTP for peer connections", NULL, false, NULL },
     { 831, "no-utp", "Disable uTP for peer connections", NULL, false, NULL },
     { 'v', "verify", "Verify the current torrent(s)", "v", false, NULL },
+    { 'T', "skip-verify", "Skip verifying the current torrent(s)", "T", false, NULL },
     { 'V', "version", "Show version number and exit", "V", false, NULL },
     { 'w', "download-dir", "When used in conjunction with --add, set the new torrent's download folder. "
         "Otherwise, set the default download folder", "w", true, "<path>" },
@@ -385,7 +386,8 @@ enum
     MODE_SESSION_STATS = (1 << 11),
     MODE_SESSION_CLOSE = (1 << 12),
     MODE_BLOCKLIST_UPDATE = (1 << 13),
-    MODE_PORT_TEST = (1 << 14)
+    MODE_PORT_TEST = (1 << 14),
+    MODE_TORRENT_SKIP_VERIFY = (1 << 15)
 };
 
 static int getOptMode(int val)
@@ -502,6 +504,9 @@ static int getOptMode(int val)
 
     case 'v': /* verify */
         return MODE_TORRENT_VERIFY;
+
+    case 'T': /* skip verify */
+	return MODE_TORRENT_SKIP_VERIFY;
 
     case 600: /* reannounce */
         return MODE_TORRENT_REANNOUNCE;
@@ -2934,6 +2939,24 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                     top = tr_new0(tr_variant, 1);
                     tr_variantInitDict(top, 2);
                     tr_variantDictAddStr(top, TR_KEY_method, "torrent-verify");
+                    addIdArg(tr_variantDictAddDict(top, ARGUMENTS, 1), id, NULL);
+                    status |= flush(rpcurl, &top);
+                    break;
+                }
+
+            case 'T':
+                {
+                    tr_variant* top;
+
+                    if (tset != NULL)
+                    {
+                        addIdArg(tr_variantDictFind(tset, ARGUMENTS), id, NULL);
+                        status |= flush(rpcurl, &tset);
+                    }
+
+                    top = tr_new0(tr_variant, 1);
+                    tr_variantInitDict(top, 2);
+                    tr_variantDictAddStr(top, TR_KEY_method, "torrent-skip-verify");
                     addIdArg(tr_variantDictAddDict(top, ARGUMENTS, 1), id, NULL);
                     status |= flush(rpcurl, &top);
                     break;


### PR DESCRIPTION
## About

skip verify option

## Use carefully!

This modification is only intended to speed up the addition of already verified torrents.  
As an example: One primary instance and several secondary instances attached to the same media.  
After the primary instance verifies the content, you can add the torrent to the secondary instances without additional verification.  
It is recommended to use RO file system mount for secondary instances.

## Thanks to

@yangzhaofeng https://github.com/transmission/transmission/pull/769  
@cfpp2p https://github.com/cfpp2p/transmission - I used this general idea from this fork by adapting it for the new version and refined the performance for large torrents 

### How to skip verify with cli

Use -T option

    transmission-remote -t 1 -T # skip verify for torrent with index 1
### How to skip verify via api (curl)

For api usage is a torrent-skip-verify method
For arguments look at rpc [protocol pt3.1](https://github.com/transmission/transmission/wiki/RPC-Protocol-Specification)

You can use test script below:

    #!/bin/bash
    host="localhost" 
    port="9091" 
    if [ -z "$1" ]; then
            echo "set filename" 
            exit 0
    fi
    token=$(curl http://${host}:${port}/transmission/rpc -s \
            | sed 's/.*Session-Id: \(.*\)<\/code>.*/\1/')
    echo "token is ${token}" 
    read -p "press enter to add torrent" 
    filename=$1
    hash=$(curl http://${host}:${port}/transmission/rpc -s \
            -H "X-Transmission-Session-Id: ${token}" \
            -H "Content-Type: application/json" \
            -d '{"method": "torrent-add", "arguments": {"filename": "'${filename}'"}}'\
            | sed 's/.*hashString\":\"\(.*\)\",\"id\".*/\1/ ') 
    echo "Torrent hashcode is ${hash}" 
    read -p "press enter to verify torrent" 
    curl http://${host}:${port}/transmission/rpc -s \
            -H "X-Transmission-Session-Id: ${token}" \
            -H "Content-Type: application/json" \
            -d '{"method": "torrent-skip-verify", "arguments": {"ids": ["'${hash}'"]}}'
    read -p "press enter to delete torrent" 
    curl http://${host}:${port}/transmission/rpc -s \
            -H "X-Transmission-Session-Id: ${token}" \
            -H "Content-Type: application/json" \
            -d '{"method": "torrent-remove", "arguments": {"ids": ["'${hash}'"]}}'
