### PR TITLE
feat: allow filtering torrents by info hash in qt client

### DIFF
--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -254,7 +254,8 @@ bool TorrentFilter::filterAcceptsRow(int source_row, QModelIndex const& source_p
     if (accepts)
     {
         auto const text = prefs_.getString(Prefs::FILTER_TEXT);
-        accepts = text.isEmpty() || tor.name().contains(text, Qt::CaseInsensitive);
+        accepts = text.isEmpty() || tor.name().contains(text, Qt::CaseInsensitive) ||
+            tor.hash().toString().contains(text, Qt::CaseInsensitive);
     }
 
     return accepts;


### PR DESCRIPTION
Does what it says in the title:

If you put an info hash into the torrent filter, then filter the torrents so that the torrent matching the hash is shown.