### PR TITLE
chore: add build/ to clang-tidy exclude list

### DIFF
--- a/code_style.sh
+++ b/code_style.sh
@@ -22,6 +22,7 @@ cfile_includes=(
   '*.m'
 )
 cfile_excludes=(
+  'build/*'
   'libtransmission/ConvertUTF.*'
   'libtransmission/jsonsl.*'
   'libtransmission/wildmat.*'


### PR DESCRIPTION
Procedural PR to omit the build/ directory from clang-tidy work