### PR TITLE
perf: do not rechoke in tr_peerMgrStartTorrent()

### DIFF
--- a/libtransmission/peer-mgr.c
+++ b/libtransmission/peer-mgr.c
@@ -2515,7 +2515,8 @@ void tr_peerMgrStartTorrent(tr_torrent* tor)
     s->maxPeers = tor->maxConnectedPeers;
     s->pieceSortState = PIECES_UNSORTED;
 
-    rechokePulse(0, 0, s->manager);
+    // rechoke soon
+    tr_timerAddMsec(s->manager->rechokeTimer, 100);
 }
 
 static void removeAllPeers(tr_swarm*);


### PR DESCRIPTION
tr_peerMgrStartTorrent() is called once per torrent on startup, so this
can be expensive if the user has a lot of torrents.

Instead, enqueue a pending rechoke that will happen on idle. This way,
all the added torrents can be handled by a single rechoke call.