### PR TITLE
perf: prioritize announces based on scrape stats

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -30,13 +30,13 @@ enum
      * This is only an upper bound: if the tracker complains about
      * length, announcer will incrementally lower the batch size.
      */
-    TR_MULTISCRAPE_MAX = 100
+    TR_MULTISCRAPE_MAX = 60
 };
 
 typedef struct
 {
     /* the scrape URL */
-    char* url;
+    char const* url;
 
     /* the name to use when deep logging is enabled */
     char log_name[128];
@@ -113,10 +113,13 @@ void tr_tracker_udp_scrape(
 
 typedef enum
 {
+    /* Note: the ordering of this enum's values is important to
+     * announcer.c's tr_tier.announce_event_priority. If changing
+     * the enum, ensure announcer.c is compatible with the change. */
     TR_ANNOUNCE_EVENT_NONE,
-    TR_ANNOUNCE_EVENT_COMPLETED,
     TR_ANNOUNCE_EVENT_STARTED,
-    TR_ANNOUNCE_EVENT_STOPPED
+    TR_ANNOUNCE_EVENT_COMPLETED,
+    TR_ANNOUNCE_EVENT_STOPPED,
 } tr_announce_event;
 
 char const* tr_announce_event_get_string(tr_announce_event);

--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -176,9 +176,6 @@ typedef struct tr_announcer
     struct event* upkeepTimer;
     int key;
     time_t tauUpkeepAt;
-
-    size_t total_scrapes;
-    size_t total_announces;
 } tr_announcer;
 
 static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* announcer, char const* url)
@@ -1614,7 +1611,6 @@ static void multiscrape(tr_announcer* announcer, tr_ptrArray* tiers)
             tier->isScraping = true;
             tier->lastScrapeStartTime = now;
             found = true;
-            ++announcer->total_scrapes;
         }
 
         /* otherwise, if there's room for another request, build a new one */
@@ -1627,7 +1623,6 @@ static void multiscrape(tr_announcer* announcer, tr_ptrArray* tiers)
             memcpy(req->info_hash[req->info_hash_count++], hash, SHA_DIGEST_LENGTH);
             tier->isScraping = true;
             tier->lastScrapeStartTime = now;
-            ++announcer->total_scrapes;
         }
     }
 
@@ -1744,14 +1739,6 @@ static void scrapeAndAnnounceMore(tr_announcer* announcer)
         }
     }
 
-    fprintf(
-        stderr,
-        "announcer: %d need announce, %d need scrape, %zu total scrapes, %zu total announces\n",
-        tr_ptrArraySize(&announceMe),
-        tr_ptrArraySize(&scrapeMe),
-        announcer->total_scrapes,
-        announcer->total_announces);
-
     /* First, scrape what we can. We handle scrapes first because
      * we can work through that queue much faster than announces
      * (thanks to multiscrape) _and_ the scrape responses will tell
@@ -1768,8 +1755,6 @@ static void scrapeAndAnnounceMore(tr_announcer* announcer)
         dbgmsg(tier, "announcing tier %d of %d", i, n);
         tierAnnounce(announcer, tier);
     }
-
-    announcer->total_announces += n;
 
     /* cleanup */
     tr_ptrArrayDestruct(&scrapeMe, NULL);


### PR DESCRIPTION
This change is to improve responsiveness when starting a large batch of
torrents, e.g. when starting up a seedbox, but is also generally useful.

First, try to scrape as many torrents as as quickly as possible, giving
preference to that even over announces. Thanks to multiscrape we can run
through scrapes an order of magnitude faster than announces. Then scrape
responses tell us which swarms have leechers and we can prioritize those
torrents' announces.

Second, increase how many scrapes and announces we start at a time. This
limit probably hasn't been needed since 2da97b25 and by scraping faster,
the sooner we'll know which torrents to announce first.