### PR TITLE
perf: do not generate address strings as log name if logging is disabled

### DIFF
--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -132,10 +132,12 @@ struct tr_handshake
 
 #define dbgmsg(handshake, ...) \
     do \
-    { \
-        char addrstr[TR_ADDRSTRLEN]; \
-        tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
-        tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+        if (tr_logGetDeepEnabled()) \
+        { \
+            char addrstr[TR_ADDRSTRLEN]; \
+            tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
+            tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+        } \
     } while (0)
 
 static char const* getStateName(handshake_state_t const state)

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -138,7 +138,8 @@ struct tr_handshake
             tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
             tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
         } \
-    } while (0)
+    } \
+    while (0)
 
 static char const* getStateName(handshake_state_t const state)
 {

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -132,14 +132,14 @@ struct tr_handshake
 
 #define dbgmsg(handshake, ...) \
     do \
+    { \
         if (tr_logGetDeepEnabled()) \
         { \
             char addrstr[TR_ADDRSTRLEN]; \
             tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
             tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
         } \
-    } \
-    while (0)
+    } while (0)
 
 static char const* getStateName(handshake_state_t const state)
 {

--- a/libtransmission/handshake.c
+++ b/libtransmission/handshake.c
@@ -137,7 +137,7 @@ struct tr_handshake
         { \
             char addrstr[TR_ADDRSTRLEN]; \
             tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
-            tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+            tr_logAddDeep(__FILE__, __LINE__, addrstr, __VA_ARGS__); \
         } \
     } while (0)
 

--- a/libtransmission/peer-io.c
+++ b/libtransmission/peer-io.c
@@ -73,9 +73,12 @@ static size_t guessPacketOverhead(size_t d)
 #define dbgmsg(io, ...) \
     do \
     { \
-        char addrstr[TR_ADDRSTRLEN]; \
-        tr_peerIoGetAddrStr(io, addrstr, sizeof(addrstr)); \
-        tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+        if (tr_logGetDeepEnabled()) \
+        { \
+            char addrstr[TR_ADDRSTRLEN]; \
+            tr_peerIoGetAddrStr(io, addrstr, sizeof(addrstr)); \
+            tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+        } \
     } while (0)
 
 /**

--- a/libtransmission/peer-io.c
+++ b/libtransmission/peer-io.c
@@ -77,7 +77,7 @@ static size_t guessPacketOverhead(size_t d)
         { \
             char addrstr[TR_ADDRSTRLEN]; \
             tr_peerIoGetAddrStr(io, addrstr, sizeof(addrstr)); \
-            tr_logAddDeepNamed(addrstr, __VA_ARGS__); \
+            tr_logAddDeep(__FILE__, __LINE__, addrstr, __VA_ARGS__); \
         } \
     } while (0)
 


### PR DESCRIPTION
perf: if logs are disabled, don't build log names

No behavioral changes; just avoiding unnecessary work.

handshake.c and peer-io.c call `tr_peerIoGetAddrStr()` to build a name for passing to `tr_logAddDeepNamed()`. Since `tr_peerIoGetAddrStr()` isn't free, make sure deep logging is enabled before building the name.

In my hotspot run of running a transmission-daemon seedbox for ~2 hours, this made up about 6% of overall CPU use. No single call was very expensive; but cumulatively, they all added up. For example `tr_peerIoNew::tr_peerIoGetAddrStr` had a cumulative 1.18%, `tr_peerIoRefImpl::tr_peerIoGetAddrStr` was 0.609%, `utp_on_overhead::tr_peerIoGetAddrStr` had a cumulative 0.59%, `tr_peerIoTryWrite::tr_peerIoGetAddrStr` was 0.585%, and so on. In each case, this call was coming from the dbgmsg() deep logging call, even though deep logging was not enabled.