### PR TITLE
fixup! perf: prioritize announces based on scrape stats (#1782)

### DIFF
--- a/libtransmission/announcer.c
+++ b/libtransmission/announcer.c
@@ -1708,7 +1708,9 @@ static int compareAnnounceTiers(void const* va, void const* vb)
         return a->announceAt < b->announceAt ? -1 : 1;
     }
 
-    return 0;
+    // the tiers are effectively equal priority, but add an arbitrary
+    // differentiation because ptrArray sorted mode hates equal items.
+    return a < b ? -1 : 1;
 }
 
 static void scrapeAndAnnounceMore(tr_announcer* announcer)

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -4377,7 +4377,8 @@ static void removeKeRangerRansomware()
         {
             [segmentedControl setImage:[NSImage imageNamed:@"ToolbarPauseAllTemplate"] forSegment:TOOLBAR_PAUSE_TAG];
         }
-        [segmentedCell setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip") forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedCell setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip")
+                       forSegment:TOOLBAR_PAUSE_TAG];
 
         [segmentedCell setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setImage:[NSImage imageNamed:@"ToolbarResumeAllTemplate"] forSegment:TOOLBAR_RESUME_TAG];

--- a/macosx/Torrent.m
+++ b/macosx/Torrent.m
@@ -1993,7 +1993,11 @@ bool trashDataFile(char const* filename, tr_error** error)
                 tempNode = [[FileListNode alloc] initWithFolderName:pathComponents[0] path:@"" torrent:self];
             }
 
-            [self insertPathForComponents:pathComponents withComponentIndex:1 forParent:tempNode fileSize:file->length index:i
+            [self insertPathForComponents:pathComponents
+                       withComponentIndex:1
+                                forParent:tempNode
+                                 fileSize:file->length
+                                    index:i
                                  flatList:flatFileList];
         }
 


### PR DESCRIPTION
In `compareAnnounceTiers()`, add a safeguard to ensure that no two items compare equally.