### PR TITLE
Switch to a standalone ARC4 implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "third-party/arc4"]
+	path = third-party/arc4
+	url = https://github.com/transmission/arc4
+	branch = v1.0.0
 [submodule "third-party/dht"]
 	path = third-party/dht
 	url = https://github.com/transmission/dht

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,8 @@ endif()
 
 tr_add_external_auto_library(B64 libb64 b64)
 
+add_subdirectory(third-party/arc4)
+
 if(WITH_INOTIFY)
     tr_get_required_flag(WITH_INOTIFY INOTIFY_IS_REQUIRED)
 

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -358,6 +358,9 @@
 		C1639A791A55F56600E42033 /* cencode.c in Sources */ = {isa = PBXBuildFile; fileRef = C1639A771A55F56600E42033 /* cencode.c */; };
 		C1639A7C1A55F57200E42033 /* cdecode.h in Headers */ = {isa = PBXBuildFile; fileRef = C1639A7A1A55F57200E42033 /* cdecode.h */; };
 		C1639A7D1A55F57200E42033 /* cencode.h in Headers */ = {isa = PBXBuildFile; fileRef = C1639A7B1A55F57200E42033 /* cencode.h */; };
+		C1A7517526ED048C0038B90A /* libarc4.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A7516426ED03140038B90A /* libarc4.a */; };
+		C1A751E526ED09A30038B90A /* arc4.c in Sources */ = {isa = PBXBuildFile; fileRef = C1A751E326ED09A30038B90A /* arc4.c */; };
+		C1A751E626ED09A30038B90A /* arc4.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A751E426ED09A30038B90A /* arc4.h */; };
 		C1BF7BA81F2A3CB7008E88A7 /* upnpdev.c in Sources */ = {isa = PBXBuildFile; fileRef = C1BF7BA71F2A3CB7008E88A7 /* upnpdev.c */; };
 		C1BF7BAA1F2A3CCE008E88A7 /* upnpdev.h in Headers */ = {isa = PBXBuildFile; fileRef = C1BF7BA91F2A3CCE008E88A7 /* upnpdev.h */; };
 		C1F690FD1AD0627500D95CF0 /* daemon-posix.c in Sources */ = {isa = PBXBuildFile; fileRef = C1F690FC1AD0627500D95CF0 /* daemon-posix.c */; };
@@ -459,6 +462,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = C1639A6E1A55F4D600E42033;
 			remoteInfo = b64;
+		};
+		C1A751C726ED06390038B90A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C1A7516326ED03140038B90A;
+			remoteInfo = arc4;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1010,6 +1020,9 @@
 		C1639A771A55F56600E42033 /* cencode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = cencode.c; path = src/cencode.c; sourceTree = "<group>"; };
 		C1639A7A1A55F57200E42033 /* cdecode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cdecode.h; path = include/b64/cdecode.h; sourceTree = "<group>"; };
 		C1639A7B1A55F57200E42033 /* cencode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cencode.h; path = include/b64/cencode.h; sourceTree = "<group>"; };
+		C1A7516426ED03140038B90A /* libarc4.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libarc4.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1A751E326ED09A30038B90A /* arc4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = arc4.c; path = "third-party/arc4/src/arc4.c"; sourceTree = SOURCE_ROOT; };
+		C1A751E426ED09A30038B90A /* arc4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = arc4.h; path = "third-party/arc4/src/arc4.h"; sourceTree = SOURCE_ROOT; };
 		C1BF7BA71F2A3CB7008E88A7 /* upnpdev.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upnpdev.c; sourceTree = "<group>"; };
 		C1BF7BA91F2A3CCE008E88A7 /* upnpdev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upnpdev.h; sourceTree = "<group>"; };
 		C1F690FC1AD0627500D95CF0 /* daemon-posix.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "daemon-posix.c"; sourceTree = "<group>"; };
@@ -1119,6 +1132,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1A7517526ED048C0038B90A /* libarc4.a in Frameworks */,
 				C1639A741A55F4E000E42033 /* libb64.a in Frameworks */,
 				A22CFCCB0FC24FDA0009BD3E /* libdht.a in Frameworks */,
 				A267927C130DFF2700CB7464 /* libutp.a in Frameworks */,
@@ -1157,6 +1171,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C1639A6C1A55F4D600E42033 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C1A7516226ED03140038B90A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1272,6 +1293,7 @@
 				A2E38544130DFEE3001F501B /* libutp.a */,
 				A2F35BB915C5A0A100EBF632 /* QuickLookPlugin.qlgenerator */,
 				C1639A6F1A55F4D600E42033 /* libb64.a */,
+				C1A7516426ED03140038B90A /* libarc4.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1286,6 +1308,7 @@
 				4DDBB71F09E16BFE00284745 /* CLI */,
 				BEFC1C0B0C07754700B0BB3C /* daemon */,
 				C15E58AC219A37C600AB292F /* utils */,
+				C1A7518626ED04EC0038B90A /* arc4 */,
 				A22CFCB50FC24F630009BD3E /* dht */,
 				A2E384BF130DFA49001F501B /* libutp */,
 				BE75C3570C72A0D600DBEFE0 /* libevent */,
@@ -1738,6 +1761,15 @@
 			path = "third-party/libb64";
 			sourceTree = "<group>";
 		};
+		C1A7518626ED04EC0038B90A /* arc4 */ = {
+			isa = PBXGroup;
+			children = (
+				C1A751E326ED09A30038B90A /* arc4.c */,
+				C1A751E426ED09A30038B90A /* arc4.h */,
+			);
+			path = arc4;
+			sourceTree = "<group>";
+		};
 		E1B6FBF80C0D719B0015FE4D /* Info Window */ = {
 			isa = PBXGroup;
 			children = (
@@ -1949,6 +1981,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C1A7516026ED03140038B90A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C1A751E626ED09A30038B90A /* arc4.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1981,6 +2021,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C1A751C826ED06390038B90A /* PBXTargetDependency */,
 				A226FDB10D0CDF6E005A7F71 /* PBXTargetDependency */,
 				BE1183760CE161040002D0F3 /* PBXTargetDependency */,
 				BE75C34F0C729ED300DBEFE0 /* PBXTargetDependency */,
@@ -2174,6 +2215,23 @@
 			productReference = C1639A6F1A55F4D600E42033 /* libb64.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		C1A7516326ED03140038B90A /* arc4 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C1A7516826ED03140038B90A /* Build configuration list for PBXNativeTarget "arc4" */;
+			buildPhases = (
+				C1A7516026ED03140038B90A /* Headers */,
+				C1A7516126ED03140038B90A /* Sources */,
+				C1A7516226ED03140038B90A /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = arc4;
+			productName = arc4;
+			productReference = C1A7516426ED03140038B90A /* libarc4.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2229,6 +2287,7 @@
 				BE1183470CE160960002D0F3 /* miniupnp */,
 				3C7A118C0D0B2EB800B5701F /* natpmp */,
 				C1639A6E1A55F4D600E42033 /* b64 */,
+				C1A7516326ED03140038B90A /* arc4 */,
 			);
 		};
 /* End PBXProject section */
@@ -2646,6 +2705,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C1A7516126ED03140038B90A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C1A751E526ED09A30038B90A /* arc4.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2708,6 +2775,11 @@
 			isa = PBXTargetDependency;
 			target = C1639A6E1A55F4D600E42033 /* b64 */;
 			targetProxy = C165AB8C1A55FAA900D37711 /* PBXContainerItemProxy */;
+		};
+		C1A751C826ED06390038B90A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C1A7516326ED03140038B90A /* arc4 */;
+			targetProxy = C1A751C726ED06390038B90A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2963,6 +3035,7 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
 					"third-party/libevent/include",
@@ -3151,6 +3224,7 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
 					"third-party/libevent/include",
@@ -3404,6 +3478,7 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
 					"third-party/libevent/include",
@@ -3644,6 +3719,30 @@
 			};
 			name = Release;
 		};
+		C1A7516526ED03140038B90A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		C1A7516626ED03140038B90A /* Release - Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release - Debug";
+		};
+		C1A7516726ED03140038B90A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3773,6 +3872,16 @@
 				C1639A701A55F4D600E42033 /* Debug */,
 				C1639A711A55F4D600E42033 /* Release - Debug */,
 				C1639A721A55F4D600E42033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C1A7516826ED03140038B90A /* Build configuration list for PBXNativeTarget "arc4" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C1A7516526ED03140038B90A /* Debug */,
+				C1A7516626ED03140038B90A /* Release - Debug */,
+				C1A7516726ED03140038B90A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -285,6 +285,7 @@ target_link_libraries(${TR_NAME}
     ${LIBINTL_LIBRARY}
     ${LIBM_LIBRARY}
     ${TR_NETWORK_LIBRARIES}
+    arc4::arc4
 )
 
 if(ICONV_FOUND)

--- a/libtransmission/crypto-utils-cyassl.c
+++ b/libtransmission/crypto-utils-cyassl.c
@@ -18,7 +18,6 @@
 #define API_VERSION_HEX LIBCYASSL_VERSION_HEX
 #endif
 
-#include API_HEADER_CRYPT(arc4.h)
 #include API_HEADER_CRYPT(dh.h)
 #include API_HEADER_CRYPT(error-crypt.h)
 #include API_HEADER_CRYPT(random.h)
@@ -159,43 +158,6 @@ bool tr_sha1_final(tr_sha1_ctx_t handle, uint8_t* hash)
 
     tr_free(handle);
     return ret;
-}
-
-/***
-****
-***/
-
-tr_rc4_ctx_t tr_rc4_new(void)
-{
-    return tr_new0(Arc4, 1);
-}
-
-void tr_rc4_free(tr_rc4_ctx_t handle)
-{
-    tr_free(handle);
-}
-
-void tr_rc4_set_key(tr_rc4_ctx_t handle, uint8_t const* key, size_t key_length)
-{
-    TR_ASSERT(handle != NULL);
-    TR_ASSERT(key != NULL);
-
-    API(Arc4SetKey)(handle, key, key_length);
-}
-
-void tr_rc4_process(tr_rc4_ctx_t handle, void const* input, void* output, size_t length)
-{
-    TR_ASSERT(handle != NULL);
-
-    if (length == 0)
-    {
-        return;
-    }
-
-    TR_ASSERT(input != NULL);
-    TR_ASSERT(output != NULL);
-
-    API(Arc4Process)(handle, output, input, length);
 }
 
 /***

--- a/libtransmission/crypto-utils-openssl.c
+++ b/libtransmission/crypto-utils-openssl.c
@@ -181,59 +181,6 @@ static void openssl_evp_cipher_context_free(EVP_CIPHER_CTX* handle)
 
 #endif
 
-tr_rc4_ctx_t tr_rc4_new(void)
-{
-    EVP_CIPHER_CTX* handle = EVP_CIPHER_CTX_new();
-
-    if (check_result(EVP_CipherInit_ex(handle, EVP_rc4(), NULL, NULL, NULL, -1)))
-    {
-        return handle;
-    }
-
-    EVP_CIPHER_CTX_free(handle);
-    return NULL;
-}
-
-void tr_rc4_free(tr_rc4_ctx_t handle)
-{
-    if (handle == NULL)
-    {
-        return;
-    }
-
-    EVP_CIPHER_CTX_free(handle);
-}
-
-void tr_rc4_set_key(tr_rc4_ctx_t handle, uint8_t const* key, size_t key_length)
-{
-    TR_ASSERT(handle != NULL);
-    TR_ASSERT(key != NULL);
-
-    if (!check_result(EVP_CIPHER_CTX_set_key_length(handle, key_length)))
-    {
-        return;
-    }
-
-    check_result(EVP_CipherInit_ex(handle, NULL, NULL, key, NULL, -1));
-}
-
-void tr_rc4_process(tr_rc4_ctx_t handle, void const* input, void* output, size_t length)
-{
-    TR_ASSERT(handle != NULL);
-
-    if (length == 0)
-    {
-        return;
-    }
-
-    TR_ASSERT(input != NULL);
-    TR_ASSERT(output != NULL);
-
-    int output_length;
-
-    check_result(EVP_CipherUpdate(handle, output, &output_length, input, length));
-}
-
 /***
 ****
 ***/

--- a/libtransmission/crypto-utils-polarssl.c
+++ b/libtransmission/crypto-utils-polarssl.c
@@ -16,7 +16,6 @@
 #define API_VERSION_NUMBER POLARSSL_VERSION_NUMBER
 #endif
 
-#include API_HEADER(arc4.h)
 #include API_HEADER(base64.h)
 #include API_HEADER(ctr_drbg.h)
 #include API_HEADER(dhm.h)
@@ -43,7 +42,6 @@
 
 typedef API(ctr_drbg_context) api_ctr_drbg_context;
 typedef API(sha1_context) api_sha1_context;
-typedef API(arc4_context) api_arc4_context;
 typedef API(dhm_context) api_dhm_context;
 
 static void log_polarssl_error(int error_code, char const* file, int line)
@@ -180,53 +178,6 @@ bool tr_sha1_final(tr_sha1_ctx_t handle, uint8_t* hash)
 
     tr_free(handle);
     return true;
-}
-
-/***
-****
-***/
-
-tr_rc4_ctx_t tr_rc4_new(void)
-{
-    api_arc4_context* handle = tr_new0(api_arc4_context, 1);
-
-#if API_VERSION_NUMBER >= 0x01030800
-    API(arc4_init)(handle);
-#endif
-
-    return handle;
-}
-
-void tr_rc4_free(tr_rc4_ctx_t handle)
-{
-#if API_VERSION_NUMBER >= 0x01030800
-    API(arc4_free)(handle);
-#endif
-
-    tr_free(handle);
-}
-
-void tr_rc4_set_key(tr_rc4_ctx_t handle, uint8_t const* key, size_t key_length)
-{
-    TR_ASSERT(handle != NULL);
-    TR_ASSERT(key != NULL);
-
-    API(arc4_setup)(handle, key, key_length);
-}
-
-void tr_rc4_process(tr_rc4_ctx_t handle, void const* input, void* output, size_t length)
-{
-    TR_ASSERT(handle != NULL);
-
-    if (length == 0)
-    {
-        return;
-    }
-
-    TR_ASSERT(input != NULL);
-    TR_ASSERT(output != NULL);
-
-    API(arc4_crypt)(handle, length, input, output);
 }
 
 /***

--- a/libtransmission/crypto-utils.c
+++ b/libtransmission/crypto-utils.c
@@ -10,6 +10,7 @@
 #include <stdlib.h> /* abs(), srand(), rand() */
 #include <string.h> /* memcpy(), memmove(), memset(), strcmp(), strlen() */
 
+#include <arc4.h>
 #include <b64/cdecode.h>
 #include <b64/cencode.h>
 

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -25,8 +25,6 @@ TR_BEGIN_DECLS
 
 /** @brief Opaque SHA1 context type. */
 typedef void* tr_sha1_ctx_t;
-/** @brief Opaque RC4 context type. */
-typedef void* tr_rc4_ctx_t;
 /** @brief Opaque DH context type. */
 typedef void* tr_dh_ctx_t;
 /** @brief Opaque DH secret key type. */
@@ -57,26 +55,6 @@ bool tr_sha1_update(tr_sha1_ctx_t handle, void const* data, size_t data_length);
  * @brief Finalize and export SHA1 hash, free hasher context.
  */
 bool tr_sha1_final(tr_sha1_ctx_t handle, uint8_t* hash);
-
-/**
- * @brief Allocate and initialize new RC4 cipher context.
- */
-tr_rc4_ctx_t tr_rc4_new(void);
-
-/**
- * @brief Free RC4 cipher context.
- */
-void tr_rc4_free(tr_rc4_ctx_t handle);
-
-/**
- * @brief Set RC4 cipher key.
- */
-void tr_rc4_set_key(tr_rc4_ctx_t handle, uint8_t const* key, size_t key_length);
-
-/**
- * @brief Process memory block with RC4 cipher.
- */
-void tr_rc4_process(tr_rc4_ctx_t handle, void const* input, void* output, size_t length);
 
 /**
  * @brief Allocate and initialize new Diffie-Hellman (DH) key exchange context.

--- a/libtransmission/crypto.c
+++ b/libtransmission/crypto.c
@@ -126,22 +126,22 @@ static void crypt_rc4(struct arc4_context* key, size_t buf_len, void const* buf_
 
 void tr_cryptoDecryptInit(tr_crypto* crypto)
 {
-    init_rc4(crypto, &crypto->dec_key, crypto->isIncoming ? "keyA" : "keyB");
+    init_rc4(crypto, &crypto->dec_key, crypto->isIncoming ? "keyA" : "keyB"); // lgtm[cpp/weak-cryptographic-algorithm]
 }
 
 void tr_cryptoDecrypt(tr_crypto* crypto, size_t buf_len, void const* buf_in, void* buf_out)
 {
-    crypt_rc4(crypto->dec_key, buf_len, buf_in, buf_out);
+    crypt_rc4(crypto->dec_key, buf_len, buf_in, buf_out); // lgtm[cpp/weak-cryptographic-algorithm]
 }
 
 void tr_cryptoEncryptInit(tr_crypto* crypto)
 {
-    init_rc4(crypto, &crypto->enc_key, crypto->isIncoming ? "keyB" : "keyA");
+    init_rc4(crypto, &crypto->enc_key, crypto->isIncoming ? "keyB" : "keyA"); // lgtm[cpp/weak-cryptographic-algorithm]
 }
 
 void tr_cryptoEncrypt(tr_crypto* crypto, size_t buf_len, void const* buf_in, void* buf_out)
 {
-    crypt_rc4(crypto->enc_key, buf_len, buf_in, buf_out);
+    crypt_rc4(crypto->enc_key, buf_len, buf_in, buf_out); // lgtm[cpp/weak-cryptographic-algorithm]
 }
 
 bool tr_cryptoSecretKeySha1(

--- a/libtransmission/crypto.h
+++ b/libtransmission/crypto.h
@@ -35,8 +35,8 @@ enum
 /** @brief Holds state information for encrypted peer communications */
 typedef struct
 {
-    tr_rc4_ctx_t dec_key;
-    tr_rc4_ctx_t enc_key;
+    struct arc4_context* dec_key;
+    struct arc4_context* enc_key;
     tr_dh_ctx_t dh;
     uint8_t myPublicKey[KEY_LEN];
     tr_dh_secret_t mySecret;

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -16,7 +16,6 @@
 #define KEY_LEN KEY_LEN_
 
 #define tr_sha1_ctx_t tr_sha1_ctx_t_
-#define tr_rc4_ctx_t tr_rc4_ctx_t_
 #define tr_dh_ctx_t tr_dh_ctx_t_
 #define tr_dh_secret_t tr_dh_secret_t_
 #define tr_ssl_ctx_t tr_ssl_ctx_t_
@@ -39,10 +38,6 @@
 #define tr_sha1_init tr_sha1_init_
 #define tr_sha1_update tr_sha1_update_
 #define tr_sha1_final tr_sha1_final_
-#define tr_rc4_new tr_rc4_new_
-#define tr_rc4_free tr_rc4_free_
-#define tr_rc4_set_key tr_rc4_set_key_
-#define tr_rc4_process tr_rc4_process_
 #define tr_dh_new tr_dh_new_
 #define tr_dh_free tr_dh_free_
 #define tr_dh_make_key tr_dh_make_key_
@@ -80,7 +75,6 @@
 #undef KEY_LEN_
 
 #undef tr_sha1_ctx_t
-#undef tr_rc4_ctx_t
 #undef tr_dh_ctx_t
 #undef tr_dh_secret_t
 #undef tr_ssl_ctx_t
@@ -103,10 +97,6 @@
 #undef tr_sha1_init
 #undef tr_sha1_update
 #undef tr_sha1_final
-#undef tr_rc4_new
-#undef tr_rc4_free
-#undef tr_rc4_set_key
-#undef tr_rc4_process
 #undef tr_dh_new
 #undef tr_dh_free
 #undef tr_dh_make_key
@@ -137,7 +127,6 @@
 #define KEY_LEN_ KEY_LEN
 
 #define tr_sha1_ctx_t_ tr_sha1_ctx_t
-#define tr_rc4_ctx_t_ tr_rc4_ctx_t
 #define tr_dh_ctx_t_ tr_dh_ctx_t
 #define tr_dh_secret_t_ tr_dh_secret_t
 #define tr_ssl_ctx_t_ tr_ssl_ctx_t
@@ -160,10 +149,6 @@
 #define tr_sha1_init_ tr_sha1_init
 #define tr_sha1_update_ tr_sha1_update
 #define tr_sha1_final_ tr_sha1_final
-#define tr_rc4_new_ tr_rc4_new
-#define tr_rc4_free_ tr_rc4_free
-#define tr_rc4_set_key_ tr_rc4_set_key
-#define tr_rc4_process_ tr_rc4_process
 #define tr_dh_new_ tr_dh_new
 #define tr_dh_free_ tr_dh_free
 #define tr_dh_make_key_ tr_dh_make_key


### PR DESCRIPTION
This frees us from expecting it being provided by one of the crypto libraries we support, all of which deprecated and/or removed it at this point.

Fixes: #1103
Fixes: #1777