### PR TITLE
C++ modernize: libtransmission/announcer.cc

### DIFF
--- a/libtransmission/README.md
+++ b/libtransmission/README.md
@@ -1,15 +1,55 @@
 # Notes on the C-to-C++ Conversion
 
-- libtransmission was written in C for fifteen years, so eliminating all
-  Cisms is nearly impossible. **Modernization patches are welcomed** but
-  it won't all happen overnight. `tr_strdup()` and `constexpr` wil exist
-  side-by-side in the codebase for the forseeable future.
+- libtransmission was written in C for fifteen years, so eliminating all Cisms is nearly impossible. **Modernization
+  patches are welcomed** but it won't all happen overnight. `tr_strdup()` and `constexpr` wil exist side-by-side in the
+  codebase for the forseeable future.
 
-- It's so tempting to refactor all the things! Please keep modernization
-  patches reasonably focused so that they will be easy to review.
+- It's so tempting to refactor all the things! Please keep modernization patches reasonably focused so that they will be
+  easy to review.
 
 - Prefer `std::` tools over bespoke ones. For example, use `std::vector`
   instead of tr_ptrArray. Redundant bespoke code should be removed.
 
-- Consider ripple effects before adding C++ into public headers. Will it
-  break C code that #includes that header?
+- Consider ripple effects before adding C++ into public headers. Will it break C code that #includes that header?
+
+## Checklist for modernization of a module
+
+- Pass 1: Satisfy clang-tidy
+- Pass 2: Group member functions and their parent structs
+- Pass 3: Memory - promote init and free functions to C++ ctors and dtors, and ensure it is only managed with new/delete
+- Pass 4: Owned memory - promote simple pointer fields owning their data to smart pointers (unique_ptr, shared_ptr)
+
+### Detailed Steps
+
+- Satisfy clang-tidy warnings
+    - Change C includes to C++ wraps, example: <string.h> becomes <cstring> and update calls to standard library to
+      use `std::` namespace prefix. This is optional but clearly delineates the border between std library and
+      transmission.
+    - Revisit type warnings, `int` vs `unsigned int`. Sizes and counts should use `size_t` type where this does not
+      break external API declarations. Ideally change that too.
+- Move member functions into structs. To minimize code churn, create function forward declarations inside structs, and
+  give `struct_name::` prefixes to the functions.
+   ```c++
+   typedef struct {} foo;
+   void foo_blep(struct foo *f) {
+       f->blergh();
+   }
+   ```
+  becomes:
+   ```c++
+   struct foo {
+       void blep(); 
+   };
+   void foo::blep() {
+       this->blergh(); 
+   }
+   ```
+- Memory management:
+    - Prefer constructors and destructors vs manual construction and destruction. But when doing so must ensure that the
+      struct is never constructed using C `malloc`/`free`, but must use C++ `new`/`delete`.
+    - Avoid using std::memset on a new struct. It is allowed in C, and C++ struct but will destroy virtual table on a
+      C++ class. Use field initializers in C++.
+- Owned memory:
+    - If destructor deletes something, it means it was owned. Promote that field to owning type (vector, unique_ptr,
+      shared_ptr or string).
+  

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -166,6 +166,8 @@ typedef struct
 
     /* the name to use when deep logging is enabled */
     char log_name[128];
+
+    static int compareStops(void const* va, void const* vb);
 } tr_announce_request;
 
 struct tr_pex;

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -124,7 +124,7 @@ typedef enum
 
 char const* tr_announce_event_get_string(tr_announce_event);
 
-typedef struct
+struct tr_announce_request
 {
     tr_announce_event event;
     bool partial_seed;
@@ -168,7 +168,8 @@ typedef struct
     char log_name[128];
 
     static int compareStops(void const* va, void const* vb);
-} tr_announce_request;
+    static void announce_request_free(struct tr_announce_request* req); // TODO: [C++] Destructor
+};
 
 struct tr_pex;
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -65,7 +65,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
         "&compact=1"
         "&supportcrypto=1",
         req->url,
-        strchr(req->url, '?') != NULL ? '&' : '?',
+        strchr(req->url, '?') != nullptr ? '&' : '?',
         escaped_info_hash,
         TR_ARG_TUPLE(PEER_ID_LEN, PEER_ID_LEN, req->peer_id),
         req->port,
@@ -110,7 +110,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
 
     ipv6 = tr_globalIPv6();
 
-    if (ipv6 != NULL)
+    if (ipv6 != nullptr)
     {
         char ipv6_readable[INET6_ADDRSTRLEN];
         evutil_inet_ntop(AF_INET6, ipv6, ipv6_readable, INET6_ADDRSTRLEN);
@@ -118,7 +118,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
         tr_http_escape(buf, ipv6_readable, TR_BAD_SIZE, true);
     }
 
-    return evbuffer_free_to_str(buf, NULL);
+    return evbuffer_free_to_str(buf, nullptr);
 }
 
 static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
@@ -134,12 +134,12 @@ static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
         tr_address addr;
         tr_variant* peer = tr_variantListChild(peerList, i);
 
-        if (peer == NULL)
+        if (peer == nullptr)
         {
             continue;
         }
 
-        if (!tr_variantDictFindStr(peer, TR_KEY_ip, &ip, NULL))
+        if (!tr_variantDictFindStr(peer, TR_KEY_ip, &ip, nullptr))
         {
             continue;
         }
@@ -185,7 +185,7 @@ static void on_announce_done_eventthread(void* vdata)
 {
     auto* data = static_cast<struct announce_data*>(vdata);
 
-    if (data->response_func != NULL)
+    if (data->response_func != nullptr)
     {
         data->response_func(&data->response, data->response_func_user_data);
     }
@@ -299,13 +299,13 @@ static void on_announce_done(
             if (tr_variantDictFindRaw(&benc, TR_KEY_peers6, &raw, &len))
             {
                 dbgmsg(data->log_name, "got a peers6 length of %zu", len);
-                response->pex6 = tr_peerMgrCompact6ToPex(raw, len, NULL, 0, &response->pex6_count);
+                response->pex6 = tr_peerMgrCompact6ToPex(raw, len, nullptr, 0, &response->pex6_count);
             }
 
             if (tr_variantDictFindRaw(&benc, TR_KEY_peers, &raw, &len))
             {
                 dbgmsg(data->log_name, "got a compact peers length of %zu", len);
-                response->pex = tr_peerMgrCompactToPex(raw, len, NULL, 0, &response->pex_count);
+                response->pex = tr_peerMgrCompactToPex(raw, len, nullptr, 0, &response->pex_count);
             }
             else if (tr_variantDictFindList(&benc, TR_KEY_peers, &tmp))
             {
@@ -365,7 +365,7 @@ static void on_scrape_done_eventthread(void* vdata)
 {
     auto* data = static_cast<struct scrape_data*>(vdata);
 
-    if (data->response_func != NULL)
+    if (data->response_func != nullptr)
     {
         data->response_func(&data->response, data->response_func_user_data);
     }
@@ -454,7 +454,7 @@ static void on_scrape_done(
                     {
                         struct tr_scrape_response_row* row = &response->rows[j];
 
-                        if (memcmp(tr_quark_get_string(key, NULL), row->info_hash, SHA_DIGEST_LENGTH) == 0)
+                        if (memcmp(tr_quark_get_string(key, nullptr), row->info_hash, SHA_DIGEST_LENGTH) == 0)
                         {
                             if (tr_variantDictFindInt(val, TR_KEY_complete, &intVal))
                             {
@@ -495,7 +495,7 @@ static char* scrape_url_new(tr_scrape_request const* req)
     struct evbuffer* buf = evbuffer_new();
 
     evbuffer_add_printf(buf, "%s", req->url);
-    delimiter = strchr(req->url, '?') != NULL ? '&' : '?';
+    delimiter = strchr(req->url, '?') != nullptr ? '&' : '?';
 
     for (int i = 0; i < req->info_hash_count; ++i)
     {
@@ -505,7 +505,7 @@ static char* scrape_url_new(tr_scrape_request const* req)
         delimiter = '&';
     }
 
-    return evbuffer_free_to_str(buf, NULL);
+    return evbuffer_free_to_str(buf, nullptr);
 }
 
 void tr_tracker_http_scrape(

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -180,7 +180,7 @@ typedef struct tr_announcer
 
 static struct tr_scrape_info* tr_announcerGetScrapeInfo(struct tr_announcer* announcer, char const* url)
 {
-    struct tr_scrape_info* info = NULL;
+    struct tr_scrape_info* info = nullptr;
 
     if (!tr_str_is_empty(url))
     {
@@ -230,12 +230,12 @@ void tr_announcerClose(tr_session* session)
     tr_tracker_udp_start_shutdown(session);
 
     event_free(announcer->upkeepTimer);
-    announcer->upkeepTimer = NULL;
+    announcer->upkeepTimer = nullptr;
 
-    tr_ptrArrayDestruct(&announcer->stops, NULL);
+    tr_ptrArrayDestruct(&announcer->stops, nullptr);
     tr_ptrArrayDestruct(&announcer->scrape_info, scrapeInfoFree);
 
-    session->announcer = NULL;
+    session->announcer = nullptr;
     tr_free(announcer);
 }
 
@@ -266,12 +266,12 @@ typedef struct
 static char* getKey(char const* url)
 {
     char* ret;
-    char* scheme = NULL;
-    char* host = NULL;
+    char* scheme = nullptr;
+    char* host = nullptr;
     int port = 0;
 
-    tr_urlParse(url, TR_BAD_SIZE, &scheme, &host, &port, NULL);
-    ret = tr_strdup_printf("%s://%s:%d", scheme != NULL ? scheme : "invalid", host != NULL ? host : "invalid", port);
+    tr_urlParse(url, TR_BAD_SIZE, &scheme, &host, &port, nullptr);
+    ret = tr_strdup_printf("%s://%s:%d", scheme != nullptr ? scheme : "invalid", host != nullptr ? host : "invalid", port);
 
     tr_free(host);
     tr_free(scheme);
@@ -405,14 +405,14 @@ static void tier_build_log_name(tr_tier const* tier, char* buf, size_t buflen)
         buf,
         buflen,
         "[%s---%s]",
-        (tier != NULL && tier->tor != NULL) ? tr_torrentName(tier->tor) : "?",
-        (tier != NULL && tier->currentTracker != NULL) ? tier->currentTracker->key : "?");
+        (tier != nullptr && tier->tor != nullptr) ? tr_torrentName(tier->tor) : "?",
+        (tier != nullptr && tier->currentTracker != nullptr) ? tier->currentTracker->key : "?");
 }
 
 static void tierIncrementTracker(tr_tier* tier)
 {
     /* move our index to the next tracker in the tier */
-    int const i = tier->currentTracker == NULL ? 0 : (tier->currentTrackerIndex + 1) % tier->tracker_count;
+    int const i = tier->currentTracker == nullptr ? 0 : (tier->currentTrackerIndex + 1) % tier->tracker_count;
     tier->currentTrackerIndex = i;
     tier->currentTracker = &tier->trackers[i];
 
@@ -477,18 +477,18 @@ static void tiersFree(tr_torrent_tiers* tt)
 
 static tr_tier* getTier(tr_announcer* announcer, uint8_t const* info_hash, int tierId)
 {
-    tr_tier* tier = NULL;
+    tr_tier* tier = nullptr;
 
-    if (announcer != NULL)
+    if (announcer != nullptr)
     {
         tr_session* session = announcer->session;
         tr_torrent* tor = tr_torrentFindFromHash(session, info_hash);
 
-        if (tor != NULL && tor->tiers != NULL)
+        if (tor != nullptr && tor->tiers != nullptr)
         {
             tr_torrent_tiers* tt = tor->tiers;
 
-            for (int i = 0; tier == NULL && i < tt->tier_count; ++i)
+            for (int i = 0; tier == nullptr && i < tt->tier_count; ++i)
             {
                 if (tt->tiers[i].key == tierId)
                 {
@@ -507,14 +507,14 @@ static tr_tier* getTier(tr_announcer* announcer, uint8_t const* info_hash, int t
 
 static void publishMessage(tr_tier* tier, char const* msg, TrackerEventType type)
 {
-    if (tier != NULL && tier->tor != NULL && tier->tor->tiers != NULL && tier->tor->tiers->callback != NULL)
+    if (tier != nullptr && tier->tor != nullptr && tier->tor->tiers != nullptr && tier->tor->tiers->callback != nullptr)
     {
         tr_torrent_tiers* tiers = tier->tor->tiers;
         auto event = tr_tracker_event{};
         event.messageType = type;
         event.text = msg;
 
-        if (tier->currentTracker != NULL)
+        if (tier->currentTracker != nullptr)
         {
             event.tracker = tier->currentTracker->announce;
         }
@@ -525,7 +525,7 @@ static void publishMessage(tr_tier* tier, char const* msg, TrackerEventType type
 
 static void publishErrorClear(tr_tier* tier)
 {
-    publishMessage(tier, NULL, TR_TRACKER_ERROR_CLEAR);
+    publishMessage(tier, nullptr, TR_TRACKER_ERROR_CLEAR);
 }
 
 static void publishWarning(tr_tier* tier, char const* msg)
@@ -540,7 +540,7 @@ static void publishError(tr_tier* tier, char const* msg)
 
 static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
 {
-    if (tier->tor->tiers->callback != NULL)
+    if (tier->tor->tiers->callback != nullptr)
     {
         auto e = tr_tracker_event{};
         e.messageType = TR_TRACKER_COUNTS;
@@ -548,13 +548,13 @@ static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
         e.leechers = leechers;
         dbgmsg(tier, "peer counts: %d seeders, %d leechers.", seeders, leechers);
 
-        (*tier->tor->tiers->callback)(tier->tor, &e, NULL);
+        (*tier->tor->tiers->callback)(tier->tor, &e, nullptr);
     }
 }
 
 static void publishPeersPex(tr_tier* tier, int seeders, int leechers, tr_pex const* pex, int n)
 {
-    if (tier->tor->tiers->callback != NULL)
+    if (tier->tor->tiers->callback != nullptr)
     {
         auto e = tr_tracker_event{};
         e.messageType = TR_TRACKER_PEERS;
@@ -564,7 +564,7 @@ static void publishPeersPex(tr_tier* tier, int seeders, int leechers, tr_pex con
         e.pexCount = n;
         dbgmsg(tier, "tracker knows of %d seeders and %d leechers and gave a list of %d peers.", seeders, leechers, n);
 
-        (*tier->tor->tiers->callback)(tier->tor, &e, NULL);
+        (*tier->tor->tiers->callback)(tier->tor, &e, nullptr);
     }
 }
 
@@ -715,7 +715,7 @@ static void addTorrentToTier(tr_torrent_tiers* tt, tr_torrent* tor)
     }
 
     /* build the array of tiers */
-    tier = NULL;
+    tier = nullptr;
     tt->tiers = tr_new0(tr_tier, tier_count);
     tt->tier_count = 0;
 
@@ -764,9 +764,9 @@ static bool tierCanManualAnnounce(tr_tier const* tier)
 bool tr_announcerCanManualAnnounce(tr_torrent const* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(tor->tiers != NULL);
+    TR_ASSERT(tor->tiers != nullptr);
 
-    struct tr_torrent_tiers const* tt = NULL;
+    struct tr_torrent_tiers const* tt = nullptr;
 
     if (tor->isRunning)
     {
@@ -774,7 +774,7 @@ bool tr_announcerCanManualAnnounce(tr_torrent const* tor)
     }
 
     /* return true if any tier can manual announce */
-    for (int i = 0; tt != NULL && i < tt->tier_count; ++i)
+    for (int i = 0; tt != nullptr && i < tt->tier_count; ++i)
     {
         if (tierCanManualAnnounce(&tt->tiers[i]))
         {
@@ -791,7 +791,7 @@ time_t tr_announcerNextManualAnnounce(tr_torrent const* tor)
     struct tr_torrent_tiers const* tt = tor->tiers;
 
     /* find the earliest manual announce time from all peers */
-    for (int i = 0; tt != NULL && i < tt->tier_count; ++i)
+    for (int i = 0; tt != nullptr && i < tt->tier_count; ++i)
     {
         if (tt->tiers[i].isRunning)
         {
@@ -819,7 +819,7 @@ static void dbgmsg_tier_announce_queue(tr_tier const* tier)
             evbuffer_add_printf(buf, "[%d:%s]", i, str);
         }
 
-        message = evbuffer_free_to_str(buf, NULL);
+        message = evbuffer_free_to_str(buf, nullptr);
         tr_logAddDeep(__FILE__, __LINE__, name, "announce queue is %s", message);
         tr_free(message);
     }
@@ -850,7 +850,7 @@ static void tier_announce_remove_trailing(tr_tier* tier, tr_announce_event e)
 
 static void tier_announce_event_push(tr_tier* tier, tr_announce_event e, time_t announceAt)
 {
-    TR_ASSERT(tier != NULL);
+    TR_ASSERT(tier != nullptr);
 
     dbgmsg_tier_announce_queue(tier);
     dbgmsg(tier, "queued \"%s\"", tr_announce_event_get_string(e));
@@ -999,7 +999,7 @@ void tr_announcerRemoveTorrent(tr_announcer* announcer, tr_torrent* tor)
 {
     struct tr_torrent_tiers const* tt = tor->tiers;
 
-    if (tt != NULL)
+    if (tt != nullptr)
     {
         for (int i = 0; i < tt->tier_count; ++i)
         {
@@ -1010,7 +1010,7 @@ void tr_announcerRemoveTorrent(tr_announcer* announcer, tr_torrent* tor)
                 tr_announce_event const e = TR_ANNOUNCE_EVENT_STOPPED;
                 tr_announce_request* req = announce_request_new(announcer, tor, tier, e);
 
-                if (tr_ptrArrayFindSorted(&announcer->stops, req, compareStops) != NULL)
+                if (tr_ptrArrayFindSorted(&announcer->stops, req, compareStops) != nullptr)
                 {
                     announce_request_free(req);
                 }
@@ -1022,7 +1022,7 @@ void tr_announcerRemoveTorrent(tr_announcer* announcer, tr_torrent* tor)
         }
 
         tiersFree(tor->tiers);
-        tor->tiers = NULL;
+        tor->tiers = nullptr;
     }
 }
 
@@ -1069,7 +1069,7 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
     int interval;
 
     /* increment the error count */
-    if (tier->currentTracker != NULL)
+    if (tier->currentTracker != nullptr)
     {
         ++tier->currentTracker->consecutiveFailures;
     }
@@ -1097,7 +1097,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
     time_t const now = tr_time();
     tr_announce_event const event = data->event;
 
-    if (tier != NULL)
+    if (tier != nullptr)
     {
         tr_tracker* tracker;
 
@@ -1123,11 +1123,11 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
             response->downloads,
             response->interval,
             response->min_interval,
-            response->tracker_id_str != NULL ? response->tracker_id_str : "none",
+            response->tracker_id_str != nullptr ? response->tracker_id_str : "none",
             response->pex_count,
             response->pex6_count,
-            response->errmsg != NULL ? response->errmsg : "none",
-            response->warning != NULL ? response->warning : "none");
+            response->errmsg != nullptr ? response->errmsg : "none",
+            response->warning != nullptr ? response->warning : "none");
 
         tier->lastAnnounceTime = now;
         tier->lastAnnounceTimedOut = response->did_timeout;
@@ -1143,7 +1143,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
         {
             on_announce_error(tier, _("Tracker did not respond"), event);
         }
-        else if (response->errmsg != NULL)
+        else if (response->errmsg != nullptr)
         {
             /* If the torrent's only tracker returned an error, publish it.
                Don't bother publishing if there are other trackers -- it's
@@ -1167,7 +1167,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
             publishErrorClear(tier);
 
-            if ((tracker = tier->currentTracker) != NULL)
+            if ((tracker = tier->currentTracker) != nullptr)
             {
                 tracker->consecutiveFailures = 0;
 
@@ -1189,14 +1189,14 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
                     ++scrape_fields;
                 }
 
-                if ((str = response->tracker_id_str) != NULL)
+                if ((str = response->tracker_id_str) != nullptr)
                 {
                     tr_free(tracker->tracker_id_str);
                     tracker->tracker_id_str = tr_strdup(str);
                 }
             }
 
-            if ((str = response->warning) != NULL)
+            if ((str = response->warning) != nullptr)
             {
                 tr_strlcpy(tier->lastAnnounceStr, str, sizeof(tier->lastAnnounceStr));
                 dbgmsg(tier, "tracker gave \"%s\"", str);
@@ -1233,7 +1233,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
             /* if the tracker included scrape fields in its announce response,
                then a separate scrape isn't needed */
-            if (scrape_fields >= 3 || (scrape_fields >= 1 && tracker->scrape_info == NULL))
+            if (scrape_fields >= 3 || (scrape_fields >= 1 && tracker->scrape_info == nullptr))
             {
                 tr_logAddTorDbg(
                     tier->tor,
@@ -1356,14 +1356,14 @@ static bool multiscrape_too_big(char const* errmsg)
         "Request-URI Too Long",
     };
 
-    if (errmsg == NULL)
+    if (errmsg == nullptr)
     {
         return false;
     }
 
     for (size_t i = 0; i < TR_N_ELEMENTS(too_long_errors); ++i)
     {
-        if (strstr(errmsg, too_long_errors[i]) != NULL)
+        if (strstr(errmsg, too_long_errors[i]) != nullptr)
         {
             return true;
         }
@@ -1377,7 +1377,7 @@ static void on_scrape_error(tr_session const* session, tr_tier* tier, char const
     int interval;
 
     /* increment the error count */
-    if (tier->currentTracker != NULL)
+    if (tier->currentTracker != nullptr)
     {
         ++tier->currentTracker->consecutiveFailures;
     }
@@ -1402,17 +1402,17 @@ static tr_tier* find_tier(tr_torrent* tor, char const* scrape)
 {
     struct tr_torrent_tiers* tt = tor->tiers;
 
-    for (int i = 0; tt != NULL && i < tt->tier_count; ++i)
+    for (int i = 0; tt != nullptr && i < tt->tier_count; ++i)
     {
         tr_tracker const* const tracker = tt->tiers[i].currentTracker;
 
-        if (tracker != NULL && tracker->scrape_info != NULL && tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
+        if (tracker != nullptr && tracker->scrape_info != nullptr && tr_strcmp0(scrape, tracker->scrape_info->url) == 0)
         {
             return &tt->tiers[i];
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 static void on_scrape_done(tr_scrape_response const* response, void* vsession)
@@ -1426,11 +1426,11 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
         struct tr_scrape_response_row const* row = &response->rows[i];
         tr_torrent* tor = tr_torrentFindFromHash(session, row->info_hash);
 
-        if (tor != NULL)
+        if (tor != nullptr)
         {
             tr_tier* tier = find_tier(tor, response->url);
 
-            if (tier != NULL)
+            if (tier != nullptr)
             {
                 dbgmsg(
                     tier,
@@ -1451,7 +1451,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                     row->downloads,
                     row->downloaders,
                     response->min_request_interval,
-                    response->errmsg != NULL ? response->errmsg : "none");
+                    response->errmsg != nullptr ? response->errmsg : "none");
 
                 tier->isScraping = false;
                 tier->lastScrapeTime = now;
@@ -1466,7 +1466,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                 {
                     on_scrape_error(session, tier, _("Tracker did not respond"));
                 }
-                else if (response->errmsg != NULL)
+                else if (response->errmsg != nullptr)
                 {
                     on_scrape_error(session, tier, response->errmsg);
                 }
@@ -1478,7 +1478,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                     tr_logAddTorDbg(tier->tor, "Scrape successful. Rescraping in %d seconds.", tier->scrapeIntervalSec);
 
                     tr_tracker* const tracker = tier->currentTracker;
-                    if (tracker != NULL)
+                    if (tracker != nullptr)
                     {
                         if (row->seeders >= 0)
                         {
@@ -1513,7 +1513,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
     {
         char const* url = response->url;
         struct tr_scrape_info* const scrape_info = tr_announcerGetScrapeInfo(announcer, url);
-        if (scrape_info != NULL)
+        if (scrape_info != nullptr)
         {
             int* multiscrape_max = &scrape_info->multiscrape_max;
 
@@ -1525,10 +1525,10 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                 int const n = MAX(1, *multiscrape_max - TR_MULTISCRAPE_STEP);
                 if (*multiscrape_max != n)
                 {
-                    char* scheme = NULL;
-                    char* host = NULL;
+                    char* scheme = nullptr;
+                    char* host = nullptr;
                     int port;
-                    if (tr_urlParse(url, strlen(url), &scheme, &host, &port, NULL))
+                    if (tr_urlParse(url, strlen(url), &scheme, &host, &port, nullptr))
                     {
                         /* don't log the full URL, since that might have a personal announce id */
                         char* sanitized_url = tr_strdup_printf("%s://%s:%d", scheme, host, port);
@@ -1582,7 +1582,7 @@ static void multiscrape(tr_announcer* announcer, tr_ptrArray* tiers)
         uint8_t const* hash = tier->tor->info.hash;
         bool found = false;
 
-        TR_ASSERT(scrape_info != NULL);
+        TR_ASSERT(scrape_info != nullptr);
 
         /* if there's a request with this scrape URL and a free slot, use it */
         for (size_t j = 0; !found && j < request_count; ++j)
@@ -1647,15 +1647,15 @@ static inline bool tierNeedsToAnnounce(tr_tier const* tier, time_t const now)
 
 static inline bool tierNeedsToScrape(tr_tier const* tier, time_t const now)
 {
-    return !tier->isScraping && tier->scrapeAt != 0 && tier->scrapeAt <= now && tier->currentTracker != NULL &&
-        tier->currentTracker->scrape_info != NULL;
+    return !tier->isScraping && tier->scrapeAt != 0 && tier->scrapeAt <= now && tier->currentTracker != nullptr &&
+        tier->currentTracker->scrape_info != nullptr;
 }
 
 static inline int countDownloaders(tr_tier const* tier)
 {
     tr_tracker const* const tracker = tier->currentTracker;
 
-    return tracker == NULL ? 0 : tracker->downloaderCount + tracker->leecherCount;
+    return tracker == nullptr ? 0 : tracker->downloaderCount + tracker->leecherCount;
 }
 
 static int compareAnnounceTiers(void const* va, void const* vb)
@@ -1716,12 +1716,12 @@ static void scrapeAndAnnounceMore(tr_announcer* announcer)
     /* build a list of tiers that need to be announced */
     auto announceMe = tr_ptrArray{};
     auto scrapeMe = tr_ptrArray{};
-    tr_torrent* tor = NULL;
-    while ((tor = tr_torrentNext(announcer->session, tor)) != NULL)
+    tr_torrent* tor = nullptr;
+    while ((tor = tr_torrentNext(announcer->session, tor)) != nullptr)
     {
         struct tr_torrent_tiers* tt = tor->tiers;
 
-        for (int i = 0; tt != NULL && i < tt->tier_count; ++i)
+        for (int i = 0; tt != nullptr && i < tt->tier_count; ++i)
         {
             tr_tier* tier = &tt->tiers[i];
 
@@ -1755,8 +1755,8 @@ static void scrapeAndAnnounceMore(tr_announcer* announcer)
     }
 
     /* cleanup */
-    tr_ptrArrayDestruct(&scrapeMe, NULL);
-    tr_ptrArrayDestruct(&announceMe, NULL);
+    tr_ptrArrayDestruct(&scrapeMe, nullptr);
+    tr_ptrArrayDestruct(&announceMe, nullptr);
 }
 
 static void onUpkeepTimer(evutil_socket_t fd, short what, void* vannouncer)
@@ -1827,7 +1827,7 @@ tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerC
             st->isBackup = tracker != tier->currentTracker;
             st->lastScrapeStartTime = tier->lastScrapeStartTime;
 
-            if (tracker->scrape_info != NULL)
+            if (tracker->scrape_info != nullptr)
             {
                 tr_strlcpy(st->scrape, tracker->scrape_info->url, sizeof(st->scrape));
             }
@@ -1971,7 +1971,7 @@ void tr_announcerResetTorrent(tr_announcer* announcer, tr_torrent* tor)
 {
     TR_UNUSED(announcer);
 
-    TR_ASSERT(tor->tiers != NULL);
+    TR_ASSERT(tor->tiers != nullptr);
 
     time_t const now = tr_time();
 
@@ -1979,8 +1979,8 @@ void tr_announcerResetTorrent(tr_announcer* announcer, tr_torrent* tor)
     tr_torrent_tiers old = *tt;
 
     /* remove the old tiers / trackers */
-    tt->tiers = NULL;
-    tt->trackers = NULL;
+    tt->tiers = nullptr;
+    tt->trackers = nullptr;
     tt->tier_count = 0;
     tt->tracker_count = 0;
 
@@ -1990,7 +1990,7 @@ void tr_announcerResetTorrent(tr_announcer* announcer, tr_torrent* tor)
     /* copy the old tiers' states into their replacements */
     for (int i = 0; i < old.tier_count; ++i)
     {
-        if (old.tiers[i].currentTracker != NULL)
+        if (old.tiers[i].currentTracker != nullptr)
         {
             copy_tier_attributes(tt, &old.tiers[i]);
         }

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -92,6 +92,7 @@ void tr_announcerAddBytes(tr_torrent*, int up_down_or_corrupt, uint32_t byteCoun
 
 time_t tr_announcerNextManualAnnounce(tr_torrent const*);
 
+// TODO: [C++] Used by torrent.cc, remove when the struct is published in a header file, and access via tr_announcer::getStats
 tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerCount);
 
 void tr_announcerStatsFree(tr_tracker_stat* trackers, int trackerCount);

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -16,7 +16,7 @@
 #include "tr-assert.h"
 #include "utils.h"
 
-#define dbgmsg(...) tr_logAddDeepNamed(NULL, __VA_ARGS__)
+#define dbgmsg(...) tr_logAddDeepNamed(nullptr, __VA_ARGS__)
 
 /***
 ****
@@ -111,8 +111,8 @@ void tr_bandwidthDestruct(tr_bandwidth* b)
 {
     TR_ASSERT(tr_isBandwidth(b));
 
-    tr_bandwidthSetParent(b, NULL);
-    tr_ptrArrayDestruct(&b->children, NULL);
+    tr_bandwidthSetParent(b, nullptr);
+    tr_ptrArrayDestruct(&b->children, nullptr);
 
     memset(b, ~0, sizeof(tr_bandwidth));
 }
@@ -126,19 +126,19 @@ void tr_bandwidthSetParent(tr_bandwidth* b, tr_bandwidth* parent)
     TR_ASSERT(tr_isBandwidth(b));
     TR_ASSERT(b != parent);
 
-    if (b->parent != NULL)
+    if (b->parent != nullptr)
     {
         TR_ASSERT(tr_isBandwidth(b->parent));
         tr_ptrArrayRemoveSortedPointer(&b->parent->children, b, compareBandwidth);
-        b->parent = NULL;
+        b->parent = nullptr;
     }
 
-    if (parent != NULL)
+    if (parent != nullptr)
     {
         TR_ASSERT(tr_isBandwidth(parent));
         TR_ASSERT(parent->parent != b);
 
-        TR_ASSERT(tr_ptrArrayFindSorted(&parent->children, b, compareBandwidth) == NULL);
+        TR_ASSERT(tr_ptrArrayFindSorted(&parent->children, b, compareBandwidth) == nullptr);
         tr_ptrArrayInsertSorted(&parent->children, b, compareBandwidth);
         TR_ASSERT(tr_ptrArrayFindSorted(&parent->children, b, compareBandwidth) == b);
         b->parent = parent;
@@ -169,7 +169,7 @@ static void allocateBandwidth(
     }
 
     /* add this bandwidth's peer, if any, to the peer pool */
-    if (b->peer != NULL)
+    if (b->peer != nullptr)
     {
         b->peer->priority = priority;
         tr_ptrArrayAppend(peer_pool, b->peer);
@@ -280,16 +280,16 @@ void tr_bandwidthAllocate(tr_bandwidth* b, tr_direction dir, unsigned int period
     }
 
     /* cleanup */
-    tr_ptrArrayDestruct(&normal, NULL);
-    tr_ptrArrayDestruct(&high, NULL);
-    tr_ptrArrayDestruct(&low, NULL);
-    tr_ptrArrayDestruct(&tmp, NULL);
+    tr_ptrArrayDestruct(&normal, nullptr);
+    tr_ptrArrayDestruct(&high, nullptr);
+    tr_ptrArrayDestruct(&low, nullptr);
+    tr_ptrArrayDestruct(&tmp, nullptr);
 }
 
 void tr_bandwidthSetPeer(tr_bandwidth* b, tr_peerIo* peer)
 {
     TR_ASSERT(tr_isBandwidth(b));
-    TR_ASSERT(peer == NULL || tr_isPeerIo(peer));
+    TR_ASSERT(peer == nullptr || tr_isPeerIo(peer));
 
     b->peer = peer;
 }
@@ -303,7 +303,7 @@ static unsigned int bandwidthClamp(tr_bandwidth const* b, uint64_t now, tr_direc
     TR_ASSERT(tr_isBandwidth(b));
     TR_ASSERT(tr_isDirection(dir));
 
-    if (b != NULL)
+    if (b != nullptr)
     {
         if (b->band[dir].isLimited)
         {
@@ -341,7 +341,7 @@ static unsigned int bandwidthClamp(tr_bandwidth const* b, uint64_t now, tr_direc
             }
         }
 
-        if (b->parent != NULL && b->band[dir].honorParentLimits && byteCount > 0)
+        if (b->parent != nullptr && b->band[dir].honorParentLimits && byteCount > 0)
         {
             byteCount = bandwidthClamp(b->parent, now, dir, byteCount);
         }
@@ -406,7 +406,7 @@ void tr_bandwidthUsed(tr_bandwidth* b, tr_direction dir, size_t byteCount, bool 
         bytesUsed(now, &band->piece, byteCount);
     }
 
-    if (b->parent != NULL)
+    if (b->parent != nullptr)
     {
         tr_bandwidthUsed(b->parent, dir, byteCount, isPieceData, now);
     }

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* memset() */
+#include <cstring> /* memset() */
+#include <algorithm>
 
 #include "transmission.h"
 #include "bandwidth.h"
@@ -159,7 +160,7 @@ static void allocateBandwidth(
     TR_ASSERT(tr_isBandwidth(b));
     TR_ASSERT(tr_isDirection(dir));
 
-    tr_priority_t const priority = MAX(parent_priority, b->priority);
+    tr_priority_t const priority = std::max(parent_priority, b->priority);
 
     /* set the available bandwidth */
     if (b->band[dir].isLimited)
@@ -307,7 +308,7 @@ static unsigned int bandwidthClamp(tr_bandwidth const* b, uint64_t now, tr_direc
     {
         if (b->band[dir].isLimited)
         {
-            byteCount = MIN(byteCount, b->band[dir].bytesLeft);
+            byteCount = std::min(byteCount, b->band[dir].bytesLeft);
 
             /* if we're getting close to exceeding the speed limit,
              * clamp down harder on the bytes available */
@@ -380,7 +381,7 @@ void tr_bandwidthUsed(tr_bandwidth* b, tr_direction dir, size_t byteCount, bool 
 
     if (band->isLimited && isPieceData)
     {
-        band->bytesLeft -= MIN(band->bytesLeft, byteCount);
+        band->bytesLeft -= std::min((unsigned long)band->bytesLeft, byteCount);
     }
 
 #ifdef DEBUG_DIRECTION

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -126,7 +126,7 @@ void tr_bandwidthDestruct(tr_bandwidth* bandwidth);
 /** @brief test to see if the pointer refers to a live bandwidth object */
 static inline bool tr_isBandwidth(tr_bandwidth const* b)
 {
-    return b != NULL && b->magicNumber == BANDWIDTH_MAGIC_NUMBER;
+    return b != nullptr && b->magicNumber == BANDWIDTH_MAGIC_NUMBER;
 }
 
 /******

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -66,7 +66,7 @@ static size_t countRange(tr_bitfield const* b, size_t begin, size_t end)
     }
 
     TR_ASSERT(begin < end);
-    TR_ASSERT(b->bits != NULL);
+    TR_ASSERT(b->bits != nullptr);
 
     if (first_byte == last_byte)
     {
@@ -158,9 +158,9 @@ bool tr_bitfieldHas(tr_bitfield const* b, size_t n)
 
 static bool tr_bitfieldIsValid(tr_bitfield const* b)
 {
-    TR_ASSERT(b != NULL);
-    TR_ASSERT((b->alloc_count == 0) == (b->bits == NULL));
-    TR_ASSERT(b->bits == NULL || b->true_count == countArray(b));
+    TR_ASSERT(b != nullptr);
+    TR_ASSERT((b->alloc_count == 0) == (b->bits == nullptr));
+    TR_ASSERT(b->bits == nullptr || b->true_count == countArray(b));
 
     return true;
 }
@@ -255,7 +255,7 @@ static bool tr_bitfieldEnsureNthBitAlloced(tr_bitfield* b, size_t nth)
 static void tr_bitfieldFreeArray(tr_bitfield* b)
 {
     tr_free(b->bits);
-    b->bits = NULL;
+    b->bits = nullptr;
     b->alloc_count = 0;
 }
 
@@ -302,7 +302,7 @@ void tr_bitfieldConstruct(tr_bitfield* b, size_t bit_count)
 {
     b->bit_count = bit_count;
     b->true_count = 0;
-    b->bits = NULL;
+    b->bits = nullptr;
     b->alloc_count = 0;
     b->have_all_hint = false;
     b->have_none_hint = false;
@@ -401,7 +401,7 @@ void tr_bitfieldAdd(tr_bitfield* b, size_t nth)
     {
         size_t const offset = nth >> 3U;
 
-        if ((b->bits != NULL) && (offset < b->alloc_count))
+        if ((b->bits != nullptr) && (offset < b->alloc_count))
         {
             b->bits[offset] |= 0x80 >> (nth & 7U);
             tr_bitfieldIncTrueCount(b, 1);

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* memset */
+#include <cstring> /* memset */
+#include <algorithm>
 
 #include "transmission.h"
 #include "bitfield.h"
@@ -85,7 +86,7 @@ static size_t countRange(tr_bitfield const* b, size_t begin, size_t end)
     else
     {
         uint8_t val;
-        size_t const walk_end = MIN(b->alloc_count, last_byte);
+        size_t const walk_end = std::min(b->alloc_count, last_byte);
 
         /* first byte */
         size_t const first_shift = begin - (first_byte * 8);
@@ -220,7 +221,7 @@ static void tr_bitfieldEnsureBitsAlloced(tr_bitfield* b, size_t n)
 
     if (has_all)
     {
-        bytes_needed = get_bytes_needed(MAX(n, b->true_count));
+        bytes_needed = get_bytes_needed(std::max(n, b->true_count));
     }
     else
     {
@@ -353,7 +354,7 @@ void tr_bitfieldSetRaw(tr_bitfield* b, void const* bits, size_t byte_count, bool
 
     if (bounded)
     {
-        byte_count = MIN(byte_count, get_bytes_needed(b->bit_count));
+        byte_count = std::min(byte_count, get_bytes_needed(b->bit_count));
     }
 
     b->bits = static_cast<uint8_t*>(tr_memdup(bits, byte_count));

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -42,11 +42,11 @@ struct tr_blocklistFile
 
 static void blocklistClose(tr_blocklistFile* b)
 {
-    if (b->rules != NULL)
+    if (b->rules != nullptr)
     {
-        tr_sys_file_unmap(b->rules, b->byteCount, NULL);
-        tr_sys_file_close(b->fd, NULL);
-        b->rules = NULL;
+        tr_sys_file_unmap(b->rules, b->byteCount, nullptr);
+        tr_sys_file_close(b->fd, nullptr);
+        b->rules = nullptr;
         b->ruleCount = 0;
         b->byteCount = 0;
         b->fd = TR_BAD_SYS_FILE;
@@ -59,12 +59,12 @@ static void blocklistLoad(tr_blocklistFile* b)
     uint64_t byteCount;
     tr_sys_path_info info;
     char* base;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
     char const* err_fmt = _("Couldn't read \"%1$s\": %2$s");
 
     blocklistClose(b);
 
-    if (!tr_sys_path_get_info(b->filename, 0, &info, NULL))
+    if (!tr_sys_path_get_info(b->filename, 0, &info, nullptr))
     {
         return;
     }
@@ -87,10 +87,10 @@ static void blocklistLoad(tr_blocklistFile* b)
 
     b->rules = static_cast<struct tr_ipv4_range*>(tr_sys_file_map_for_reading(fd, 0, byteCount, &error));
 
-    if (b->rules == NULL)
+    if (b->rules == nullptr)
     {
         tr_logAddError(err_fmt, b->filename, error->message);
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
         tr_error_free(error);
         return;
     }
@@ -99,14 +99,14 @@ static void blocklistLoad(tr_blocklistFile* b)
     b->byteCount = byteCount;
     b->ruleCount = byteCount / sizeof(struct tr_ipv4_range);
 
-    base = tr_sys_path_basename(b->filename, NULL);
+    base = tr_sys_path_basename(b->filename, nullptr);
     tr_logAddInfo(_("Blocklist \"%s\" contains %zu entries"), base, b->ruleCount);
     tr_free(base);
 }
 
 static void blocklistEnsureLoaded(tr_blocklistFile* b)
 {
-    if (b->rules == NULL)
+    if (b->rules == nullptr)
     {
         blocklistLoad(b);
     }
@@ -133,7 +133,7 @@ static int compareAddressToRange(void const* va, void const* vb)
 static void blocklistDelete(tr_blocklistFile* b)
 {
     blocklistClose(b);
-    tr_sys_path_remove(b->filename, NULL);
+    tr_sys_path_remove(b->filename, nullptr);
 }
 
 /***
@@ -166,7 +166,7 @@ void tr_blocklistFileFree(tr_blocklistFile* b)
 
 bool tr_blocklistFileExists(tr_blocklistFile const* b)
 {
-    return tr_sys_path_exists(b->filename, NULL);
+    return tr_sys_path_exists(b->filename, nullptr);
 }
 
 int tr_blocklistFileGetRuleCount(tr_blocklistFile const* b)
@@ -183,7 +183,7 @@ bool tr_blocklistFileIsEnabled(tr_blocklistFile* b)
 
 void tr_blocklistFileSetEnabled(tr_blocklistFile* b, bool isEnabled)
 {
-    TR_ASSERT(b != NULL);
+    TR_ASSERT(b != nullptr);
 
     b->isEnabled = isEnabled;
 }
@@ -201,7 +201,7 @@ bool tr_blocklistFileHasAddress(tr_blocklistFile* b, tr_address const* addr)
 
     blocklistEnsureLoaded(b);
 
-    if (b->rules == NULL || b->ruleCount == 0)
+    if (b->rules == nullptr || b->ruleCount == 0)
     {
         return false;
     }
@@ -211,7 +211,7 @@ bool tr_blocklistFileHasAddress(tr_blocklistFile* b, tr_address const* addr)
     auto const* range = static_cast<struct tr_ipv4_range const*>(
         bsearch(&needle, b->rules, b->ruleCount, sizeof(struct tr_ipv4_range), compareAddressToRange));
 
-    return range != NULL;
+    return range != nullptr;
 }
 
 /*
@@ -228,7 +228,7 @@ static bool parseLine1(char const* line, struct tr_ipv4_range* range)
 
     char const* walk = strrchr(line, ':');
 
-    if (walk == NULL)
+    if (walk == nullptr)
     {
         return false;
     }
@@ -365,12 +365,12 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     int inCount = 0;
     char line[2048];
     char const* err_fmt = _("Couldn't read \"%1$s\": %2$s");
-    struct tr_ipv4_range* ranges = NULL;
+    struct tr_ipv4_range* ranges = nullptr;
     size_t ranges_alloc = 0;
     size_t ranges_count = 0;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
-    if (filename == NULL)
+    if (filename == nullptr)
     {
         blocklistDelete(b);
         return 0;
@@ -393,12 +393,12 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     {
         tr_logAddError(err_fmt, b->filename, error->message);
         tr_error_free(error);
-        tr_sys_file_close(in, NULL);
+        tr_sys_file_close(in, nullptr);
         return 0;
     }
 
     /* load the rules into memory */
-    while (tr_sys_file_read_line(in, line, sizeof(line), NULL))
+    while (tr_sys_file_read_line(in, line, sizeof(line), nullptr))
     {
         struct tr_ipv4_range range;
 
@@ -462,21 +462,21 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
 #endif
     }
 
-    if (!tr_sys_file_write(out, ranges, sizeof(struct tr_ipv4_range) * ranges_count, NULL, &error))
+    if (!tr_sys_file_write(out, ranges, sizeof(struct tr_ipv4_range) * ranges_count, nullptr, &error))
     {
         tr_logAddError(_("Couldn't save file \"%1$s\": %2$s"), b->filename, error->message);
         tr_error_free(error);
     }
     else
     {
-        char* base = tr_sys_path_basename(b->filename, NULL);
+        char* base = tr_sys_path_basename(b->filename, nullptr);
         tr_logAddInfo(_("Blocklist \"%s\" updated with %zu entries"), base, ranges_count);
         tr_free(base);
     }
 
     tr_free(ranges);
-    tr_sys_file_close(out, NULL);
-    tr_sys_file_close(in, NULL);
+    tr_sys_file_close(out, nullptr);
+    tr_sys_file_close(in, nullptr);
 
     blocklistLoad(b);
 

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -96,7 +96,7 @@ static int getBlockRun(tr_cache const* cache, int pos, struct run_info* info)
         ++len;
     }
 
-    if (info != NULL)
+    if (info != nullptr)
     {
         struct cache_block const* b = blocks[pos + len - 1];
         info->last_block_time = b->time;
@@ -275,7 +275,7 @@ void tr_cacheFree(tr_cache* cache)
 {
     TR_ASSERT(tr_ptrArrayEmpty(&cache->blocks));
 
-    tr_ptrArrayDestruct(&cache->blocks, NULL);
+    tr_ptrArrayDestruct(&cache->blocks, nullptr);
     tr_free(cache);
 }
 
@@ -324,7 +324,7 @@ int tr_cacheWriteBlock(
 
     struct cache_block* cb = findBlock(cache, torrent, piece, offset);
 
-    if (cb == NULL)
+    if (cb == nullptr)
     {
         cb = tr_new(struct cache_block, 1);
         cb->tor = torrent;
@@ -360,7 +360,7 @@ int tr_cacheReadBlock(
     int err = 0;
     struct cache_block* cb = findBlock(cache, torrent, piece, offset);
 
-    if (cb != NULL)
+    if (cb != nullptr)
     {
         evbuffer_copyout(cb->evbuf, setme, len);
     }
@@ -377,7 +377,7 @@ int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t
     int err = 0;
     struct cache_block const* const cb = findBlock(cache, torrent, piece, offset);
 
-    if (cb == NULL)
+    if (cb == nullptr)
     {
         err = tr_ioPrefetch(torrent, piece, offset, len);
     }
@@ -394,7 +394,7 @@ static int findBlockPos(tr_cache const* cache, tr_torrent* torrent, tr_piece_ind
     struct cache_block key;
     key.tor = torrent;
     key.block = block;
-    return tr_ptrArrayLowerBound(&cache->blocks, &key, cache_block_compare, NULL);
+    return tr_ptrArrayLowerBound(&cache->blocks, &key, cache_block_compare, nullptr);
 }
 
 int tr_cacheFlushDone(tr_cache* cache)
@@ -449,7 +449,7 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
             break;
         }
 
-        err = flushContiguous(cache, pos, getBlockRun(cache, pos, NULL));
+        err = flushContiguous(cache, pos, getBlockRun(cache, pos, nullptr));
     }
 
     return err;
@@ -470,7 +470,7 @@ int tr_cacheFlushTorrent(tr_cache* cache, tr_torrent* torrent)
             break;
         }
 
-        err = flushContiguous(cache, pos, getBlockRun(cache, pos, NULL));
+        err = flushContiguous(cache, pos, getBlockRun(cache, pos, nullptr));
     }
 
     return err;

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -907,7 +907,8 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         int b;
         int c;
 
-        if (strchr("AOQRSTU", id[0]) != nullptr && getShadowInt(id[1], &a) && getShadowInt(id[2], &b) && getShadowInt(id[3], &c))
+        if (strchr("AOQRSTU", id[0]) != nullptr && getShadowInt(id[1], &a) && getShadowInt(id[2], &b) &&
+            getShadowInt(id[3], &c))
         {
             char const* name = nullptr;
 

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -41,7 +41,7 @@ static bool getShadowInt(uint8_t ch, int* setme)
     char const* str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.-";
     char const* pch = strchr(str, ch);
 
-    if (pch == NULL)
+    if (pch == nullptr)
     {
         return false;
     }
@@ -55,7 +55,7 @@ static bool getFDMInt(uint8_t ch, int* setme)
     char const* str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_.!~*()";
     char const* pch = strchr(str, ch);
 
-    if (pch == NULL)
+    if (pch == nullptr)
     {
         return false;
     }
@@ -69,7 +69,7 @@ static int strint(void const* pch, int span)
     char tmp[64];
     memcpy(tmp, pch, span);
     tmp[span] = '\0';
-    return strtol(tmp, NULL, 0);
+    return strtol(tmp, nullptr, 0);
 }
 
 static char const* getMnemonicEnd(uint8_t ch)
@@ -150,7 +150,7 @@ static bool decodeBitCometClient(char* buf, size_t buflen, uint8_t const* id)
     int major;
     int minor;
     char const* name;
-    char const* mod = NULL;
+    char const* mod = nullptr;
 
     if (strncmp(chid, "exbc", 4) == 0)
     {
@@ -197,7 +197,7 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
 
     *buf = '\0';
 
-    if (id == NULL)
+    if (id == nullptr)
     {
         return buf;
     }
@@ -907,9 +907,9 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
         int b;
         int c;
 
-        if (strchr("AOQRSTU", id[0]) != NULL && getShadowInt(id[1], &a) && getShadowInt(id[2], &b) && getShadowInt(id[3], &c))
+        if (strchr("AOQRSTU", id[0]) != nullptr && getShadowInt(id[1], &a) && getShadowInt(id[2], &b) && getShadowInt(id[3], &c))
         {
-            char const* name = NULL;
+            char const* name = nullptr;
 
             switch (id[0])
             {
@@ -942,7 +942,7 @@ char* tr_clientForId(char* buf, size_t buflen, void const* id_in)
                 break;
             }
 
-            if (name != NULL)
+            if (name != nullptr)
             {
                 tr_snprintf(buf, buflen, "%s %d.%d.%d", name, a, b, c);
                 return buf;

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -93,7 +93,7 @@ static RNG* get_rng(void)
     {
         if (!check_result(API(InitRng)(&rng)))
         {
-            return NULL;
+            return nullptr;
         }
 
         rng_initialized = true;
@@ -104,9 +104,9 @@ static RNG* get_rng(void)
 
 static tr_lock* get_rng_lock(void)
 {
-    static tr_lock* lock = NULL;
+    static tr_lock* lock = nullptr;
 
-    if (lock == NULL)
+    if (lock == nullptr)
     {
         lock = tr_lockNew();
     }
@@ -128,20 +128,20 @@ tr_sha1_ctx_t tr_sha1_init(void)
     }
 
     tr_free(handle);
-    return NULL;
+    return nullptr;
 }
 
 bool tr_sha1_update(tr_sha1_ctx_t raw_handle, void const* data, size_t data_length)
 {
     auto* handle = static_cast<Sha*>(raw_handle);
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     if (data_length == 0)
     {
         return true;
     }
 
-    TR_ASSERT(data != NULL);
+    TR_ASSERT(data != nullptr);
 
     return check_result(API(ShaUpdate)(handle, static_cast<byte const*>(data), data_length));
 }
@@ -151,9 +151,9 @@ bool tr_sha1_final(tr_sha1_ctx_t raw_handle, uint8_t* hash)
     auto* handle = static_cast<Sha*>(raw_handle);
     bool ret = true;
 
-    if (hash != NULL)
+    if (hash != nullptr)
     {
-        TR_ASSERT(handle != NULL);
+        TR_ASSERT(handle != nullptr);
 
         ret = check_result(API(ShaFinal)(handle, hash));
     }
@@ -172,8 +172,8 @@ tr_dh_ctx_t tr_dh_new(
     uint8_t const* generator_num,
     size_t generator_num_length)
 {
-    TR_ASSERT(prime_num != NULL);
-    TR_ASSERT(generator_num != NULL);
+    TR_ASSERT(prime_num != nullptr);
+    TR_ASSERT(generator_num != nullptr);
 
     struct tr_dh_ctx* handle = tr_new0(struct tr_dh_ctx, 1);
 
@@ -182,7 +182,7 @@ tr_dh_ctx_t tr_dh_new(
     if (!check_result(API(DhSetKey)(&handle->dh, prime_num, prime_num_length, generator_num, generator_num_length)))
     {
         tr_free(handle);
-        return NULL;
+        return nullptr;
     }
 
     handle->key_length = prime_num_length;
@@ -194,7 +194,7 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
 {
     auto* handle = static_cast<struct tr_dh_ctx*>(raw_handle);
 
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
@@ -208,15 +208,15 @@ bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* 
 {
     TR_UNUSED(private_key_length);
 
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(public_key != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(public_key != nullptr);
 
     auto* handle = static_cast<struct tr_dh_ctx*>(raw_handle);
     word32 my_private_key_length;
     word32 my_public_key_length;
     tr_lock* rng_lock = get_rng_lock();
 
-    if (handle->private_key == NULL)
+    if (handle->private_key == nullptr)
     {
         handle->private_key = static_cast<uint8_t*>(tr_malloc(handle->key_length));
     }
@@ -241,7 +241,7 @@ bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* 
 
     handle->private_key_length = my_private_key_length;
 
-    if (public_key_length != NULL)
+    if (public_key_length != nullptr)
     {
         *public_key_length = handle->key_length;
     }
@@ -251,8 +251,8 @@ bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* 
 
 tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_key, size_t other_public_key_length)
 {
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(other_public_key != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(other_public_key != nullptr);
 
     auto* handle = static_cast<struct tr_dh_ctx*>(raw_handle);
     struct tr_dh_secret* ret;
@@ -274,7 +274,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
     else
     {
         tr_dh_secret_free(ret);
-        ret = NULL;
+        ret = nullptr;
     }
 
     return ret;
@@ -286,7 +286,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 
 bool tr_rand_buffer(void* buffer, size_t length)
 {
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
 
     bool ret;
     tr_lock* rng_lock = get_rng_lock();

--- a/libtransmission/crypto-utils-fallback.cc
+++ b/libtransmission/crypto-utils-fallback.cc
@@ -51,20 +51,20 @@ bool tr_dh_secret_derive(
     size_t append_data_size,
     uint8_t* hash)
 {
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(hash != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(hash != nullptr);
 
     auto* handle = static_cast<struct tr_dh_secret*>(raw_handle);
 
     return tr_sha1(
         hash,
-        prepend_data == NULL ? "" : prepend_data,
-        prepend_data == NULL ? 0 : (int)prepend_data_size,
+        prepend_data == nullptr ? "" : prepend_data,
+        prepend_data == nullptr ? 0 : (int)prepend_data_size,
         handle->key,
         (int)handle->key_length,
         append_data,
-        append_data == NULL ? 0 : (int)append_data_size,
-        NULL);
+        append_data == nullptr ? 0 : (int)append_data_size,
+        nullptr);
 }
 
 void tr_dh_secret_free(tr_dh_secret_t handle)
@@ -80,7 +80,7 @@ tr_x509_store_t tr_ssl_get_x509_store(tr_ssl_ctx_t handle)
 {
     TR_UNUSED(handle);
 
-    return NULL;
+    return nullptr;
 }
 
 bool tr_x509_store_add(tr_x509_store_t handle, tr_x509_cert_t cert)
@@ -96,7 +96,7 @@ tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length)
     TR_UNUSED(der);
     TR_UNUSED(der_length);
 
-    return NULL;
+    return nullptr;
 }
 
 void tr_x509_cert_free(tr_x509_cert_t handle)

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -53,7 +53,7 @@ static void log_openssl_error(char const* file, int line)
 #if OPENSSL_VERSION_NUMBER < 0x10100000 || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000)
             ERR_load_crypto_strings();
 #else
-            OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+            OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, nullptr);
 #endif
 
             strings_loaded = true;
@@ -85,7 +85,7 @@ static bool check_openssl_result(int result, int expected_result, bool expected_
 
 static bool check_openssl_pointer(void const* pointer, char const* file, int line)
 {
-    bool const ret = pointer != NULL;
+    bool const ret = pointer != nullptr;
 
     if (!ret)
     {
@@ -105,27 +105,27 @@ tr_sha1_ctx_t tr_sha1_init(void)
 {
     EVP_MD_CTX* handle = EVP_MD_CTX_create();
 
-    if (check_result(EVP_DigestInit_ex(handle, EVP_sha1(), NULL)))
+    if (check_result(EVP_DigestInit_ex(handle, EVP_sha1(), nullptr)))
     {
         return handle;
     }
 
     EVP_MD_CTX_destroy(handle);
-    return NULL;
+    return nullptr;
 }
 
 bool tr_sha1_update(tr_sha1_ctx_t raw_handle, void const* data, size_t data_length)
 {
     auto* handle = static_cast<EVP_MD_CTX*>(raw_handle);
 
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     if (data_length == 0)
     {
         return true;
     }
 
-    TR_ASSERT(data != NULL);
+    TR_ASSERT(data != nullptr);
 
     return check_result(EVP_DigestUpdate(handle, data, data_length));
 }
@@ -136,9 +136,9 @@ bool tr_sha1_final(tr_sha1_ctx_t raw_handle, uint8_t* hash)
 
     bool ret = true;
 
-    if (hash != NULL)
+    if (hash != nullptr)
     {
-        TR_ASSERT(handle != NULL);
+        TR_ASSERT(handle != nullptr);
 
         unsigned int hash_length;
 
@@ -161,7 +161,7 @@ static EVP_CIPHER_CTX* openssl_evp_cipher_context_new(void)
 {
     EVP_CIPHER_CTX* handle = tr_new(EVP_CIPHER_CTX, 1);
 
-    if (handle != NULL)
+    if (handle != nullptr)
     {
         EVP_CIPHER_CTX_init(handle);
     }
@@ -171,7 +171,7 @@ static EVP_CIPHER_CTX* openssl_evp_cipher_context_new(void)
 
 static void openssl_evp_cipher_context_free(EVP_CIPHER_CTX* handle)
 {
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
@@ -196,30 +196,30 @@ static inline int DH_set0_pqg(DH* dh, BIGNUM* p, BIGNUM* q, BIGNUM* g)
     /* If the fields p and g in d are NULL, the corresponding input
      * parameters MUST be non-NULL. q may remain NULL.
      */
-    if ((dh->p == NULL && p == NULL) || (dh->g == NULL && g == NULL))
+    if ((dh->p == nullptr && p == nullptr) || (dh->g == nullptr && g == nullptr))
     {
         return 0;
     }
 
-    if (p != NULL)
+    if (p != nullptr)
     {
         BN_free(dh->p);
         dh->p = p;
     }
 
-    if (q != NULL)
+    if (q != nullptr)
     {
         BN_free(dh->q);
         dh->q = q;
     }
 
-    if (g != NULL)
+    if (g != nullptr)
     {
         BN_free(dh->g);
         dh->g = g;
     }
 
-    if (q != NULL)
+    if (q != nullptr)
     {
         dh->length = BN_num_bits(q);
     }
@@ -235,12 +235,12 @@ static inline int DH_set_length(DH* dh, long length)
 
 static inline void DH_get0_key(DH const* dh, BIGNUM const** pub_key, BIGNUM const** priv_key)
 {
-    if (pub_key != NULL)
+    if (pub_key != nullptr)
     {
         *pub_key = dh->pub_key;
     }
 
-    if (priv_key != NULL)
+    if (priv_key != nullptr)
     {
         *priv_key = dh->priv_key;
     }
@@ -254,22 +254,22 @@ tr_dh_ctx_t tr_dh_new(
     uint8_t const* generator_num,
     size_t generator_num_length)
 {
-    TR_ASSERT(prime_num != NULL);
-    TR_ASSERT(generator_num != NULL);
+    TR_ASSERT(prime_num != nullptr);
+    TR_ASSERT(generator_num != nullptr);
 
     DH* handle = DH_new();
     BIGNUM* p;
     BIGNUM* g;
 
-    p = BN_bin2bn(prime_num, prime_num_length, NULL);
-    g = BN_bin2bn(generator_num, generator_num_length, NULL);
+    p = BN_bin2bn(prime_num, prime_num_length, nullptr);
+    g = BN_bin2bn(generator_num, generator_num_length, nullptr);
 
-    if (!check_pointer(p) || !check_pointer(g) || DH_set0_pqg(handle, p, NULL, g) == 0)
+    if (!check_pointer(p) || !check_pointer(g) || DH_set0_pqg(handle, p, nullptr, g) == 0)
     {
         BN_free(p);
         BN_free(g);
         DH_free(handle);
-        handle = NULL;
+        handle = nullptr;
     }
 
     return handle;
@@ -279,7 +279,7 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
 {
     auto* handle = static_cast<DH*>(raw_handle);
 
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
@@ -289,8 +289,8 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
 
 bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* public_key, size_t* public_key_length)
 {
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(public_key != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(public_key != nullptr);
 
     auto* handle = static_cast<DH*>(raw_handle);
     int dh_size;
@@ -304,14 +304,14 @@ bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* 
         return false;
     }
 
-    DH_get0_key(handle, &my_public_key, NULL);
+    DH_get0_key(handle, &my_public_key, nullptr);
 
     my_public_key_length = BN_bn2bin(my_public_key, public_key);
     dh_size = DH_size(handle);
 
     tr_dh_align_key(public_key, my_public_key_length, dh_size);
 
-    if (public_key_length != NULL)
+    if (public_key_length != nullptr)
     {
         *public_key_length = dh_size;
     }
@@ -323,17 +323,17 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 {
     auto* handle = static_cast<DH*>(raw_handle);
 
-    TR_ASSERT(handle != NULL);
-    TR_ASSERT(other_public_key != NULL);
+    TR_ASSERT(handle != nullptr);
+    TR_ASSERT(other_public_key != nullptr);
 
     struct tr_dh_secret* ret;
     int dh_size;
     int secret_key_length;
     BIGNUM* other_key;
 
-    if (!check_pointer(other_key = BN_bin2bn(other_public_key, other_public_key_length, NULL)))
+    if (!check_pointer(other_key = BN_bin2bn(other_public_key, other_public_key_length, nullptr)))
     {
-        return NULL;
+        return nullptr;
     }
 
     dh_size = DH_size(handle);
@@ -348,7 +348,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
     else
     {
         tr_dh_secret_free(ret);
-        ret = NULL;
+        ret = nullptr;
     }
 
     BN_free(other_key);
@@ -361,9 +361,9 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 
 tr_x509_store_t tr_ssl_get_x509_store(tr_ssl_ctx_t handle)
 {
-    if (handle == NULL)
+    if (handle == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     return SSL_CTX_get_cert_store(static_cast<SSL_CTX const*>(handle));
@@ -371,19 +371,19 @@ tr_x509_store_t tr_ssl_get_x509_store(tr_ssl_ctx_t handle)
 
 bool tr_x509_store_add(tr_x509_store_t handle, tr_x509_cert_t cert)
 {
-    TR_ASSERT(handle != NULL);
-    TR_ASSERT(cert != NULL);
+    TR_ASSERT(handle != nullptr);
+    TR_ASSERT(cert != nullptr);
 
     return check_result(X509_STORE_add_cert(static_cast<X509_STORE*>(handle), static_cast<X509*>(cert)));
 }
 
 tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length)
 {
-    TR_ASSERT(der != NULL);
+    TR_ASSERT(der != nullptr);
 
-    X509* const ret = d2i_X509(NULL, (unsigned char const**)&der, der_length);
+    X509* const ret = d2i_X509(nullptr, (unsigned char const**)&der, der_length);
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         log_error();
     }
@@ -393,7 +393,7 @@ tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length)
 
 void tr_x509_cert_free(tr_x509_cert_t handle)
 {
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
@@ -407,7 +407,7 @@ void tr_x509_cert_free(tr_x509_cert_t handle)
 
 bool tr_rand_buffer(void* buffer, size_t length)
 {
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
 
     return check_result(RAND_bytes(static_cast<unsigned char*>(buffer), (int)length));
 }

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -105,13 +105,13 @@ static api_ctr_drbg_context* get_rng(void)
 #if API_VERSION_NUMBER >= 0x02000000
         API(ctr_drbg_init)(&rng);
 
-        if (!check_result(API(ctr_drbg_seed)(&rng, &my_rand, NULL, NULL, 0)))
+        if (!check_result(API(ctr_drbg_seed)(&rng, &my_rand, nullptr, nullptr, 0)))
 #else
 
-        if (!check_result(API(ctr_drbg_init)(&rng, &my_rand, NULL, NULL, 0)))
+        if (!check_result(API(ctr_drbg_init)(&rng, &my_rand, nullptr, nullptr, 0)))
 #endif
         {
-            return NULL;
+            return nullptr;
         }
 
         rng_initialized = true;
@@ -122,9 +122,9 @@ static api_ctr_drbg_context* get_rng(void)
 
 static tr_lock* get_rng_lock(void)
 {
-    static tr_lock* lock = NULL;
+    static tr_lock* lock = nullptr;
 
-    if (lock == NULL)
+    if (lock == nullptr)
     {
         lock = tr_lockNew();
     }
@@ -151,14 +151,14 @@ tr_sha1_ctx_t tr_sha1_init(void)
 bool tr_sha1_update(tr_sha1_ctx_t raw_handle, void const* data, size_t data_length)
 {
     auto* handle = static_cast<api_sha1_context*>(raw_handle);
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     if (data_length == 0)
     {
         return true;
     }
 
-    TR_ASSERT(data != NULL);
+    TR_ASSERT(data != nullptr);
 
     API(sha1_update)(handle, static_cast<unsigned char const*>(data), data_length);
     return true;
@@ -168,9 +168,9 @@ bool tr_sha1_final(tr_sha1_ctx_t raw_handle, uint8_t* hash)
 {
     auto* handle = static_cast<api_sha1_context*>(raw_handle);
 
-    if (hash != NULL)
+    if (hash != nullptr)
     {
-        TR_ASSERT(handle != NULL);
+        TR_ASSERT(handle != nullptr);
 
         API(sha1_finish)(handle, hash);
     }
@@ -193,8 +193,8 @@ tr_dh_ctx_t tr_dh_new(
     uint8_t const* generator_num,
     size_t generator_num_length)
 {
-    TR_ASSERT(prime_num != NULL);
-    TR_ASSERT(generator_num != NULL);
+    TR_ASSERT(prime_num != nullptr);
+    TR_ASSERT(generator_num != nullptr);
 
     api_dhm_context* handle = tr_new0(api_dhm_context, 1);
 
@@ -206,7 +206,7 @@ tr_dh_ctx_t tr_dh_new(
         !check_result(API(mpi_read_binary)(&handle->G, generator_num, generator_num_length)))
     {
         API(dhm_free)(handle);
-        return NULL;
+        return nullptr;
     }
 
     handle->len = prime_num_length;
@@ -218,7 +218,7 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
 {
     auto* handle = static_cast<api_dhm_context*>(raw_handle);
 
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
@@ -228,23 +228,23 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
 
 bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* public_key, size_t* public_key_length)
 {
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(public_key != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(public_key != nullptr);
 
     auto* handle = static_cast<api_dhm_context*>(raw_handle);
 
-    if (public_key_length != NULL)
+    if (public_key_length != nullptr)
     {
         *public_key_length = handle->len;
     }
 
-    return check_result(API(dhm_make_public)(handle, private_key_length, public_key, handle->len, my_rand, NULL));
+    return check_result(API(dhm_make_public)(handle, private_key_length, public_key, handle->len, my_rand, nullptr));
 }
 
 tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_key, size_t other_public_key_length)
 {
-    TR_ASSERT(raw_handle != NULL);
-    TR_ASSERT(other_public_key != NULL);
+    TR_ASSERT(raw_handle != nullptr);
+    TR_ASSERT(other_public_key != nullptr);
 
     auto* handle = static_cast<api_dhm_context*>(raw_handle);
     struct tr_dh_secret* ret;
@@ -252,7 +252,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 
     if (!check_result(API(dhm_read_public)(handle, other_public_key, other_public_key_length)))
     {
-        return NULL;
+        return nullptr;
     }
 
     ret = tr_dh_secret_new(handle->len);
@@ -261,17 +261,17 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 
 #if API_VERSION_NUMBER >= 0x02000000
 
-    if (!check_result(API(dhm_calc_secret)(handle, ret->key, secret_key_length, &secret_key_length, my_rand, NULL)))
+    if (!check_result(API(dhm_calc_secret)(handle, ret->key, secret_key_length, &secret_key_length, my_rand, nullptr)))
 #elif API_VERSION_NUMBER >= 0x01030000
 
-    if (!check_result(API(dhm_calc_secret)(handle, ret->key, &secret_key_length, my_rand, NULL)))
+    if (!check_result(API(dhm_calc_secret)(handle, ret->key, &secret_key_length, my_rand, nullptr)))
 #else
 
     if (!check_result(API(dhm_calc_secret)(handle, ret->key, &secret_key_length)))
 #endif
     {
         tr_dh_secret_free(ret);
-        return NULL;
+        return nullptr;
     }
 
     tr_dh_secret_align(ret, secret_key_length);
@@ -285,7 +285,7 @@ tr_dh_secret_t tr_dh_agree(tr_dh_ctx_t raw_handle, uint8_t const* other_public_k
 
 bool tr_rand_buffer(void* buffer, size_t length)
 {
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
 
     bool ret;
     tr_lock* rng_lock = get_rng_lock();

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -50,7 +50,7 @@ bool tr_sha1(uint8_t* hash, void const* data1, int data1_length, ...)
 {
     tr_sha1_ctx_t sha;
 
-    if ((sha = tr_sha1_init()) == NULL)
+    if ((sha = tr_sha1_init()) == nullptr)
     {
         return false;
     }
@@ -62,7 +62,7 @@ bool tr_sha1(uint8_t* hash, void const* data1, int data1_length, ...)
 
         va_start(vl, data1_length);
 
-        while ((data = va_arg(vl, void const*)) != NULL)
+        while ((data = va_arg(vl, void const*)) != nullptr)
         {
             int const data_length = va_arg(vl, int);
             TR_ASSERT(data_length >= 0);
@@ -76,13 +76,13 @@ bool tr_sha1(uint8_t* hash, void const* data1, int data1_length, ...)
         va_end(vl);
 
         /* did we reach the end of argument list? */
-        if (data == NULL)
+        if (data == nullptr)
         {
             return tr_sha1_final(sha, hash);
         }
     }
 
-    tr_sha1_final(sha, NULL);
+    tr_sha1_final(sha, nullptr);
     return false;
 }
 
@@ -126,7 +126,7 @@ int tr_rand_int_weak(int upper_bound)
 
 char* tr_ssha1(char const* plain_text)
 {
-    TR_ASSERT(plain_text != NULL);
+    TR_ASSERT(plain_text != nullptr);
 
     enum
     {
@@ -151,7 +151,7 @@ char* tr_ssha1(char const* plain_text)
         salt[i] = salter[salt[i] % salter_len];
     }
 
-    tr_sha1(sha, plain_text, (int)strlen(plain_text), salt, saltval_len, NULL);
+    tr_sha1(sha, plain_text, (int)strlen(plain_text), salt, saltval_len, nullptr);
     tr_sha1_to_hex(&buf[1], sha);
     memcpy(&buf[1 + 2 * SHA_DIGEST_LENGTH], &salt, saltval_len);
     buf[1 + 2 * SHA_DIGEST_LENGTH + saltval_len] = '\0';
@@ -162,8 +162,8 @@ char* tr_ssha1(char const* plain_text)
 
 bool tr_ssha1_matches(char const* ssha1, char const* plain_text)
 {
-    TR_ASSERT(ssha1 != NULL);
-    TR_ASSERT(plain_text != NULL);
+    TR_ASSERT(ssha1 != nullptr);
+    TR_ASSERT(plain_text != nullptr);
 
     size_t const brace_len = 1;
     size_t const brace_and_hash_len = brace_len + 2 * SHA_DIGEST_LENGTH;
@@ -182,7 +182,7 @@ bool tr_ssha1_matches(char const* ssha1, char const* plain_text)
     uint8_t buf[SHA_DIGEST_LENGTH * 2 + 1];
 
     /* hash pass + salt */
-    tr_sha1(buf, plain_text, (int)strlen(plain_text), salt, (int)salt_len, NULL);
+    tr_sha1(buf, plain_text, (int)strlen(plain_text), salt, (int)salt_len, nullptr);
     tr_sha1_to_hex((char*)buf, buf);
 
     return strncmp(ssha1 + brace_len, (char const*)buf, SHA_DIGEST_LENGTH * 2) == 0;
@@ -196,7 +196,7 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
 {
     char* ret;
 
-    if (input != NULL)
+    if (input != nullptr)
     {
         if (input_length != 0)
         {
@@ -214,7 +214,7 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
             ret_length = base64_encode_block(static_cast<char const*>(input), input_length, ret, &state);
             ret_length += base64_encode_blockend(ret + ret_length, &state);
 
-            if (output_length != NULL)
+            if (output_length != nullptr)
             {
                 *output_length = ret_length;
             }
@@ -230,10 +230,10 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
     }
     else
     {
-        ret = NULL;
+        ret = nullptr;
     }
 
-    if (output_length != NULL)
+    if (output_length != nullptr)
     {
         *output_length = 0;
     }
@@ -243,14 +243,14 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
 
 void* tr_base64_encode_str(char const* input, size_t* output_length)
 {
-    return tr_base64_encode(input, input == NULL ? 0 : strlen(input), output_length);
+    return tr_base64_encode(input, input == nullptr ? 0 : strlen(input), output_length);
 }
 
 void* tr_base64_decode(void const* input, size_t input_length, size_t* output_length)
 {
     char* ret;
 
-    if (input != NULL)
+    if (input != nullptr)
     {
         if (input_length != 0)
         {
@@ -262,7 +262,7 @@ void* tr_base64_decode(void const* input, size_t input_length, size_t* output_le
             base64_init_decodestate(&state);
             ret_length = base64_decode_block(static_cast<char const*>(input), input_length, ret, &state);
 
-            if (output_length != NULL)
+            if (output_length != nullptr)
             {
                 *output_length = ret_length;
             }
@@ -278,10 +278,10 @@ void* tr_base64_decode(void const* input, size_t input_length, size_t* output_le
     }
     else
     {
-        ret = NULL;
+        ret = nullptr;
     }
 
-    if (output_length != NULL)
+    if (output_length != nullptr)
     {
         *output_length = 0;
     }
@@ -291,5 +291,5 @@ void* tr_base64_decode(void const* input, size_t input_length, size_t* output_le
 
 void* tr_base64_decode_str(char const* input, size_t* output_length)
 {
-    return tr_base64_decode(input, input == NULL ? 0 : strlen(input), output_length);
+    return tr_base64_decode(input, input == nullptr ? 0 : strlen(input), output_length);
 }

--- a/libtransmission/crypto.cc
+++ b/libtransmission/crypto.cc
@@ -42,7 +42,7 @@ static uint8_t const dh_G[] = { 2 };
 
 static void ensureKeyExists(tr_crypto* crypto)
 {
-    if (crypto->dh == NULL)
+    if (crypto->dh == nullptr)
     {
         size_t public_key_length;
 
@@ -77,7 +77,7 @@ bool tr_cryptoComputeSecret(tr_crypto* crypto, uint8_t const* peerPublicKey)
 {
     ensureKeyExists(crypto);
     crypto->mySecret = tr_dh_agree(crypto->dh, peerPublicKey, KEY_LEN);
-    return crypto->mySecret != NULL;
+    return crypto->mySecret != nullptr;
 }
 
 uint8_t const* tr_cryptoGetMyPublicKey(tr_crypto const* crypto, int* setme_len)
@@ -95,7 +95,7 @@ static void init_rc4(tr_crypto const* crypto, struct arc4_context** setme, char 
 {
     TR_ASSERT(crypto->torrentHashIsSet);
 
-    if (*setme == NULL)
+    if (*setme == nullptr)
     {
         *setme = tr_new0(struct arc4_context, 1);
     }
@@ -111,7 +111,7 @@ static void init_rc4(tr_crypto const* crypto, struct arc4_context** setme, char 
 
 static void crypt_rc4(struct arc4_context* key, size_t buf_len, void const* buf_in, void* buf_out)
 {
-    if (key == NULL)
+    if (key == nullptr)
     {
         if (buf_in != buf_out)
         {
@@ -152,8 +152,8 @@ bool tr_cryptoSecretKeySha1(
     size_t append_data_size,
     uint8_t* hash)
 {
-    TR_ASSERT(crypto != NULL);
-    TR_ASSERT(crypto->mySecret != NULL);
+    TR_ASSERT(crypto != nullptr);
+    TR_ASSERT(crypto->mySecret != nullptr);
 
     return tr_dh_secret_derive(crypto->mySecret, prepend_data, prepend_data_size, append_data, append_data_size, hash);
 }
@@ -164,9 +164,9 @@ bool tr_cryptoSecretKeySha1(
 
 void tr_cryptoSetTorrentHash(tr_crypto* crypto, uint8_t const* hash)
 {
-    crypto->torrentHashIsSet = hash != NULL;
+    crypto->torrentHashIsSet = hash != nullptr;
 
-    if (hash != NULL)
+    if (hash != nullptr)
     {
         memcpy(crypto->torrentHash, hash, SHA_DIGEST_LENGTH);
     }
@@ -178,14 +178,14 @@ void tr_cryptoSetTorrentHash(tr_crypto* crypto, uint8_t const* hash)
 
 uint8_t const* tr_cryptoGetTorrentHash(tr_crypto const* crypto)
 {
-    TR_ASSERT(crypto != NULL);
+    TR_ASSERT(crypto != nullptr);
 
-    return crypto->torrentHashIsSet ? crypto->torrentHash : NULL;
+    return crypto->torrentHashIsSet ? crypto->torrentHash : nullptr;
 }
 
 bool tr_cryptoHasTorrentHash(tr_crypto const* crypto)
 {
-    TR_ASSERT(crypto != NULL);
+    TR_ASSERT(crypto != nullptr);
 
     return crypto->torrentHashIsSet;
 }

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -13,7 +13,7 @@
 
 tr_error* tr_error_new_literal(int code, char const* message)
 {
-    TR_ASSERT(message != NULL);
+    TR_ASSERT(message != nullptr);
 
     tr_error* error = tr_new(tr_error, 1);
     error->code = code;
@@ -24,7 +24,7 @@ tr_error* tr_error_new_literal(int code, char const* message)
 
 tr_error* tr_error_new_valist(int code, char const* message_format, va_list args)
 {
-    TR_ASSERT(message_format != NULL);
+    TR_ASSERT(message_format != nullptr);
 
     tr_error* error = tr_new(tr_error, 1);
     error->code = code;
@@ -35,7 +35,7 @@ tr_error* tr_error_new_valist(int code, char const* message_format, va_list args
 
 void tr_error_free(tr_error* error)
 {
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
@@ -46,14 +46,14 @@ void tr_error_free(tr_error* error)
 
 void tr_error_set(tr_error** error, int code, char const* message_format, ...)
 {
-    TR_ASSERT(message_format != NULL);
+    TR_ASSERT(message_format != nullptr);
 
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
-    TR_ASSERT(*error == NULL);
+    TR_ASSERT(*error == nullptr);
 
     va_list args;
 
@@ -64,29 +64,29 @@ void tr_error_set(tr_error** error, int code, char const* message_format, ...)
 
 void tr_error_set_literal(tr_error** error, int code, char const* message)
 {
-    TR_ASSERT(message != NULL);
+    TR_ASSERT(message != nullptr);
 
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
-    TR_ASSERT(*error == NULL);
+    TR_ASSERT(*error == nullptr);
 
     *error = tr_error_new_literal(code, message);
 }
 
 void tr_error_propagate(tr_error** new_error, tr_error** old_error)
 {
-    TR_ASSERT(old_error != NULL);
-    TR_ASSERT(*old_error != NULL);
+    TR_ASSERT(old_error != nullptr);
+    TR_ASSERT(*old_error != nullptr);
 
-    if (new_error != NULL)
+    if (new_error != nullptr)
     {
-        TR_ASSERT(*new_error == NULL);
+        TR_ASSERT(*new_error == nullptr);
 
         *new_error = *old_error;
-        *old_error = NULL;
+        *old_error = nullptr;
     }
     else
     {
@@ -96,23 +96,23 @@ void tr_error_propagate(tr_error** new_error, tr_error** old_error)
 
 void tr_error_clear(tr_error** error)
 {
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
     tr_error_free(*error);
 
-    *error = NULL;
+    *error = nullptr;
 }
 
 static void error_prefix_valist(tr_error** error, char const* prefix_format, va_list args) TR_GNUC_PRINTF(2, 0);
 
 static void error_prefix_valist(tr_error** error, char const* prefix_format, va_list args)
 {
-    TR_ASSERT(error != NULL);
-    TR_ASSERT(*error != NULL);
-    TR_ASSERT(prefix_format != NULL);
+    TR_ASSERT(error != nullptr);
+    TR_ASSERT(*error != nullptr);
+    TR_ASSERT(prefix_format != nullptr);
 
     char* prefix = tr_strdup_vprintf(prefix_format, args);
 
@@ -125,9 +125,9 @@ static void error_prefix_valist(tr_error** error, char const* prefix_format, va_
 
 void tr_error_prefix(tr_error** error, char const* prefix_format, ...)
 {
-    TR_ASSERT(prefix_format != NULL);
+    TR_ASSERT(prefix_format != nullptr);
 
-    if (error == NULL || *error == NULL)
+    if (error == nullptr || *error == nullptr)
     {
         return;
     }
@@ -141,11 +141,11 @@ void tr_error_prefix(tr_error** error, char const* prefix_format, ...)
 
 void tr_error_propagate_prefixed(tr_error** new_error, tr_error** old_error, char const* prefix_format, ...)
 {
-    TR_ASSERT(prefix_format != NULL);
+    TR_ASSERT(prefix_format != nullptr);
 
     tr_error_propagate(new_error, old_error);
 
-    if (new_error == NULL)
+    if (new_error == nullptr)
     {
         return;
     }

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -20,7 +20,7 @@
 #include "torrent.h" /* tr_isTorrent() */
 #include "tr-assert.h"
 
-#define dbgmsg(...) tr_logAddDeepNamed(NULL, __VA_ARGS__)
+#define dbgmsg(...) tr_logAddDeepNamed(nullptr, __VA_ARGS__)
 
 /***
 ****
@@ -30,7 +30,7 @@
 
 static bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error** error)
 {
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
 
     if (length == 0)
     {
@@ -51,7 +51,7 @@ static bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error*
         tr_error_clear(&my_error);
 
         /* fallback: the old-style seek-and-write */
-        if (tr_sys_file_write_at(fd, &zero, 1, length - 1, NULL, &my_error) && tr_sys_file_truncate(fd, length, &my_error))
+        if (tr_sys_file_write_at(fd, &zero, 1, length - 1, nullptr, &my_error) && tr_sys_file_truncate(fd, length, &my_error))
         {
             return true;
         }
@@ -65,7 +65,7 @@ static bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error*
 
 static bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error** error)
 {
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
 
     if (length == 0)
     {
@@ -125,18 +125,18 @@ struct tr_cached_file
 
 static inline bool cached_file_is_open(struct tr_cached_file const* o)
 {
-    TR_ASSERT(o != NULL);
+    TR_ASSERT(o != nullptr);
 
-    return (o != NULL) && (o->fd != TR_BAD_SYS_FILE);
+    return (o != nullptr) && (o->fd != TR_BAD_SYS_FILE);
 }
 
 static void cached_file_close(struct tr_cached_file* o)
 {
     TR_ASSERT(cached_file_is_open(o));
 
-    if (o != NULL)
+    if (o != nullptr)
     {
-        tr_sys_file_close(o->fd, NULL);
+        tr_sys_file_close(o->fd, nullptr);
         o->fd = TR_BAD_SYS_FILE;
     }
 }
@@ -158,14 +158,14 @@ static int cached_file_open(
     bool already_existed;
     bool resize_needed;
     tr_sys_file_t fd = TR_BAD_SYS_FILE;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     /* create subfolders, if any */
     if (writable)
     {
         char* dir = tr_sys_path_dirname(filename, &error);
 
-        if (dir == NULL)
+        if (dir == nullptr)
         {
             tr_logAddError(_("Couldn't get directory for \"%1$s\": %2$s"), filename, error->message);
             goto FAIL;
@@ -181,7 +181,7 @@ static int cached_file_open(
         tr_free(dir);
     }
 
-    already_existed = tr_sys_path_get_info(filename, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_FILE;
+    already_existed = tr_sys_path_get_info(filename, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_FILE;
 
     /* we can't resize the file w/o write permissions */
     resize_needed = already_existed && (file_size < info.size);
@@ -201,7 +201,7 @@ static int cached_file_open(
     if (writable && !already_existed && allocation != TR_PREALLOCATE_NONE)
     {
         bool success = false;
-        char const* type = NULL;
+        char const* type = nullptr;
 
         if (allocation == TR_PREALLOCATE_FULL)
         {
@@ -214,7 +214,7 @@ static int cached_file_open(
             type = _("sparse");
         }
 
-        TR_ASSERT(type != NULL);
+        TR_ASSERT(type != nullptr);
 
         if (!success)
         {
@@ -252,7 +252,7 @@ FAIL:
 
         if (fd != TR_BAD_SYS_FILE)
         {
-            tr_sys_file_close(fd, NULL);
+            tr_sys_file_close(fd, nullptr);
         }
 
         return err;
@@ -282,7 +282,7 @@ static void fileset_construct(struct tr_fileset* set, int n)
 
 static void fileset_close_all(struct tr_fileset* set)
 {
-    if (set != NULL)
+    if (set != nullptr)
     {
         for (struct tr_cached_file* o = set->begin; o != set->end; ++o)
         {
@@ -298,12 +298,12 @@ static void fileset_destruct(struct tr_fileset* set)
 {
     fileset_close_all(set);
     tr_free(set->begin);
-    set->end = set->begin = NULL;
+    set->end = set->begin = nullptr;
 }
 
 static void fileset_close_torrent(struct tr_fileset* set, int torrent_id)
 {
-    if (set != NULL)
+    if (set != nullptr)
     {
         for (struct tr_cached_file* o = set->begin; o != set->end; ++o)
         {
@@ -317,7 +317,7 @@ static void fileset_close_torrent(struct tr_fileset* set, int torrent_id)
 
 static struct tr_cached_file* fileset_lookup(struct tr_fileset* set, int torrent_id, tr_file_index_t i)
 {
-    if (set != NULL)
+    if (set != nullptr)
     {
         for (struct tr_cached_file* o = set->begin; o != set->end; ++o)
         {
@@ -328,14 +328,14 @@ static struct tr_cached_file* fileset_lookup(struct tr_fileset* set, int torrent
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 static struct tr_cached_file* fileset_get_empty_slot(struct tr_fileset* set)
 {
-    struct tr_cached_file* cull = NULL;
+    struct tr_cached_file* cull = nullptr;
 
-    if (set != NULL && set->begin != NULL)
+    if (set != nullptr && set->begin != nullptr)
     {
         /* try to find an unused slot */
         for (struct tr_cached_file* o = set->begin; o != set->end; ++o)
@@ -349,7 +349,7 @@ static struct tr_cached_file* fileset_get_empty_slot(struct tr_fileset* set)
         /* all slots are full... recycle the least recently used */
         for (struct tr_cached_file* o = set->begin; o != set->end; ++o)
         {
-            if (cull == NULL || o->used_at < cull->used_at)
+            if (cull == nullptr || o->used_at < cull->used_at)
             {
                 cull = o;
             }
@@ -377,7 +377,7 @@ static void ensureSessionFdInfoExists(tr_session* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    if (session->fdInfo == NULL)
+    if (session->fdInfo == nullptr)
     {
         struct tr_fdInfo* i;
         int const FILE_CACHE_SIZE = 32;
@@ -391,12 +391,12 @@ static void ensureSessionFdInfoExists(tr_session* session)
 
 void tr_fdClose(tr_session* session)
 {
-    if (session != NULL && session->fdInfo != NULL)
+    if (session != nullptr && session->fdInfo != nullptr)
     {
         struct tr_fdInfo* i = session->fdInfo;
         fileset_destruct(&i->fileset);
         tr_free(i);
-        session->fdInfo = NULL;
+        session->fdInfo = nullptr;
     }
 }
 
@@ -406,9 +406,9 @@ void tr_fdClose(tr_session* session)
 
 static struct tr_fileset* get_fileset(tr_session* session)
 {
-    if (session == NULL)
+    if (session == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     ensureSessionFdInfoExists(session);
@@ -419,13 +419,13 @@ void tr_fdFileClose(tr_session* s, tr_torrent const* tor, tr_file_index_t i)
 {
     struct tr_cached_file* o;
 
-    if ((o = fileset_lookup(get_fileset(s), tr_torrentId(tor), i)) != NULL)
+    if ((o = fileset_lookup(get_fileset(s), tr_torrentId(tor), i)) != nullptr)
     {
         /* flush writable files so that their mtimes will be
          * up-to-date when this function returns to the caller... */
         if (o->is_writable)
         {
-            tr_sys_file_flush(o->fd, NULL);
+            tr_sys_file_flush(o->fd, nullptr);
         }
 
         cached_file_close(o);
@@ -436,7 +436,7 @@ tr_sys_file_t tr_fdFileGetCached(tr_session* s, int torrent_id, tr_file_index_t 
 {
     struct tr_cached_file* o = fileset_lookup(get_fileset(s), torrent_id, i);
 
-    if (o == NULL || (writable && !o->is_writable))
+    if (o == nullptr || (writable && !o->is_writable))
     {
         return TR_BAD_SYS_FILE;
     }
@@ -449,7 +449,7 @@ bool tr_fdFileGetCachedMTime(tr_session* s, int torrent_id, tr_file_index_t i, t
 {
     struct tr_cached_file const* o = fileset_lookup(get_fileset(s), torrent_id, i);
     auto info = tr_sys_path_info{};
-    bool const success = o != NULL && tr_sys_file_get_info(o->fd, &info, NULL);
+    bool const success = o != nullptr && tr_sys_file_get_info(o->fd, &info, nullptr);
 
     if (success)
     {
@@ -479,11 +479,11 @@ tr_sys_file_t tr_fdFileCheckout(
     struct tr_fileset* set = get_fileset(session);
     struct tr_cached_file* o = fileset_lookup(set, torrent_id, i);
 
-    if (o != NULL && writable && !o->is_writable)
+    if (o != nullptr && writable && !o->is_writable)
     {
         cached_file_close(o); /* close it so we can reopen in rw mode */
     }
-    else if (o == NULL)
+    else if (o == nullptr)
     {
         o = fileset_get_empty_slot(set);
     }
@@ -575,8 +575,8 @@ tr_socket_t tr_fdSocketCreate(tr_session* session, int domain, int type)
 tr_socket_t tr_fdSocketAccept(tr_session* s, tr_socket_t sockfd, tr_address* addr, tr_port* port)
 {
     TR_ASSERT(tr_isSession(s));
-    TR_ASSERT(addr != NULL);
-    TR_ASSERT(port != NULL);
+    TR_ASSERT(addr != nullptr);
+    TR_ASSERT(port != nullptr);
 
     tr_socket_t fd;
     socklen_t len;
@@ -609,7 +609,7 @@ void tr_fdSocketClose(tr_session* session, tr_socket_t fd)
 {
     TR_ASSERT(tr_isSession(session));
 
-    if (session->fdInfo != NULL)
+    if (session->fdInfo != nullptr)
     {
         struct tr_fdInfo* gFd = session->fdInfo;
 

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -6,9 +6,10 @@
  *
  */
 
-#include <errno.h>
-#include <inttypes.h>
-#include <string.h>
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
+#include <algorithm>
 
 #include "transmission.h"
 #include "error.h"
@@ -90,7 +91,7 @@ static bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error** 
         /* fallback: the old-fashioned way */
         while (success && length > 0)
         {
-            uint64_t const thisPass = MIN(length, sizeof(buf));
+            uint64_t const thisPass = std::min(length, sizeof(buf));
             uint64_t bytes_written;
             success = tr_sys_file_write(fd, buf, thisPass, &bytes_written, &my_error);
             length -= bytes_written;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -10,19 +10,20 @@
 #define _GNU_SOURCE
 
 #include <dirent.h>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h> /* O_LARGEFILE, posix_fadvise(), [posix_]fallocate(), fcntl() */
 #include <libgen.h> /* basename(), dirname() */
-#include <limits.h> /* PATH_MAX */
-#include <stdint.h> /* SIZE_MAX */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <climits> /* PATH_MAX */
+#include <cstdint> /* SIZE_MAX */
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/file.h> /* flock() */
 #include <sys/mman.h> /* mmap(), munmap() */
 #include <sys/stat.h>
 #include <unistd.h> /* lseek(), write(), ftruncate(), pread(), pwrite(), pathconf(), etc */
+#include <algorithm>
 
 #ifdef HAVE_XFS_XFS_H
 #include <xfs/xfs.h>
@@ -486,7 +487,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 
     while (file_size > 0)
     {
-        size_t const chunk_size = MIN(file_size, SSIZE_MAX);
+        size_t const chunk_size = std::min(file_size, (unsigned long)SSIZE_MAX);
         ssize_t const copied =
 #ifdef USE_COPY_FILE_RANGE
             copy_file_range(in, nullptr, out, nullptr, chunk_size, 0);

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -95,7 +95,7 @@
 
 static void set_system_error(tr_error** error, int code)
 {
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
@@ -201,10 +201,10 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
 
     char* pp;
     bool ret = false;
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
 
     /* Go one level up on each iteration and attempt to create */
-    for (pp = path_end; pp != NULL; pp = strrchr(p, TR_PATH_DELIMITER))
+    for (pp = path_end; pp != nullptr; pp = strrchr(p, TR_PATH_DELIMITER))
     {
         *pp = '\0';
 
@@ -240,7 +240,7 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
     }
 
     /* Go one level down on each iteration and attempt to create */
-    for (pp = pp == NULL ? p + strlen(p) : pp; pp < path_end; pp += strlen(pp))
+    for (pp = pp == nullptr ? p + strlen(p) : pp; pp < path_end; pp += strlen(pp))
     {
         *pp = TR_PATH_DELIMITER;
 
@@ -260,14 +260,14 @@ static bool create_path(char const* path_in, int permissions, tr_error** error)
 FAILURE:
 
     TR_ASSERT(!ret);
-    TR_ASSERT(my_error != NULL);
+    TR_ASSERT(my_error != nullptr);
 
     tr_logAddError(_("Couldn't create \"%1$s\": %2$s"), path, my_error->message);
     tr_error_propagate(error, &my_error);
 
 CLEANUP:
 
-    TR_ASSERT(my_error == NULL);
+    TR_ASSERT(my_error == nullptr);
 
     tr_free(path);
     return ret;
@@ -277,7 +277,7 @@ CLEANUP:
 
 bool tr_sys_path_exists(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret = access(path, F_OK) != -1;
 
@@ -291,8 +291,8 @@ bool tr_sys_path_exists(char const* path, tr_error** error)
 
 bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(path != nullptr);
+    TR_ASSERT(info != nullptr);
 
     bool ret;
     struct stat sb;
@@ -320,15 +320,15 @@ bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, t
 
 bool tr_sys_path_is_relative(char const* path)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     return path[0] != '/';
 }
 
 bool tr_sys_path_is_same(char const* path1, char const* path2, tr_error** error)
 {
-    TR_ASSERT(path1 != NULL);
-    TR_ASSERT(path2 != NULL);
+    TR_ASSERT(path1 != nullptr);
+    TR_ASSERT(path2 != nullptr);
 
     bool ret = false;
     struct stat sb1;
@@ -348,9 +348,9 @@ bool tr_sys_path_is_same(char const* path1, char const* path2, tr_error** error)
 
 char* tr_sys_path_resolve(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
-    char* ret = NULL;
+    char* ret = nullptr;
 
 #if defined(HAVE_CANONICALIZE_FILE_NAME)
 
@@ -358,18 +358,18 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
 
 #endif
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         char tmp[PATH_MAX];
         ret = realpath(path, tmp);
 
-        if (ret != NULL)
+        if (ret != nullptr)
         {
             ret = tr_strdup(ret);
         }
     }
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         set_system_error(error, errno);
     }
@@ -379,15 +379,15 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
 
 char* tr_sys_path_basename(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
-    char* ret = NULL;
+    char* ret = nullptr;
     char* tmp;
 
     tmp = tr_strdup(path);
     ret = basename(tmp);
 
-    if (ret != NULL)
+    if (ret != nullptr)
     {
         ret = tr_strdup(ret);
     }
@@ -403,12 +403,12 @@ char* tr_sys_path_basename(char const* path, tr_error** error)
 
 char* tr_sys_path_dirname(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     char* tmp = tr_strdup(path);
     char* ret = dirname(tmp);
 
-    if (ret != NULL)
+    if (ret != nullptr)
     {
         ret = tr_strdup(ret);
     }
@@ -424,8 +424,8 @@ char* tr_sys_path_dirname(char const* path, tr_error** error)
 
 bool tr_sys_path_rename(char const* src_path, char const* dst_path, tr_error** error)
 {
-    TR_ASSERT(src_path != NULL);
-    TR_ASSERT(dst_path != NULL);
+    TR_ASSERT(src_path != nullptr);
+    TR_ASSERT(dst_path != nullptr);
 
     bool ret = rename(src_path, dst_path) != -1;
 
@@ -442,11 +442,11 @@ bool tr_sys_path_rename(char const* src_path, char const* dst_path, tr_error** e
  * use a user-space fallback instead. */
 bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** error)
 {
-    TR_ASSERT(src_path != NULL);
-    TR_ASSERT(dst_path != NULL);
+    TR_ASSERT(src_path != nullptr);
+    TR_ASSERT(dst_path != nullptr);
 
 #if defined(USE_COPYFILE)
-    if (copyfile(src_path, dst_path, NULL, COPYFILE_CLONE | COPYFILE_ALL) < 0)
+    if (copyfile(src_path, dst_path, nullptr, COPYFILE_CLONE | COPYFILE_ALL) < 0)
     {
         set_system_error(error, errno);
         return false;
@@ -468,7 +468,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
     if (!tr_sys_file_get_info(in, &info, error))
     {
         tr_error_prefix(error, "Unable to get information on source file: ");
-        tr_sys_file_close(in, NULL);
+        tr_sys_file_close(in, nullptr);
         return false;
     }
 
@@ -476,7 +476,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
     if (out == TR_BAD_SYS_FILE)
     {
         tr_error_prefix(error, "Unable to open destination file: ");
-        tr_sys_file_close(in, NULL);
+        tr_sys_file_close(in, nullptr);
         return false;
     }
 
@@ -489,9 +489,9 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         size_t const chunk_size = MIN(file_size, SSIZE_MAX);
         ssize_t const copied =
 #ifdef USE_COPY_FILE_RANGE
-            copy_file_range(in, NULL, out, NULL, chunk_size, 0);
+            copy_file_range(in, nullptr, out, nullptr, chunk_size, 0);
 #elif defined(USE_SENDFILE64)
-            sendfile64(out, in, NULL, chunk_size);
+            sendfile64(out, in, nullptr, chunk_size);
 #else
 #error File copy mechanism not implemented.
 #endif
@@ -542,8 +542,8 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 #endif /* USE_COPY_FILE_RANGE || USE_SENDFILE64 */
 
     /* cleanup */
-    tr_sys_file_close(out, NULL);
-    tr_sys_file_close(in, NULL);
+    tr_sys_file_close(out, nullptr);
+    tr_sys_file_close(in, nullptr);
 
     if (file_size != 0)
     {
@@ -558,7 +558,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 
 bool tr_sys_path_remove(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret = remove(path) != -1;
 
@@ -603,7 +603,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
 
 tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
     TR_ASSERT((flags & (TR_SYS_FILE_READ | TR_SYS_FILE_WRITE)) != 0);
 
     tr_sys_file_t ret;
@@ -649,7 +649,7 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
 
 tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error** error)
 {
-    TR_ASSERT(path_template != NULL);
+    TR_ASSERT(path_template != nullptr);
 
     tr_sys_file_t ret = mkstemp(path_template);
 
@@ -680,7 +680,7 @@ bool tr_sys_file_close(tr_sys_file_t handle, tr_error** error)
 bool tr_sys_file_get_info(tr_sys_file_t handle, tr_sys_path_info* info, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(info != nullptr);
 
     struct stat sb;
     bool ret = fstat(handle, &sb) != -1;
@@ -715,7 +715,7 @@ bool tr_sys_file_seek(tr_sys_file_t handle, int64_t offset, tr_seek_origin_t ori
 
     if (my_new_offset != -1)
     {
-        if (new_offset != NULL)
+        if (new_offset != nullptr)
         {
             *new_offset = my_new_offset;
         }
@@ -733,7 +733,7 @@ bool tr_sys_file_seek(tr_sys_file_t handle, int64_t offset, tr_seek_origin_t ori
 bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_t* bytes_read, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     bool ret = false;
     ssize_t my_bytes_read;
@@ -744,7 +744,7 @@ bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_
 
     if (my_bytes_read != -1)
     {
-        if (bytes_read != NULL)
+        if (bytes_read != nullptr)
         {
             *bytes_read = my_bytes_read;
         }
@@ -768,7 +768,7 @@ bool tr_sys_file_read_at(
     tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
     /* seek requires signed offset, so it should be in mod range */
     TR_ASSERT(offset < UINT64_MAX / 2);
 
@@ -796,7 +796,7 @@ bool tr_sys_file_read_at(
 
     if (my_bytes_read != -1)
     {
-        if (bytes_read != NULL)
+        if (bytes_read != nullptr)
         {
             *bytes_read = my_bytes_read;
         }
@@ -814,7 +814,7 @@ bool tr_sys_file_read_at(
 bool tr_sys_file_write(tr_sys_file_t handle, void const* buffer, uint64_t size, uint64_t* bytes_written, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     bool ret = false;
     ssize_t my_bytes_written;
@@ -825,7 +825,7 @@ bool tr_sys_file_write(tr_sys_file_t handle, void const* buffer, uint64_t size, 
 
     if (my_bytes_written != -1)
     {
-        if (bytes_written != NULL)
+        if (bytes_written != nullptr)
         {
             *bytes_written = my_bytes_written;
         }
@@ -849,7 +849,7 @@ bool tr_sys_file_write_at(
     tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
     /* seek requires signed offset, so it should be in mod range */
     TR_ASSERT(offset < UINT64_MAX / 2);
 
@@ -877,7 +877,7 @@ bool tr_sys_file_write_at(
 
     if (my_bytes_written != -1)
     {
-        if (bytes_written != NULL)
+        if (bytes_written != nullptr)
         {
             *bytes_written = my_bytes_written;
         }
@@ -1009,7 +1009,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
             fl.l_start = 0;
             fl.l_len = size;
 
-            ret = xfsctl(NULL, handle, XFS_IOC_RESVSP64, &fl) != -1;
+            ret = xfsctl(nullptr, handle, XFS_IOC_RESVSP64, &fl) != -1;
 
             if (ret)
             {
@@ -1084,12 +1084,12 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
     TR_ASSERT(size > 0);
 
-    void* ret = mmap(NULL, size, PROT_READ, MAP_SHARED, handle, offset);
+    void* ret = mmap(nullptr, size, PROT_READ, MAP_SHARED, handle, offset);
 
     if (ret == MAP_FAILED)
     {
         set_system_error(error, errno);
-        ret = NULL;
+        ret = nullptr;
     }
 
     return ret;
@@ -1097,7 +1097,7 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
 
 bool tr_sys_file_unmap(void const* address, uint64_t size, tr_error** error)
 {
-    TR_ASSERT(address != NULL);
+    TR_ASSERT(address != nullptr);
     TR_ASSERT(size > 0);
 
     bool ret = munmap((void*)address, size) != -1;
@@ -1201,27 +1201,27 @@ char* tr_sys_dir_get_current(tr_error** error)
 {
     char* ret;
 
-    ret = getcwd(NULL, 0);
+    ret = getcwd(nullptr, 0);
 
-    if (ret == NULL && (errno == EINVAL || errno == ERANGE))
+    if (ret == nullptr && (errno == EINVAL || errno == ERANGE))
     {
         size_t size = PATH_MAX;
-        char* tmp = NULL;
+        char* tmp = nullptr;
 
         do
         {
             tmp = tr_renew(char, tmp, size);
 
-            if (tmp == NULL)
+            if (tmp == nullptr)
             {
                 break;
             }
 
             ret = getcwd(tmp, size);
             size += 2048;
-        } while (ret == NULL && errno == ERANGE);
+        } while (ret == nullptr && errno == ERANGE);
 
-        if (ret == NULL)
+        if (ret == nullptr)
         {
             int const err = errno;
             tr_free(tmp);
@@ -1229,7 +1229,7 @@ char* tr_sys_dir_get_current(tr_error** error)
         }
     }
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         set_system_error(error, errno);
     }
@@ -1239,10 +1239,10 @@ char* tr_sys_dir_get_current(tr_error** error)
 
 bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret;
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
 
     if ((flags & TR_SYS_DIR_CREATE_PARENTS) != 0)
     {
@@ -1274,7 +1274,7 @@ bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error** 
 
     if (!ret)
     {
-        if (my_error != NULL)
+        if (my_error != nullptr)
         {
             tr_error_propagate(error, &my_error);
         }
@@ -1289,17 +1289,17 @@ bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error** 
 
 bool tr_sys_dir_create_temp(char* path_template, tr_error** error)
 {
-    TR_ASSERT(path_template != NULL);
+    TR_ASSERT(path_template != nullptr);
 
     bool ret;
 
 #ifdef HAVE_MKDTEMP
 
-    ret = mkdtemp(path_template) != NULL;
+    ret = mkdtemp(path_template) != nullptr;
 
 #else
 
-    ret = mktemp(path_template) != NULL && mkdir(path_template, 0700) != -1;
+    ret = mktemp(path_template) != nullptr && mkdir(path_template, 0700) != -1;
 
 #endif
 
@@ -1313,11 +1313,11 @@ bool tr_sys_dir_create_temp(char* path_template, tr_error** error)
 
 tr_sys_dir_t tr_sys_dir_open(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     DIR* ret = opendir(path);
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         set_system_error(error, errno);
         return TR_BAD_SYS_DIR;
@@ -1330,12 +1330,12 @@ char const* tr_sys_dir_read_name(tr_sys_dir_t handle, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_DIR);
 
-    char const* ret = NULL;
+    char const* ret = nullptr;
 
     errno = 0;
     struct dirent const* const entry = readdir((DIR*)handle);
 
-    if (entry != NULL)
+    if (entry != nullptr)
     {
         ret = entry->d_name;
     }

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -41,14 +41,14 @@ static void set_system_error(tr_error** error, DWORD code)
 {
     char* message;
 
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
     message = tr_win32_format_message(code);
 
-    if (message != NULL)
+    if (message != nullptr)
     {
         tr_error_set_literal(error, code, message);
         tr_free(message);
@@ -69,7 +69,7 @@ static void set_system_error_if_file_found(tr_error** error, DWORD code)
 
 static time_t filetime_to_unix_time(FILETIME const* t)
 {
-    TR_ASSERT(t != NULL);
+    TR_ASSERT(t != nullptr);
 
     uint64_t tmp = 0;
     tmp |= t->dwHighDateTime;
@@ -88,8 +88,8 @@ static void stat_to_sys_path_info(
     FILETIME const* mtime,
     tr_sys_path_info* info)
 {
-    TR_ASSERT(mtime != NULL);
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(mtime != nullptr);
+    TR_ASSERT(info != nullptr);
 
     if ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
     {
@@ -134,7 +134,7 @@ static bool is_valid_path(char const* path)
     {
         char const* colon_pos = strchr(path, ':');
 
-        if (colon_pos != NULL)
+        if (colon_pos != nullptr)
         {
             if (colon_pos != path + 1 || !isalpha(path[0]))
             {
@@ -145,7 +145,7 @@ static bool is_valid_path(char const* path)
         }
     }
 
-    return strpbrk(path, "<>:\"|?*") == NULL;
+    return strpbrk(path, "<>:\"|?*") == nullptr;
 }
 
 static wchar_t* path_to_native_path_ex(char const* path, int extra_chars_after, int* real_result_size)
@@ -165,9 +165,9 @@ static wchar_t* path_to_native_path_ex(char const* path, int extra_chars_after, 
 
     wchar_t* const wide_path = tr_win32_utf8_to_native_ex(path, -1, extra_chars_before, extra_chars_after, real_result_size);
 
-    if (wide_path == NULL)
+    if (wide_path == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     /* Relative paths cannot be used with "\\?\" prefixes. This also means that relative paths are
@@ -189,12 +189,12 @@ static wchar_t* path_to_native_path_ex(char const* path, int extra_chars_after, 
     /* Automatic '/' to '\' conversion is disabled for "\\?\"-prefixed paths */
     wchar_t* p = wide_path + extra_chars_before;
 
-    while ((p = wcschr(p, L'/')) != NULL)
+    while ((p = wcschr(p, L'/')) != nullptr)
     {
         *p++ = L'\\';
     }
 
-    if (real_result_size != NULL)
+    if (real_result_size != nullptr)
     {
         *real_result_size += extra_chars_before;
     }
@@ -204,14 +204,14 @@ static wchar_t* path_to_native_path_ex(char const* path, int extra_chars_after, 
 
 static wchar_t* path_to_native_path(char const* path)
 {
-    return path_to_native_path_ex(path, 0, NULL);
+    return path_to_native_path_ex(path, 0, nullptr);
 }
 
 static char* native_path_to_path(wchar_t const* wide_path)
 {
-    if (wide_path == NULL)
+    if (wide_path == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     bool const is_unc = wcsncmp(wide_path, native_unc_path_prefix, TR_N_ELEMENTS(native_unc_path_prefix)) == 0;
@@ -220,9 +220,9 @@ static char* native_path_to_path(wchar_t const* wide_path)
     size_t const skip_chars = is_unc ? TR_N_ELEMENTS(native_unc_path_prefix) :
                                        (is_local ? TR_N_ELEMENTS(native_local_path_prefix) : 0);
 
-    char* const path = tr_win32_native_to_utf8_ex(wide_path + skip_chars, -1, is_unc ? 2 : 0, 0, NULL);
+    char* const path = tr_win32_native_to_utf8_ex(wide_path + skip_chars, -1, is_unc ? 2 : 0, 0, nullptr);
 
-    if (is_unc && path != NULL)
+    if (is_unc && path != nullptr)
     {
         path[0] = '\\';
         path[1] = '\\';
@@ -233,21 +233,21 @@ static char* native_path_to_path(wchar_t const* wide_path)
 
 static tr_sys_file_t open_file(char const* path, DWORD access, DWORD disposition, DWORD flags, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     tr_sys_file_t ret = TR_BAD_SYS_FILE;
     wchar_t* wide_path = path_to_native_path(path);
 
-    if (wide_path != NULL)
+    if (wide_path != nullptr)
     {
         ret = CreateFileW(
             wide_path,
             access,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            NULL,
+            nullptr,
             disposition,
             flags,
-            NULL);
+            nullptr);
     }
 
     if (ret == TR_BAD_SYS_FILE)
@@ -264,7 +264,7 @@ static bool create_dir(char const* path, int flags, int permissions, bool okay_i
 {
     TR_UNUSED(permissions);
 
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret;
     DWORD error_code = ERROR_SUCCESS;
@@ -272,12 +272,12 @@ static bool create_dir(char const* path, int flags, int permissions, bool okay_i
 
     if ((flags & TR_SYS_DIR_CREATE_PARENTS) != 0)
     {
-        error_code = SHCreateDirectoryExW(NULL, wide_path, NULL);
+        error_code = SHCreateDirectoryExW(nullptr, wide_path, nullptr);
         ret = error_code == ERROR_SUCCESS;
     }
     else
     {
-        ret = CreateDirectoryW(wide_path, NULL);
+        ret = CreateDirectoryW(wide_path, nullptr);
 
         if (!ret)
         {
@@ -311,15 +311,15 @@ static void create_temp_path(
     void* callback_param,
     tr_error** error)
 {
-    TR_ASSERT(path_template != NULL);
-    TR_ASSERT(callback != NULL);
+    TR_ASSERT(path_template != nullptr);
+    TR_ASSERT(callback != nullptr);
 
     char* path = tr_strdup(path_template);
     size_t path_size = strlen(path);
 
     TR_ASSERT(path_size > 0);
 
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
 
     for (int attempt = 0; attempt < 100; ++attempt)
     {
@@ -338,13 +338,13 @@ static void create_temp_path(
 
         (*callback)(path, callback_param, &my_error);
 
-        if (my_error == NULL)
+        if (my_error == nullptr)
         {
             break;
         }
     }
 
-    if (my_error != NULL)
+    if (my_error != nullptr)
     {
         tr_error_propagate(error, &my_error);
     }
@@ -358,13 +358,13 @@ static void create_temp_path(
 
 bool tr_sys_path_exists(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret = false;
     HANDLE handle = INVALID_HANDLE_VALUE;
     wchar_t* wide_path = path_to_native_path(path);
 
-    if (wide_path != NULL)
+    if (wide_path != nullptr)
     {
         DWORD attributes = GetFileAttributesW(wide_path);
 
@@ -372,7 +372,7 @@ bool tr_sys_path_exists(char const* path, tr_error** error)
         {
             if ((attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
             {
-                handle = CreateFileW(wide_path, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+                handle = CreateFileW(wide_path, 0, 0, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
                 ret = handle != INVALID_HANDLE_VALUE;
             }
             else
@@ -399,8 +399,8 @@ bool tr_sys_path_exists(char const* path, tr_error** error)
 
 bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(path != nullptr);
+    TR_ASSERT(info != nullptr);
 
     bool ret = false;
     wchar_t* wide_path = path_to_native_path(path);
@@ -409,14 +409,14 @@ bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, t
     {
         HANDLE handle = INVALID_HANDLE_VALUE;
 
-        if (wide_path != NULL)
+        if (wide_path != nullptr)
         {
-            handle = CreateFileW(wide_path, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+            handle = CreateFileW(wide_path, 0, 0, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
         }
 
         if (handle != INVALID_HANDLE_VALUE)
         {
-            tr_error* my_error = NULL;
+            tr_error* my_error = nullptr;
             ret = tr_sys_file_get_info(handle, info, &my_error);
 
             if (!ret)
@@ -435,7 +435,7 @@ bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, t
     {
         WIN32_FILE_ATTRIBUTE_DATA attributes;
 
-        if (wide_path != NULL)
+        if (wide_path != nullptr)
         {
             ret = GetFileAttributesExW(wide_path, GetFileExInfoStandard, &attributes);
         }
@@ -462,7 +462,7 @@ bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, t
 
 bool tr_sys_path_is_relative(char const* path)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     /* UNC path: `\\...`. */
     if (is_unc_path(path))
@@ -481,38 +481,38 @@ bool tr_sys_path_is_relative(char const* path)
 
 bool tr_sys_path_is_same(char const* path1, char const* path2, tr_error** error)
 {
-    TR_ASSERT(path1 != NULL);
-    TR_ASSERT(path2 != NULL);
+    TR_ASSERT(path1 != nullptr);
+    TR_ASSERT(path2 != nullptr);
 
     bool ret = false;
-    wchar_t* wide_path1 = NULL;
-    wchar_t* wide_path2 = NULL;
+    wchar_t* wide_path1 = nullptr;
+    wchar_t* wide_path2 = nullptr;
     HANDLE handle1 = INVALID_HANDLE_VALUE;
     HANDLE handle2 = INVALID_HANDLE_VALUE;
     BY_HANDLE_FILE_INFORMATION fi1, fi2;
 
     wide_path1 = path_to_native_path(path1);
 
-    if (wide_path1 == NULL)
+    if (wide_path1 == nullptr)
     {
         goto fail;
     }
 
     wide_path2 = path_to_native_path(path2);
 
-    if (wide_path2 == NULL)
+    if (wide_path2 == nullptr)
     {
         goto fail;
     }
 
-    handle1 = CreateFileW(wide_path1, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    handle1 = CreateFileW(wide_path1, 0, 0, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
     if (handle1 == INVALID_HANDLE_VALUE)
     {
         goto fail;
     }
 
-    handle2 = CreateFileW(wide_path2, 0, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    handle2 = CreateFileW(wide_path2, 0, 0, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
     if (handle2 == INVALID_HANDLE_VALUE)
     {
@@ -546,17 +546,17 @@ cleanup:
 
 char* tr_sys_path_resolve(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
-    char* ret = NULL;
+    char* ret = nullptr;
     wchar_t* wide_path;
-    wchar_t* wide_ret = NULL;
+    wchar_t* wide_ret = nullptr;
     HANDLE handle = INVALID_HANDLE_VALUE;
     DWORD wide_ret_size;
 
     wide_path = path_to_native_path(path);
 
-    if (wide_path == NULL)
+    if (wide_path == nullptr)
     {
         goto fail;
     }
@@ -565,17 +565,17 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
         wide_path,
         FILE_READ_EA,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        NULL,
+        nullptr,
         OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS,
-        NULL);
+        nullptr);
 
     if (handle == INVALID_HANDLE_VALUE)
     {
         goto fail;
     }
 
-    wide_ret_size = GetFinalPathNameByHandleW(handle, NULL, 0, 0);
+    wide_ret_size = GetFinalPathNameByHandleW(handle, nullptr, 0, 0);
 
     if (wide_ret_size == 0)
     {
@@ -593,7 +593,7 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
 
     ret = native_path_to_path(wide_ret);
 
-    if (ret != NULL)
+    if (ret != nullptr)
     {
         goto cleanup;
     }
@@ -602,7 +602,7 @@ fail:
     set_system_error(error, GetLastError());
 
     tr_free(ret);
-    ret = NULL;
+    ret = nullptr;
 
 cleanup:
     tr_free(wide_ret);
@@ -626,7 +626,7 @@ char* tr_sys_path_basename(char const* path, tr_error** error)
     if (!is_valid_path(path))
     {
         set_system_error(error, ERROR_PATH_NOT_FOUND);
-        return NULL;
+        return nullptr;
     }
 
     char const* end = path + strlen(path);
@@ -666,7 +666,7 @@ char* tr_sys_path_dirname(char const* path, tr_error** error)
     if (!is_valid_path(path))
     {
         set_system_error(error, ERROR_PATH_NOT_FOUND);
-        return NULL;
+        return nullptr;
     }
 
     bool const is_unc = is_unc_path(path);
@@ -715,14 +715,14 @@ char* tr_sys_path_dirname(char const* path, tr_error** error)
 
 bool tr_sys_path_rename(char const* src_path, char const* dst_path, tr_error** error)
 {
-    TR_ASSERT(src_path != NULL);
-    TR_ASSERT(dst_path != NULL);
+    TR_ASSERT(src_path != nullptr);
+    TR_ASSERT(dst_path != nullptr);
 
     bool ret = false;
     wchar_t* wide_src_path = path_to_native_path(src_path);
     wchar_t* wide_dst_path = path_to_native_path(dst_path);
 
-    if (wide_src_path != NULL && wide_dst_path != NULL)
+    if (wide_src_path != nullptr && wide_dst_path != nullptr)
     {
         DWORD flags = MOVEFILE_REPLACE_EXISTING;
         DWORD attributes;
@@ -759,15 +759,15 @@ bool tr_sys_path_rename(char const* src_path, char const* dst_path, tr_error** e
 
 bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** error)
 {
-    TR_ASSERT(src_path != NULL);
-    TR_ASSERT(dst_path != NULL);
+    TR_ASSERT(src_path != nullptr);
+    TR_ASSERT(dst_path != nullptr);
 
     bool ret = false;
 
     wchar_t* wide_src_path = path_to_native_path(src_path);
     wchar_t* wide_dst_path = path_to_native_path(dst_path);
 
-    if (wide_src_path == NULL || wide_dst_path == NULL)
+    if (wide_src_path == nullptr || wide_dst_path == nullptr)
     {
         set_system_error(error, ERROR_INVALID_PARAMETER);
         goto out;
@@ -775,7 +775,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 
     auto cancel = BOOL{ FALSE };
     DWORD const flags = COPY_FILE_ALLOW_DECRYPTED_DESTINATION | COPY_FILE_FAIL_IF_EXISTS;
-    if (CopyFileExW(wide_src_path, wide_dst_path, NULL, NULL, &cancel, flags) == 0)
+    if (CopyFileExW(wide_src_path, wide_dst_path, nullptr, nullptr, &cancel, flags) == 0)
     {
         set_system_error(error, GetLastError());
         goto out;
@@ -794,12 +794,12 @@ out:
 
 bool tr_sys_path_remove(char const* path, tr_error** error)
 {
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     bool ret = false;
     wchar_t* wide_path = path_to_native_path(path);
 
-    if (wide_path != NULL)
+    if (wide_path != nullptr)
     {
         DWORD const attributes = GetFileAttributesW(wide_path);
 
@@ -828,12 +828,12 @@ bool tr_sys_path_remove(char const* path, tr_error** error)
 
 char* tr_sys_path_native_separators(char* path)
 {
-    if (path == NULL)
+    if (path == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
-    for (char* slash = strchr(path, '/'); slash != NULL; slash = strchr(slash, '/'))
+    for (char* slash = strchr(path, '/'); slash != nullptr; slash = strchr(slash, '/'))
     {
         *slash = '\\';
     }
@@ -869,7 +869,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
     {
         set_system_error(error, GetLastError());
     }
-    else if (ret == NULL)
+    else if (ret == nullptr)
     {
         ret = TR_BAD_SYS_FILE;
     }
@@ -881,7 +881,7 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
 {
     TR_UNUSED(permissions);
 
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
     TR_ASSERT((flags & (TR_SYS_FILE_READ | TR_SYS_FILE_WRITE)) != 0);
 
     tr_sys_file_t ret;
@@ -924,12 +924,12 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
 
     if (success && (flags & TR_SYS_FILE_APPEND) != 0)
     {
-        success = SetFilePointer(ret, 0, NULL, FILE_END) != INVALID_SET_FILE_POINTER;
+        success = SetFilePointer(ret, 0, nullptr, FILE_END) != INVALID_SET_FILE_POINTER;
     }
 
     if (!success)
     {
-        if (error == NULL)
+        if (error == nullptr)
         {
             set_system_error(error, GetLastError());
         }
@@ -945,14 +945,14 @@ static void file_open_temp_callback(char const* path, void* param, tr_error** er
 {
     tr_sys_file_t* result = (tr_sys_file_t*)param;
 
-    TR_ASSERT(result != NULL);
+    TR_ASSERT(result != nullptr);
 
     *result = open_file(path, GENERIC_READ | GENERIC_WRITE, CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, error);
 }
 
 tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error** error)
 {
-    TR_ASSERT(path_template != NULL);
+    TR_ASSERT(path_template != nullptr);
 
     tr_sys_file_t ret = TR_BAD_SYS_FILE;
 
@@ -978,7 +978,7 @@ bool tr_sys_file_close(tr_sys_file_t handle, tr_error** error)
 bool tr_sys_file_get_info(tr_sys_file_t handle, tr_sys_path_info* info, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(info != nullptr);
 
     BY_HANDLE_FILE_INFORMATION attributes;
     bool ret = GetFileInformationByHandle(handle, &attributes);
@@ -1017,7 +1017,7 @@ bool tr_sys_file_seek(tr_sys_file_t handle, int64_t offset, tr_seek_origin_t ori
 
     if (SetFilePointerEx(handle, native_offset, &new_native_pointer, origin))
     {
-        if (new_offset != NULL)
+        if (new_offset != nullptr)
         {
             *new_offset = new_native_pointer.QuadPart;
         }
@@ -1035,7 +1035,7 @@ bool tr_sys_file_seek(tr_sys_file_t handle, int64_t offset, tr_seek_origin_t ori
 bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_t* bytes_read, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     if (size > MAXDWORD)
     {
@@ -1046,9 +1046,9 @@ bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_
     bool ret = false;
     DWORD my_bytes_read;
 
-    if (ReadFile(handle, buffer, (DWORD)size, &my_bytes_read, NULL))
+    if (ReadFile(handle, buffer, (DWORD)size, &my_bytes_read, nullptr))
     {
-        if (bytes_read != NULL)
+        if (bytes_read != nullptr)
         {
             *bytes_read = my_bytes_read;
         }
@@ -1072,7 +1072,7 @@ bool tr_sys_file_read_at(
     tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     if (size > MAXDWORD)
     {
@@ -1087,11 +1087,11 @@ bool tr_sys_file_read_at(
     overlapped.Offset = (DWORD)offset;
     offset >>= 32;
     overlapped.OffsetHigh = (DWORD)offset;
-    overlapped.hEvent = NULL;
+    overlapped.hEvent = nullptr;
 
     if (ReadFile(handle, buffer, (DWORD)size, &my_bytes_read, &overlapped))
     {
-        if (bytes_read != NULL)
+        if (bytes_read != nullptr)
         {
             *bytes_read = my_bytes_read;
         }
@@ -1109,7 +1109,7 @@ bool tr_sys_file_read_at(
 bool tr_sys_file_write(tr_sys_file_t handle, void const* buffer, uint64_t size, uint64_t* bytes_written, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     if (size > MAXDWORD)
     {
@@ -1120,9 +1120,9 @@ bool tr_sys_file_write(tr_sys_file_t handle, void const* buffer, uint64_t size, 
     bool ret = false;
     DWORD my_bytes_written;
 
-    if (WriteFile(handle, buffer, (DWORD)size, &my_bytes_written, NULL))
+    if (WriteFile(handle, buffer, (DWORD)size, &my_bytes_written, nullptr))
     {
-        if (bytes_written != NULL)
+        if (bytes_written != nullptr)
         {
             *bytes_written = my_bytes_written;
         }
@@ -1146,7 +1146,7 @@ bool tr_sys_file_write_at(
     tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL || size == 0);
+    TR_ASSERT(buffer != nullptr || size == 0);
 
     if (size > MAXDWORD)
     {
@@ -1161,11 +1161,11 @@ bool tr_sys_file_write_at(
     overlapped.Offset = (DWORD)offset;
     offset >>= 32;
     overlapped.OffsetHigh = (DWORD)offset;
-    overlapped.hEvent = NULL;
+    overlapped.hEvent = nullptr;
 
     if (WriteFile(handle, buffer, (DWORD)size, &my_bytes_written, &overlapped))
     {
-        if (bytes_written != NULL)
+        if (bytes_written != nullptr)
         {
             *bytes_written = my_bytes_written;
         }
@@ -1238,7 +1238,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
     {
         DWORD tmp;
 
-        if (!DeviceIoControl(handle, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &tmp, NULL))
+        if (!DeviceIoControl(handle, FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, &tmp, nullptr))
         {
             set_system_error(error, GetLastError());
             return false;
@@ -1259,10 +1259,10 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
         return false;
     }
 
-    void* ret = NULL;
-    HANDLE mappingHandle = CreateFileMappingW(handle, NULL, PAGE_READONLY, 0, 0, NULL);
+    void* ret = nullptr;
+    HANDLE mappingHandle = CreateFileMappingW(handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
 
-    if (mappingHandle != NULL)
+    if (mappingHandle != nullptr)
     {
         ULARGE_INTEGER native_offset;
 
@@ -1271,7 +1271,7 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
         ret = MapViewOfFile(mappingHandle, FILE_MAP_READ, native_offset.u.HighPart, native_offset.u.LowPart, (SIZE_T)size);
     }
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         set_system_error(error, GetLastError());
     }
@@ -1285,7 +1285,7 @@ bool tr_sys_file_unmap(void const* address, uint64_t size, tr_error** error)
 {
     TR_UNUSED(size);
 
-    TR_ASSERT(address != NULL);
+    TR_ASSERT(address != nullptr);
     TR_ASSERT(size > 0);
 
     bool ret = UnmapViewOfFile(address);
@@ -1339,11 +1339,11 @@ bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error** error)
 
 char* tr_sys_dir_get_current(tr_error** error)
 {
-    char* ret = NULL;
-    wchar_t* wide_ret = NULL;
+    char* ret = nullptr;
+    wchar_t* wide_ret = nullptr;
     DWORD size;
 
-    size = GetCurrentDirectoryW(0, NULL);
+    size = GetCurrentDirectoryW(0, nullptr);
 
     if (size != 0)
     {
@@ -1355,7 +1355,7 @@ char* tr_sys_dir_get_current(tr_error** error)
         }
     }
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         set_system_error(error, GetLastError());
     }
@@ -1374,14 +1374,14 @@ static void dir_create_temp_callback(char const* path, void* param, tr_error** e
 {
     bool* result = (bool*)param;
 
-    TR_ASSERT(result != NULL);
+    TR_ASSERT(result != nullptr);
 
     *result = create_dir(path, 0, 0, false, error);
 }
 
 bool tr_sys_dir_create_temp(char* path_template, tr_error** error)
 {
-    TR_ASSERT(path_template != NULL);
+    TR_ASSERT(path_template != nullptr);
 
     bool ret = false;
 
@@ -1394,23 +1394,23 @@ tr_sys_dir_t tr_sys_dir_open(char const* path, tr_error** error)
 {
 #ifndef __clang__
     /* Clang gives "static_assert expression is not an integral constant expression" error */
-    TR_STATIC_ASSERT(TR_BAD_SYS_DIR == NULL, "values should match");
+    TR_STATIC_ASSERT(TR_BAD_SYS_DIR == nullptr, "values should match");
 #endif
 
-    TR_ASSERT(path != NULL);
+    TR_ASSERT(path != nullptr);
 
     tr_sys_dir_t ret = tr_new(struct tr_sys_dir_win32, 1);
 
     int pattern_size;
     ret->pattern = path_to_native_path_ex(path, 2, &pattern_size);
 
-    if (ret->pattern != NULL)
+    if (ret->pattern != nullptr)
     {
         ret->pattern[pattern_size + 0] = L'\\';
         ret->pattern[pattern_size + 1] = L'*';
 
         ret->find_handle = INVALID_HANDLE_VALUE;
-        ret->utf8_name = NULL;
+        ret->utf8_name = nullptr;
     }
     else
     {
@@ -1419,7 +1419,7 @@ tr_sys_dir_t tr_sys_dir_open(char const* path, tr_error** error)
         tr_free(ret->pattern);
         tr_free(ret);
 
-        ret = NULL;
+        ret = nullptr;
     }
 
     return ret;
@@ -1451,12 +1451,12 @@ char const* tr_sys_dir_read_name(tr_sys_dir_t handle, tr_error** error)
     if (error_code != ERROR_SUCCESS)
     {
         set_system_error_if_file_found(error, error_code);
-        return NULL;
+        return nullptr;
     }
 
     char* ret = tr_win32_native_to_utf8(handle->find_data.cFileName, -1);
 
-    if (ret != NULL)
+    if (ret != nullptr)
     {
         tr_free(handle->utf8_name);
         handle->utf8_name = ret;

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -17,7 +17,7 @@
 bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_size, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
     TR_ASSERT(buffer_size > 0);
 
     bool ret = false;
@@ -57,7 +57,7 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
         {
             if (delta != 0)
             {
-                ret = tr_sys_file_seek(handle, delta, TR_SEEK_CUR, NULL, error);
+                ret = tr_sys_file_seek(handle, delta, TR_SEEK_CUR, nullptr, error);
 
                 if (!ret)
                 {
@@ -84,13 +84,13 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
 bool tr_sys_file_write_line(tr_sys_file_t handle, char const* buffer, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
 
-    bool ret = tr_sys_file_write(handle, buffer, strlen(buffer), NULL, error);
+    bool ret = tr_sys_file_write(handle, buffer, strlen(buffer), nullptr, error);
 
     if (ret)
     {
-        ret = tr_sys_file_write(handle, TR_NATIVE_EOL_STR, TR_NATIVE_EOL_STR_SIZE, NULL, error);
+        ret = tr_sys_file_write(handle, TR_NATIVE_EOL_STR, TR_NATIVE_EOL_STR_SIZE, nullptr, error);
     }
 
     return ret;
@@ -99,7 +99,7 @@ bool tr_sys_file_write_line(tr_sys_file_t handle, char const* buffer, tr_error**
 bool tr_sys_file_write_fmt(tr_sys_file_t handle, char const* format, tr_error** error, ...)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(format != NULL);
+    TR_ASSERT(format != nullptr);
 
     bool ret = false;
     char* buffer;
@@ -109,9 +109,9 @@ bool tr_sys_file_write_fmt(tr_sys_file_t handle, char const* format, tr_error** 
     buffer = tr_strdup_vprintf(format, args);
     va_end(args);
 
-    if (buffer != NULL)
+    if (buffer != nullptr)
     {
-        ret = tr_sys_file_write(handle, buffer, strlen(buffer), NULL, error);
+        ret = tr_sys_file_write(handle, buffer, strlen(buffer), nullptr, error);
         tr_free(buffer);
     }
     else

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* strlen() */
+#include <cstring> /* strlen() */
+#include <algorithm>
 
 #include "transmission.h"
 #include "error.h"
@@ -26,7 +27,7 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
 
     while (buffer_size > 0)
     {
-        size_t const bytes_needed = MIN(buffer_size, 1024u);
+        size_t const bytes_needed = std::min(buffer_size, 1024LU);
 
         ret = tr_sys_file_read(handle, buffer + offset, bytes_needed, &bytes_read, error);
 

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -50,7 +50,7 @@ typedef struct tr_sys_dir_win32* tr_sys_dir_t;
 #endif
 
 /** @brief Platform-specific invalid directory descriptor constant. */
-#define TR_BAD_SYS_DIR ((tr_sys_dir_t)NULL)
+#define TR_BAD_SYS_DIR ((tr_sys_dir_t)nullptr)
 
 typedef enum
 {

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -50,7 +50,7 @@ typedef struct tr_sys_dir_win32* tr_sys_dir_t;
 #endif
 
 /** @brief Platform-specific invalid directory descriptor constant. */
-#define TR_BAD_SYS_DIR ((tr_sys_dir_t)nullptr)
+#define TR_BAD_SYS_DIR ((tr_sys_dir_t) nullptr)
 
 typedef enum
 {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -175,9 +175,9 @@ static void setReadState(tr_handshake* handshake, handshake_state_t state)
 static bool buildHandshakeMessage(tr_handshake* handshake, uint8_t* buf)
 {
     uint8_t const* const torrent_hash = tr_cryptoGetTorrentHash(handshake->crypto);
-    tr_torrent* const tor = torrent_hash == NULL ? NULL : tr_torrentFindFromHash(handshake->session, torrent_hash);
-    unsigned char const* const peer_id = tor == NULL ? NULL : tr_torrentGetPeerId(tor);
-    bool const success = peer_id != NULL;
+    tr_torrent* const tor = torrent_hash == nullptr ? nullptr : tr_torrentFindFromHash(handshake->session, torrent_hash);
+    unsigned char const* const peer_id = tor == nullptr ? nullptr : tr_torrentGetPeerId(tor);
+    bool const success = peer_id != nullptr;
 
     if (success)
     {
@@ -300,7 +300,7 @@ static void sendYa(tr_handshake* handshake)
     /* add our public key (Ya) */
     public_key = tr_cryptoGetMyPublicKey(handshake->crypto, &len);
     TR_ASSERT(len == KEY_LEN);
-    TR_ASSERT(public_key != NULL);
+    TR_ASSERT(public_key != nullptr);
     memcpy(walk, public_key, len);
     walk += len;
 
@@ -368,7 +368,7 @@ static uint32_t getCryptoSelect(tr_handshake const* handshake, uint32_t crypto_p
 
 static void computeRequestHash(tr_handshake const* handshake, char const* name, uint8_t* hash)
 {
-    tr_cryptoSecretKeySha1(handshake->crypto, name, 4, NULL, 0, hash);
+    tr_cryptoSecretKeySha1(handshake->crypto, name, 4, nullptr, 0, hash);
 }
 
 static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
@@ -432,7 +432,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
         uint8_t req3[SHA_DIGEST_LENGTH];
         uint8_t buf[SHA_DIGEST_LENGTH];
 
-        tr_sha1(req2, "req2", 4, tr_cryptoGetTorrentHash(handshake->crypto), SHA_DIGEST_LENGTH, NULL);
+        tr_sha1(req2, "req2", 4, tr_cryptoGetTorrentHash(handshake->crypto), SHA_DIGEST_LENGTH, nullptr);
         computeRequestHash(handshake, "req3", req3);
 
         for (int i = 0; i < SHA_DIGEST_LENGTH; ++i)
@@ -719,7 +719,7 @@ static ReadState readPeerId(tr_handshake* handshake, struct evbuffer* inbuf)
 
     /* if we've somehow connected to ourselves, don't keep the connection */
     tor = tr_torrentFindFromHash(handshake->session, tr_peerIoGetTorrentHash(handshake->io));
-    connected_to_self = tor != NULL && memcmp(peer_id, tr_torrentGetPeerId(tor), PEER_ID_LEN) == 0;
+    connected_to_self = tor != nullptr && memcmp(peer_id, tr_torrentGetPeerId(tor), PEER_ID_LEN) == 0;
 
     return tr_handshakeDone(handshake, !connected_to_self);
 }
@@ -767,7 +767,7 @@ static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
 static ReadState readPadA(tr_handshake* handshake, struct evbuffer* inbuf)
 {
     /* resynchronizing on HASH('req1', S) */
-    struct evbuffer_ptr ptr = evbuffer_search(inbuf, (char const*)handshake->myReq1, SHA_DIGEST_LENGTH, NULL);
+    struct evbuffer_ptr ptr = evbuffer_search(inbuf, (char const*)handshake->myReq1, SHA_DIGEST_LENGTH, nullptr);
 
     if (ptr.pos != -1) /* match */
     {
@@ -824,10 +824,10 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     }
 
     tr_torrent const* tor;
-    if ((tor = tr_torrentFindFromObfuscatedHash(handshake->session, obfuscatedTorrentHash)) != NULL)
+    if ((tor = tr_torrentFindFromObfuscatedHash(handshake->session, obfuscatedTorrentHash)) != nullptr)
     {
         bool const clientIsSeed = tr_torrentIsSeed(tor);
-        bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, tr_peerIoGetAddress(handshake->io, NULL));
+        bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, tr_peerIoGetAddress(handshake->io, nullptr));
         dbgmsg(handshake, "got INCOMING connection's encrypted handshake for torrent [%s]", tr_torrentName(tor));
         tr_peerIoSetTorrentHash(handshake->io, tor->info.hash);
 
@@ -1094,7 +1094,7 @@ static ReadState canRead(struct tr_peerIo* io, void* vhandshake, size_t* piece)
 
 static bool fireDoneFunc(tr_handshake* handshake, bool isConnected)
 {
-    uint8_t const* peer_id = (isConnected && handshake->havePeerID) ? tr_peerIoGetPeersId(handshake->io) : NULL;
+    uint8_t const* peer_id = (isConnected && handshake->havePeerID) ? tr_peerIoGetPeersId(handshake->io) : nullptr;
     bool const success = (*handshake->doneCB)(
         handshake,
         handshake->io,
@@ -1108,7 +1108,7 @@ static bool fireDoneFunc(tr_handshake* handshake, bool isConnected)
 
 static void tr_handshakeFree(tr_handshake* handshake)
 {
-    if (handshake->io != NULL)
+    if (handshake->io != nullptr)
     {
         tr_peerIoUnref(handshake->io); /* balanced by the ref in tr_handshakeNew */
     }
@@ -1122,7 +1122,7 @@ static ReadState tr_handshakeDone(tr_handshake* handshake, bool isOK)
     bool success;
 
     dbgmsg(handshake, "handshakeDone: %s", isOK ? "connected" : "aborting");
-    tr_peerIoSetIOFuncs(handshake->io, NULL, NULL, NULL, NULL);
+    tr_peerIoSetIOFuncs(handshake->io, nullptr, nullptr, nullptr, nullptr);
 
     success = fireDoneFunc(handshake, isOK);
 
@@ -1133,7 +1133,7 @@ static ReadState tr_handshakeDone(tr_handshake* handshake, bool isOK)
 
 void tr_handshakeAbort(tr_handshake* handshake)
 {
-    if (handshake != NULL)
+    if (handshake != nullptr)
     {
         tr_handshakeDone(handshake, false);
     }
@@ -1156,13 +1156,13 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
         }
         else
         {
-            tor = NULL;
+            tor = nullptr;
         }
 
         /* Don't mark a peer as non-uTP unless it's really a connect failure. */
         if ((errcode == ETIMEDOUT || errcode == ECONNREFUSED) && tr_isTorrent(tor))
         {
-            tr_peerMgrSetUtpFailed(tor, tr_peerIoGetAddress(io, NULL), true);
+            tr_peerMgrSetUtpFailed(tor, tr_peerIoGetAddress(io, nullptr), true);
         }
 
         if (tr_peerIoReconnect(handshake->io) == 0)
@@ -1224,7 +1224,7 @@ tr_handshake* tr_handshakeNew(tr_peerIo* io, tr_encryption_mode encryptionMode, 
     tr_timerAdd(handshake->timeout_timer, HANDSHAKE_TIMEOUT_SEC, 0);
 
     tr_peerIoRef(io); /* balanced by the unref in tr_handshakeFree */
-    tr_peerIoSetIOFuncs(handshake->io, canRead, NULL, gotError, handshake);
+    tr_peerIoSetIOFuncs(handshake->io, canRead, nullptr, gotError, handshake);
     tr_peerIoSetEncryption(io, PEER_ENCRYPTION_NONE);
 
     if (tr_peerIoIsIncoming(handshake->io))
@@ -1250,18 +1250,18 @@ tr_handshake* tr_handshakeNew(tr_peerIo* io, tr_encryption_mode encryptionMode, 
 
 struct tr_peerIo* tr_handshakeStealIO(tr_handshake* handshake)
 {
-    TR_ASSERT(handshake != NULL);
-    TR_ASSERT(handshake->io != NULL);
+    TR_ASSERT(handshake != nullptr);
+    TR_ASSERT(handshake->io != nullptr);
 
     struct tr_peerIo* io = handshake->io;
-    handshake->io = NULL;
+    handshake->io = nullptr;
     return io;
 }
 
 tr_address const* tr_handshakeGetAddr(struct tr_handshake const* handshake, tr_port* port)
 {
-    TR_ASSERT(handshake != NULL);
-    TR_ASSERT(handshake->io != NULL);
+    TR_ASSERT(handshake != nullptr);
+    TR_ASSERT(handshake->io != nullptr);
 
     return tr_peerIoGetAddress(handshake->io, port);
 }

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -74,7 +74,7 @@ static int readOrWriteBytes(
         char const* base;
 
         /* see if the file exists... */
-        if (!tr_torrentFindFile2(tor, fileIndex, &base, &subpath, NULL))
+        if (!tr_torrentFindFile2(tor, fileIndex, &base, &subpath, nullptr))
         {
             /* we can't read a file that doesn't exist... */
             if (!doWrite)
@@ -91,7 +91,7 @@ static int readOrWriteBytes(
         if (err == 0)
         {
             /* open (and maybe create) the file */
-            char* filename = tr_buildPath(base, subpath, NULL);
+            char* filename = tr_buildPath(base, subpath, nullptr);
             tr_preallocation_mode const prealloc = (file->dnd || !doWrite) ? TR_PREALLOCATE_NONE :
                                                                              tor->session->preallocationMode;
 
@@ -119,11 +119,11 @@ static int readOrWriteBytes(
 
     if (err == 0)
     {
-        tr_error* error = NULL;
+        tr_error* error = nullptr;
 
         if (ioMode == TR_IO_READ)
         {
-            if (!tr_sys_file_read_at(fd, buf, buflen, fileOffset, NULL, &error))
+            if (!tr_sys_file_read_at(fd, buf, buflen, fileOffset, nullptr, &error))
             {
                 err = error->code;
                 tr_logAddTorErr(tor, "read failed for \"%s\": %s", file->name, error->message);
@@ -132,7 +132,7 @@ static int readOrWriteBytes(
         }
         else if (ioMode == TR_IO_WRITE)
         {
-            if (!tr_sys_file_write_at(fd, buf, buflen, fileOffset, NULL, &error))
+            if (!tr_sys_file_write_at(fd, buf, buflen, fileOffset, nullptr, &error))
             {
                 err = error->code;
                 tr_logAddTorErr(tor, "write failed for \"%s\": %s", file->name, error->message);
@@ -141,7 +141,7 @@ static int readOrWriteBytes(
         }
         else if (ioMode == TR_IO_PREFETCH)
         {
-            tr_sys_file_advise(fd, fileOffset, buflen, TR_SYS_FILE_ADVICE_WILL_NEED, NULL);
+            tr_sys_file_advise(fd, fileOffset, buflen, TR_SYS_FILE_ADVICE_WILL_NEED, nullptr);
         }
         else
         {
@@ -184,7 +184,7 @@ void tr_ioFindFileLocation(
 
     auto const* file = static_cast<tr_file const*>(
         bsearch(&offset, tor->info.files, tor->info.fileCount, sizeof(tr_file), compareOffsetToFile));
-    TR_ASSERT(file != NULL);
+    TR_ASSERT(file != nullptr);
 
     *fileIndex = file - tor->info.files;
     *fileOffset = offset - file->offset;
@@ -227,7 +227,7 @@ static int readOrWritePiece(
 
         if (err != 0 && ioMode == TR_IO_WRITE && tor->error != TR_STAT_LOCAL_ERROR)
         {
-            char* path = tr_buildPath(tor->downloadDir, file->name, NULL);
+            char* path = tr_buildPath(tor->downloadDir, file->name, nullptr);
             tr_torrentSetLocalError(tor, "%s (%s)", tr_strerror(err), path);
             tr_free(path);
         }
@@ -243,7 +243,7 @@ int tr_ioRead(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uint
 
 int tr_ioPrefetch(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uint32_t len)
 {
-    return readOrWritePiece(tor, TR_IO_PREFETCH, pieceIndex, begin, NULL, len);
+    return readOrWritePiece(tor, TR_IO_PREFETCH, pieceIndex, begin, nullptr, len);
 }
 
 int tr_ioWrite(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uint32_t len, uint8_t const* buf)
@@ -257,9 +257,9 @@ int tr_ioWrite(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uin
 
 static bool recalculateHash(tr_torrent* tor, tr_piece_index_t pieceIndex, uint8_t* setme)
 {
-    TR_ASSERT(tor != NULL);
+    TR_ASSERT(tor != nullptr);
     TR_ASSERT(pieceIndex < tor->info.pieceCount);
-    TR_ASSERT(setme != NULL);
+    TR_ASSERT(setme != nullptr);
 
     size_t bytesLeft;
     uint32_t offset = 0;
@@ -268,7 +268,7 @@ static bool recalculateHash(tr_torrent* tor, tr_piece_index_t pieceIndex, uint8_
     void* const buffer = tr_malloc(buflen);
     tr_sha1_ctx_t sha;
 
-    TR_ASSERT(buffer != NULL);
+    TR_ASSERT(buffer != nullptr);
     TR_ASSERT(buflen > 0);
 
     sha = tr_sha1_init();
@@ -291,7 +291,7 @@ static bool recalculateHash(tr_torrent* tor, tr_piece_index_t pieceIndex, uint8_
         bytesLeft -= len;
     }
 
-    tr_sha1_final(sha, success ? setme : NULL);
+    tr_sha1_final(sha, success ? setme : nullptr);
 
     tr_free(buffer);
     return success;

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -6,9 +6,10 @@
  *
  */
 
-#include <errno.h>
-#include <stdlib.h> /* bsearch() */
-#include <string.h> /* memcmp() */
+#include <cerrno>
+#include <cstdlib> /* bsearch() */
+#include <cstring> /* memcmp() */
+#include <algorithm>
 
 #include "transmission.h"
 #include "cache.h" /* tr_cacheReadBlock() */
@@ -217,7 +218,7 @@ static int readOrWritePiece(
     while (buflen != 0 && err == 0)
     {
         tr_file const* file = &info->files[fileIndex];
-        uint64_t const bytesThisPass = MIN(buflen, file->length - fileOffset);
+        uint64_t const bytesThisPass = std::min(buflen, file->length - fileOffset);
 
         err = readOrWriteBytes(tor->session, tor, ioMode, fileIndex, fileOffset, buf, bytesThisPass);
         buf += bytesThisPass;
@@ -278,7 +279,7 @@ static bool recalculateHash(tr_torrent* tor, tr_piece_index_t pieceIndex, uint8_
 
     while (bytesLeft != 0)
     {
-        size_t const len = MIN(bytesLeft, buflen);
+        size_t const len = std::min(bytesLeft, buflen);
         success = tr_cacheReadBlock(tor->session->cache, tor, pieceIndex, offset, len, static_cast<uint8_t*>(buffer)) == 0;
 
         if (!success)

--- a/libtransmission/jsonsl.h
+++ b/libtransmission/jsonsl.h
@@ -995,7 +995,7 @@ size_t jsonsl_util_unescape_ex(const char *in,
  * Convenience macro to avoid passing too many parameters
  */
 #define jsonsl_util_unescape(in, out, len, toEscape, err) \
-    jsonsl_util_unescape_ex(in, out, len, toEscape, NULL, err, NULL)
+    jsonsl_util_unescape_ex(in, out, len, toEscape, nullptr, err, nullptr)
 
 #endif /* JSONSL_NO_JPR */
 

--- a/libtransmission/list.cc
+++ b/libtransmission/list.cc
@@ -11,13 +11,13 @@
 #include "platform.h"
 #include "utils.h"
 
-static tr_list* recycled_nodes = NULL;
+static tr_list* recycled_nodes = nullptr;
 
 static tr_lock* getRecycledNodesLock(void)
 {
-    static tr_lock* l = NULL;
+    static tr_lock* l = nullptr;
 
-    if (l == NULL)
+    if (l == nullptr)
     {
         l = tr_lockNew();
     }
@@ -27,12 +27,12 @@ static tr_lock* getRecycledNodesLock(void)
 
 static tr_list* node_alloc(void)
 {
-    tr_list* ret = NULL;
+    tr_list* ret = nullptr;
     tr_lock* lock = getRecycledNodesLock();
 
     tr_lockLock(lock);
 
-    if (recycled_nodes != NULL)
+    if (recycled_nodes != nullptr)
     {
         ret = recycled_nodes;
         recycled_nodes = recycled_nodes->next;
@@ -40,7 +40,7 @@ static tr_list* node_alloc(void)
 
     tr_lockUnlock(lock);
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         ret = tr_new(tr_list, 1);
     }
@@ -53,7 +53,7 @@ static void node_free(tr_list* node)
 {
     tr_lock* lock = getRecycledNodesLock();
 
-    if (node != NULL)
+    if (node != nullptr)
     {
         *node = {};
         tr_lockLock(lock);
@@ -69,12 +69,12 @@ static void node_free(tr_list* node)
 
 void tr_list_free(tr_list** list, TrListForeachFunc data_free_func)
 {
-    while (*list != NULL)
+    while (*list != nullptr)
     {
         tr_list* node = *list;
         *list = (*list)->next;
 
-        if (data_free_func != NULL)
+        if (data_free_func != nullptr)
         {
             data_free_func(node->data);
         }
@@ -90,7 +90,7 @@ void tr_list_prepend(tr_list** list, void* data)
     node->data = data;
     node->next = *list;
 
-    if (*list != NULL)
+    if (*list != nullptr)
     {
         (*list)->prev = node;
     }
@@ -104,7 +104,7 @@ void tr_list_append(tr_list** list, void* data)
 
     node->data = data;
 
-    if (*list == NULL)
+    if (*list == nullptr)
     {
         *list = node;
     }
@@ -112,7 +112,7 @@ void tr_list_append(tr_list** list, void* data)
     {
         tr_list* l = *list;
 
-        while (l->next != NULL)
+        while (l->next != nullptr)
         {
             l = l->next;
         }
@@ -124,7 +124,7 @@ void tr_list_append(tr_list** list, void* data)
 
 static tr_list* tr_list_find_data(tr_list* list, void const* data)
 {
-    for (; list != NULL; list = list->next)
+    for (; list != nullptr; list = list->next)
     {
         if (list->data == data)
         {
@@ -132,21 +132,21 @@ static tr_list* tr_list_find_data(tr_list* list, void const* data)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 static void* tr_list_remove_node(tr_list** list, tr_list* node)
 {
     void* data;
-    tr_list* prev = node != NULL ? node->prev : NULL;
-    tr_list* next = node != NULL ? node->next : NULL;
+    tr_list* prev = node != nullptr ? node->prev : nullptr;
+    tr_list* next = node != nullptr ? node->next : nullptr;
 
-    if (prev != NULL)
+    if (prev != nullptr)
     {
         prev->next = next;
     }
 
-    if (next != NULL)
+    if (next != nullptr)
     {
         next->prev = prev;
     }
@@ -156,16 +156,16 @@ static void* tr_list_remove_node(tr_list** list, tr_list* node)
         *list = next;
     }
 
-    data = node != NULL ? node->data : NULL;
+    data = node != nullptr ? node->data : nullptr;
     node_free(node);
     return data;
 }
 
 void* tr_list_pop_front(tr_list** list)
 {
-    void* ret = NULL;
+    void* ret = nullptr;
 
-    if (*list != NULL)
+    if (*list != nullptr)
     {
         ret = (*list)->data;
         tr_list_remove_node(list, *list);
@@ -186,7 +186,7 @@ void* tr_list_remove(tr_list** list, void const* b, TrListCompareFunc compare_fu
 
 tr_list* tr_list_find(tr_list* list, void const* b, TrListCompareFunc func)
 {
-    for (; list != NULL; list = list->next)
+    for (; list != nullptr; list = list->next)
     {
         if (func(list->data, b) == 0)
         {
@@ -194,15 +194,15 @@ tr_list* tr_list_find(tr_list* list, void const* b, TrListCompareFunc func)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void tr_list_insert_sorted(tr_list** list, void* data, TrListCompareFunc compare)
 {
     /* find the node that we'll insert this data before */
-    tr_list* next_node = NULL;
+    tr_list* next_node = nullptr;
 
-    for (tr_list* l = *list; l != NULL; l = l->next)
+    for (tr_list* l = *list; l != nullptr; l = l->next)
     {
         int const c = (*compare)(data, l->data);
 
@@ -213,7 +213,7 @@ void tr_list_insert_sorted(tr_list** list, void* data, TrListCompareFunc compare
         }
     }
 
-    if (next_node == NULL)
+    if (next_node == nullptr)
     {
         tr_list_append(list, data);
     }
@@ -236,7 +236,7 @@ int tr_list_size(tr_list const* list)
 {
     int size = 0;
 
-    while (list != NULL)
+    while (list != nullptr)
     {
         ++size;
         list = list->next;

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -21,7 +21,7 @@
 tr_log_level __tr_message_level = TR_LOG_ERROR;
 
 static bool myQueueEnabled = false;
-static tr_log_message* myQueue = NULL;
+static tr_log_message* myQueue = nullptr;
 static tr_log_message** myQueueTail = &myQueue;
 static int myQueueLength = 0;
 
@@ -50,9 +50,9 @@ tr_log_level tr_logGetLevel(void)
 
 static tr_lock* getMessageLock(void)
 {
-    static tr_lock* l = NULL;
+    static tr_lock* l = nullptr;
 
-    if (l == NULL)
+    if (l == nullptr)
     {
         l = tr_lockNew();
     }
@@ -72,11 +72,11 @@ tr_sys_file_t tr_logGetFile(void)
         switch (fd)
         {
         case 1:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_OUT, NULL);
+            file = tr_sys_file_get_std(TR_STD_SYS_FILE_OUT, nullptr);
             break;
 
         case 2:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, NULL);
+            file = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, nullptr);
             break;
         }
 
@@ -107,7 +107,7 @@ tr_log_message* tr_logGetQueue(void)
     tr_lockLock(getMessageLock());
 
     ret = myQueue;
-    myQueue = NULL;
+    myQueue = nullptr;
     myQueueTail = &myQueue;
     myQueueLength = 0;
 
@@ -119,7 +119,7 @@ void tr_logFreeQueue(tr_log_message* list)
 {
     tr_log_message* next;
 
-    while (list != NULL)
+    while (list != nullptr)
     {
         next = list->next;
         tr_free(list->message);
@@ -170,12 +170,12 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
     if (fp != TR_BAD_SYS_FILE || IsDebuggerPresent())
     {
         struct evbuffer* buf = evbuffer_new();
-        char* base = tr_sys_path_basename(file, NULL);
+        char* base = tr_sys_path_basename(file, nullptr);
 
         char timestr[64];
         evbuffer_add_printf(buf, "[%s] ", tr_logGetTimeStr(timestr, sizeof(timestr)));
 
-        if (name != NULL)
+        if (name != nullptr)
         {
             evbuffer_add_printf(buf, "%s ", name);
         }
@@ -195,7 +195,7 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
 
         if (fp != TR_BAD_SYS_FILE)
         {
-            tr_sys_file_write(fp, message, message_len, NULL, NULL);
+            tr_sys_file_write(fp, message, message_len, nullptr, nullptr);
         }
 
         tr_free(message);
@@ -264,7 +264,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
             {
                 tr_log_message* old = myQueue;
                 myQueue = old->next;
-                old->next = NULL;
+                old->next = nullptr;
                 tr_logFreeQueue(old);
                 --myQueueLength;
                 TR_ASSERT(myQueueLength == TR_LOG_MAX_QUEUE_LENGTH);
@@ -279,21 +279,21 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 
             if (fp == TR_BAD_SYS_FILE)
             {
-                fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, NULL);
+                fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, nullptr);
             }
 
             tr_logGetTimeStr(timestr, sizeof(timestr));
 
-            if (name != NULL)
+            if (name != nullptr)
             {
-                tr_sys_file_write_fmt(fp, "[%s] %s: %s" TR_NATIVE_EOL_STR, NULL, timestr, name, buf);
+                tr_sys_file_write_fmt(fp, "[%s] %s: %s" TR_NATIVE_EOL_STR, nullptr, timestr, name, buf);
             }
             else
             {
-                tr_sys_file_write_fmt(fp, "[%s] %s" TR_NATIVE_EOL_STR, NULL, timestr, buf);
+                tr_sys_file_write_fmt(fp, "[%s] %s" TR_NATIVE_EOL_STR, nullptr, timestr, buf);
             }
 
-            tr_sys_file_flush(fp, NULL);
+            tr_sys_file_flush(fp, nullptr);
         }
     }
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -47,7 +47,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 #define tr_logAddTorInfo(tor, ...) tr_logAddTor(TR_LOG_INFO, tor, __VA_ARGS__)
 #define tr_logAddTorDbg(tor, ...) tr_logAddTor(TR_LOG_DEBUG, tor, __VA_ARGS__)
 
-#define tr_logAdd(level, ...) tr_logAddNamed(level, NULL, __VA_ARGS__)
+#define tr_logAdd(level, ...) tr_logAddNamed(level, nullptr, __VA_ARGS__)
 
 #define tr_logAddError(...) tr_logAdd(TR_LOG_ERROR, __VA_ARGS__)
 #define tr_logAddInfo(...) tr_logAdd(TR_LOG_INFO, __VA_ARGS__)

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -47,7 +47,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 #define tr_logAddTorInfo(tor, ...) tr_logAddTor(TR_LOG_INFO, tor, __VA_ARGS__)
 #define tr_logAddTorDbg(tor, ...) tr_logAddTor(TR_LOG_DEBUG, tor, __VA_ARGS__)
 
-#define tr_logAdd(level, ...) tr_logAddNamed(level, nullptr, __VA_ARGS__)
+#define tr_logAdd(level, ...) tr_logAddNamed(level, NULL, __VA_ARGS__)
 
 #define tr_logAddError(...) tr_logAdd(TR_LOG_ERROR, __VA_ARGS__)
 #define tr_logAddInfo(...) tr_logAdd(TR_LOG_INFO, __VA_ARGS__)

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -115,26 +115,26 @@ tr_magnet_info* tr_magnetParse(char const* uri)
     int wsCount = 0;
     char* tr[MAX_TRACKERS];
     char* ws[MAX_WEBSEEDS];
-    char* displayName = NULL;
+    char* displayName = nullptr;
     uint8_t sha1[SHA_DIGEST_LENGTH];
-    tr_magnet_info* info = NULL;
+    tr_magnet_info* info = nullptr;
 
-    if (uri != NULL && strncmp(uri, "magnet:?", 8) == 0)
+    if (uri != nullptr && strncmp(uri, "magnet:?", 8) == 0)
     {
         for (char const* walk = uri + 8; !tr_str_is_empty(walk);)
         {
             char const* key = walk;
             char const* delim = strchr(key, '=');
-            char const* val = delim == NULL ? NULL : delim + 1;
-            char const* next = strchr(delim == NULL ? key : val, '&');
+            char const* val = delim == nullptr ? nullptr : delim + 1;
+            char const* next = strchr(delim == nullptr ? key : val, '&');
             size_t keylen;
             size_t vallen;
 
-            if (delim != NULL)
+            if (delim != nullptr)
             {
                 keylen = (size_t)(delim - key);
             }
-            else if (next != NULL)
+            else if (next != nullptr)
             {
                 keylen = (size_t)(next - key);
             }
@@ -143,11 +143,11 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 keylen = strlen(key);
             }
 
-            if (val == NULL)
+            if (val == nullptr)
             {
                 vallen = 0;
             }
-            else if (next != NULL)
+            else if (next != nullptr)
             {
                 vallen = (size_t)(next - val);
             }
@@ -156,7 +156,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 vallen = strlen(val);
             }
 
-            if (keylen == 2 && memcmp(key, "xt", 2) == 0 && val != NULL && strncmp(val, "urn:btih:", 9) == 0)
+            if (keylen == 2 && memcmp(key, "xt", 2) == 0 && val != nullptr && strncmp(val, "urn:btih:", 9) == 0)
             {
                 char const* hash = val + 9;
                 size_t const hashlen = vallen - 9;
@@ -173,7 +173,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 }
             }
 
-            if (displayName == NULL && vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0)
+            if (displayName == nullptr && vallen > 0 && keylen == 2 && memcmp(key, "dn", 2) == 0)
             {
                 displayName = tr_http_unescape(val, vallen);
             }
@@ -197,7 +197,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 ws[wsCount++] = tr_http_unescape(val, vallen);
             }
 
-            walk = next != NULL ? next + 1 : NULL;
+            walk = next != nullptr ? next + 1 : nullptr;
         }
     }
 
@@ -231,7 +231,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
 
 void tr_magnetFree(tr_magnet_info* info)
 {
-    if (info != NULL)
+    if (info != nullptr)
     {
         for (int i = 0; i < info->trackerCount; ++i)
         {
@@ -287,7 +287,7 @@ void tr_magnetCreateMetainfo(tr_magnet_info const* info, tr_variant* top)
     d = tr_variantDictAddDict(top, TR_KEY_magnet_info, 2);
     tr_variantDictAddRaw(d, TR_KEY_info_hash, info->hash, 20);
 
-    if (info->displayName != NULL)
+    if (info->displayName != nullptr)
     {
         tr_variantDictAddStr(d, TR_KEY_display_name, info->displayName);
     }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -38,16 +38,16 @@ struct FileList
 
 static struct FileList* getFiles(char const* dir, char const* base, struct FileList* list)
 {
-    if (dir == NULL || base == NULL)
+    if (dir == nullptr || base == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
-    char* buf = tr_buildPath(dir, base, NULL);
+    char* buf = tr_buildPath(dir, base, nullptr);
     (void)tr_sys_path_native_separators(buf);
 
     tr_sys_path_info info;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
     if (!tr_sys_path_get_info(buf, 0, &info, &error))
     {
         tr_logAddError(_("Torrent Creator is skipping file \"%s\": %s"), buf, error->message);
@@ -56,13 +56,13 @@ static struct FileList* getFiles(char const* dir, char const* base, struct FileL
         return list;
     }
 
-    tr_sys_dir_t odir = info.type == TR_SYS_PATH_IS_DIRECTORY ? tr_sys_dir_open(buf, NULL) : TR_BAD_SYS_DIR;
+    tr_sys_dir_t odir = info.type == TR_SYS_PATH_IS_DIRECTORY ? tr_sys_dir_open(buf, nullptr) : TR_BAD_SYS_DIR;
 
     if (odir != TR_BAD_SYS_DIR)
     {
         char const* name;
 
-        while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (name[0] != '.') /* skip dotfiles */
             {
@@ -70,7 +70,7 @@ static struct FileList* getFiles(char const* dir, char const* base, struct FileL
             }
         }
 
-        tr_sys_dir_close(odir, NULL);
+        tr_sys_dir_close(odir, nullptr);
     }
     else if (info.type == TR_SYS_PATH_IS_FILE && info.size > 0)
     {
@@ -134,12 +134,12 @@ static int builderFileCompare(void const* va, void const* vb)
 
 tr_metainfo_builder* tr_metaInfoBuilderCreate(char const* topFileArg)
 {
-    char* const real_top = tr_sys_path_resolve(topFileArg, NULL);
+    char* const real_top = tr_sys_path_resolve(topFileArg, nullptr);
 
-    if (real_top == NULL)
+    if (real_top == nullptr)
     {
         /* TODO: Better error reporting */
-        return NULL;
+        return nullptr;
     }
 
     struct FileList* files;
@@ -149,20 +149,20 @@ tr_metainfo_builder* tr_metaInfoBuilderCreate(char const* topFileArg)
 
     {
         tr_sys_path_info info;
-        ret->isFolder = tr_sys_path_get_info(ret->top, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_DIRECTORY;
+        ret->isFolder = tr_sys_path_get_info(ret->top, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY;
     }
 
     /* build a list of files containing top file and,
        if it's a directory, all of its children */
     {
-        char* dir = tr_sys_path_dirname(ret->top, NULL);
-        char* base = tr_sys_path_basename(ret->top, NULL);
-        files = getFiles(dir, base, NULL);
+        char* dir = tr_sys_path_dirname(ret->top, nullptr);
+        char* base = tr_sys_path_basename(ret->top, nullptr);
+        files = getFiles(dir, base, nullptr);
         tr_free(base);
         tr_free(dir);
     }
 
-    for (struct FileList* walk = files; walk != NULL; walk = walk->next)
+    for (struct FileList* walk = files; walk != nullptr; walk = walk->next)
     {
         ++ret->fileCount;
     }
@@ -170,7 +170,7 @@ tr_metainfo_builder* tr_metaInfoBuilderCreate(char const* topFileArg)
     ret->files = tr_new0(tr_metainfo_builder_file, ret->fileCount);
 
     int i = 0;
-    while (files != NULL)
+    while (files != nullptr)
     {
         struct FileList* const tmp = files;
         files = files->next;
@@ -223,7 +223,7 @@ bool tr_metaInfoBuilderSetPieceSize(tr_metainfo_builder* b, uint32_t bytes)
 
 void tr_metaInfoBuilderFree(tr_metainfo_builder* builder)
 {
-    if (builder != NULL)
+    if (builder != nullptr)
     {
         for (uint32_t i = 0; i < builder->fileCount; ++i)
         {
@@ -255,7 +255,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
     uint8_t* ret = tr_new0(uint8_t, SHA_DIGEST_LENGTH * b->pieceCount);
     uint8_t* walk = ret;
     uint64_t off = 0;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     if (b->totalSize == 0)
     {
@@ -275,7 +275,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
         tr_free(buf);
         tr_free(ret);
         tr_error_free(error);
-        return NULL;
+        return nullptr;
     }
 
     while (totalRemain != 0)
@@ -290,7 +290,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
         {
             uint64_t const n_this_pass = MIN(b->files[fileIndex].size - off, leftInPiece);
             uint64_t n_read = 0;
-            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, NULL);
+            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, nullptr);
             bufptr += n_read;
             off += n_read;
             leftInPiece -= n_read;
@@ -298,7 +298,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
             if (off == b->files[fileIndex].size)
             {
                 off = 0;
-                tr_sys_file_close(fd, NULL);
+                tr_sys_file_close(fd, nullptr);
                 fd = TR_BAD_SYS_FILE;
 
                 if (++fileIndex < b->fileCount)
@@ -313,7 +313,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
                         tr_free(buf);
                         tr_free(ret);
                         tr_error_free(error);
-                        return NULL;
+                        return nullptr;
                     }
                 }
             }
@@ -321,7 +321,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
 
         TR_ASSERT(bufptr - buf == (int)thisPieceSize);
         TR_ASSERT(leftInPiece == 0);
-        tr_sha1(walk, buf, (int)thisPieceSize, NULL);
+        tr_sha1(walk, buf, (int)thisPieceSize, nullptr);
         walk += SHA_DIGEST_LENGTH;
 
         if (b->abortFlag)
@@ -339,7 +339,7 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
 
     if (fd != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
     }
 
     tr_free(buf);
@@ -374,7 +374,7 @@ static void getFileInfo(
         char* walk = filename;
         char const* token;
 
-        while ((token = tr_strsep(&walk, TR_PATH_DELIMITER_STR)) != NULL)
+        while ((token = tr_strsep(&walk, TR_PATH_DELIMITER_STR)) != nullptr)
         {
             if (!tr_str_is_empty(token))
             {
@@ -410,9 +410,9 @@ static void makeInfoDict(tr_variant* dict, tr_metainfo_builder* builder)
         tr_variantDictAddInt(dict, TR_KEY_length, builder->files[0].size);
     }
 
-    base = tr_sys_path_basename(builder->top, NULL);
+    base = tr_sys_path_basename(builder->top, nullptr);
 
-    if (base != NULL)
+    if (base != nullptr)
     {
         tr_variantDictAddStr(dict, TR_KEY_name, base);
         tr_free(base);
@@ -420,7 +420,7 @@ static void makeInfoDict(tr_variant* dict, tr_metainfo_builder* builder)
 
     tr_variantDictAddInt(dict, TR_KEY_piece_length, builder->pieceSize);
 
-    if ((pch = getHashInfo(builder)) != NULL)
+    if ((pch = getHashInfo(builder)) != nullptr)
     {
         tr_variantDictAddRaw(dict, TR_KEY_pieces, pch, SHA_DIGEST_LENGTH * builder->pieceCount);
         tr_free(pch);
@@ -456,7 +456,7 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
     if (builder->result == TR_MAKEMETA_OK && builder->trackerCount != 0)
     {
         int prevTier = -1;
-        tr_variant* tier = NULL;
+        tr_variant* tier = nullptr;
 
         if (builder->trackerCount > 1)
         {
@@ -485,7 +485,7 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
         }
 
         tr_variantDictAddStr(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
-        tr_variantDictAddInt(&top, TR_KEY_creation_date, time(NULL));
+        tr_variantDictAddInt(&top, TR_KEY_creation_date, time(nullptr));
         tr_variantDictAddStr(&top, TR_KEY_encoding, "UTF-8");
         makeInfoDict(tr_variantDictAddDict(&top, TR_KEY_info, 666), builder);
     }
@@ -516,15 +516,15 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
 ****
 ***/
 
-static tr_metainfo_builder* queue = NULL;
+static tr_metainfo_builder* queue = nullptr;
 
-static tr_thread* workerThread = NULL;
+static tr_thread* workerThread = nullptr;
 
 static tr_lock* getQueueLock(void)
 {
-    static tr_lock* lock = NULL;
+    static tr_lock* lock = nullptr;
 
-    if (lock == NULL)
+    if (lock == nullptr)
     {
         lock = tr_lockNew();
     }
@@ -538,13 +538,13 @@ static void makeMetaWorkerFunc(void* user_data)
 
     for (;;)
     {
-        tr_metainfo_builder* builder = NULL;
+        tr_metainfo_builder* builder = nullptr;
 
         /* find the next builder to process */
         tr_lock* lock = getQueueLock();
         tr_lockLock(lock);
 
-        if (queue != NULL)
+        if (queue != nullptr)
         {
             builder = queue;
             queue = queue->nextBuilder;
@@ -553,7 +553,7 @@ static void makeMetaWorkerFunc(void* user_data)
         tr_lockUnlock(lock);
 
         /* if no builders, this worker thread is done */
-        if (builder == NULL)
+        if (builder == nullptr)
         {
             break;
         }
@@ -561,7 +561,7 @@ static void makeMetaWorkerFunc(void* user_data)
         tr_realMakeMetaInfo(builder);
     }
 
-    workerThread = NULL;
+    workerThread = nullptr;
 }
 
 void tr_makeMetaInfo(
@@ -616,9 +616,9 @@ void tr_makeMetaInfo(
     builder->nextBuilder = queue;
     queue = builder;
 
-    if (workerThread == NULL)
+    if (workerThread == nullptr)
     {
-        workerThread = tr_threadNew(makeMetaWorkerFunc, NULL);
+        workerThread = tr_threadNew(makeMetaWorkerFunc, nullptr);
     }
 
     tr_lockUnlock(lock);

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -6,9 +6,10 @@
  *
  */
 
-#include <errno.h>
-#include <stdlib.h> /* qsort */
-#include <string.h> /* strcmp, strlen */
+#include <cerrno>
+#include <cstdlib> /* qsort */
+#include <cstring> /* strcmp, strlen */
+#include <algorithm>
 
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 
@@ -283,12 +284,12 @@ static uint8_t* getHashInfo(tr_metainfo_builder* b)
         TR_ASSERT(b->pieceIndex < b->pieceCount);
 
         uint8_t* bufptr = buf;
-        uint32_t const thisPieceSize = (uint32_t)MIN(b->pieceSize, totalRemain);
+        uint32_t const thisPieceSize = (uint32_t)std::min((unsigned long)b->pieceSize, totalRemain);
         uint64_t leftInPiece = thisPieceSize;
 
         while (leftInPiece != 0)
         {
-            uint64_t const n_this_pass = MIN(b->files[fileIndex].size - off, leftInPiece);
+            uint64_t const n_this_pass = std::min(b->files[fileIndex].size - off, leftInPiece);
             uint64_t n_read = 0;
             (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, nullptr);
             bufptr += n_read;

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -33,7 +33,7 @@
 
 static inline bool char_is_path_separator(char c)
 {
-    return strchr(PATH_DELIMITER_CHARS, c) != NULL;
+    return strchr(PATH_DELIMITER_CHARS, c) != nullptr;
 }
 
 static char* metainfoGetBasenameNameAndPartialHash(tr_info const* inf)
@@ -70,7 +70,7 @@ char* tr_metainfoGetBasename(tr_info const* inf, enum tr_metainfo_basename_forma
 
     default:
         TR_ASSERT_MSG(false, "unknown metainfo basename format %d", (int)format);
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -90,7 +90,7 @@ char* tr_metainfo_sanitize_path_component(char const* str, size_t len, bool* is_
 {
     if (len == 0 || (len == 1 && str[0] == '.'))
     {
-        return NULL;
+        return nullptr;
     }
 
     *is_adjusted = false;
@@ -109,7 +109,7 @@ char* tr_metainfo_sanitize_path_component(char const* str, size_t len, bool* is_
 
     for (size_t i = 0; i < len; ++i)
     {
-        if (strchr(reserved_chars, ret[i]) != NULL || (unsigned char)ret[i] < 0x20)
+        if (strchr(reserved_chars, ret[i]) != nullptr || (unsigned char)ret[i] < 0x20)
         {
             ret[i] = '_';
             *is_adjusted = true;
@@ -148,7 +148,7 @@ char* tr_metainfo_sanitize_path_component(char const* str, size_t len, bool* is_
     if (start_pos == end_pos)
     {
         tr_free(ret);
-        return NULL;
+        return nullptr;
     }
 
     if (start_pos != 0 || end_pos != len)
@@ -167,7 +167,7 @@ static bool getfile(char** setme, bool* is_adjusted, char const* root, tr_varian
     bool success = false;
     size_t root_len = 0;
 
-    *setme = NULL;
+    *setme = nullptr;
     *is_adjusted = false;
 
     if (tr_variantIsList(path))
@@ -190,7 +190,7 @@ static bool getfile(char** setme, bool* is_adjusted, char const* root, tr_varian
 
             bool is_component_adjusted;
             char* final_str = tr_metainfo_sanitize_path_component(str, len, &is_component_adjusted);
-            if (final_str == NULL)
+            if (final_str == nullptr)
             {
                 continue;
             }
@@ -233,19 +233,19 @@ static char const* parseFiles(tr_info* inf, tr_variant* files, tr_variant const*
 
     bool is_root_adjusted;
     char* const root_name = tr_metainfo_sanitize_path_component(inf->name, strlen(inf->name), &is_root_adjusted);
-    if (root_name == NULL)
+    if (root_name == nullptr)
     {
         return "path";
     }
 
-    char const* result = NULL;
+    char const* result = nullptr;
 
     if (tr_variantIsList(files)) /* multi-file mode */
     {
         struct evbuffer* buf;
 
         buf = evbuffer_new();
-        result = NULL;
+        result = nullptr;
 
         inf->isFolder = true;
         inf->fileCount = tr_variantListSize(files);
@@ -311,7 +311,7 @@ static char const* parseFiles(tr_info* inf, tr_variant* files, tr_variant const*
 
 static char* tr_convertAnnounceToScrape(char const* announce)
 {
-    char* scrape = NULL;
+    char* scrape = nullptr;
 
     /* To derive the scrape URL use the following steps:
      * Begin with the announce URL. Find the last '/' in it.
@@ -322,7 +322,7 @@ static char* tr_convertAnnounceToScrape(char const* announce)
 
     char const* s = strrchr(announce, '/');
 
-    if (s != NULL && strncmp(s + 1, "announce", 8) == 0)
+    if (s != nullptr && strncmp(s + 1, "announce", 8) == 0)
     {
         char const* prefix = announce;
         size_t const prefix_len = s + 1 - announce;
@@ -356,7 +356,7 @@ static char const* getannounce(tr_info* inf, tr_variant* meta)
 {
     size_t len;
     char const* str;
-    tr_tracker_info* trackers = NULL;
+    tr_tracker_info* trackers = nullptr;
     int trackerCount = 0;
     tr_variant* tiers;
 
@@ -416,7 +416,7 @@ static char const* getannounce(tr_info* inf, tr_variant* meta)
         if (trackerCount == 0)
         {
             tr_free(trackers);
-            trackers = NULL;
+            trackers = nullptr;
         }
     }
 
@@ -443,7 +443,7 @@ static char const* getannounce(tr_info* inf, tr_variant* meta)
     inf->trackers = trackers;
     inf->trackerCount = trackerCount;
 
-    return NULL;
+    return nullptr;
 }
 
 /**
@@ -461,7 +461,7 @@ static char* fix_webseed_url(tr_info const* inf, char const* url_in)
 {
     size_t len;
     char* url;
-    char* ret = NULL;
+    char* ret = nullptr;
 
     url = tr_strdup(url_in);
     tr_strstrip(url);
@@ -497,22 +497,22 @@ static void geturllist(tr_info* inf, tr_variant* meta)
 
         for (int i = 0; i < n; i++)
         {
-            if (tr_variantGetStr(tr_variantListChild(urls, i), &url, NULL))
+            if (tr_variantGetStr(tr_variantListChild(urls, i), &url, nullptr))
             {
                 char* fixed_url = fix_webseed_url(inf, url);
 
-                if (fixed_url != NULL)
+                if (fixed_url != nullptr)
                 {
                     inf->webseeds[inf->webseedCount++] = fixed_url;
                 }
             }
         }
     }
-    else if (tr_variantDictFindStr(meta, TR_KEY_url_list, &url, NULL)) /* handle single items in webseeds */
+    else if (tr_variantDictFindStr(meta, TR_KEY_url_list, &url, nullptr)) /* handle single items in webseeds */
     {
         char* fixed_url = fix_webseed_url(inf, url);
 
-        if (fixed_url != NULL)
+        if (fixed_url != nullptr)
         {
             inf->webseedCount = 1;
             inf->webseeds = tr_new0(char*, 1);
@@ -533,7 +533,7 @@ static char const* tr_metainfoParseImpl(
     char const* str;
     uint8_t const* raw;
     tr_variant* d;
-    tr_variant* infoDict = NULL;
+    tr_variant* infoDict = nullptr;
     tr_variant* meta = (tr_variant*)meta_in;
     bool b;
     bool isMagnet = false;
@@ -543,7 +543,7 @@ static char const* tr_metainfoParseImpl(
      * dictionary, given the definition of the info key above. */
     b = tr_variantDictFindDict(meta, TR_KEY_info, &infoDict);
 
-    if (hasInfoDict != NULL)
+    if (hasInfoDict != nullptr)
     {
         *hasInfoDict = b;
     }
@@ -578,12 +578,12 @@ static char const* tr_metainfoParseImpl(
                 inf->originalName = tr_strndup(str, len);
             }
 
-            if (inf->name == NULL)
+            if (inf->name == nullptr)
             {
                 inf->name = tr_strdup(inf->hashString);
             }
 
-            if (inf->originalName == NULL)
+            if (inf->originalName == nullptr)
             {
                 inf->originalName = tr_strdup(inf->hashString);
             }
@@ -597,10 +597,10 @@ static char const* tr_metainfoParseImpl(
     {
         size_t blen;
         char* bstr = tr_variantToStr(infoDict, TR_VARIANT_FMT_BENC, &blen);
-        tr_sha1(inf->hash, bstr, (int)blen, NULL);
+        tr_sha1(inf->hash, bstr, (int)blen, nullptr);
         tr_sha1_to_hex(inf->hashString, inf->hash);
 
-        if (infoDictLength != NULL)
+        if (infoDictLength != nullptr)
         {
             *infoDictLength = blen;
         }
@@ -707,7 +707,7 @@ static char const* tr_metainfoParseImpl(
     if (!isMagnet)
     {
         if ((str = parseFiles(inf, tr_variantDictFind(infoDict, TR_KEY_files), tr_variantDictFind(infoDict, TR_KEY_length))) !=
-            NULL)
+            nullptr)
         {
             return str;
         }
@@ -724,7 +724,7 @@ static char const* tr_metainfoParseImpl(
     }
 
     /* get announce or announce-list */
-    if ((str = getannounce(inf, meta)) != NULL)
+    if ((str = getannounce(inf, meta)) != nullptr)
     {
         return str;
     }
@@ -734,9 +734,9 @@ static char const* tr_metainfoParseImpl(
 
     /* filename of Transmission's copy */
     tr_free(inf->torrent);
-    inf->torrent = session != NULL ? getTorrentFilename(session, inf, TR_METAINFO_BASENAME_HASH) : NULL;
+    inf->torrent = session != nullptr ? getTorrentFilename(session, inf, TR_METAINFO_BASENAME_HASH) : nullptr;
 
-    return NULL;
+    return nullptr;
 }
 
 bool tr_metainfoParse(
@@ -747,9 +747,9 @@ bool tr_metainfoParse(
     size_t* infoDictLength)
 {
     char const* badTag = tr_metainfoParseImpl(session, inf, hasInfoDict, infoDictLength, meta_in);
-    bool const success = badTag == NULL;
+    bool const success = badTag == nullptr;
 
-    if (badTag != NULL)
+    if (badTag != nullptr)
     {
         tr_logAddNamedError(inf->name, _("Invalid metadata entry \"%s\""), badTag);
         tr_metainfoFree(inf);
@@ -795,11 +795,11 @@ void tr_metainfoRemoveSaved(tr_session const* session, tr_info const* inf)
     char* filename;
 
     filename = getTorrentFilename(session, inf, TR_METAINFO_BASENAME_HASH);
-    tr_sys_path_remove(filename, NULL);
+    tr_sys_path_remove(filename, nullptr);
     tr_free(filename);
 
     filename = getTorrentFilename(session, inf, TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH);
-    tr_sys_path_remove(filename, NULL);
+    tr_sys_path_remove(filename, nullptr);
     tr_free(filename);
 }
 
@@ -812,7 +812,7 @@ void tr_metainfoMigrateFile(
     char* old_filename = getTorrentFilename(session, info, old_format);
     char* new_filename = getTorrentFilename(session, info, new_format);
 
-    if (tr_sys_path_rename(old_filename, new_filename, NULL))
+    if (tr_sys_path_rename(old_filename, new_filename, nullptr))
     {
         tr_logAddNamedError(info->name, "Migrated torrent file from \"%s\" to \"%s\"", old_filename, new_filename);
     }

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -98,7 +98,7 @@ struct tr_natpmp* tr_natpmpInit(void)
 
 void tr_natpmpClose(tr_natpmp* nat)
 {
-    if (nat != NULL)
+    if (nat != nullptr)
     {
         closenatpmp(&nat->natpmp);
         tr_free(nat);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -62,7 +62,7 @@ char* tr_net_strerror(char* buf, size_t buflen, int err)
 
 #ifdef _WIN32
 
-    DWORD len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, buf, buflen, NULL);
+    DWORD len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, 0, buf, buflen, nullptr);
 
     while (len > 0 && buf[len - 1] >= '\0' && buf[len - 1] <= ' ')
     {
@@ -319,8 +319,8 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
     addrlen = setup_sockaddr(addr, port, &sock);
 
     /* set source address */
-    source_addr = tr_sessionGetPublicAddress(session, addr->type, NULL);
-    TR_ASSERT(source_addr != NULL);
+    source_addr = tr_sessionGetPublicAddress(session, addr->type, nullptr);
+    TR_ASSERT(source_addr != nullptr);
     sourcelen = setup_sockaddr(source_addr, 0, &source_sock);
 
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
@@ -364,7 +364,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
     {
         char addrstr[TR_ADDRSTRLEN];
         tr_address_and_port_to_string(addrstr, sizeof(addrstr), addr, port);
-        tr_logAddDeep(__FILE__, __LINE__, NULL, "New OUTGOING connection %" PRIdMAX " (%s)", (intmax_t)s, addrstr);
+        tr_logAddDeep(__FILE__, __LINE__, nullptr, "New OUTGOING connection %" PRIdMAX " (%s)", (intmax_t)s, addrstr);
     }
 
     return ret;
@@ -382,7 +382,7 @@ struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address co
         socklen_t const sslen = setup_sockaddr(addr, port, &ss);
         struct UTPSocket* const socket = UTP_Create(tr_utpSendTo, session, (struct sockaddr*)&ss, sslen);
 
-        if (socket != NULL)
+        if (socket != nullptr)
         {
             ret = tr_peer_socket_utp_create(socket);
         }
@@ -451,10 +451,10 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
             }
             else
             {
-                hint = NULL;
+                hint = nullptr;
             }
 
-            if (hint == NULL)
+            if (hint == nullptr)
             {
                 fmt = _("Couldn't bind port %d on %s: %s");
             }
@@ -726,7 +726,7 @@ unsigned char const* tr_globalIPv6(void)
         last_time = now;
     }
 
-    return have_ipv6 ? ipv6 : NULL;
+    return have_ipv6 ? ipv6 : nullptr;
 }
 
 /***
@@ -786,7 +786,7 @@ struct tr_peer_socket tr_peer_socket_tcp_create(tr_socket_t const handle)
 
 struct tr_peer_socket tr_peer_socket_utp_create(struct UTPSocket* const handle)
 {
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     auto ret = tr_peer_socket{ TR_PEER_SOCKET_TYPE_UTP, {} };
     ret.handle.utp = handle;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -114,7 +114,7 @@ bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);
 
 static inline bool tr_address_is_valid(tr_address const* a)
 {
-    return a != NULL && (a->type == TR_AF_INET || a->type == TR_AF_INET6);
+    return a != nullptr && (a->type == TR_AF_INET || a->type == TR_AF_INET6);
 }
 
 /***********************************************************************

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -6,14 +6,15 @@
  *
  */
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
+#include <algorithm>
 
 #include <event2/event.h>
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 #include "transmission.h"
@@ -158,7 +159,7 @@ static void didWriteWrapper(tr_peerIo* io, unsigned int bytes_transferred)
     {
         struct tr_datatype* next = io->outbuf_datatypes;
 
-        unsigned int const payload = MIN(next->length, bytes_transferred);
+        unsigned int const payload = std::min(next->length, (unsigned long)bytes_transferred);
         /* For uTP sockets, the overhead is computed in utp_on_overhead. */
         unsigned int const overhead = io->socket.type == TR_PEER_SOCKET_TYPE_TCP ? guessPacketOverhead(payload) : 0;
         uint64_t const now = tr_time_msec();
@@ -1097,7 +1098,7 @@ static unsigned int getDesiredOutputBufferSize(tr_peerIo const* io, uint64_t now
     unsigned int const period = 15U; /* arbitrary */
     /* the 3 is arbitrary; the .5 is to leave room for messages */
     static unsigned int const ceiling = (unsigned int)(MAX_BLOCK_SIZE * 3.5);
-    return MAX(ceiling, currentSpeed_Bps * period);
+    return std::max(ceiling, currentSpeed_Bps * period);
 }
 
 size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now)
@@ -1301,7 +1302,7 @@ void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byteCount)
 
     while (byteCount > 0)
     {
-        size_t const thisPass = MIN(byteCount, buflen);
+        size_t const thisPass = std::min(byteCount, buflen);
         tr_peerIoReadBytes(io, inbuf, buf, thisPass);
         byteCount -= thisPass;
     }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -92,13 +92,13 @@ struct tr_datatype
     bool isPieceData;
 };
 
-static struct tr_datatype* datatype_pool = NULL;
+static struct tr_datatype* datatype_pool = nullptr;
 
 static struct tr_datatype* datatype_new(void)
 {
     struct tr_datatype* ret;
 
-    if (datatype_pool == NULL)
+    if (datatype_pool == nullptr)
     {
         ret = tr_new(struct tr_datatype, 1);
     }
@@ -122,7 +122,7 @@ static void peer_io_pull_datatype(tr_peerIo* io)
 {
     struct tr_datatype* tmp;
 
-    if ((tmp = io->outbuf_datatypes) != NULL)
+    if ((tmp = io->outbuf_datatypes) != nullptr)
     {
         io->outbuf_datatypes = tmp->next;
         datatype_free(tmp);
@@ -133,9 +133,9 @@ static void peer_io_push_datatype(tr_peerIo* io, struct tr_datatype* datatype)
 {
     struct tr_datatype* tmp;
 
-    if ((tmp = io->outbuf_datatypes) != NULL)
+    if ((tmp = io->outbuf_datatypes) != nullptr)
     {
-        while (tmp->next != NULL)
+        while (tmp->next != nullptr)
         {
             tmp = tmp->next;
         }
@@ -170,7 +170,7 @@ static void didWriteWrapper(tr_peerIo* io, unsigned int bytes_transferred)
             tr_bandwidthUsed(&io->bandwidth, TR_UP, overhead, false, now);
         }
 
-        if (io->didWrite != NULL)
+        if (io->didWrite != nullptr)
         {
             io->didWrite(io, payload, next->isPieceData, io->userData);
         }
@@ -201,7 +201,7 @@ static void canReadWrapper(tr_peerIo* io)
     session = io->session;
 
     /* try to consume the input buffer */
-    if (io->canRead != NULL)
+    if (io->canRead != nullptr)
     {
         uint64_t const now = tr_time_msec();
 
@@ -334,7 +334,7 @@ static void event_read_cb(evutil_socket_t fd, short event, void* vio)
             e,
             tr_net_strerror(errstr, sizeof(errstr), e));
 
-        if (io->gotError != NULL)
+        if (io->gotError != nullptr)
         {
             io->gotError(io, what, io->userData);
         }
@@ -431,7 +431,7 @@ FAIL:
     tr_net_strerror(errstr, sizeof(errstr), e);
     dbgmsg(io, "event_write_cb got an error. res is %d, what is %hd, errno is %d (%s)", res, what, e, errstr);
 
-    if (io->gotError != NULL)
+    if (io->gotError != nullptr)
     {
         io->gotError(io, what, io->userData);
     }
@@ -535,7 +535,7 @@ static void utp_on_state_change(void* vio, int state)
     }
     else if (state == UTP_STATE_EOF)
     {
-        if (io->gotError != NULL)
+        if (io->gotError != nullptr)
         {
             io->gotError(io, BEV_EVENT_EOF, io->userData);
         }
@@ -559,7 +559,7 @@ static void utp_on_error(void* vio, int errcode)
 
     dbgmsg(io, "utp_on_error -- errcode is %d", errcode);
 
-    if (io->gotError != NULL)
+    if (io->gotError != nullptr)
     {
         errno = errcode;
         io->gotError(io, BEV_EVENT_ERROR, io->userData);
@@ -650,8 +650,8 @@ static tr_peerIo* tr_peerIoNew(
     bool isSeed,
     struct tr_peer_socket const socket)
 {
-    TR_ASSERT(session != NULL);
-    TR_ASSERT(session->events != NULL);
+    TR_ASSERT(session != nullptr);
+    TR_ASSERT(session->events != nullptr);
     TR_ASSERT(tr_amInEventThread(session));
 
 #ifdef WITH_UTP
@@ -723,10 +723,10 @@ tr_peerIo* tr_peerIoNewIncoming(
     tr_port port,
     struct tr_peer_socket const socket)
 {
-    TR_ASSERT(session != NULL);
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_address_is_valid(addr));
 
-    return tr_peerIoNew(session, parent, addr, port, NULL, true, false, socket);
+    return tr_peerIoNew(session, parent, addr, port, nullptr, true, false, socket);
 }
 
 tr_peerIo* tr_peerIoNewOutgoing(
@@ -738,9 +738,9 @@ tr_peerIo* tr_peerIoNewOutgoing(
     bool isSeed,
     bool utp)
 {
-    TR_ASSERT(session != NULL);
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_address_is_valid(addr));
-    TR_ASSERT(torrentHash != NULL);
+    TR_ASSERT(torrentHash != nullptr);
 
     auto socket = tr_peer_socket{};
 
@@ -753,14 +753,14 @@ tr_peerIo* tr_peerIoNewOutgoing(
     {
         socket = tr_netOpenPeerSocket(session, addr, port, isSeed);
         dbgmsg(
-            NULL,
+            nullptr,
             "tr_netOpenPeerSocket returned fd %" PRIdMAX,
             (intmax_t)(socket.type != TR_PEER_SOCKET_TYPE_NONE ? socket.handle.tcp : TR_BAD_SOCKET));
     }
 
     if (socket.type == TR_PEER_SOCKET_TYPE_NONE)
     {
-        return NULL;
+        return nullptr;
     }
 
     return tr_peerIoNew(session, parent, addr, port, torrentHash, false, isSeed, socket);
@@ -773,8 +773,8 @@ tr_peerIo* tr_peerIoNewOutgoing(
 static void event_enable(tr_peerIo* io, short event)
 {
     TR_ASSERT(tr_amInEventThread(io->session));
-    TR_ASSERT(io->session != NULL);
-    TR_ASSERT(io->session->events != NULL);
+    TR_ASSERT(io->session != nullptr);
+    TR_ASSERT(io->session->events != nullptr);
 
     bool const need_events = io->socket.type == TR_PEER_SOCKET_TYPE_TCP;
 
@@ -790,7 +790,7 @@ static void event_enable(tr_peerIo* io, short event)
 
         if (need_events)
         {
-            event_add(io->event_read, NULL);
+            event_add(io->event_read, nullptr);
         }
 
         io->pendingEvents |= EV_READ;
@@ -802,7 +802,7 @@ static void event_enable(tr_peerIo* io, short event)
 
         if (need_events)
         {
-            event_add(io->event_write, NULL);
+            event_add(io->event_write, nullptr);
         }
 
         io->pendingEvents |= EV_WRITE;
@@ -812,8 +812,8 @@ static void event_enable(tr_peerIo* io, short event)
 static void event_disable(struct tr_peerIo* io, short event)
 {
     TR_ASSERT(tr_amInEventThread(io->session));
-    TR_ASSERT(io->session != NULL);
-    TR_ASSERT(io->session->events != NULL);
+    TR_ASSERT(io->session != nullptr);
+    TR_ASSERT(io->session->events != nullptr);
 
     bool const need_events = io->socket.type == TR_PEER_SOCKET_TYPE_TCP;
 
@@ -853,7 +853,7 @@ void tr_peerIoSetEnabled(tr_peerIo* io, tr_direction dir, bool isEnabled)
     TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(tr_isDirection(dir));
     TR_ASSERT(tr_amInEventThread(io->session));
-    TR_ASSERT(io->session->events != NULL);
+    TR_ASSERT(io->session->events != nullptr);
 
     short const event = dir == TR_UP ? EV_WRITE : EV_READ;
 
@@ -885,7 +885,7 @@ static void io_close_socket(tr_peerIo* io)
 #ifdef WITH_UTP
 
     case TR_PEER_SOCKET_TYPE_UTP:
-        UTP_SetCallbacks(io->socket.handle.utp, &dummy_utp_function_table, NULL);
+        UTP_SetCallbacks(io->socket.handle.utp, &dummy_utp_function_table, nullptr);
         UTP_Close(io->socket.handle.utp);
         break;
 
@@ -897,16 +897,16 @@ static void io_close_socket(tr_peerIo* io)
 
     io->socket = {};
 
-    if (io->event_read != NULL)
+    if (io->event_read != nullptr)
     {
         event_free(io->event_read);
-        io->event_read = NULL;
+        io->event_read = nullptr;
     }
 
-    if (io->event_write != NULL)
+    if (io->event_write != nullptr)
     {
         event_free(io->event_write);
-        io->event_write = NULL;
+        io->event_write = nullptr;
     }
 }
 
@@ -916,7 +916,7 @@ static void io_dtor(void* vio)
 
     TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(tr_amInEventThread(io->session));
-    TR_ASSERT(io->session->events != NULL);
+    TR_ASSERT(io->session->events != nullptr);
 
     dbgmsg(io, "in tr_peerIo destructor");
     event_disable(io, EV_READ | EV_WRITE);
@@ -926,7 +926,7 @@ static void io_dtor(void* vio)
     io_close_socket(io);
     tr_cryptoDestruct(&io->crypto);
 
-    while (io->outbuf_datatypes != NULL)
+    while (io->outbuf_datatypes != nullptr)
     {
         peer_io_pull_datatype(io);
     }
@@ -937,12 +937,12 @@ static void io_dtor(void* vio)
 
 static void tr_peerIoFree(tr_peerIo* io)
 {
-    if (io != NULL)
+    if (io != nullptr)
     {
         dbgmsg(io, "in tr_peerIoFree");
-        io->canRead = NULL;
-        io->didWrite = NULL;
-        io->gotError = NULL;
+        io->canRead = nullptr;
+        io->didWrite = nullptr;
+        io->gotError = nullptr;
         tr_runInEventThread(io->session, io_dtor, io);
     }
 }
@@ -972,7 +972,7 @@ tr_address const* tr_peerIoGetAddress(tr_peerIo const* io, tr_port* port)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
-    if (port != NULL)
+    if (port != nullptr)
     {
         *port = io->port;
     }
@@ -1004,7 +1004,7 @@ void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb w
 
 void tr_peerIoClear(tr_peerIo* io)
 {
-    tr_peerIoSetIOFuncs(io, NULL, NULL, NULL, NULL);
+    tr_peerIoSetIOFuncs(io, nullptr, nullptr, nullptr, nullptr);
     tr_peerIoSetEnabled(io, TR_UP, false);
     tr_peerIoSetEnabled(io, TR_DOWN, false);
 }
@@ -1071,7 +1071,7 @@ void tr_peerIoSetPeersId(tr_peerIo* io, uint8_t const* peer_id)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
-    if (peer_id == NULL)
+    if (peer_id == nullptr)
     {
         memset(io->peerId, '\0', sizeof(io->peerId));
         io->peerIdIsSet = false;
@@ -1346,7 +1346,7 @@ static int tr_peerIoTryRead(tr_peerIo* io, size_t howmuch)
                     canReadWrapper(io);
                 }
 
-                if (res <= 0 && io->gotError != NULL && e != EAGAIN && e != EINTR && e != EINPROGRESS)
+                if (res <= 0 && io->gotError != nullptr && e != EAGAIN && e != EINTR && e != EINPROGRESS)
                 {
                     short what = BEV_EVENT_READING | BEV_EVENT_ERROR;
 
@@ -1410,7 +1410,7 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch)
                     didWriteWrapper(io, n);
                 }
 
-                if (n < 0 && io->gotError != NULL && e != 0 && e != EPIPE && e != EAGAIN && e != EINTR && e != EINPROGRESS)
+                if (n < 0 && io->gotError != nullptr && e != 0 && e != EPIPE && e != EAGAIN && e != EINTR && e != EINPROGRESS)
                 {
                     char errstr[512];
                     short const what = BEV_EVENT_WRITING | BEV_EVENT_ERROR;
@@ -1463,7 +1463,7 @@ int tr_peerIoFlushOutgoingProtocolMsgs(tr_peerIo* io)
 
     /* count up how many bytes are used by non-piece-data messages
        at the front of our outbound queue */
-    for (struct tr_datatype const* it = io->outbuf_datatypes; it != NULL; it = it->next)
+    for (struct tr_datatype const* it = io->outbuf_datatypes; it != nullptr; it = it->next)
     {
         if (it->isPieceData)
         {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -134,7 +134,7 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io);
 
 static inline bool tr_isPeerIo(tr_peerIo const* io)
 {
-    return io != NULL && io->magicNumber == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 && tr_isBandwidth(&io->bandwidth) &&
+    return io != nullptr && io->magicNumber == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 && tr_isBandwidth(&io->bandwidth) &&
         tr_address_is_valid(&io->addr);
 }
 
@@ -184,7 +184,7 @@ static inline bool tr_peerIoSupportsUTP(tr_peerIo const* io)
 static inline tr_session* tr_peerIoGetSession(tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
-    TR_ASSERT(io->session != NULL);
+    TR_ASSERT(io->session != nullptr);
 
     return io->session;
 }
@@ -254,7 +254,7 @@ void tr_peerIoSetEncryption(tr_peerIo* io, tr_encryption_type encryption_type);
 
 static inline bool tr_peerIoIsEncrypted(tr_peerIo const* io)
 {
-    return io != NULL && io->encryption_type == PEER_ENCRYPTION_RC4;
+    return io != nullptr && io->encryption_type == PEER_ENCRYPTION_RC4;
 }
 
 void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t byte);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -127,7 +127,7 @@ struct peer_atom
 
 static bool tr_isAtom(struct peer_atom const* atom)
 {
-    return atom != NULL && atom->fromFirst < TR_PEER_FROM__MAX && atom->fromBest < TR_PEER_FROM__MAX &&
+    return atom != nullptr && atom->fromFirst < TR_PEER_FROM__MAX && atom->fromBest < TR_PEER_FROM__MAX &&
         tr_address_is_valid(&atom->addr);
 }
 
@@ -136,7 +136,7 @@ static bool tr_isAtom(struct peer_atom const* atom)
 static char const* tr_atomAddrStr(struct peer_atom const* atom)
 {
     static char addrstr[TR_ADDRSTRLEN];
-    return atom != NULL ? tr_address_and_port_to_string(addrstr, sizeof(addrstr), &atom->addr, atom->port) : "[no atom]";
+    return atom != nullptr ? tr_address_and_port_to_string(addrstr, sizeof(addrstr), &atom->addr, atom->port) : "[no atom]";
 }
 
 struct block_request
@@ -219,7 +219,7 @@ struct tr_peerMgr
 
 #define tordbg(t, ...) tr_logAddDeepNamed(tr_torrentName((t)->tor), __VA_ARGS__)
 
-#define dbgmsg(...) tr_logAddDeepNamed(NULL, __VA_ARGS__)
+#define dbgmsg(...) tr_logAddDeepNamed(nullptr, __VA_ARGS__)
 
 /**
 *** tr_peer virtual functions
@@ -227,8 +227,8 @@ struct tr_peerMgr
 
 static bool tr_peerIsTransferringPieces(tr_peer const* peer, uint64_t now, tr_direction direction, unsigned int* Bps)
 {
-    TR_ASSERT(peer != NULL);
-    TR_ASSERT(peer->funcs != NULL);
+    TR_ASSERT(peer != nullptr);
+    TR_ASSERT(peer->funcs != nullptr);
 
     return (*peer->funcs->is_transferring_pieces)(peer, now, direction, Bps);
 }
@@ -242,8 +242,8 @@ unsigned int tr_peerGetPieceSpeed_Bps(tr_peer const* peer, uint64_t now, tr_dire
 
 static void tr_peerFree(tr_peer* peer)
 {
-    TR_ASSERT(peer != NULL);
-    TR_ASSERT(peer->funcs != NULL);
+    TR_ASSERT(peer != nullptr);
+    TR_ASSERT(peer->funcs != nullptr);
 
     (*peer->funcs->destruct)(peer);
 
@@ -252,7 +252,7 @@ static void tr_peerFree(tr_peer* peer)
 
 void tr_peerConstruct(tr_peer* peer, tr_torrent const* tor)
 {
-    TR_ASSERT(peer != NULL);
+    TR_ASSERT(peer != nullptr);
     TR_ASSERT(tr_isTorrent(tor));
 
     memset(peer, 0, sizeof(tr_peer));
@@ -267,9 +267,9 @@ static void peerDeclinedAllRequests(tr_swarm*, tr_peer const*);
 
 void tr_peerDestruct(tr_peer* peer)
 {
-    TR_ASSERT(peer != NULL);
+    TR_ASSERT(peer != nullptr);
 
-    if (peer->swarm != NULL)
+    if (peer->swarm != nullptr)
     {
         peerDeclinedAllRequests(peer->swarm, peer);
     }
@@ -277,9 +277,9 @@ void tr_peerDestruct(tr_peer* peer)
     tr_bitfieldDestruct(&peer->have);
     tr_bitfieldDestruct(&peer->blame);
 
-    if (peer->atom != NULL)
+    if (peer->atom != nullptr)
     {
-        peer->atom->peer = NULL;
+        peer->atom->peer = nullptr;
     }
 }
 
@@ -338,7 +338,7 @@ static inline tr_handshake* getExistingHandshake(tr_ptrArray* handshakes, tr_add
 {
     if (tr_ptrArrayEmpty(handshakes))
     {
-        return NULL;
+        return nullptr;
     }
 
     return static_cast<tr_handshake*>(tr_ptrArrayFindSorted(handshakes, addr, handshakeCompareToAddr));
@@ -374,7 +374,7 @@ static tr_swarm* getExistingSwarm(tr_peerMgr* manager, uint8_t const* hash)
 {
     tr_torrent* tor = tr_torrentFindFromHash(manager->session, hash);
 
-    return tor == NULL ? NULL : tor->swarm;
+    return tor == nullptr ? nullptr : tor->swarm;
 }
 
 static int peerCompare(void const* va, void const* vb)
@@ -396,19 +396,19 @@ static bool peerIsInUse(tr_swarm const* cs, struct peer_atom const* atom)
 
     TR_ASSERT(swarmIsLocked(s));
 
-    return atom->peer != NULL || getExistingHandshake(&s->outgoingHandshakes, &atom->addr) != NULL ||
-        getExistingHandshake(&s->manager->incomingHandshakes, &atom->addr) != NULL;
+    return atom->peer != nullptr || getExistingHandshake(&s->outgoingHandshakes, &atom->addr) != nullptr ||
+        getExistingHandshake(&s->manager->incomingHandshakes, &atom->addr) != nullptr;
 }
 
 static inline bool replicationExists(tr_swarm const* s)
 {
-    return s->pieceReplication != NULL;
+    return s->pieceReplication != nullptr;
 }
 
 static void replicationFree(tr_swarm* s)
 {
     tr_free(s->pieceReplication);
-    s->pieceReplication = NULL;
+    s->pieceReplication = nullptr;
     s->pieceReplicationSize = 0;
 }
 
@@ -444,7 +444,7 @@ static void swarmFree(void* vs)
 {
     auto* s = static_cast<tr_swarm*>(vs);
 
-    TR_ASSERT(s != NULL);
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(!s->isRunning);
     TR_ASSERT(swarmIsLocked(s));
     TR_ASSERT(tr_ptrArrayEmpty(&s->outgoingHandshakes));
@@ -452,8 +452,8 @@ static void swarmFree(void* vs)
 
     tr_ptrArrayDestruct(&s->webseeds, (PtrArrayForeachFunc)tr_peerFree);
     tr_ptrArrayDestruct(&s->pool, (PtrArrayForeachFunc)tr_free);
-    tr_ptrArrayDestruct(&s->outgoingHandshakes, NULL);
-    tr_ptrArrayDestruct(&s->peers, NULL);
+    tr_ptrArrayDestruct(&s->outgoingHandshakes, nullptr);
+    tr_ptrArrayDestruct(&s->peers, nullptr);
     s->stats = {};
 
     replicationFree(s);
@@ -512,10 +512,10 @@ tr_peerMgr* tr_peerMgrNew(tr_session* session)
 
 static void deleteTimer(struct event** t)
 {
-    if (*t != NULL)
+    if (*t != nullptr)
     {
         event_free(*t);
-        *t = NULL;
+        *t = nullptr;
     }
 }
 
@@ -540,7 +540,7 @@ void tr_peerMgrFree(tr_peerMgr* manager)
         tr_handshakeAbort(static_cast<tr_handshake*>(tr_ptrArrayNth(&manager->incomingHandshakes, 0)));
     }
 
-    tr_ptrArrayDestruct(&manager->incomingHandshakes, NULL);
+    tr_ptrArrayDestruct(&manager->incomingHandshakes, nullptr);
 
     managerUnlock(manager);
     tr_free(manager);
@@ -552,12 +552,12 @@ void tr_peerMgrFree(tr_peerMgr* manager)
 
 void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
 {
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
     tr_session* session = mgr->session;
 
     /* we cache whether or not a peer is blocklisted...
        since the blocklist has changed, erase that cached value */
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         tr_swarm* s = tor->swarm;
 
@@ -601,7 +601,7 @@ bool tr_peerMgrPeerIsSeed(tr_torrent const* tor, tr_address const* addr)
     tr_swarm const* s = tor->swarm;
     struct peer_atom const* atom = getExistingAtom(s, addr);
 
-    if (atom != NULL)
+    if (atom != nullptr)
     {
         isSeed = atomIsSeed(atom);
     }
@@ -613,7 +613,7 @@ void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const* addr)
 {
     struct peer_atom* atom = getExistingAtom(tor->swarm, addr);
 
-    if (atom != NULL)
+    if (atom != nullptr)
     {
         atom->flags |= ADDED_F_UTP_FLAGS;
     }
@@ -623,7 +623,7 @@ void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const* addr, bool failed
 {
     struct peer_atom* atom = getExistingAtom(tor->swarm, addr);
 
-    if (atom != NULL)
+    if (atom != nullptr)
     {
         atom->utp_failed = failed;
     }
@@ -705,7 +705,7 @@ static void requestListAdd(tr_swarm* s, tr_block_index_t block, tr_peer* peer)
         s->requests[pos] = key;
     }
 
-    if (peer != NULL)
+    if (peer != nullptr)
     {
         ++peer->pendingReqsToPeer;
         TR_ASSERT(peer->pendingReqsToPeer >= 0);
@@ -733,7 +733,7 @@ static void getBlockRequestPeers(tr_swarm* s, tr_block_index_t block, tr_ptrArra
     struct block_request key;
 
     key.block = block;
-    key.peer = NULL;
+    key.peer = nullptr;
     pos = tr_lowerBound(&key, s->requests, s->requestCount, sizeof(struct block_request), compareReqByBlock, &exact);
 
     TR_ASSERT(!exact); /* shouldn't have a request with .peer == NULL */
@@ -751,7 +751,7 @@ static void getBlockRequestPeers(tr_swarm* s, tr_block_index_t block, tr_ptrArra
 
 static void decrementPendingReqCount(struct block_request const* b)
 {
-    if ((b->peer != NULL) && (b->peer->pendingReqsToPeer > 0))
+    if ((b->peer != nullptr) && (b->peer->pendingReqsToPeer > 0))
     {
         --b->peer->pendingReqsToPeer;
     }
@@ -761,7 +761,7 @@ static void requestListRemove(tr_swarm* s, tr_block_index_t block, tr_peer const
 {
     struct block_request const* b = requestListLookup(s, block, peer);
 
-    if (b != NULL)
+    if (b != nullptr)
     {
         int const pos = b - s->requests;
         TR_ASSERT(pos < s->requestCount);
@@ -783,7 +783,7 @@ static int countActiveWebseeds(tr_swarm* s)
 
         for (int i = 0, n = tr_ptrArraySize(&s->webseeds); i < n; ++i)
         {
-            if (tr_peerIsTransferringPieces(static_cast<tr_peer const*>(tr_ptrArrayNth(&s->webseeds, i)), now, TR_DOWN, NULL))
+            if (tr_peerIsTransferringPieces(static_cast<tr_peer const*>(tr_ptrArrayNth(&s->webseeds, i)), now, TR_DOWN, nullptr))
             {
                 ++activeCount;
             }
@@ -954,7 +954,7 @@ static void pieceListSort(tr_swarm* s, enum piece_sort_state state)
 {
     TR_ASSERT(state == PIECES_SORTED_BY_INDEX || state == PIECES_SORTED_BY_WEIGHT);
 
-    if ((s->pieceCount > 0) && (s->pieces != NULL))
+    if ((s->pieceCount > 0) && (s->pieces != nullptr))
     {
         if (state == PIECES_SORTED_BY_WEIGHT)
         {
@@ -1036,7 +1036,7 @@ static struct weighted_piece* pieceListLookup(tr_swarm* s, tr_piece_index_t inde
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 static void pieceListRebuild(tr_swarm* s)
@@ -1074,7 +1074,7 @@ static void pieceListRebuild(tr_swarm* s)
 
         /* if we already had a list of pieces, merge it into
          * the new list so we don't lose its requestCounts */
-        if (s->pieces != NULL)
+        if (s->pieces != nullptr)
         {
             struct weighted_piece const* o = s->pieces;
             struct weighted_piece const* const oend = o + s->pieceCount;
@@ -1116,7 +1116,7 @@ static void pieceListRemovePiece(tr_swarm* s, tr_piece_index_t piece)
 {
     struct weighted_piece const* p;
 
-    if ((p = pieceListLookup(s, piece)) != NULL)
+    if ((p = pieceListLookup(s, piece)) != nullptr)
     {
         int const pos = p - s->pieces;
 
@@ -1126,7 +1126,7 @@ static void pieceListRemovePiece(tr_swarm* s, tr_piece_index_t piece)
         if (s->pieceCount == 0)
         {
             tr_free(s->pieces);
-            s->pieces = NULL;
+            s->pieces = nullptr;
         }
     }
 }
@@ -1136,7 +1136,7 @@ static void pieceListResortPiece(tr_swarm* s, struct weighted_piece* p)
     int pos;
     bool isSorted = true;
 
-    if (p == NULL)
+    if (p == nullptr)
     {
         return;
     }
@@ -1186,7 +1186,7 @@ static void pieceListRemoveRequest(tr_swarm* s, tr_block_index_t block)
     struct weighted_piece* p;
     tr_piece_index_t const index = tr_torBlockPiece(s->tor, block);
 
-    if ((p = pieceListLookup(s, index)) != NULL && p->requestCount > 0)
+    if ((p = pieceListLookup(s, index)) != nullptr && p->requestCount > 0)
     {
         --p->requestCount;
         pieceListResortPiece(s, p);
@@ -1317,7 +1317,7 @@ void tr_peerMgrGetNextRequests(
     s = tor->swarm;
 
     /* prep the pieces list */
-    if (s->pieces == NULL)
+    if (s->pieces == nullptr)
     {
         pieceListRebuild(s);
     }
@@ -1420,7 +1420,7 @@ void tr_peerMgrGetNextRequests(
                 ++p->requestCount;
             }
 
-            tr_ptrArrayDestruct(&peerArr, NULL);
+            tr_ptrArrayDestruct(&peerArr, nullptr);
         }
     }
 
@@ -1465,7 +1465,7 @@ void tr_peerMgrGetNextRequests(
 
 bool tr_peerMgrDidPeerRequest(tr_torrent const* tor, tr_peer const* peer, tr_block_index_t block)
 {
-    return requestListLookup(tor->swarm, block, peer) != NULL;
+    return requestListLookup(tor->swarm, block, peer) != nullptr;
 }
 
 /* cancel requests that are too old */
@@ -1478,7 +1478,7 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
     time_t too_old;
     tr_torrent* tor;
     int cancel_buflen = 0;
-    struct block_request* cancel = NULL;
+    struct block_request* cancel = nullptr;
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     managerLock(mgr);
 
@@ -1486,9 +1486,9 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
     too_old = now - REQUEST_TTL_SECS;
 
     /* alloc the temporary "cancel" buffer */
-    tor = NULL;
+    tor = nullptr;
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         cancel_buflen = MAX(cancel_buflen, tor->swarm->requestCount);
     }
@@ -1499,9 +1499,9 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
     }
 
     /* prune requests that are too old */
-    tor = NULL;
+    tor = nullptr;
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         tr_swarm* s = tor->swarm;
         int const n = s->requestCount;
@@ -1516,9 +1516,9 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
                 struct block_request const* const request = &s->requests[i];
                 tr_peerMsgs const* const msgs = PEER_MSGS(request->peer);
 
-                if (msgs != NULL && request->sentAt <= too_old && !tr_peerMsgsIsReadingBlock(msgs, request->block))
+                if (msgs != nullptr && request->sentAt <= too_old && !tr_peerMsgsIsReadingBlock(msgs, request->block))
                 {
-                    TR_ASSERT(cancel != NULL);
+                    TR_ASSERT(cancel != nullptr);
                     TR_ASSERT(cancelCount < cancel_buflen);
 
                     cancel[cancelCount++] = *request;
@@ -1543,7 +1543,7 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
                 struct block_request const* const request = &cancel[i];
                 tr_peerMsgs* msgs = PEER_MSGS(request->peer);
 
-                if (msgs != NULL)
+                if (msgs != nullptr)
                 {
                     tr_historyAdd(&request->peer->cancelsSentToPeer, now, 1);
                     tr_peerMsgsCancel(msgs, request->block);
@@ -1585,9 +1585,9 @@ static void peerSuggestedPiece(tr_swarm* s, tr_peer* peer, tr_piece_index_t piec
 
 #if 0
 
-    TR_ASSERT(t != NULL);
-    TR_ASSERT(peer != NULL);
-    TR_ASSERT(peer->msgs != NULL);
+    TR_ASSERT(t != nullptr);
+    TR_ASSERT(peer != nullptr);
+    TR_ASSERT(peer->msgs != nullptr);
 
     /* is this a valid piece? */
     if (pieceIndex >= t->tor->info.pieceCount)
@@ -1692,7 +1692,7 @@ static void cancelAllRequestsForBlock(tr_swarm* s, tr_block_index_t block, tr_pe
         removeRequestFromTables(s, block, p);
     }
 
-    tr_ptrArrayDestruct(&peerArr, NULL);
+    tr_ptrArrayDestruct(&peerArr, nullptr);
 }
 
 void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t p)
@@ -1726,7 +1726,7 @@ void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t p)
 
 static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
 {
-    TR_ASSERT(peer != NULL);
+    TR_ASSERT(peer != nullptr);
 
     auto* s = static_cast<tr_swarm*>(vs);
 
@@ -1745,7 +1745,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
             tr_torrentSetDirty(tor);
             tr_statsAddUploaded(tor->session, e->length);
 
-            if (peer->atom != NULL)
+            if (peer->atom != nullptr)
             {
                 peer->atom->piece_data_time = now;
             }
@@ -1764,7 +1764,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
 
             tr_statsAddDownloaded(tor->session, e->length);
 
-            if (peer->atom != NULL)
+            if (peer->atom != nullptr)
             {
                 peer->atom->piece_data_time = now;
             }
@@ -1795,7 +1795,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
         break;
 
     case TR_PEER_CLIENT_GOT_BITFIELD:
-        TR_ASSERT(e->bitfield != NULL);
+        TR_ASSERT(e->bitfield != nullptr);
 
         if (replicationExists(s))
         {
@@ -1826,7 +1826,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
         break;
 
     case TR_PEER_CLIENT_GOT_PORT:
-        if (peer->atom != NULL)
+        if (peer->atom != nullptr)
         {
             peer->atom->port = e->port;
         }
@@ -1921,7 +1921,7 @@ static struct peer_atom* ensureAtomExists(
 
     struct peer_atom* a = getExistingAtom(s, addr);
 
-    if (a == NULL)
+    if (a == nullptr)
     {
         int const jitter = tr_rand_int_weak(60 * 10);
         a = tr_new0(struct peer_atom, 1);
@@ -1963,9 +1963,9 @@ static int getPeerCount(tr_swarm const* s)
 
 static void createBitTorrentPeer(tr_torrent* tor, struct tr_peerIo* io, struct peer_atom* atom, tr_quark client)
 {
-    TR_ASSERT(atom != NULL);
+    TR_ASSERT(atom != nullptr);
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(tor->swarm != NULL);
+    TR_ASSERT(tor->swarm != nullptr);
 
     tr_swarm* swarm = tor->swarm;
 
@@ -1995,38 +1995,38 @@ static bool myHandshakeDoneCB(
     uint8_t const* peer_id,
     void* vmanager)
 {
-    TR_ASSERT(io != NULL);
+    TR_ASSERT(io != nullptr);
 
     bool ok = isConnected;
     bool success = false;
     tr_port port;
     tr_address const* addr;
     auto* manager = static_cast<tr_peerMgr*>(vmanager);
-    tr_swarm* s = tr_peerIoHasTorrentHash(io) ? getExistingSwarm(manager, tr_peerIoGetTorrentHash(io)) : NULL;
+    tr_swarm* s = tr_peerIoHasTorrentHash(io) ? getExistingSwarm(manager, tr_peerIoGetTorrentHash(io)) : nullptr;
 
     if (tr_peerIoIsIncoming(io))
     {
         tr_ptrArrayRemoveSortedPointer(&manager->incomingHandshakes, handshake, handshakeCompare);
     }
-    else if (s != NULL)
+    else if (s != nullptr)
     {
         tr_ptrArrayRemoveSortedPointer(&s->outgoingHandshakes, handshake, handshakeCompare);
     }
 
-    if (s != NULL)
+    if (s != nullptr)
     {
         swarmLock(s);
     }
 
     addr = tr_peerIoGetAddress(io, &port);
 
-    if (!ok || s == NULL || !s->isRunning)
+    if (!ok || s == nullptr || !s->isRunning)
     {
-        if (s != NULL)
+        if (s != nullptr)
         {
             struct peer_atom* atom = getExistingAtom(s, addr);
 
-            if (atom != NULL)
+            if (atom != nullptr)
             {
                 ++atom->numFails;
 
@@ -2071,7 +2071,7 @@ static bool myHandshakeDoneCB(
         {
             tr_peer const* const peer = atom->peer;
 
-            if (peer != NULL)
+            if (peer != nullptr)
             {
                 /* we already have this peer */
             }
@@ -2080,7 +2080,7 @@ static bool myHandshakeDoneCB(
                 tr_quark client;
                 char buf[128];
 
-                if (peer_id != NULL)
+                if (peer_id != nullptr)
                 {
                     client = tr_quark_new(tr_clientForId(buf, sizeof(buf), peer_id), TR_BAD_SIZE);
                 }
@@ -2099,7 +2099,7 @@ static bool myHandshakeDoneCB(
         }
     }
 
-    if (s != NULL)
+    if (s != nullptr)
     {
         swarmUnlock(s);
     }
@@ -2144,7 +2144,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address* addr, tr_port port, 
         tr_logAddDebug("Banned IP address \"%s\" tried to connect to us", tr_address_to_string(addr));
         close_peer_socket(socket, session);
     }
-    else if (getExistingHandshake(&manager->incomingHandshakes, addr) != NULL)
+    else if (getExistingHandshake(&manager->incomingHandshakes, addr) != nullptr)
     {
         close_peer_socket(socket, session);
     }
@@ -2223,7 +2223,7 @@ tr_pex* tr_peerMgrCompactToPex(
         memcpy(&pex[i].port, walk, 2);
         walk += 2;
 
-        if (added_f != NULL && n == added_f_len)
+        if (added_f != nullptr && n == added_f_len)
         {
             pex[i].flags = added_f[i];
         }
@@ -2252,7 +2252,7 @@ tr_pex* tr_peerMgrCompact6ToPex(
         memcpy(&pex[i].port, walk, 2);
         walk += 2;
 
-        if (added_f != NULL && n == added_f_len)
+        if (added_f != nullptr && n == added_f_len)
         {
             pex[i].flags = added_f[i];
         }
@@ -2368,7 +2368,7 @@ static bool isAtomInteresting(tr_torrent const* tor, struct peer_atom* atom)
 int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, uint8_t list_mode, int maxCount)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(setme_pex != NULL);
+    TR_ASSERT(setme_pex != nullptr);
     TR_ASSERT(af == TR_AF_INET || af == TR_AF_INET6);
     TR_ASSERT(list_mode == TR_PEERS_CONNECTED || list_mode == TR_PEERS_INTERESTING);
 
@@ -2376,7 +2376,7 @@ int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, ui
     int count = 0;
     int atomCount = 0;
     tr_swarm const* s = tor->swarm;
-    struct peer_atom** atoms = NULL;
+    struct peer_atom** atoms = nullptr;
     tr_pex* pex;
     tr_pex* walk;
 
@@ -2462,22 +2462,22 @@ static struct event* createTimer(tr_session* session, int msec, event_callback_f
 
 static void ensureMgrTimersExist(struct tr_peerMgr* m)
 {
-    if (m->atomTimer == NULL)
+    if (m->atomTimer == nullptr)
     {
         m->atomTimer = createTimer(m->session, ATOM_PERIOD_MSEC, atomPulse, m);
     }
 
-    if (m->bandwidthTimer == NULL)
+    if (m->bandwidthTimer == nullptr)
     {
         m->bandwidthTimer = createTimer(m->session, BANDWIDTH_PERIOD_MSEC, bandwidthPulse, m);
     }
 
-    if (m->rechokeTimer == NULL)
+    if (m->rechokeTimer == nullptr)
     {
         m->rechokeTimer = createTimer(m->session, RECHOKE_PERIOD_MSEC, rechokePulse, m);
     }
 
-    if (m->refillUpkeepTimer == NULL)
+    if (m->refillUpkeepTimer == nullptr)
     {
         m->refillUpkeepTimer = createTimer(m->session, REFILL_UPKEEP_PERIOD_MSEC, refillUpkeep, m);
     }
@@ -2531,7 +2531,7 @@ void tr_peerMgrAddTorrent(tr_peerMgr* manager, tr_torrent* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_torrentIsLocked(tor));
-    TR_ASSERT(tor->swarm == NULL);
+    TR_ASSERT(tor->swarm == nullptr);
 
     tor->swarm = swarmNew(manager, tor);
 }
@@ -2582,7 +2582,7 @@ void tr_peerUpdateProgress(tr_torrent* tor, tr_peer* peer)
         peer->progress = 1.0F;
     }
 
-    if (peer->atom != NULL && peer->progress >= 1.0F)
+    if (peer->atom != nullptr && peer->progress >= 1.0F)
     {
         atomSetSeed(tor->swarm, peer->atom);
     }
@@ -2617,7 +2617,7 @@ void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor)
 void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned int tabCount)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(tab != NULL);
+    TR_ASSERT(tab != nullptr);
     TR_ASSERT(tabCount > 0);
 
     memset(tab, 0, tabCount);
@@ -2653,8 +2653,8 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
 
 void tr_swarmGetStats(tr_swarm const* swarm, tr_swarm_stats* setme)
 {
-    TR_ASSERT(swarm != NULL);
-    TR_ASSERT(setme != NULL);
+    TR_ASSERT(swarm != nullptr);
+    TR_ASSERT(setme != nullptr);
 
     *setme = swarm->stats;
 }
@@ -2685,7 +2685,7 @@ bool tr_peerIsSeed(tr_peer const* peer)
         return true;
     }
 
-    if (peer->atom != NULL && atomIsSeed(peer->atom))
+    if (peer->atom != nullptr && atomIsSeed(peer->atom))
     {
         return true;
     }
@@ -2707,7 +2707,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
     tr_swarm const* s = tor->swarm;
 
-    if (s == NULL || !s->isRunning)
+    if (s == nullptr || !s->isRunning)
     {
         return 0;
     }
@@ -2724,14 +2724,14 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
         for (size_t i = 0; i < peer_count; ++i)
         {
-            if (peers[i]->atom != NULL && atomIsSeed(peers[i]->atom))
+            if (peers[i]->atom != nullptr && atomIsSeed(peers[i]->atom))
             {
                 return tr_torrentGetLeftUntilDone(tor);
             }
         }
     }
 
-    if (s->pieceReplication == NULL || s->pieceReplicationSize == 0)
+    if (s->pieceReplication == nullptr || s->pieceReplicationSize == 0)
     {
         return 0;
     }
@@ -2759,7 +2759,7 @@ double* tr_peerMgrWebSpeeds_KBps(tr_torrent const* tor)
     uint64_t const now = tr_time_msec();
 
     tr_swarm* s = tor->swarm;
-    TR_ASSERT(s->manager != NULL);
+    TR_ASSERT(s->manager != nullptr);
 
     unsigned int n = tr_ptrArraySize(&s->webseeds);
     TR_ASSERT(n == tor->info.webseedCount);
@@ -2787,7 +2787,7 @@ double* tr_peerMgrWebSpeeds_KBps(tr_torrent const* tor)
 struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setmeCount)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(tor->swarm->manager != NULL);
+    TR_ASSERT(tor->swarm->manager != nullptr);
 
     time_t const now = tr_time();
     uint64_t const now_msec = tr_time_msec();
@@ -2806,7 +2806,7 @@ struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setmeCount)
         tr_peer_stat* stat = ret + i;
 
         tr_address_to_string_with_buf(&atom->addr, stat->addr, sizeof(stat->addr));
-        tr_strlcpy(stat->client, tr_quark_get_string(peer->client, NULL), sizeof(stat->client));
+        tr_strlcpy(stat->client, tr_quark_get_string(peer->client, nullptr), sizeof(stat->client));
         stat->port = ntohs(peer->atom->port);
         stat->from = atom->fromFirst;
         stat->progress = peer->progress;
@@ -2971,7 +2971,7 @@ static void rechokeDownloads(tr_swarm* s)
 {
     int maxPeers = 0;
     int rechoke_count = 0;
-    struct tr_rechoke_info* rechoke = NULL;
+    struct tr_rechoke_info* rechoke = nullptr;
     int const MIN_INTERESTING_PEERS = 5;
     int const peerCount = tr_ptrArraySize(&s->peers);
     time_t const now = tr_time();
@@ -3117,7 +3117,7 @@ static void rechokeDownloads(tr_swarm* s)
                     rechoke_state = RECHOKE_STATE_BAD;
                 }
 
-                if (rechoke == NULL)
+                if (rechoke == nullptr)
                 {
                     rechoke = tr_new(struct tr_rechoke_info, peerCount);
                 }
@@ -3132,7 +3132,7 @@ static void rechokeDownloads(tr_swarm* s)
         tr_free(piece_is_interesting);
     }
 
-    if ((rechoke != NULL) && (rechoke_count > 0))
+    if ((rechoke != nullptr) && (rechoke_count > 0))
     {
         qsort(rechoke, rechoke_count, sizeof(struct tr_rechoke_info), compare_rechoke_info);
     }
@@ -3190,7 +3190,7 @@ static int compareChoke(void const* va, void const* vb)
 /* is this a new connection? */
 static bool isNew(tr_peerMsgs const* msgs)
 {
-    return msgs != NULL && tr_peerMsgsGetConnectionAge(msgs) < 45;
+    return msgs != nullptr && tr_peerMsgsGetConnectionAge(msgs) < 45;
 }
 
 /* get a rate for deciding which peers to choke and unchoke. */
@@ -3252,7 +3252,7 @@ static void rechokeUploads(tr_swarm* s, uint64_t const now)
     }
     else
     {
-        s->optimistic = NULL;
+        s->optimistic = nullptr;
     }
 
     int size = 0;
@@ -3320,7 +3320,7 @@ static void rechokeUploads(tr_swarm* s, uint64_t const now)
     }
 
     /* optimistic unchoke */
-    if (s->optimistic == NULL && !isMaxedOut && checkedChokeCount < size)
+    if (s->optimistic == nullptr && !isMaxedOut && checkedChokeCount < size)
     {
         int n;
         auto randPool = tr_ptrArray{};
@@ -3347,7 +3347,7 @@ static void rechokeUploads(tr_swarm* s, uint64_t const now)
             s->optimisticUnchokeTimeScaler = OPTIMISTIC_UNCHOKE_MULTIPLIER;
         }
 
-        tr_ptrArrayDestruct(&randPool, NULL);
+        tr_ptrArrayDestruct(&randPool, nullptr);
     }
 
     for (int i = 0; i < size; ++i)
@@ -3364,13 +3364,13 @@ static void rechokePulse(evutil_socket_t fd, short what, void* vmgr)
     TR_UNUSED(fd);
     TR_UNUSED(what);
 
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     uint64_t const now = tr_time_msec();
 
     managerLock(mgr);
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         if (tor->isRunning)
         {
@@ -3441,14 +3441,14 @@ static tr_peer** getPeersToClose(tr_swarm* s, time_t const now_sec, int* setmeSi
 
     int peerCount;
     int outsize = 0;
-    struct tr_peer** ret = NULL;
+    struct tr_peer** ret = nullptr;
     tr_peer** peers = (tr_peer**)tr_ptrArrayPeek(&s->peers, &peerCount);
 
     for (int i = 0; i < peerCount; ++i)
     {
         if (shouldPeerBeClosed(s, peers[i], peerCount, now_sec))
         {
-            if (ret == NULL)
+            if (ret == nullptr)
             {
                 ret = tr_new(tr_peer*, peerCount);
             }
@@ -3526,7 +3526,7 @@ static void removePeer(tr_swarm* s, tr_peer* peer)
     TR_ASSERT(swarmIsLocked(s));
 
     struct peer_atom* atom = peer->atom;
-    TR_ASSERT(atom != NULL);
+    TR_ASSERT(atom != nullptr);
 
     atom->time = tr_time();
 
@@ -3547,8 +3547,8 @@ static void removePeer(tr_swarm* s, tr_peer* peer)
 
 static void closePeer(tr_swarm* s, tr_peer* peer)
 {
-    TR_ASSERT(s != NULL);
-    TR_ASSERT(peer != NULL);
+    TR_ASSERT(s != nullptr);
+    TR_ASSERT(peer != nullptr);
 
     struct peer_atom* atom = peer->atom;
 
@@ -3653,7 +3653,7 @@ static void sortPeersByLivelinessImpl(tr_peer** peers, void** clientData, int n,
         l->time = p->atom->time;
         l->speed = tr_peerGetPieceSpeed_Bps(p, now, TR_UP) + tr_peerGetPieceSpeed_Bps(p, now, TR_DOWN);
 
-        if (clientData != NULL)
+        if (clientData != nullptr)
         {
             l->clientData = clientData[i];
         }
@@ -3669,7 +3669,7 @@ static void sortPeersByLivelinessImpl(tr_peer** peers, void** clientData, int n,
 
         peers[i] = l->peer;
 
-        if (clientData != NULL)
+        if (clientData != nullptr)
         {
             clientData[i] = l->clientData;
         }
@@ -3693,7 +3693,7 @@ static void enforceTorrentPeerLimit(tr_swarm* s, uint64_t now)
     {
         void const* const base = tr_ptrArrayBase(&s->peers);
         auto** const peers = static_cast<tr_peer**>(tr_memdup(base, n * sizeof(tr_peer*)));
-        sortPeersByLiveliness(peers, NULL, n, now);
+        sortPeersByLiveliness(peers, nullptr, n, now);
 
         while (n > max)
         {
@@ -3707,11 +3707,11 @@ static void enforceTorrentPeerLimit(tr_swarm* s, uint64_t now)
 static void enforceSessionPeerLimit(tr_session* session, uint64_t now)
 {
     int n = 0;
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
     int const max = tr_sessionGetPeerLimit(session);
 
     /* count the total number of peers */
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         n += tr_ptrArraySize(&tor->swarm->peers);
     }
@@ -3724,9 +3724,9 @@ static void enforceSessionPeerLimit(tr_session* session, uint64_t now)
 
         /* populate the peer array */
         n = 0;
-        tor = NULL;
+        tor = nullptr;
 
-        while ((tor = tr_torrentNext(session, tor)) != NULL)
+        while ((tor = tr_torrentNext(session, tor)) != nullptr)
         {
             tr_swarm* s = tor->swarm;
 
@@ -3770,9 +3770,9 @@ static void reconnectPulse(evutil_socket_t fd, short what, void* vmgr)
     **/
 
     /* if we're over the per-torrent peer limits, cull some peers */
-    tor = NULL;
+    tor = nullptr;
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         if (tor->isRunning)
         {
@@ -3784,9 +3784,9 @@ static void reconnectPulse(evutil_socket_t fd, short what, void* vmgr)
     enforceSessionPeerLimit(mgr->session, now_msec);
 
     /* remove crappy peers */
-    tor = NULL;
+    tor = nullptr;
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         if (!tor->swarm->isRunning)
         {
@@ -3811,9 +3811,9 @@ static void reconnectPulse(evutil_socket_t fd, short what, void* vmgr)
 
 static void pumpAllPeers(tr_peerMgr* mgr)
 {
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         tr_swarm* s = tor->swarm;
 
@@ -3830,7 +3830,7 @@ static void queuePulseForeach(void* vtor)
 
     tr_torrentStartNow(tor);
 
-    if (tor->queue_started_callback != NULL)
+    if (tor->queue_started_callback != nullptr)
     {
         (*tor->queue_started_callback)(tor, tor->queue_started_user_data);
     }
@@ -3849,7 +3849,7 @@ static void queuePulse(tr_session* session, tr_direction dir)
 
         tr_ptrArrayForeach(&torrents, queuePulseForeach);
 
-        tr_ptrArrayDestruct(&torrents, NULL);
+        tr_ptrArrayDestruct(&torrents, nullptr);
     }
 }
 
@@ -3869,8 +3869,8 @@ static void bandwidthPulse(evutil_socket_t fd, short what, void* vmgr)
     tr_bandwidthAllocate(&session->bandwidth, TR_DOWN, BANDWIDTH_PERIOD_MSEC);
 
     /* torrent upkeep */
-    tr_torrent* tor = NULL;
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    tr_torrent* tor = nullptr;
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         /* possibly stop torrents that have seeded enough */
         tr_torrentCheckSeedLimit(tor);
@@ -3972,8 +3972,8 @@ static void atomPulse(evutil_socket_t fd, short what, void* vmgr)
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     managerLock(mgr);
 
-    tr_torrent* tor = NULL;
-    while ((tor = tr_torrentNext(mgr->session, tor)) != NULL)
+    tr_torrent* tor = nullptr;
+    while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
         int atomCount;
         tr_swarm* s = tor->swarm;
@@ -4022,7 +4022,7 @@ static void atomPulse(evutil_socket_t fd, short what, void* vmgr)
             }
 
             /* rebuild Torrent.pool with what's left */
-            tr_ptrArrayDestruct(&s->pool, NULL);
+            tr_ptrArrayDestruct(&s->pool, nullptr);
             s->pool = {};
             qsort(keep, keepCount, sizeof(struct peer_atom*), compareAtomPtrsByAddress);
 
@@ -4263,11 +4263,11 @@ static struct peer_candidate* getPeerCandidates(tr_session* session, int* candid
     int const maxCandidates = tr_sessionGetPeerLimit(session) * 0.95;
 
     /* count how many peers and atoms we've got */
-    tor = NULL;
+    tor = nullptr;
     atomCount = 0;
     peerCount = 0;
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         atomCount += tr_ptrArraySize(&tor->swarm->pool);
         peerCount += tr_ptrArraySize(&tor->swarm->peers);
@@ -4277,16 +4277,16 @@ static struct peer_candidate* getPeerCandidates(tr_session* session, int* candid
     if (maxCandidates <= peerCount)
     {
         *candidateCount = 0;
-        return NULL;
+        return nullptr;
     }
 
     /* allocate an array of candidates */
     walk = candidates = tr_new(struct peer_candidate, atomCount);
 
     /* populate the candidate array */
-    tor = NULL;
+    tor = nullptr;
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         int nAtoms;
         struct peer_atom** atoms;
@@ -4369,7 +4369,7 @@ static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* a
         s->tor->completeness == TR_SEED,
         utp);
 
-    if (io == NULL)
+    if (io == nullptr)
     {
         tordbg(s, "peerIo not created; marking peer %s as unreachable", tr_atomAddrStr(atom));
         atom->flags2 |= MYFLAG_UNREACHABLE;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -6,14 +6,15 @@
  *
  */
 
-#include <errno.h> /* error codes ERANGE, ... */
-#include <limits.h> /* INT_MAX */
-#include <string.h> /* memcpy, memcmp, strstr */
-#include <stdlib.h> /* qsort */
+#include <cerrno> /* error codes ERANGE, ... */
+#include <climits> /* INT_MAX */
+#include <cstring> /* memcpy, memcmp, strstr */
+#include <cstdlib> /* qsort */
+#include <algorithm>
 
 #include <event2/event.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 #include "transmission.h"
@@ -832,7 +833,7 @@ static void updateEndgame(tr_swarm* s)
         numDownloading += countActiveWebseeds(s);
 
         /* average number of pending requests per downloading peer */
-        s->endgame = s->requestCount / MAX(numDownloading, 1);
+        s->endgame = s->requestCount / std::max(numDownloading, 1);
     }
 }
 
@@ -1494,7 +1495,7 @@ static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
 
     while ((tor = tr_torrentNext(mgr->session, tor)) != nullptr)
     {
-        cancel_buflen = MAX(cancel_buflen, tor->swarm->requestCount);
+        cancel_buflen = std::max(cancel_buflen, tor->swarm->requestCount);
     }
 
     if (cancel_buflen > 0)
@@ -2422,7 +2423,7 @@ int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, ui
     ***  add the first N of them into our return list
     **/
 
-    n = MIN(atomCount, maxCount);
+    n = std::min(atomCount, maxCount);
     pex = walk = tr_new0(tr_pex, n);
 
     for (int i = 0; i < atomCount && count < n; ++i)
@@ -2744,7 +2745,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
     uint64_t desiredAvailable = 0;
 
-    for (size_t i = 0, n = MIN(tor->info.pieceCount, s->pieceReplicationSize); i < n; ++i)
+    for (size_t i = 0, n = std::min((unsigned long)tor->info.pieceCount, s->pieceReplicationSize); i < n; ++i)
     {
         if (!tor->info.pieces[i].dnd && s->pieceReplication[i] > 0)
         {
@@ -3031,7 +3032,7 @@ static void rechokeDownloads(tr_swarm* s)
             /* cancelRate: of the block requests we've recently made, the percentage we cancelled.
              * higher values indicate more congestion. */
             double const cancelRate = cancels / (double)(cancels + blocks);
-            double const mult = 1 - MIN(cancelRate, 0.5);
+            double const mult = 1 - std::min(cancelRate, 0.5);
             maxPeers = s->interestedCount * mult;
             tordbg(
                 s,
@@ -3047,7 +3048,7 @@ static void rechokeDownloads(tr_swarm* s)
         {
             int const maxIncrease = 15;
             time_t const maxHistory = 2 * CANCEL_HISTORY_SEC;
-            double const mult = MIN(timeSinceCancel, maxHistory) / (double)maxHistory;
+            double const mult = std::min(timeSinceCancel, maxHistory) / (double)maxHistory;
             int const inc = maxIncrease * mult;
             maxPeers = s->maxPeers + inc;
             tordbg(
@@ -3143,7 +3144,7 @@ static void rechokeDownloads(tr_swarm* s)
 
     /* now that we know which & how many peers to be interested in... update the peer interest */
 
-    s->interestedCount = MIN(maxPeers, rechoke_count);
+    s->interestedCount = std::min(maxPeers, rechoke_count);
 
     for (int i = 0; i < rechoke_count; ++i)
     {
@@ -3427,7 +3428,7 @@ static bool shouldPeerBeClosed(tr_swarm const* s, tr_peer const* peer, int peerC
         int const lo = MIN_UPLOAD_IDLE_SECS;
         int const hi = MAX_UPLOAD_IDLE_SECS;
         int const limit = hi - (hi - lo) * strictness;
-        int const idleTime = now - MAX(atom->time, atom->piece_data_time);
+        int const idleTime = now - std::max(atom->time, atom->piece_data_time);
 
         if (idleTime > limit)
         {
@@ -3965,7 +3966,7 @@ static int compareAtomPtrsByShelfDate(void const* va, void const* vb)
 
 static int getMaxAtomCount(tr_torrent const* tor)
 {
-    return MIN(50, tor->maxConnectedPeers * 3);
+    return std::min(50, tor->maxConnectedPeers * 3);
 }
 
 static void atomPulse(evutil_socket_t fd, short what, void* vmgr)
@@ -4201,7 +4202,7 @@ static void selectPeerCandidates(struct peer_candidate* candidates, int candidat
 static bool checkBestScoresComeFirst(struct peer_candidate const* candidates, int n, int k)
 {
     uint64_t worstFirstScore = 0;
-    int const x = MIN(n, k) - 1;
+    int const x = std::min(n, k) - 1;
 
     for (int i = 0; i < x; i++)
     {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -783,7 +783,11 @@ static int countActiveWebseeds(tr_swarm* s)
 
         for (int i = 0, n = tr_ptrArraySize(&s->webseeds); i < n; ++i)
         {
-            if (tr_peerIsTransferringPieces(static_cast<tr_peer const*>(tr_ptrArrayNth(&s->webseeds, i)), now, TR_DOWN, nullptr))
+            if (tr_peerIsTransferringPieces(
+                    static_cast<tr_peer const*>(tr_ptrArrayNth(&s->webseeds, i)),
+                    now,
+                    TR_DOWN,
+                    nullptr))
             {
                 ++activeCount;
             }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -6,10 +6,11 @@
  *
  */
 
-#include <errno.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
 
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
@@ -1165,7 +1166,7 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         }
 
         pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
-        n = MIN(n, MAX_PEX_PEER_COUNT);
+        n = std::min(n, (unsigned long)MAX_PEX_PEER_COUNT);
         tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
 
         tr_free(pex);
@@ -1185,7 +1186,7 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         }
 
         pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
-        n = MIN(n, MAX_PEX_PEER_COUNT);
+        n = std::min(n, (unsigned long)MAX_PEX_PEER_COUNT);
         tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
 
         tr_free(pex);
@@ -1447,7 +1448,7 @@ static ReadState readBtPiece(tr_peerMsgs* msgs, struct evbuffer* inbuf, size_t i
 
         /* read in another chunk of data */
         nLeft = req->length - evbuffer_get_length(block_buffer);
-        n = MIN(nLeft, inlen);
+        n = std::min(nLeft, inlen);
 
         tr_peerIoReadBytesToBuf(msgs->io, inbuf, block_buffer, n);
 
@@ -1883,20 +1884,20 @@ static void updateDesiredRequestCount(tr_peerMsgs* msgs)
 
         if (tr_torrentUsesSpeedLimit(torrent, TR_PEER_TO_CLIENT))
         {
-            rate_Bps = MIN(rate_Bps, tr_torrentGetSpeedLimit_Bps(torrent, TR_PEER_TO_CLIENT));
+            rate_Bps = std::min(rate_Bps, tr_torrentGetSpeedLimit_Bps(torrent, TR_PEER_TO_CLIENT));
         }
 
         /* honor the session limits, if enabled */
         if (tr_torrentUsesSessionLimits(torrent) &&
             tr_sessionGetActiveSpeedLimit_Bps(torrent->session, TR_PEER_TO_CLIENT, &irate_Bps))
         {
-            rate_Bps = MIN(rate_Bps, irate_Bps);
+            rate_Bps = std::min(rate_Bps, irate_Bps);
         }
 
         /* use this desired rate to figure out how
          * many requests we should send to this peer */
         estimatedBlocksInPeriod = (rate_Bps * seconds) / torrent->blockSize;
-        msgs->desiredRequestCount = MAX(floor, estimatedBlocksInPeriod);
+        msgs->desiredRequestCount = std::max(floor, estimatedBlocksInPeriod);
 
         /* honor the peer's maximum request count, if specified */
         if ((msgs->reqq > 0) && (msgs->desiredRequestCount > msgs->reqq))

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -265,7 +265,7 @@ static void myDebug(char const* file, int line, struct tr_peerMsgs const* msgs, 
         char timestr[64];
         char addrstr[TR_ADDRSTRLEN];
         struct evbuffer* buf = evbuffer_new();
-        char* base = tr_sys_path_basename(file, NULL);
+        char* base = tr_sys_path_basename(file, nullptr);
         char* message;
 
         evbuffer_add_printf(
@@ -274,14 +274,14 @@ static void myDebug(char const* file, int line, struct tr_peerMsgs const* msgs, 
             tr_logGetTimeStr(timestr, sizeof(timestr)),
             tr_torrentName(msgs->torrent),
             tr_peerIoGetAddrStr(msgs->io, addrstr, sizeof(addrstr)),
-            tr_quark_get_string(msgs->peer.client, NULL));
+            tr_quark_get_string(msgs->peer.client, nullptr));
         va_start(args, fmt);
         evbuffer_add_vprintf(buf, fmt, args);
         va_end(args);
         evbuffer_add_printf(buf, " (%s:%d)", base, line);
 
-        message = evbuffer_free_to_str(buf, NULL);
-        tr_sys_file_write_line(fp, message, NULL);
+        message = evbuffer_free_to_str(buf, nullptr);
+        tr_sys_file_write_line(fp, message, nullptr);
 
         tr_free(base);
         tr_free(message);
@@ -449,7 +449,7 @@ static void protocolSendHaveNone(tr_peerMsgs* msgs)
 
 static void publish(tr_peerMsgs* msgs, tr_peer_event* e)
 {
-    if (msgs->callback != NULL)
+    if (msgs->callback != nullptr)
     {
         (*msgs->callback)(&msgs->peer, e, msgs->callbackData);
     }
@@ -570,12 +570,12 @@ static void fireClientGotHave(tr_peerMsgs* msgs, tr_piece_index_t index)
 size_t tr_generateAllowedSet(tr_piece_index_t* setmePieces, size_t desiredSetSize, size_t pieceCount, uint8_t const* infohash,
     tr_address const* addr)
 {
-    TR_ASSERT(setmePieces != NULL);
+    TR_ASSERT(setmePieces != nullptr);
     TR_ASSERT(desiredSetSize <= pieceCount);
     TR_ASSERT(desiredSetSize != 0);
     TR_ASSERT(pieceCount != 0);
-    TR_ASSERT(infohash != NULL);
-    TR_ASSERT(addr != NULL);
+    TR_ASSERT(infohash != nullptr);
+    TR_ASSERT(addr != nullptr);
 
     size_t setSize = 0;
 
@@ -590,7 +590,7 @@ size_t tr_generateAllowedSet(tr_piece_index_t* setmePieces, size_t desiredSetSiz
         walk += sizeof(uint32_t);
         memcpy(walk, infohash, SHA_DIGEST_LENGTH); /* (2) */
         walk += SHA_DIGEST_LENGTH;
-        tr_sha1(x, w, walk - w, NULL); /* (3) */
+        tr_sha1(x, w, walk - w, nullptr); /* (3) */
         TR_ASSERT(sizeof(w) == walk - w);
 
         while (setSize < desiredSetSize)
@@ -613,7 +613,7 @@ size_t tr_generateAllowedSet(tr_piece_index_t* setmePieces, size_t desiredSetSiz
                 }
             }
 
-            tr_sha1(x, x, sizeof(x), NULL); /* (3) */
+            tr_sha1(x, x, sizeof(x), nullptr); /* (3) */
         }
     }
 
@@ -629,7 +629,7 @@ static void updateFastSet(tr_peerMsgs* msgs)
 
     if (fext && peerIsNeedy && !msgs->haveFastSet)
     {
-        struct tr_address const* addr = tr_peerIoGetAddress(msgs->io, NULL);
+        struct tr_address const* addr = tr_peerIoGetAddress(msgs->io, nullptr);
         tr_info const* inf = &msgs->torrent->info;
         size_t const numwant = MIN(MAX_FAST_SET_SIZE, inf->pieceCount);
 
@@ -719,7 +719,7 @@ void tr_peerMsgsUpdateActive(tr_peerMsgs* msgs, tr_direction direction)
 
 static void sendInterest(tr_peerMsgs* msgs, bool b)
 {
-    TR_ASSERT(msgs != NULL);
+    TR_ASSERT(msgs != nullptr);
 
     struct evbuffer* out = msgs->outMessages;
 
@@ -795,7 +795,7 @@ static void cancelAllRequestsToClient(tr_peerMsgs* msgs)
 
 void tr_peerMsgsSetChoke(tr_peerMsgs* msgs, bool peer_is_choked)
 {
-    TR_ASSERT(msgs != NULL);
+    TR_ASSERT(msgs != nullptr);
 
     time_t const now = tr_time();
     time_t const fibrillationTime = now - MIN_CHOKE_PERIOD_SEC;
@@ -898,7 +898,7 @@ static void sendLtepHandshake(tr_peerMsgs* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, getSession(msgs)->encryptionMode != TR_CLEAR_PREFERRED);
 
-    if (ipv6 != NULL)
+    if (ipv6 != nullptr)
     {
         tr_variantDictAddRaw(&val, TR_KEY_ipv6, ipv6, 16);
     }
@@ -1009,7 +1009,7 @@ static void parseLtepHandshake(tr_peerMsgs* msgs, uint32_t len, struct evbuffer*
         {
             /* Mysterious µTorrent extension that we don't grok.  However,
                it implies support for µTP, so use it to indicate that. */
-            tr_peerMgrSetUtpFailed(msgs->torrent, tr_peerIoGetAddress(msgs->io, NULL), false);
+            tr_peerMgrSetUtpFailed(msgs->torrent, tr_peerIoGetAddress(msgs->io, nullptr), false);
         }
     }
 
@@ -1069,7 +1069,7 @@ static void parseUtMetadata(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer*
 
     tr_variant dict;
     char const* benc_end;
-    if (tr_variantFromBencFull(&dict, tmp, msglen, NULL, &benc_end) == 0)
+    if (tr_variantFromBencFull(&dict, tmp, msglen, nullptr, &benc_end) == 0)
     {
         (void)tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
         (void)tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
@@ -1161,7 +1161,7 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         if (!tr_variantDictFindRaw(&val, TR_KEY_added_f, &added_f, &added_f_len))
         {
             added_f_len = 0;
-            added_f = NULL;
+            added_f = nullptr;
         }
 
         pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
@@ -1181,7 +1181,7 @@ static void parseUtPex(tr_peerMsgs* msgs, uint32_t msglen, struct evbuffer* inbu
         if (!tr_variantDictFindRaw(&val, TR_KEY_added6_f, &added_f, &added_f_len))
         {
             added_f_len = 0;
-            added_f = NULL;
+            added_f = nullptr;
         }
 
         pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
@@ -1438,7 +1438,7 @@ static ReadState readBtPiece(tr_peerMsgs* msgs, struct evbuffer* inbuf, size_t i
         size_t nLeft;
         struct evbuffer* block_buffer;
 
-        if (msgs->incoming.block == NULL)
+        if (msgs->incoming.block == nullptr)
         {
             msgs->incoming.block = evbuffer_new();
         }
@@ -1737,8 +1737,8 @@ static ReadState readBtMessage(tr_peerMsgs* msgs, struct evbuffer* inbuf, size_t
 /* returns 0 on success, or an errno on failure */
 static int clientGotBlock(tr_peerMsgs* msgs, struct evbuffer* data, struct peer_request const* req)
 {
-    TR_ASSERT(msgs != NULL);
-    TR_ASSERT(req != NULL);
+    TR_ASSERT(msgs != nullptr);
+    TR_ASSERT(req != nullptr);
 
     int err;
     tr_torrent* tor = msgs->torrent;
@@ -1795,7 +1795,7 @@ static void didWrite(tr_peerIo* io, size_t bytesWritten, bool wasPieceData, void
         firePeerGotPieceData(msgs, bytesWritten);
     }
 
-    if (tr_isPeerIo(io) && io->userData != NULL)
+    if (tr_isPeerIo(io) && io->userData != nullptr)
     {
         peerPulse(msgs);
     }
@@ -2004,7 +2004,7 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
 
         auto* data = static_cast<char*>(tr_torrentGetMetadataPiece(msgs->torrent, piece, &dataLen));
 
-        if (data != NULL)
+        if (data != nullptr)
         {
             tr_variant tmp;
             struct evbuffer* payload;
@@ -2129,7 +2129,7 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
             if (err)
             {
                 bytesWritten = 0;
-                msgs = NULL;
+                msgs = nullptr;
             }
         }
         else if (fext) /* peer needs a reject message */
@@ -2137,7 +2137,7 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
             protocolSendReject(msgs, &req);
         }
 
-        if (msgs != NULL)
+        if (msgs != nullptr)
         {
             prefetchPieces(msgs);
         }
@@ -2147,7 +2147,7 @@ static size_t fillOutputBuffer(tr_peerMsgs* msgs, time_t now)
     ***  Keepalive
     **/
 
-    if (msgs != NULL && msgs->clientSentAnythingAt != 0 && now - msgs->clientSentAnythingAt > KEEPALIVE_INTERVAL_SECS)
+    if (msgs != nullptr && msgs->clientSentAnythingAt != 0 && now - msgs->clientSentAnythingAt > KEEPALIVE_INTERVAL_SECS)
     {
         dbgmsg(msgs, "sending a keepalive message");
         evbuffer_add_uint32(msgs->outMessages, 0);
@@ -2180,7 +2180,7 @@ static void peerPulse(void* vmsgs)
 
 void tr_peerMsgsPulse(tr_peerMsgs* msgs)
 {
-    if (msgs != NULL)
+    if (msgs != nullptr)
     {
         peerPulse(msgs);
     }
@@ -2366,8 +2366,8 @@ static void sendPex(tr_peerMsgs* msgs)
     {
         PexDiffs diffs;
         PexDiffs diffs6;
-        tr_pex* newPex = NULL;
-        tr_pex* newPex6 = NULL;
+        tr_pex* newPex = nullptr;
+        tr_pex* newPex6 = nullptr;
         int const newCount = tr_peerMgrGetPeers(msgs->torrent, &newPex, TR_AF_INET, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
         int const newCount6 = tr_peerMgrGetPeers(msgs->torrent, &newPex6, TR_AF_INET6, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
 
@@ -2573,7 +2573,7 @@ static void pexPulse(evutil_socket_t fd, short what, void* vmsgs)
 
     sendPex(msgs);
 
-    TR_ASSERT(msgs->pexTimer != NULL);
+    TR_ASSERT(msgs->pexTimer != nullptr);
     tr_timerAdd(msgs->pexTimer, PEX_INTERVAL_SECS, 0);
 }
 
@@ -2595,7 +2595,7 @@ static bool peermsgs_is_transferring_pieces(
         Bps = tr_peerIoGetPieceSpeed_Bps(msgs->io, now, direction);
     }
 
-    if (setme_Bps != NULL)
+    if (setme_Bps != nullptr)
     {
         *setme_Bps = Bps;
     }
@@ -2606,23 +2606,23 @@ static bool peermsgs_is_transferring_pieces(
 static void peermsgs_destruct(tr_peer* peer)
 {
     tr_peerMsgs* const msgs = PEER_MSGS(peer);
-    TR_ASSERT(msgs != NULL);
-    if (msgs != NULL)
+    TR_ASSERT(msgs != nullptr);
+    if (msgs != nullptr)
     {
         tr_peerMsgsSetActive(msgs, TR_UP, false);
         tr_peerMsgsSetActive(msgs, TR_DOWN, false);
 
-        if (msgs->pexTimer != NULL)
+        if (msgs->pexTimer != nullptr)
         {
             event_free(msgs->pexTimer);
         }
 
-        if (msgs->incoming.block != NULL)
+        if (msgs->incoming.block != nullptr)
         {
             evbuffer_free(msgs->incoming.block);
         }
 
-        if (msgs->io != NULL)
+        if (msgs->io != nullptr)
         {
             tr_peerIoClear(msgs->io);
             tr_peerIoUnref(msgs->io); /* balanced by the ref in handshakeDoneCB() */
@@ -2709,18 +2709,18 @@ bool tr_peerMsgsIsIncomingConnection(tr_peerMsgs const* msgs)
 
 bool tr_isPeerMsgs(void const* msgs)
 {
-    return msgs != NULL && ((struct tr_peerMsgs const*)msgs)->magic_number == MAGIC_NUMBER;
+    return msgs != nullptr && ((struct tr_peerMsgs const*)msgs)->magic_number == MAGIC_NUMBER;
 }
 
 tr_peerMsgs* tr_peerMsgsCast(void* vm)
 {
     auto* m = static_cast<tr_peerMsgs*>(vm);
-    return tr_isPeerMsgs(m) ? m : NULL;
+    return tr_isPeerMsgs(m) ? m : nullptr;
 }
 
 tr_peerMsgs* tr_peerMsgsNew(struct tr_torrent* torrent, struct tr_peerIo* io, tr_peer_callback callback, void* callbackData)
 {
-    TR_ASSERT(io != NULL);
+    TR_ASSERT(io != nullptr);
 
     tr_peerMsgs* m = tr_new0(tr_peerMsgs, 1);
 
@@ -2751,7 +2751,7 @@ tr_peerMsgs* tr_peerMsgsNew(struct tr_torrent* torrent, struct tr_peerIo* io, tr
 
     if (tr_peerIoSupportsUTP(m->io))
     {
-        tr_address const* addr = tr_peerIoGetAddress(m->io, NULL);
+        tr_address const* addr = tr_peerIoGetAddress(m->io, nullptr);
         tr_peerMgrSetUtpSupported(torrent, addr);
         tr_peerMgrSetUtpFailed(torrent, addr, false);
     }
@@ -2766,9 +2766,9 @@ tr_peerMsgs* tr_peerMsgsNew(struct tr_torrent* torrent, struct tr_peerIo* io, tr
     if (tr_dhtEnabled(torrent->session) && tr_peerIoSupportsDHT(m->io))
     {
         /* Only send PORT over IPv6 when the IPv6 DHT is running (BEP-32). */
-        struct tr_address const* addr = tr_peerIoGetAddress(m->io, NULL);
+        struct tr_address const* addr = tr_peerIoGetAddress(m->io, nullptr);
 
-        if (addr->type == TR_AF_INET || tr_globalIPv6() != NULL)
+        if (addr->type == TR_AF_INET || tr_globalIPv6() != nullptr)
         {
             protocolSendPort(m, tr_dhtPort(torrent->session));
         }

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -87,9 +87,9 @@ static char const* getdev(char const* path)
     struct mnttab mnt;
     fp = fopen(_PATH_MOUNTED, "r");
 
-    if (fp == NULL)
+    if (fp == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     while (getmntent(fp, &mnt) != -1)
@@ -109,12 +109,12 @@ static char const* getdev(char const* path)
 
     fp = setmntent(_PATH_MOUNTED, "r");
 
-    if (fp == NULL)
+    if (fp == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
-    while ((mnt = getmntent(fp)) != NULL)
+    while ((mnt = getmntent(fp)) != nullptr)
     {
         if (tr_strcmp0(path, mnt->mnt_dir) == 0)
         {
@@ -123,7 +123,7 @@ static char const* getdev(char const* path)
     }
 
     endmntent(fp);
-    return mnt != NULL ? mnt->mnt_fsname : NULL;
+    return mnt != nullptr ? mnt->mnt_fsname : nullptr;
 
 #endif
 
@@ -136,7 +136,7 @@ static char const* getdev(char const* path)
 
     if (n == 0)
     {
-        return NULL;
+        return nullptr;
     }
 
     for (int i = 0; i < n; i++)
@@ -147,7 +147,7 @@ static char const* getdev(char const* path)
         }
     }
 
-    return NULL;
+    return nullptr;
 
 #endif
 }
@@ -163,9 +163,9 @@ static char const* getfstype(char const* device)
     struct mnttab mnt;
     fp = fopen(_PATH_MOUNTED, "r");
 
-    if (fp == NULL)
+    if (fp == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     while (getmntent(fp, &mnt) != -1)
@@ -185,12 +185,12 @@ static char const* getfstype(char const* device)
 
     fp = setmntent(_PATH_MOUNTED, "r");
 
-    if (fp == NULL)
+    if (fp == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
-    while ((mnt = getmntent(fp)) != NULL)
+    while ((mnt = getmntent(fp)) != nullptr)
     {
         if (tr_strcmp0(device, mnt->mnt_fsname) == 0)
         {
@@ -199,7 +199,7 @@ static char const* getfstype(char const* device)
     }
 
     endmntent(fp);
-    return mnt != NULL ? mnt->mnt_type : NULL;
+    return mnt != nullptr ? mnt->mnt_type : nullptr;
 
 #endif
 
@@ -212,7 +212,7 @@ static char const* getfstype(char const* device)
 
     if (n == 0)
     {
-        return NULL;
+        return nullptr;
     }
 
     for (int i = 0; i < n; i++)
@@ -223,7 +223,7 @@ static char const* getfstype(char const* device)
         }
     }
 
-    return NULL;
+    return nullptr;
 
 #endif
 }
@@ -240,14 +240,14 @@ static char const* getblkdev(char const* path)
     {
         device = getdev(dir);
 
-        if (device != NULL)
+        if (device != nullptr)
         {
             break;
         }
 
         c = strrchr(dir, '/');
 
-        if (c != NULL)
+        if (c != nullptr)
         {
             *c = '\0';
         }
@@ -279,7 +279,7 @@ static int64_t getquota(char const* device)
 
     qh = quota_open(device);
 
-    if (qh == NULL)
+    if (qh == nullptr)
     {
         return -1;
     }
@@ -441,7 +441,7 @@ static int64_t tr_getQuotaFreeSpace(struct tr_device_info const* info)
 
 #ifndef _WIN32
 
-    if (info->fstype != NULL && evutil_ascii_strcasecmp(info->fstype, "xfs") == 0)
+    if (info->fstype != nullptr && evutil_ascii_strcasecmp(info->fstype, "xfs") == 0)
     {
 #ifdef HAVE_XQM
         ret = getxfsquota(info->device);
@@ -470,11 +470,11 @@ static int64_t tr_getDiskFreeSpace(char const* path)
 
     wide_path = tr_win32_utf8_to_native(path, -1);
 
-    if (wide_path != NULL)
+    if (wide_path != nullptr)
     {
         ULARGE_INTEGER freeBytesAvailable;
 
-        if (GetDiskFreeSpaceExW(wide_path, &freeBytesAvailable, NULL, NULL))
+        if (GetDiskFreeSpaceExW(wide_path, &freeBytesAvailable, nullptr, nullptr))
         {
             ret = freeBytesAvailable.QuadPart;
         }
@@ -515,7 +515,7 @@ struct tr_device_info* tr_device_info_create(char const* path)
 
 void tr_device_info_free(struct tr_device_info* info)
 {
-    if (info != NULL)
+    if (info != nullptr)
     {
         tr_free(info->fstype);
         tr_free(info->device);
@@ -528,7 +528,7 @@ int64_t tr_device_info_get_free_space(struct tr_device_info const* info)
 {
     int64_t free_space;
 
-    if (info == NULL || info->path == NULL)
+    if (info == nullptr || info->path == nullptr)
     {
         errno = EINVAL;
         free_space = -1;

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -109,7 +109,7 @@ static ThreadFuncReturnType ThreadFunc(void* _t)
     _endthreadex(0);
     return 0;
 #else
-    return NULL;
+    return nullptr;
 #endif
 }
 
@@ -124,13 +124,13 @@ tr_thread* tr_threadNew(void (*func)(void*), void* arg)
 
     {
         unsigned int id;
-        t->thread_handle = (HANDLE)_beginthreadex(NULL, 0, &ThreadFunc, t, 0, &id);
+        t->thread_handle = (HANDLE)_beginthreadex(nullptr, 0, &ThreadFunc, t, 0, &id);
         t->thread = (DWORD)id;
     }
 
 #else
 
-    pthread_create(&t->thread, NULL, (void* (*)(void*))ThreadFunc, t);
+    pthread_create(&t->thread, nullptr, (void* (*)(void*))ThreadFunc, t);
 
 #endif
 
@@ -232,10 +232,10 @@ void tr_lockUnlock(tr_lock* l)
 
 static char* win32_get_known_folder_ex(REFKNOWNFOLDERID folder_id, DWORD flags)
 {
-    char* ret = NULL;
+    char* ret = nullptr;
     PWSTR path;
 
-    if (SHGetKnownFolderPath(folder_id, flags | KF_FLAG_DONT_UNEXPAND, NULL, &path) == S_OK)
+    if (SHGetKnownFolderPath(folder_id, flags | KF_FLAG_DONT_UNEXPAND, nullptr, &path) == S_OK)
     {
         ret = tr_win32_native_to_utf8(path, -1);
         CoTaskMemFree(path);
@@ -253,13 +253,13 @@ static char* win32_get_known_folder(REFKNOWNFOLDERID folder_id)
 
 static char const* getHomeDir(void)
 {
-    static char const* home = NULL;
+    static char const* home = nullptr;
 
-    if (home == NULL)
+    if (home == nullptr)
     {
-        home = tr_env_get_string("HOME", NULL);
+        home = tr_env_get_string("HOME", nullptr);
 
-        if (home == NULL)
+        if (home == nullptr)
         {
 #ifdef _WIN32
 
@@ -268,10 +268,10 @@ static char const* getHomeDir(void)
 #else
 
             struct passwd pwent;
-            struct passwd* pw = NULL;
+            struct passwd* pw = nullptr;
             char buf[4096];
             getpwuid_r(getuid(), &pwent, buf, sizeof buf, &pw);
-            if (pw != NULL)
+            if (pw != nullptr)
             {
                 home = tr_strdup(pw->pw_dir);
             }
@@ -279,7 +279,7 @@ static char const* getHomeDir(void)
 #endif
         }
 
-        if (home == NULL)
+        if (home == nullptr)
         {
             home = tr_strdup("");
         }
@@ -302,12 +302,12 @@ void tr_setConfigDir(tr_session* session, char const* configDir)
 
     session->configDir = tr_strdup(configDir);
 
-    path = tr_buildPath(configDir, RESUME_SUBDIR, NULL);
-    tr_sys_dir_create(path, TR_SYS_DIR_CREATE_PARENTS, 0777, NULL);
+    path = tr_buildPath(configDir, RESUME_SUBDIR, nullptr);
+    tr_sys_dir_create(path, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
     session->resumeDir = path;
 
-    path = tr_buildPath(configDir, TORRENT_SUBDIR, NULL);
-    tr_sys_dir_create(path, TR_SYS_DIR_CREATE_PARENTS, 0777, NULL);
+    path = tr_buildPath(configDir, TORRENT_SUBDIR, nullptr);
+    tr_sys_dir_create(path, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
     session->torrentDir = path;
 }
 
@@ -328,47 +328,47 @@ char const* tr_getResumeDir(tr_session const* session)
 
 char const* tr_getDefaultConfigDir(char const* appname)
 {
-    static char const* s = NULL;
+    static char const* s = nullptr;
 
     if (tr_str_is_empty(appname))
     {
         appname = "Transmission";
     }
 
-    if (s == NULL)
+    if (s == nullptr)
     {
-        s = tr_env_get_string("TRANSMISSION_HOME", NULL);
+        s = tr_env_get_string("TRANSMISSION_HOME", nullptr);
 
-        if (s == NULL)
+        if (s == nullptr)
         {
 #ifdef __APPLE__
 
-            s = tr_buildPath(getHomeDir(), "Library", "Application Support", appname, NULL);
+            s = tr_buildPath(getHomeDir(), "Library", "Application Support", appname, nullptr);
 
 #elif defined(_WIN32)
 
             char* appdata = win32_get_known_folder(FOLDERID_LocalAppData);
-            s = tr_buildPath(appdata, appname, NULL);
+            s = tr_buildPath(appdata, appname, nullptr);
             tr_free(appdata);
 
 #elif defined(__HAIKU__)
 
             char buf[PATH_MAX];
             find_directory(B_USER_SETTINGS_DIRECTORY, -1, true, buf, sizeof(buf));
-            s = tr_buildPath(buf, appname, NULL);
+            s = tr_buildPath(buf, appname, nullptr);
 
 #else
 
-            char* const xdg_config_home = tr_env_get_string("XDG_CONFIG_HOME", NULL);
+            char* const xdg_config_home = tr_env_get_string("XDG_CONFIG_HOME", nullptr);
 
-            if (xdg_config_home != NULL)
+            if (xdg_config_home != nullptr)
             {
-                s = tr_buildPath(xdg_config_home, appname, NULL);
+                s = tr_buildPath(xdg_config_home, appname, nullptr);
                 tr_free(xdg_config_home);
             }
             else
             {
-                s = tr_buildPath(getHomeDir(), ".config", appname, NULL);
+                s = tr_buildPath(getHomeDir(), ".config", appname, nullptr);
             }
 
 #endif
@@ -380,9 +380,9 @@ char const* tr_getDefaultConfigDir(char const* appname)
 
 char const* tr_getDefaultDownloadDir(void)
 {
-    static char const* user_dir = NULL;
+    static char const* user_dir = nullptr;
 
-    if (user_dir == NULL)
+    if (user_dir == nullptr)
     {
         char* config_home;
         char* config_file;
@@ -390,39 +390,39 @@ char const* tr_getDefaultDownloadDir(void)
         size_t content_len;
 
         /* figure out where to look for user-dirs.dirs */
-        config_home = tr_env_get_string("XDG_CONFIG_HOME", NULL);
+        config_home = tr_env_get_string("XDG_CONFIG_HOME", nullptr);
 
         if (!tr_str_is_empty(config_home))
         {
-            config_file = tr_buildPath(config_home, "user-dirs.dirs", NULL);
+            config_file = tr_buildPath(config_home, "user-dirs.dirs", nullptr);
         }
         else
         {
-            config_file = tr_buildPath(getHomeDir(), ".config", "user-dirs.dirs", NULL);
+            config_file = tr_buildPath(getHomeDir(), ".config", "user-dirs.dirs", nullptr);
         }
 
         tr_free(config_home);
 
         /* read in user-dirs.dirs and look for the download dir entry */
-        content = (char*)tr_loadFile(config_file, &content_len, NULL);
+        content = (char*)tr_loadFile(config_file, &content_len, nullptr);
 
-        if (content != NULL && content_len > 0)
+        if (content != nullptr && content_len > 0)
         {
             char const* key = "XDG_DOWNLOAD_DIR=\"";
             char* line = strstr(content, key);
 
-            if (line != NULL)
+            if (line != nullptr)
             {
                 char* value = line + strlen(key);
                 char* end = strchr(value, '"');
 
-                if (end != NULL)
+                if (end != nullptr)
                 {
                     *end = '\0';
 
                     if (strncmp(value, "$HOME/", 6) == 0)
                     {
-                        user_dir = tr_buildPath(getHomeDir(), value + 6, NULL);
+                        user_dir = tr_buildPath(getHomeDir(), value + 6, nullptr);
                     }
                     else if (strcmp(value, "$HOME") == 0)
                     {
@@ -438,19 +438,19 @@ char const* tr_getDefaultDownloadDir(void)
 
 #ifdef _WIN32
 
-        if (user_dir == NULL)
+        if (user_dir == nullptr)
         {
             user_dir = win32_get_known_folder(FOLDERID_Downloads);
         }
 
 #endif
 
-        if (user_dir == NULL)
+        if (user_dir == nullptr)
         {
 #ifdef __HAIKU__
-            user_dir = tr_buildPath(getHomeDir(), "Desktop", NULL);
+            user_dir = tr_buildPath(getHomeDir(), "Desktop", nullptr);
 #else
-            user_dir = tr_buildPath(getHomeDir(), "Downloads", NULL);
+            user_dir = tr_buildPath(getHomeDir(), "Downloads", nullptr);
 #endif
         }
 
@@ -467,8 +467,8 @@ char const* tr_getDefaultDownloadDir(void)
 
 static bool isWebClientDir(char const* path)
 {
-    char* tmp = tr_buildPath(path, "index.html", NULL);
-    bool const ret = tr_sys_path_exists(tmp, NULL);
+    char* tmp = tr_buildPath(path, "index.html", nullptr);
+    bool const ret = tr_sys_path_exists(tmp, nullptr);
     tr_logAddInfo(_("Searching for web interface file \"%s\""), tmp);
     tr_free(tmp);
 
@@ -477,23 +477,23 @@ static bool isWebClientDir(char const* path)
 
 char const* tr_getWebClientDir(tr_session const* session)
 {
-    static char const* s = NULL;
+    static char const* s = nullptr;
 
-    if (s == NULL)
+    if (s == nullptr)
     {
-        s = tr_env_get_string("CLUTCH_HOME", NULL);
+        s = tr_env_get_string("CLUTCH_HOME", nullptr);
 
-        if (s == NULL)
+        if (s == nullptr)
         {
-            s = tr_env_get_string("TRANSMISSION_WEB_HOME", NULL);
+            s = tr_env_get_string("TRANSMISSION_WEB_HOME", nullptr);
         }
 
-        if (s == NULL)
+        if (s == nullptr)
         {
 #ifdef BUILD_MAC_CLIENT /* on Mac, look in the Application Support folder first, then in the app bundle. */
 
             /* Look in the Application Support folder */
-            s = tr_buildPath(tr_sessionGetConfigDir(session), "public_html", NULL);
+            s = tr_buildPath(tr_sessionGetConfigDir(session), "public_html", nullptr);
 
             if (!isWebClientDir(s))
             {
@@ -511,12 +511,12 @@ char const* tr_getWebClientDir(tr_session const* session)
                 CFRelease(appRef);
 
                 /* Fallback to the app bundle */
-                s = tr_buildPath(appString, "Contents", "Resources", "public_html", NULL);
+                s = tr_buildPath(appString, "Contents", "Resources", "public_html", nullptr);
 
                 if (!isWebClientDir(s))
                 {
                     tr_free(const_cast<char*>(s));
-                    s = NULL;
+                    s = nullptr;
                 }
 
                 tr_free(appString);
@@ -535,10 +535,10 @@ char const* tr_getWebClientDir(tr_session const* session)
                 &FOLDERID_ProgramData,
             };
 
-            for (size_t i = 0; s == NULL && i < TR_N_ELEMENTS(known_folder_ids); ++i)
+            for (size_t i = 0; s == nullptr && i < TR_N_ELEMENTS(known_folder_ids); ++i)
             {
                 char* dir = win32_get_known_folder(*known_folder_ids[i]);
-                char* path = tr_buildPath(dir, "Transmission", "Web", NULL);
+                char* path = tr_buildPath(dir, "Transmission", "Web", nullptr);
                 tr_free(dir);
 
                 if (isWebClientDir(path))
@@ -551,19 +551,19 @@ char const* tr_getWebClientDir(tr_session const* session)
                 }
             }
 
-            if (s == NULL) /* check calling module place */
+            if (s == nullptr) /* check calling module place */
             {
                 wchar_t wide_module_path[MAX_PATH];
                 char* module_path;
                 char* dir;
-                GetModuleFileNameW(NULL, wide_module_path, TR_N_ELEMENTS(wide_module_path));
+                GetModuleFileNameW(nullptr, wide_module_path, TR_N_ELEMENTS(wide_module_path));
                 module_path = tr_win32_native_to_utf8(wide_module_path, -1);
-                dir = tr_sys_path_dirname(module_path, NULL);
+                dir = tr_sys_path_dirname(module_path, nullptr);
                 tr_free(module_path);
 
-                if (dir != NULL)
+                if (dir != nullptr)
                 {
-                    char* path = tr_buildPath(dir, "Web", NULL);
+                    char* path = tr_buildPath(dir, "Web", nullptr);
                     tr_free(dir);
 
                     if (isWebClientDir(path))
@@ -581,11 +581,11 @@ char const* tr_getWebClientDir(tr_session const* session)
 
             TR_UNUSED(session);
 
-            tr_list* candidates = NULL;
+            tr_list* candidates = nullptr;
             char* tmp;
 
             /* XDG_DATA_HOME should be the first in the list of candidates */
-            tmp = tr_env_get_string("XDG_DATA_HOME", NULL);
+            tmp = tr_env_get_string("XDG_DATA_HOME", nullptr);
 
             if (!tr_str_is_empty(tmp))
             {
@@ -593,7 +593,7 @@ char const* tr_getWebClientDir(tr_session const* session)
             }
             else
             {
-                char* dhome = tr_buildPath(getHomeDir(), ".local", "share", NULL);
+                char* dhome = tr_buildPath(getHomeDir(), ".local", "share", nullptr);
                 tr_list_append(&candidates, dhome);
                 tr_free(tmp);
             }
@@ -601,9 +601,9 @@ char const* tr_getWebClientDir(tr_session const* session)
             /* XDG_DATA_DIRS are the backup directories */
             {
                 char const* const pkg = PACKAGE_DATA_DIR;
-                char* xdg = tr_env_get_string("XDG_DATA_DIRS", NULL);
+                char* xdg = tr_env_get_string("XDG_DATA_DIRS", nullptr);
                 char const* fallback = "/usr/local/share:/usr/share";
-                char* buf = tr_strdup_printf("%s:%s:%s", pkg, xdg != NULL ? xdg : "", fallback);
+                char* buf = tr_strdup_printf("%s:%s:%s", pkg, xdg != nullptr ? xdg : "", fallback);
                 tr_free(xdg);
                 tmp = buf;
 
@@ -611,7 +611,7 @@ char const* tr_getWebClientDir(tr_session const* session)
                 {
                     char const* end = strchr(tmp, ':');
 
-                    if (end != NULL)
+                    if (end != nullptr)
                     {
                         if (end - tmp > 1)
                         {
@@ -631,9 +631,9 @@ char const* tr_getWebClientDir(tr_session const* session)
             }
 
             /* walk through the candidates & look for a match */
-            for (tr_list* l = candidates; l != NULL; l = l->next)
+            for (tr_list* l = candidates; l != nullptr; l = l->next)
             {
-                char* path = tr_buildPath(static_cast<char const*>(l->data), "transmission", "public_html", NULL);
+                char* path = tr_buildPath(static_cast<char const*>(l->data), "transmission", "public_html", nullptr);
                 bool const found = isWebClientDir(path);
 
                 if (found)
@@ -663,9 +663,9 @@ char* tr_getSessionIdDir(void)
 #else
 
     char* program_data_dir = win32_get_known_folder_ex(FOLDERID_ProgramData, KF_FLAG_CREATE);
-    char* result = tr_buildPath(program_data_dir, "Transmission", NULL);
+    char* result = tr_buildPath(program_data_dir, "Transmission", nullptr);
     tr_free(program_data_dir);
-    tr_sys_dir_create(result, 0, 0, NULL);
+    tr_sys_dir_create(result, 0, 0, nullptr);
     return result;
 
 #endif

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -6,10 +6,10 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
+#include <algorithm>
 
 #include <sys/types.h>
-
 #include <event2/event.h>
 
 #include "transmission.h"
@@ -262,5 +262,5 @@ bool tr_sharedTraversalIsEnabled(tr_shared const* s)
 
 int tr_sharedTraversalStatus(tr_shared const* s)
 {
-    return MAX(s->natpmpStatus, s->upnpStatus);
+    return std::max(s->natpmpStatus, s->upnpStatus);
 }

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -78,12 +78,12 @@ static void natPulse(tr_shared* s, bool do_check)
     tr_port const private_peer_port = s->session->private_peer_port;
     bool const is_enabled = s->isEnabled && !s->isShuttingDown;
 
-    if (s->natpmp == NULL)
+    if (s->natpmp == nullptr)
     {
         s->natpmp = tr_natpmpInit();
     }
 
-    if (s->upnp == NULL)
+    if (s->upnp == nullptr)
     {
         s->upnp = tr_upnpInit();
     }
@@ -137,7 +137,7 @@ static void set_evtimer_from_status(tr_shared* s)
         break;
     }
 
-    if (s->timer != NULL)
+    if (s->timer != nullptr)
     {
         tr_timerAdd(s->timer, sec, msec);
     }
@@ -150,8 +150,8 @@ static void onTimer(evutil_socket_t fd, short what, void* vshared)
 
     auto* s = static_cast<tr_shared*>(vshared);
 
-    TR_ASSERT(s != NULL);
-    TR_ASSERT(s->timer != NULL);
+    TR_ASSERT(s != nullptr);
+    TR_ASSERT(s->timer != nullptr);
 
     /* do something */
     natPulse(s, s->doPortCheck);
@@ -190,10 +190,10 @@ tr_shared* tr_sharedInit(tr_session* session)
 
 static void stop_timer(tr_shared* s)
 {
-    if (s->timer != NULL)
+    if (s->timer != nullptr)
     {
         event_free(s->timer);
-        s->timer = NULL;
+        s->timer = nullptr;
     }
 }
 
@@ -203,11 +203,11 @@ static void stop_forwarding(tr_shared* s)
     natPulse(s, false);
 
     tr_natpmpClose(s->natpmp);
-    s->natpmp = NULL;
+    s->natpmp = nullptr;
     s->natpmpStatus = TR_PORT_UNMAPPED;
 
     tr_upnpClose(s->upnp);
-    s->upnp = NULL;
+    s->upnp = nullptr;
     s->upnpStatus = TR_PORT_UNMAPPED;
 
     stop_timer(s);
@@ -219,7 +219,7 @@ void tr_sharedClose(tr_session* session)
 
     s->isShuttingDown = true;
     stop_forwarding(s);
-    s->session->shared = NULL;
+    s->session->shared = nullptr;
     tr_free(s);
 }
 

--- a/libtransmission/ptrarray.cc
+++ b/libtransmission/ptrarray.cc
@@ -17,10 +17,10 @@
 
 void tr_ptrArrayDestruct(tr_ptrArray* p, PtrArrayForeachFunc func)
 {
-    TR_ASSERT(p != NULL);
-    TR_ASSERT(p->items != NULL || p->n_items == 0);
+    TR_ASSERT(p != nullptr);
+    TR_ASSERT(p->items != nullptr || p->n_items == 0);
 
-    if (func != NULL)
+    if (func != nullptr)
     {
         tr_ptrArrayForeach(p, func);
     }
@@ -30,9 +30,9 @@ void tr_ptrArrayDestruct(tr_ptrArray* p, PtrArrayForeachFunc func)
 
 void tr_ptrArrayForeach(tr_ptrArray* t, PtrArrayForeachFunc func)
 {
-    TR_ASSERT(t != NULL);
-    TR_ASSERT(t->items != NULL || t->n_items == 0);
-    TR_ASSERT(func != NULL);
+    TR_ASSERT(t != nullptr);
+    TR_ASSERT(t->items != nullptr || t->n_items == 0);
+    TR_ASSERT(func != nullptr);
 
     for (int i = 0; i < t->n_items; ++i)
     {
@@ -70,7 +70,7 @@ int tr_ptrArrayInsert(tr_ptrArray* t, void* ptr, int pos)
 
 void* tr_ptrArrayPop(tr_ptrArray* t)
 {
-    void* ret = NULL;
+    void* ret = nullptr;
 
     if (t->n_items != 0)
     {
@@ -152,7 +152,7 @@ int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, tr_voidptr_comp
         }
     }
 
-    if (exact_match != NULL)
+    if (exact_match != nullptr)
     {
         *exact_match = match;
     }
@@ -169,7 +169,7 @@ int tr_ptrArrayLowerBound(tr_ptrArray const* t, void const* ptr, tr_voidptr_comp
 
 static void assertArrayIsSortedAndUnique(tr_ptrArray const* t, tr_voidptr_compare_func compare)
 {
-    if (t->items == NULL)
+    if (t->items == nullptr)
     {
         TR_ASSERT(t->n_items == 0);
     }
@@ -203,7 +203,7 @@ int tr_ptrArrayInsertSorted(tr_ptrArray* t, void* ptr, tr_voidptr_compare_func c
     int ret;
     assertArrayIsSortedAndUnique(t, compare);
 
-    pos = tr_ptrArrayLowerBound(t, ptr, compare, NULL);
+    pos = tr_ptrArrayLowerBound(t, ptr, compare, nullptr);
     ret = tr_ptrArrayInsert(t, ptr, pos);
 
     assertIndexIsSortedAndUnique(t, ret, compare);
@@ -214,14 +214,14 @@ void* tr_ptrArrayFindSorted(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_
 {
     bool match = false;
     int const pos = tr_ptrArrayLowerBound(t, ptr, compare, &match);
-    return match ? t->items[pos] : NULL;
+    return match ? t->items[pos] : nullptr;
 }
 
 static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare)
 {
     int pos;
     bool match;
-    void* ret = NULL;
+    void* ret = nullptr;
 
     assertArrayIsSortedAndUnique(t, compare);
 
@@ -234,7 +234,7 @@ static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, tr_vo
         tr_ptrArrayErase(t, pos, pos + 1);
     }
 
-    TR_ASSERT(ret == NULL || compare(ret, ptr) == 0);
+    TR_ASSERT(ret == nullptr || compare(ret, ptr) == 0);
     return ret;
 }
 
@@ -248,9 +248,9 @@ void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, tr_voidptr_
 
 #else
 
-    TR_ASSERT(removed != NULL);
+    TR_ASSERT(removed != nullptr);
     TR_ASSERT(removed == ptr);
-    TR_ASSERT(tr_ptrArrayFindSorted(t, ptr, compare) == NULL);
+    TR_ASSERT(tr_ptrArrayFindSorted(t, ptr, compare) == nullptr);
 
 #endif
 }

--- a/libtransmission/ptrarray.cc
+++ b/libtransmission/ptrarray.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* memmove */
+#include <cstring> /* memmove */
+#include <algorithm>
 
 #include "ptrarray.h"
 #include "tr-assert.h"
@@ -50,7 +51,7 @@ int tr_ptrArrayInsert(tr_ptrArray* t, void* ptr, int pos)
 {
     if (t->n_items >= t->n_alloc)
     {
-        t->n_alloc = MAX(FLOOR, t->n_alloc * 2);
+        t->n_alloc = std::max(FLOOR, t->n_alloc * 2);
         t->items = tr_renew(void*, t->items, t->n_alloc);
     }
 

--- a/libtransmission/ptrarray.h
+++ b/libtransmission/ptrarray.h
@@ -44,7 +44,7 @@ void tr_ptrArrayForeach(tr_ptrArray* array, PtrArrayForeachFunc func);
     @return the nth item in a tr_ptrArray */
 static inline void* tr_ptrArrayNth(tr_ptrArray* array, int i)
 {
-    TR_ASSERT(array != NULL);
+    TR_ASSERT(array != nullptr);
     TR_ASSERT(i >= 0);
     TR_ASSERT(i < array->n_items);
 
@@ -61,7 +61,7 @@ void* tr_ptrArrayPop(tr_ptrArray* array);
     @see tr_ptrArrayPop() */
 static inline void* tr_ptrArrayBack(tr_ptrArray* array)
 {
-    return array->n_items > 0 ? tr_ptrArrayNth(array, array->n_items - 1) : NULL;
+    return array->n_items > 0 ? tr_ptrArrayNth(array, array->n_items - 1) : nullptr;
 }
 
 void tr_ptrArrayErase(tr_ptrArray* t, int begin, int end);

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -6,8 +6,9 @@
  *
  */
 
-#include <stdlib.h> /* bsearch() */
-#include <string.h> /* memcmp() */
+#include <cstdlib> /* bsearch() */
+#include <cstring> /* memcmp() */
+#include <algorithm>
 
 #include "transmission.h"
 #include "ptrarray.h"
@@ -424,7 +425,7 @@ static int compareKeys(void const* va, void const* vb)
     auto const* a = static_cast<struct tr_key_struct const*>(va);
     auto const* b = static_cast<struct tr_key_struct const*>(vb);
 
-    int ret = memcmp(a->str, b->str, MIN(a->len, b->len));
+    int ret = memcmp(a->str, b->str, std::min(a->len, b->len));
 
     if (ret == 0 && a->len != b->len)
     {

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -450,7 +450,7 @@ bool tr_quark_lookup(void const* str, size_t len, tr_quark* setme)
         bsearch(&tmp, my_static, n_static, sizeof(struct tr_key_struct), compareKeys));
 
     bool success = false;
-    if (match != NULL)
+    if (match != nullptr)
     {
         *setme = match - my_static;
         success = true;
@@ -492,7 +492,7 @@ tr_quark tr_quark_new(void const* str, size_t len)
 {
     tr_quark ret = TR_KEY_NONE;
 
-    if (str != NULL)
+    if (str != nullptr)
     {
         if (len == TR_BAD_SIZE)
         {
@@ -521,7 +521,7 @@ char const* tr_quark_get_string(tr_quark q, size_t* len)
         tmp = static_cast<struct tr_key_struct const*>(tr_ptrArrayNth(&my_runtime, q - TR_N_KEYS));
     }
 
-    if (len != NULL)
+    if (len != nullptr)
     {
         *len = tmp->len;
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -123,7 +123,7 @@ static uint64_t loadLabels(tr_variant* dict, tr_torrent* tor)
         size_t str_len;
         for (int i = 0; i < n; ++i)
         {
-            if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != NULL && str_len != 0)
+            if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != nullptr && str_len != 0)
             {
                 tr_ptrArrayAppend(&tor->labels, tr_strndup(str, str_len));
             }
@@ -156,7 +156,7 @@ static void saveDND(tr_variant* dict, tr_torrent const* tor)
 static uint64_t loadDND(tr_variant* dict, tr_torrent* tor)
 {
     uint64_t ret = 0;
-    tr_variant* list = NULL;
+    tr_variant* list = nullptr;
     tr_file_index_t const n = tor->info.fileCount;
 
     if (tr_variantDictFindList(dict, TR_KEY_dnd, &list) && tr_variantListSize(list) == n)
@@ -394,7 +394,7 @@ static uint64_t loadName(tr_variant* dict, tr_torrent* tor)
     uint64_t ret = 0;
     char const* name;
 
-    if (tr_variantDictFindStr(dict, TR_KEY_name, &name, NULL))
+    if (tr_variantDictFindStr(dict, TR_KEY_name, &name, nullptr))
     {
         ret = TR_FR_NAME;
 
@@ -451,7 +451,7 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
             char const* str;
             size_t str_len;
 
-            if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != NULL && str_len != 0)
+            if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != nullptr && str_len != 0)
             {
                 tr_free(files[i].name);
                 files[i].name = tr_strndup(str, str_len);
@@ -658,11 +658,11 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
             }
         }
 
-        err = NULL;
+        err = nullptr;
         tr_bitfieldConstruct(&blocks, tor->blockCount);
 
         tr_variant const* const b = tr_variantDictFind(prog, TR_KEY_blocks);
-        if (b != NULL)
+        if (b != nullptr)
         {
             size_t buflen;
             uint8_t const* buf;
@@ -684,7 +684,7 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
                 tr_bitfieldSetRaw(&blocks, buf, buflen, true);
             }
         }
-        else if (tr_variantDictFindStr(prog, TR_KEY_have, &str, NULL))
+        else if (tr_variantDictFindStr(prog, TR_KEY_have, &str, nullptr))
         {
             if (strcmp(str, "all") == 0)
             {
@@ -704,7 +704,7 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
             err = "Couldn't find 'pieces' or 'have' or 'bitfield'";
         }
 
-        if (err != NULL)
+        if (err != nullptr)
         {
             tr_logAddTorDbg(tor, "Torrent needs to be verified - %s", err);
         }
@@ -744,7 +744,7 @@ void tr_torrentSaveResume(tr_torrent* tor)
     tr_variantDictAddInt(&top, TR_KEY_done_date, tor->doneDate);
     tr_variantDictAddStr(&top, TR_KEY_destination, tor->downloadDir);
 
-    if (tor->incompleteDir != NULL)
+    if (tor->incompleteDir != nullptr)
     {
         tr_variantDictAddStr(&top, TR_KEY_incomplete_dir, tor->incompleteDir);
     }
@@ -794,9 +794,9 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
     bool boolVal;
     uint64_t fieldsLoaded = 0;
     bool const wasDirty = tor->isDirty;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
-    if (didRenameToHashOnlyName != NULL)
+    if (didRenameToHashOnlyName != nullptr)
     {
         *didRenameToHashOnlyName = false;
     }
@@ -820,11 +820,11 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
             return fieldsLoaded;
         }
 
-        if (tr_sys_path_rename(old_filename, filename, NULL))
+        if (tr_sys_path_rename(old_filename, filename, nullptr))
         {
             tr_logAddTorDbg(tor, "Migrated resume file from \"%s\" to \"%s\"", old_filename, filename);
 
-            if (didRenameToHashOnlyName != NULL)
+            if (didRenameToHashOnlyName != nullptr)
             {
                 *didRenameToHashOnlyName = true;
             }
@@ -1057,10 +1057,10 @@ void tr_torrentRemoveResume(tr_torrent const* tor)
     char* filename;
 
     filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
-    tr_sys_path_remove(filename, NULL);
+    tr_sys_path_remove(filename, nullptr);
     tr_free(filename);
 
     filename = getResumeFilename(tor, TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH);
-    tr_sys_path_remove(filename, NULL);
+    tr_sys_path_remove(filename, nullptr);
     tr_free(filename);
 }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h>
+#include <cstring>
+#include <algorithm>
 
 #include "transmission.h"
 #include "completion.h"
@@ -67,7 +68,7 @@ static void savePeers(tr_variant* dict, tr_torrent const* tor)
 static size_t addPeers(tr_torrent* tor, uint8_t const* buf, size_t buflen)
 {
     size_t const n_in = buflen / sizeof(tr_pex);
-    size_t const n_pex = MIN(n_in, MAX_REMEMBERED_PEERS);
+    size_t const n_pex = std::min(n_in, (unsigned long)MAX_REMEMBERED_PEERS);
 
     tr_pex pex[MAX_REMEMBERED_PEERS];
     memcpy(pex, buf, sizeof(tr_pex) * n_pex);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -6,8 +6,9 @@
  *
  */
 
-#include <errno.h>
-#include <string.h> /* memcpy */
+#include <cerrno>
+#include <cstring> /* memcpy */
+#include <algorithm>
 
 #include <zlib.h>
 
@@ -802,7 +803,7 @@ static void rpc_server_on_start_retry(evutil_socket_t fd, short type, void* cont
 static int rpc_server_start_retry(tr_rpc_server* server)
 {
     int retry_delay = (server->start_retry_counter / SERVER_START_RETRY_DELAY_STEP + 1) * SERVER_START_RETRY_DELAY_INCREMENT;
-    retry_delay = MIN(retry_delay, SERVER_START_RETRY_MAX_DELAY);
+    retry_delay = std::min(retry_delay, (int)SERVER_START_RETRY_MAX_DELAY);
 
     if (server->start_retry_timer == nullptr)
     {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -691,7 +691,8 @@ static void handle_request(struct evhttp_request* req, void* arg)
         }
 
         if (server->isPasswordEnabled &&
-            (pass == nullptr || user == nullptr || strcmp(server->username, user) != 0 || !tr_ssha1_matches(server->password, pass)))
+            (pass == nullptr || user == nullptr || strcmp(server->username, user) != 0 ||
+             !tr_ssha1_matches(server->password, pass)))
         {
             evhttp_add_header(req->output_headers, "WWW-Authenticate", "Basic realm=\"" MY_REALM "\"");
             if (server->isAntiBruteForceEnabled)

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -94,7 +94,7 @@ static void send_simple_response(struct evhttp_request* req, int code, char cons
 
     evbuffer_add_printf(body, "<h1>%d: %s</h1>", code, code_text);
 
-    if (text != NULL)
+    if (text != nullptr)
     {
         evbuffer_add_printf(body, "%s", text);
     }
@@ -126,14 +126,14 @@ static void extract_parts_from_multipart(struct evkeyvalq const* headers, struct
     size_t inlen = evbuffer_get_length(body);
 
     char const* boundary_key = "boundary=";
-    char const* boundary_key_begin = content_type != NULL ? strstr(content_type, boundary_key) : NULL;
-    char const* boundary_val = boundary_key_begin != NULL ? boundary_key_begin + strlen(boundary_key) : "arglebargle";
+    char const* boundary_key_begin = content_type != nullptr ? strstr(content_type, boundary_key) : nullptr;
+    char const* boundary_val = boundary_key_begin != nullptr ? boundary_key_begin + strlen(boundary_key) : "arglebargle";
     char* boundary = tr_strdup_printf("--%s", boundary_val);
     size_t const boundary_len = strlen(boundary);
 
     char const* delim = tr_memmem(in, inlen, boundary, boundary_len);
 
-    while (delim != NULL)
+    while (delim != nullptr)
     {
         size_t part_len;
         char const* part = delim + boundary_len;
@@ -142,13 +142,13 @@ static void extract_parts_from_multipart(struct evkeyvalq const* headers, struct
         in = part;
 
         delim = tr_memmem(in, inlen, boundary, boundary_len);
-        part_len = delim != NULL ? (size_t)(delim - part) : inlen;
+        part_len = delim != nullptr ? (size_t)(delim - part) : inlen;
 
         if (part_len != 0)
         {
             char const* rnrn = tr_memmem(part, part_len, "\r\n\r\n", 4);
 
-            if (rnrn != NULL)
+            if (rnrn != nullptr)
             {
                 struct tr_mimepart* p = tr_new(struct tr_mimepart, 1);
                 p->headers_len = (size_t)(rnrn - part);
@@ -167,7 +167,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
 {
     if (req->type != EVHTTP_REQ_POST)
     {
-        send_simple_response(req, 405, NULL);
+        send_simple_response(req, 405, nullptr);
     }
     else
     {
@@ -176,7 +176,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
         auto parts = tr_ptrArray{};
 
         char const* query = strchr(req->uri, '?');
-        bool const paused = query != NULL && strstr(query + 1, "paused=true") != NULL;
+        bool const paused = query != nullptr && strstr(query + 1, "paused=true") != nullptr;
 
         extract_parts_from_multipart(req->input_headers, req->input_buffer, &parts);
         n = tr_ptrArraySize(&parts);
@@ -186,7 +186,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
         {
             auto const* const p = static_cast<struct tr_mimepart const*>(tr_ptrArrayNth(&parts, i));
 
-            if (tr_strcasestr(p->headers, TR_RPC_SESSION_ID_HEADER) != NULL)
+            if (tr_strcasestr(p->headers, TR_RPC_SESSION_ID_HEADER) != nullptr)
             {
                 char const* ours = get_current_session_id(server);
                 size_t const ourlen = strlen(ours);
@@ -233,7 +233,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
                 }
                 else if (tr_variantFromBenc(&test, body, body_len) == 0)
                 {
-                    auto* b64 = static_cast<char*>(tr_base64_encode(body, body_len, NULL));
+                    auto* b64 = static_cast<char*>(tr_base64_encode(body, body_len, nullptr));
                     tr_variantDictAddStr(args, TR_KEY_metainfo, b64);
                     tr_free(b64);
                     have_source = true;
@@ -241,7 +241,7 @@ static void handle_upload(struct evhttp_request* req, struct tr_rpc_server* serv
 
                 if (have_source)
                 {
-                    tr_rpc_request_exec_json(server->session, &top, NULL, NULL);
+                    tr_rpc_request_exec_json(server->session, &top, nullptr, nullptr);
                 }
 
                 tr_variantFree(&top);
@@ -284,7 +284,7 @@ static char const* mimetype_guess(char const* path)
     };
     char const* dot = strrchr(path, '.');
 
-    for (unsigned int i = 0; dot != NULL && i < TR_N_ELEMENTS(types); ++i)
+    for (unsigned int i = 0; dot != nullptr && i < TR_N_ELEMENTS(types); ++i)
     {
         if (strcmp(dot + 1, types[i].suffix) == 0)
         {
@@ -303,7 +303,7 @@ static void add_response(
 {
     char const* key = "Accept-Encoding";
     char const* encoding = evhttp_find_header(req->input_headers, key);
-    bool const do_compress = encoding != NULL && strstr(encoding, "gzip") != NULL;
+    bool const do_compress = encoding != nullptr && strstr(encoding, "gzip") != nullptr;
 
     if (!do_compress)
     {
@@ -394,18 +394,18 @@ static void serve_file(struct evhttp_request* req, struct tr_rpc_server* server,
     if (req->type != EVHTTP_REQ_GET)
     {
         evhttp_add_header(req->output_headers, "Allow", "GET");
-        send_simple_response(req, 405, NULL);
+        send_simple_response(req, 405, nullptr);
     }
     else
     {
         void* file;
         size_t file_len;
-        tr_error* error = NULL;
+        tr_error* error = nullptr;
 
         file_len = 0;
         file = tr_loadFile(filename, &file_len, &error);
 
-        if (file == NULL)
+        if (file == nullptr)
         {
             char* tmp = tr_strdup_printf("%s (%s)", filename, error->message);
             send_simple_response(req, HTTP_NOTFOUND, tmp);
@@ -459,12 +459,12 @@ static void handle_web_client(struct evhttp_request* req, struct tr_rpc_server* 
 
         subpath = tr_strdup(req->uri + strlen(server->url) + 4);
 
-        if ((pch = strchr(subpath, '?')) != NULL)
+        if ((pch = strchr(subpath, '?')) != nullptr)
         {
             *pch = '\0';
         }
 
-        if (strstr(subpath, "..") != NULL)
+        if (strstr(subpath, "..") != nullptr)
         {
             send_simple_response(req, HTTP_NOTFOUND, "<p>Tsk, tsk.</p>");
         }
@@ -516,7 +516,7 @@ static void handle_rpc_from_json(struct evhttp_request* req, struct tr_rpc_serve
     data->req = req;
     data->server = server;
 
-    tr_rpc_request_exec_json(server->session, have_content ? &top : NULL, rpc_response_func, data);
+    tr_rpc_request_exec_json(server->session, have_content ? &top : nullptr, rpc_response_func, data);
 
     if (have_content)
     {
@@ -540,7 +540,7 @@ static void handle_rpc(struct evhttp_request* req, struct tr_rpc_server* server)
     {
         char const* q = strchr(req->uri, '?');
 
-        if (q != NULL)
+        if (q != nullptr)
         {
             struct rpc_response_data* data = tr_new0(struct rpc_response_data, 1);
             data->req = req;
@@ -550,7 +550,7 @@ static void handle_rpc(struct evhttp_request* req, struct tr_rpc_server* server)
         }
     }
 
-    send_simple_response(req, 405, NULL);
+    send_simple_response(req, 405, nullptr);
 }
 
 static bool isAddressAllowed(tr_rpc_server const* server, char const* address)
@@ -560,7 +560,7 @@ static bool isAddressAllowed(tr_rpc_server const* server, char const* address)
         return true;
     }
 
-    for (tr_list* l = server->whitelist; l != NULL; l = l->next)
+    for (tr_list* l = server->whitelist; l != nullptr; l = l->next)
     {
         if (tr_wildmat(address, static_cast<char const*>(l->data)))
         {
@@ -597,7 +597,7 @@ static bool isHostnameAllowed(tr_rpc_server const* server, struct evhttp_request
     char const* const host = evhttp_find_header(req->input_headers, "Host");
 
     /* No host header, invalid request. */
-    if (host == NULL)
+    if (host == nullptr)
     {
         return false;
     }
@@ -619,7 +619,7 @@ static bool isHostnameAllowed(tr_rpc_server const* server, struct evhttp_request
     }
 
     /* Otherwise, hostname must be whitelisted. */
-    for (tr_list* l = server->hostWhitelist; l != NULL; l = l->next)
+    for (tr_list* l = server->hostWhitelist; l != nullptr; l = l->next)
     {
         if (tr_wildmat(hostname, static_cast<char const*>(l->data)))
         {
@@ -636,7 +636,7 @@ static bool test_session_id(struct tr_rpc_server* server, struct evhttp_request*
 {
     char const* ours = get_current_session_id(server);
     char const* theirs = evhttp_find_header(req->input_headers, TR_RPC_SESSION_ID_HEADER);
-    bool const success = theirs != NULL && strcmp(theirs, ours) == 0;
+    bool const success = theirs != nullptr && strcmp(theirs, ours) == 0;
     return success;
 }
 
@@ -644,11 +644,11 @@ static void handle_request(struct evhttp_request* req, void* arg)
 {
     auto* server = static_cast<struct tr_rpc_server*>(arg);
 
-    if (req != NULL && req->evcon != NULL)
+    if (req != nullptr && req->evcon != nullptr)
     {
         char const* auth;
-        char* user = NULL;
-        char* pass = NULL;
+        char* user = nullptr;
+        char* pass = nullptr;
 
         evhttp_add_header(req->output_headers, "Server", MY_REALM);
 
@@ -672,13 +672,13 @@ static void handle_request(struct evhttp_request* req, void* arg)
 
         auth = evhttp_find_header(req->input_headers, "Authorization");
 
-        if (auth != NULL && evutil_ascii_strncasecmp(auth, "basic ", 6) == 0)
+        if (auth != nullptr && evutil_ascii_strncasecmp(auth, "basic ", 6) == 0)
         {
-            auto* p = static_cast<char*>(tr_base64_decode_str(auth + 6, NULL));
+            auto* p = static_cast<char*>(tr_base64_decode_str(auth + 6, nullptr));
 
-            if (p != NULL)
+            if (p != nullptr)
             {
-                if ((pass = strchr(p, ':')) != NULL)
+                if ((pass = strchr(p, ':')) != nullptr)
                 {
                     user = p;
                     *pass++ = '\0';
@@ -691,7 +691,7 @@ static void handle_request(struct evhttp_request* req, void* arg)
         }
 
         if (server->isPasswordEnabled &&
-            (pass == NULL || user == NULL || strcmp(server->username, user) != 0 || !tr_ssha1_matches(server->password, pass)))
+            (pass == nullptr || user == nullptr || strcmp(server->username, user) != 0 || !tr_ssha1_matches(server->password, pass)))
         {
             evhttp_add_header(req->output_headers, "WWW-Authenticate", "Basic realm=\"" MY_REALM "\"");
             if (server->isAntiBruteForceEnabled)
@@ -714,7 +714,7 @@ static void handle_request(struct evhttp_request* req, void* arg)
         {
             char* location = tr_strdup_printf("%sweb/", server->url);
             evhttp_add_header(req->output_headers, "Location", location);
-            send_simple_response(req, HTTP_MOVEPERM, NULL);
+            send_simple_response(req, HTTP_MOVEPERM, nullptr);
             tr_free(location);
         }
         else if (strncmp(req->uri + strlen(server->url), "web/", 4) == 0)
@@ -803,7 +803,7 @@ static int rpc_server_start_retry(tr_rpc_server* server)
     int retry_delay = (server->start_retry_counter / SERVER_START_RETRY_DELAY_STEP + 1) * SERVER_START_RETRY_DELAY_INCREMENT;
     retry_delay = MIN(retry_delay, SERVER_START_RETRY_MAX_DELAY);
 
-    if (server->start_retry_timer == NULL)
+    if (server->start_retry_timer == nullptr)
     {
         server->start_retry_timer = evtimer_new(server->session->event_base, rpc_server_on_start_retry, server);
     }
@@ -816,10 +816,10 @@ static int rpc_server_start_retry(tr_rpc_server* server)
 
 static void rpc_server_start_retry_cancel(tr_rpc_server* server)
 {
-    if (server->start_retry_timer != NULL)
+    if (server->start_retry_timer != nullptr)
     {
         event_free(server->start_retry_timer);
-        server->start_retry_timer = NULL;
+        server->start_retry_timer = nullptr;
     }
 
     server->start_retry_counter = 0;
@@ -829,7 +829,7 @@ static void startServer(void* vserver)
 {
     auto* server = static_cast<tr_rpc_server*>(vserver);
 
-    if (server->httpd != NULL)
+    if (server->httpd != nullptr)
     {
         return;
     }
@@ -876,7 +876,7 @@ static void stopServer(tr_rpc_server* server)
 
     struct evhttp* httpd = server->httpd;
 
-    if (httpd == NULL)
+    if (httpd == nullptr)
     {
         return;
     }
@@ -884,7 +884,7 @@ static void stopServer(tr_rpc_server* server)
     char const* address = tr_rpcGetBindAddress(server);
     int const port = server->port;
 
-    server->httpd = NULL;
+    server->httpd = nullptr;
     evhttp_free(httpd);
 
     tr_logAddNamedDbg(MY_NAME, "Stopped listening on %s:%d", address, port);
@@ -929,7 +929,7 @@ static void restartServer(void* vserver)
 
 void tr_rpcSetPort(tr_rpc_server* server, tr_port port)
 {
-    TR_ASSERT(server != NULL);
+    TR_ASSERT(server != nullptr);
 
     if (server->port != port)
     {
@@ -957,7 +957,7 @@ void tr_rpcSetUrl(tr_rpc_server* server, char const* url)
 
 char const* tr_rpcGetUrl(tr_rpc_server const* server)
 {
-    return server->url != NULL ? server->url : "";
+    return server->url != nullptr ? server->url : "";
 }
 
 static void tr_rpcSetList(char const* whitelistStr, tr_list** list)
@@ -965,7 +965,7 @@ static void tr_rpcSetList(char const* whitelistStr, tr_list** list)
     void* tmp;
 
     /* clear out the old whitelist entries */
-    while ((tmp = tr_list_pop_front(list)) != NULL)
+    while ((tmp = tr_list_pop_front(list)) != nullptr)
     {
         tr_free(tmp);
     }
@@ -1019,7 +1019,7 @@ void tr_rpcSetWhitelist(tr_rpc_server* server, char const* whitelistStr)
 
 char const* tr_rpcGetWhitelist(tr_rpc_server const* server)
 {
-    return server->whitelistStr != NULL ? server->whitelistStr : "";
+    return server->whitelistStr != nullptr ? server->whitelistStr : "";
 }
 
 void tr_rpcSetWhitelistEnabled(tr_rpc_server* server, bool isEnabled)
@@ -1051,7 +1051,7 @@ void tr_rpcSetUsername(tr_rpc_server* server, char const* username)
 
 char const* tr_rpcGetUsername(tr_rpc_server const* server)
 {
-    return server->username != NULL ? server->username : "";
+    return server->username != nullptr ? server->username : "";
 }
 
 void tr_rpcSetPassword(tr_rpc_server* server, char const* password)
@@ -1072,7 +1072,7 @@ void tr_rpcSetPassword(tr_rpc_server* server, char const* password)
 
 char const* tr_rpcGetPassword(tr_rpc_server const* server)
 {
-    return server->password != NULL ? server->password : "";
+    return server->password != nullptr ? server->password : "";
 }
 
 void tr_rpcSetPasswordEnabled(tr_rpc_server* server, bool isEnabled)
@@ -1126,7 +1126,7 @@ static void closeServer(void* vserver)
 
     stopServer(server);
 
-    while ((tmp = tr_list_pop_front(&server->whitelist)) != NULL)
+    while ((tmp = tr_list_pop_front(&server->whitelist)) != nullptr)
     {
         tr_free(tmp);
     }
@@ -1146,12 +1146,12 @@ static void closeServer(void* vserver)
 void tr_rpcClose(tr_rpc_server** ps)
 {
     tr_runInEventThread((*ps)->session, closeServer, *ps);
-    *ps = NULL;
+    *ps = nullptr;
 }
 
 static void missing_settings_key(tr_quark const q)
 {
-    char const* str = tr_quark_get_string(q, NULL);
+    char const* str = tr_quark_get_string(q, nullptr);
     tr_logAddNamedError(MY_NAME, _("Couldn't find settings key \"%s\""), str);
 }
 
@@ -1190,7 +1190,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_url;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL))
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr))
     {
         missing_settings_key(key);
     }
@@ -1223,7 +1223,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_host_whitelist;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL) && str != NULL)
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr) && str != nullptr)
     {
         missing_settings_key(key);
     }
@@ -1245,7 +1245,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_whitelist;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL) && str != NULL)
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr) && str != nullptr)
     {
         missing_settings_key(key);
     }
@@ -1256,7 +1256,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_username;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL))
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr))
     {
         missing_settings_key(key);
     }
@@ -1267,7 +1267,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_password;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL))
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr))
     {
         missing_settings_key(key);
     }
@@ -1300,7 +1300,7 @@ tr_rpc_server* tr_rpcInit(tr_session* session, tr_variant* settings)
 
     key = TR_KEY_rpc_bind_address;
 
-    if (!tr_variantDictFindStr(settings, key, &str, NULL))
+    if (!tr_variantDictFindStr(settings, key, &str, nullptr))
     {
         missing_settings_key(key);
         address = tr_inaddr_any;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -6,10 +6,11 @@
  *
  */
 
-#include <ctype.h> /* isdigit */
-#include <errno.h>
-#include <stdlib.h> /* strtol */
-#include <string.h> /* strcmp */
+#include <cctype> /* isdigit */
+#include <cerrno>
+#include <cstdlib> /* strtol */
+#include <cstring> /* strcmp */
+#include <algorithm>
 
 #ifndef ZLIB_CONST
 #define ZLIB_CONST
@@ -1246,7 +1247,7 @@ static int copyTrackers(tr_tracker_info* tgt, tr_tracker_info const* src, int n)
     {
         tgt[i].tier = src[i].tier;
         tgt[i].announce = tr_strdup(src[i].announce);
-        maxTier = MAX(maxTier, src[i].tier);
+        maxTier = std::max(maxTier, src[i].tier);
     }
 
     return maxTier;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -63,7 +63,7 @@ static tr_rpc_callback_status notify(tr_session* session, tr_rpc_callback_type t
 {
     tr_rpc_callback_status status = TR_RPC_OK;
 
-    if (session->rpc_func != NULL)
+    if (session->rpc_func != nullptr)
     {
         status = (*session->rpc_func)(session, type, tor, session->rpc_func_user_data);
     }
@@ -89,7 +89,7 @@ struct tr_rpc_idle_data
 
 static void tr_idle_function_done(struct tr_rpc_idle_data* data, char const* result)
 {
-    if (result == NULL)
+    if (result == nullptr)
     {
         result = "success";
     }
@@ -111,7 +111,7 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
 {
     int torrentCount = 0;
     int64_t id;
-    tr_torrent** torrents = NULL;
+    tr_torrent** torrents = nullptr;
     tr_variant* ids;
     char const* str;
 
@@ -130,16 +130,16 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
             {
                 tor = tr_torrentFindFromId(session, id);
             }
-            else if (tr_variantGetStr(node, &str, NULL))
+            else if (tr_variantGetStr(node, &str, nullptr))
             {
                 tor = tr_torrentFindFromHashString(session, str);
             }
             else
             {
-                tor = NULL;
+                tor = nullptr;
             }
 
-            if (tor != NULL)
+            if (tor != nullptr)
             {
                 torrents[torrentCount++] = tor;
             }
@@ -150,22 +150,22 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
         tr_torrent* tor;
         torrents = tr_new0(tr_torrent*, 1);
 
-        if ((tor = tr_torrentFindFromId(session, id)) != NULL)
+        if ((tor = tr_torrentFindFromId(session, id)) != nullptr)
         {
             torrents[torrentCount++] = tor;
         }
     }
-    else if (tr_variantDictFindStr(args, TR_KEY_ids, &str, NULL))
+    else if (tr_variantDictFindStr(args, TR_KEY_ids, &str, nullptr))
     {
         if (strcmp(str, "recently-active") == 0)
         {
-            tr_torrent* tor = NULL;
+            tr_torrent* tor = nullptr;
             time_t const now = tr_time();
             time_t const window = RECENTLY_ACTIVE_SECONDS;
             int const n = tr_sessionCountTorrents(session);
             torrents = tr_new0(tr_torrent*, n);
 
-            while ((tor = tr_torrentNext(session, tor)) != NULL)
+            while ((tor = tr_torrentNext(session, tor)) != nullptr)
             {
                 if (tor->anyDate >= now - window)
                 {
@@ -178,7 +178,7 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
             tr_torrent* tor;
             torrents = tr_new0(tr_torrent*, 1);
 
-            if ((tor = tr_torrentFindFromHashString(session, str)) != NULL)
+            if ((tor = tr_torrentFindFromHashString(session, str)) != nullptr)
             {
                 torrents[torrentCount++] = tor;
             }
@@ -200,7 +200,7 @@ static void notifyBatchQueueChange(tr_session* session, tr_torrent** torrents, i
         notify(session, TR_RPC_TORRENT_CHANGED, torrents[i]);
     }
 
-    notify(session, TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED, NULL);
+    notify(session, TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED, nullptr);
 }
 
 static char const* queueMoveTop(
@@ -217,7 +217,7 @@ static char const* queueMoveTop(
     tr_torrentsQueueMoveTop(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* queueMoveUp(
@@ -234,7 +234,7 @@ static char const* queueMoveUp(
     tr_torrentsQueueMoveUp(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* queueMoveDown(
@@ -251,7 +251,7 @@ static char const* queueMoveDown(
     tr_torrentsQueueMoveDown(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* queueMoveBottom(
@@ -268,7 +268,7 @@ static char const* queueMoveBottom(
     tr_torrentsQueueMoveBottom(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static int compareTorrentByQueuePosition(void const* va, void const* vb)
@@ -288,7 +288,7 @@ static char const* torrentStart(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -307,7 +307,7 @@ static char const* torrentStart(
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* torrentStartNow(
@@ -319,7 +319,7 @@ static char const* torrentStartNow(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -338,7 +338,7 @@ static char const* torrentStartNow(
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* torrentStop(
@@ -350,7 +350,7 @@ static char const* torrentStop(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -367,7 +367,7 @@ static char const* torrentStop(
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* torrentRemove(
@@ -379,7 +379,7 @@ static char const* torrentRemove(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     bool deleteFlag;
 
@@ -400,12 +400,12 @@ static char const* torrentRemove(
 
         if ((status & TR_RPC_NOREMOVE) == 0)
         {
-            tr_torrentRemove(tor, deleteFlag, NULL);
+            tr_torrentRemove(tor, deleteFlag, nullptr);
         }
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* torrentReannounce(
@@ -417,7 +417,7 @@ static char const* torrentReannounce(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -434,7 +434,7 @@ static char const* torrentReannounce(
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 static char const* torrentVerify(
@@ -446,7 +446,7 @@ static char const* torrentVerify(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -454,12 +454,12 @@ static char const* torrentVerify(
     for (int i = 0; i < torrentCount; ++i)
     {
         tr_torrent* tor = torrents[i];
-        tr_torrentVerify(tor, NULL, NULL);
+        tr_torrentVerify(tor, nullptr, nullptr);
         notify(session, TR_RPC_TORRENT_CHANGED, tor);
     }
 
     tr_free(torrents);
-    return NULL;
+    return nullptr;
 }
 
 /***
@@ -625,7 +625,7 @@ static void initField(
         break;
 
     case TR_KEY_comment:
-        tr_variantInitStr(initme, inf->comment != NULL ? inf->comment : "", TR_BAD_SIZE);
+        tr_variantInitStr(initme, inf->comment != nullptr ? inf->comment : "", TR_BAD_SIZE);
         break;
 
     case TR_KEY_corruptEver:
@@ -633,7 +633,7 @@ static void initField(
         break;
 
     case TR_KEY_creator:
-        tr_variantInitStr(initme, inf->creator != NULL ? inf->creator : "", TR_BAD_SIZE);
+        tr_variantInitStr(initme, inf->creator != nullptr ? inf->creator : "", TR_BAD_SIZE);
         break;
 
     case TR_KEY_dateCreated:
@@ -799,8 +799,8 @@ static void initField(
         {
             size_t byte_count = 0;
             void* bytes = tr_torrentCreatePieceBitfield(tor, &byte_count);
-            auto* enc = static_cast<char*>(tr_base64_encode(bytes, byte_count, NULL));
-            tr_variantInitStr(initme, enc != NULL ? enc : "", TR_BAD_SIZE);
+            auto* enc = static_cast<char*>(tr_base64_encode(bytes, byte_count, nullptr));
+            tr_variantInitStr(initme, enc != nullptr ? enc : "", TR_BAD_SIZE);
             tr_free(enc);
             tr_free(bytes);
         }
@@ -984,17 +984,17 @@ static char const* torrentGet(
 {
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
     tr_variant* list = tr_variantDictAddList(args_out, TR_KEY_torrents, torrentCount + 1);
     tr_variant* fields;
     char const* strVal;
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
     tr_format format;
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_format, &strVal, NULL) && strcmp(strVal, "table") == 0)
+    if (tr_variantDictFindStr(args_in, TR_KEY_format, &strVal, nullptr) && strcmp(strVal, "table") == 0)
     {
         format = TR_FORMAT_TABLE;
     }
@@ -1003,7 +1003,7 @@ static char const* torrentGet(
         format = TR_FORMAT_OBJECT;
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_ids, &strVal, NULL) && strcmp(strVal, "recently-active") == 0)
+    if (tr_variantDictFindStr(args_in, TR_KEY_ids, &strVal, nullptr) && strcmp(strVal, "recently-active") == 0)
     {
         int n = 0;
         tr_variant* d;
@@ -1011,7 +1011,7 @@ static char const* torrentGet(
         int const interval = RECENTLY_ACTIVE_SECONDS;
         tr_variant* removed_out = tr_variantDictAddList(args_out, TR_KEY_removed, 0);
 
-        while ((d = tr_variantListChild(&session->removedTorrents, n)) != NULL)
+        while ((d = tr_variantListChild(&session->removedTorrents, n)) != nullptr)
         {
             int64_t date;
             int64_t id;
@@ -1074,14 +1074,14 @@ static char const* torrentGet(
 static char const* setLabels(tr_torrent* tor, tr_variant* list)
 {
     size_t const n = tr_variantListSize(list);
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
     auto labels = tr_ptrArray{};
     int labelcount = 0;
     for (size_t i = 0; i < n; ++i)
     {
         char const* str;
         size_t str_len;
-        if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != NULL)
+        if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != nullptr)
         {
             char* label = tr_strndup(str, str_len);
             tr_strstrip(label);
@@ -1090,12 +1090,12 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
                 errmsg = "labels cannot be empty";
             }
 
-            if (errmsg == NULL && strchr(str, ',') != NULL)
+            if (errmsg == nullptr && strchr(str, ',') != nullptr)
             {
                 errmsg = "labels cannot contain comma (,) character";
             }
 
-            if (errmsg == NULL)
+            if (errmsg == nullptr)
             {
                 bool dup = false;
                 for (int j = 0; j < labelcount; j++)
@@ -1116,14 +1116,14 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
             tr_ptrArrayAppend(&labels, label);
             labelcount++;
 
-            if (errmsg != NULL)
+            if (errmsg != nullptr)
             {
                 break;
             }
         }
     }
 
-    if (errmsg == NULL)
+    if (errmsg == nullptr)
     {
         tr_torrentSetLabels(tor, &labels);
     }
@@ -1137,7 +1137,7 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
     int64_t tmp;
     int fileCount = 0;
     size_t const n = tr_variantListSize(list);
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
     tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
 
     if (n != 0)
@@ -1179,7 +1179,7 @@ static char const* setFileDLs(tr_torrent* tor, bool do_download, tr_variant* lis
     int64_t tmp;
     int fileCount = 0;
     size_t const n = tr_variantListSize(list);
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
     tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
 
     if (n != 0) /* if argument list, process them */
@@ -1226,7 +1226,7 @@ static bool findAnnounceUrl(tr_tracker_info const* t, int n, char const* url, in
         {
             found = true;
 
-            if (pos != NULL)
+            if (pos != nullptr)
             {
                 *pos = i;
             }
@@ -1270,7 +1270,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
     tr_tracker_info* trackers;
     bool changed = false;
     tr_info const* inf = tr_torrentInfo(tor);
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
 
     /* make a working copy of the existing announce list */
     n = inf->trackerCount;
@@ -1281,12 +1281,12 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
     i = 0;
 
     tr_variant const* val;
-    while ((val = tr_variantListChild(urls, i)) != NULL)
+    while ((val = tr_variantListChild(urls, i)) != nullptr)
     {
-        char const* announce = NULL;
+        char const* announce = nullptr;
 
-        if (tr_variantGetStr(val, &announce, NULL) && tr_urlIsValidTracker(announce) &&
-            !findAnnounceUrl(trackers, n, announce, NULL))
+        if (tr_variantGetStr(val, &announce, nullptr) && tr_urlIsValidTracker(announce) &&
+            !findAnnounceUrl(trackers, n, announce, nullptr))
         {
             trackers[n].tier = ++tier; /* add a new tier */
             trackers[n].announce = tr_strdup(announce);
@@ -1316,7 +1316,7 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
     bool changed = false;
     tr_info const* inf = tr_torrentInfo(tor);
     int const n = inf->trackerCount;
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
 
     /* make a working copy of the existing announce list */
     trackers = tr_new0(tr_tracker_info, n);
@@ -1365,7 +1365,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
     int i = 0;
     int t = 0;
     tr_variant const* val;
-    while ((val = tr_variantListChild(ids, i)) != NULL)
+    while ((val = tr_variantListChild(ids, i)) != nullptr)
     {
         int64_t pos;
 
@@ -1397,7 +1397,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         changed = true;
     }
 
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
     if (!changed)
     {
         errmsg = "invalid argument";
@@ -1421,12 +1421,12 @@ static char const* torrentSet(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
 
     for (int i = 0; i < torrentCount; ++i)
     {
@@ -1448,17 +1448,17 @@ static char const* torrentSet(
             }
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_labels, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_labels, &tmp_variant))
         {
             errmsg = setLabels(tor, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_files_unwanted, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_files_unwanted, &tmp_variant))
         {
             errmsg = setFileDLs(tor, false, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_files_wanted, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_files_wanted, &tmp_variant))
         {
             errmsg = setFileDLs(tor, true, tmp_variant);
         }
@@ -1468,17 +1468,17 @@ static char const* torrentSet(
             tr_torrentSetPeerLimit(tor, tmp);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_priority_high, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_priority_high, &tmp_variant))
         {
             errmsg = setFilePriorities(tor, TR_PRI_HIGH, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_priority_low, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_priority_low, &tmp_variant))
         {
             errmsg = setFilePriorities(tor, TR_PRI_LOW, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_priority_normal, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_priority_normal, &tmp_variant))
         {
             errmsg = setFilePriorities(tor, TR_PRI_NORMAL, tmp_variant);
         }
@@ -1533,17 +1533,17 @@ static char const* torrentSet(
             tr_torrentSetQueuePosition(tor, (int)tmp);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_trackerAdd, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_trackerAdd, &tmp_variant))
         {
             errmsg = addTrackerUrls(tor, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_trackerRemove, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_trackerRemove, &tmp_variant))
         {
             errmsg = removeTrackers(tor, tmp_variant);
         }
 
-        if (errmsg == NULL && tr_variantDictFindList(args_in, TR_KEY_trackerReplace, &tmp_variant))
+        if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_trackerReplace, &tmp_variant))
         {
             errmsg = replaceTrackers(tor, tmp_variant);
         }
@@ -1564,11 +1564,11 @@ static char const* torrentSetLocation(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
-    char const* location = NULL;
+    char const* location = nullptr;
 
-    if (!tr_variantDictFindStr(args_in, TR_KEY_location, &location, NULL))
+    if (!tr_variantDictFindStr(args_in, TR_KEY_location, &location, nullptr))
     {
         return "no location";
     }
@@ -1590,13 +1590,13 @@ static char const* torrentSetLocation(
     for (int i = 0; i < torrentCount; ++i)
     {
         tr_torrent* tor = torrents[i];
-        tr_torrentSetLocation(tor, location, move, NULL, NULL);
+        tr_torrentSetLocation(tor, location, move, nullptr, nullptr);
         notify(session, TR_RPC_TORRENT_MOVED, tor);
     }
 
     tr_free(torrents);
 
-    return NULL;
+    return nullptr;
 }
 
 /***
@@ -1614,7 +1614,7 @@ static void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char con
 
     if (error == 0)
     {
-        result = NULL;
+        result = nullptr;
     }
     else
     {
@@ -1632,12 +1632,12 @@ static char const* torrentRenamePath(
 {
     TR_UNUSED(args_out);
 
-    char const* errmsg = NULL;
+    char const* errmsg = nullptr;
 
-    char const* oldpath = NULL;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_path, &oldpath, NULL);
-    char const* newname = NULL;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_name, &newname, NULL);
+    char const* oldpath = nullptr;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_path, &oldpath, nullptr);
+    char const* newname = nullptr;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_name, &newname, nullptr);
 
     int torrentCount = 0;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
@@ -1703,7 +1703,7 @@ static char const* portTest(tr_session* session, tr_variant* args_in, tr_variant
     char* url = tr_strdup_printf("https://portcheck.transmissionbt.com/%d", port);
     tr_webRun(session, url, portTested, idle_data);
     tr_free(url);
-    return NULL;
+    return nullptr;
 }
 
 /***
@@ -1743,7 +1743,7 @@ static void gotNewBlocklist(
         char const* configDir = tr_sessionGetConfigDir(session);
         size_t const buflen = 1024 * 128; /* 128 KiB buffer */
         auto* const buf = static_cast<uint8_t*>(tr_malloc(buflen));
-        tr_error* error = NULL;
+        tr_error* error = nullptr;
 
         /* this is an odd Magic Number required by zlib to enable gz support.
            See zlib's inflateInit2() documentation for a full description */
@@ -1756,7 +1756,7 @@ static void gotNewBlocklist(
         stream.avail_in = response_byte_count;
         inflateInit2(&stream, windowBits);
 
-        char* const filename = tr_buildPath(configDir, "blocklist.tmp.XXXXXX", NULL);
+        char* const filename = tr_buildPath(configDir, "blocklist.tmp.XXXXXX", nullptr);
         tr_sys_file_t const fd = tr_sys_file_open_temp(filename, &error);
 
         if (fd == TR_BAD_SYS_FILE)
@@ -1771,7 +1771,7 @@ static void gotNewBlocklist(
             stream.avail_out = buflen;
             err = inflate(&stream, Z_NO_FLUSH);
 
-            if ((stream.avail_out < buflen) && (!tr_sys_file_write(fd, buf, buflen - stream.avail_out, NULL, &error)))
+            if ((stream.avail_out < buflen) && (!tr_sys_file_write(fd, buf, buflen - stream.avail_out, nullptr, &error)))
             {
                 tr_snprintf(result, sizeof(result), _("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
                 tr_error_clear(&error);
@@ -1792,13 +1792,13 @@ static void gotNewBlocklist(
         inflateEnd(&stream);
 
         if ((err == Z_DATA_ERROR) && // couldn't inflate it... it's probably already uncompressed
-            !tr_sys_file_write(fd, response, response_byte_count, NULL, &error))
+            !tr_sys_file_write(fd, response, response_byte_count, nullptr, &error))
         {
             tr_snprintf(result, sizeof(result), _("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
             tr_error_clear(&error);
         }
 
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
 
         if (!tr_str_is_empty(result))
         {
@@ -1812,7 +1812,7 @@ static void gotNewBlocklist(
             tr_snprintf(result, sizeof(result), "success");
         }
 
-        tr_sys_path_remove(filename, NULL);
+        tr_sys_path_remove(filename, nullptr);
         tr_free(filename);
         tr_free(buf);
     }
@@ -1830,7 +1830,7 @@ static char const* blocklistUpdate(
     TR_UNUSED(args_out);
 
     tr_webRun(session, session->blocklist_url, gotNewBlocklist, idle_data);
-    return NULL;
+    return nullptr;
 }
 
 /***
@@ -1853,7 +1853,7 @@ static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
     if (err == 0)
     {
         key = TR_KEY_torrent_added;
-        result = NULL;
+        result = nullptr;
     }
     else if (err == TR_PARSE_DUPLICATE)
     {
@@ -1867,7 +1867,7 @@ static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
         result = "invalid or corrupt torrent file";
     }
 
-    if (tor != NULL && key != 0)
+    if (tor != nullptr && key != 0)
     {
         tr_quark const fields[] = {
             TR_KEY_id,
@@ -1877,12 +1877,12 @@ static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
 
         addTorrentInfo(tor, TR_FORMAT_OBJECT, tr_variantDictAdd(data->args_out, key), fields, TR_N_ELEMENTS(fields));
 
-        if (result == NULL)
+        if (result == nullptr)
         {
             notify(data->session, TR_RPC_TORRENT_ADDED, tor);
         }
 
-        result = NULL;
+        result = nullptr;
     }
 
     tr_idle_function_done(data, result);
@@ -1937,7 +1937,7 @@ static void gotMetadataFromURL(
 
 static bool isCurlURL(char const* filename)
 {
-    if (filename == NULL)
+    if (filename == nullptr)
     {
         return false;
     }
@@ -1973,22 +1973,22 @@ static char const* torrentAdd(
 {
     TR_UNUSED(args_out);
 
-    TR_ASSERT(idle_data != NULL);
+    TR_ASSERT(idle_data != nullptr);
 
-    char const* filename = NULL;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_filename, &filename, NULL);
+    char const* filename = nullptr;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_filename, &filename, nullptr);
 
-    char const* metainfo_base64 = NULL;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_metainfo, &metainfo_base64, NULL);
+    char const* metainfo_base64 = nullptr;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_metainfo, &metainfo_base64, nullptr);
 
-    if (filename == NULL && metainfo_base64 == NULL)
+    if (filename == nullptr && metainfo_base64 == nullptr)
     {
         return "no filename or metainfo specified";
     }
 
-    char const* download_dir = NULL;
+    char const* download_dir = nullptr;
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_download_dir, &download_dir, NULL) && tr_sys_path_is_relative(download_dir))
+    if (tr_variantDictFindStr(args_in, TR_KEY_download_dir, &download_dir, nullptr) && tr_sys_path_is_relative(download_dir))
     {
         return "download directory path is not absolute";
     }
@@ -2000,10 +2000,10 @@ static char const* torrentAdd(
 
     /* set the optional arguments */
 
-    char const* cookies = NULL;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_cookies, &cookies, NULL);
+    char const* cookies = nullptr;
+    (void)tr_variantDictFindStr(args_in, TR_KEY_cookies, &cookies, nullptr);
 
-    if (download_dir != NULL)
+    if (download_dir != nullptr)
     {
         tr_ctorSetDownloadDir(ctor, TR_FORCE, download_dir);
     }
@@ -2076,7 +2076,7 @@ static char const* torrentAdd(
     {
         char* fname = tr_strstrip(tr_strdup(filename));
 
-        if (fname == NULL)
+        if (fname == nullptr)
         {
             size_t len;
             auto* metainfo = static_cast<char*>(tr_base64_decode_str(metainfo_base64, &len));
@@ -2097,7 +2097,7 @@ static char const* torrentAdd(
         tr_free(fname);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 /***
@@ -2113,17 +2113,17 @@ static char const* sessionSet(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
-    char const* download_dir = NULL;
-    char const* incomplete_dir = NULL;
+    char const* download_dir = nullptr;
+    char const* incomplete_dir = nullptr;
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_download_dir, &download_dir, NULL) && tr_sys_path_is_relative(download_dir))
+    if (tr_variantDictFindStr(args_in, TR_KEY_download_dir, &download_dir, nullptr) && tr_sys_path_is_relative(download_dir))
     {
         return "download directory path is not absolute";
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_incomplete_dir, &incomplete_dir, NULL) && tr_sys_path_is_relative(incomplete_dir))
+    if (tr_variantDictFindStr(args_in, TR_KEY_incomplete_dir, &incomplete_dir, nullptr) && tr_sys_path_is_relative(incomplete_dir))
     {
         return "incomplete torrents directory path is not absolute";
     }
@@ -2178,12 +2178,12 @@ static char const* sessionSet(
         tr_blocklistSetEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_blocklist_url, &str, NULL))
+    if (tr_variantDictFindStr(args_in, TR_KEY_blocklist_url, &str, nullptr))
     {
         tr_blocklistSetURL(session, str);
     }
 
-    if (download_dir != NULL)
+    if (download_dir != nullptr)
     {
         tr_sessionSetDownloadDir(session, download_dir);
     }
@@ -2208,7 +2208,7 @@ static char const* sessionSet(
         tr_sessionSetQueueEnabled(session, TR_DOWN, boolVal);
     }
 
-    if (incomplete_dir != NULL)
+    if (incomplete_dir != nullptr)
     {
         tr_sessionSetIncompleteDir(session, incomplete_dir);
     }
@@ -2303,7 +2303,7 @@ static char const* sessionSet(
         tr_sessionSetQueueSize(session, TR_UP, (int)i);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_done_filename, &str, NULL))
+    if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_done_filename, &str, nullptr))
     {
         tr_sessionSetTorrentDoneScript(session, str);
     }
@@ -2338,7 +2338,7 @@ static char const* sessionSet(
         tr_sessionLimitSpeed(session, TR_UP, boolVal);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_encryption, &str, NULL))
+    if (tr_variantDictFindStr(args_in, TR_KEY_encryption, &str, nullptr))
     {
         if (tr_strcmp0(str, "required") == 0)
         {
@@ -2364,9 +2364,9 @@ static char const* sessionSet(
         tr_sessionSetAntiBruteForceEnabled(session, boolVal);
     }
 
-    notify(session, TR_RPC_SESSION_CHANGED, NULL);
+    notify(session, TR_RPC_SESSION_CHANGED, nullptr);
 
-    return NULL;
+    return nullptr;
 }
 
 static char const* sessionStats(
@@ -2378,15 +2378,15 @@ static char const* sessionStats(
     TR_UNUSED(args_in);
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     int running = 0;
     int total = 0;
     auto currentStats = tr_session_stats{};
     auto cumulativeStats = tr_session_stats{};
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         ++total;
 
@@ -2419,7 +2419,7 @@ static char const* sessionStats(
     tr_variantDictAddInt(d, TR_KEY_sessionCount, currentStats.sessionCount);
     tr_variantDictAddInt(d, TR_KEY_uploadedBytes, currentStats.uploadedBytes);
 
-    return NULL;
+    return nullptr;
 }
 
 static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
@@ -2659,7 +2659,7 @@ static char const* sessionGet(tr_session* s, tr_variant* args_in, tr_variant* ar
 {
     TR_UNUSED(idle_data);
 
-    TR_ASSERT(idle_data == NULL);
+    TR_ASSERT(idle_data == nullptr);
 
     tr_variant* fields;
 
@@ -2694,7 +2694,7 @@ static char const* sessionGet(tr_session* s, tr_variant* args_in, tr_variant* ar
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_variant* args_out, struct tr_rpc_idle_data* idle_data)
@@ -2702,11 +2702,11 @@ static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_varian
     TR_UNUSED(idle_data);
 
     int tmperr;
-    char const* path = NULL;
-    char const* err = NULL;
+    char const* path = nullptr;
+    char const* err = nullptr;
     int64_t free_space = -1;
 
-    if (!tr_variantDictFindStr(args_in, TR_KEY_path, &path, NULL))
+    if (!tr_variantDictFindStr(args_in, TR_KEY_path, &path, nullptr))
     {
         return "directory path argument is missing";
     }
@@ -2729,7 +2729,7 @@ static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_varian
     errno = tmperr;
 
     /* response */
-    if (path != NULL)
+    if (path != nullptr)
     {
         tr_variantDictAddStr(args_out, TR_KEY_path, path);
     }
@@ -2752,8 +2752,8 @@ static char const* sessionClose(
     TR_UNUSED(args_out);
     TR_UNUSED(idle_data);
 
-    notify(session, TR_RPC_SESSION_CLOSE, NULL);
-    return NULL;
+    notify(session, TR_RPC_SESSION_CLOSE, nullptr);
+    return nullptr;
 }
 
 /***
@@ -2808,22 +2808,22 @@ void tr_rpc_request_exec_json(
     char const* str;
     tr_variant* const mutable_request = (tr_variant*)request;
     tr_variant* args_in = tr_variantDictFind(mutable_request, TR_KEY_arguments);
-    char const* result = NULL;
-    struct method const* method = NULL;
+    char const* result = nullptr;
+    struct method const* method = nullptr;
 
-    if (callback == NULL)
+    if (callback == nullptr)
     {
         callback = noop_response_callback;
     }
 
     /* parse the request */
-    if (!tr_variantDictFindStr(mutable_request, TR_KEY_method, &str, NULL))
+    if (!tr_variantDictFindStr(mutable_request, TR_KEY_method, &str, nullptr))
     {
         result = "no method name";
     }
     else
     {
-        for (size_t i = 0; method == NULL && i < TR_N_ELEMENTS(methods); ++i)
+        for (size_t i = 0; method == nullptr && i < TR_N_ELEMENTS(methods); ++i)
         {
             if (strcmp(str, methods[i].name) == 0)
             {
@@ -2831,14 +2831,14 @@ void tr_rpc_request_exec_json(
             }
         }
 
-        if (method == NULL)
+        if (method == nullptr)
         {
             result = "method name not recognized";
         }
     }
 
     /* if we couldn't figure out which method to use, return an error */
-    if (result != NULL)
+    if (result != nullptr)
     {
         int64_t tag;
         tr_variant response;
@@ -2864,9 +2864,9 @@ void tr_rpc_request_exec_json(
 
         tr_variantInitDict(&response, 3);
         args_out = tr_variantDictAddDict(&response, TR_KEY_arguments, 0);
-        result = (*method->func)(session, args_in, args_out, NULL);
+        result = (*method->func)(session, args_in, args_out, nullptr);
 
-        if (result == NULL)
+        if (result == nullptr)
         {
             result = "success";
         }
@@ -2901,7 +2901,7 @@ void tr_rpc_request_exec_json(
         result = (*method->func)(session, args_in, data->args_out, data);
 
         /* Async operation failed prematurely? Invoke callback or else client will not get a reply */
-        if (result != NULL)
+        if (result != nullptr)
         {
             tr_idle_function_done(data, result);
         }
@@ -2960,17 +2960,17 @@ void tr_rpc_request_exec_uri(
 
     pch = strchr(request, '?');
 
-    if (pch == NULL)
+    if (pch == nullptr)
     {
         pch = request;
     }
 
-    while (pch != NULL)
+    while (pch != nullptr)
     {
         char const* delim = strchr(pch, '=');
         char const* next = strchr(pch, '&');
 
-        if (delim != NULL)
+        if (delim != nullptr)
         {
             char* key = tr_strndup(pch, (size_t)(delim - pch));
             bool isArg = strcmp(key, "method") != 0 && strcmp(key, "tag") != 0;
@@ -2979,11 +2979,11 @@ void tr_rpc_request_exec_uri(
             tr_rpc_parse_list_str(
                 tr_variantDictAdd(parent, tr_quark_new(key, (size_t)(delim - pch))),
                 delim + 1,
-                next != NULL ? (size_t)(next - (delim + 1)) : strlen(delim + 1));
+                next != nullptr ? (size_t)(next - (delim + 1)) : strlen(delim + 1));
             tr_free(key);
         }
 
-        pch = next != NULL ? next + 1 : NULL;
+        pch = next != nullptr ? next + 1 : nullptr;
     }
 
     tr_rpc_request_exec_json(session, &top, callback, callback_user_data);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2123,7 +2123,8 @@ static char const* sessionSet(
         return "download directory path is not absolute";
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_incomplete_dir, &incomplete_dir, nullptr) && tr_sys_path_is_relative(incomplete_dir))
+    if (tr_variantDictFindStr(args_in, TR_KEY_incomplete_dir, &incomplete_dir, nullptr) &&
+        tr_sys_path_is_relative(incomplete_dir))
     {
         return "incomplete torrents directory path is not absolute";
     }

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -64,14 +64,14 @@ static char* get_session_id_lock_file_path(char const* session_id)
 
 static tr_sys_file_t create_session_id_lock_file(char const* session_id)
 {
-    if (session_id == NULL)
+    if (session_id == nullptr)
     {
         return TR_BAD_SYS_FILE;
     }
 
     char* lock_file_path = get_session_id_lock_file_path(session_id);
     tr_sys_file_t lock_file;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     lock_file = tr_sys_file_open(lock_file_path, TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, &error);
 
@@ -86,12 +86,12 @@ static tr_sys_file_t create_session_id_lock_file(char const* session_id)
         }
         else
         {
-            tr_sys_file_close(lock_file, NULL);
+            tr_sys_file_close(lock_file, nullptr);
             lock_file = TR_BAD_SYS_FILE;
         }
     }
 
-    if (error != NULL)
+    if (error != nullptr)
     {
         tr_logAddError("Unable to create session lock file (%d): %s", error->code, error->message);
         tr_error_free(error);
@@ -105,13 +105,13 @@ static void destroy_session_id_lock_file(tr_sys_file_t lock_file, char const* se
 {
     if (lock_file != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(lock_file, NULL);
+        tr_sys_file_close(lock_file, nullptr);
     }
 
-    if (session_id != NULL)
+    if (session_id != nullptr)
     {
         char* lock_file_path = get_session_id_lock_file_path(session_id);
-        tr_sys_path_remove(lock_file_path, NULL);
+        tr_sys_path_remove(lock_file_path, nullptr);
         tr_free(lock_file_path);
     }
 }
@@ -128,7 +128,7 @@ tr_session_id_t tr_session_id_new(void)
 
 void tr_session_id_free(tr_session_id_t session_id)
 {
-    if (session_id == NULL)
+    if (session_id == nullptr)
     {
         return;
     }
@@ -146,7 +146,7 @@ char const* tr_session_id_get_current(tr_session_id_t session_id)
 {
     time_t const now = tr_time();
 
-    if (session_id->current_value == NULL || now >= session_id->expires_at)
+    if (session_id->current_value == nullptr || now >= session_id->expires_at)
     {
         destroy_session_id_lock_file(session_id->previous_lock_file, session_id->previous_value);
         tr_free(session_id->previous_value);
@@ -167,11 +167,11 @@ bool tr_session_id_is_local(char const* session_id)
 {
     bool ret = false;
 
-    if (session_id != NULL)
+    if (session_id != nullptr)
     {
         char* lock_file_path = get_session_id_lock_file_path(session_id);
         tr_sys_file_t lock_file;
-        tr_error* error = NULL;
+        tr_error* error = nullptr;
 
         lock_file = tr_sys_file_open(lock_file_path, TR_SYS_FILE_READ, 0, &error);
 
@@ -195,10 +195,10 @@ bool tr_session_id_is_local(char const* session_id)
                 tr_error_clear(&error);
             }
 
-            tr_sys_file_close(lock_file, NULL);
+            tr_sys_file_close(lock_file, nullptr);
         }
 
-        if (error != NULL)
+        if (error != nullptr)
         {
             tr_logAddError("Unable to open session lock file (%d): %s", error->code, error->message);
             tr_error_free(error);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -73,7 +73,7 @@ enum
     SAVE_INTERVAL_SECS = 360
 };
 
-#define dbgmsg(...) tr_logAddDeepNamed(NULL, __VA_ARGS__)
+#define dbgmsg(...) tr_logAddDeepNamed(nullptr, __VA_ARGS__)
 
 static tr_port getRandomPort(tr_session* s)
 {
@@ -113,14 +113,14 @@ void tr_peerIdInit(uint8_t* buf)
 
 tr_encryption_mode tr_sessionGetEncryption(tr_session* session)
 {
-    TR_ASSERT(session != NULL);
+    TR_ASSERT(session != nullptr);
 
     return session->encryptionMode;
 }
 
 void tr_sessionSetEncryption(tr_session* session, tr_encryption_mode mode)
 {
-    TR_ASSERT(session != NULL);
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(mode == TR_ENCRYPTION_PREFERRED || mode == TR_ENCRYPTION_REQUIRED || mode == TR_CLEAR_PREFERRED);
 
     session->encryptionMode = mode;
@@ -139,10 +139,10 @@ struct tr_bindinfo
 
 static void close_bindinfo(struct tr_bindinfo* b)
 {
-    if (b != NULL && b->socket != TR_BAD_SOCKET)
+    if (b != nullptr && b->socket != TR_BAD_SOCKET)
     {
         event_free(b->ev);
-        b->ev = NULL;
+        b->ev = nullptr;
         tr_netCloseSocket(b->socket);
     }
 }
@@ -157,11 +157,11 @@ static void free_incoming_peer_port(tr_session* session)
 {
     close_bindinfo(session->bind_ipv4);
     tr_free(session->bind_ipv4);
-    session->bind_ipv4 = NULL;
+    session->bind_ipv4 = nullptr;
 
     close_bindinfo(session->bind_ipv6);
     tr_free(session->bind_ipv6);
-    session->bind_ipv6 = NULL;
+    session->bind_ipv6 = nullptr;
 }
 
 static void accept_incoming_peer(evutil_socket_t fd, short what, void* vsession)
@@ -184,7 +184,7 @@ static void accept_incoming_peer(evutil_socket_t fd, short what, void* vsession)
             tr_logAddDeep(
                 __FILE__,
                 __LINE__,
-                NULL,
+                nullptr,
                 "new incoming connection %" PRIdMAX " (%s)",
                 (intmax_t)clientSocket,
                 addrstr);
@@ -205,7 +205,7 @@ static void open_incoming_peer_port(tr_session* session)
     if (b->socket != TR_BAD_SOCKET)
     {
         b->ev = event_new(session->event_base, b->socket, EV_READ | EV_PERSIST, accept_incoming_peer, session);
-        event_add(b->ev, NULL);
+        event_add(b->ev, nullptr);
     }
 
     /* and do the exact same thing for ipv6, if it's supported... */
@@ -217,7 +217,7 @@ static void open_incoming_peer_port(tr_session* session)
         if (b->socket != TR_BAD_SOCKET)
         {
             b->ev = event_new(session->event_base, b->socket, EV_READ | EV_PERSIST, accept_incoming_peer, session);
-            event_add(b->ev, NULL);
+            event_add(b->ev, nullptr);
         }
     }
 }
@@ -240,17 +240,17 @@ tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_a
         break;
 
     default:
-        bindinfo = NULL;
+        bindinfo = nullptr;
         default_value = "";
         break;
     }
 
-    if (is_default_value != NULL && bindinfo != NULL)
+    if (is_default_value != nullptr && bindinfo != nullptr)
     {
         *is_default_value = tr_strcmp0(default_value, tr_address_to_string(&bindinfo->addr)) == 0;
     }
 
-    return bindinfo != NULL ? &bindinfo->addr : NULL;
+    return bindinfo != nullptr ? &bindinfo->addr : nullptr;
 }
 
 /***
@@ -305,7 +305,7 @@ static int parse_tos(char const* str)
 
     value = strtol(str, &p, 0);
 
-    if (p == NULL || p == str)
+    if (p == nullptr || p == str)
     {
         return 0;
     }
@@ -495,7 +495,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* configDir, char const*
     tr_variant oldDict;
     tr_variant fileSettings;
     bool success;
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     /* initializing the defaults: caller may have passed in some app-level defaults.
      * preserve those and use the session defaults to fill in any missing gaps. */
@@ -512,7 +512,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* configDir, char const*
     }
 
     /* file settings override the defaults */
-    filename = tr_buildPath(configDir, "settings.json", NULL);
+    filename = tr_buildPath(configDir, "settings.json", nullptr);
 
     if (tr_variantFromFile(&fileSettings, TR_VARIANT_FMT_JSON, filename, &error))
     {
@@ -536,7 +536,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* configDir, tr_varia
     TR_ASSERT(tr_variantIsDict(clientSettings));
 
     tr_variant settings;
-    char* filename = tr_buildPath(configDir, "settings.json", NULL);
+    char* filename = tr_buildPath(configDir, "settings.json", nullptr);
 
     tr_variantInitDict(&settings, 0);
 
@@ -544,7 +544,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* configDir, tr_varia
     {
         tr_variant fileSettings;
 
-        if (tr_variantFromFile(&fileSettings, TR_VARIANT_FMT_JSON, filename, NULL))
+        if (tr_variantFromFile(&fileSettings, TR_VARIANT_FMT_JSON, filename, nullptr))
         {
             tr_variantMergeDicts(&settings, &fileSettings);
             tr_variantFree(&fileSettings);
@@ -593,7 +593,7 @@ static void onSaveTimer(evutil_socket_t fd, short what, void* vsession)
         tr_logAddError("Error while flushing completed pieces from cache");
     }
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         tr_torrentSave(tor);
     }
@@ -626,7 +626,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     tr_session* session;
     struct init_data data;
 
-    tr_timeUpdate(time(NULL));
+    tr_timeUpdate(time(nullptr));
 
     /* initialize the bare skeleton of the session object */
     session = tr_new0(tr_session, 1);
@@ -639,7 +639,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     session->torrentsSortedByHash = {};
     session->torrentsSortedByHashString = {};
     session->torrentsSortedById = {};
-    tr_bandwidthConstruct(&session->bandwidth, session, NULL);
+    tr_bandwidthConstruct(&session->bandwidth, session, nullptr);
     tr_variantInitList(&session->removedTorrents, 0);
 
     /* nice to start logging at the very beginning */
@@ -651,7 +651,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     /* start the libtransmission thread */
     tr_net_init(); /* must go before tr_eventInit */
     tr_eventInit(session);
-    TR_ASSERT(session->events != NULL);
+    TR_ASSERT(session->events != nullptr);
 
     /* run the rest in the libtransmission thread */
     data.done = false;
@@ -679,14 +679,14 @@ static void onNowTimer(evutil_socket_t fd, short what, void* vsession)
     auto* session = static_cast<tr_session*>(vsession);
 
     TR_ASSERT(tr_isSession(session));
-    TR_ASSERT(session->nowTimer != NULL);
+    TR_ASSERT(session->nowTimer != nullptr);
 
     int usec;
     int const min = 100;
     int const max = 999999;
     struct timeval tv;
-    tr_torrent* tor = NULL;
-    time_t const now = time(NULL);
+    tr_torrent* tor = nullptr;
+    time_t const now = time(nullptr);
 
     /**
     ***  tr_session things to do once per second
@@ -701,7 +701,7 @@ static void onNowTimer(evutil_socket_t fd, short what, void* vsession)
         turtleCheckClock(session, &session->turtle);
     }
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         if (tor->isRunning)
         {
@@ -756,7 +756,7 @@ static void tr_sessionInitImpl(void* vdata)
     tr_sessionGetDefaultSettings(&settings);
     tr_variantMergeDicts(&settings, clientSettings);
 
-    TR_ASSERT(session->event_base != NULL);
+    TR_ASSERT(session->event_base != nullptr);
     session->nowTimer = evtimer_new(session->event_base, onNowTimer, session);
     onNowTimer(0, 0, session);
 
@@ -778,8 +778,8 @@ static void tr_sessionInitImpl(void* vdata)
     **/
 
     {
-        char* filename = tr_buildPath(session->configDir, "blocklists", NULL);
-        tr_sys_dir_create(filename, TR_SYS_DIR_CREATE_PARENTS, 0777, NULL);
+        char* filename = tr_buildPath(session->configDir, "blocklists", nullptr);
+        tr_sys_dir_create(filename, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
         tr_free(filename);
         loadBlocklists(session);
     }
@@ -882,12 +882,12 @@ static void sessionSetImpl(void* vdata)
         tr_sessionSetEncryption(session, tr_encryption_mode(i));
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_peer_socket_tos, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_peer_socket_tos, &str, nullptr))
     {
         session->peerSocketTOS = parse_tos(str);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_peer_congestion_algorithm, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_peer_congestion_algorithm, &str, nullptr))
     {
         session->peer_congestion_algorithm = tr_strdup(str);
     }
@@ -901,7 +901,7 @@ static void sessionSetImpl(void* vdata)
         tr_blocklistSetEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_blocklist_url, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_blocklist_url, &str, nullptr))
     {
         tr_blocklistSetURL(session, str);
     }
@@ -963,12 +963,12 @@ static void sessionSetImpl(void* vdata)
         session->preallocationMode = tr_preallocation_mode(i);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_download_dir, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_download_dir, &str, nullptr))
     {
         tr_sessionSetDownloadDir(session, str);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_incomplete_dir, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_incomplete_dir, &str, nullptr))
     {
         tr_sessionSetIncompleteDir(session, str);
     }
@@ -984,7 +984,7 @@ static void sessionSetImpl(void* vdata)
     }
 
     /* rpc server */
-    if (session->rpcServer != NULL) /* close the old one */
+    if (session->rpcServer != nullptr) /* close the old one */
     {
         tr_rpcClose(&session->rpcServer);
     }
@@ -995,7 +995,7 @@ static void sessionSetImpl(void* vdata)
 
     free_incoming_peer_port(session);
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, NULL) || !tr_address_from_string(&b.addr, str) ||
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, nullptr) || !tr_address_from_string(&b.addr, str) ||
         b.addr.type != TR_AF_INET)
     {
         b.addr = tr_inaddr_any;
@@ -1004,7 +1004,7 @@ static void sessionSetImpl(void* vdata)
     b.socket = TR_BAD_SOCKET;
     session->bind_ipv4 = static_cast<struct tr_bindinfo*>(tr_memdup(&b, sizeof(struct tr_bindinfo)));
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, NULL) || !tr_address_from_string(&b.addr, str) ||
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, nullptr) || !tr_address_from_string(&b.addr, str) ||
         b.addr.type != TR_AF_INET6)
     {
         b.addr = tr_in6addr_any;
@@ -1145,7 +1145,7 @@ static void sessionSetImpl(void* vdata)
         tr_sessionSetTorrentDoneScriptEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_done_filename, &str, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_done_filename, &str, nullptr))
     {
         tr_sessionSetTorrentDoneScript(session, str);
     }
@@ -1196,9 +1196,9 @@ void tr_sessionSetDownloadDir(tr_session* session, char const* dir)
 {
     TR_ASSERT(tr_isSession(session));
 
-    struct tr_device_info* info = NULL;
+    struct tr_device_info* info = nullptr;
 
-    if (dir != NULL)
+    if (dir != nullptr)
     {
         info = tr_device_info_create(dir);
     }
@@ -1211,9 +1211,9 @@ char const* tr_sessionGetDownloadDir(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    char const* dir = NULL;
+    char const* dir = nullptr;
 
-    if (session != NULL && session->downloadDir != NULL)
+    if (session != nullptr && session->downloadDir != nullptr)
     {
         dir = session->downloadDir->path;
     }
@@ -1324,13 +1324,13 @@ static void peerPortChanged(void* vsession)
     auto* session = static_cast<tr_session*>(vsession);
     TR_ASSERT(tr_isSession(session));
 
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
     close_incoming_peer_port(session);
     open_incoming_peer_port(session);
     tr_sharedPortChanged(session);
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         tr_torrentChangeMyPort(tor);
     }
@@ -1544,7 +1544,7 @@ static void altSpeedToggled(void* vsession)
 
     struct tr_turtle_info* t = &session->turtle;
 
-    if (t->callback != NULL)
+    if (t->callback != nullptr)
     {
         (*t->callback)(session, t->isEnabled, t->changedByUser, t->callbackUserData);
     }
@@ -1553,7 +1553,7 @@ static void altSpeedToggled(void* vsession)
 static void useAltSpeed(tr_session* s, struct tr_turtle_info* t, bool enabled, bool byUser)
 {
     TR_ASSERT(tr_isSession(s));
-    TR_ASSERT(t != NULL);
+    TR_ASSERT(t != nullptr);
 
     if (t->isEnabled != enabled)
     {
@@ -1913,13 +1913,13 @@ int tr_sessionCountTorrents(tr_session const* session)
 tr_torrent** tr_sessionGetTorrents(tr_session* session, int* setme_n)
 {
     TR_ASSERT(tr_isSession(session));
-    TR_ASSERT(setme_n != NULL);
+    TR_ASSERT(setme_n != nullptr);
 
     int n = tr_sessionCountTorrents(session);
     *setme_n = n;
 
     tr_torrent** torrents = tr_new(tr_torrent*, n);
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
     for (int i = 0; i < n; ++i)
     {
@@ -1966,10 +1966,10 @@ static void sessionCloseImplStart(tr_session* session)
     tr_dhtUninit(session);
 
     event_free(session->saveTimer);
-    session->saveTimer = NULL;
+    session->saveTimer = nullptr;
 
     event_free(session->nowTimer);
-    session->nowTimer = NULL;
+    session->nowTimer = nullptr;
 
     tr_verifyClose(session);
     tr_sharedClose(session);
@@ -1998,10 +1998,10 @@ static void sessionCloseImplStart(tr_session* session)
     tr_webClose(session, TR_WEB_CLOSE_WHEN_IDLE);
 
     tr_cacheFree(session->cache);
-    session->cache = NULL;
+    session->cache = nullptr;
 
     /* saveTimer is not used at this point, reusing for UDP shutdown wait */
-    TR_ASSERT(session->saveTimer == NULL);
+    TR_ASSERT(session->saveTimer == nullptr);
     session->saveTimer = evtimer_new(session->event_base, sessionCloseImplWaitForIdleUdp, session);
     tr_timerAdd(session->saveTimer, 0, 0);
 }
@@ -2032,11 +2032,11 @@ static void sessionCloseImplWaitForIdleUdp(evutil_socket_t fd, short what, void*
 static void sessionCloseImplFinish(tr_session* session)
 {
     event_free(session->saveTimer);
-    session->saveTimer = NULL;
+    session->saveTimer = nullptr;
 
     /* we had to wait until UDP trackers were closed before closing these: */
     evdns_base_free(session->evdns_base, 0);
-    session->evdns_base = NULL;
+    session->evdns_base = nullptr;
     tr_tracker_udp_close(session);
     tr_udpUninit(session);
 
@@ -2061,7 +2061,7 @@ static void sessionCloseImpl(void* vsession)
 
 static bool deadlineReached(time_t const deadline)
 {
-    return time(NULL) >= deadline;
+    return time(nullptr) >= deadline;
 }
 
 #define SHUTDOWN_MAX_SECONDS 20
@@ -2070,12 +2070,12 @@ void tr_sessionClose(tr_session* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    time_t const deadline = time(NULL) + SHUTDOWN_MAX_SECONDS;
+    time_t const deadline = time(nullptr) + SHUTDOWN_MAX_SECONDS;
 
     dbgmsg(
         "shutting down transmission session %p... now is %zu, deadline is %zu",
         (void*)session,
-        (size_t)time(NULL),
+        (size_t)time(nullptr),
         (size_t)deadline);
 
     /* close the session */
@@ -2091,14 +2091,14 @@ void tr_sessionClose(tr_session* session)
      * so we need to keep the transmission thread alive
      * for a bit while they tell the router & tracker
      * that we're closing now */
-    while ((session->shared != NULL || session->web != NULL || session->announcer != NULL || session->announcer_udp != NULL) &&
+    while ((session->shared != nullptr || session->web != nullptr || session->announcer != nullptr || session->announcer_udp != nullptr) &&
            !deadlineReached(deadline))
     {
         dbgmsg(
             "waiting on port unmap (%p) or announcer (%p)... now %zu deadline %zu",
             (void*)session->shared,
             (void*)session->announcer,
-            (size_t)time(NULL),
+            (size_t)time(nullptr),
             (size_t)deadline);
         tr_wait_msec(50);
     }
@@ -2108,10 +2108,10 @@ void tr_sessionClose(tr_session* session)
     /* close the libtransmission thread */
     tr_eventClose(session);
 
-    while (session->events != NULL)
+    while (session->events != nullptr)
     {
         static bool forced = false;
-        dbgmsg("waiting for libtransmission thread to finish... now %zu deadline %zu", (size_t)time(NULL), (size_t)deadline);
+        dbgmsg("waiting for libtransmission thread to finish... now %zu deadline %zu", (size_t)time(nullptr), (size_t)deadline);
         tr_wait_msec(100);
 
         if (deadlineReached(deadline) && !forced)
@@ -2135,16 +2135,16 @@ void tr_sessionClose(tr_session* session)
     tr_session_id_free(session->session_id);
     tr_lockFree(session->lock);
 
-    if (session->metainfoLookup != NULL)
+    if (session->metainfoLookup != nullptr)
     {
         tr_variantFree(session->metainfoLookup);
         tr_free(session->metainfoLookup);
     }
 
     tr_device_info_free(session->downloadDir);
-    tr_ptrArrayDestruct(&session->torrentsSortedByHash, NULL);
-    tr_ptrArrayDestruct(&session->torrentsSortedByHashString, NULL);
-    tr_ptrArrayDestruct(&session->torrentsSortedById, NULL);
+    tr_ptrArrayDestruct(&session->torrentsSortedByHash, nullptr);
+    tr_ptrArrayDestruct(&session->torrentsSortedByHashString, nullptr);
+    tr_ptrArrayDestruct(&session->torrentsSortedById, nullptr);
     tr_free(session->torrentDoneScript);
     tr_free(session->configDir);
     tr_free(session->resumeDir);
@@ -2171,29 +2171,29 @@ static void sessionLoadTorrents(void* vdata)
 
     int i;
     int n = 0;
-    tr_list* list = NULL;
+    tr_list* list = nullptr;
 
     tr_ctorSetSave(data->ctor, false); /* since we already have them */
 
     tr_sys_path_info info;
     char const* dirname = tr_getTorrentDir(data->session);
-    tr_sys_dir_t odir = (tr_sys_path_get_info(dirname, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_DIRECTORY) ?
-        tr_sys_dir_open(dirname, NULL) :
+    tr_sys_dir_t odir = (tr_sys_path_get_info(dirname, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY) ?
+        tr_sys_dir_open(dirname, nullptr) :
         TR_BAD_SYS_DIR;
 
     if (odir != TR_BAD_SYS_DIR)
     {
         char const* name;
 
-        while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (tr_str_has_suffix(name, ".torrent"))
             {
                 tr_torrent* tor;
-                char* path = tr_buildPath(dirname, name, NULL);
+                char* path = tr_buildPath(dirname, name, nullptr);
                 tr_ctorSetMetainfoFromFile(data->ctor, path);
 
-                if ((tor = tr_torrentNew(data->ctor, NULL, NULL)) != NULL)
+                if ((tor = tr_torrentNew(data->ctor, nullptr, nullptr)) != nullptr)
                 {
                     tr_list_prepend(&list, tor);
                     ++n;
@@ -2203,27 +2203,27 @@ static void sessionLoadTorrents(void* vdata)
             }
         }
 
-        tr_sys_dir_close(odir, NULL);
+        tr_sys_dir_close(odir, nullptr);
     }
 
     data->torrents = tr_new(tr_torrent*, n);
     i = 0;
 
-    for (tr_list* l = list; l != NULL; l = l->next)
+    for (tr_list* l = list; l != nullptr; l = l->next)
     {
         data->torrents[i++] = (tr_torrent*)l->data;
     }
 
     TR_ASSERT(i == n);
 
-    tr_list_free(&list, NULL);
+    tr_list_free(&list, nullptr);
 
     if (n != 0)
     {
         tr_logAddInfo(_("Loaded %d torrents"), n);
     }
 
-    if (data->setmeCount != NULL)
+    if (data->setmeCount != nullptr)
     {
         *data->setmeCount = n;
     }
@@ -2238,7 +2238,7 @@ tr_torrent** tr_sessionLoadTorrents(tr_session* session, tr_ctor* ctor, int* set
     data.session = session;
     data.ctor = ctor;
     data.setmeCount = setmeCount;
-    data.torrents = NULL;
+    data.torrents = nullptr;
     data.done = false;
 
     tr_runInEventThread(session, sessionLoadTorrents, &data);
@@ -2454,13 +2454,13 @@ static void loadBlocklists(tr_session* session)
     tr_sys_dir_t odir;
     char* dirname;
     char const* name;
-    tr_list* blocklists = NULL;
+    tr_list* blocklists = nullptr;
     auto loadme = tr_ptrArray{};
     bool const isEnabled = session->isBlocklistEnabled;
 
     /* walk the blocklist directory... */
-    dirname = tr_buildPath(session->configDir, "blocklists", NULL);
-    odir = tr_sys_dir_open(dirname, NULL);
+    dirname = tr_buildPath(session->configDir, "blocklists", nullptr);
+    odir = tr_sys_dir_open(dirname, nullptr);
 
     if (odir == TR_BAD_SYS_DIR)
     {
@@ -2468,17 +2468,17 @@ static void loadBlocklists(tr_session* session)
         return;
     }
 
-    while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+    while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
     {
         char* path;
-        char* load = NULL;
+        char* load = nullptr;
 
         if (name[0] == '.') /* ignore dotfiles */
         {
             continue;
         }
 
-        path = tr_buildPath(dirname, name, NULL);
+        path = tr_buildPath(dirname, name, nullptr);
 
         if (tr_stringEndsWith(path, ".bin"))
         {
@@ -2492,7 +2492,7 @@ static void loadBlocklists(tr_session* session)
 
             binname = tr_strdup_printf("%s" TR_PATH_DELIMITER_STR "%s.bin", dirname, name);
 
-            if (!tr_sys_path_get_info(binname, 0, &binname_info, NULL)) /* create it */
+            if (!tr_sys_path_get_info(binname, 0, &binname_info, nullptr)) /* create it */
             {
                 tr_blocklistFile* b = tr_blocklistFileNew(binname, isEnabled);
                 int const n = tr_blocklistFileSetContent(b, path);
@@ -2505,25 +2505,25 @@ static void loadBlocklists(tr_session* session)
                 tr_blocklistFileFree(b);
             }
             else if (
-                tr_sys_path_get_info(path, 0, &path_info, NULL) &&
+                tr_sys_path_get_info(path, 0, &path_info, nullptr) &&
                 path_info.last_modified_at >= binname_info.last_modified_at) /* update it */
             {
                 char* old;
                 tr_blocklistFile* b;
 
                 old = tr_strdup_printf("%s.old", binname);
-                tr_sys_path_remove(old, NULL);
-                tr_sys_path_rename(binname, old, NULL);
+                tr_sys_path_remove(old, nullptr);
+                tr_sys_path_rename(binname, old, nullptr);
                 b = tr_blocklistFileNew(binname, isEnabled);
 
                 if (tr_blocklistFileSetContent(b, path) > 0)
                 {
-                    tr_sys_path_remove(old, NULL);
+                    tr_sys_path_remove(old, nullptr);
                 }
                 else
                 {
-                    tr_sys_path_remove(binname, NULL);
-                    tr_sys_path_rename(old, binname, NULL);
+                    tr_sys_path_remove(binname, nullptr);
+                    tr_sys_path_rename(old, binname, nullptr);
                 }
 
                 tr_blocklistFileFree(b);
@@ -2533,9 +2533,9 @@ static void loadBlocklists(tr_session* session)
             tr_free(binname);
         }
 
-        if (load != NULL)
+        if (load != nullptr)
         {
-            if (tr_ptrArrayFindSorted(&loadme, load, (PtrArrayCompareFunc)strcmp) == NULL)
+            if (tr_ptrArrayFindSorted(&loadme, load, (PtrArrayCompareFunc)strcmp) == nullptr)
             {
                 tr_ptrArrayInsertSorted(&loadme, load, (PtrArrayCompareFunc)strcmp);
             }
@@ -2560,7 +2560,7 @@ static void loadBlocklists(tr_session* session)
     }
 
     /* cleanup */
-    tr_sys_dir_close(odir, NULL);
+    tr_sys_dir_close(odir, nullptr);
     tr_free(dirname);
     tr_ptrArrayDestruct(&loadme, (PtrArrayForeachFunc)tr_free);
     session->blocklists = blocklists;
@@ -2585,7 +2585,7 @@ int tr_blocklistGetRuleCount(tr_session const* session)
 
     int n = 0;
 
-    for (tr_list* l = session->blocklists; l != NULL; l = l->next)
+    for (tr_list* l = session->blocklists; l != nullptr; l = l->next)
     {
         auto const* blocklistFile = static_cast<tr_blocklistFile*>(l->data);
         n += tr_blocklistFileGetRuleCount(blocklistFile);
@@ -2607,7 +2607,7 @@ void tr_blocklistSetEnabled(tr_session* session, bool isEnabled)
 
     session->isBlocklistEnabled = isEnabled;
 
-    for (tr_list* l = session->blocklists; l != NULL; l = l->next)
+    for (tr_list* l = session->blocklists; l != nullptr; l = l->next)
     {
         auto* blocklistFile = static_cast<tr_blocklistFile*>(l->data);
         tr_blocklistFileSetEnabled(blocklistFile, isEnabled);
@@ -2618,17 +2618,17 @@ bool tr_blocklistExists(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->blocklists != NULL;
+    return session->blocklists != nullptr;
 }
 
 int tr_blocklistSetContent(tr_session* session, char const* contentFilename)
 {
     int ruleCount;
-    tr_blocklistFile* b = NULL;
+    tr_blocklistFile* b = nullptr;
     char const* defaultName = DEFAULT_BLOCKLIST_FILENAME;
     tr_sessionLock(session);
 
-    for (tr_list* l = session->blocklists; b == NULL && l != NULL; l = l->next)
+    for (tr_list* l = session->blocklists; b == nullptr && l != nullptr; l = l->next)
     {
         auto const* blocklistFile = static_cast<tr_blocklistFile*>(l->data);
         if (tr_stringEndsWith(tr_blocklistFileGetFilename(blocklistFile), defaultName))
@@ -2637,9 +2637,9 @@ int tr_blocklistSetContent(tr_session* session, char const* contentFilename)
         }
     }
 
-    if (b == NULL)
+    if (b == nullptr)
     {
-        char* path = tr_buildPath(session->configDir, "blocklists", defaultName, NULL);
+        char* path = tr_buildPath(session->configDir, "blocklists", defaultName, nullptr);
         b = tr_blocklistFileNew(path, session->isBlocklistEnabled);
         tr_list_append(&session->blocklists, b);
         tr_free(path);
@@ -2654,7 +2654,7 @@ bool tr_sessionIsAddressBlocked(tr_session const* session, tr_address const* add
 {
     TR_ASSERT(tr_isSession(session));
 
-    for (tr_list* l = session->blocklists; l != NULL; l = l->next)
+    for (tr_list* l = session->blocklists; l != nullptr; l = l->next)
     {
         if (tr_blocklistFileHasAddress(static_cast<tr_blocklistFile*>(l->data), addr))
         {
@@ -2694,8 +2694,8 @@ static void metainfoLookupInit(tr_session* session)
 
     tr_sys_path_info info;
     char const* dirname = tr_getTorrentDir(session);
-    tr_sys_dir_t odir = (tr_sys_path_get_info(dirname, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_DIRECTORY) ?
-        tr_sys_dir_open(dirname, NULL) :
+    tr_sys_dir_t odir = (tr_sys_path_get_info(dirname, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY) ?
+        tr_sys_dir_open(dirname, nullptr) :
         TR_BAD_SYS_DIR;
 
     if (odir != TR_BAD_SYS_DIR)
@@ -2706,12 +2706,12 @@ static void metainfoLookupInit(tr_session* session)
         char const* name;
 
         /* walk through the directory and find the mappings */
-        while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (tr_str_has_suffix(name, ".torrent"))
             {
                 tr_info inf;
-                char* path = tr_buildPath(dirname, name, NULL);
+                char* path = tr_buildPath(dirname, name, nullptr);
                 tr_ctorSetMetainfoFromFile(ctor, path);
 
                 if (tr_torrentParse(ctor, &inf) == TR_PARSE_OK)
@@ -2724,7 +2724,7 @@ static void metainfoLookupInit(tr_session* session)
             }
         }
 
-        tr_sys_dir_close(odir, NULL);
+        tr_sys_dir_close(odir, nullptr);
         tr_ctorFree(ctor);
     }
 
@@ -2734,13 +2734,13 @@ static void metainfoLookupInit(tr_session* session)
 
 char const* tr_sessionFindTorrentFile(tr_session const* session, char const* hashString)
 {
-    if (session->metainfoLookup == NULL)
+    if (session->metainfoLookup == nullptr)
     {
         metainfoLookupInit((tr_session*)session);
     }
 
-    char const* filename = NULL;
-    (void)tr_variantDictFindStr(session->metainfoLookup, tr_quark_new(hashString, TR_BAD_SIZE), &filename, NULL);
+    char const* filename = nullptr;
+    (void)tr_variantDictFindStr(session->metainfoLookup, tr_quark_new(hashString, TR_BAD_SIZE), &filename, nullptr);
     return filename;
 }
 
@@ -2750,7 +2750,7 @@ void tr_sessionSetTorrentFile(tr_session* session, char const* hashString, char 
      * and tr_sessionSetTorrentFile() is just to tell us there's a new file
      * in that same directory, we don't need to do anything here if the
      * lookup table hasn't been built yet */
-    if (session->metainfoLookup != NULL)
+    if (session->metainfoLookup != nullptr)
     {
         tr_variantDictAddStr(session->metainfoLookup, tr_quark_new(hashString, TR_BAD_SIZE), filename);
     }
@@ -3053,9 +3053,9 @@ void tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction
     size_t n = tr_sessionCountTorrents(session);
     struct TorrentAndPosition* candidates = tr_new(struct TorrentAndPosition, n);
     size_t num_candidates = 0;
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         if (!tr_torrentIsQueued(tor))
         {
@@ -3112,8 +3112,8 @@ int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)
     bool const stalled_enabled = tr_sessionGetQueueStalledEnabled(session);
     int const stalled_if_idle_for_n_seconds = tr_sessionGetQueueStalledMinutes(session) * 60;
     time_t const now = tr_time();
-    tr_torrent* tor = NULL;
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    tr_torrent* tor = nullptr;
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         /* is it the right activity? */
         if (activity != tr_torrentGetActivity(tor))
@@ -3182,7 +3182,7 @@ void tr_sessionRemoveTorrent(tr_session* session, tr_torrent* tor)
     }
     else
     {
-        for (tr_torrent* t = session->torrentList; t != NULL; t = t->next)
+        for (tr_torrent* t = session->torrentList; t != nullptr; t = t->next)
         {
             if (t->next == tor)
             {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -6,12 +6,12 @@
  *
  */
 
-#include <errno.h> /* ENOENT */
-#include <limits.h> /* INT_MAX */
-#include <stdlib.h>
-#include <string.h> /* memcpy */
-
-#include <signal.h>
+#include <cerrno> /* ENOENT */
+#include <climits> /* INT_MAX */
+#include <cstdlib>
+#include <cstring> /* memcpy */
+#include <csignal>
+#include <algorithm>
 
 #ifndef _WIN32
 #include <sys/types.h> /* umask() */
@@ -21,7 +21,7 @@
 #include <event2/dns.h> /* evdns_base_free() */
 #include <event2/event.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 // #define TR_SHOW_DEPRECATED
@@ -3123,7 +3123,7 @@ int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)
         /* is it stalled? */
         if (stalled_enabled)
         {
-            int const idle_secs = (int)difftime(now, MAX(tor->startDate, tor->activityDate));
+            int const idle_secs = (int)difftime(now, std::max(tor->startDate, tor->activityDate));
             if (idle_secs >= stalled_if_idle_for_n_seconds)
                 continue;
         }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2091,7 +2091,8 @@ void tr_sessionClose(tr_session* session)
      * so we need to keep the transmission thread alive
      * for a bit while they tell the router & tracker
      * that we're closing now */
-    while ((session->shared != nullptr || session->web != nullptr || session->announcer != nullptr || session->announcer_udp != nullptr) &&
+    while ((session->shared != nullptr || session->web != nullptr || session->announcer != nullptr ||
+            session->announcer_udp != nullptr) &&
            !deadlineReached(deadline))
     {
         dbgmsg(

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -265,7 +265,7 @@ enum
 
 static inline bool tr_isSession(tr_session const* session)
 {
-    return session != NULL && session->magicNumber == SESSION_MAGIC_NUMBER;
+    return session != nullptr && session->magicNumber == SESSION_MAGIC_NUMBER;
 }
 
 static inline bool tr_isPreallocationMode(tr_preallocation_mode m)

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -29,12 +29,12 @@ struct tr_stats_handle
 
 static char* getOldFilename(tr_session const* session)
 {
-    return tr_buildPath(tr_sessionGetConfigDir(session), "stats.benc", NULL);
+    return tr_buildPath(tr_sessionGetConfigDir(session), "stats.benc", nullptr);
 }
 
 static char* getFilename(tr_session const* session)
 {
-    return tr_buildPath(tr_sessionGetConfigDir(session), "stats.json", NULL);
+    return tr_buildPath(tr_sessionGetConfigDir(session), "stats.json", nullptr);
 }
 
 static void loadCumulativeStats(tr_session const* session, tr_session_stats* setme)
@@ -44,13 +44,13 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
     bool loaded = false;
 
     filename = getFilename(session);
-    loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_JSON, filename, NULL);
+    loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_JSON, filename, nullptr);
     tr_free(filename);
 
     if (!loaded)
     {
         filename = getOldFilename(session);
-        loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_BENC, filename, NULL);
+        loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_BENC, filename, nullptr);
         tr_free(filename);
     }
 
@@ -102,7 +102,7 @@ static void saveCumulativeStats(tr_session const* session, tr_session_stats cons
     filename = getFilename(session);
     if (tr_logGetDeepEnabled())
     {
-        tr_logAddDeep(__FILE__, __LINE__, NULL, "Saving stats to \"%s\"", filename);
+        tr_logAddDeep(__FILE__, __LINE__, nullptr, "Saving stats to \"%s\"", filename);
     }
 
     tr_variantToFile(&top, TR_VARIANT_FMT_JSON, filename);
@@ -127,14 +127,14 @@ void tr_statsInit(tr_session* session)
 
 static struct tr_stats_handle* getStats(tr_session const* session)
 {
-    return session != NULL ? session->sessionStats : NULL;
+    return session != nullptr ? session->sessionStats : nullptr;
 }
 
 void tr_statsSaveDirty(tr_session* session)
 {
     struct tr_stats_handle* h = getStats(session);
 
-    if (h != NULL && h->isDirty)
+    if (h != nullptr && h->isDirty)
     {
         auto cumulative = tr_session_stats{};
         tr_sessionGetCumulativeStats(session, &cumulative);
@@ -148,7 +148,7 @@ void tr_statsClose(tr_session* session)
     tr_statsSaveDirty(session);
 
     tr_free(session->sessionStats);
-    session->sessionStats = NULL;
+    session->sessionStats = nullptr;
 }
 
 /***
@@ -174,7 +174,7 @@ void tr_sessionGetStats(tr_session const* session, tr_session_stats* setme)
 {
     struct tr_stats_handle const* stats = getStats(session);
 
-    if (stats != NULL)
+    if (stats != nullptr)
     {
         *setme = stats->single;
         setme->secondsActive = tr_time() - stats->startTime;
@@ -187,7 +187,7 @@ void tr_sessionGetCumulativeStats(tr_session const* session, tr_session_stats* s
     struct tr_stats_handle const* stats = getStats(session);
     auto current = tr_session_stats{};
 
-    if (stats != NULL)
+    if (stats != nullptr)
     {
         tr_sessionGetStats(session, &current);
         addStats(setme, &stats->old, &current);
@@ -218,7 +218,7 @@ void tr_statsAddUploaded(tr_session* session, uint32_t bytes)
 {
     struct tr_stats_handle* s;
 
-    if ((s = getStats(session)) != NULL)
+    if ((s = getStats(session)) != nullptr)
     {
         s->single.uploadedBytes += bytes;
         s->isDirty = true;
@@ -229,7 +229,7 @@ void tr_statsAddDownloaded(tr_session* session, uint32_t bytes)
 {
     struct tr_stats_handle* s;
 
-    if ((s = getStats(session)) != NULL)
+    if ((s = getStats(session)) != nullptr)
     {
         s->single.downloadedBytes += bytes;
         s->isDirty = true;
@@ -240,7 +240,7 @@ void tr_statsFileCreated(tr_session* session)
 {
     struct tr_stats_handle* s;
 
-    if ((s = getStats(session)) != NULL)
+    if ((s = getStats(session)) != nullptr)
     {
         s->single.filesAdded++;
     }

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -31,7 +31,7 @@ static void handle_sigchld(int i)
     do
     {
         /* FIXME: Only check for our own PIDs */
-        rc = waitpid(-1, NULL, WNOHANG);
+        rc = waitpid(-1, nullptr, WNOHANG);
     } while (rc > 0 || (rc == -1 && errno == EINTR));
 
     /* FIXME: Call old handler, if any */
@@ -39,12 +39,12 @@ static void handle_sigchld(int i)
 
 static void set_system_error(tr_error** error, int code, char const* what)
 {
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
-    if (what == NULL)
+    if (what == nullptr)
     {
         tr_error_set_literal(error, code, tr_strerror(code));
     }
@@ -56,9 +56,9 @@ static void set_system_error(tr_error** error, int code, char const* what)
 
 static bool tr_spawn_async_in_child(char* const* cmd, char* const* env, char const* work_dir, int pipe_fd)
 {
-    if (env != NULL)
+    if (env != nullptr)
     {
-        for (size_t i = 0; env[i] != NULL; ++i)
+        for (size_t i = 0; env[i] != nullptr; ++i)
         {
             if (putenv(env[i]) != 0)
             {
@@ -67,7 +67,7 @@ static bool tr_spawn_async_in_child(char* const* cmd, char* const* env, char con
         }
     }
 
-    if (work_dir != NULL && chdir(work_dir) == -1)
+    if (work_dir != nullptr && chdir(work_dir) == -1)
     {
         goto FAIL;
     }

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -27,19 +27,19 @@ enum tr_app_type
 
 static void set_system_error(tr_error** error, DWORD code, char const* what)
 {
-    if (error == NULL)
+    if (error == nullptr)
     {
         return;
     }
 
     char* message = tr_win32_format_message(code);
 
-    if (message == NULL)
+    if (message == nullptr)
     {
         message = tr_strdup_printf("Unknown error: 0x%08lx", code);
     }
 
-    if (what == NULL)
+    if (what == nullptr)
     {
         tr_error_set_literal(error, code, message);
     }
@@ -60,11 +60,11 @@ static void append_to_env_block(wchar_t** env_block, size_t* env_block_len, wcha
 
 static bool parse_env_block_part(wchar_t const* part, size_t* full_len, size_t* name_len)
 {
-    TR_ASSERT(part != NULL);
+    TR_ASSERT(part != nullptr);
 
     auto const* const equals_pos = wcschr(part, L'=');
 
-    if (equals_pos == NULL)
+    if (equals_pos == nullptr)
     {
         /* Invalid part */
         return false;
@@ -78,13 +78,13 @@ static bool parse_env_block_part(wchar_t const* part, size_t* full_len, size_t* 
         return false;
     }
 
-    if (full_len != NULL)
+    if (full_len != nullptr)
     {
         /* Includes terminating '\0' */
         *full_len = wcslen(part) + 1;
     }
 
-    if (name_len != NULL)
+    if (name_len != nullptr)
     {
         *name_len = (size_t)my_name_len;
     }
@@ -129,14 +129,14 @@ static int compare_env_part_names(void const* vlhs, void const* vrhs)
 
 static wchar_t** to_wide_env(char const* const* env)
 {
-    if (env == NULL || env[0] == NULL)
+    if (env == nullptr || env[0] == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     size_t part_count = 0;
 
-    while (env[part_count] != NULL)
+    while (env[part_count] != nullptr)
     {
         ++part_count;
     }
@@ -148,7 +148,7 @@ static wchar_t** to_wide_env(char const* const* env)
         wide_env[i] = tr_win32_utf8_to_native(env[i], -1);
     }
 
-    wide_env[part_count] = NULL;
+    wide_env[part_count] = nullptr;
 
     /* "The sort is case-insensitive, Unicode order, without regard to locale" (c) MSDN */
     qsort(wide_env, part_count, sizeof(wchar_t*), &compare_env_part_names);
@@ -160,26 +160,26 @@ static bool create_env_block(char const* const* env, wchar_t** env_block, tr_err
 {
     wchar_t** wide_env = to_wide_env(env);
 
-    if (wide_env == NULL)
+    if (wide_env == nullptr)
     {
-        *env_block = NULL;
+        *env_block = nullptr;
         return true;
     }
 
     wchar_t* const old_env_block = GetEnvironmentStringsW();
 
-    if (old_env_block == NULL)
+    if (old_env_block == nullptr)
     {
         set_system_error(error, GetLastError(), "Call to GetEnvironmentStrings()");
         return false;
     }
 
-    *env_block = NULL;
+    *env_block = nullptr;
 
     wchar_t const* old_part = old_env_block;
     size_t env_block_len = 0;
 
-    for (size_t i = 0; wide_env[i] != NULL; ++i)
+    for (size_t i = 0; wide_env[i] != nullptr; ++i)
     {
         wchar_t const* const part = wide_env[i];
 
@@ -226,7 +226,7 @@ static bool create_env_block(char const* const* env, wchar_t** env_block, tr_err
     {
         size_t old_part_len;
 
-        if (!parse_env_block_part(old_part, &old_part_len, NULL))
+        if (!parse_env_block_part(old_part, &old_part_len, nullptr))
         {
             continue;
         }
@@ -247,7 +247,7 @@ static bool create_env_block(char const* const* env, wchar_t** env_block, tr_err
 
 static void append_argument(char** arguments, char const* argument)
 {
-    size_t arguments_len = *arguments != NULL ? strlen(*arguments) : 0u;
+    size_t arguments_len = *arguments != nullptr ? strlen(*arguments) : 0u;
     size_t const argument_len = strlen(argument);
 
     if (arguments_len > 0)
@@ -255,7 +255,7 @@ static void append_argument(char** arguments, char const* argument)
         (*arguments)[arguments_len++] = ' ';
     }
 
-    if (!tr_str_is_empty(argument) && strpbrk(argument, " \t\n\v\"") == NULL)
+    if (!tr_str_is_empty(argument) && strpbrk(argument, " \t\n\v\"") == nullptr)
     {
         *arguments = tr_renew(char, *arguments, arguments_len + argument_len + 2);
         strcpy(*arguments + arguments_len, argument);
@@ -310,7 +310,7 @@ static bool contains_batch_metachars(char const* text)
     return strpbrk(
                text,
                "&<>()@^|"
-               "%!^\"") != NULL;
+               "%!^\"") != nullptr;
 }
 
 static enum tr_app_type get_app_type(char const* app)
@@ -351,13 +351,13 @@ static bool construct_cmd_line(char const* const* cmd, wchar_t** cmd_line)
 {
     enum tr_app_type const app_type = get_app_type(cmd[0]);
 
-    char* args = NULL;
+    char* args = nullptr;
     size_t arg_count = 0;
     bool ret = false;
 
     append_app_launcher_arguments(app_type, &args);
 
-    for (size_t i = 0; cmd[i] != NULL; ++i)
+    for (size_t i = 0; cmd[i] != nullptr; ++i)
     {
         if (app_type == TR_APP_TYPE_BATCH && i > 0 && contains_batch_metachars(cmd[i]))
         {
@@ -369,7 +369,7 @@ static bool construct_cmd_line(char const* const* cmd, wchar_t** cmd_line)
         ++arg_count;
     }
 
-    *cmd_line = args != NULL ? tr_win32_utf8_to_native(args, -1) : NULL;
+    *cmd_line = args != nullptr ? tr_win32_utf8_to_native(args, -1) : nullptr;
 
     ret = true;
 
@@ -380,7 +380,7 @@ cleanup:
 
 bool tr_spawn_async(char* const* cmd, char* const* env, char const* work_dir, tr_error** error)
 {
-    wchar_t* env_block = NULL;
+    wchar_t* env_block = nullptr;
 
     if (!create_env_block(env, &env_block, error))
     {
@@ -395,7 +395,7 @@ bool tr_spawn_async(char* const* cmd, char* const* env, char const* work_dir, tr
         return false;
     }
 
-    wchar_t* current_dir = work_dir != NULL ? tr_win32_utf8_to_native(work_dir, -1) : NULL;
+    wchar_t* current_dir = work_dir != nullptr ? tr_win32_utf8_to_native(work_dir, -1) : nullptr;
 
     auto si = STARTUPINFOW{};
     si.cb = sizeof(si);
@@ -405,10 +405,10 @@ bool tr_spawn_async(char* const* cmd, char* const* env, char const* work_dir, tr
     PROCESS_INFORMATION pi;
 
     bool const ret = CreateProcessW(
-        NULL,
+        nullptr,
         cmd_line,
-        NULL,
-        NULL,
+        nullptr,
+        nullptr,
         FALSE,
         NORMAL_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW | CREATE_DEFAULT_ERROR_MODE,
         env_block,

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -77,7 +77,7 @@ static void clearMetainfo(tr_ctor* ctor)
         tr_variantFree(&ctor->metainfo);
     }
 
-    setSourceFile(ctor, NULL);
+    setSourceFile(ctor, nullptr);
 }
 
 int tr_ctorSetMetainfo(tr_ctor* ctor, void const* metainfo, size_t len)
@@ -100,7 +100,7 @@ int tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, char const* magnet_link)
     int err;
     tr_magnet_info* magnet_info = tr_magnetParse(magnet_link);
 
-    if (magnet_info == NULL)
+    if (magnet_info == nullptr)
     {
         err = -1;
     }
@@ -128,9 +128,9 @@ int tr_ctorSetMetainfoFromFile(tr_ctor* ctor, char const* filename)
     size_t len;
     int err;
 
-    metainfo = tr_loadFile(filename, &len, NULL);
+    metainfo = tr_loadFile(filename, &len, nullptr);
 
-    if (metainfo != NULL && len != 0)
+    if (metainfo != nullptr && len != 0)
     {
         err = tr_ctorSetMetainfo(ctor, metainfo, len);
     }
@@ -151,17 +151,17 @@ int tr_ctorSetMetainfoFromFile(tr_ctor* ctor, char const* filename)
         {
             char const* name;
 
-            if (!tr_variantDictFindStr(info, TR_KEY_name_utf_8, &name, NULL) &&
-                !tr_variantDictFindStr(info, TR_KEY_name, &name, NULL))
+            if (!tr_variantDictFindStr(info, TR_KEY_name_utf_8, &name, nullptr) &&
+                !tr_variantDictFindStr(info, TR_KEY_name, &name, nullptr))
             {
-                name = NULL;
+                name = nullptr;
             }
 
             if (tr_str_is_empty(name))
             {
-                char* base = tr_sys_path_basename(filename, NULL);
+                char* base = tr_sys_path_basename(filename, nullptr);
 
-                if (base != NULL)
+                if (base != nullptr)
                 {
                     tr_variantDictAddStr(info, TR_KEY_name, base);
                     tr_free(base);
@@ -181,7 +181,7 @@ int tr_ctorSetMetainfoFromHash(tr_ctor* ctor, char const* hashString)
 
     filename = tr_sessionFindTorrentFile(ctor->session, hashString);
 
-    if (filename == NULL)
+    if (filename == nullptr)
     {
         err = EINVAL;
     }
@@ -284,7 +284,7 @@ bool tr_ctorGetDeleteSource(tr_ctor const* ctor, bool* setme)
     {
         ret = false;
     }
-    else if (setme != NULL)
+    else if (setme != nullptr)
     {
         *setme = ctor->doDelete;
     }
@@ -303,12 +303,12 @@ void tr_ctorSetSave(tr_ctor* ctor, bool saveInOurTorrentsDir)
 
 bool tr_ctorGetSave(tr_ctor const* ctor)
 {
-    return ctor != NULL && ctor->saveInOurTorrentsDir;
+    return ctor != nullptr && ctor->saveInOurTorrentsDir;
 }
 
 void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool isPaused)
 {
-    TR_ASSERT(ctor != NULL);
+    TR_ASSERT(ctor != nullptr);
     TR_ASSERT(mode == TR_FALLBACK || mode == TR_FORCE);
 
     struct optional_args* args = &ctor->optionalArgs[mode];
@@ -318,7 +318,7 @@ void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool isPaused)
 
 void tr_ctorSetPeerLimit(tr_ctor* ctor, tr_ctorMode mode, uint16_t peerLimit)
 {
-    TR_ASSERT(ctor != NULL);
+    TR_ASSERT(ctor != nullptr);
     TR_ASSERT(mode == TR_FALLBACK || mode == TR_FORCE);
 
     struct optional_args* args = &ctor->optionalArgs[mode];
@@ -328,12 +328,12 @@ void tr_ctorSetPeerLimit(tr_ctor* ctor, tr_ctorMode mode, uint16_t peerLimit)
 
 void tr_ctorSetDownloadDir(tr_ctor* ctor, tr_ctorMode mode, char const* directory)
 {
-    TR_ASSERT(ctor != NULL);
+    TR_ASSERT(ctor != nullptr);
     TR_ASSERT(mode == TR_FALLBACK || mode == TR_FORCE);
 
     struct optional_args* args = &ctor->optionalArgs[mode];
     tr_free(args->downloadDir);
-    args->downloadDir = NULL;
+    args->downloadDir = nullptr;
     args->isSet_downloadDir = false;
 
     if (!tr_str_is_empty(directory))
@@ -358,7 +358,7 @@ bool tr_ctorGetPeerLimit(tr_ctor const* ctor, tr_ctorMode mode, uint16_t* setmeC
     {
         ret = false;
     }
-    else if (setmeCount != NULL)
+    else if (setmeCount != nullptr)
     {
         *setmeCount = args->peerLimit;
     }
@@ -375,7 +375,7 @@ bool tr_ctorGetPaused(tr_ctor const* ctor, tr_ctorMode mode, bool* setmeIsPaused
     {
         ret = false;
     }
-    else if (setmeIsPaused != NULL)
+    else if (setmeIsPaused != nullptr)
     {
         *setmeIsPaused = args->isPaused;
     }
@@ -392,7 +392,7 @@ bool tr_ctorGetDownloadDir(tr_ctor const* ctor, tr_ctorMode mode, char const** s
     {
         ret = false;
     }
-    else if (setmeDownloadDir != NULL)
+    else if (setmeDownloadDir != nullptr)
     {
         *setmeDownloadDir = args->downloadDir;
     }
@@ -404,7 +404,7 @@ bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDi
 {
     bool ret = true;
 
-    if (ctor->incompleteDir == NULL)
+    if (ctor->incompleteDir == nullptr)
     {
         ret = false;
     }
@@ -424,7 +424,7 @@ bool tr_ctorGetMetainfo(tr_ctor const* ctor, tr_variant const** setme)
     {
         ret = false;
     }
-    else if (setme != NULL)
+    else if (setme != nullptr)
     {
         *setme = &ctor->metainfo;
     }
@@ -470,7 +470,7 @@ tr_ctor* tr_ctorNew(tr_session const* session)
     ctor->session = session;
     ctor->bandwidthPriority = TR_PRI_NORMAL;
 
-    if (session != NULL)
+    if (session != nullptr)
     {
         tr_ctorSetDeleteSource(ctor, tr_sessionGetDeleteSource(session));
         tr_ctorSetPaused(ctor, TR_FALLBACK, tr_sessionGetPaused(session));

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -68,7 +68,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
         return false;
     }
 
-    if (tor->incompleteMetadata != NULL)
+    if (tor->incompleteMetadata != nullptr)
     {
         return false;
     }
@@ -84,7 +84,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
 
     struct tr_incomplete_metadata* m = tr_new(struct tr_incomplete_metadata, 1);
 
-    if (m == NULL)
+    if (m == nullptr)
     {
         return false;
     }
@@ -95,7 +95,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
     m->piecesNeededCount = n;
     m->piecesNeeded = tr_new(struct metadata_node, n);
 
-    if (m->metadata == NULL || m->piecesNeeded == NULL)
+    if (m->metadata == nullptr || m->piecesNeeded == nullptr)
     {
         incompleteMetadataFree(m);
         return false;
@@ -118,7 +118,7 @@ static size_t findInfoDictOffset(tr_torrent const* tor)
     size_t offset = 0;
 
     /* load the file, and find the info dict's offset inside the file */
-    if ((fileContents = tr_loadFile(tor->info.torrent, &fileLen, NULL)) != NULL)
+    if ((fileContents = tr_loadFile(tor->info.torrent, &fileLen, nullptr)) != nullptr)
     {
         tr_variant top;
 
@@ -131,7 +131,7 @@ static size_t findInfoDictOffset(tr_torrent const* tor)
                 size_t infoLen;
                 char* infoContents = tr_variantToStr(infoDict, TR_VARIANT_FMT_BENC, &infoLen);
                 uint8_t const* i = (uint8_t const*)tr_memmem((char*)fileContents, fileLen, infoContents, infoLen);
-                offset = i != NULL ? i - fileContents : 0;
+                offset = i != nullptr ? i - fileContents : 0;
                 tr_free(infoContents);
             }
 
@@ -159,9 +159,9 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 {
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(piece >= 0);
-    TR_ASSERT(len != NULL);
+    TR_ASSERT(len != nullptr);
 
-    char* ret = NULL;
+    char* ret = nullptr;
 
     if (tr_torrentHasMetadata(tor))
     {
@@ -171,13 +171,13 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 
         TR_ASSERT(tor->infoDictLength > 0);
 
-        fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, NULL);
+        fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, nullptr);
 
         if (fd != TR_BAD_SYS_FILE)
         {
             size_t const o = piece * METADATA_PIECE_SIZE;
 
-            if (tr_sys_file_seek(fd, tor->infoDictOffset + o, TR_SEEK_SET, NULL, NULL))
+            if (tr_sys_file_seek(fd, tor->infoDictOffset + o, TR_SEEK_SET, nullptr, nullptr))
             {
                 size_t const l = o + METADATA_PIECE_SIZE <= tor->infoDictLength ? METADATA_PIECE_SIZE : tor->infoDictLength - o;
 
@@ -186,22 +186,22 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
                     char* buf = tr_new(char, l);
                     uint64_t n;
 
-                    if (tr_sys_file_read(fd, buf, l, &n, NULL) && n == l)
+                    if (tr_sys_file_read(fd, buf, l, &n, nullptr) && n == l)
                     {
                         *len = l;
                         ret = buf;
-                        buf = NULL;
+                        buf = nullptr;
                     }
 
                     tr_free(buf);
                 }
             }
 
-            tr_sys_file_close(fd, NULL);
+            tr_sys_file_close(fd, nullptr);
         }
     }
 
-    TR_ASSERT(ret == NULL || *len > 0);
+    TR_ASSERT(ret == nullptr || *len > 0);
 
     return ret;
 }
@@ -229,14 +229,14 @@ static int getPieceLength(struct tr_incomplete_metadata const* m, int piece)
 void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, int len)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(data != NULL);
+    TR_ASSERT(data != nullptr);
     TR_ASSERT(len >= 0);
 
     dbgmsg(tor, "got metadata piece %d of %d bytes", piece, len);
 
     // are we set up to download metadata?
     struct tr_incomplete_metadata* const m = tor->incompleteMetadata;
-    if (m == NULL)
+    if (m == nullptr)
     {
         return;
     }
@@ -277,7 +277,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
 
         /* we've got a complete set of metainfo... see if it passes the checksum test */
         dbgmsg(tor, "metainfo piece %d was the last one", piece);
-        tr_sha1(sha1, m->metadata, m->metadata_size, NULL);
+        tr_sha1(sha1, m->metadata, m->metadata_size, nullptr);
 
         bool const checksumPassed = memcmp(sha1, tor->info.hash, SHA_DIGEST_LENGTH) == 0;
         if (checksumPassed)
@@ -294,14 +294,14 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
                 tr_variant newMetainfo;
                 char* path = tr_strdup(tor->info.torrent);
 
-                if (tr_variantFromFile(&newMetainfo, TR_VARIANT_FMT_BENC, path, NULL))
+                if (tr_variantFromFile(&newMetainfo, TR_VARIANT_FMT_BENC, path, nullptr))
                 {
                     bool hasInfo;
                     tr_info info;
                     size_t infoDictLength;
 
                     /* remove any old .torrent and .resume files */
-                    tr_sys_path_remove(path, NULL);
+                    tr_sys_path_remove(path, nullptr);
                     tr_torrentRemoveResume(tor);
 
                     dbgmsg(tor, "Saving completed metadata to \"%s\"", path);
@@ -341,7 +341,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
         if (success)
         {
             incompleteMetadataFree(tor->incompleteMetadata);
-            tor->incompleteMetadata = NULL;
+            tor->incompleteMetadata = nullptr;
             tor->isStopping = true;
             tor->magnetVerify = true;
             tor->startAfterVerify = !tor->prefetchMagnetMetadata;
@@ -372,7 +372,7 @@ bool tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now, int* setme_pi
     bool have_request = false;
     struct tr_incomplete_metadata* m = tor->incompleteMetadata;
 
-    if (m != NULL && m->piecesNeededCount > 0 && m->piecesNeeded[0].requestedAt + MIN_REPEAT_INTERVAL_SECS < now)
+    if (m != nullptr && m->piecesNeededCount > 0 && m->piecesNeeded[0].requestedAt + MIN_REPEAT_INTERVAL_SECS < now)
     {
         int const piece = m->piecesNeeded[0].piece;
         tr_removeElementFromArray(m->piecesNeeded, 0, sizeof(struct metadata_node), m->piecesNeededCount);
@@ -401,7 +401,7 @@ double tr_torrentGetMetadataPercent(tr_torrent const* tor)
     {
         struct tr_incomplete_metadata const* m = tor->incompleteMetadata;
 
-        if (m == NULL || m->pieceCount == 0)
+        if (m == nullptr || m->pieceCount == 0)
         {
             ret = 0.0;
         }
@@ -442,5 +442,5 @@ char* tr_torrentInfoGetMagnetLink(tr_info const* inf)
         tr_http_escape(s, inf->webseeds[i], TR_BAD_SIZE, true);
     }
 
-    return evbuffer_free_to_str(s, NULL);
+    return evbuffer_free_to_str(s, nullptr);
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -65,12 +65,12 @@
 
 char const* tr_torrentName(tr_torrent const* tor)
 {
-    return tor != NULL ? tor->info.name : "";
+    return tor != nullptr ? tor->info.name : "";
 }
 
 int tr_torrentId(tr_torrent const* tor)
 {
-    return tor != NULL ? tor->uniqueId : -1;
+    return tor != nullptr ? tor->uniqueId : -1;
 }
 
 static int compareKeyToTorrentId(void const* va, void const* vb)
@@ -114,9 +114,9 @@ tr_torrent* tr_torrentFindFromHash(tr_session* session, uint8_t const* torrentHa
 tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* magnet)
 {
     tr_magnet_info* info;
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
-    if ((info = tr_magnetParse(magnet)) != NULL)
+    if ((info = tr_magnetParse(magnet)) != nullptr)
     {
         tor = tr_torrentFindFromHash(session, info->hash);
         tr_magnetFree(info);
@@ -127,9 +127,9 @@ tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* magnet
 
 tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, uint8_t const* obfuscatedTorrentHash)
 {
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         if (memcmp(tor->obfuscatedHash, obfuscatedTorrentHash, SHA_DIGEST_LENGTH) == 0)
         {
@@ -137,7 +137,7 @@ tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, uint8_t const*
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 bool tr_torrentIsPieceTransferAllowed(tr_torrent const* tor, tr_direction direction)
@@ -334,7 +334,7 @@ bool tr_torrentGetSeedRatio(tr_torrent const* tor, double* ratio)
     case TR_RATIOLIMIT_SINGLE:
         isLimited = true;
 
-        if (ratio != NULL)
+        if (ratio != nullptr)
         {
             *ratio = tr_torrentGetRatioLimit(tor);
         }
@@ -344,7 +344,7 @@ bool tr_torrentGetSeedRatio(tr_torrent const* tor, double* ratio)
     case TR_RATIOLIMIT_GLOBAL:
         isLimited = tr_sessionIsRatioLimited(tor->session);
 
-        if (isLimited && ratio != NULL)
+        if (isLimited && ratio != nullptr)
         {
             *ratio = tr_sessionGetRatioLimit(tor->session);
         }
@@ -375,12 +375,12 @@ static bool tr_torrentGetSeedRatioBytes(tr_torrent const* tor, uint64_t* setmeLe
         uint64_t const baseline = d != 0 ? d : tr_cpSizeWhenDone(&tor->completion);
         uint64_t const goal = baseline * seedRatio;
 
-        if (setmeLeft != NULL)
+        if (setmeLeft != nullptr)
         {
             *setmeLeft = goal > u ? goal - u : 0;
         }
 
-        if (setmeGoal != NULL)
+        if (setmeGoal != nullptr)
         {
             *setmeGoal = goal;
         }
@@ -394,7 +394,7 @@ static bool tr_torrentGetSeedRatioBytes(tr_torrent const* tor, uint64_t* setmeLe
 static bool tr_torrentIsSeedRatioDone(tr_torrent const* tor)
 {
     uint64_t bytesLeft;
-    return tr_torrentGetSeedRatioBytes(tor, &bytesLeft, NULL) && bytesLeft == 0;
+    return tr_torrentGetSeedRatioBytes(tor, &bytesLeft, nullptr) && bytesLeft == 0;
 }
 
 /***
@@ -449,7 +449,7 @@ bool tr_torrentGetSeedIdle(tr_torrent const* tor, uint16_t* idleMinutes)
     case TR_IDLELIMIT_SINGLE:
         isLimited = true;
 
-        if (idleMinutes != NULL)
+        if (idleMinutes != nullptr)
         {
             *idleMinutes = tr_torrentGetIdleLimit(tor);
         }
@@ -459,7 +459,7 @@ bool tr_torrentGetSeedIdle(tr_torrent const* tor, uint16_t* idleMinutes)
     case TR_IDLELIMIT_GLOBAL:
         isLimited = tr_sessionIsIdleLimited(tor->session);
 
-        if (isLimited && idleMinutes != NULL)
+        if (isLimited && idleMinutes != nullptr)
         {
             *idleMinutes = tr_sessionGetIdleLimit(tor->session);
         }
@@ -502,7 +502,7 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor)
         tor->isStopping = true;
 
         /* maybe notify the client */
-        if (tor->ratio_limit_hit_func != NULL)
+        if (tor->ratio_limit_hit_func != nullptr)
         {
             (*tor->ratio_limit_hit_func)(tor, tor->ratio_limit_hit_func_user_data);
         }
@@ -516,7 +516,7 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor)
         tor->finishedSeedingByIdle = true;
 
         /* maybe notify the client */
-        if (tor->idle_limit_hit_func != NULL)
+        if (tor->idle_limit_hit_func != nullptr)
         {
             (*tor->idle_limit_hit_func)(tor, tor->idle_limit_hit_func_user_data);
         }
@@ -605,7 +605,7 @@ static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, vo
 
 static tr_piece_index_t getBytePiece(tr_info const* info, uint64_t byteOffset)
 {
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(info != nullptr);
     TR_ASSERT(info->pieceSize != 0);
 
     tr_piece_index_t piece = byteOffset / info->pieceSize;
@@ -621,7 +621,7 @@ static tr_piece_index_t getBytePiece(tr_info const* info, uint64_t byteOffset)
 
 static void initFilePieces(tr_info* info, tr_file_index_t fileIndex)
 {
-    TR_ASSERT(info != NULL);
+    TR_ASSERT(info != nullptr);
     TR_ASSERT(fileIndex < info->fileCount);
 
     tr_file* file = &info->files[fileIndex];
@@ -840,7 +840,7 @@ static bool hasAnyLocalData(tr_torrent const* tor)
 {
     for (tr_file_index_t i = 0; i < tor->info.fileCount; ++i)
     {
-        if (tr_torrentFindFile2(tor, i, NULL, NULL, NULL))
+        if (tr_torrentFindFile2(tor, i, nullptr, nullptr, nullptr))
         {
             return true;
         }
@@ -870,7 +870,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 {
     tr_session* session = tr_ctorGetSession(ctor);
 
-    TR_ASSERT(session != NULL);
+    TR_ASSERT(session != nullptr);
 
     tr_sessionLock(session);
 
@@ -886,7 +886,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->queuePosition = session->torrentCount;
     tor->labels = {};
 
-    tr_sha1(tor->obfuscatedHash, "req2", 4, tor->info.hash, SHA_DIGEST_LENGTH, NULL);
+    tr_sha1(tor->obfuscatedHash, "req2", 4, tor->info.hash, SHA_DIGEST_LENGTH, nullptr);
 
     if (tr_ctorGetDownloadDir(ctor, TR_FORCE, &dir) || tr_ctorGetDownloadDir(ctor, TR_FALLBACK, &dir))
     {
@@ -962,7 +962,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tr_sessionAddTorrent(session, tor);
 
     /* if we don't have a local .torrent file already, assume the torrent is new */
-    isNewTorrent = !tr_sys_path_exists(tor->info.torrent, NULL);
+    isNewTorrent = !tr_sys_path_exists(tor->info.torrent, nullptr);
 
     /* maybe save our own copy of the metainfo */
     if (tr_ctorGetSave(ctor))
@@ -983,7 +983,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         }
     }
 
-    tor->tiers = tr_announcerAddTorrent(tor, onTrackerResponse, NULL);
+    tor->tiers = tr_announcerAddTorrent(tor, onTrackerResponse, nullptr);
 
     if (isNewTorrent)
     {
@@ -995,7 +995,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         else
         {
             tor->startAfterVerify = doStart;
-            tr_torrentVerify(tor, NULL, NULL);
+            tr_torrentVerify(tor, nullptr, nullptr);
         }
     }
     else if (doStart)
@@ -1021,7 +1021,7 @@ static tr_parse_result torrentParseImpl(
     tr_session* session = tr_ctorGetSession(ctor);
     tr_parse_result result = TR_PARSE_OK;
 
-    if (setmeInfo == NULL)
+    if (setmeInfo == nullptr)
     {
         setmeInfo = &tmp;
     }
@@ -1046,15 +1046,15 @@ static tr_parse_result torrentParseImpl(
         result = TR_PARSE_ERR;
     }
 
-    if (didParse && session != NULL && result == TR_PARSE_OK)
+    if (didParse && session != nullptr && result == TR_PARSE_OK)
     {
         tr_torrent const* const tor = tr_torrentFindFromHash(session, setmeInfo->hash);
 
-        if (tor != NULL)
+        if (tor != nullptr)
         {
             result = TR_PARSE_DUPLICATE;
 
-            if (setme_duplicate_id != NULL)
+            if (setme_duplicate_id != nullptr)
             {
                 *setme_duplicate_id = tr_torrentId(tor);
             }
@@ -1066,7 +1066,7 @@ static tr_parse_result torrentParseImpl(
         tr_metainfoFree(setmeInfo);
     }
 
-    if (setmeHasInfo != NULL)
+    if (setmeHasInfo != nullptr)
     {
         *setmeHasInfo = hasInfo;
     }
@@ -1076,19 +1076,19 @@ static tr_parse_result torrentParseImpl(
 
 tr_parse_result tr_torrentParse(tr_ctor const* ctor, tr_info* setmeInfo)
 {
-    return torrentParseImpl(ctor, setmeInfo, NULL, NULL, NULL);
+    return torrentParseImpl(ctor, setmeInfo, nullptr, nullptr, nullptr);
 }
 
 tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_duplicate_id)
 {
-    TR_ASSERT(ctor != NULL);
+    TR_ASSERT(ctor != nullptr);
     TR_ASSERT(tr_isSession(tr_ctorGetSession(ctor)));
 
     size_t len;
     bool hasInfo;
     tr_info tmpInfo;
     tr_parse_result r;
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
 
     r = torrentParseImpl(ctor, &tmpInfo, &hasInfo, &len, setme_duplicate_id);
 
@@ -1111,7 +1111,7 @@ tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_dupl
             tr_metainfoFree(&tmpInfo);
         }
 
-        if (setme_error != NULL)
+        if (setme_error != nullptr)
         {
             *setme_error = r;
         }
@@ -1128,7 +1128,7 @@ void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (path == NULL || tor->downloadDir == NULL || strcmp(path, tor->downloadDir) != 0)
+    if (path == nullptr || tor->downloadDir == nullptr || strcmp(path, tor->downloadDir) != 0)
     {
         tr_free(tor->downloadDir);
         tor->downloadDir = tr_strdup(path);
@@ -1190,7 +1190,7 @@ bool tr_torrentCanManualUpdate(tr_torrent const* tor)
 
 tr_info const* tr_torrentInfo(tr_torrent const* tor)
 {
-    return tr_isTorrent(tor) ? &tor->info : NULL;
+    return tr_isTorrent(tor) ? &tor->info : nullptr;
 }
 
 tr_stat const* tr_torrentStatCached(tr_torrent* tor)
@@ -1293,7 +1293,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 
     tor->lastStatTime = tr_time();
 
-    if (tor->swarm != NULL)
+    if (tor->swarm != nullptr)
     {
         tr_swarmGetStats(tor->swarm, &swarm_stats);
     }
@@ -1516,7 +1516,7 @@ tr_file_stat* tr_torrentFiles(tr_torrent const* tor, tr_file_index_t* fileCount)
         ++walk;
     }
 
-    if (fileCount != NULL)
+    if (fileCount != nullptr)
     {
         *fileCount = n;
     }
@@ -1572,7 +1572,7 @@ void tr_torrentAvailability(tr_torrent const* tor, int8_t* tab, int size)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tab != NULL && size > 0)
+    if (tab != nullptr && size > 0)
     {
         tr_peerMgrTorrentAvailability(tor, tab, size);
     }
@@ -1644,9 +1644,9 @@ static void freeTorrent(tr_torrent* tor)
     tr_sessionRemoveTorrent(session, tor);
 
     /* resequence the queue positions */
-    tr_torrent* t = NULL;
+    tr_torrent* t = nullptr;
 
-    while ((t = tr_torrentNext(session, t)) != NULL)
+    while ((t = tr_torrentNext(session, t)) != nullptr)
     {
         if (t->queuePosition > tor->queuePosition)
         {
@@ -1713,7 +1713,7 @@ uint64_t tr_torrentGetCurrentSizeOnDisk(tr_torrent const* tor)
         tr_sys_path_info info;
         char* filename = tr_torrentFindFile(tor, i);
 
-        if (filename != NULL && tr_sys_path_get_info(filename, 0, &info, NULL))
+        if (filename != nullptr && tr_sys_path_get_info(filename, 0, &info, nullptr))
         {
             byte_count += info.size;
         }
@@ -1830,7 +1830,7 @@ static void onVerifyDoneThreadFunc(void* vdata)
             tr_torrentRecheckCompleteness(tor);
         }
 
-        if (data->callback_func != NULL)
+        if (data->callback_func != nullptr)
         {
             (*data->callback_func)(tor, data->aborted, data->callback_data);
         }
@@ -1951,7 +1951,7 @@ static void stopTorrent(void* vtor)
         tor->magnetVerify = false;
         tr_logAddTorInfo(tor, "%s", "Magnet Verify");
         refreshCurrentDir(tor);
-        tr_torrentVerify(tor, NULL, NULL);
+        tr_torrentVerify(tor, nullptr, nullptr);
     }
 }
 
@@ -2083,7 +2083,7 @@ static void fireCompletenessChange(tr_torrent* tor, tr_completeness status, bool
 {
     TR_ASSERT(status == TR_LEECH || status == TR_SEED || status == TR_PARTIAL_SEED);
 
-    if (tor->completeness_func != NULL)
+    if (tor->completeness_func != nullptr)
     {
         (*tor->completeness_func)(tor, status, wasRunning, tor->completeness_func_user_data);
     }
@@ -2099,7 +2099,7 @@ void tr_torrentSetCompletenessCallback(tr_torrent* tor, tr_torrent_completeness_
 
 void tr_torrentClearCompletenessCallback(tr_torrent* torrent)
 {
-    tr_torrentSetCompletenessCallback(torrent, NULL, NULL);
+    tr_torrentSetCompletenessCallback(torrent, nullptr, nullptr);
 }
 
 void tr_torrentSetRatioLimitHitCallback(tr_torrent* tor, tr_torrent_ratio_limit_hit_func func, void* user_data)
@@ -2112,7 +2112,7 @@ void tr_torrentSetRatioLimitHitCallback(tr_torrent* tor, tr_torrent_ratio_limit_
 
 void tr_torrentClearRatioLimitHitCallback(tr_torrent* torrent)
 {
-    tr_torrentSetRatioLimitHitCallback(torrent, NULL, NULL);
+    tr_torrentSetRatioLimitHitCallback(torrent, nullptr, nullptr);
 }
 
 void tr_torrentSetIdleLimitHitCallback(tr_torrent* tor, tr_torrent_idle_limit_hit_func func, void* user_data)
@@ -2125,7 +2125,7 @@ void tr_torrentSetIdleLimitHitCallback(tr_torrent* tor, tr_torrent_idle_limit_hi
 
 void tr_torrentClearIdleLimitHitCallback(tr_torrent* torrent)
 {
-    tr_torrentSetIdleLimitHitCallback(torrent, NULL, NULL);
+    tr_torrentSetIdleLimitHitCallback(torrent, nullptr, nullptr);
 }
 
 static void torrentCallScript(tr_torrent const* tor, char const* script)
@@ -2145,7 +2145,7 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
 
     char* const cmd[] = {
         tr_strdup(script),
-        NULL,
+        nullptr,
     };
 
     char* labels = tr_strjoin((char const* const*)tr_ptrArrayBase(&tor->labels), tr_ptrArraySize(&tor->labels), ",");
@@ -2158,12 +2158,12 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
         tr_strdup_printf("TR_TORRENT_ID=%d", tr_torrentId(tor)),
         tr_strdup_printf("TR_TORRENT_NAME=%s", tr_torrentName(tor)),
         tr_strdup_printf("TR_TORRENT_LABELS=%s", labels),
-        NULL,
+        nullptr,
     };
 
     tr_logAddTorInfo(tor, "Calling script \"%s\"", script);
 
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     if (!tr_spawn_async(cmd, env, TR_IF_WIN32("\\", "/"), &error))
     {
@@ -2219,7 +2219,7 @@ void tr_torrentRecheckCompleteness(tr_torrent* tor)
 
             if (tor->currentDir == tor->incompleteDir)
             {
-                tr_torrentSetLocation(tor, tor->downloadDir, true, NULL, NULL);
+                tr_torrentSetLocation(tor, tor->downloadDir, true, nullptr, nullptr);
             }
         }
 
@@ -2253,7 +2253,7 @@ static void tr_torrentFireMetadataCompleted(tr_torrent* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tor->metadata_func != NULL)
+    if (tor->metadata_func != nullptr)
     {
         (*tor->metadata_func)(tor, tor->metadata_func_user_data);
     }
@@ -2665,7 +2665,7 @@ time_t tr_torrentGetFileMTime(tr_torrent const* tor, tr_file_index_t i)
 
     if (!tr_fdFileGetCachedMTime(tor->session, tor->uniqueId, i, &mtime))
     {
-        tr_torrentFindFile2(tor, i, NULL, NULL, &mtime);
+        tr_torrentFindFile2(tor, i, nullptr, nullptr, &mtime);
     }
 
     return mtime;
@@ -2674,7 +2674,7 @@ time_t tr_torrentGetFileMTime(tr_torrent const* tor, tr_file_index_t i)
 bool tr_torrentPieceNeedsCheck(tr_torrent const* tor, tr_piece_index_t p)
 {
     tr_info const* const inf = tr_torrentInfo(tor);
-    if (inf == NULL)
+    if (inf == nullptr)
     {
         return false;
     }
@@ -2745,7 +2745,7 @@ bool tr_torrentSetAnnounceList(tr_torrent* tor, tr_tracker_info const* trackers_
     }
 
     /* save to the .torrent file */
-    if (ok && tr_variantFromFile(&metainfo, TR_VARIANT_FMT_BENC, tor->info.torrent, NULL))
+    if (ok && tr_variantFromFile(&metainfo, TR_VARIANT_FMT_BENC, tor->info.torrent, nullptr))
     {
         bool hasInfo;
         tr_info tmpInfo;
@@ -2763,7 +2763,7 @@ bool tr_torrentSetAnnounceList(tr_torrent* tor, tr_tracker_info const* trackers_
         if (trackerCount > 1)
         {
             int prevTier = -1;
-            tr_variant* tier = NULL;
+            tr_variant* tier = nullptr;
             tr_variant* announceList = tr_variantDictAddList(&metainfo, TR_KEY_announce_list, 0);
 
             for (int i = 0; i < trackerCount; ++i)
@@ -2890,7 +2890,7 @@ uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor)
 
             bytesLeft += length;
 
-            if (path != NULL && tr_sys_path_get_info(path, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_FILE &&
+            if (path != nullptr && tr_sys_path_get_info(path, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_FILE &&
                 info.size <= length)
             {
                 bytesLeft -= info.size;
@@ -2940,32 +2940,32 @@ static void removeEmptyFoldersAndJunkFiles(char const* folder)
 {
     tr_sys_dir_t odir;
 
-    if ((odir = tr_sys_dir_open(folder, NULL)) != TR_BAD_SYS_DIR)
+    if ((odir = tr_sys_dir_open(folder, nullptr)) != TR_BAD_SYS_DIR)
     {
         char const* name;
 
-        while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
             {
                 tr_sys_path_info info;
-                char* filename = tr_buildPath(folder, name, NULL);
+                char* filename = tr_buildPath(folder, name, nullptr);
 
-                if (tr_sys_path_get_info(filename, 0, &info, NULL) && info.type == TR_SYS_PATH_IS_DIRECTORY)
+                if (tr_sys_path_get_info(filename, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY)
                 {
                     removeEmptyFoldersAndJunkFiles(filename);
                 }
                 else if (isJunkFile(name))
                 {
-                    tr_sys_path_remove(filename, NULL);
+                    tr_sys_path_remove(filename, nullptr);
                 }
 
                 tr_free(filename);
             }
         }
 
-        tr_sys_path_remove(folder, NULL);
-        tr_sys_dir_close(odir, NULL);
+        tr_sys_path_remove(folder, nullptr);
+        tr_sys_dir_close(odir, nullptr);
     }
 }
 
@@ -2986,7 +2986,7 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
     char const* const top = tor->currentDir;
 
     /* don't try to delete local data if the directory's gone missing */
-    if (!tr_sys_path_exists(top, NULL))
+    if (!tr_sys_path_exists(top, nullptr))
     {
         return;
     }
@@ -3002,8 +3002,8 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
     ***/
 
     char* base = tr_strdup_printf("%s__XXXXXX", tr_torrentName(tor));
-    char* tmpdir = tr_buildPath(top, base, NULL);
-    tr_sys_dir_create_temp(tmpdir, NULL);
+    char* tmpdir = tr_buildPath(top, base, nullptr);
+    tr_sys_dir_create_temp(tmpdir, nullptr);
     tr_free(base);
 
     for (tr_file_index_t f = 0; f < tor->info.fileCount; ++f)
@@ -3011,27 +3011,27 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
         char* filename;
 
         /* try to find the file, looking in the partial and download dirs */
-        filename = tr_buildPath(top, tor->info.files[f].name, NULL);
+        filename = tr_buildPath(top, tor->info.files[f].name, nullptr);
 
-        if (!tr_sys_path_exists(filename, NULL))
+        if (!tr_sys_path_exists(filename, nullptr))
         {
             char* partial = tr_torrentBuildPartial(tor, f);
             tr_free(filename);
-            filename = tr_buildPath(top, partial, NULL);
+            filename = tr_buildPath(top, partial, nullptr);
             tr_free(partial);
 
-            if (!tr_sys_path_exists(filename, NULL))
+            if (!tr_sys_path_exists(filename, nullptr))
             {
                 tr_free(filename);
-                filename = NULL;
+                filename = nullptr;
             }
         }
 
         /* if we found the file, move it */
-        if (filename != NULL)
+        if (filename != nullptr)
         {
-            char* target = tr_buildPath(tmpdir, tor->info.files[f].name, NULL);
-            tr_moveFile(filename, target, NULL);
+            char* target = tr_buildPath(tmpdir, tor->info.files[f].name, nullptr);
+            tr_moveFile(filename, target, nullptr);
             tr_ptrArrayAppend(&files, target);
             tr_free(filename);
         }
@@ -3048,21 +3048,21 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
 
     /* try deleting the local data's top-level files & folders */
     tr_sys_dir_t odir;
-    if ((odir = tr_sys_dir_open(tmpdir, NULL)) != TR_BAD_SYS_DIR)
+    if ((odir = tr_sys_dir_open(tmpdir, nullptr)) != TR_BAD_SYS_DIR)
     {
         char const* name;
 
-        while ((name = tr_sys_dir_read_name(odir, NULL)) != NULL)
+        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
             {
-                char* file = tr_buildPath(tmpdir, name, NULL);
-                (*func)(file, NULL);
+                char* file = tr_buildPath(tmpdir, name, nullptr);
+                (*func)(file, nullptr);
                 tr_free(file);
             }
         }
 
-        tr_sys_dir_close(odir, NULL);
+        tr_sys_dir_close(odir, nullptr);
     }
 
     /* go from the bottom up */
@@ -3070,10 +3070,10 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
     {
         char* walk = tr_strdup(tr_ptrArrayNth(&files, i));
 
-        while (tr_sys_path_exists(walk, NULL) && !tr_sys_path_is_same(tmpdir, walk, NULL))
+        while (tr_sys_path_exists(walk, nullptr) && !tr_sys_path_is_same(tmpdir, walk, nullptr))
         {
-            char* tmp = tr_sys_path_dirname(walk, NULL);
-            (*func)(walk, NULL);
+            char* tmp = tr_sys_path_dirname(walk, nullptr);
+            (*func)(walk, nullptr);
             tr_free(walk);
             walk = tmp;
         }
@@ -3094,25 +3094,25 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
         char* filename;
 
         /* get the directory that this file goes in... */
-        filename = tr_buildPath(top, tor->info.files[f].name, NULL);
-        dir = tr_sys_path_dirname(filename, NULL);
+        filename = tr_buildPath(top, tor->info.files[f].name, nullptr);
+        dir = tr_sys_path_dirname(filename, nullptr);
         tr_free(filename);
 
-        if (dir == NULL)
+        if (dir == nullptr)
         {
             continue;
         }
 
         /* walk up the directory tree until we reach 'top' */
-        if (!tr_sys_path_is_same(top, dir, NULL) && strcmp(top, dir) != 0)
+        if (!tr_sys_path_is_same(top, dir, nullptr) && strcmp(top, dir) != 0)
         {
             for (;;)
             {
-                char* parent = tr_sys_path_dirname(dir, NULL);
+                char* parent = tr_sys_path_dirname(dir, nullptr);
 
-                if (tr_sys_path_is_same(top, parent, NULL) || strcmp(top, parent) == 0)
+                if (tr_sys_path_is_same(top, parent, nullptr) || strcmp(top, parent) == 0)
                 {
-                    if (tr_ptrArrayFindSorted(&folders, dir, vstrcmp) == NULL)
+                    if (tr_ptrArrayFindSorted(&folders, dir, vstrcmp) == nullptr)
                     {
                         tr_ptrArrayInsertSorted(&folders, tr_strdup(dir), vstrcmp);
                     }
@@ -3136,7 +3136,7 @@ static void deleteLocalData(tr_torrent* tor, tr_fileFunc func)
     }
 
     /* cleanup */
-    tr_sys_path_remove(tmpdir, NULL);
+    tr_sys_path_remove(tmpdir, nullptr);
     tr_free(tmpdir);
     tr_ptrArrayDestruct(&folders, tr_free);
     tr_ptrArrayDestruct(&files, tr_free);
@@ -3146,7 +3146,7 @@ static void tr_torrentDeleteLocalData(tr_torrent* tor, tr_fileFunc func)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (func == NULL)
+    if (func == nullptr)
     {
         func = tr_sys_path_remove;
     }
@@ -3187,9 +3187,9 @@ static void setLocation(void* vdata)
 
     tr_logAddDebug("Moving \"%s\" location from currentDir \"%s\" to \"%s\"", tr_torrentName(tor), tor->currentDir, location);
 
-    tr_sys_dir_create(location, TR_SYS_DIR_CREATE_PARENTS, 0777, NULL);
+    tr_sys_dir_create(location, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
 
-    if (!tr_sys_path_is_same(location, tor->currentDir, NULL))
+    if (!tr_sys_path_is_same(location, tor->currentDir, nullptr))
     {
         /* bad idea to move files while they're being verified... */
         tr_verifyRemove(tor);
@@ -3203,16 +3203,16 @@ static void setLocation(void* vdata)
             char const* oldbase;
             tr_file const* f = &tor->info.files[i];
 
-            if (tr_torrentFindFile2(tor, i, &oldbase, &sub, NULL))
+            if (tr_torrentFindFile2(tor, i, &oldbase, &sub, nullptr))
             {
-                char* oldpath = tr_buildPath(oldbase, sub, NULL);
-                char* newpath = tr_buildPath(location, sub, NULL);
+                char* oldpath = tr_buildPath(oldbase, sub, nullptr);
+                char* newpath = tr_buildPath(location, sub, nullptr);
 
                 tr_logAddDebug("Found file #%d: %s", (int)i, oldpath);
 
-                if (do_move && !tr_sys_path_is_same(oldpath, newpath, NULL))
+                if (do_move && !tr_sys_path_is_same(oldpath, newpath, nullptr))
                 {
-                    tr_error* error = NULL;
+                    tr_error* error = nullptr;
 
                     tr_logAddTorInfo(tor, "moving \"%s\" to \"%s\"", oldpath, newpath);
 
@@ -3229,7 +3229,7 @@ static void setLocation(void* vdata)
                 tr_free(sub);
             }
 
-            if (data->setme_progress != NULL)
+            if (data->setme_progress != nullptr)
             {
                 bytesHandled += f->length;
                 *data->setme_progress = bytesHandled / tor->info.totalSize;
@@ -3251,12 +3251,12 @@ static void setLocation(void* vdata)
         if (do_move)
         {
             tr_free(tor->incompleteDir);
-            tor->incompleteDir = NULL;
+            tor->incompleteDir = nullptr;
             tor->currentDir = tor->downloadDir;
         }
     }
 
-    if (data->setme_state != NULL)
+    if (data->setme_state != nullptr)
     {
         *data->setme_state = err ? TR_LOC_ERROR : TR_LOC_DONE;
     }
@@ -3276,12 +3276,12 @@ void tr_torrentSetLocation(
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (setme_state != NULL)
+    if (setme_state != nullptr)
     {
         *setme_state = TR_LOC_MOVING;
     }
 
-    if (setme_progress != NULL)
+    if (setme_progress != nullptr)
     {
         *setme_progress = 0;
     }
@@ -3330,10 +3330,10 @@ char const* tr_torrentPrimaryMimeType(tr_torrent const* tor)
     }
 
     uint64_t max_len = 0;
-    char const* mime_type = NULL;
+    char const* mime_type = nullptr;
     for (struct count const *it = counts, *end = it + num_counts; it != end; ++it)
     {
-        if ((max_len < it->length) && (it->mime_type != NULL))
+        if ((max_len < it->length) && (it->mime_type != nullptr))
         {
             max_len = it->length;
             mime_type = it->mime_type;
@@ -3345,7 +3345,7 @@ char const* tr_torrentPrimaryMimeType(tr_torrent const* tor)
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
     // application/octet-stream is the default value for all other cases.
     // An unknown file type should use this type.
-    return mime_type != NULL ? mime_type : "application/octet-stream";
+    return mime_type != nullptr ? mime_type : "application/octet-stream";
 }
 
 /***
@@ -3374,13 +3374,13 @@ static void tr_torrentFileCompleted(tr_torrent* tor, tr_file_index_t fileIndex)
     /* if the torrent's current filename isn't the same as the one in the
      * metadata -- for example, if it had the ".part" suffix appended to
      * it until now -- then rename it to match the one in the metadata */
-    if (tr_torrentFindFile2(tor, fileIndex, &base, &sub, NULL))
+    if (tr_torrentFindFile2(tor, fileIndex, &base, &sub, nullptr))
     {
         if (strcmp(sub, f->name) != 0)
         {
-            char* oldpath = tr_buildPath(base, sub, NULL);
-            char* newpath = tr_buildPath(base, f->name, NULL);
-            tr_error* error = NULL;
+            char* oldpath = tr_buildPath(base, sub, nullptr);
+            char* newpath = tr_buildPath(base, f->name, nullptr);
+            tr_error* error = nullptr;
 
             if (!tr_sys_path_rename(oldpath, newpath, &error))
             {
@@ -3465,9 +3465,9 @@ static void find_file_in_dir(
     char const** subpath,
     tr_sys_path_info* file_info)
 {
-    char* filename = tr_buildPath(search_dir, name, NULL);
+    char* filename = tr_buildPath(search_dir, name, nullptr);
 
-    if (tr_sys_path_get_info(filename, 0, file_info, NULL))
+    if (tr_sys_path_get_info(filename, 0, file_info, nullptr))
     {
         *base = search_dir;
         *subpath = name;
@@ -3481,73 +3481,73 @@ bool tr_torrentFindFile2(tr_torrent const* tor, tr_file_index_t fileNum, char co
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(fileNum < tor->info.fileCount);
 
-    char* part = NULL;
+    char* part = nullptr;
     tr_file const* file;
-    char const* b = NULL;
-    char const* s = NULL;
+    char const* b = nullptr;
+    char const* s = nullptr;
     auto file_info = tr_sys_path_info{};
 
     file = &tor->info.files[fileNum];
 
     /* look in the download dir... */
-    if (b == NULL)
+    if (b == nullptr)
     {
         find_file_in_dir(file->name, tor->downloadDir, &b, &s, &file_info);
     }
 
     /* look in the incomplete dir... */
-    if (b == NULL && tor->incompleteDir != NULL)
+    if (b == nullptr && tor->incompleteDir != nullptr)
     {
         find_file_in_dir(file->name, tor->incompleteDir, &b, &s, &file_info);
     }
 
-    if (b == NULL)
+    if (b == nullptr)
     {
         part = tr_torrentBuildPartial(tor, fileNum);
     }
 
     /* look for a .part file in the incomplete dir... */
-    if (b == NULL && tor->incompleteDir != NULL)
+    if (b == nullptr && tor->incompleteDir != nullptr)
     {
         find_file_in_dir(part, tor->incompleteDir, &b, &s, &file_info);
     }
 
     /* look for a .part file in the download dir... */
-    if (b == NULL)
+    if (b == nullptr)
     {
         find_file_in_dir(part, tor->downloadDir, &b, &s, &file_info);
     }
 
     /* return the results */
-    if (base != NULL)
+    if (base != nullptr)
     {
         *base = b;
     }
 
-    if (subpath != NULL)
+    if (subpath != nullptr)
     {
         *subpath = tr_strdup(s);
     }
 
-    if (mtime != NULL)
+    if (mtime != nullptr)
     {
         *mtime = file_info.last_modified_at;
     }
 
     /* cleanup */
     tr_free(part);
-    return b != NULL;
+    return b != nullptr;
 }
 
 char* tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t fileNum)
 {
     char* subpath;
-    char* ret = NULL;
+    char* ret = nullptr;
     char const* base;
 
-    if (tr_torrentFindFile2(tor, fileNum, &base, &subpath, NULL))
+    if (tr_torrentFindFile2(tor, fileNum, &base, &subpath, nullptr))
     {
-        ret = tr_buildPath(base, subpath, NULL);
+        ret = tr_buildPath(base, subpath, nullptr);
         tr_free(subpath);
     }
 
@@ -3557,9 +3557,9 @@ char* tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t fileNum)
 /* Decide whether we should be looking for files in downloadDir or incompleteDir. */
 static void refreshCurrentDir(tr_torrent* tor)
 {
-    char const* dir = NULL;
+    char const* dir = nullptr;
 
-    if (tor->incompleteDir == NULL)
+    if (tor->incompleteDir == nullptr)
     {
         dir = tor->downloadDir;
     }
@@ -3567,12 +3567,12 @@ static void refreshCurrentDir(tr_torrent* tor)
     {
         dir = tor->incompleteDir;
     }
-    else if (!tr_torrentFindFile2(tor, 0, &dir, NULL, NULL))
+    else if (!tr_torrentFindFile2(tor, 0, &dir, nullptr, nullptr))
     {
         dir = tor->incompleteDir;
     }
 
-    TR_ASSERT(dir != NULL);
+    TR_ASSERT(dir != nullptr);
     TR_ASSERT(dir == tor->downloadDir || dir == tor->incompleteDir);
 
     tor->currentDir = dir;
@@ -3653,9 +3653,9 @@ void tr_torrentSetQueuePosition(tr_torrent* tor, int pos)
 
     tor->queuePosition = -1;
 
-    walk = NULL;
+    walk = nullptr;
 
-    while ((walk = tr_torrentNext(tor->session, walk)) != NULL)
+    while ((walk = tr_torrentNext(tor->session, walk)) != nullptr)
     {
         if ((old_pos < pos) && (old_pos <= walk->queuePosition) && (walk->queuePosition <= pos))
         {
@@ -3760,7 +3760,7 @@ void tr_torrentSetQueueStartCallback(tr_torrent* torrent, void (*callback)(tr_to
 static bool renameArgsAreValid(char const* oldpath, char const* newname)
 {
     return !tr_str_is_empty(oldpath) && !tr_str_is_empty(newname) && strcmp(newname, ".") != 0 && strcmp(newname, "..") != 0 &&
-        strchr(newname, TR_PATH_DELIMITER) == NULL;
+        strchr(newname, TR_PATH_DELIMITER) == nullptr;
 }
 
 static tr_file_index_t* renameFindAffectedFiles(tr_torrent* tor, char const* oldpath, size_t* setme_n)
@@ -3793,7 +3793,7 @@ static int renamePath(tr_torrent* tor, char const* oldpath, char const* newname)
     char const* base;
     int err = 0;
 
-    if (!tr_torrentIsSeed(tor) && tor->incompleteDir != NULL)
+    if (!tr_torrentIsSeed(tor) && tor->incompleteDir != nullptr)
     {
         base = tor->incompleteDir;
     }
@@ -3802,20 +3802,20 @@ static int renamePath(tr_torrent* tor, char const* oldpath, char const* newname)
         base = tor->downloadDir;
     }
 
-    src = tr_buildPath(base, oldpath, NULL);
+    src = tr_buildPath(base, oldpath, nullptr);
 
-    if (!tr_sys_path_exists(src, NULL)) /* check for it as a partial */
+    if (!tr_sys_path_exists(src, nullptr)) /* check for it as a partial */
     {
         char* tmp = tr_strdup_printf("%s.part", src);
         tr_free(src);
         src = tmp;
     }
 
-    if (tr_sys_path_exists(src, NULL))
+    if (tr_sys_path_exists(src, nullptr))
     {
         int tmp;
         bool tgt_exists;
-        char* parent = tr_sys_path_dirname(src, NULL);
+        char* parent = tr_sys_path_dirname(src, nullptr);
         char* tgt;
 
         if (tr_str_has_suffix(src, ".part"))
@@ -3824,16 +3824,16 @@ static int renamePath(tr_torrent* tor, char const* oldpath, char const* newname)
         }
         else
         {
-            tgt = tr_buildPath(parent, newname, NULL);
+            tgt = tr_buildPath(parent, newname, nullptr);
         }
 
         tmp = errno;
-        tgt_exists = tr_sys_path_exists(tgt, NULL);
+        tgt_exists = tr_sys_path_exists(tgt, nullptr);
         errno = tmp;
 
         if (!tgt_exists)
         {
-            tr_error* error = NULL;
+            tr_error* error = nullptr;
 
             tmp = errno;
 
@@ -3861,33 +3861,33 @@ static void renameTorrentFileString(tr_torrent* tor, char const* oldpath, char c
     tr_file* file = &tor->info.files[fileIndex];
     size_t const oldpath_len = strlen(oldpath);
 
-    if (strchr(oldpath, TR_PATH_DELIMITER) == NULL)
+    if (strchr(oldpath, TR_PATH_DELIMITER) == nullptr)
     {
         if (oldpath_len >= strlen(file->name))
         {
-            name = tr_buildPath(newname, NULL);
+            name = tr_buildPath(newname, nullptr);
         }
         else
         {
-            name = tr_buildPath(newname, file->name + oldpath_len + 1, NULL);
+            name = tr_buildPath(newname, file->name + oldpath_len + 1, nullptr);
         }
     }
     else
     {
-        char* tmp = tr_sys_path_dirname(oldpath, NULL);
+        char* tmp = tr_sys_path_dirname(oldpath, nullptr);
 
-        if (tmp == NULL)
+        if (tmp == nullptr)
         {
             return;
         }
 
         if (oldpath_len >= strlen(file->name))
         {
-            name = tr_buildPath(tmp, newname, NULL);
+            name = tr_buildPath(tmp, newname, nullptr);
         }
         else
         {
-            name = tr_buildPath(tmp, newname, file->name + oldpath_len + 1, NULL);
+            name = tr_buildPath(tmp, newname, file->name + oldpath_len + 1, nullptr);
         }
 
         tr_free(tmp);
@@ -3957,7 +3957,7 @@ static void torrentRenamePath(void* vdata)
                 }
 
                 /* update tr_info.name if user changed the toplevel */
-                if (n == tor->info.fileCount && strchr(oldpath, '/') == NULL)
+                if (n == tor->info.fileCount && strchr(oldpath, '/') == nullptr)
                 {
                     tr_free(tor->info.name);
                     tor->info.name = tr_strdup(newname);
@@ -3978,7 +3978,7 @@ static void torrentRenamePath(void* vdata)
     tor->anyDate = tr_time();
 
     /* callback */
-    if (data->callback != NULL)
+    if (data->callback != nullptr)
     {
         (*data->callback)(tor, data->oldpath, data->newname, error, data->callback_user_data);
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -478,7 +478,7 @@ static bool tr_torrentIsSeedIdleLimitDone(tr_torrent* tor)
 {
     uint16_t idleMinutes;
     return tr_torrentGetSeedIdle(tor, &idleMinutes) &&
-        difftime(tr_time(), MAX(tor->startDate, tor->activityDate)) >= idleMinutes * 60U;
+        difftime(tr_time(), std::max(tor->startDate, tor->activityDate)) >= idleMinutes * 60U;
 }
 
 /***
@@ -641,7 +641,7 @@ static tr_priority_t calculatePiecePriority(tr_torrent const* tor, tr_piece_inde
 {
     // safeguard against a bad arg
     tr_info const* const inf = tr_torrentInfo(tor);
-    file_hint = MIN(file_hint, inf->fileCount - 1);
+    file_hint = std::min(file_hint, inf->fileCount - 1);
 
     // find the first file with data in this piece
     tr_file_index_t first = file_hint;
@@ -661,7 +661,7 @@ static tr_priority_t calculatePiecePriority(tr_torrent const* tor, tr_piece_inde
             break;
         }
 
-        priority = MAX(priority, file->priority);
+        priority = std::max(priority, file->priority);
 
         /* When dealing with multimedia files, getting the first and
            last pieces can sometimes allow you to preview it a bit
@@ -1245,7 +1245,7 @@ tr_torrent_activity tr_torrentGetActivity(tr_torrent const* tor)
 static int torrentGetIdleSecs(tr_torrent const* tor, tr_torrent_activity activity)
 {
     return ((activity == TR_STATUS_DOWNLOAD || activity == TR_STATUS_SEED) && tor->startDate != 0) ?
-        (int)difftime(tr_time(), MAX(tor->startDate, tor->activityDate)) :
+        (int)difftime(tr_time(), std::max(tor->startDate, tor->activityDate)) :
         -1;
 }
 
@@ -2851,7 +2851,7 @@ void tr_torrentSetDateAdded(tr_torrent* tor, time_t t)
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->addedDate = t;
-    tor->anyDate = MAX(tor->anyDate, tor->addedDate);
+    tor->anyDate = std::max(tor->anyDate, tor->addedDate);
 }
 
 void tr_torrentSetDateActive(tr_torrent* tor, time_t t)
@@ -2859,7 +2859,7 @@ void tr_torrentSetDateActive(tr_torrent* tor, time_t t)
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->activityDate = t;
-    tor->anyDate = MAX(tor->anyDate, tor->activityDate);
+    tor->anyDate = std::max(tor->anyDate, tor->activityDate);
 }
 
 void tr_torrentSetDateDone(tr_torrent* tor, time_t t)
@@ -2867,7 +2867,7 @@ void tr_torrentSetDateDone(tr_torrent* tor, time_t t)
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->doneDate = t;
-    tor->anyDate = MAX(tor->anyDate, tor->doneDate);
+    tor->anyDate = std::max(tor->anyDate, tor->doneDate);
 }
 
 /**
@@ -3441,7 +3441,7 @@ void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block)
                 uint32_t const n = tr_torPieceCountBytes(tor, p);
                 tr_logAddTorErr(tor, _("Piece %" PRIu32 ", which was just downloaded, failed its checksum test"), p);
                 tor->corruptCur += n;
-                tor->downloadedCur -= MIN(tor->downloadedCur, n);
+                tor->downloadedCur -= std::min(tor->downloadedCur, (unsigned long)n);
                 tr_peerMgrGotBadPiece(tor, p);
             }
         }
@@ -3449,7 +3449,7 @@ void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block)
     else
     {
         uint32_t const n = tr_torBlockCountBytes(tor, block);
-        tor->downloadedCur -= MIN(tor->downloadedCur, n);
+        tor->downloadedCur -= std::min(tor->downloadedCur, (unsigned long)n);
         tr_logAddTorDbg(tor, "we have this block already...");
     }
 }
@@ -3675,7 +3675,7 @@ void tr_torrentSetQueuePosition(tr_torrent* tor, int pos)
         }
     }
 
-    tor->queuePosition = MIN(pos, back + 1);
+    tor->queuePosition = std::min(pos, back + 1);
     tor->anyDate = now;
 
     TR_ASSERT(queueIsSequenced(tor->session));

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -273,7 +273,7 @@ struct tr_torrent
 
 static inline tr_torrent* tr_torrentNext(tr_session* session, tr_torrent* current)
 {
-    return current != NULL ? current->next : session->torrentList;
+    return current != nullptr ? current->next : session->torrentList;
 }
 
 /* what piece index is this block in? */
@@ -311,7 +311,7 @@ static inline void tr_torrentUnlock(tr_torrent const* tor)
 
 static inline bool tr_torrentExists(tr_session const* session, uint8_t const* torrentHash)
 {
-    return tr_torrentFindFromHash((tr_session*)session, torrentHash) != NULL;
+    return tr_torrentFindFromHash((tr_session*)session, torrentHash) != nullptr;
 }
 
 static inline tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
@@ -326,22 +326,22 @@ static inline bool tr_torrentIsSeed(tr_torrent const* tor)
 
 static inline bool tr_torrentIsPrivate(tr_torrent const* tor)
 {
-    return tor != NULL && tor->info.isPrivate;
+    return tor != nullptr && tor->info.isPrivate;
 }
 
 static inline bool tr_torrentAllowsPex(tr_torrent const* tor)
 {
-    return tor != NULL && tor->session->isPexEnabled && !tr_torrentIsPrivate(tor);
+    return tor != nullptr && tor->session->isPexEnabled && !tr_torrentIsPrivate(tor);
 }
 
 static inline bool tr_torrentAllowsDHT(tr_torrent const* tor)
 {
-    return tor != NULL && tr_sessionAllowsDHT(tor->session) && !tr_torrentIsPrivate(tor);
+    return tor != nullptr && tr_sessionAllowsDHT(tor->session) && !tr_torrentIsPrivate(tor);
 }
 
 static inline bool tr_torrentAllowsLPD(tr_torrent const* tor)
 {
-    return tor != NULL && tr_sessionAllowsLPD(tor->session) && !tr_torrentIsPrivate(tor);
+    return tor != nullptr && tr_sessionAllowsLPD(tor->session) && !tr_torrentIsPrivate(tor);
 }
 
 /***
@@ -355,7 +355,7 @@ enum
 
 static inline bool tr_isTorrent(tr_torrent const* tor)
 {
-    return tor != NULL && tor->magicNumber == TORRENT_MAGIC_NUMBER && tr_isSession(tor->session);
+    return tor != nullptr && tor->magicNumber == TORRENT_MAGIC_NUMBER && tr_isSession(tor->session);
 }
 
 /* set a flag indicating that the torrent's .resume file

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -23,13 +23,14 @@
  */
 
 /* ansi */
-#include <errno.h>
-#include <stdio.h>
-#include <string.h> /* memcpy(), memset(), memchr(), strlen() */
-#include <stdlib.h> /* atoi() */
+#include <cerrno>
+#include <cstdio>
+#include <cstring> /* memcpy(), memset(), memchr(), strlen() */
+#include <cstdlib> /* atoi() */
+#include <algorithm>
 
 /* posix */
-#include <signal.h> /* sig_atomic_t */
+#include <csignal> /* sig_atomic_t */
 
 #ifdef _WIN32
 #include <inttypes.h>
@@ -177,7 +178,7 @@ static void dht_bootstrap(void* closure)
         tr_logAddNamedInfo("DHT", "Bootstrapping from %d IPv6 nodes", num6);
     }
 
-    for (int i = 0; i < MAX(num, num6); ++i)
+    for (int i = 0; i < std::max(num, num6); ++i)
     {
         if (i < num && !bootstrap_done(cl->session, AF_INET))
         {
@@ -859,7 +860,7 @@ void dht_hash(void* hash_return, int hash_size, void const* v1, int len1, void c
     unsigned char sha1[SHA_DIGEST_LENGTH];
     tr_sha1(sha1, v1, len1, v2, len2, v3, len3, nullptr);
     memset(hash_return, 0, hash_size);
-    memcpy(hash_return, sha1, MIN(hash_size, SHA_DIGEST_LENGTH));
+    memcpy(hash_return, sha1, std::min(hash_size, SHA_DIGEST_LENGTH));
 }
 
 int dht_random_bytes(void* buf, size_t size)

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -64,9 +64,9 @@
 #include "utils.h"
 #include "variant.h"
 
-static struct event* dht_timer = NULL;
+static struct event* dht_timer = nullptr;
 static unsigned char myid[20];
-static tr_session* session_ = NULL;
+static tr_session* session_ = nullptr;
 
 static void timer_callback(evutil_socket_t s, short type, void* ignore);
 
@@ -88,7 +88,7 @@ static bool bootstrap_done(tr_session* session, int af)
         return bootstrap_done(session, AF_INET) && bootstrap_done(session, AF_INET6);
     }
 
-    status = tr_dhtStatus(session, af, NULL);
+    status = tr_dhtStatus(session, af, nullptr);
     return status == TR_DHT_STOPPED || status >= TR_DHT_FIREWALLED;
 }
 
@@ -139,7 +139,7 @@ static void bootstrap_from_name(char const* name, tr_port port, int af)
 
     infop = info;
 
-    while (infop != NULL)
+    while (infop != nullptr)
     {
         dht_ping_node(infop->ai_addr, infop->ai_addrlen);
 
@@ -228,11 +228,11 @@ static void dht_bootstrap(void* closure)
         char* bootstrap_file;
         tr_sys_file_t f = TR_BAD_SYS_FILE;
 
-        bootstrap_file = tr_buildPath(cl->session->configDir, "dht.bootstrap", NULL);
+        bootstrap_file = tr_buildPath(cl->session->configDir, "dht.bootstrap", nullptr);
 
-        if (bootstrap_file != NULL)
+        if (bootstrap_file != nullptr)
         {
-            f = tr_sys_file_open(bootstrap_file, TR_SYS_FILE_READ, 0, NULL);
+            f = tr_sys_file_open(bootstrap_file, TR_SYS_FILE_READ, 0, nullptr);
         }
 
         if (f != TR_BAD_SYS_FILE)
@@ -242,7 +242,7 @@ static void dht_bootstrap(void* closure)
             for (;;)
             {
                 char buf[201];
-                if (!tr_sys_file_read_line(f, buf, 200, NULL))
+                if (!tr_sys_file_read_line(f, buf, 200, nullptr))
                 {
                     break;
                 }
@@ -250,12 +250,12 @@ static void dht_bootstrap(void* closure)
                 auto* p = static_cast<char*>(memchr(buf, ' ', strlen(buf)));
                 int port = 0;
 
-                if (p != NULL)
+                if (p != nullptr)
                 {
                     port = atoi(p + 1);
                 }
 
-                if (p == NULL || port <= 0 || port >= 0x10000)
+                if (p == nullptr || port <= 0 || port >= 0x10000)
                 {
                     tr_logAddNamedError("DHT", "Couldn't parse %s", buf);
                     continue;
@@ -271,7 +271,7 @@ static void dht_bootstrap(void* closure)
                 }
             }
 
-            tr_sys_file_close(f, NULL);
+            tr_sys_file_close(f, nullptr);
         }
 
         tr_free(bootstrap_file);
@@ -301,12 +301,12 @@ static void dht_bootstrap(void* closure)
         }
     }
 
-    if (cl->nodes != NULL)
+    if (cl->nodes != nullptr)
     {
         tr_free(cl->nodes);
     }
 
-    if (cl->nodes6 != NULL)
+    if (cl->nodes6 != nullptr)
     {
         tr_free(cl->nodes6);
     }
@@ -321,14 +321,14 @@ int tr_dhtInit(tr_session* ss)
     int rc;
     bool have_id = false;
     char* dat_file;
-    uint8_t* nodes = NULL;
-    uint8_t* nodes6 = NULL;
+    uint8_t* nodes = nullptr;
+    uint8_t* nodes6 = nullptr;
     uint8_t const* raw;
     size_t len = 0;
     size_t len6 = 0;
     struct bootstrap_closure* cl;
 
-    if (session_ != NULL) /* already initialized */
+    if (session_ != nullptr) /* already initialized */
     {
         return -1;
     }
@@ -340,8 +340,8 @@ int tr_dhtInit(tr_session* ss)
         dht_debug = stderr;
     }
 
-    dat_file = tr_buildPath(ss->configDir, "dht.dat", NULL);
-    rc = tr_variantFromFile(&benc, TR_VARIANT_FMT_BENC, dat_file, NULL) ? 0 : -1;
+    dat_file = tr_buildPath(ss->configDir, "dht.dat", nullptr);
+    rc = tr_variantFromFile(&benc, TR_VARIANT_FMT_BENC, dat_file, nullptr) ? 0 : -1;
     tr_free(dat_file);
 
     if (rc == 0)
@@ -366,12 +366,12 @@ int tr_dhtInit(tr_session* ss)
         tr_variantFree(&benc);
     }
 
-    if (nodes == NULL)
+    if (nodes == nullptr)
     {
         len = 0;
     }
 
-    if (nodes6 == NULL)
+    if (nodes6 == nullptr)
     {
         len6 = 0;
     }
@@ -388,7 +388,7 @@ int tr_dhtInit(tr_session* ss)
         tr_rand_buffer(myid, 20);
     }
 
-    rc = dht_init(ss->udp_socket, ss->udp6_socket, myid, NULL);
+    rc = dht_init(ss->udp_socket, ss->udp6_socket, myid, nullptr);
 
     if (rc < 0)
     {
@@ -417,7 +417,7 @@ fail:
     tr_free(nodes);
 
     tr_logAddNamedDbg("DHT", "DHT initialization failed (errno = %d)", errno);
-    session_ = NULL;
+    session_ = nullptr;
     return -1;
 }
 
@@ -430,15 +430,15 @@ void tr_dhtUninit(tr_session* ss)
 
     tr_logAddNamedDbg("DHT", "Uninitializing DHT");
 
-    if (dht_timer != NULL)
+    if (dht_timer != nullptr)
     {
         event_free(dht_timer);
-        dht_timer = NULL;
+        dht_timer = nullptr;
     }
 
     /* Since we only save known good nodes, avoid erasing older data if we
        don't know enough nodes. */
-    if (tr_dhtStatus(ss, AF_INET, NULL) < TR_DHT_FIREWALLED && tr_dhtStatus(ss, AF_INET6, NULL) < TR_DHT_FIREWALLED)
+    if (tr_dhtStatus(ss, AF_INET, nullptr) < TR_DHT_FIREWALLED && tr_dhtStatus(ss, AF_INET6, nullptr) < TR_DHT_FIREWALLED)
     {
         tr_logAddNamedInfo("DHT", "Not saving nodes, DHT not ready");
     }
@@ -495,7 +495,7 @@ void tr_dhtUninit(tr_session* ss)
             tr_variantDictAddRaw(&benc, TR_KEY_nodes6, compact6, out6 - compact6);
         }
 
-        char* const dat_file = tr_buildPath(ss->configDir, "dht.dat", NULL);
+        char* const dat_file = tr_buildPath(ss->configDir, "dht.dat", nullptr);
         tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file);
         tr_variantFree(&benc);
         tr_free(dat_file);
@@ -504,12 +504,12 @@ void tr_dhtUninit(tr_session* ss)
     dht_uninit();
     tr_logAddNamedDbg("DHT", "Done uninitializing DHT");
 
-    session_ = NULL;
+    session_ = nullptr;
 }
 
 bool tr_dhtEnabled(tr_session const* ss)
 {
-    return ss != NULL && ss == session_;
+    return ss != nullptr && ss == session_;
 }
 
 struct getstatus_closure
@@ -526,7 +526,7 @@ static void getstatus(void* cl)
     int dubious;
     int incoming;
 
-    dht_nodes(closure->af, &good, &dubious, NULL, &incoming);
+    dht_nodes(closure->af, &good, &dubious, nullptr, &incoming);
 
     closure->count = good + dubious;
 
@@ -555,7 +555,7 @@ int tr_dhtStatus(tr_session* session, int af, int* nodes_return)
     if (!tr_dhtEnabled(session) || (af == AF_INET && session->udp_socket == TR_BAD_SOCKET) ||
         (af == AF_INET6 && session->udp6_socket == TR_BAD_SOCKET))
     {
-        if (nodes_return != NULL)
+        if (nodes_return != nullptr)
         {
             *nodes_return = 0;
         }
@@ -570,7 +570,7 @@ int tr_dhtStatus(tr_session* session, int af, int* nodes_return)
         tr_wait_msec(50 /*msec*/);
     }
 
-    if (nodes_return != NULL)
+    if (nodes_return != nullptr)
     {
         *nodes_return = closure.count;
     }
@@ -595,7 +595,7 @@ bool tr_dhtAddNode(tr_session* ss, tr_address const* address, tr_port port, bool
     /* Since we don't want to abuse our bootstrap nodes,
      * we don't ping them if the DHT is in a good state. */
 
-    if (bootstrap && (tr_dhtStatus(ss, af, NULL) >= TR_DHT_FIREWALLED))
+    if (bootstrap && (tr_dhtStatus(ss, af, nullptr) >= TR_DHT_FIREWALLED))
     {
         return false;
     }
@@ -658,18 +658,18 @@ static void callback(void* ignore, int event, unsigned char const* info_hash, vo
         tr_sessionLock(session_);
         tor = tr_torrentFindFromHash(session_, info_hash);
 
-        if (tor != NULL && tr_torrentAllowsDHT(tor))
+        if (tor != nullptr && tr_torrentAllowsDHT(tor))
         {
             size_t n;
             tr_pex* pex;
 
             if (event == DHT_EVENT_VALUES)
             {
-                pex = tr_peerMgrCompactToPex(data, data_len, NULL, 0, &n);
+                pex = tr_peerMgrCompactToPex(data, data_len, nullptr, 0, &n);
             }
             else
             {
-                pex = tr_peerMgrCompact6ToPex(data, data_len, NULL, 0, &n);
+                pex = tr_peerMgrCompact6ToPex(data, data_len, nullptr, 0, &n);
             }
 
             tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex, n);
@@ -684,7 +684,7 @@ static void callback(void* ignore, int event, unsigned char const* info_hash, vo
     {
         tr_torrent* tor = tr_torrentFindFromHash(session_, info_hash);
 
-        if (tor != NULL)
+        if (tor != nullptr)
         {
             if (event == DHT_EVENT_SEARCH_DONE)
             {
@@ -722,7 +722,7 @@ static int tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
 
     if (status >= TR_DHT_POOR)
     {
-        rc = dht_search(tor->info.hash, announce ? tr_sessionGetPeerPort(session_) : 0, af, callback, NULL);
+        rc = dht_search(tor->info.hash, announce ? tr_sessionGetPeerPort(session_) : 0, af, callback, nullptr);
 
         if (rc >= 0)
         {
@@ -770,10 +770,10 @@ static int tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
 
 void tr_dhtUpkeep(tr_session* session)
 {
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
     time_t const now = tr_time();
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL)
+    while ((tor = tr_torrentNext(session, tor)) != nullptr)
     {
         if (!tor->isRunning || !tr_torrentAllowsDHT(tor))
         {
@@ -806,7 +806,7 @@ void tr_dhtCallback(unsigned char* buf, int buflen, struct sockaddr* from, sockl
     }
 
     time_t tosleep;
-    int rc = dht_periodic(buf, buflen, from, fromlen, &tosleep, callback, NULL);
+    int rc = dht_periodic(buf, buflen, from, fromlen, &tosleep, callback, nullptr);
 
     if (rc < 0)
     {
@@ -837,7 +837,7 @@ static void timer_callback(evutil_socket_t s, short type, void* session)
     TR_UNUSED(s);
     TR_UNUSED(type);
 
-    tr_dhtCallback(NULL, 0, NULL, 0, session);
+    tr_dhtCallback(nullptr, 0, nullptr, 0, session);
 }
 
 /* This function should return true when a node is blacklisted.  We do
@@ -857,7 +857,7 @@ int dht_blacklisted(struct sockaddr const* sa, int salen)
 void dht_hash(void* hash_return, int hash_size, void const* v1, int len1, void const* v2, int len2, void const* v3, int len3)
 {
     unsigned char sha1[SHA_DIGEST_LENGTH];
-    tr_sha1(sha1, v1, len1, v2, len2, v3, len3, NULL);
+    tr_sha1(sha1, v1, len1, v2, len2, v3, len3, nullptr);
     memset(hash_return, 0, hash_size);
     memcpy(hash_return, sha1, MIN(hash_size, SHA_DIGEST_LENGTH));
 }
@@ -877,7 +877,7 @@ int dht_sendto(int sockfd, void const* buf, int len, int flags, struct sockaddr 
 
 extern "C" int dht_gettimeofday(struct timeval* tv, struct timezone* tz)
 {
-    TR_ASSERT(tz == NULL);
+    TR_ASSERT(tz == nullptr);
 
     return tr_gettimeofday(tv);
 }

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -26,7 +26,7 @@ static char const* getArgName(tr_option const* opt)
     {
         arg = "";
     }
-    else if (opt->argName != NULL)
+    else if (opt->argName != nullptr)
     {
         arg = opt->argName;
     }
@@ -61,8 +61,8 @@ static int get_next_line_len(char const* description, int maxlen)
 static void getopts_usage_line(tr_option const* opt, int longWidth, int shortWidth, int argWidth)
 {
     int len;
-    char const* longName = opt->longName != NULL ? opt->longName : "";
-    char const* shortName = opt->shortName != NULL ? opt->shortName : "";
+    char const* longName = opt->longName != nullptr ? opt->longName : "";
+    char const* shortName = opt->shortName != nullptr ? opt->shortName : "";
     char const* arg = getArgName(opt);
 
     int const d_indent = shortWidth + longWidth + argWidth + 7;
@@ -102,17 +102,17 @@ static void maxWidth(struct tr_option const* o, int* longWidth, int* shortWidth,
 {
     char const* arg;
 
-    if (o->longName != NULL)
+    if (o->longName != nullptr)
     {
         *longWidth = MAX(*longWidth, (int)strlen(o->longName));
     }
 
-    if (o->shortName != NULL)
+    if (o->shortName != nullptr)
     {
         *shortWidth = MAX(*shortWidth, (int)strlen(o->shortName));
     }
 
-    if ((arg = getArgName(o)) != NULL)
+    if ((arg = getArgName(o)) != nullptr)
     {
         *argWidth = MAX(*argWidth, (int)strlen(arg));
     }
@@ -137,7 +137,7 @@ void tr_getopt_usage(char const* progName, char const* description, struct tr_op
     help.has_arg = false;
     maxWidth(&help, &longWidth, &shortWidth, &argWidth);
 
-    if (description == NULL)
+    if (description == nullptr)
     {
         description = "Usage: %s [options]";
     }
@@ -155,23 +155,23 @@ void tr_getopt_usage(char const* progName, char const* description, struct tr_op
 static tr_option const* findOption(tr_option const* opts, char const* str, char const** setme_arg)
 {
     size_t matchlen = 0;
-    char const* arg = NULL;
-    tr_option const* match = NULL;
+    char const* arg = nullptr;
+    tr_option const* match = nullptr;
 
     /* find the longest matching option */
     for (tr_option const* o = opts; o->val != 0; ++o)
     {
-        size_t len = o->longName != NULL ? strlen(o->longName) : 0;
+        size_t len = o->longName != nullptr ? strlen(o->longName) : 0;
 
         if (matchlen < len && str[0] == '-' && str[1] == '-' && strncmp(str + 2, o->longName, len) == 0 &&
             (str[len + 2] == '\0' || (o->has_arg && str[len + 2] == '=')))
         {
             matchlen = len;
             match = o;
-            arg = str[len + 2] == '=' ? str + len + 3 : NULL;
+            arg = str[len + 2] == '=' ? str + len + 3 : nullptr;
         }
 
-        len = o->shortName != NULL ? strlen(o->shortName) : 0;
+        len = o->shortName != nullptr ? strlen(o->shortName) : 0;
 
         if (matchlen < len && str[0] == '-' && strncmp(str + 1, o->shortName, len) == 0 && (str[len + 1] == '\0' || o->has_arg))
         {
@@ -181,7 +181,7 @@ static tr_option const* findOption(tr_option const* opts, char const* str, char 
             switch (str[len + 1])
             {
             case '\0':
-                arg = NULL;
+                arg = nullptr;
                 break;
 
             case '=':
@@ -195,7 +195,7 @@ static tr_option const* findOption(tr_option const* opts, char const* str, char 
         }
     }
 
-    if (setme_arg != NULL)
+    if (setme_arg != nullptr)
     {
         *setme_arg = arg;
     }
@@ -205,10 +205,10 @@ static tr_option const* findOption(tr_option const* opts, char const* str, char 
 
 int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option const* opts, char const** setme_optarg)
 {
-    char const* arg = NULL;
-    tr_option const* o = NULL;
+    char const* arg = nullptr;
+    tr_option const* o = nullptr;
 
-    *setme_optarg = NULL;
+    *setme_optarg = nullptr;
 
     /* handle the builtin 'help' option */
     for (int i = 1; i < argc; ++i)
@@ -228,7 +228,7 @@ int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option co
 
     o = findOption(opts, argv[tr_optind], &arg);
 
-    if (o == NULL)
+    if (o == nullptr)
     {
         /* let the user know we got an unknown option... */
         *setme_optarg = argv[tr_optind++];
@@ -238,18 +238,18 @@ int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option co
     if (!o->has_arg)
     {
         /* no argument needed for this option, so we're done */
-        if (arg != NULL)
+        if (arg != nullptr)
         {
             return TR_OPT_ERR;
         }
 
-        *setme_optarg = NULL;
+        *setme_optarg = nullptr;
         ++tr_optind;
         return o->val;
     }
 
     /* option needed an argument, and it was embedded in this string */
-    if (arg != NULL)
+    if (arg != nullptr)
     {
         *setme_optarg = arg;
         ++tr_optind;
@@ -262,7 +262,7 @@ int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option co
         return TR_OPT_ERR;
     }
 
-    if (findOption(opts, argv[tr_optind], NULL) != NULL)
+    if (findOption(opts, argv[tr_optind], nullptr) != nullptr)
     {
         return TR_OPT_ERR;
     }

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -6,10 +6,11 @@
  *
  */
 
-#include <ctype.h> /* isspace() */
-#include <stdio.h>
-#include <stdlib.h> /* exit() */
-#include <string.h>
+#include <cctype> /* isspace() */
+#include <cstdio>
+#include <cstdlib> /* exit() */
+#include <cstring>
+#include <algorithm>
 
 #include "transmission.h"
 #include "tr-getopt.h"
@@ -104,17 +105,17 @@ static void maxWidth(struct tr_option const* o, int* longWidth, int* shortWidth,
 
     if (o->longName != nullptr)
     {
-        *longWidth = MAX(*longWidth, (int)strlen(o->longName));
+        *longWidth = std::max(*longWidth, (int)strlen(o->longName));
     }
 
     if (o->shortName != nullptr)
     {
-        *shortWidth = MAX(*shortWidth, (int)strlen(o->shortName));
+        *shortWidth = std::max(*shortWidth, (int)strlen(o->shortName));
     }
 
     if ((arg = getArgName(o)) != nullptr)
     {
-        *argWidth = MAX(*argWidth, (int)strlen(arg));
+        *argWidth = std::max(*argWidth, (int)strlen(arg));
     }
 }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -75,11 +75,11 @@ enum
     UPKEEP_INTERVAL_SECS = 5
 };
 
-static struct event* upkeep_timer = NULL;
+static struct event* upkeep_timer = nullptr;
 
 static tr_socket_t lpd_socket; /**<separate multicast receive socket */
 static tr_socket_t lpd_socket2; /**<and multicast send socket */
-static struct event* lpd_event = NULL;
+static struct event* lpd_event = nullptr;
 static tr_port lpd_port;
 
 static tr_session* session;
@@ -172,7 +172,7 @@ static int lpd_unsolicitedMsgCounter;
 */
 static char const* lpd_extractHeader(char const* s, struct lpd_protocolVersion* const ver)
 {
-    TR_ASSERT(s != NULL);
+    TR_ASSERT(s != nullptr);
 
     int major = -1;
     int minor = -1;
@@ -181,18 +181,18 @@ static char const* lpd_extractHeader(char const* s, struct lpd_protocolVersion* 
     /* something might be rotten with this chunk of data */
     if (len == 0 || len > lpd_maxDatagramLength)
     {
-        return NULL;
+        return nullptr;
     }
 
     /* now we can attempt to look up the BT-SEARCH header */
     if (sscanf(s, "BT-SEARCH * HTTP/%d.%d" CRLF, &major, &minor) != 2)
     {
-        return NULL;
+        return nullptr;
     }
 
     if (major < 0 || minor < 0)
     {
-        return NULL;
+        return nullptr;
     }
 
     {
@@ -200,13 +200,13 @@ static char const* lpd_extractHeader(char const* s, struct lpd_protocolVersion* 
         char const* const two_blank = CRLF CRLF CRLF;
         char const* const end = strstr(s, two_blank);
 
-        if (end == NULL || strlen(end) > strlen(two_blank))
+        if (end == nullptr || strlen(end) > strlen(two_blank))
         {
-            return NULL;
+            return nullptr;
         }
     }
 
-    if (ver != NULL)
+    if (ver != nullptr)
     {
         ver->major = major;
         ver->minor = minor;
@@ -232,9 +232,9 @@ static char const* lpd_extractHeader(char const* s, struct lpd_protocolVersion* 
 */
 static bool lpd_extractParam(char const* const str, char const* const name, int n, char* const val)
 {
-    TR_ASSERT(str != NULL);
-    TR_ASSERT(name != NULL);
-    TR_ASSERT(val != NULL);
+    TR_ASSERT(str != nullptr);
+    TR_ASSERT(name != nullptr);
+    TR_ASSERT(val != nullptr);
 
     enum
     {
@@ -255,7 +255,7 @@ static bool lpd_extractParam(char const* const str, char const* const name, int 
 
     pos = strstr(str, sstr);
 
-    if (pos == NULL)
+    if (pos == nullptr)
     {
         return false; /* search was not successful */
     }
@@ -306,7 +306,7 @@ int tr_lpdInit(tr_session* ss, tr_address* tr_addr)
     int const opt_on = 1;
     int const opt_off = 0;
 
-    if (session != NULL) /* already initialized */
+    if (session != nullptr) /* already initialized */
     {
         return -1;
     }
@@ -408,8 +408,8 @@ int tr_lpdInit(tr_session* ss, tr_address* tr_addr)
     /* Note: lpd_unsolicitedMsgCounter remains 0 until the first timeout event, thus
      * any announcement received during the initial interval will be discarded. */
 
-    lpd_event = event_new(ss->event_base, lpd_socket, EV_READ | EV_PERSIST, event_callback, NULL);
-    event_add(lpd_event, NULL);
+    lpd_event = event_new(ss->event_base, lpd_socket, EV_READ | EV_PERSIST, event_callback, nullptr);
+    event_add(lpd_event, nullptr);
 
     upkeep_timer = evtimer_new(ss->event_base, on_upkeep_timer, ss);
     tr_timerAdd(upkeep_timer, UPKEEP_INTERVAL_SECS, 0);
@@ -424,7 +424,7 @@ fail:
         evutil_closesocket(lpd_socket);
         evutil_closesocket(lpd_socket2);
         lpd_socket = lpd_socket2 = TR_BAD_SOCKET;
-        session = NULL;
+        session = nullptr;
         tr_logAddNamedDbg("LPD", "LPD initialisation failed (errno = %d)", save);
         errno = save;
     }
@@ -442,22 +442,22 @@ void tr_lpdUninit(tr_session* ss)
     tr_logAddNamedDbg("LPD", "Uninitialising Local Peer Discovery");
 
     event_free(lpd_event);
-    lpd_event = NULL;
+    lpd_event = nullptr;
 
     evtimer_del(upkeep_timer);
-    upkeep_timer = NULL;
+    upkeep_timer = nullptr;
 
     /* just shut down, we won't remember any former nodes */
     evutil_closesocket(lpd_socket);
     evutil_closesocket(lpd_socket2);
     tr_logAddNamedDbg("LPD", "Done uninitialising Local Peer Discovery");
 
-    session = NULL;
+    session = nullptr;
 }
 
 bool tr_lpdEnabled(tr_session const* ss)
 {
-    return ss != NULL && ss == session;
+    return ss != nullptr && ss == session;
 }
 
 /**
@@ -491,7 +491,7 @@ bool tr_lpdSendAnnounce(tr_torrent const* t)
     char hashString[SIZEOF_HASH_STRING];
     char query[lpd_maxDatagramLength + 1] = { 0 };
 
-    if (t == NULL)
+    if (t == nullptr)
     {
         return false;
     }
@@ -552,13 +552,13 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
     int res = 0;
     int peerPort = 0;
 
-    if (peer != NULL && msg != NULL)
+    if (peer != nullptr && msg != nullptr)
     {
-        tr_torrent* tor = NULL;
+        tr_torrent* tor = nullptr;
 
         char const* params = lpd_extractHeader(msg, &ver);
 
-        if (params == NULL || ver.major != 1) /* allow messages of protocol v1 */
+        if (params == nullptr || ver.major != 1) /* allow messages of protocol v1 */
         {
             return 0;
         }
@@ -620,7 +620,7 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
 */
 static int tr_lpdAnnounceMore(time_t const now, int const interval)
 {
-    tr_torrent* tor = NULL;
+    tr_torrent* tor = nullptr;
     int announcesSent = 0;
 
     if (!tr_isSession(session))
@@ -628,7 +628,7 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
         return -1;
     }
 
-    while ((tor = tr_torrentNext(session, tor)) != NULL && tr_sessionAllowsLPD(session))
+    while ((tor = tr_torrentNext(session, tor)) != nullptr && tr_sessionAllowsLPD(session))
     {
         if (tr_isTorrent(tor))
         {

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -26,15 +26,16 @@ THE SOFTWARE.
 #include <string.h> /* strlen(), strncpy(), strstr(), memset() */
 
 /* posix */
-#include <signal.h> /* sig_atomic_t */
-#include <ctype.h> /* toupper() */
+#include <csignal> /* sig_atomic_t */
+#include <cctype> /* toupper() */
+#include <algorithm>
 
 #ifdef _WIN32
 #include <inttypes.h>
 #include <ws2tcpip.h>
 typedef uint16_t in_port_t; /* all missing */
 #else
-#include <sys/time.h>
+#include <ctime>
 #include <unistd.h> /* close() */
 #include <sys/types.h>
 #include <sys/socket.h> /* socket(), bind() */
@@ -269,7 +270,7 @@ static bool lpd_extractParam(char const* const str, char const* const name, int 
 
         /* if value string hits the length limit n,
          * leave space for a trailing '\0' character */
-        n = MIN(len, n - 1);
+        n = std::min(len, n - 1);
         strncpy(val, beg, n);
         val[n] = 0;
     }

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -151,10 +151,12 @@
    In the latter case, define those here since we will use them */
 
 #ifndef MAX
+#warning Use std::max
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #ifndef MIN
+#warning Use std::min
 #define MIN(a, b) ((a) > (b) ? (b) : (a))
 #endif
 

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -147,19 +147,6 @@
     } while (0)
 #endif
 
-/* Sometimes the system defines MAX/MIN, sometimes not.
-   In the latter case, define those here since we will use them */
-
-#ifndef MAX
-#warning Use std::max
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
-#ifndef MIN
-#warning Use std::min
-#define MIN(a, b) ((a) > (b) ? (b) : (a))
-#endif
-
 /***
 ****
 ***/

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -141,18 +141,18 @@ static void rebind_ipv6(tr_session* ss, bool force)
 
     /* We currently have no way to enable or disable IPv6 after initialisation.
        No way to fix that without some surgery to the DHT code itself. */
-    if (ipv6 == NULL || (!force && ss->udp6_socket == TR_BAD_SOCKET))
+    if (ipv6 == nullptr || (!force && ss->udp6_socket == TR_BAD_SOCKET))
     {
-        if (ss->udp6_bound != NULL)
+        if (ss->udp6_bound != nullptr)
         {
             free(ss->udp6_bound);
-            ss->udp6_bound = NULL;
+            ss->udp6_bound = nullptr;
         }
 
         return;
     }
 
-    if (ss->udp6_bound != NULL && memcmp(ipv6, ss->udp6_bound, 16) == 0)
+    if (ss->udp6_bound != nullptr && memcmp(ipv6, ss->udp6_bound, 16) == 0)
     {
         return;
     }
@@ -173,7 +173,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
 
-    if (ipv6 != NULL)
+    if (ipv6 != nullptr)
     {
         memcpy(&sin6.sin6_addr, ipv6, 16);
     }
@@ -181,7 +181,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
     sin6.sin6_port = htons(ss->udp_port);
     public_addr = tr_sessionGetPublicAddress(ss, TR_AF_INET6, &is_default);
 
-    if (public_addr != NULL && !is_default)
+    if (public_addr != nullptr && !is_default)
     {
         sin6.sin6_addr = public_addr->addr.addr6;
     }
@@ -210,12 +210,12 @@ static void rebind_ipv6(tr_session* ss, bool force)
         tr_netCloseSocket(s);
     }
 
-    if (ss->udp6_bound == NULL)
+    if (ss->udp6_bound == nullptr)
     {
         ss->udp6_bound = static_cast<unsigned char*>(malloc(16));
     }
 
-    if (ss->udp6_bound != NULL)
+    if (ss->udp6_bound != nullptr)
     {
         memcpy(ss->udp6_bound, ipv6, 16);
     }
@@ -232,10 +232,10 @@ FAIL:
         tr_netCloseSocket(s);
     }
 
-    if (ss->udp6_bound != NULL)
+    if (ss->udp6_bound != nullptr)
     {
         free(ss->udp6_bound);
-        ss->udp6_bound = NULL;
+        ss->udp6_bound = nullptr;
     }
 }
 
@@ -325,7 +325,7 @@ void tr_udpInit(tr_session* ss)
     sin.sin_family = AF_INET;
     public_addr = tr_sessionGetPublicAddress(ss, TR_AF_INET, &is_default);
 
-    if (public_addr != NULL && !is_default)
+    if (public_addr != nullptr && !is_default)
     {
         memcpy(&sin.sin_addr, &public_addr->addr.addr4, sizeof(struct in_addr));
     }
@@ -343,13 +343,13 @@ void tr_udpInit(tr_session* ss)
 
     ss->udp_event = event_new(ss->event_base, ss->udp_socket, EV_READ | EV_PERSIST, event_callback, ss);
 
-    if (ss->udp_event == NULL)
+    if (ss->udp_event == nullptr)
     {
         tr_logAddNamedError("UDP", "Couldn't allocate IPv4 event");
     }
 
 IPV6:
-    if (tr_globalIPv6() != NULL)
+    if (tr_globalIPv6() != nullptr)
     {
         rebind_ipv6(ss, true);
     }
@@ -358,7 +358,7 @@ IPV6:
     {
         ss->udp6_event = event_new(ss->event_base, ss->udp6_socket, EV_READ | EV_PERSIST, event_callback, ss);
 
-        if (ss->udp6_event == NULL)
+        if (ss->udp6_event == nullptr)
         {
             tr_logAddNamedError("UDP", "Couldn't allocate IPv6 event");
         }
@@ -371,14 +371,14 @@ IPV6:
         tr_dhtInit(ss);
     }
 
-    if (ss->udp_event != NULL)
+    if (ss->udp_event != nullptr)
     {
-        event_add(ss->udp_event, NULL);
+        event_add(ss->udp_event, nullptr);
     }
 
-    if (ss->udp6_event != NULL)
+    if (ss->udp6_event != nullptr)
     {
-        event_add(ss->udp6_event, NULL);
+        event_add(ss->udp6_event, nullptr);
     }
 }
 
@@ -392,10 +392,10 @@ void tr_udpUninit(tr_session* ss)
         ss->udp_socket = TR_BAD_SOCKET;
     }
 
-    if (ss->udp_event != NULL)
+    if (ss->udp_event != nullptr)
     {
         event_free(ss->udp_event);
-        ss->udp_event = NULL;
+        ss->udp_event = nullptr;
     }
 
     if (ss->udp6_socket != TR_BAD_SOCKET)
@@ -404,15 +404,15 @@ void tr_udpUninit(tr_session* ss)
         ss->udp6_socket = TR_BAD_SOCKET;
     }
 
-    if (ss->udp6_event != NULL)
+    if (ss->udp6_event != nullptr)
     {
         event_free(ss->udp6_event);
-        ss->udp6_event = NULL;
+        ss->udp6_event = nullptr;
     }
 
-    if (ss->udp6_bound != NULL)
+    if (ss->udp6_bound != nullptr)
     {
         free(ss->udp6_bound);
-        ss->udp6_bound = NULL;
+        ss->udp6_bound = nullptr;
     }
 }

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -81,7 +81,7 @@ struct UTPSocket* UTP_Create(SendToProc* send_to_proc, void* send_to_userdata, s
     TR_UNUSED(addrlen);
 
     errno = ENOSYS;
-    return NULL;
+    return nullptr;
 }
 
 void tr_utpClose(tr_session* ss)
@@ -181,11 +181,11 @@ static void timer_callback(evutil_socket_t s, short type, void* vsession)
 
 int tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, tr_session* ss)
 {
-    if (!ss->isClosed && ss->utp_timer == NULL)
+    if (!ss->isClosed && ss->utp_timer == nullptr)
     {
         ss->utp_timer = evtimer_new(ss->event_base, timer_callback, ss);
 
-        if (ss->utp_timer == NULL)
+        if (ss->utp_timer == nullptr)
         {
             return -1;
         }
@@ -198,10 +198,10 @@ int tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const*
 
 void tr_utpClose(tr_session* session)
 {
-    if (session->utp_timer != NULL)
+    if (session->utp_timer != nullptr)
     {
         evtimer_del(session->utp_timer);
-        session->utp_timer = NULL;
+        session->utp_timer = nullptr;
     }
 }
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1421,7 +1421,7 @@ typedef enum
     TR_TRACKER_ACTIVE = 3
 } tr_tracker_state;
 
-typedef struct
+typedef struct tr_tracker_stat
 {
     /* how many downloads this tracker knows of (-1 means it does not know) */
     int downloadCount;

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -206,7 +206,7 @@ static void readFromPipe(evutil_socket_t fd, short eventType, void* veh)
             dbgmsg("pipe eof reached... removing event listener");
             event_free(eh->pipeEvent);
             tr_netCloseSocket(eh->fds[0]);
-            event_base_loopexit(eh->base, NULL);
+            event_base_loopexit(eh->base, nullptr);
             break;
         }
 
@@ -250,7 +250,7 @@ static void libeventThreadFunc(void* veh)
 
     /* listen to the pipe's read fd */
     eh->pipeEvent = event_new(base, eh->fds[0], EV_READ | EV_PERSIST, readFromPipe, veh);
-    event_add(eh->pipeEvent, NULL);
+    event_add(eh->pipeEvent, nullptr);
     event_set_log_callback(logFunc);
 
     /* loop until all the events are done */
@@ -262,7 +262,7 @@ static void libeventThreadFunc(void* veh)
     /* shut down the thread */
     tr_lockFree(eh->lock);
     event_base_free(base);
-    eh->session->events = NULL;
+    eh->session->events = nullptr;
     tr_free(eh);
     tr_logAddDebug("Closing libevent thread");
 }
@@ -271,7 +271,7 @@ void tr_eventInit(tr_session* session)
 {
     tr_event_handle* eh;
 
-    session->events = NULL;
+    session->events = nullptr;
 
     eh = tr_new0(tr_event_handle, 1);
     eh->lock = tr_lockNew();
@@ -285,7 +285,7 @@ void tr_eventInit(tr_session* session)
     eh->thread = tr_threadNew(libeventThreadFunc, eh);
 
     /* wait until the libevent thread is running */
-    while (session->events == NULL)
+    while (session->events == nullptr)
     {
         tr_wait_msec(100);
     }
@@ -295,7 +295,7 @@ void tr_eventClose(tr_session* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    if (session->events == NULL)
+    if (session->events == nullptr)
     {
         return;
     }
@@ -303,7 +303,7 @@ void tr_eventClose(tr_session* session)
     session->events->die = true;
     if (tr_logGetDeepEnabled())
     {
-        tr_logAddDeep(__FILE__, __LINE__, NULL, "closing trevent pipe");
+        tr_logAddDeep(__FILE__, __LINE__, nullptr, "closing trevent pipe");
     }
 
     tr_netCloseSocket(session->events->fds[1]);
@@ -316,7 +316,7 @@ void tr_eventClose(tr_session* session)
 bool tr_amInEventThread(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
-    TR_ASSERT(session->events != NULL);
+    TR_ASSERT(session->events != nullptr);
 
     return tr_amInThread(session->events->thread);
 }
@@ -328,7 +328,7 @@ bool tr_amInEventThread(tr_session const* session)
 void tr_runInEventThread(tr_session* session, void (*func)(void*), void* user_data)
 {
     TR_ASSERT(tr_isSession(session));
-    TR_ASSERT(session->events != NULL);
+    TR_ASSERT(session->events != nullptr);
 
     if (tr_amInThread(session->events->thread))
     {

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -88,15 +88,15 @@ static struct UPNPDev* tr_upnpDiscover(int msec)
     int err = UPNPDISCOVER_SUCCESS;
 
 #if (MINIUPNPC_API_VERSION >= 14) /* adds ttl */
-    ret = upnpDiscover(msec, NULL, NULL, 0, 0, 2, &err);
+    ret = upnpDiscover(msec, nullptr, nullptr, 0, 0, 2, &err);
 #else
-    ret = upnpDiscover(msec, NULL, NULL, 0, 0, &err);
+    ret = upnpDiscover(msec, nullptr, nullptr, 0, 0, &err);
 #endif
 
     have_err = err != UPNPDISCOVER_SUCCESS;
 #else
-    ret = upnpDiscover(msec, NULL, NULL, 0);
-    have_err = ret == NULL;
+    ret = upnpDiscover(msec, nullptr, nullptr, 0);
+    have_err = ret == nullptr;
 #endif
 
     if (have_err)
@@ -125,12 +125,12 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
         handle->data.first.servicetype,
         portStr,
         proto,
-        NULL /*remoteHost*/,
+        nullptr /*remoteHost*/,
         intClient,
         intPort,
-        NULL /*desc*/,
-        NULL /*enabled*/,
-        NULL /*duration*/);
+        nullptr /*desc*/,
+        nullptr /*enabled*/,
+        nullptr /*duration*/);
 #elif (MINIUPNPC_API_VERSION >= 8) /* adds desc, enabled and leaseDuration args */
     err = UPNP_GetSpecificPortMappingEntry(
         handle->urls.controlURL,
@@ -139,9 +139,9 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
         proto,
         intClient,
         intPort,
-        NULL /*desc*/,
-        NULL /*enabled*/,
-        NULL /*duration*/);
+        nullptr /*desc*/,
+        nullptr /*enabled*/,
+        nullptr /*duration*/);
 #else
     err = UPNP_GetSpecificPortMappingEntry(
         handle->urls.controlURL,
@@ -173,8 +173,8 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
         handle->lanaddr,
         desc,
         proto,
-        NULL,
-        NULL);
+        nullptr,
+        nullptr);
 #else
     err = UPNP_AddPortMapping(
         handle->urls.controlURL,
@@ -184,7 +184,7 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
         handle->lanaddr,
         desc,
         proto,
-        NULL);
+        nullptr);
 #endif
 
     if (err != 0)
@@ -208,7 +208,7 @@ static void tr_upnpDeletePortMapping(tr_upnp const* handle, char const* proto, t
 
     tr_snprintf(portStr, sizeof(portStr), "%d", (int)port);
 
-    UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, portStr, proto, NULL);
+    UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, portStr, proto, nullptr);
 }
 
 /**
@@ -291,7 +291,7 @@ tr_port_forwarding tr_upnpPulse(tr_upnp* handle, tr_port port, bool isEnabled, b
     {
         errno = 0;
 
-        if (handle->urls.controlURL == NULL)
+        if (handle->urls.controlURL == nullptr)
         {
             handle->isMapped = false;
         }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -71,18 +71,18 @@ struct tm* tr_gmtime_r(time_t const* timep, struct tm* result)
 
 #elif defined(HAVE_GMTIME_S)
 
-    return gmtime_s(result, timep) == 0 ? result : NULL;
+    return gmtime_s(result, timep) == 0 ? result : nullptr;
 
 #else
 
     struct tm* p = gmtime(timep);
-    if (p != NULL)
+    if (p != nullptr)
     {
         *result = *p;
         return result;
     }
 
-    return NULL;
+    return nullptr;
 
 #endif
 }
@@ -95,18 +95,18 @@ struct tm* tr_localtime_r(time_t const* timep, struct tm* result)
 
 #elif defined(HAVE_LOCALTIME_S)
 
-    return localtime_s(result, timep) == 0 ? result : NULL;
+    return localtime_s(result, timep) == 0 ? result : nullptr;
 
 #else
 
     struct tm* p = localtime(timep);
-    if (p != NULL)
+    if (p != nullptr)
     {
         *result = *p;
         return result;
     }
 
-    return NULL;
+    return nullptr;
 
 #endif
 }
@@ -120,7 +120,7 @@ int tr_gettimeofday(struct timeval* tv)
     FILETIME ft;
     uint64_t tmp = 0;
 
-    if (tv == NULL)
+    if (tv == nullptr)
     {
         errno = EINVAL;
         return -1;
@@ -142,7 +142,7 @@ int tr_gettimeofday(struct timeval* tv)
 
 #else
 
-    return gettimeofday(tv, NULL);
+    return gettimeofday(tv, nullptr);
 
 #endif
 }
@@ -153,19 +153,19 @@ int tr_gettimeofday(struct timeval* tv)
 
 void* tr_malloc(size_t size)
 {
-    return size != 0 ? malloc(size) : NULL;
+    return size != 0 ? malloc(size) : nullptr;
 }
 
 void* tr_malloc0(size_t size)
 {
-    return size != 0 ? calloc(1, size) : NULL;
+    return size != 0 ? calloc(1, size) : nullptr;
 }
 
 void* tr_realloc(void* p, size_t size)
 {
-    void* result = size != 0 ? realloc(p, size) : NULL;
+    void* result = size != 0 ? realloc(p, size) : nullptr;
 
-    if (result == NULL)
+    if (result == nullptr)
     {
         tr_free(p);
     }
@@ -175,7 +175,7 @@ void* tr_realloc(void* p, size_t size)
 
 void tr_free(void* p)
 {
-    if (p != NULL)
+    if (p != nullptr)
     {
         free(p);
     }
@@ -183,12 +183,12 @@ void tr_free(void* p)
 
 void tr_free_ptrv(void* const* p)
 {
-    if (p == NULL)
+    if (p == nullptr)
     {
         return;
     }
 
-    while (*p != NULL)
+    while (*p != nullptr)
     {
         tr_free(*p);
         ++p;
@@ -273,7 +273,7 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
 {
     tr_sys_path_info info;
     tr_sys_file_t fd;
-    tr_error* my_error = NULL;
+    tr_error* my_error = nullptr;
     char const* const err_fmt = _("Couldn't read \"%1$s\": %2$s");
 
     /* try to stat the file */
@@ -281,14 +281,14 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     {
         tr_logAddDebug(err_fmt, path, my_error->message);
         tr_error_propagate(error, &my_error);
-        return NULL;
+        return nullptr;
     }
 
     if (info.type != TR_SYS_PATH_IS_FILE)
     {
         tr_logAddError(err_fmt, path, _("Not a regular file"));
         tr_error_set_literal(error, TR_ERROR_EISDIR, _("Not a regular file"));
-        return NULL;
+        return nullptr;
     }
 
     /* file size should be able to fit into size_t */
@@ -304,21 +304,21 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     {
         tr_logAddError(err_fmt, path, my_error->message);
         tr_error_propagate(error, &my_error);
-        return NULL;
+        return nullptr;
     }
 
     auto* buf = static_cast<uint8_t*>(tr_malloc(info.size + 1));
 
-    if (!tr_sys_file_read(fd, buf, info.size, NULL, &my_error))
+    if (!tr_sys_file_read(fd, buf, info.size, nullptr, &my_error))
     {
         tr_logAddError(err_fmt, path, my_error->message);
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
         free(buf);
         tr_error_propagate(error, &my_error);
-        return NULL;
+        return nullptr;
     }
 
-    tr_sys_file_close(fd, NULL);
+    tr_sys_file_close(fd, nullptr);
     buf[info.size] = '\0';
     *size = info.size;
     return buf;
@@ -336,7 +336,7 @@ char* tr_buildPath(char const* first_element, ...)
     va_start(vl, first_element);
     element = first_element;
 
-    while (element != NULL)
+    while (element != nullptr)
     {
         bufLen += strlen(element) + 1;
         element = va_arg(vl, char const*);
@@ -345,16 +345,16 @@ char* tr_buildPath(char const* first_element, ...)
     pch = buf = tr_new(char, bufLen);
     va_end(vl);
 
-    if (buf == NULL)
+    if (buf == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     /* pass 2: build the string piece by piece */
     va_start(vl, first_element);
     element = first_element;
 
-    while (element != NULL)
+    while (element != nullptr)
     {
         size_t const elementLen = strlen(element);
         memcpy(pch, element, elementLen);
@@ -410,7 +410,7 @@ char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len)
     evbuffer_free(buf);
     ret[n] = '\0';
 
-    if (result_len != NULL)
+    if (result_len != nullptr)
     {
         *result_len = n;
     }
@@ -420,22 +420,22 @@ char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len)
 
 char* tr_strdup(void const* in)
 {
-    return tr_strndup(in, in != NULL ? strlen(static_cast<char const*>(in)) : 0);
+    return tr_strndup(in, in != nullptr ? strlen(static_cast<char const*>(in)) : 0);
 }
 
 char* tr_strndup(void const* in, size_t len)
 {
-    char* out = NULL;
+    char* out = nullptr;
 
     if (len == TR_BAD_SIZE)
     {
         out = tr_strdup(in);
     }
-    else if (in != NULL)
+    else if (in != nullptr)
     {
         out = static_cast<char*>(tr_malloc(len + 1));
 
-        if (out != NULL)
+        if (out != nullptr)
         {
             memcpy(out, in, len);
             out[len] = '\0';
@@ -458,9 +458,9 @@ char const* tr_memmem(char const* haystack, size_t haystacklen, char const* need
         return haystack;
     }
 
-    if (needlelen > haystacklen || haystack == NULL || needle == NULL)
+    if (needlelen > haystacklen || haystack == nullptr || needle == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     for (size_t i = 0; i <= haystacklen - needlelen; ++i)
@@ -471,7 +471,7 @@ char const* tr_memmem(char const* haystack, size_t haystacklen, char const* need
         }
     }
 
-    return NULL;
+    return nullptr;
 
 #endif
 }
@@ -509,14 +509,14 @@ char* tr_strdup_vprintf(char const* fmt, va_list args)
 {
     struct evbuffer* buf = evbuffer_new();
     evbuffer_add_vprintf(buf, fmt, args);
-    return evbuffer_free_to_str(buf, NULL);
+    return evbuffer_free_to_str(buf, nullptr);
 }
 
 char const* tr_strerror(int i)
 {
     char const* ret = strerror(i);
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         ret = "Unknown Error";
     }
@@ -526,17 +526,17 @@ char const* tr_strerror(int i)
 
 int tr_strcmp0(char const* str1, char const* str2)
 {
-    if (str1 != NULL && str2 != NULL)
+    if (str1 != nullptr && str2 != nullptr)
     {
         return strcmp(str1, str2);
     }
 
-    if (str1 != NULL)
+    if (str1 != nullptr)
     {
         return 1;
     }
 
-    if (str2 != NULL)
+    if (str2 != nullptr)
     {
         return -1;
     }
@@ -559,16 +559,16 @@ char* tr_strsep(char** str, char const* delims)
 
     char* token;
 
-    if (*str == NULL) /* no more tokens */
+    if (*str == nullptr) /* no more tokens */
     {
-        return NULL;
+        return nullptr;
     }
 
     token = *str;
 
     while (**str != '\0')
     {
-        if (strchr(delims, **str) != NULL)
+        if (strchr(delims, **str) != nullptr)
         {
             **str = '\0';
             (*str)++;
@@ -579,7 +579,7 @@ char* tr_strsep(char** str, char const* delims)
     }
 
     /* there is not another token */
-    *str = NULL;
+    *str = nullptr;
 
     return token;
 
@@ -619,7 +619,7 @@ char* tr_strjoin(char const* const* arr, size_t len, char const* delim)
 
 char* tr_strstrip(char* str)
 {
-    if (str != NULL)
+    if (str != nullptr)
     {
         size_t len = strlen(str);
 
@@ -648,12 +648,12 @@ bool tr_str_has_suffix(char const* str, char const* suffix)
     size_t str_len;
     size_t suffix_len;
 
-    if (str == NULL)
+    if (str == nullptr)
     {
         return false;
     }
 
-    if (suffix == NULL)
+    if (suffix == nullptr)
     {
         return true;
     }
@@ -692,7 +692,7 @@ void tr_wait_msec(long int msec)
     struct timespec ts;
     ts.tv_sec = msec / 1000;
     ts.tv_nsec = (msec % 1000) * 1000000;
-    nanosleep(&ts, NULL);
+    nanosleep(&ts, nullptr);
 
 #endif
 }
@@ -721,8 +721,8 @@ size_t tr_strlcpy(void* vdst, void const* vsrc, size_t siz)
     auto* dst = static_cast<char*>(vdst);
     auto const* const src = static_cast<char const*>(vsrc);
 
-    TR_ASSERT(dst != NULL);
-    TR_ASSERT(src != NULL);
+    TR_ASSERT(dst != nullptr);
+    TR_ASSERT(src != nullptr);
 
 #ifdef HAVE_STRLCPY
 
@@ -839,14 +839,14 @@ static bool isValidURLChars(char const* url, size_t url_len)
              "<>#%<\"" /* delims */
              "{}|\\^[]`"; /* unwise */
 
-    if (url == NULL)
+    if (url == nullptr)
     {
         return false;
     }
 
     for (char const *c = url, *end = url + url_len; c < end && *c != '\0'; ++c)
     {
-        if (memchr(rfc2396_valid_chars, *c, sizeof(rfc2396_valid_chars) - 1) == NULL)
+        if (memchr(rfc2396_valid_chars, *c, sizeof(rfc2396_valid_chars) - 1) == nullptr)
         {
             return false;
         }
@@ -857,20 +857,20 @@ static bool isValidURLChars(char const* url, size_t url_len)
 
 bool tr_urlIsValidTracker(char const* url)
 {
-    if (url == NULL)
+    if (url == nullptr)
     {
         return false;
     }
 
     size_t const url_len = strlen(url);
 
-    return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, NULL, NULL, NULL, NULL) &&
+    return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, nullptr, nullptr, nullptr, nullptr) &&
         (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "udp://", 6) == 0);
 }
 
 bool tr_urlIsValid(char const* url, size_t url_len)
 {
-    if (url == NULL)
+    if (url == nullptr)
     {
         return false;
     }
@@ -880,7 +880,7 @@ bool tr_urlIsValid(char const* url, size_t url_len)
         url_len = strlen(url);
     }
 
-    return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, NULL, NULL, NULL, NULL) &&
+    return isValidURLChars(url, url_len) && tr_urlParse(url, url_len, nullptr, nullptr, nullptr, nullptr) &&
         (memcmp(url, "http://", 7) == 0 || memcmp(url, "https://", 8) == 0 || memcmp(url, "ftp://", 6) == 0 ||
          memcmp(url, "sftp://", 7) == 0);
 }
@@ -922,10 +922,10 @@ static int get_port_for_scheme(char const* scheme, size_t scheme_len)
         { "sftp", 22 }, //
         { "http", 80 }, //
         { "https", 443 }, //
-        { NULL, 0 }, //
+        { nullptr, 0 }, //
     };
 
-    for (struct known_scheme const* s = known_schemes; s->name != NULL; ++s)
+    for (struct known_scheme const* s = known_schemes; s->name != nullptr; ++s)
     {
         if (scheme_len == strlen(s->name) && memcmp(scheme, s->name, scheme_len) == 0)
         {
@@ -946,7 +946,7 @@ bool tr_urlParse(char const* url, size_t url_len, char** setme_scheme, char** se
     char const* scheme = url;
     char const* scheme_end = tr_memmem(scheme, url_len, "://", 3);
 
-    if (scheme_end == NULL)
+    if (scheme_end == nullptr)
     {
         return false;
     }
@@ -964,7 +964,7 @@ bool tr_urlParse(char const* url, size_t url_len, char** setme_scheme, char** se
     char const* authority = url;
     auto const* authority_end = static_cast<char const*>(memchr(authority, '/', url_len));
 
-    if (authority_end == NULL)
+    if (authority_end == nullptr)
     {
         authority_end = authority + url_len;
     }
@@ -981,31 +981,31 @@ bool tr_urlParse(char const* url, size_t url_len, char** setme_scheme, char** se
 
     auto const* host_end = static_cast<char const*>(memchr(authority, ':', authority_len));
 
-    size_t const host_len = host_end != NULL ? (size_t)(host_end - authority) : authority_len;
+    size_t const host_len = host_end != nullptr ? (size_t)(host_end - authority) : authority_len;
 
     if (host_len == 0)
     {
         return false;
     }
 
-    size_t const port_len = host_end != NULL ? authority_end - host_end - 1 : 0;
+    size_t const port_len = host_end != nullptr ? authority_end - host_end - 1 : 0;
 
-    if (setme_scheme != NULL)
+    if (setme_scheme != nullptr)
     {
         *setme_scheme = tr_strndup(scheme, scheme_len);
     }
 
-    if (setme_host != NULL)
+    if (setme_host != nullptr)
     {
         *setme_host = tr_strndup(authority, host_len);
     }
 
-    if (setme_port != NULL)
+    if (setme_port != nullptr)
     {
         *setme_port = port_len > 0 ? parse_port(host_end + 1, port_len) : get_port_for_scheme(scheme, scheme_len);
     }
 
-    if (setme_path != NULL)
+    if (setme_path != nullptr)
     {
         if (url[0] == '\0')
         {
@@ -1222,12 +1222,12 @@ static char* strip_non_utf8(char const* in, size_t inlen)
     }
 
     evbuffer_add(buf, in, inlen);
-    return evbuffer_free_to_str(buf, NULL);
+    return evbuffer_free_to_str(buf, nullptr);
 }
 
 static char* to_utf8(char const* in, size_t inlen)
 {
-    char* ret = NULL;
+    char* ret = nullptr;
 
 #ifdef HAVE_ICONV
 
@@ -1235,7 +1235,7 @@ static char* to_utf8(char const* in, size_t inlen)
     size_t const buflen = inlen * 4 + 10;
     char* out = tr_new(char, buflen);
 
-    for (size_t i = 0; ret == NULL && i < TR_N_ELEMENTS(encodings); ++i)
+    for (size_t i = 0; ret == nullptr && i < TR_N_ELEMENTS(encodings); ++i)
     {
 #ifdef ICONV_SECOND_ARGUMENT_IS_CONST
         auto const* inbuf = in;
@@ -1264,7 +1264,7 @@ static char* to_utf8(char const* in, size_t inlen)
 
 #endif
 
-    if (ret == NULL)
+    if (ret == nullptr)
     {
         ret = strip_non_utf8(in, inlen);
     }
@@ -1291,7 +1291,7 @@ char* tr_utf8clean(char const* str, size_t max_len)
         ret = to_utf8(str, max_len);
     }
 
-    TR_ASSERT(tr_utf8_validate(ret, TR_BAD_SIZE, NULL));
+    TR_ASSERT(tr_utf8_validate(ret, TR_BAD_SIZE, nullptr));
     return ret;
 }
 
@@ -1299,7 +1299,7 @@ char* tr_utf8clean(char const* str, size_t max_len)
 
 char* tr_win32_native_to_utf8(wchar_t const* text, int text_size)
 {
-    return tr_win32_native_to_utf8_ex(text, text_size, 0, 0, NULL);
+    return tr_win32_native_to_utf8_ex(text, text_size, 0, 0, nullptr);
 }
 
 char* tr_win32_native_to_utf8_ex(
@@ -1309,7 +1309,7 @@ char* tr_win32_native_to_utf8_ex(
     int extra_chars_after,
     int* real_result_size)
 {
-    char* ret = NULL;
+    char* ret = nullptr;
     int size;
 
     if (text_size == -1)
@@ -1317,7 +1317,7 @@ char* tr_win32_native_to_utf8_ex(
         text_size = wcslen(text);
     }
 
-    size = WideCharToMultiByte(CP_UTF8, 0, text, text_size, NULL, 0, NULL, NULL);
+    size = WideCharToMultiByte(CP_UTF8, 0, text, text_size, nullptr, 0, nullptr, nullptr);
 
     if (size == 0)
     {
@@ -1325,7 +1325,7 @@ char* tr_win32_native_to_utf8_ex(
     }
 
     ret = tr_new(char, size + extra_chars_before + extra_chars_after + 1);
-    size = WideCharToMultiByte(CP_UTF8, 0, text, text_size, ret + extra_chars_before, size, NULL, NULL);
+    size = WideCharToMultiByte(CP_UTF8, 0, text, text_size, ret + extra_chars_before, size, nullptr, nullptr);
 
     if (size == 0)
     {
@@ -1334,7 +1334,7 @@ char* tr_win32_native_to_utf8_ex(
 
     ret[size + extra_chars_before + extra_chars_after] = '\0';
 
-    if (real_result_size != NULL)
+    if (real_result_size != nullptr)
     {
         *real_result_size = size;
     }
@@ -1344,12 +1344,12 @@ char* tr_win32_native_to_utf8_ex(
 fail:
     tr_free(ret);
 
-    return NULL;
+    return nullptr;
 }
 
 wchar_t* tr_win32_utf8_to_native(char const* text, int text_size)
 {
-    return tr_win32_utf8_to_native_ex(text, text_size, 0, 0, NULL);
+    return tr_win32_utf8_to_native_ex(text, text_size, 0, 0, nullptr);
 }
 
 wchar_t* tr_win32_utf8_to_native_ex(
@@ -1359,7 +1359,7 @@ wchar_t* tr_win32_utf8_to_native_ex(
     int extra_chars_after,
     int* real_result_size)
 {
-    wchar_t* ret = NULL;
+    wchar_t* ret = nullptr;
     int size;
 
     if (text_size == -1)
@@ -1367,7 +1367,7 @@ wchar_t* tr_win32_utf8_to_native_ex(
         text_size = strlen(text);
     }
 
-    size = MultiByteToWideChar(CP_UTF8, 0, text, text_size, NULL, 0);
+    size = MultiByteToWideChar(CP_UTF8, 0, text, text_size, nullptr, 0);
 
     if (size == 0)
     {
@@ -1384,7 +1384,7 @@ wchar_t* tr_win32_utf8_to_native_ex(
 
     ret[size + extra_chars_before + extra_chars_after] = L'\0';
 
-    if (real_result_size != NULL)
+    if (real_result_size != nullptr)
     {
         *real_result_size = size;
     }
@@ -1394,38 +1394,38 @@ wchar_t* tr_win32_utf8_to_native_ex(
 fail:
     tr_free(ret);
 
-    return NULL;
+    return nullptr;
 }
 
 char* tr_win32_format_message(uint32_t code)
 {
-    wchar_t* wide_text = NULL;
+    wchar_t* wide_text = nullptr;
     DWORD wide_size;
-    char* text = NULL;
+    char* text = nullptr;
     size_t text_size;
 
     wide_size = FormatMessageW(
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL,
+        nullptr,
         code,
         0,
         (LPWSTR)&wide_text,
         0,
-        NULL);
+        nullptr);
 
     if (wide_size == 0)
     {
         return tr_strdup_printf("Unknown error (0x%08x)", code);
     }
 
-    if (wide_size != 0 && wide_text != NULL)
+    if (wide_size != 0 && wide_text != nullptr)
     {
         text = tr_win32_native_to_utf8(wide_text, wide_size);
     }
 
     LocalFree(wide_text);
 
-    if (text != NULL)
+    if (text != nullptr)
     {
         /* Most (all?) messages contain "\r\n" in the end, chop it */
         text_size = strlen(text);
@@ -1446,7 +1446,7 @@ void tr_win32_make_args_utf8(int* argc, char*** argv)
 
     my_wide_argv = CommandLineToArgvW(GetCommandLineW(), &my_argc);
 
-    if (my_wide_argv == NULL)
+    if (my_wide_argv == nullptr)
     {
         return;
     }
@@ -1460,7 +1460,7 @@ void tr_win32_make_args_utf8(int* argc, char*** argv)
     {
         my_argv[i] = tr_win32_native_to_utf8(my_wide_argv[i], -1);
 
-        if (my_argv[i] == NULL)
+        if (my_argv[i] == nullptr)
         {
             break;
         }
@@ -1477,7 +1477,7 @@ void tr_win32_make_args_utf8(int* argc, char*** argv)
     }
     else
     {
-        my_argv[my_argc] = NULL;
+        my_argv[my_argc] = nullptr;
 
         *argc = my_argc;
         *argv = my_argv;
@@ -1577,10 +1577,10 @@ int compareInt(void const* va, void const* vb)
 int* tr_parseNumberRange(char const* str_in, size_t len, int* setmeCount)
 {
     int n = 0;
-    int* uniq = NULL;
+    int* uniq = nullptr;
     char* str = tr_strndup(str_in, len);
     char const* walk;
-    tr_list* ranges = NULL;
+    tr_list* ranges = nullptr;
     bool success = true;
 
     walk = str;
@@ -1590,7 +1590,7 @@ int* tr_parseNumberRange(char const* str_in, size_t len, int* setmeCount)
         struct number_range range;
         char const* pch = strchr(walk, ',');
 
-        if (pch != NULL)
+        if (pch != nullptr)
         {
             success = parseNumberSection(walk, (size_t)(pch - walk), &range);
             walk = pch + 1;
@@ -1610,17 +1610,17 @@ int* tr_parseNumberRange(char const* str_in, size_t len, int* setmeCount)
     if (!success)
     {
         *setmeCount = 0;
-        uniq = NULL;
+        uniq = nullptr;
     }
     else
     {
         int n2;
-        int* sorted = NULL;
+        int* sorted = nullptr;
 
         /* build a sorted number array */
         n = n2 = 0;
 
-        for (tr_list* l = ranges; l != NULL; l = l->next)
+        for (tr_list* l = ranges; l != nullptr; l = l->next)
         {
             auto const* r = static_cast<struct number_range const*>(l->data);
             n += r->high + 1 - r->low;
@@ -1628,14 +1628,14 @@ int* tr_parseNumberRange(char const* str_in, size_t len, int* setmeCount)
 
         sorted = tr_new(int, n);
 
-        if (sorted == NULL)
+        if (sorted == nullptr)
         {
             n = 0;
-            uniq = NULL;
+            uniq = nullptr;
         }
         else
         {
-            for (tr_list* l = ranges; l != NULL; l = l->next)
+            for (tr_list* l = ranges; l != nullptr; l = l->next)
             {
                 auto const* r = static_cast<struct number_range const*>(l->data);
 
@@ -1652,7 +1652,7 @@ int* tr_parseNumberRange(char const* str_in, size_t len, int* setmeCount)
             uniq = tr_new(int, n);
             n = 0;
 
-            if (uniq != NULL)
+            if (uniq != nullptr)
             {
                 for (int i = 0; i < n2; ++i)
                 {
@@ -1686,7 +1686,7 @@ double tr_truncd(double x, int precision)
     char buf[128];
     tr_snprintf(buf, sizeof(buf), "%.*f", TR_ARG_TUPLE(DBL_DIG, x));
 
-    if ((pt = strstr(buf, localeconv()->decimal_point)) != NULL)
+    if ((pt = strstr(buf, localeconv()->decimal_point)) != nullptr)
     {
         pt[precision != 0 ? precision + 1 : 0] = '\0';
     }
@@ -1757,7 +1757,7 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
     /* make sure the target directory exists */
     {
         char* newdir = tr_sys_path_dirname(newpath, error);
-        bool const i = newdir != NULL && tr_sys_dir_create(newdir, TR_SYS_DIR_CREATE_PARENTS, 0777, error);
+        bool const i = newdir != nullptr && tr_sys_dir_create(newdir, TR_SYS_DIR_CREATE_PARENTS, 0777, error);
         tr_free(newdir);
 
         if (!i)
@@ -1768,7 +1768,7 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
     }
 
     /* they might be on the same filesystem... */
-    if (tr_sys_path_rename(oldpath, newpath, NULL))
+    if (tr_sys_path_rename(oldpath, newpath, nullptr))
     {
         return true;
     }
@@ -1781,7 +1781,7 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
     }
 
     {
-        tr_error* my_error = NULL;
+        tr_error* my_error = nullptr;
 
         if (!tr_sys_path_remove(oldpath, &my_error))
         {
@@ -2039,18 +2039,18 @@ void tr_formatter_get_units(void* vdict)
 
 bool tr_env_key_exists(char const* key)
 {
-    TR_ASSERT(key != NULL);
+    TR_ASSERT(key != nullptr);
 
 #ifdef _WIN32
-    return GetEnvironmentVariableA(key, NULL, 0) != 0;
+    return GetEnvironmentVariableA(key, nullptr, 0) != 0;
 #else
-    return getenv(key) != NULL;
+    return getenv(key) != nullptr;
 #endif
 }
 
 int tr_env_get_int(char const* key, int default_value)
 {
-    TR_ASSERT(key != NULL);
+    TR_ASSERT(key != nullptr);
 
 #ifdef _WIN32
 
@@ -2077,16 +2077,16 @@ int tr_env_get_int(char const* key, int default_value)
 
 char* tr_env_get_string(char const* key, char const* default_value)
 {
-    TR_ASSERT(key != NULL);
+    TR_ASSERT(key != nullptr);
 
 #ifdef _WIN32
 
     wchar_t* wide_key = tr_win32_utf8_to_native(key, -1);
-    char* value = NULL;
+    char* value = nullptr;
 
-    if (wide_key != NULL)
+    if (wide_key != nullptr)
     {
-        DWORD const size = GetEnvironmentVariableW(wide_key, NULL, 0);
+        DWORD const size = GetEnvironmentVariableW(wide_key, nullptr, 0);
 
         if (size != 0)
         {
@@ -2103,7 +2103,7 @@ char* tr_env_get_string(char const* key, char const* default_value)
         tr_free(wide_key);
     }
 
-    if (value == NULL && default_value != NULL)
+    if (value == nullptr && default_value != nullptr)
     {
         value = tr_strdup(default_value);
     }
@@ -2114,12 +2114,12 @@ char* tr_env_get_string(char const* key, char const* default_value)
 
     char const* value = getenv(key);
 
-    if (value == NULL)
+    if (value == nullptr)
     {
         value = default_value;
     }
 
-    return value != NULL ? tr_strdup(value) : NULL;
+    return value != nullptr ? tr_strdup(value) : nullptr;
 
 #endif
 }
@@ -2154,10 +2154,10 @@ static int compareSuffix(void const* va, void const* vb)
 
 char const* tr_get_mime_type_for_filename(char const* filename)
 {
-    struct mime_type_suffix const* info = NULL;
+    struct mime_type_suffix const* info = nullptr;
 
     char const* in = strrchr(filename, '.');
-    if (in != NULL)
+    if (in != nullptr)
     {
         ++in; // walk past '.'
         if (strlen(in) <= MIME_TYPE_SUFFIX_MAXLEN)
@@ -2180,5 +2180,5 @@ char const* tr_get_mime_type_for_filename(char const* filename)
         }
     }
 
-    return info != NULL ? info->mime_type : NULL;
+    return info != nullptr ? info->mime_type : nullptr;
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -13,16 +13,16 @@
 #endif
 
 #include <array> // std::array
-#include <ctype.h> /* isdigit(), tolower() */
-#include <errno.h>
-#include <float.h> /* DBL_DIG */
-#include <locale.h> /* localeconv() */
-#include <math.h> /* fabs(), floor() */
-#include <stdint.h> /* SIZE_MAX */
-#include <stdio.h>
-#include <stdlib.h> /* getenv() */
-#include <string.h> /* strerror(), memset(), memmem() */
-#include <time.h> /* nanosleep() */
+#include <cctype> /* isdigit(), tolower() */
+#include <cerrno>
+#include <cfloat> /* DBL_DIG */
+#include <clocale> /* localeconv() */
+#include <cmath> /* fabs(), floor() */
+#include <cstdint> /* SIZE_MAX */
+#include <cstdio>
+#include <cstdlib> /* getenv() */
+#include <cstring> /* strerror(), memset(), memmem() */
+#include <ctime> /* nanosleep() */
 
 #ifdef _WIN32
 #include <ws2tcpip.h> /* WSAStartup() */
@@ -30,7 +30,7 @@
 #include <shellapi.h> /* CommandLineToArgv() */
 #include <shlwapi.h> /* StrStrIA() */
 #else
-#include <sys/time.h>
+#include <ctime>
 #include <unistd.h> /* getpagesize() */
 #endif
 
@@ -153,17 +153,17 @@ int tr_gettimeofday(struct timeval* tv)
 
 void* tr_malloc(size_t size)
 {
-    return size != 0 ? malloc(size) : nullptr;
+    return size != 0 ? std::malloc(size) : nullptr;
 }
 
 void* tr_malloc0(size_t size)
 {
-    return size != 0 ? calloc(1, size) : nullptr;
+    return size != 0 ? std::calloc(1, size) : nullptr;
 }
 
 void* tr_realloc(void* p, size_t size)
 {
-    void* result = size != 0 ? realloc(p, size) : nullptr;
+    void* result = size != 0 ? std::realloc(p, size) : nullptr;
 
     if (result == nullptr)
     {
@@ -175,9 +175,10 @@ void* tr_realloc(void* p, size_t size)
 
 void tr_free(void* p)
 {
+    // Deprecate this check: C free and C++ delete allow nullptr args and do nothing
     if (p != nullptr)
     {
-        free(p);
+        std::free(p);
     }
 }
 
@@ -197,7 +198,7 @@ void tr_free_ptrv(void* const* p)
 
 void* tr_memdup(void const* src, size_t byteCount)
 {
-    return memcpy(tr_malloc(byteCount), src, byteCount);
+    return std::memcpy(tr_malloc(byteCount), src, byteCount);
 }
 
 /***
@@ -215,11 +216,11 @@ char const* tr_strip_positional_args(char const* str)
     {
         buf[pos++] = *str;
 
-        if (*str == '%' && isdigit(str[1]))
+        if (*str == '%' && std::isdigit(str[1]))
         {
             char const* tmp = str + 1;
 
-            while (isdigit(*tmp))
+            while (std::isdigit(*tmp))
             {
                 ++tmp;
             }
@@ -238,7 +239,7 @@ char const* tr_strip_positional_args(char const* str)
 
     buf[pos] = '\0';
 
-    return in && !strcmp(buf.data(), in) ? in : buf.data();
+    return in && !std::strcmp(buf.data(), in) ? in : buf.data();
 }
 
 /**
@@ -247,9 +248,10 @@ char const* tr_strip_positional_args(char const* str)
 
 void tr_timerAdd(struct event* timer, int seconds, int microseconds)
 {
-    struct timeval tv;
-    tv.tv_sec = seconds;
-    tv.tv_usec = microseconds;
+    struct timeval tv
+    {
+        .tv_sec = seconds, .tv_usec = microseconds
+    };
 
     TR_ASSERT(tv.tv_sec >= 0);
     TR_ASSERT(tv.tv_usec >= 0);
@@ -437,7 +439,7 @@ char* tr_strndup(void const* in, size_t len)
 
         if (out != nullptr)
         {
-            memcpy(out, in, len);
+            std::memcpy(out, in, len);
             out[len] = '\0';
         }
     }
@@ -528,7 +530,7 @@ int tr_strcmp0(char const* str1, char const* str2)
 {
     if (str1 != nullptr && str2 != nullptr)
     {
-        return strcmp(str1, str2);
+        return std::strcmp(str1, str2);
     }
 
     if (str1 != nullptr)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1555,8 +1555,8 @@ static bool parseNumberSection(char const* str, size_t len, struct number_range*
 
     tr_free(tmp);
 
-    setme->low = MIN(a, b);
-    setme->high = MAX(a, b);
+    setme->low = (int)std::min(a, b);
+    setme->high = (int)std::max(a, b);
 
     errno = error;
     return success;

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -55,7 +55,7 @@ int tr_bencParseInt(void const* vbuf, void const* vbufend, uint8_t const** setme
     void const* begin = buf + 1;
     void const* end = memchr(begin, 'e', (bufend - buf) - 1);
 
-    if (end == NULL)
+    if (end == nullptr)
     {
         return EILSEQ;
     }
@@ -99,7 +99,7 @@ int tr_bencParseStr(
     {
         void const* end = memchr(buf, ':', bufend - buf);
 
-        if (end != NULL)
+        if (end != nullptr)
         {
             errno = 0;
             char* ulend;
@@ -121,15 +121,15 @@ int tr_bencParseStr(
         }
     }
 
-    *setme_end = NULL;
-    *setme_str = NULL;
+    *setme_end = nullptr;
+    *setme_str = nullptr;
     *setme_strlen = 0;
     return EILSEQ;
 }
 
 static tr_variant* get_node(tr_ptrArray* stack, tr_quark* key, tr_variant* top, int* err)
 {
-    tr_variant* node = NULL;
+    tr_variant* node = nullptr;
 
     if (tr_ptrArrayEmpty(stack))
     {
@@ -170,7 +170,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
     auto stack = tr_ptrArray{};
     tr_quark key = 0;
 
-    if ((buf_in == NULL) || (bufend_in == NULL) || (top == NULL))
+    if ((buf_in == nullptr) || (bufend_in == nullptr) || (top == nullptr))
     {
         return EINVAL;
     }
@@ -202,7 +202,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
             buf = end;
 
-            if ((v = get_node(&stack, &key, top, &err)) != NULL)
+            if ((v = get_node(&stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitInt(v, val);
             }
@@ -213,7 +213,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
             ++buf;
 
-            if ((v = get_node(&stack, &key, top, &err)) != NULL)
+            if ((v = get_node(&stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitList(v, 0);
                 tr_ptrArrayAppend(&stack, v);
@@ -225,7 +225,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
             ++buf;
 
-            if ((v = get_node(&stack, &key, top, &err)) != NULL)
+            if ((v = get_node(&stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitDict(v, 0);
                 tr_ptrArrayAppend(&stack, v);
@@ -268,7 +268,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
             {
                 key = tr_quark_new(str, str_len);
             }
-            else if ((v = get_node(&stack, &key, top, &err)) != NULL)
+            else if ((v = get_node(&stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitStr(v, str, str_len);
             }
@@ -291,7 +291,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
     if (err == 0)
     {
-        if (setme_end != NULL)
+        if (setme_end != nullptr)
         {
             *setme_end = (char const*)buf;
         }
@@ -302,7 +302,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
         tr_variantInit(top, 0);
     }
 
-    tr_ptrArrayDestruct(&stack, NULL);
+    tr_ptrArrayDestruct(&stack, nullptr);
     return err;
 }
 
@@ -346,7 +346,7 @@ static void saveStringFunc(tr_variant const* v, void* vevbuf)
     if (!tr_variantGetStr(v, &str, &len))
     {
         len = 0;
-        str = NULL;
+        str = nullptr;
     }
 
     auto* evbuf = static_cast<struct evbuffer*>(vevbuf);

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -54,10 +54,10 @@ static tr_variant* get_node(struct jsonsl_st* jsn)
 {
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
-    auto* parent = static_cast<tr_variant*>(tr_ptrArrayEmpty(&data->stack) ? NULL : tr_ptrArrayBack(&data->stack));
+    auto* parent = static_cast<tr_variant*>(tr_ptrArrayEmpty(&data->stack) ? nullptr : tr_ptrArrayBack(&data->stack));
 
-    tr_variant* node = NULL;
-    if (parent == NULL)
+    tr_variant* node = nullptr;
+    if (parent == nullptr)
     {
         node = data->top;
     }
@@ -65,11 +65,11 @@ static tr_variant* get_node(struct jsonsl_st* jsn)
     {
         node = tr_variantListAdd(parent);
     }
-    else if (tr_variantIsDict(parent) && data->key != NULL)
+    else if (tr_variantIsDict(parent) && data->key != nullptr)
     {
         node = tr_variantDictAdd(parent, tr_quark_new(data->key, data->keylen));
 
-        data->key = NULL;
+        data->key = nullptr;
         data->keylen = 0;
     }
 
@@ -82,7 +82,7 @@ static void error_handler(jsonsl_t jsn, jsonsl_error_t error, struct jsonsl_stat
 
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
-    if (data->source != NULL)
+    if (data->source != nullptr)
     {
         tr_logAddError(
             "JSON parse failed in %s at pos %zu: %s -- remaining text \"%.16s\"",
@@ -135,7 +135,7 @@ static void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t action, struct js
 /* like sscanf(in+2, "%4x", &val) but less slow */
 static bool decode_hex_string(char const* in, unsigned int* setme)
 {
-    TR_ASSERT(in != NULL);
+    TR_ASSERT(in != nullptr);
 
     unsigned int val = 0;
     char const* const end = in + 6;
@@ -290,7 +290,7 @@ static char const* extract_string(jsonsl_t jsn, struct jsonsl_state_st* state, s
     in_end = jsn->base + state->pos_cur;
     in_len = in_end - in_begin;
 
-    if (memchr(in_begin, '\\', in_len) == NULL)
+    if (memchr(in_begin, '\\', in_len) == nullptr)
     {
         /* it's not escaped */
         ret = in_begin;
@@ -338,13 +338,13 @@ static void action_callback_POP(jsonsl_t jsn, jsonsl_action_t action, struct jso
         {
             char const* begin = jsn->base + state->pos_begin;
             data->has_content = true;
-            tr_variantInitReal(get_node(jsn), strtod(begin, NULL));
+            tr_variantInitReal(get_node(jsn), strtod(begin, nullptr));
         }
         else if ((state->special_flags & JSONSL_SPECIALf_NUMERIC) != 0)
         {
             char const* begin = jsn->base + state->pos_begin;
             data->has_content = true;
-            tr_variantInitInt(get_node(jsn), evutil_strtoll(begin, NULL, 10));
+            tr_variantInitInt(get_node(jsn), evutil_strtoll(begin, nullptr, 10));
         }
         else if ((state->special_flags & JSONSL_SPECIALf_BOOLEAN) != 0)
         {
@@ -375,7 +375,7 @@ int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* s
 
     data.error = 0;
     data.has_content = false;
-    data.key = NULL;
+    data.key = nullptr;
     data.top = setme_variant;
     data.stack = {};
     data.source = source;
@@ -396,7 +396,7 @@ int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* s
     }
 
     /* maybe set the end ptr */
-    if (setme_end != NULL)
+    if (setme_end != nullptr)
     {
         *setme_end = ((char const*)vbuf) + jsn->pos;
     }
@@ -405,7 +405,7 @@ int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* s
     error = data.error;
     evbuffer_free(data.keybuf);
     evbuffer_free(data.strbuf);
-    tr_ptrArrayDestruct(&data.stack, NULL);
+    tr_ptrArrayDestruct(&data.stack, nullptr);
     jsonsl_destroy(jsn);
     return error;
 }
@@ -446,7 +446,7 @@ static void jsonIndent(struct jsonWalk* data)
 
 static void jsonChildFunc(struct jsonWalk* data)
 {
-    if (data->parents != NULL && data->parents->data != NULL)
+    if (data->parents != nullptr && data->parents->data != nullptr)
     {
         auto* pstate = static_cast<struct ParentState*>(data->parents->data);
 
@@ -560,7 +560,7 @@ static void jsonStringFunc(tr_variant const* val, void* vdata)
     struct evbuffer_iovec vec[1];
     auto* data = static_cast<struct jsonWalk*>(vdata);
 
-    char const* str = NULL;
+    char const* str = nullptr;
     size_t len = 0;
     (void)tr_variantGetStr(val, &str, &len);
     auto const* it = reinterpret_cast<unsigned char const*>(str);
@@ -709,7 +709,7 @@ void tr_variantToBufJson(tr_variant const* top, struct evbuffer* buf, bool lean)
 
     data.doIndent = !lean;
     data.out = buf;
-    data.parents = NULL;
+    data.parents = nullptr;
 
     tr_variantWalk(top, &walk_funcs, &data, true);
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -70,7 +70,7 @@ static void use_numeric_locale(struct locale_context* context, char const* local
 {
 #ifdef HAVE_USELOCALE
 
-    context->new_locale = newlocale(LC_NUMERIC_MASK, locale_name, NULL);
+    context->new_locale = newlocale(LC_NUMERIC_MASK, locale_name, nullptr);
     context->old_locale = uselocale(context->new_locale);
 
 #else
@@ -80,7 +80,7 @@ static void use_numeric_locale(struct locale_context* context, char const* local
 #endif
 
     context->category = LC_NUMERIC;
-    tr_strlcpy(context->old_locale, setlocale(context->category, NULL), sizeof(context->old_locale));
+    tr_strlcpy(context->old_locale, setlocale(context->category, nullptr), sizeof(context->old_locale));
     setlocale(context->category, locale_name);
 
 #endif
@@ -166,7 +166,7 @@ static char const* tr_variant_string_get_string(struct tr_variant_string const* 
         break;
 
     default:
-        ret = NULL;
+        ret = nullptr;
     }
 
     return ret;
@@ -185,7 +185,7 @@ static void tr_variant_string_set_string(struct tr_variant_string* str, char con
 {
     tr_variant_string_clear(str);
 
-    if (bytes == NULL)
+    if (bytes == nullptr)
     {
         len = 0;
     }
@@ -247,7 +247,7 @@ tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark const key)
 {
     int const i = dictIndexOf(dict, key);
 
-    return i < 0 ? NULL : dict->val.l.vals + i;
+    return i < 0 ? nullptr : dict->val.l.vals + i;
 }
 
 static bool tr_variantDictFindType(tr_variant* dict, tr_quark const key, int type, tr_variant** setme)
@@ -263,7 +263,7 @@ size_t tr_variantListSize(tr_variant const* list)
 
 tr_variant* tr_variantListChild(tr_variant* v, size_t i)
 {
-    tr_variant* ret = NULL;
+    tr_variant* ret = nullptr;
 
     if (tr_variantIsList(v) && i < v->val.l.count)
     {
@@ -294,7 +294,7 @@ bool tr_variantGetInt(tr_variant const* v, int64_t* setme)
 
     if (tr_variantIsInt(v))
     {
-        if (setme != NULL)
+        if (setme != nullptr)
         {
             *setme = v->val.i;
         }
@@ -304,7 +304,7 @@ bool tr_variantGetInt(tr_variant const* v, int64_t* setme)
 
     if (!success && tr_variantIsBool(v))
     {
-        if (setme != NULL)
+        if (setme != nullptr)
         {
             *setme = v->val.b ? 1 : 0;
         }
@@ -324,7 +324,7 @@ bool tr_variantGetStr(tr_variant const* v, char const** setme, size_t* len)
         *setme = getStr(v);
     }
 
-    if (len != NULL)
+    if (len != nullptr)
     {
         *len = success ? v->val.s.len : 0;
     }
@@ -362,7 +362,7 @@ bool tr_variantGetBool(tr_variant const* v, bool* setme)
         success = true;
     }
 
-    if ((!success) && tr_variantGetStr(v, &str, NULL) && (strcmp(str, "true") == 0 || strcmp(str, "false") == 0))
+    if ((!success) && tr_variantGetStr(v, &str, nullptr) && (strcmp(str, "true") == 0 || strcmp(str, "false") == 0))
     {
         *setme = strcmp(str, "true") == 0;
         success = true;
@@ -622,12 +622,12 @@ static tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark const key, int type)
     tr_variant* child;
 
     /* see if it already exists, and if so, try to reuse it */
-    if ((child = tr_variantDictFind(dict, key)) != NULL)
+    if ((child = tr_variantDictFind(dict, key)) != nullptr)
     {
         if (!tr_variantIsType(child, type))
         {
             tr_variantDictRemove(dict, key);
-            child = NULL;
+            child = nullptr;
         }
         else if (child->type == TR_VARIANT_TYPE_STR)
         {
@@ -636,7 +636,7 @@ static tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark const key, int type)
     }
 
     /* if it doesn't exist, create it */
-    if (child == NULL)
+    if (child == nullptr)
     {
         child = tr_variantDictAdd(dict, key);
     }
@@ -774,7 +774,7 @@ static void nodeConstruct(struct SaveNode* node, tr_variant const* v, bool sort_
         for (size_t i = 0; i < n; i++)
         {
             tmp[i].val = v->val.l.vals + i;
-            tmp[i].keystr = tr_quark_get_string(tmp[i].val->key, NULL);
+            tmp[i].keystr = tr_quark_get_string(tmp[i].val->key, nullptr);
         }
 
         qsort(tmp, n, sizeof(struct KeyIndex), compareKeyIndex);
@@ -795,7 +795,7 @@ static void nodeConstruct(struct SaveNode* node, tr_variant const* v, bool sort_
     }
     else
     {
-        node->sorted = NULL;
+        node->sorted = nullptr;
     }
 
     node->v = v;
@@ -803,9 +803,9 @@ static void nodeConstruct(struct SaveNode* node, tr_variant const* v, bool sort_
 
 static void nodeDestruct(struct SaveNode* node)
 {
-    TR_ASSERT(node != NULL);
+    TR_ASSERT(node != nullptr);
 
-    if (node->sorted != NULL)
+    if (node->sorted != nullptr)
     {
         tr_free(node->sorted->val.l.vals);
         tr_free(node->sorted);
@@ -861,7 +861,7 @@ void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkF
             continue;
         }
 
-        if (v != NULL)
+        if (v != nullptr)
         {
             switch (v->type)
             {
@@ -966,7 +966,7 @@ void tr_variantFree(tr_variant* v)
 {
     if (tr_variantIsSomething(v))
     {
-        tr_variantWalk(v, &freeWalkFuncs, NULL, false);
+        tr_variantWalk(v, &freeWalkFuncs, nullptr, false);
     }
 }
 
@@ -979,7 +979,7 @@ static void tr_variantListCopy(tr_variant* target, tr_variant const* src)
     int i = 0;
     tr_variant const* val;
 
-    while ((val = tr_variantListChild((tr_variant*)src, i)) != NULL)
+    while ((val = tr_variantListChild((tr_variant*)src, i)) != nullptr)
     {
         if (tr_variantIsBool(val))
         {
@@ -1002,7 +1002,7 @@ static void tr_variantListCopy(tr_variant* target, tr_variant const* src)
         else if (tr_variantIsString(val))
         {
             size_t len = 0;
-            char const* str = NULL;
+            char const* str = nullptr;
             (void)tr_variantGetStr(val, &str, &len);
             tr_variantListAddRaw(target, str, len);
         }
@@ -1089,7 +1089,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             else if (tr_variantIsString(val))
             {
                 size_t len = 0;
-                char const* str = NULL;
+                char const* str = nullptr;
                 (void)tr_variantGetStr(val, &str, &len);
                 tr_variantDictAddRaw(target, key, str, len);
             }
@@ -1099,7 +1099,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             }
             else if (tr_variantIsList(val))
             {
-                if (tr_variantDictFind(target, key) == NULL)
+                if (tr_variantDictFind(target, key) == nullptr)
                 {
                     tr_variantListCopy(tr_variantDictAddList(target, key, tr_variantListSize(val)), val);
                 }
@@ -1108,7 +1108,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             {
                 tr_variant* target_dict = tr_variantDictFind(target, key);
 
-                if (target_dict == NULL)
+                if (target_dict == nullptr)
                 {
                     target_dict = tr_variantDictAddDict(target, key, tr_variantDictSize(val));
                 }
@@ -1120,7 +1120,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
             }
             else
             {
-                tr_logAddDebug("tr_variantMergeDicts skipping \"%s\"", tr_quark_get_string(key, NULL));
+                tr_logAddDebug("tr_variantMergeDicts skipping \"%s\"", tr_quark_get_string(key, nullptr));
             }
         }
     }
@@ -1177,7 +1177,7 @@ static int writeVariantToFd(tr_variant const* v, tr_variant_fmt fmt, tr_sys_file
     {
         uint64_t n = 0;
 
-        tr_error* tmperr = NULL;
+        tr_error* tmperr = nullptr;
         if (!tr_sys_file_write(fd, walk, nleft, &n, &tmperr))
         {
             err = tmperr->code;
@@ -1197,27 +1197,27 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
 {
     /* follow symlinks to find the "real" file, to make sure the temporary
      * we build with tr_sys_file_open_temp() is created on the right partition */
-    char* real_filename = tr_sys_path_resolve(filename, NULL);
-    if (real_filename != NULL)
+    char* real_filename = tr_sys_path_resolve(filename, nullptr);
+    if (real_filename != nullptr)
     {
         filename = real_filename;
     }
 
     /* if the file already exists, try to move it out of the way & keep it as a backup */
     char* const tmp = tr_strdup_printf("%s.tmp.XXXXXX", filename);
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
     tr_sys_file_t const fd = tr_sys_file_open_temp(tmp, &error);
 
     int err = 0;
     if (fd != TR_BAD_SYS_FILE)
     {
         err = writeVariantToFd(v, fmt, fd, &error);
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
 
         if (err)
         {
             tr_logAddError(_("Couldn't save temporary file \"%1$s\": %2$s"), tmp, error->message);
-            tr_sys_path_remove(tmp, NULL);
+            tr_sys_path_remove(tmp, nullptr);
             tr_error_free(error);
         }
         else
@@ -1232,7 +1232,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
             {
                 err = error->code;
                 tr_logAddError(_("Couldn't save file \"%1$s\": %2$s"), filename, error->message);
-                tr_sys_path_remove(tmp, NULL);
+                tr_sys_path_remove(tmp, nullptr);
                 tr_error_free(error);
             }
         }
@@ -1261,9 +1261,9 @@ bool tr_variantFromFile(tr_variant* setme, tr_variant_fmt fmt, char const* filen
 
     buf = tr_loadFile(filename, &buflen, error);
 
-    if (buf != NULL)
+    if (buf != nullptr)
     {
-        if (tr_variantFromBuf(setme, fmt, buf, buflen, filename, NULL) == 0)
+        if (tr_variantFromBuf(setme, fmt, buf, buflen, filename, nullptr) == 0)
         {
             ret = true;
         }

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -6,8 +6,9 @@
  *
  */
 
-#include <string.h> /* memcmp() */
-#include <stdlib.h> /* free() */
+#include <cstring> /* memcmp() */
+#include <cstdlib> /* free() */
+#include <algorithm>
 
 #include "transmission.h"
 #include "completion.h"
@@ -76,8 +77,8 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         /* figure out how much we can read this pass */
         leftInPiece = tr_torPieceCountBytes(tor, pieceIndex) - piecePos;
         leftInFile = file->length - filePos;
-        bytesThisPass = MIN(leftInFile, leftInPiece);
-        bytesThisPass = MIN(bytesThisPass, buflen);
+        bytesThisPass = std::min(leftInFile, leftInPiece);
+        bytesThisPass = std::min(bytesThisPass, buflen);
 
         /* read a bit */
         if (fd != TR_BAD_SYS_FILE)

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -67,8 +67,8 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         if (filePos == 0 && fd == TR_BAD_SYS_FILE && fileIndex != prevFileIndex)
         {
             char* filename = tr_torrentFindFile(tor, fileIndex);
-            fd = filename == NULL ? TR_BAD_SYS_FILE :
-                                    tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, NULL);
+            fd = filename == nullptr ? TR_BAD_SYS_FILE :
+                                    tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
             tr_free(filename);
             prevFileIndex = fileIndex;
         }
@@ -84,11 +84,11 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         {
             uint64_t numRead;
 
-            if (tr_sys_file_read_at(fd, buffer, bytesThisPass, filePos, &numRead, NULL) && numRead > 0)
+            if (tr_sys_file_read_at(fd, buffer, bytesThisPass, filePos, &numRead, nullptr) && numRead > 0)
             {
                 bytesThisPass = numRead;
                 tr_sha1_update(sha, buffer, bytesThisPass);
-                tr_sys_file_advise(fd, filePos, bytesThisPass, TR_SYS_FILE_ADVICE_DONT_NEED, NULL);
+                tr_sys_file_advise(fd, filePos, bytesThisPass, TR_SYS_FILE_ADVICE_DONT_NEED, nullptr);
             }
         }
 
@@ -136,7 +136,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         {
             if (fd != TR_BAD_SYS_FILE)
             {
-                tr_sys_file_close(fd, NULL);
+                tr_sys_file_close(fd, nullptr);
                 fd = TR_BAD_SYS_FILE;
             }
 
@@ -148,10 +148,10 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
     /* cleanup */
     if (fd != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(fd, NULL);
+        tr_sys_file_close(fd, nullptr);
     }
 
-    tr_sha1_final(sha, NULL);
+    tr_sha1_final(sha, nullptr);
     free(buffer);
 
     /* stopwatch */
@@ -179,15 +179,15 @@ struct verify_node
 };
 
 static struct verify_node currentNode;
-static tr_list* verifyList = NULL;
-static tr_thread* verifyThread = NULL;
+static tr_list* verifyList = nullptr;
+static tr_thread* verifyThread = nullptr;
 static bool stopCurrent = false;
 
 static tr_lock* getVerifyLock(void)
 {
-    static tr_lock* lock = NULL;
+    static tr_lock* lock = nullptr;
 
-    if (lock == NULL)
+    if (lock == nullptr)
     {
         lock = tr_lockNew();
     }
@@ -206,11 +206,11 @@ static void verifyThreadFunc(void* user_data)
 
         tr_lockLock(getVerifyLock());
         stopCurrent = false;
-        auto* node = static_cast<struct verify_node*>(verifyList != NULL ? verifyList->data : NULL);
+        auto* node = static_cast<struct verify_node*>(verifyList != nullptr ? verifyList->data : nullptr);
 
-        if (node == NULL)
+        if (node == nullptr)
         {
-            currentNode.torrent = NULL;
+            currentNode.torrent = nullptr;
             break;
         }
 
@@ -231,13 +231,13 @@ static void verifyThreadFunc(void* user_data)
             tr_torrentSetDirty(tor);
         }
 
-        if (currentNode.callback_func != NULL)
+        if (currentNode.callback_func != nullptr)
         {
             (*currentNode.callback_func)(tor, stopCurrent, currentNode.callback_data);
         }
     }
 
-    verifyThread = NULL;
+    verifyThread = nullptr;
     tr_lockUnlock(getVerifyLock());
 }
 
@@ -284,9 +284,9 @@ void tr_verifyAdd(tr_torrent* tor, tr_verify_done_func callback_func, void* call
     tr_torrentSetVerifyState(tor, TR_VERIFY_WAIT);
     tr_list_insert_sorted(&verifyList, node, compareVerifyByPriorityAndSize);
 
-    if (verifyThread == NULL)
+    if (verifyThread == nullptr)
     {
-        verifyThread = tr_threadNew(verifyThreadFunc, NULL);
+        verifyThread = tr_threadNew(verifyThreadFunc, nullptr);
     }
 
     tr_lockUnlock(getVerifyLock());
@@ -323,9 +323,9 @@ void tr_verifyRemove(tr_torrent* tor)
 
         tr_torrentSetVerifyState(tor, TR_VERIFY_NONE);
 
-        if (node != NULL)
+        if (node != nullptr)
         {
-            if (node->callback_func != NULL)
+            if (node->callback_func != nullptr)
             {
                 (*node->callback_func)(tor, true, node->callback_data);
             }

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -68,7 +68,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         {
             char* filename = tr_torrentFindFile(tor, fileIndex);
             fd = filename == nullptr ? TR_BAD_SYS_FILE :
-                                    tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
+                                       tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
             tr_free(filename);
             prevFileIndex = fileIndex;
         }

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -64,14 +64,14 @@ static void tr_watchdir_generic_free(tr_watchdir_backend* backend_base)
 {
     tr_watchdir_generic* const backend = BACKEND_UPCAST(backend_base);
 
-    if (backend == NULL)
+    if (backend == nullptr)
     {
         return;
     }
 
     TR_ASSERT(backend->base.free_func == &tr_watchdir_generic_free);
 
-    if (backend->event != NULL)
+    if (backend->event != nullptr)
     {
         event_del(backend->event);
         event_free(backend->event);
@@ -91,7 +91,7 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
 
     if ((backend
              ->event = event_new(tr_watchdir_get_event_base(handle), -1, EV_PERSIST, &tr_watchdir_generic_on_event, handle)) ==
-        NULL)
+        nullptr)
     {
         log_error("Failed to create event: %s", tr_strerror(errno));
         goto FAIL;
@@ -110,5 +110,5 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
 
 FAIL:
     tr_watchdir_generic_free(BACKEND_DOWNCAST(backend));
-    return NULL;
+    return nullptr;
 }

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -62,12 +62,12 @@ static void tr_watchdir_inotify_on_first_scan(evutil_socket_t fd, short type, vo
 
     auto const handle = static_cast<tr_watchdir_t>(context);
 
-    tr_watchdir_scan(handle, NULL);
+    tr_watchdir_scan(handle, nullptr);
 }
 
 static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* context)
 {
-    TR_ASSERT(context != NULL);
+    TR_ASSERT(context != nullptr);
 
     auto const handle = static_cast<tr_watchdir_t>(context);
 #ifdef TR_ENABLE_ASSERTS
@@ -127,14 +127,14 @@ static void tr_watchdir_inotify_free(tr_watchdir_backend* backend_base)
 {
     tr_watchdir_inotify* const backend = BACKEND_UPCAST(backend_base);
 
-    if (backend == NULL)
+    if (backend == nullptr)
     {
         return;
     }
 
     TR_ASSERT(backend->base.free_func == &tr_watchdir_inotify_free);
 
-    if (backend->event != NULL)
+    if (backend->event != nullptr)
     {
         bufferevent_disable(backend->event, EV_READ);
         bufferevent_free(backend->event);
@@ -175,7 +175,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
         goto FAIL;
     }
 
-    if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->infd, 0)) == NULL)
+    if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->infd, 0)) == nullptr)
     {
         log_error("Failed to create event buffer: %s", tr_strerror(errno));
         goto FAIL;
@@ -184,11 +184,11 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
     /* Guarantees at least the sizeof an inotify event will be available in the
        event buffer */
     bufferevent_setwatermark(backend->event, EV_READ, sizeof(struct inotify_event), 0);
-    bufferevent_setcb(backend->event, &tr_watchdir_inotify_on_event, NULL, NULL, handle);
+    bufferevent_setcb(backend->event, &tr_watchdir_inotify_on_event, nullptr, nullptr, handle);
     bufferevent_enable(backend->event, EV_READ);
 
     /* Perform an initial scan on the directory */
-    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_inotify_on_first_scan, handle, NULL) ==
+    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_inotify_on_first_scan, handle, nullptr) ==
         -1)
     {
         log_error("Failed to perform initial scan: %s", tr_strerror(errno));
@@ -198,5 +198,5 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
 
 FAIL:
     tr_watchdir_inotify_free(BACKEND_DOWNCAST(backend));
-    return NULL;
+    return nullptr;
 }

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -188,8 +188,13 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
     bufferevent_enable(backend->event, EV_READ);
 
     /* Perform an initial scan on the directory */
-    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_inotify_on_first_scan, handle, nullptr) ==
-        -1)
+    if (event_base_once(
+            tr_watchdir_get_event_base(handle),
+            -1,
+            EV_TIMEOUT,
+            &tr_watchdir_inotify_on_first_scan,
+            handle,
+            nullptr) == -1)
     {
         log_error("Failed to perform initial scan: %s", tr_strerror(errno));
     }

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -138,7 +138,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
     }
 
     /* Register kevent filter with kqueue descriptor */
-    EV_SET(&ke, backend->dirfd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, KQUEUE_WATCH_MASK, 0, nullptr);
+    EV_SET(&ke, backend->dirfd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, KQUEUE_WATCH_MASK, 0, NULL);
 
     if (kevent(backend->kq, &ke, 1, nullptr, 0, nullptr) == -1)
     {

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -71,7 +71,7 @@ static void tr_watchdir_kqueue_on_event(evutil_socket_t fd, short type, void* co
     struct kevent ke;
     auto ts = timespec{};
 
-    if (kevent(backend->kq, NULL, 0, &ke, 1, &ts) == -1)
+    if (kevent(backend->kq, nullptr, 0, &ke, 1, &ts) == -1)
     {
         log_error("Failed to fetch kevent: %s", tr_strerror(errno));
         return;
@@ -85,14 +85,14 @@ static void tr_watchdir_kqueue_free(tr_watchdir_backend* backend_base)
 {
     tr_watchdir_kqueue* const backend = BACKEND_UPCAST(backend_base);
 
-    if (backend == NULL)
+    if (backend == nullptr)
     {
         return;
     }
 
     TR_ASSERT(backend->base.free_func == &tr_watchdir_kqueue_free);
 
-    if (backend->event != NULL)
+    if (backend->event != nullptr)
     {
         event_del(backend->event);
         event_free(backend->event);
@@ -138,9 +138,9 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
     }
 
     /* Register kevent filter with kqueue descriptor */
-    EV_SET(&ke, backend->dirfd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, KQUEUE_WATCH_MASK, 0, NULL);
+    EV_SET(&ke, backend->dirfd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR, KQUEUE_WATCH_MASK, 0, nullptr);
 
-    if (kevent(backend->kq, &ke, 1, NULL, 0, NULL) == -1)
+    if (kevent(backend->kq, &ke, 1, nullptr, 0, nullptr) == -1)
     {
         log_error("Failed to set directory event filter with fd %d: %s", backend->kq, tr_strerror(errno));
         goto fail;
@@ -152,13 +152,13 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
              backend->kq,
              EV_READ | EV_ET | EV_PERSIST,
              &tr_watchdir_kqueue_on_event,
-             handle)) == NULL)
+             handle)) == nullptr)
     {
         log_error("Failed to create event: %s", tr_strerror(errno));
         goto fail;
     }
 
-    if (event_add(backend->event, NULL) == -1)
+    if (event_add(backend->event, nullptr) == -1)
     {
         log_error("Failed to add event: %s", tr_strerror(errno));
         goto fail;
@@ -171,5 +171,5 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
 
 fail:
     tr_watchdir_kqueue_free(BACKEND_DOWNCAST(backend));
-    return NULL;
+    return nullptr;
 }

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -69,7 +69,7 @@ static BOOL tr_get_overlapped_result_ex(
 {
     typedef BOOL(WINAPI * impl_t)(HANDLE, LPOVERLAPPED, LPDWORD, DWORD, BOOL);
 
-    static impl_t real_impl = NULL;
+    static impl_t real_impl = nullptr;
     static bool is_real_impl_valid = false;
 
     if (!is_real_impl_valid)
@@ -78,7 +78,7 @@ static BOOL tr_get_overlapped_result_ex(
         is_real_impl_valid = true;
     }
 
-    if (real_impl != NULL)
+    if (real_impl != nullptr)
     {
         return (*real_impl)(handle, overlapped, bytes_transferred, timeout, alertable);
     }
@@ -126,9 +126,9 @@ static unsigned int __stdcall tr_watchdir_win32_thread(void* context)
                 sizeof(backend->buffer),
                 FALSE,
                 WIN32_WATCH_MASK,
-                NULL,
+                nullptr,
                 &backend->overlapped,
-                NULL))
+                nullptr))
         {
             log_error("Failed to read directory changes");
             return 0;
@@ -150,7 +150,7 @@ static void tr_watchdir_win32_on_first_scan(evutil_socket_t fd, short type, void
 
     auto const handle = static_cast<tr_watchdir_t>(context);
 
-    tr_watchdir_scan(handle, NULL);
+    tr_watchdir_scan(handle, nullptr);
 }
 
 static void tr_watchdir_win32_on_event(struct bufferevent* event, void* context)
@@ -208,7 +208,7 @@ static void tr_watchdir_win32_on_event(struct bufferevent* event, void* context)
         {
             char* name = tr_win32_native_to_utf8(ev->FileName, ev->FileNameLength / sizeof(WCHAR));
 
-            if (name != NULL)
+            if (name != nullptr)
             {
                 tr_watchdir_process(handle, name);
                 tr_free(name);
@@ -223,7 +223,7 @@ static void tr_watchdir_win32_free(tr_watchdir_backend* backend_base)
 {
     tr_watchdir_win32* const backend = BACKEND_UPCAST(backend_base);
 
-    if (backend == NULL)
+    if (backend == nullptr)
     {
         return;
     }
@@ -235,13 +235,13 @@ static void tr_watchdir_win32_free(tr_watchdir_backend* backend_base)
         CancelIoEx(backend->fd, &backend->overlapped);
     }
 
-    if (backend->thread != NULL)
+    if (backend->thread != nullptr)
     {
         WaitForSingleObject(backend->thread, INFINITE);
         CloseHandle(backend->thread);
     }
 
-    if (backend->event != NULL)
+    if (backend->event != nullptr)
     {
         bufferevent_free(backend->event);
     }
@@ -275,7 +275,7 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
     backend->fd = INVALID_HANDLE_VALUE;
     backend->notify_pipe[0] = backend->notify_pipe[1] = TR_BAD_SOCKET;
 
-    if ((wide_path = tr_win32_utf8_to_native(path, -1)) == NULL)
+    if ((wide_path = tr_win32_utf8_to_native(path, -1)) == nullptr)
     {
         log_error("Failed to convert \"%s\" to native path", path);
         goto fail;
@@ -285,17 +285,17 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
              wide_path,
              FILE_LIST_DIRECTORY,
              FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-             NULL,
+             nullptr,
              OPEN_EXISTING,
              FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
-             NULL)) == INVALID_HANDLE_VALUE)
+             nullptr)) == INVALID_HANDLE_VALUE)
     {
         log_error("Failed to open directory \"%s\"", path);
         goto fail;
     }
 
     tr_free(wide_path);
-    wide_path = NULL;
+    wide_path = nullptr;
 
     backend->overlapped.Pointer = handle;
 
@@ -305,9 +305,9 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
             sizeof(backend->buffer),
             FALSE,
             WIN32_WATCH_MASK,
-            NULL,
+            nullptr,
             &backend->overlapped,
-            NULL))
+            nullptr))
     {
         log_error("Failed to read directory changes");
         goto fail;
@@ -319,24 +319,24 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
         goto fail;
     }
 
-    if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->notify_pipe[0], 0)) == NULL)
+    if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->notify_pipe[0], 0)) == nullptr)
     {
         log_error("Failed to create event buffer: %s", tr_strerror(errno));
         goto fail;
     }
 
     bufferevent_setwatermark(backend->event, EV_READ, sizeof(FILE_NOTIFY_INFORMATION), 0);
-    bufferevent_setcb(backend->event, &tr_watchdir_win32_on_event, NULL, NULL, handle);
+    bufferevent_setcb(backend->event, &tr_watchdir_win32_on_event, nullptr, nullptr, handle);
     bufferevent_enable(backend->event, EV_READ);
 
-    if ((backend->thread = (HANDLE)_beginthreadex(NULL, 0, &tr_watchdir_win32_thread, handle, 0, NULL)) == NULL)
+    if ((backend->thread = (HANDLE)_beginthreadex(nullptr, 0, &tr_watchdir_win32_thread, handle, 0, nullptr)) == nullptr)
     {
         log_error("Failed to create thread");
         goto fail;
     }
 
     /* Perform an initial scan on the directory */
-    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_win32_on_first_scan, handle, NULL) ==
+    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_win32_on_first_scan, handle, nullptr) ==
         -1)
     {
         log_error("Failed to perform initial scan: %s", tr_strerror(errno));
@@ -347,5 +347,5 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
 fail:
     tr_watchdir_win32_free(BACKEND_DOWNCAST(backend));
     tr_free(wide_path);
-    return NULL;
+    return nullptr;
 }

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -336,8 +336,13 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
     }
 
     /* Perform an initial scan on the directory */
-    if (event_base_once(tr_watchdir_get_event_base(handle), -1, EV_TIMEOUT, &tr_watchdir_win32_on_first_scan, handle, nullptr) ==
-        -1)
+    if (event_base_once(
+            tr_watchdir_get_event_base(handle),
+            -1,
+            EV_TIMEOUT,
+            &tr_watchdir_win32_on_first_scan,
+            handle,
+            nullptr) == -1)
     {
         log_error("Failed to perform initial scan: %s", tr_strerror(errno));
     }

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -54,13 +54,13 @@ struct tr_watchdir
 
 static bool is_regular_file(char const* dir, char const* name)
 {
-    char* const path = tr_buildPath(dir, name, NULL);
+    char* const path = tr_buildPath(dir, name, nullptr);
     auto path_info = tr_sys_path_info{};
-    tr_error* error = NULL;
+    tr_error* error = nullptr;
 
     bool const ret = tr_sys_path_get_info(path, 0, &path_info, &error) && (path_info.type == TR_SYS_PATH_IS_FILE);
 
-    if (error != NULL)
+    if (error != nullptr)
     {
         if (!TR_ERROR_IS_ENOENT(error->code))
         {
@@ -145,7 +145,7 @@ static void tr_watchdir_on_retry_timer(evutil_socket_t fd, short type, void* con
     TR_UNUSED(fd);
     TR_UNUSED(type);
 
-    TR_ASSERT(context != NULL);
+    TR_ASSERT(context != nullptr);
 
     auto* const retry = static_cast<tr_watchdir_retry*>(context);
     tr_watchdir_t const handle = retry->handle;
@@ -190,12 +190,12 @@ static tr_watchdir_retry* tr_watchdir_retry_new(tr_watchdir_t handle, char const
 
 static void tr_watchdir_retry_free(tr_watchdir_retry* retry)
 {
-    if (retry == NULL)
+    if (retry == nullptr)
     {
         return;
     }
 
-    if (retry->timer != NULL)
+    if (retry->timer != nullptr)
     {
         evtimer_del(retry->timer);
         event_free(retry->timer);
@@ -207,7 +207,7 @@ static void tr_watchdir_retry_free(tr_watchdir_retry* retry)
 
 static void tr_watchdir_retry_restart(tr_watchdir_retry* retry)
 {
-    TR_ASSERT(retry != NULL);
+    TR_ASSERT(retry != nullptr);
 
     evtimer_del(retry->timer);
 
@@ -237,7 +237,7 @@ tr_watchdir_t tr_watchdir_new(
     handle->event_base = event_base;
     tr_watchdir_retries_init(&handle->active_retries);
 
-    if (!force_generic && (handle->backend == NULL))
+    if (!force_generic && (handle->backend == nullptr))
     {
 #if defined(WITH_INOTIFY)
         handle->backend = tr_watchdir_inotify_new(handle);
@@ -248,19 +248,19 @@ tr_watchdir_t tr_watchdir_new(
 #endif
     }
 
-    if (handle->backend == NULL)
+    if (handle->backend == nullptr)
     {
         handle->backend = tr_watchdir_generic_new(handle);
     }
 
-    if (handle->backend == NULL)
+    if (handle->backend == nullptr)
     {
         tr_watchdir_free(handle);
-        handle = NULL;
+        handle = nullptr;
     }
     else
     {
-        TR_ASSERT(handle->backend->free_func != NULL);
+        TR_ASSERT(handle->backend->free_func != nullptr);
     }
 
     return handle;
@@ -268,14 +268,14 @@ tr_watchdir_t tr_watchdir_new(
 
 void tr_watchdir_free(tr_watchdir_t handle)
 {
-    if (handle == NULL)
+    if (handle == nullptr)
     {
         return;
     }
 
     tr_watchdir_retries_destroy(&handle->active_retries);
 
-    if (handle->backend != NULL)
+    if (handle->backend != nullptr)
     {
         handle->backend->free_func(handle->backend);
     }
@@ -286,21 +286,21 @@ void tr_watchdir_free(tr_watchdir_t handle)
 
 char const* tr_watchdir_get_path(tr_watchdir_t handle)
 {
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     return handle->path;
 }
 
 tr_watchdir_backend* tr_watchdir_get_backend(tr_watchdir_t handle)
 {
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     return handle->backend;
 }
 
 struct event_base* tr_watchdir_get_event_base(tr_watchdir_t handle)
 {
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     return handle->event_base;
 }
@@ -311,7 +311,7 @@ struct event_base* tr_watchdir_get_event_base(tr_watchdir_t handle)
 
 void tr_watchdir_process(tr_watchdir_t handle, char const* name)
 {
-    TR_ASSERT(handle != NULL);
+    TR_ASSERT(handle != nullptr);
 
     auto const search_key = tr_watchdir_retry{ {}, const_cast<char*>(name), {}, {}, {} };
     auto* existing_retry = static_cast<tr_watchdir_retry*>(tr_watchdir_retries_find(&handle->active_retries, &search_key));
@@ -333,8 +333,8 @@ void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
     tr_sys_dir_t dir;
     char const* name;
     auto new_dir_entries = tr_ptrArray{};
-    PtrArrayCompareFunc const name_compare_func = (PtrArrayCompareFunc)&strcmp;
-    tr_error* error = NULL;
+    auto const name_compare_func = (PtrArrayCompareFunc)&strcmp;
+    tr_error* error = nullptr;
 
     if ((dir = tr_sys_dir_open(handle->path, &error)) == TR_BAD_SYS_DIR)
     {
@@ -343,18 +343,18 @@ void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
         return;
     }
 
-    while ((name = tr_sys_dir_read_name(dir, &error)) != NULL)
+    while ((name = tr_sys_dir_read_name(dir, &error)) != nullptr)
     {
         if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
         {
             continue;
         }
 
-        if (dir_entries != NULL)
+        if (dir_entries != nullptr)
         {
             tr_ptrArrayInsertSorted(&new_dir_entries, tr_strdup(name), name_compare_func);
 
-            if (tr_ptrArrayFindSorted(dir_entries, name, name_compare_func) != NULL)
+            if (tr_ptrArrayFindSorted(dir_entries, name, name_compare_func) != nullptr)
             {
                 continue;
             }
@@ -363,15 +363,15 @@ void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
         tr_watchdir_process(handle, name);
     }
 
-    if (error != NULL)
+    if (error != nullptr)
     {
         log_error("Failed to read directory \"%s\" (%d): %s", handle->path, error->code, error->message);
         tr_error_free(error);
     }
 
-    tr_sys_dir_close(dir, NULL);
+    tr_sys_dir_close(dir, nullptr);
 
-    if (dir_entries != NULL)
+    if (dir_entries != nullptr)
     {
         tr_ptrArrayDestruct(dir_entries, &tr_free);
         *dir_entries = new_dir_entries;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* strlen(), strstr() */
+#include <cstring> /* strlen(), strstr() */
+#include <algorithm>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -541,7 +542,7 @@ static void tr_webThreadFunc(void* vsession)
                     /* curl_multi_wait() returns immediately if there are
                      * no fds to wait for, so we need an explicit wait here
                      * to emulate select() behavior */
-                    tr_wait_msec(MIN(msec, THREADFUNC_MAX_SLEEP_MSEC / 2));
+                    tr_wait_msec(std::min(msec, THREADFUNC_MAX_SLEEP_MSEC / 2L));
                 }
             }
             else

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -73,7 +73,7 @@ struct tr_web_task
 
 static void task_free(struct tr_web_task* task)
 {
-    if (task->freebuf != NULL)
+    if (task->freebuf != nullptr)
     {
         evbuffer_free(task->freebuf);
     }
@@ -88,7 +88,7 @@ static void task_free(struct tr_web_task* task)
 ****
 ***/
 
-static tr_list* paused_easy_handles = NULL;
+static tr_list* paused_easy_handles = nullptr;
 
 struct tr_web
 {
@@ -115,7 +115,7 @@ static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
     {
         tr_torrent const* const tor = tr_torrentFindFromId(task->session, task->torrentId);
 
-        if (tor != NULL && tr_bandwidthClamp(&tor->bandwidth, TR_DOWN, nmemb) == 0)
+        if (tor != nullptr && tr_bandwidthClamp(&tor->bandwidth, TR_DOWN, nmemb) == 0)
         {
             tr_list_append(&paused_easy_handles, task->curl_easy);
             return CURL_WRITEFUNC_PAUSE;
@@ -134,8 +134,8 @@ static int sockoptfunction(void* vtask, curl_socket_t fd, curlsocktype purpose)
     TR_UNUSED(purpose);
 
     auto* task = static_cast<struct tr_web_task*>(vtask);
-    bool const isScrape = strstr(task->url, "scrape") != NULL;
-    bool const isAnnounce = strstr(task->url, "announce") != NULL;
+    bool const isScrape = strstr(task->url, "scrape") != nullptr;
+    bool const isAnnounce = strstr(task->url, "announce") != nullptr;
 
     /* announce and scrape requests have tiny payloads. */
     if (isScrape || isAnnounce)
@@ -160,7 +160,7 @@ static CURLcode ssl_context_func(CURL* curl, void* ssl_ctx, void* user_data)
     TR_UNUSED(user_data);
 
     tr_x509_store_t const cert_store = tr_ssl_get_x509_store(ssl_ctx);
-    if (cert_store == NULL)
+    if (cert_store == nullptr)
     {
         return CURLE_OK;
     }
@@ -181,23 +181,23 @@ static CURLcode ssl_context_func(CURL* curl, void* ssl_ctx, void* user_data)
     for (size_t i = 0; i < TR_N_ELEMENTS(sys_store_names); ++i)
     {
         HCERTSTORE const sys_cert_store = CertOpenSystemStoreW(0, sys_store_names[i]);
-        if (sys_cert_store == NULL)
+        if (sys_cert_store == nullptr)
         {
             continue;
         }
 
-        PCCERT_CONTEXT sys_cert = NULL;
+        PCCERT_CONTEXT sys_cert = nullptr;
 
         while (true)
         {
-            sys_cert = CertFindCertificateInStore(sys_cert_store, X509_ASN_ENCODING, 0, CERT_FIND_ANY, NULL, sys_cert);
-            if (sys_cert == NULL)
+            sys_cert = CertFindCertificateInStore(sys_cert_store, X509_ASN_ENCODING, 0, CERT_FIND_ANY, nullptr, sys_cert);
+            if (sys_cert == nullptr)
             {
                 break;
             }
 
             tr_x509_cert_t const cert = tr_x509_cert_new(sys_cert->pbCertEncoded, sys_cert->cbCertEncoded);
-            if (cert == NULL)
+            if (cert == nullptr)
             {
                 continue;
             }
@@ -219,15 +219,15 @@ static long getTimeoutFromURL(struct tr_web_task const* task)
     long timeout;
     tr_session const* session = task->session;
 
-    if (session == NULL || session->isClosed)
+    if (session == nullptr || session->isClosed)
     {
         timeout = 20L;
     }
-    else if (strstr(task->url, "scrape") != NULL)
+    else if (strstr(task->url, "scrape") != nullptr)
     {
         timeout = 30L;
     }
-    else if (strstr(task->url, "announce") != NULL)
+    else if (strstr(task->url, "announce") != nullptr)
     {
         timeout = 90L;
     }
@@ -262,7 +262,7 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
 
     if (web->curl_ssl_verify)
     {
-        if (web->curl_ca_bundle != NULL)
+        if (web->curl_ca_bundle != nullptr)
         {
             curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
         }
@@ -284,26 +284,26 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
     curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
     curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);
 
-    if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET, &is_default_value)) != NULL && !is_default_value)
+    if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET, &is_default_value)) != nullptr && !is_default_value)
     {
         curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
     }
-    else if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, &is_default_value)) != NULL && !is_default_value)
+    else if ((addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, &is_default_value)) != nullptr && !is_default_value)
     {
         curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
     }
 
-    if (task->cookies != NULL)
+    if (task->cookies != nullptr)
     {
         curl_easy_setopt(e, CURLOPT_COOKIE, task->cookies);
     }
 
-    if (web->cookie_filename != NULL)
+    if (web->cookie_filename != nullptr)
     {
         curl_easy_setopt(e, CURLOPT_COOKIEFILE, web->cookie_filename);
     }
 
-    if (task->range != NULL)
+    if (task->range != nullptr)
     {
         curl_easy_setopt(e, CURLOPT_RANGE, task->range);
         /* don't bother asking the server to compress webseed fragments */
@@ -322,7 +322,7 @@ static void task_finish_func(void* vtask)
     auto* task = static_cast<struct tr_web_task*>(vtask);
     dbgmsg("finished web task %p; got %ld", (void*)task, task->code);
 
-    if (task->done_func != NULL)
+    if (task->done_func != nullptr)
     {
         (*task->done_func)(
             task->session,
@@ -353,15 +353,15 @@ static struct tr_web_task* tr_webRunImpl(
     void* done_func_user_data,
     struct evbuffer* buffer)
 {
-    struct tr_web_task* task = NULL;
+    struct tr_web_task* task = nullptr;
 
     if (!session->isClosing)
     {
-        if (session->web == NULL)
+        if (session->web == nullptr)
         {
             tr_threadNew(tr_webThreadFunc, session);
 
-            while (session->web == NULL)
+            while (session->web == nullptr)
             {
                 tr_wait_msec(20);
             }
@@ -375,8 +375,8 @@ static struct tr_web_task* tr_webRunImpl(
         task->cookies = tr_strdup(cookies);
         task->done_func = done_func;
         task->done_func_user_data = done_func_user_data;
-        task->response = buffer != NULL ? buffer : evbuffer_new();
-        task->freebuf = buffer != NULL ? NULL : task->response;
+        task->response = buffer != nullptr ? buffer : evbuffer_new();
+        task->freebuf = buffer != nullptr ? nullptr : task->response;
 
         tr_lockLock(session->web->taskLock);
         task->next = session->web->tasks;
@@ -394,12 +394,12 @@ struct tr_web_task* tr_webRunWithCookies(
     tr_web_done_func done_func,
     void* done_func_user_data)
 {
-    return tr_webRunImpl(session, -1, url, NULL, cookies, done_func, done_func_user_data, NULL);
+    return tr_webRunImpl(session, -1, url, nullptr, cookies, done_func, done_func_user_data, nullptr);
 }
 
 struct tr_web_task* tr_webRun(tr_session* session, char const* url, tr_web_done_func done_func, void* done_func_user_data)
 {
-    return tr_webRunWithCookies(session, url, NULL, done_func, done_func_user_data);
+    return tr_webRunWithCookies(session, url, nullptr, done_func, done_func_user_data);
 }
 
 struct tr_web_task* tr_webRunWebseed(
@@ -410,7 +410,7 @@ struct tr_web_task* tr_webRunWebseed(
     void* done_func_user_data,
     struct evbuffer* buffer)
 {
-    return tr_webRunImpl(tor->session, tr_torrentId(tor), url, range, NULL, done_func, done_func_user_data, buffer);
+    return tr_webRunImpl(tor->session, tr_torrentId(tor), url, range, nullptr, done_func, done_func_user_data, buffer);
 }
 
 static void tr_webThreadFunc(void* vsession)
@@ -432,24 +432,24 @@ static void tr_webThreadFunc(void* vsession)
     web = tr_new0(struct tr_web, 1);
     web->close_mode = ~0;
     web->taskLock = tr_lockNew();
-    web->tasks = NULL;
+    web->tasks = nullptr;
     web->curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
     web->curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
-    web->curl_ca_bundle = tr_env_get_string("CURL_CA_BUNDLE", NULL);
+    web->curl_ca_bundle = tr_env_get_string("CURL_CA_BUNDLE", nullptr);
 
     if (web->curl_ssl_verify)
     {
         tr_logAddNamedInfo(
             "web",
             "will verify tracker certs using envvar CURL_CA_BUNDLE: %s",
-            web->curl_ca_bundle == NULL ? "none" : web->curl_ca_bundle);
+            web->curl_ca_bundle == nullptr ? "none" : web->curl_ca_bundle);
         tr_logAddNamedInfo("web", "NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
         tr_logAddNamedInfo("web", "NB: invalid certs will show up as 'Could not connect to tracker' like many other errors");
     }
 
-    str = tr_buildPath(session->configDir, "cookies.txt", NULL);
+    str = tr_buildPath(session->configDir, "cookies.txt", nullptr);
 
-    if (tr_sys_path_exists(str, NULL))
+    if (tr_sys_path_exists(str, nullptr))
     {
         web->cookie_filename = tr_strdup(str);
     }
@@ -472,7 +472,7 @@ static void tr_webThreadFunc(void* vsession)
             break;
         }
 
-        if (web->close_mode == TR_WEB_CLOSE_WHEN_IDLE && web->tasks == NULL)
+        if (web->close_mode == TR_WEB_CLOSE_WHEN_IDLE && web->tasks == nullptr)
         {
             break;
         }
@@ -480,12 +480,12 @@ static void tr_webThreadFunc(void* vsession)
         /* add tasks from the queue */
         tr_lockLock(web->taskLock);
 
-        while (web->tasks != NULL)
+        while (web->tasks != nullptr)
         {
             /* pop the task */
             struct tr_web_task* task = web->tasks;
             web->tasks = task->next;
-            task->next = NULL;
+            task->next = nullptr;
 
             dbgmsg("adding task to curl: [%s]", task->url);
             curl_multi_add_handle(multi, createEasy(session, web, task));
@@ -495,7 +495,7 @@ static void tr_webThreadFunc(void* vsession)
         tr_lockUnlock(web->taskLock);
 
         /* unpause any paused curl handles */
-        if (paused_easy_handles != NULL)
+        if (paused_easy_handles != nullptr)
         {
             CURL* handle;
             tr_list* tmp;
@@ -503,9 +503,9 @@ static void tr_webThreadFunc(void* vsession)
             /* swap paused_easy_handles to prevent oscillation
                between writeFunc this while loop */
             tmp = paused_easy_handles;
-            paused_easy_handles = NULL;
+            paused_easy_handles = nullptr;
 
-            while ((handle = tr_list_pop_front(&tmp)) != NULL)
+            while ((handle = tr_list_pop_front(&tmp)) != nullptr)
             {
                 curl_easy_pause(handle, CURLPAUSE_CONT);
             }
@@ -532,7 +532,7 @@ static void tr_webThreadFunc(void* vsession)
                 msec = THREADFUNC_MAX_SLEEP_MSEC;
             }
 
-            curl_multi_wait(multi, NULL, 0, msec, &numfds);
+            curl_multi_wait(multi, nullptr, 0, msec, &numfds);
             if (!numfds)
             {
                 repeats++;
@@ -557,9 +557,9 @@ static void tr_webThreadFunc(void* vsession)
         } while (mcode == CURLM_CALL_MULTI_PERFORM);
 
         /* pump completed tasks from the multi */
-        while ((msg = curl_multi_info_read(multi, &unused)) != NULL)
+        while ((msg = curl_multi_info_read(multi, &unused)) != nullptr)
         {
-            if (msg->msg == CURLMSG_DONE && msg->easy_handle != NULL)
+            if (msg->msg == CURLMSG_DONE && msg->easy_handle != nullptr)
             {
                 double total_time;
                 struct tr_web_task* task;
@@ -585,7 +585,7 @@ static void tr_webThreadFunc(void* vsession)
 
     /* Discard any remaining tasks.
      * This is rare, but can happen on shutdown with unresponsive trackers. */
-    while (web->tasks != NULL)
+    while (web->tasks != nullptr)
     {
         struct tr_web_task* task = web->tasks;
         web->tasks = task->next;
@@ -594,24 +594,24 @@ static void tr_webThreadFunc(void* vsession)
     }
 
     /* cleanup */
-    tr_list_free(&paused_easy_handles, NULL);
+    tr_list_free(&paused_easy_handles, nullptr);
     curl_multi_cleanup(multi);
     tr_lockFree(web->taskLock);
     tr_free(web->curl_ca_bundle);
     tr_free(web->cookie_filename);
     tr_free(web);
-    session->web = NULL;
+    session->web = nullptr;
 }
 
 void tr_webClose(tr_session* session, tr_web_close_mode close_mode)
 {
-    if (session->web != NULL)
+    if (session->web != nullptr)
     {
         session->web->close_mode = close_mode;
 
         if (close_mode == TR_WEB_CLOSE_NOW)
         {
-            while (session->web != NULL)
+            while (session->web != nullptr)
             {
                 tr_wait_msec(100);
             }
@@ -628,7 +628,7 @@ long tr_webGetTaskResponseCode(struct tr_web_task* task)
 
 char const* tr_webGetTaskRealUrl(struct tr_web_task* task)
 {
-    char* url = NULL;
+    char* url = nullptr;
     curl_easy_getinfo(task->curl_easy, CURLINFO_EFFECTIVE_URL, &url);
     return url;
 }
@@ -775,7 +775,7 @@ char const* tr_webGetResponseStr(long code)
 
 void tr_http_escape(struct evbuffer* out, char const* str, size_t len, bool escape_slashes)
 {
-    if (str == NULL)
+    if (str == nullptr)
     {
         return;
     }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -6,7 +6,8 @@
  *
  */
 
-#include <string.h> /* strlen() */
+#include <cstring> /* strlen() */
+#include <algorithm>
 
 #include <event2/buffer.h>
 #include <event2/event.h>
@@ -163,7 +164,7 @@ static void write_block_func(void* vdata)
         {
             while (len > 0)
             {
-                uint32_t const bytes_this_pass = MIN(len, block_size);
+                uint32_t const bytes_this_pass = std::min(len, block_size);
                 tr_cacheWriteBlock(cache, tor, piece, offset_end - len, bytes_this_pass, buf);
                 len -= bytes_this_pass;
             }
@@ -323,7 +324,7 @@ static void on_idle(tr_webseed* w)
         blocks = tr_new(tr_block_index_t, want * 2);
         tr_peerMgrGetNextRequests(tor, &w->parent, want, blocks, &got, true);
 
-        w->idle_connections -= MIN(w->idle_connections, got);
+        w->idle_connections -= std::min(w->idle_connections, got);
 
         if (w->retry_tickcount >= FAILURE_RETRY_INTERVAL && got == want)
         {
@@ -488,7 +489,7 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
 
         tr_ioFindFileLocation(tor, step_piece, step_piece_offset, &file_index, &file_offset);
         file = &inf->files[file_index];
-        this_pass = MIN(remain, file->length - file_offset);
+        this_pass = std::min(remain, file->length - file_offset);
 
         if (urls[file_index] == nullptr)
         {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -76,7 +76,7 @@ enum
 
 static void publish(tr_webseed* w, tr_peer_event* e)
 {
-    if (w->callback != NULL)
+    if (w->callback != nullptr)
     {
         (*w->callback)(&w->parent, e, w->callback_data);
     }
@@ -151,7 +151,7 @@ static void write_block_func(void* vdata)
 
     tor = tr_torrentFindFromId(data->session, data->torrent_id);
 
-    if (tor != NULL)
+    if (tor != nullptr)
     {
         uint32_t const block_size = tor->blockSize;
         uint32_t len = evbuffer_get_length(buf);
@@ -199,11 +199,11 @@ static void connection_succeeded(void* vdata)
         w->consecutive_failures = w->retry_tickcount = w->retry_challenge = 0;
     }
 
-    if (data->real_url != NULL)
+    if (data->real_url != nullptr)
     {
         tr_torrent const* const tor = tr_torrentFindFromId(w->session, w->torrent_id);
 
-        if (tor != NULL)
+        if (tor != nullptr)
         {
             uint64_t file_offset;
             tr_file_index_t file_index;
@@ -211,7 +211,7 @@ static void connection_succeeded(void* vdata)
             tr_ioFindFileLocation(tor, data->piece_index, data->piece_offset, &file_index, &file_offset);
             tr_free(w->file_urls[file_index]);
             w->file_urls[file_index] = data->real_url;
-            data->real_url = NULL;
+            data->real_url = nullptr;
         }
     }
 
@@ -315,10 +315,10 @@ static void on_idle(tr_webseed* w)
         w->retry_challenge = running_tasks + w->idle_connections + 1;
     }
 
-    if (tor != NULL && tor->isRunning && !tr_torrentIsSeed(tor) && want > 0)
+    if (tor != nullptr && tor->isRunning && !tr_torrentIsSeed(tor) && want > 0)
     {
         int got = 0;
-        tr_block_index_t* blocks = NULL;
+        tr_block_index_t* blocks = nullptr;
 
         blocks = tr_new(tr_block_index_t, want * 2);
         tr_peerMgrGetNextRequests(tor, &w->parent, want, blocks, &got, true);
@@ -383,7 +383,7 @@ static void web_response_func(
     tr_webseed* w = t->webseed;
     tr_torrent* tor = tr_torrentFindFromId(session, w->torrent_id);
 
-    if (tor != NULL)
+    if (tor != nullptr)
     {
         /* active_transfers was only increased if the connection was successful */
         if (t->response_code == 206)
@@ -456,7 +456,7 @@ static struct evbuffer* make_url(tr_webseed* w, tr_file const* file)
     evbuffer_add(buf, w->base_url, w->base_url_len);
 
     /* if url ends with a '/', add the torrent name */
-    if (w->base_url[w->base_url_len - 1] == '/' && file->name != NULL)
+    if (w->base_url[w->base_url_len - 1] == '/' && file->name != nullptr)
     {
         tr_http_escape(buf, file->name, strlen(file->name), false);
     }
@@ -469,7 +469,7 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
     tr_webseed* w = t->webseed;
     tr_torrent* tor = tr_torrentFindFromId(w->session, w->torrent_id);
 
-    if (tor != NULL)
+    if (tor != nullptr)
     {
         char range[64];
         char** urls = t->webseed->file_urls;
@@ -490,9 +490,9 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
         file = &inf->files[file_index];
         this_pass = MIN(remain, file->length - file_offset);
 
-        if (urls[file_index] == NULL)
+        if (urls[file_index] == nullptr)
         {
-            urls[file_index] = evbuffer_free_to_str(make_url(t->webseed, file), NULL);
+            urls[file_index] = evbuffer_free_to_str(make_url(t->webseed, file), nullptr);
         }
 
         tr_snprintf(range, sizeof(range), "%" PRIu64 "-%" PRIu64, file_offset, file_offset + this_pass - 1);
@@ -534,11 +534,11 @@ static bool webseed_is_transferring_pieces(tr_peer const* peer, uint64_t now, tr
     if (direction == TR_DOWN)
     {
         tr_webseed const* w = (tr_webseed const*)peer;
-        is_active = w->tasks != NULL;
+        is_active = w->tasks != nullptr;
         Bps = tr_bandwidthGetPieceSpeed_Bps(&w->bandwidth, now, direction);
     }
 
-    if (setme_Bps != NULL)
+    if (setme_Bps != nullptr)
     {
         *setme_Bps = Bps;
     }
@@ -551,16 +551,16 @@ static void webseed_destruct(tr_peer* peer)
     tr_webseed* w = (tr_webseed*)peer;
 
     /* flag all the pending tasks as dead */
-    for (tr_list* l = w->tasks; l != NULL; l = l->next)
+    for (tr_list* l = w->tasks; l != nullptr; l = l->next)
     {
         auto* task = static_cast<struct tr_webseed_task*>(l->data);
         task->dead = true;
     }
 
-    tr_list_free(&w->tasks, NULL);
+    tr_list_free(&w->tasks, nullptr);
 
     /* if we have an array of file URLs, free it */
-    if (w->file_urls != NULL)
+    if (w->file_urls != nullptr)
     {
         tr_torrent const* const tor = tr_torrentFindFromId(w->session, w->torrent_id);
         tr_info const* const inf = tr_torrentInfo(tor);

--- a/macosx/Controller.m
+++ b/macosx/Controller.m
@@ -4377,8 +4377,7 @@ static void removeKeRangerRansomware()
         {
             [segmentedControl setImage:[NSImage imageNamed:@"ToolbarPauseAllTemplate"] forSegment:TOOLBAR_PAUSE_TAG];
         }
-        [segmentedCell setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip")
-                       forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedCell setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip") forSegment:TOOLBAR_PAUSE_TAG];
 
         [segmentedCell setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setImage:[NSImage imageNamed:@"ToolbarResumeAllTemplate"] forSegment:TOOLBAR_RESUME_TAG];

--- a/macosx/Torrent.m
+++ b/macosx/Torrent.m
@@ -1993,11 +1993,7 @@ bool trashDataFile(char const* filename, tr_error** error)
                 tempNode = [[FileListNode alloc] initWithFolderName:pathComponents[0] path:@"" torrent:self];
             }
 
-            [self insertPathForComponents:pathComponents
-                       withComponentIndex:1
-                                forParent:tempNode
-                                 fileSize:file->length
-                                    index:i
+            [self insertPathForComponents:pathComponents withComponentIndex:1 forParent:tempNode fileSize:file->length index:i
                                  flatList:flatFileList];
         }
 

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -6,6 +6,7 @@
  *
  */
 
+#include <algorithm>
 #include "transmission.h"
 #include "error.h"
 #include "file.h"
@@ -57,7 +58,7 @@ private:
         size_t buf_pos = 0;
         while (buf_pos < buf_len && bytes_remaining > 0)
         {
-            uint64_t const chunk_size = MIN(buf_len - buf_pos, bytes_remaining);
+            uint64_t const chunk_size = std::min(buf_len - buf_pos, bytes_remaining);
             uint64_t bytes_read = 0;
 
             tr_sys_file_read(fd, buf + buf_pos, chunk_size, &bytes_read, nullptr);

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -38,14 +38,14 @@ int main(int argc, char** argv)
 
     if (test_action == "--dump-args")
     {
-        for (size_t i = 3; i < argc; ++i)
+        for (int i = 3; i < argc; ++i)
         {
             tr_sys_file_write_line(fd, argv[i], nullptr);
         }
     }
     else if (test_action == "--dump-env")
     {
-        for (size_t i = 3; i < argc; ++i)
+        for (int i = 3; i < argc; ++i)
         {
             char* const value = tr_env_get_string(argv[i], "<null>");
             tr_sys_file_write_line(fd, value, nullptr);


### PR DESCRIPTION
This PR is based on #1799, merge after 1799

- C include files replaced with C++ wrappers
- MIN/MAX replaced with std::min/std::max everywhere in all C++ code
- Announcer's internal structs now are grouped with their functions
- Some TODO's left for external C calls marking temporary compatibility code