### PR TITLE
fix: dead store warning in handshake

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1067,8 +1067,12 @@ static ReadState canRead(struct tr_peerIo* io, void* vhandshake, size_t* piece)
             break;
 
         default:
-            ret = READ_ERR;
+#ifdef TR_ENABLE_ASSERTS
             TR_ASSERT_MSG(false, "unhandled handshake state %d", (int)handshake->state);
+#else
+            ret = READ_ERR;
+            break;
+#endif
         }
 
         if (ret != READ_NOW)


### PR DESCRIPTION
The variable is being set before an unconditional assertion, which is why we get a dead-store warning when building with assertions enabled.

This PR adds an #if block so that the we assign only if assertions are disabled. That way the code will do the Right Thing whether assertions are enabled or not.