### PR TITLE
fix: dead store warning in peer-msgs.cc

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1835,8 +1835,12 @@ static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
             break;
 
         default:
-            ret = READ_ERR;
+#ifdef TR_ENABLE_ASSERTS
             TR_ASSERT_MSG(false, "unhandled peer messages state %d", (int)msgs->state);
+#else
+            ret = READ_ERR;
+            break;
+#endif
         }
     }
 


### PR DESCRIPTION
Another trivial PR. Sibling to https://github.com/transmission/transmission/pull/1803.

The variable is being set before an unconditional assertion, which is why a dead-store warning is raised when building with assertions enabled.

This PR adds an #if block so that the variable is assigned only if assertions are disabled. That way the code will do the Right Thing whether assertions are enabled or not.