### PR TITLE
Add authentication information to the RPC spec

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -81,6 +81,19 @@
    For more information on configuration, see settings.json documentation for
    "rpc-host-whitelist-enabled" and "rpc-host-whitelist" keys.
 
+2.3.3.  Authentication
+
+   Enabling authentication is an optional security feature that can be enabled
+   on Transmission RPC servers. Authentication occurs by method of HTTP Basic
+   Access Authentication.
+
+   If authentication is enabled, Transmission inspects the "Authorization:"
+   HTTP header value to validate the credentials of the request. The value
+   of this HTTP header is expected to be "Basic <b64 credentials>", where
+   <b64 credentials> is equal to a base64 encoded string of the username
+   and password (respectively), separated by a colon.
+
+
 3.  Torrent Requests
 
 3.1.  Torrent Action Requests


### PR DESCRIPTION
When writing code that interacted with the Transmission RPC server, I struggled to find any information regarding the authentication method used when auth is enabled on remote connections.

I found the solution with the help of Fishman in IRC, but I think it would be nice if this was documented so other people don't encounter a similar issue.