### PR TITLE
fix: 'enumerated and non-enumerated type' warnings

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -66,8 +66,6 @@ enum
     UT_PEX_ID = 1,
     UT_METADATA_ID = 3,
     /* */
-    MAX_PEX_PEER_COUNT = 50,
-    /* */
     MIN_CHOKE_PERIOD_SEC = 10,
     /* idle seconds before we send a keepalive */
     KEEPALIVE_INTERVAL_SECS = 100,
@@ -96,6 +94,13 @@ enum
     METADATA_MSG_TYPE_DATA = 1,
     METADATA_MSG_TYPE_REJECT = 2
 };
+
+namespace
+{
+
+constexpr int MAX_PEX_PEER_COUNT = 50;
+
+} // unnamed namespace
 
 enum
 {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -23,10 +23,12 @@
 #include "utils.h" /* tr_buildPath */
 #include "variant.h"
 
-enum
+namespace
 {
-    MAX_REMEMBERED_PEERS = 200
-};
+
+constexpr int MAX_REMEMBERED_PEERS = 200;
+
+} // unnamed namespace
 
 static char* getResumeFilename(tr_torrent const* tor, enum tr_metainfo_basename_format format)
 {

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -15,11 +15,8 @@
 #include <inttypes.h>
 #include <time.h>
 
-enum
-{
-    /* defined by BEP #9 */
-    METADATA_PIECE_SIZE = (1024 * 16)
-};
+// defined by BEP #9
+inline constexpr int METADATA_PIECE_SIZE = 1024 * 16;
 
 void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len);
 


### PR DESCRIPTION
Simple change to silence warnings, changes the offending enums to be constexprs. There is still more cleanup work to update other enums; this just addresses the ones causing compiler warnings