### PR TITLE
fix: clang warnings

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -385,7 +385,7 @@ void tr_bitfieldSetFromFlags(tr_bitfield* b, bool const* flags, size_t n)
 
     for (size_t i = 0; i < n; ++i)
     {
-        if (flags[i])
+        if (flags[i] && b->bits != nullptr)
         {
             ++trueCount;
             b->bits[i >> 3U] |= (0x80 >> (i & 7U));

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -154,7 +154,7 @@ static void peer_io_push_datatype(tr_peerIo* io, struct tr_datatype* datatype)
 
 static void didWriteWrapper(tr_peerIo* io, unsigned int bytes_transferred)
 {
-    while (bytes_transferred != 0 && tr_isPeerIo(io))
+    while (bytes_transferred != 0 && tr_isPeerIo(io) && io->outbuf_datatypes != nullptr)
     {
         struct tr_datatype* next = io->outbuf_datatypes;
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1208,9 +1208,9 @@ void tr_peerIoWriteBytes(tr_peerIo* io, void const* bytes, size_t byteCount, boo
 ****
 ***/
 
-void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t byte)
+void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t addme)
 {
-    evbuffer_add(outbuf, &byte, 1);
+    evbuffer_add(outbuf, &addme, 1);
 }
 
 void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t addme_hs)

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1337,6 +1337,15 @@ void tr_peerMgrGetNextRequests(
 
     updateEndgame(s);
 
+    // TODO(ckerr) this safeguard is here to silence a false nullptr dereference
+    // warning. The better fix is to refactor the `pieces` array to be a std
+    // container but that's out-of-scope for a "fix all the warnings" PR
+    if (s->pieces == nullptr)
+    {
+        *numgot = 0;
+        return;
+    }
+
     struct weighted_piece* pieces = s->pieces;
     int got = 0;
     int checkedPieceCount = 0;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -265,49 +265,49 @@ tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_a
 #define TR_DEFAULT_ENCRYPTION TR_ENCRYPTION_PREFERRED
 #endif
 
-static int parse_tos(char const* str)
+static int parse_tos(char const* tos)
 {
     char* p;
     int value;
 
-    if (evutil_ascii_strcasecmp(str, "") == 0)
+    if (evutil_ascii_strcasecmp(tos, "") == 0)
     {
         return 0;
     }
 
-    if (evutil_ascii_strcasecmp(str, "default") == 0)
+    if (evutil_ascii_strcasecmp(tos, "default") == 0)
     {
         return 0;
     }
 
-    if (evutil_ascii_strcasecmp(str, "lowcost") == 0)
+    if (evutil_ascii_strcasecmp(tos, "lowcost") == 0)
     {
         return TR_IPTOS_LOWCOST;
     }
 
-    if (evutil_ascii_strcasecmp(str, "mincost") == 0)
+    if (evutil_ascii_strcasecmp(tos, "mincost") == 0)
     {
         return TR_IPTOS_LOWCOST;
     }
 
-    if (evutil_ascii_strcasecmp(str, "throughput") == 0)
+    if (evutil_ascii_strcasecmp(tos, "throughput") == 0)
     {
         return TR_IPTOS_THRUPUT;
     }
 
-    if (evutil_ascii_strcasecmp(str, "reliability") == 0)
+    if (evutil_ascii_strcasecmp(tos, "reliability") == 0)
     {
         return TR_IPTOS_RELIABLE;
     }
 
-    if (evutil_ascii_strcasecmp(str, "lowdelay") == 0)
+    if (evutil_ascii_strcasecmp(tos, "lowdelay") == 0)
     {
         return TR_IPTOS_LOWDELAY;
     }
 
-    value = strtol(str, &p, 0);
+    value = strtol(tos, &p, 0);
 
-    if (p == nullptr || p == str)
+    if (p == nullptr || p == tos)
     {
         return 0;
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2444,12 +2444,12 @@ bool tr_sessionIsPortForwardingEnabled(tr_session const* session)
 ****
 ***/
 
-static bool tr_stringEndsWith(char const* str, char const* end)
+static bool tr_stringEndsWith(char const* strval, char const* end)
 {
-    size_t const slen = strlen(str);
+    size_t const slen = strlen(strval);
     size_t const elen = strlen(end);
 
-    return slen >= elen && memcmp(&str[slen - elen], end, elen) == 0;
+    return slen >= elen && memcmp(&strval[slen - elen], end, elen) == 0;
 }
 
 static void loadBlocklists(tr_session* session)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -829,7 +829,7 @@ static void sessionSetImpl(void* vdata)
     int64_t i;
     double d;
     bool boolVal;
-    char const* str;
+    char const* strVal;
     struct tr_bindinfo b;
     struct tr_turtle_info* turtle = &session->turtle;
 
@@ -884,14 +884,14 @@ static void sessionSetImpl(void* vdata)
         tr_sessionSetEncryption(session, tr_encryption_mode(i));
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_peer_socket_tos, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_peer_socket_tos, &strVal, nullptr))
     {
-        session->peerSocketTOS = parse_tos(str);
+        session->peerSocketTOS = parse_tos(strVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_peer_congestion_algorithm, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_peer_congestion_algorithm, &strVal, nullptr))
     {
-        session->peer_congestion_algorithm = tr_strdup(str);
+        session->peer_congestion_algorithm = tr_strdup(strVal);
     }
     else
     {
@@ -903,9 +903,9 @@ static void sessionSetImpl(void* vdata)
         tr_blocklistSetEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_blocklist_url, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_blocklist_url, &strVal, nullptr))
     {
-        tr_blocklistSetURL(session, str);
+        tr_blocklistSetURL(session, strVal);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_start_added_torrents, &boolVal))
@@ -965,14 +965,14 @@ static void sessionSetImpl(void* vdata)
         session->preallocationMode = tr_preallocation_mode(i);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_download_dir, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_download_dir, &strVal, nullptr))
     {
-        tr_sessionSetDownloadDir(session, str);
+        tr_sessionSetDownloadDir(session, strVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_incomplete_dir, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_incomplete_dir, &strVal, nullptr))
     {
-        tr_sessionSetIncompleteDir(session, str);
+        tr_sessionSetIncompleteDir(session, strVal);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_incomplete_dir_enabled, &boolVal))
@@ -997,8 +997,8 @@ static void sessionSetImpl(void* vdata)
 
     free_incoming_peer_port(session);
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &str, nullptr) || !tr_address_from_string(&b.addr, str) ||
-        b.addr.type != TR_AF_INET)
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &strVal, nullptr) ||
+        !tr_address_from_string(&b.addr, strVal) || b.addr.type != TR_AF_INET)
     {
         b.addr = tr_inaddr_any;
     }
@@ -1006,8 +1006,8 @@ static void sessionSetImpl(void* vdata)
     b.socket = TR_BAD_SOCKET;
     session->bind_ipv4 = static_cast<struct tr_bindinfo*>(tr_memdup(&b, sizeof(struct tr_bindinfo)));
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &str, nullptr) || !tr_address_from_string(&b.addr, str) ||
-        b.addr.type != TR_AF_INET6)
+    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &strVal, nullptr) ||
+        !tr_address_from_string(&b.addr, strVal) || b.addr.type != TR_AF_INET6)
     {
         b.addr = tr_in6addr_any;
     }
@@ -1147,9 +1147,9 @@ static void sessionSetImpl(void* vdata)
         tr_sessionSetTorrentDoneScriptEnabled(session, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_done_filename, &str, nullptr))
+    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_done_filename, &strVal, nullptr))
     {
-        tr_sessionSetTorrentDoneScript(session, str);
+        tr_sessionSetTorrentDoneScript(session, strVal);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_scrape_paused_torrents_enabled, &boolVal))


### PR DESCRIPTION
Get libtransmission passing clang-tidy without any warnings.

There are no serious refactors in here, just silencing the warnings to set a baseline. Some of the warnings were false positives that will be better fixed with followup refactors.