### PR TITLE
refactor: std::filesystem tr_sys_dir_create() impl

### DIFF
--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1365,11 +1365,6 @@ char* tr_sys_dir_get_current(tr_error** error)
     return ret;
 }
 
-bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error** error)
-{
-    return create_dir(path, flags, permissions, true, error);
-}
-
 static void dir_create_temp_callback(char const* path, void* param, tr_error** error)
 {
     bool* result = (bool*)param;


### PR DESCRIPTION
Migrate libtransmission to std::filesystem where sensible, part 1.

This PR adds a std::filesystem implementation of `tr_sys_dir_create()` in `file.cc` and removes the platform-dependent ones from `file-posix.cc` and `file-win32.cc`.