### PR TITLE
build: use CXX_WARNING_FLAGS in libtransmission

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -78,9 +78,9 @@ set(PROJECT_FILES
   webseed.cc
 )
 
-string(REPLACE ";" " " C_WARNING_FLAGS_STR "${C_WARNING_FLAGS}")
+string(REPLACE ";" " " CXX_WARNING_FLAGS_STR "${CXX_WARNING_FLAGS}")
 foreach(FILE ${PROJECT_FILES})
-  set_source_files_properties(${FILE} PROPERTIES COMPILE_FLAGS "${C_WARNING_FLAGS_STR}")
+  set_source_files_properties(${FILE} PROPERTIES COMPILE_FLAGS "${CXX_WARNING_FLAGS_STR}")
 endforeach()
 
 set(THIRD_PARTY_FILES


### PR DESCRIPTION
A minor followup to 4c1b6276479d177122df4ee5c9919f014c24faca, which forgot to change libtransmission/CMakeLists.txt over from C_WARNING_FLAGS to CXX_WARNING_FLAGS.

No code changes.