### PR TITLE
Reimplement quarks order check as a static assert

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdlib> /* bsearch() */
 #include <cstring> /* memcmp() */
+#include <iterator>
 
 #include "transmission.h"
 #include "ptrarray.h"
@@ -27,7 +28,7 @@ struct tr_key_struct
         "" name "", sizeof("" name "") - 1, \
     }
 
-static struct tr_key_struct const my_static[] = {
+static struct tr_key_struct constexpr my_static[] = {
     Q(""),
     Q("activeTorrentCount"),
     Q("activity-date"),
@@ -417,6 +418,36 @@ static struct tr_key_struct const my_static[] = {
     Q("webseeds"),
     Q("webseedsSendingToUs"),
 };
+
+static size_t constexpr quarks_are_sorted = ( //
+    []() constexpr
+    {
+        for (size_t i = 1; i < std::size(my_static); ++i)
+        {
+            char const* lhs = my_static[i - 1].str;
+            char const* rhs = my_static[i].str;
+
+            while (true)
+            {
+                if (*lhs > *rhs)
+                {
+                    return false;
+                }
+
+                if (*lhs < *rhs || *lhs == '\0' || *rhs == '\0')
+                {
+                    break;
+                }
+
+                ++lhs;
+                ++rhs;
+            }
+        }
+
+        return true;
+    })();
+
+static_assert(quarks_are_sorted, "Predefined quarks must be sorted by their string value");
 
 #undef Q
 

--- a/tests/libtransmission/quark-test.cc
+++ b/tests/libtransmission/quark-test.cc
@@ -39,16 +39,6 @@ TEST_F(QuarkTest, allPredefinedKeysCanBeLookedUp)
     }
 }
 
-TEST_F(QuarkTest, allPredefinedKeysAreSorted)
-{
-    for (int i = 0; i + 1 < TR_N_KEYS; i++)
-    {
-        auto const str1 = quarkGetString(i);
-        auto const str2 = quarkGetString(i + 1);
-        EXPECT_LT(str1, str2);
-    }
-}
-
 TEST_F(QuarkTest, newEmptyQuarkReturnsNone)
 {
     auto const q = tr_quark_new(nullptr, TR_BAD_SIZE);


### PR DESCRIPTION
Just something funny to do apart from all the serious stuff going on :) Helps to catch issues early, given that contributors may not run unit tests that frequently. Slightly reduced error reporting quality though: can't see the particular strings that failed the test.