### PR TITLE
refactor: remove TR_BEGIN_DECLS, TR_END_DECLS

### DIFF
--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -15,8 +15,6 @@
 #include "transmission.h"
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /** @brief Implementation of the BitTorrent spec's Bitfield array of bits */
 typedef struct tr_bitfield
 {
@@ -91,5 +89,3 @@ static inline bool tr_bitfieldHasNone(tr_bitfield const* b)
 }
 
 bool tr_bitfieldHas(tr_bitfield const* b, size_t n);
-
-TR_END_DECLS

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -14,8 +14,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 struct tr_address;
 
 typedef struct tr_blocklistFile tr_blocklistFile;
@@ -37,5 +35,3 @@ void tr_blocklistFileSetEnabled(tr_blocklistFile* b, bool isEnabled);
 bool tr_blocklistFileHasAddress(tr_blocklistFile* b, struct tr_address const* addr);
 
 int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename);
-
-TR_END_DECLS

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -14,8 +14,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 struct evbuffer;
 
 typedef struct tr_cache tr_cache;
@@ -63,5 +61,3 @@ int tr_cacheFlushDone(tr_cache* cache);
 int tr_cacheFlushTorrent(tr_cache* cache, tr_torrent* torrent);
 
 int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t file);
-
-TR_END_DECLS

--- a/libtransmission/clients.h
+++ b/libtransmission/clients.h
@@ -14,12 +14,8 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /**
  * @brief parse a peer-id into a human-readable client name and version number
  * @ingroup utils
  */
 char* tr_clientForId(char* buf, size_t buflen, void const* peer_id);
-
-TR_END_DECLS

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -16,8 +16,6 @@
 #include "tr-macros.h"
 #include "utils.h" /* TR_GNUC_MALLOC, TR_GNUC_NULL_TERMINATED */
 
-TR_BEGIN_DECLS
-
 /**
 *** @addtogroup utils Utilities
 *** @{
@@ -191,7 +189,5 @@ static inline void tr_hex_to_sha1(void* sha1, void const* hex)
 }
 
 /** @} */
-
-TR_END_DECLS
 
 #endif /* TR_CRYPTO_UTILS_H */

--- a/libtransmission/crypto.h
+++ b/libtransmission/crypto.h
@@ -20,8 +20,6 @@
 #include "tr-macros.h"
 #include "utils.h" /* TR_GNUC_NULL_TERMINATED */
 
-TR_BEGIN_DECLS
-
 /**
 *** @addtogroup peers
 *** @{
@@ -78,7 +76,5 @@ bool tr_cryptoSecretKeySha1(
     uint8_t* hash);
 
 /* @} */
-
-TR_END_DECLS
 
 #endif // TR_ENCRYPTION_H

--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -12,8 +12,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /**
  * @addtogroup error Error reporting
  * @{
@@ -129,5 +127,3 @@ void tr_error_propagate_prefixed(tr_error** new_error, tr_error** old_error, cha
     TR_GNUC_PRINTF(3, 4);
 
 /** @} */
-
-TR_END_DECLS

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -17,8 +17,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 struct tr_error;
 
 /**
@@ -687,5 +685,3 @@ bool tr_sys_dir_close(tr_sys_dir_t handle, struct tr_error** error);
 
 /** @} */
 /** @} */
-
-TR_END_DECLS

--- a/libtransmission/history.h
+++ b/libtransmission/history.h
@@ -16,8 +16,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /**
  * A generic short-term memory object that remembers how many times
  * something happened over the last N seconds.
@@ -58,5 +56,3 @@ void tr_historyAdd(tr_recentHistory*, time_t when, unsigned int n);
  * @param seconds how many seconds to count back through.
  */
 unsigned int tr_historyGet(tr_recentHistory const*, time_t when, unsigned int seconds);
-
-TR_END_DECLS

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -14,8 +14,6 @@
 #include "tr-macros.h"
 #include "utils.h" /* TR_GNUC_PRINTF, TR_GNUC_NONNULL */
 
-TR_BEGIN_DECLS
-
 #define TR_LOG_MAX_QUEUE_LENGTH 10000
 
 tr_log_level tr_logGetLevel(void);
@@ -74,5 +72,3 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
 char* tr_logGetTimeStr(char* buf, size_t buflen) TR_GNUC_NONNULL(1);
 
 /** @} */
-
-TR_END_DECLS

--- a/libtransmission/magnet.h
+++ b/libtransmission/magnet.h
@@ -16,8 +16,6 @@
 #include "transmission.h"
 #include "variant.h"
 
-TR_BEGIN_DECLS
-
 typedef struct tr_magnet_info
 {
     uint8_t hash[20];
@@ -38,5 +36,3 @@ struct tr_variant;
 void tr_magnetCreateMetainfo(tr_magnet_info const*, tr_variant*);
 
 void tr_magnetFree(tr_magnet_info* info);
-
-TR_END_DECLS

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -11,8 +11,6 @@
 #include "tr-macros.h"
 #include "transmission.h"
 
-TR_BEGIN_DECLS
-
 typedef struct tr_metainfo_builder_file
 {
     char* filename;
@@ -118,5 +116,3 @@ void tr_makeMetaInfo(
     int trackerCount,
     char const* comment,
     bool isPrivate);
-
-TR_END_DECLS

--- a/libtransmission/metainfo.h
+++ b/libtransmission/metainfo.h
@@ -16,8 +16,6 @@
 #include "variant.h"
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 enum tr_metainfo_basename_format
 {
     TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH,
@@ -43,5 +41,3 @@ void tr_metainfoMigrateFile(
 
 /** @brief Private function that's exposed here only for unit tests */
 char* tr_metainfo_sanitize_path_component(char const* str, size_t len, bool* is_adjusted);
-
-TR_END_DECLS

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -37,8 +37,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 #ifdef _WIN32
 typedef SOCKET tr_socket_t;
 #define TR_BAD_SOCKET INVALID_SOCKET
@@ -153,5 +151,3 @@ bool tr_net_hasIPv6(tr_port);
 char* tr_net_strerror(char* buf, size_t buflen, int err);
 
 unsigned char const* tr_globalIPv6(void);
-
-TR_END_DECLS

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -16,8 +16,6 @@
 #include "tr-assert.h"
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 enum tr_peer_socket_type
 {
     TR_PEER_SOCKET_TYPE_NONE,
@@ -47,5 +45,3 @@ struct tr_address;
 struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
 
 struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
-
-TR_END_DECLS

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -10,8 +10,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /* Quarks — a 2-way association between a string and a unique integer identifier */
 typedef size_t tr_quark;
 
@@ -433,9 +431,3 @@ char const* tr_quark_get_string(tr_quark quark, size_t* len);
  * created.
  */
 tr_quark tr_quark_new(void const* str, size_t len);
-
-/***
-****
-***/
-
-TR_END_DECLS

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -14,8 +14,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 enum
 {
     TR_FR_DOWNLOADED = (1 << 0),
@@ -53,5 +51,3 @@ void tr_torrentSaveResume(tr_torrent* tor);
 void tr_torrentRemoveResume(tr_torrent const* tor);
 
 int tr_torrentRenameResume(tr_torrent const* tor, char const* newname);
-
-TR_END_DECLS

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -12,8 +12,6 @@
 #include "tr-macros.h"
 #include "variant.h"
 
-TR_BEGIN_DECLS
-
 /***
 ****  RPC processing
 ***/
@@ -36,5 +34,3 @@ void tr_rpc_request_exec_uri(
     void* callback_user_data);
 
 void tr_rpc_parse_list_str(tr_variant* setme, char const* list_str, size_t list_str_len);
-
-TR_END_DECLS

--- a/libtransmission/session-id.h
+++ b/libtransmission/session-id.h
@@ -10,8 +10,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 typedef struct tr_session_id* tr_session_id_t;
 
 /**
@@ -50,5 +48,3 @@ char const* tr_session_id_get_current(tr_session_id_t session_id);
  * @return `True` if session is valid and local, `false` otherwise.
  */
 bool tr_session_id_is_local(char const* session_id);
-
-TR_END_DECLS

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -10,8 +10,4 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 bool tr_spawn_async(char* const* cmd, char* const* env, char const* work_dir, struct tr_error** error);
-
-TR_END_DECLS

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -20,8 +20,6 @@
 #include "utils.h" /* TR_GNUC_PRINTF */
 #include "ptrarray.h"
 
-TR_BEGIN_DECLS
-
 struct tr_torrent_tiers;
 struct tr_magnet_info;
 
@@ -474,5 +472,3 @@ static inline tr_direction tr_torrentGetQueueDirection(tr_torrent const* tor)
 {
     return tr_torrentIsSeed(tor) ? TR_UP : TR_DOWN;
 }
-
-TR_END_DECLS

--- a/libtransmission/tr-getopt.h
+++ b/libtransmission/tr-getopt.h
@@ -10,8 +10,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /**
  * @addtogroup utils Utilities
  * @{
@@ -51,5 +49,3 @@ int tr_getopt(char const* summary, int argc, char const* const* argv, tr_option 
 void tr_getopt_usage(char const* appName, char const* description, tr_option const* opts);
 
 /** @} */
-
-TR_END_DECLS

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -162,16 +162,5 @@
 
 #define TR_BAD_SIZE ((size_t)-1)
 
-/* Guard C code in headers, while including them from C++ */
-#ifdef __cplusplus
-#define TR_BEGIN_DECLS \
-    extern "C" \
-    {
-#define TR_END_DECLS }
-#else
-#define TR_BEGIN_DECLS
-#define TR_END_DECLS
-#endif
-
 // Mostly to enforce better formatting
 #define TR_ARG_TUPLE(...) __VA_ARGS__

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -27,8 +27,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 typedef uint32_t tr_file_index_t;
 typedef uint32_t tr_piece_index_t;
 /* assuming a 16 KiB block, a 32-bit block index gives us a maximum torrent size of 63 TiB.
@@ -1891,5 +1889,3 @@ static inline bool tr_isDirection(tr_direction d)
 {
     return d == TR_UP || d == TR_DOWN;
 }
-
-TR_END_DECLS

--- a/libtransmission/trevent.h
+++ b/libtransmission/trevent.h
@@ -14,8 +14,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 void tr_eventInit(tr_session*);
 
 void tr_eventClose(tr_session*);
@@ -23,5 +21,3 @@ void tr_eventClose(tr_session*);
 bool tr_amInEventThread(tr_session const*);
 
 void tr_runInEventThread(tr_session*, void (*func)(void*), void* user_data);
-
-TR_END_DECLS

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -476,6 +476,17 @@ char const* tr_memmem(char const* haystack, size_t haystacklen, char const* need
 #endif
 }
 
+extern "C"
+{
+    int DoMatch(char const* text, char const* p);
+}
+
+/* User-level routine. returns whether or not 'text' and 'p' matched */
+bool tr_wildmat(char const* text, char const* p)
+{
+    return (p[0] == '*' && p[1] == '\0') || (DoMatch(text, p) == true);
+}
+
 char const* tr_strcasestr(char const* haystack, char const* needle)
 {
 #ifdef HAVE_STRCASESTR

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -15,8 +15,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 /***
 ****
 ***/
@@ -61,12 +59,6 @@ char const* tr_strip_positional_args(char const* fmt);
 #define TR_N_ELEMENTS(ary) (sizeof(ary) / sizeof(*(ary)))
 
 char const* tr_get_mime_type_for_filename(char const* filename);
-
-/**
- * @brief Rich Salz's classic implementation of shell-style pattern matching for ?, \, [], and * characters.
- * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occured
- */
-bool tr_wildmat(char const* text, char const* pattern) TR_GNUC_NONNULL(1, 2);
 
 /**
  * @brief Loads a file and returns its contents.
@@ -423,5 +415,13 @@ char* tr_env_get_string(char const* key, char const* default_value);
 void tr_net_init(void);
 
 /** @} */
+
+TR_BEGIN_DECLS
+
+/**
+ * @brief Rich Salz's classic implementation of shell-style pattern matching for ?, \, [], and * characters.
+ * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occured
+ */
+bool tr_wildmat(char const* text, char const* pattern) TR_GNUC_NONNULL(1, 2);
 
 TR_END_DECLS

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -61,6 +61,12 @@ char const* tr_strip_positional_args(char const* fmt);
 char const* tr_get_mime_type_for_filename(char const* filename);
 
 /**
+ * @brief Rich Salz's classic implementation of shell-style pattern matching for ?, \, [], and * characters.
+ * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occured
+ */
+bool tr_wildmat(char const* text, char const* pattern) TR_GNUC_NONNULL(1, 2);
+
+/**
  * @brief Loads a file and returns its contents.
  * On failure, NULL is returned and errno is set.
  */
@@ -413,15 +419,3 @@ char* tr_env_get_string(char const* key, char const* default_value);
 ***/
 
 void tr_net_init(void);
-
-/** @} */
-
-TR_BEGIN_DECLS
-
-/**
- * @brief Rich Salz's classic implementation of shell-style pattern matching for ?, \, [], and * characters.
- * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occured
- */
-bool tr_wildmat(char const* text, char const* pattern) TR_GNUC_NONNULL(1, 2);
-
-TR_END_DECLS

--- a/libtransmission/variant-common.h
+++ b/libtransmission/variant-common.h
@@ -14,8 +14,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 typedef void (*VariantWalkFunc)(tr_variant const* val, void* user_data);
 
 struct VariantWalkFuncs
@@ -52,5 +50,3 @@ int tr_bencParseStr(
     size_t* setme_strlen);
 
 int tr_variantParseBenc(void const* buf, void const* end, tr_variant* top, char const** setme_end);
-
-TR_END_DECLS

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -13,8 +13,6 @@
 #include "tr-macros.h"
 #include "quark.h"
 
-TR_BEGIN_DECLS
-
 struct evbuffer;
 
 struct tr_error;
@@ -276,15 +274,4 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const**
 /* this is only quasi-supported. don't rely on it too heavily outside of libT */
 void tr_variantMergeDicts(tr_variant* dict_target, tr_variant const* dict_source);
 
-/***
-****
-****
-***/
-
-/**
-***
-**/
-
 /* @} */
-
-TR_END_DECLS

--- a/libtransmission/watchdir.h
+++ b/libtransmission/watchdir.h
@@ -10,8 +10,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 struct event_base;
 
 typedef struct tr_watchdir* tr_watchdir_t;
@@ -37,5 +35,3 @@ tr_watchdir_t tr_watchdir_new(
 void tr_watchdir_free(tr_watchdir_t handle);
 
 char const* tr_watchdir_get_path(tr_watchdir_t handle);
-
-TR_END_DECLS

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -10,8 +10,6 @@
 
 #include "tr-macros.h"
 
-TR_BEGIN_DECLS
-
 struct tr_address;
 struct tr_web_task;
 
@@ -62,5 +60,3 @@ void tr_http_escape(struct evbuffer* out, char const* str, size_t len, bool esca
 void tr_http_escape_sha1(char* out, uint8_t const* sha1_digest);
 
 char* tr_http_unescape(char const* str, size_t len);
-
-TR_END_DECLS

--- a/libtransmission/wildmat.c
+++ b/libtransmission/wildmat.c
@@ -53,7 +53,7 @@
 /*
 **  Match text and p, return true, false, or ABORT.
 */
-static int
+int
 DoMatch (const char * text, const char * p)
 {
     register int	last;
@@ -106,15 +106,4 @@ DoMatch (const char * text, const char * p)
 	return true;
 #endif	/* MATCH_TAR_ATTERN */
     return *text == '\0';
-}
-
-
-/* User-level routine. returns whether or not 'text' and 'p' matched */
-bool
-tr_wildmat (const char * text, const char * p)
-{
-    if (p[0] == '*' && p[1] == '\0')
-	return true;
-
-    return DoMatch (text, p) == true;
 }


### PR DESCRIPTION
procedural PR to remove the `extern "C"` declarations from libtransmission headers.