### PR TITLE
refactor: replace tr_ptrArray with std::unordered_set in tr_watchdir_scan()

### DIFF
--- a/libtransmission/watchdir-common.h
+++ b/libtransmission/watchdir-common.h
@@ -12,14 +12,15 @@
 #error only the libtransmission watchdir module should #include this header.
 #endif
 
-struct tr_ptrArray;
+#include <string>
+#include <unordered_set>
 
 typedef struct tr_watchdir_backend
 {
     void (*free_func)(struct tr_watchdir_backend*);
 } tr_watchdir_backend;
 
-#define BACKEND_DOWNCAST(b) ((tr_watchdir_backend*)(b))
+#define BACKEND_DOWNCAST(b) (reinterpret_cast<tr_watchdir_backend*>(b))
 
 /* ... */
 
@@ -31,7 +32,7 @@ struct event_base* tr_watchdir_get_event_base(tr_watchdir_t handle);
 
 void tr_watchdir_process(tr_watchdir_t handle, char const* name);
 
-void tr_watchdir_scan(tr_watchdir_t handle, struct tr_ptrArray* dir_entries);
+void tr_watchdir_scan(tr_watchdir_t handle, std::unordered_set<std::string>* dir_entries);
 
 /* ... */
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -117,7 +117,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
     char const* const path = tr_watchdir_get_path(handle);
     struct kevent ke;
 
-    auto* backend = tr_watchdir_kqueue{};
+    auto* backend = new tr_watchdir_kqueue{};
     backend->base.free_func = &tr_watchdir_kqueue_free;
     backend->kq = -1;
     backend->dirfd = -1;

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -328,12 +328,11 @@ void tr_watchdir_process(tr_watchdir_t handle, char const* name)
     }
 }
 
-void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
+void tr_watchdir_scan(tr_watchdir_t handle, std::unordered_set<std::string>* dir_entries)
 {
     tr_sys_dir_t dir;
     char const* name;
-    auto new_dir_entries = tr_ptrArray{};
-    auto const name_compare_func = (PtrArrayCompareFunc)&strcmp;
+    auto new_dir_entries = std::unordered_set<std::string>{};
     tr_error* error = nullptr;
 
     if ((dir = tr_sys_dir_open(handle->path, &error)) == TR_BAD_SYS_DIR)
@@ -352,9 +351,10 @@ void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
 
         if (dir_entries != nullptr)
         {
-            tr_ptrArrayInsertSorted(&new_dir_entries, tr_strdup(name), name_compare_func);
+            auto const namestr = std::string(name);
+            new_dir_entries.insert(namestr);
 
-            if (tr_ptrArrayFindSorted(dir_entries, name, name_compare_func) != nullptr)
+            if (dir_entries->count(namestr) != 0)
             {
                 continue;
             }
@@ -373,7 +373,6 @@ void tr_watchdir_scan(tr_watchdir_t handle, tr_ptrArray* dir_entries)
 
     if (dir_entries != nullptr)
     {
-        tr_ptrArrayDestruct(dir_entries, &tr_free);
         *dir_entries = new_dir_entries;
     }
 }

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -360,6 +360,8 @@ TEST_P(WatchDirTest, retry)
     processEvents();
     EXPECT_EQ(wd, wd_data.wd);
     EXPECT_EQ(test_file, wd_data.name);
+
+    tr_watchdir_free(wd);
 }
 
 INSTANTIATE_TEST_SUITE_P( //


### PR DESCRIPTION
A minor refactor to use std:: tools instead of bespoke ones.

This PR replaces the `tr_ptrArray` field with a `std::unordered_set` in `tr_watchdir_scan()`