### PR TITLE
refactor: use std::unordered_set for tr_torrent.labels

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -106,12 +106,11 @@ static uint64_t loadPeers(tr_variant* dict, tr_torrent* tor)
 
 static void saveLabels(tr_variant* dict, tr_torrent const* tor)
 {
-    size_t const n = tr_ptrArraySize(&tor->labels);
-    tr_variant* list = tr_variantDictAddList(dict, TR_KEY_labels, n);
-    char const* const* labels = (char const* const*)tr_ptrArrayBase(&tor->labels);
-    for (size_t i = 0; i < n; ++i)
+    auto const& labels = tor->labels;
+    tr_variant* list = tr_variantDictAddList(dict, TR_KEY_labels, std::size(labels));
+    for (auto const& label : labels)
     {
-        tr_variantListAddStr(list, labels[i]);
+        tr_variantListAddStr(list, label.c_str());
     }
 }
 
@@ -128,7 +127,7 @@ static uint64_t loadLabels(tr_variant* dict, tr_torrent* tor)
         {
             if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != nullptr && str_len != 0)
             {
-                tr_ptrArrayAppend(&tor->labels, tr_strndup(str, str_len));
+                tor->labels.emplace(str, str_len);
             }
         }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -12,13 +12,15 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <string>
+#include <unordered_set>
+
 #include "bandwidth.h" /* tr_bandwidth */
 #include "completion.h" /* tr_completion */
 #include "session.h" /* tr_sessionLock(), tr_sessionUnlock() */
 #include "tr-assert.h"
 #include "tr-macros.h"
 #include "utils.h" /* TR_GNUC_PRINTF */
-#include "ptrarray.h"
 
 struct tr_torrent_tiers;
 struct tr_magnet_info;
@@ -44,7 +46,9 @@ void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 /* just like tr_torrentSetFileDLs but doesn't trigger a fastresume save */
 void tr_torrentInitFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file_index_t fileCount, bool do_download);
 
-void tr_torrentSetLabels(tr_torrent* tor, tr_ptrArray* labels);
+using tr_labels_t = std::unordered_set<std::string>;
+
+void tr_torrentSetLabels(tr_torrent* tor, tr_labels_t&& labels);
 
 void tr_torrentRecheckCompleteness(tr_torrent*);
 
@@ -264,7 +268,7 @@ struct tr_torrent
     tr_idlelimit idleLimitMode;
     bool finishedSeedingByIdle;
 
-    tr_ptrArray labels;
+    tr_labels_t labels;
 };
 
 /* what piece index is this block in? */

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -608,37 +608,6 @@ char* tr_strsep(char** str, char const* delims)
 #endif
 }
 
-char* tr_strjoin(char const* const* arr, size_t len, char const* delim)
-{
-    size_t total_len = 1;
-    size_t delim_len = strlen(delim);
-    for (size_t i = 0; i < len; ++i)
-    {
-        total_len += strlen(arr[i]);
-    }
-
-    total_len += len > 0 ? (len - 1) * delim_len : 0;
-
-    char* const ret = tr_new(char, total_len);
-    char* p = ret;
-
-    for (size_t i = 0; i < len; ++i)
-    {
-        if (i > 0)
-        {
-            memcpy(p, delim, delim_len);
-            p += delim_len;
-        }
-
-        size_t const part_len = strlen(arr[i]);
-        memcpy(p, arr[i], part_len);
-        p += part_len;
-    }
-
-    *p = '\0';
-    return ret;
-}
-
 char* tr_strstrip(char* str)
 {
     if (str != nullptr)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -250,9 +250,6 @@ char const* tr_strcasestr(char const* haystack, char const* needle);
 /** @brief Portability wrapper for strsep() that uses the system implementation if available */
 char* tr_strsep(char** str, char const* delim);
 
-/** @brief Concatenates array of strings with delimiter in between elements */
-char* tr_strjoin(char const* const* arr, size_t len, char const* delim);
-
 /***
 ****
 ***/

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -68,29 +68,6 @@ TEST_F(UtilsTest, trStrstrip)
     tr_free(in);
 }
 
-TEST_F(UtilsTest, trStrjoin)
-{
-    auto const in1 = std::array<char const*, 2>{ "one", "two" };
-    auto out = makeString(tr_strjoin(in1.data(), in1.size(), ", "));
-    EXPECT_EQ("one, two", out);
-
-    auto const in2 = std::array<char const*, 1>{ "hello" };
-    out = makeString(tr_strjoin(in2.data(), in2.size(), "###"));
-    EXPECT_EQ("hello", out);
-
-    auto const in3 = std::array<char const*, 5>{ "a", "b", "ccc", "d", "eeeee" };
-    out = makeString(tr_strjoin(in3.data(), in3.size(), " "));
-    EXPECT_EQ("a b ccc d eeeee", out);
-
-    auto const in4 = std::array<char const*, 3>{ "7", "ate", "9" };
-    out = makeString(tr_strjoin(in4.data(), in4.size(), ""));
-    EXPECT_EQ("7ate9", out);
-
-    char const** in5 = nullptr;
-    out = makeString(tr_strjoin(in5, 0, "a"));
-    EXPECT_EQ("", out);
-}
-
 TEST_F(UtilsTest, trBuildpath)
 {
     auto out = makeString(tr_buildPath("foo", "bar", nullptr));


### PR DESCRIPTION
An incremental refactor to use std:: tools instead of bespoke ones.

This PR changes `tr_torrent.labels` from being a `tr_ptrArray` to a `std::unordered_set<std::string>`.