### PR TITLE
refactor: use std::set in tr_announcer.stops

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2963,7 +2963,7 @@ int tr_sessionGetAntiBruteForceThreshold(tr_session const* session)
     return tr_rpcGetAntiBruteForceThreshold(session->rpcServer);
 }
 
-void tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction, size_t num_wanted, tr_ptrArray* setme)
+std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction, size_t num_wanted)
 {
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(tr_isDirection(direction));
@@ -2991,11 +2991,7 @@ void tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction
         candidates.resize(num_wanted);
     }
 
-    // add them to the return array
-    for (auto* candidate : candidates)
-    {
-        tr_ptrArrayAppend(setme, candidate);
-    }
+    return candidates;
 }
 
 int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -46,7 +46,6 @@
 #include "platform.h" /* tr_lock, tr_getTorrentDir() */
 #include "platform-quota.h" /* tr_device_info_free() */
 #include "port-forwarding.h"
-#include "ptrarray.h"
 #include "rpc-server.h"
 #include "session.h"
 #include "session-id.h"

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -344,7 +344,7 @@ void tr_sessionSetAltSpeed_Bps(tr_session*, tr_direction, unsigned int Bps);
 
 bool tr_sessionGetActiveSpeedLimit_Bps(tr_session const* session, tr_direction dir, unsigned int* setme);
 
-void tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction dir, size_t numwanted, tr_ptrArray* setme);
+std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction dir, size_t numwanted);
 
 int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction);
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -25,7 +25,6 @@
 #include "bandwidth.h"
 #include "bitfield.h"
 #include "net.h"
-#include "ptrarray.h"
 #include "tr-macros.h"
 #include "utils.h"
 #include "variant.h"


### PR DESCRIPTION
An incremental refactor to use std:: tools instead of bespoke ones.

This PR changes `tr_announcer.stops` from being a `tr_ptrArray` to a `std::set<tr_announce_request*>`.