### PR TITLE
refactor: use std::map for tr_announcer.scrape_info

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstdlib> /* qsort() */
 #include <cstring> /* strcmp(), memcpy(), strncmp() */
+#include <map>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
An incremental refactor to use std:: tools instead of bespoke ones.

This PR changes `tr_announcer.scrape_info` to be a `std::map` instead of a `tr_ptrArray`.