### PR TITLE
refactor: use std::string in tr_scrape_response

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -12,6 +12,8 @@
 #error only the libtransmission announcer module should #include this header.
 #endif
 
+#include <string>
+
 #include "transmission.h" /* SHA_DIGEST_LENGTH */
 #include "session.h" /* PEER_ID_LEN */
 
@@ -68,7 +70,7 @@ struct tr_scrape_response_row
     int downloaders;
 };
 
-typedef struct
+struct tr_scrape_response
 {
     /* whether or not we managed to connect to the tracker */
     bool did_connect;
@@ -83,15 +85,15 @@ typedef struct
     struct tr_scrape_response_row rows[TR_MULTISCRAPE_MAX];
 
     /* the raw scrape url */
-    char* url;
+    std::string url;
 
     /* human-readable error string on failure, or NULL */
-    char* errmsg;
+    std::string errmsg;
 
     /* minimum interval (in seconds) allowed between scrapes.
      * this is an unofficial extension that some trackers won't support. */
     int min_request_interval;
-} tr_scrape_response;
+};
 
 typedef void (*tr_scrape_response_func)(tr_scrape_response const* response, void* user_data);
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -370,9 +370,7 @@ static void on_scrape_done_eventthread(void* vdata)
         data->response_func(&data->response, data->response_func_user_data);
     }
 
-    tr_free(data->response.errmsg);
-    tr_free(data->response.url);
-    tr_free(data);
+    delete data;
 }
 
 static void on_scrape_done(
@@ -389,7 +387,7 @@ static void on_scrape_done(
     tr_scrape_response* response = &data->response;
     response->did_connect = did_connect;
     response->did_timeout = did_timeout;
-    dbgmsg(data->log_name, "Got scrape response for \"%s\"", response->url);
+    dbgmsg(data->log_name, "Got scrape response for \"%s\"", response->url.c_str());
 
     if (response_code != HTTP_OK)
     {
@@ -514,11 +512,10 @@ void tr_tracker_http_scrape(
     tr_scrape_response_func response_func,
     void* response_func_user_data)
 {
-    struct scrape_data* d;
     char* url = scrape_url_new(request);
 
-    d = tr_new0(struct scrape_data, 1);
-    d->response.url = tr_strdup(request->url);
+    auto* d = new scrape_data{};
+    d->response.url = request->url;
     d->response_func = response_func;
     d->response_func_user_data = response_func_user_data;
     d->response.row_count = request->info_hash_count;

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -213,8 +213,6 @@ static struct tau_scrape_request* tau_scrape_request_new(
 
 static void tau_scrape_request_free(struct tau_scrape_request* req)
 {
-    tr_free(req->response.errmsg);
-    tr_free(req->response.url);
     delete req;
 }
 


### PR DESCRIPTION
An incremental refactor to use std:: tools instead of bespoke ones.

This PR changes `tr_scrape_response.url` and `tr_scrape_response.errmsg` to be `std::string`s instead of raw `char*`s.