### PR TITLE
Change systemd service type from 'notify' to 'simple'

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 User=transmission
-Type=notify
+Type=simple
 ExecStart=/usr/bin/transmission-daemon -f --log-error
 ExecReload=/bin/kill -s HUP $MAINPID
 NoNewPrivileges=true


### PR DESCRIPTION
Having the type set to `notify` in the service file causes systemd to block startup until the transmission service is activated, which, for me, added about 10 seconds to my system's boot up time. Setting it to `simple` instead will start the service and allow systemd to continue startup without waiting for it to finish.