### PR TITLE
refactor: make tr_info.errorString a const char*.

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1287,7 +1287,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->queuePosition = tor->queuePosition;
     s->idleSecs = torrentGetIdleSecs(tor, s->activity);
     s->isStalled = tr_torrentIsStalled(tor, s->idleSecs);
-    tr_strlcpy(s->errorString, tor->errorString, sizeof(s->errorString));
+    s->errorString = tor->errorString;
 
     s->manualAnnounceTime = tr_announcerNextManualAnnounce(tor);
     s->peersConnected = swarm_stats.peerCount;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1703,7 +1703,7 @@ typedef struct tr_stat
 
     /** A warning or error message regarding the torrent.
         @see error */
-    char errorString[512];
+    char const* errorString;
 
     /** When tr_stat.activity is TR_STATUS_CHECK or TR_STATUS_CHECK_WAIT,
         this is the percentage of how much of the files has been


### PR DESCRIPTION
this field now points to `tr_torrent.errorString` instead of copying into a standalone char array.

old: sizeof(tr_torrent) 2640
new: sizeof(tr_torrent) 2136