### PR TITLE
refactor: remove unused property tr variant string.quark

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -134,7 +134,6 @@ void tr_variantInit(tr_variant* v, char type)
 
 static auto constexpr STRING_INIT = tr_variant_string{
     TR_STRING_TYPE_QUARK,
-    TR_KEY_NONE,
     0,
     {},
 };
@@ -180,7 +179,6 @@ static void tr_variant_string_set_quark(struct tr_variant_string* str, tr_quark 
     tr_variant_string_clear(str);
 
     str->type = TR_STRING_TYPE_QUARK;
-    str->quark = quark;
     str->str.str = tr_quark_get_string(quark, &str->len);
 }
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -42,7 +42,6 @@ typedef enum
 struct tr_variant_string
 {
     tr_string_type type;
-    tr_quark quark;
     size_t len;
     union
     {


### PR DESCRIPTION
This field was assigned but never used. Shrinks sizeof(tr_variant) by 8 bytes.
