### PR TITLE
refactor: remove unused tr_variant_string.session

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -95,11 +95,10 @@ static int compareBandwidth(void const* va, void const* vb)
 ****
 ***/
 
-void tr_bandwidthConstruct(tr_bandwidth* b, tr_session* session, tr_bandwidth* parent)
+void tr_bandwidthConstruct(tr_bandwidth* b, tr_bandwidth* parent)
 {
     static unsigned int uniqueKey = 0;
 
-    b->session = session;
     b->children = {};
     b->magicNumber = BANDWIDTH_MAGIC_NUMBER;
     b->uniqueKey = uniqueKey++;

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -110,7 +110,6 @@ typedef struct tr_bandwidth
     tr_priority_t priority;
     int magicNumber;
     unsigned int uniqueKey;
-    tr_session* session;
     tr_ptrArray children; /* struct tr_bandwidth */
     struct tr_peerIo* peer;
 } tr_bandwidth;
@@ -119,7 +118,7 @@ typedef struct tr_bandwidth
 ***
 **/
 
-void tr_bandwidthConstruct(tr_bandwidth* bandwidth, tr_session* session, tr_bandwidth* parent);
+void tr_bandwidthConstruct(tr_bandwidth* bandwidth, tr_bandwidth* parent);
 
 void tr_bandwidthDestruct(tr_bandwidth* bandwidth);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -680,7 +680,7 @@ static tr_peerIo* tr_peerIoNew(
     io->timeCreated = tr_time();
     io->inbuf = evbuffer_new();
     io->outbuf = evbuffer_new();
-    tr_bandwidthConstruct(&io->bandwidth, session, parent);
+    tr_bandwidthConstruct(&io->bandwidth, parent);
     tr_bandwidthSetPeer(&io->bandwidth, io);
     dbgmsg(io, "bandwidth is %p; its parent is %p", (void*)&io->bandwidth, (void*)parent);
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -636,7 +636,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     session->cache = tr_cacheNew(1024 * 1024 * 2);
     session->magicNumber = SESSION_MAGIC_NUMBER;
     session->session_id = tr_session_id_new();
-    tr_bandwidthConstruct(&session->bandwidth, session, nullptr);
+    tr_bandwidthConstruct(&session->bandwidth, nullptr);
     tr_variantInitList(&session->removedTorrents, 0);
 
     /* nice to start logging at the very beginning */

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -885,7 +885,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         tor->incompleteDir = tr_strdup(dir);
     }
 
-    tr_bandwidthConstruct(&tor->bandwidth, session, &session->bandwidth);
+    tr_bandwidthConstruct(&tor->bandwidth, &session->bandwidth);
 
     tor->bandwidth.priority = tr_ctorGetBandwidthPriority(ctor);
     tor->error = TR_STAT_OK;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -614,7 +614,7 @@ tr_webseed* tr_webseedNew(struct tr_torrent* tor, char const* url, tr_peer_callb
     w->callback = callback;
     w->callback_data = callback_data;
     w->file_urls = tr_new0(char*, inf->fileCount);
-    tr_bandwidthConstruct(&w->bandwidth, tor->session, &tor->bandwidth);
+    tr_bandwidthConstruct(&w->bandwidth, &tor->bandwidth);
     w->timer = evtimer_new(w->session->event_base, webseed_timer_func, w);
     tr_timerAddMsec(w->timer, TR_IDLE_TIMER_MSEC);
     return w;


### PR DESCRIPTION
This was assigned but never used. Shrinks sizeof(tr_bandwidth) by 8 bytes.