### PR TITLE
refactor: prefer constexpr functions over static inline ones

### DIFF
--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -123,7 +123,7 @@ void tr_bandwidthConstruct(tr_bandwidth* bandwidth, tr_bandwidth* parent);
 void tr_bandwidthDestruct(tr_bandwidth* bandwidth);
 
 /** @brief test to see if the pointer refers to a live bandwidth object */
-static inline bool tr_isBandwidth(tr_bandwidth const* b)
+constexpr bool tr_isBandwidth(tr_bandwidth const* b)
 {
     return b != nullptr && b->magicNumber == BANDWIDTH_MAGIC_NUMBER;
 }
@@ -137,7 +137,7 @@ static inline bool tr_isBandwidth(tr_bandwidth const* b)
  * @see tr_bandwidthAllocate
  * @see tr_bandwidthGetDesiredSpeed
  */
-static inline bool tr_bandwidthSetDesiredSpeed_Bps(tr_bandwidth* bandwidth, tr_direction dir, unsigned int desiredSpeed)
+constexpr bool tr_bandwidthSetDesiredSpeed_Bps(tr_bandwidth* bandwidth, tr_direction dir, unsigned int desiredSpeed)
 {
     unsigned int* value = &bandwidth->band[dir].desiredSpeed_Bps;
     bool const didChange = desiredSpeed != *value;
@@ -149,7 +149,7 @@ static inline bool tr_bandwidthSetDesiredSpeed_Bps(tr_bandwidth* bandwidth, tr_d
  * @brief Get the desired speed for the bandwidth subtree.
  * @see tr_bandwidthSetDesiredSpeed
  */
-static inline double tr_bandwidthGetDesiredSpeed_Bps(tr_bandwidth const* bandwidth, tr_direction dir)
+constexpr double tr_bandwidthGetDesiredSpeed_Bps(tr_bandwidth const* bandwidth, tr_direction dir)
 {
     return bandwidth->band[dir].desiredSpeed_Bps;
 }
@@ -157,7 +157,7 @@ static inline double tr_bandwidthGetDesiredSpeed_Bps(tr_bandwidth const* bandwid
 /**
  * @brief Set whether or not this bandwidth should throttle its peer-io's speeds
  */
-static inline bool tr_bandwidthSetLimited(tr_bandwidth* bandwidth, tr_direction dir, bool isLimited)
+constexpr bool tr_bandwidthSetLimited(tr_bandwidth* bandwidth, tr_direction dir, bool isLimited)
 {
     bool* value = &bandwidth->band[dir].isLimited;
     bool const didChange = isLimited != *value;
@@ -168,7 +168,7 @@ static inline bool tr_bandwidthSetLimited(tr_bandwidth* bandwidth, tr_direction 
 /**
  * @return nonzero if this bandwidth throttles its peer-ios speeds
  */
-static inline bool tr_bandwidthIsLimited(tr_bandwidth const* bandwidth, tr_direction dir)
+constexpr bool tr_bandwidthIsLimited(tr_bandwidth const* bandwidth, tr_direction dir)
 {
     return bandwidth->band[dir].isLimited;
 }
@@ -211,7 +211,7 @@ void tr_bandwidthSetParent(tr_bandwidth* bandwidth, tr_bandwidth* parent);
  * But when we set a torrent's speed mode to TR_SPEEDLIMIT_UNLIMITED, then
  * in that particular case we want to ignore the global speed limit...
  */
-static inline bool tr_bandwidthHonorParentLimits(tr_bandwidth* bandwidth, tr_direction direction, bool isEnabled)
+constexpr bool tr_bandwidthHonorParentLimits(tr_bandwidth* bandwidth, tr_direction direction, bool isEnabled)
 {
     bool* value = &bandwidth->band[direction].honorParentLimits;
     bool const didChange = isEnabled != *value;
@@ -219,7 +219,7 @@ static inline bool tr_bandwidthHonorParentLimits(tr_bandwidth* bandwidth, tr_dir
     return didChange;
 }
 
-static inline bool tr_bandwidthAreParentLimitsHonored(tr_bandwidth const* bandwidth, tr_direction direction)
+constexpr bool tr_bandwidthAreParentLimitsHonored(tr_bandwidth const* bandwidth, tr_direction direction)
 {
     TR_ASSERT(tr_isBandwidth(bandwidth));
     TR_ASSERT(tr_isDirection(direction));

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -53,7 +53,7 @@ void tr_bitfieldRemRange(tr_bitfield*, size_t begin, size_t end);
 
 void tr_bitfieldConstruct(tr_bitfield*, size_t bit_count);
 
-static inline void tr_bitfieldDestruct(tr_bitfield* b)
+constexpr void tr_bitfieldDestruct(tr_bitfield* b)
 {
     tr_bitfieldSetHasNone(b);
 }
@@ -78,12 +78,12 @@ size_t tr_bitfieldCountRange(tr_bitfield const*, size_t begin, size_t end);
 
 size_t tr_bitfieldCountTrueBits(tr_bitfield const* b);
 
-static inline bool tr_bitfieldHasAll(tr_bitfield const* b)
+constexpr bool tr_bitfieldHasAll(tr_bitfield const* b)
 {
     return b->bit_count != 0 ? (b->true_count == b->bit_count) : b->have_all_hint;
 }
 
-static inline bool tr_bitfieldHasNone(tr_bitfield const* b)
+constexpr bool tr_bitfieldHasNone(tr_bitfield const* b)
 {
     return b->bit_count != 0 ? (b->true_count == 0) : b->have_none_hint;
 }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -50,7 +50,7 @@ void tr_cpConstruct(tr_completion*, tr_torrent*);
 
 void tr_cpBlockInit(tr_completion* cp, tr_bitfield const* blocks);
 
-static inline void tr_cpDestruct(tr_completion* cp)
+constexpr void tr_cpDestruct(tr_completion* cp)
 {
     tr_bitfieldDestruct(&cp->blockBitfield);
 }
@@ -73,17 +73,17 @@ uint64_t tr_cpLeftUntilDone(tr_completion const*);
 
 void tr_cpGetAmountDone(tr_completion const* completion, float* tab, int tabCount);
 
-static inline uint64_t tr_cpHaveTotal(tr_completion const* cp)
+constexpr uint64_t tr_cpHaveTotal(tr_completion const* cp)
 {
     return cp->sizeNow;
 }
 
-static inline bool tr_cpHasAll(tr_completion const* cp)
+constexpr bool tr_cpHasAll(tr_completion const* cp)
 {
     return tr_torrentHasMetadata(cp->tor) && tr_bitfieldHasAll(&cp->blockBitfield);
 }
 
-static inline bool tr_cpHasNone(tr_completion const* cp)
+constexpr bool tr_cpHasNone(tr_completion const* cp)
 {
     return !tr_torrentHasMetadata(cp->tor) || tr_bitfieldHasNone(&cp->blockBitfield);
 }
@@ -100,7 +100,7 @@ size_t tr_cpMissingBlocksInPiece(tr_completion const*, tr_piece_index_t);
 
 size_t tr_cpMissingBytesInPiece(tr_completion const*, tr_piece_index_t);
 
-static inline bool tr_cpPieceIsComplete(tr_completion const* cp, tr_piece_index_t i)
+constexpr bool tr_cpPieceIsComplete(tr_completion const* cp, tr_piece_index_t i)
 {
     return tr_cpMissingBlocksInPiece(cp, i) == 0;
 }
@@ -111,7 +111,7 @@ static inline bool tr_cpPieceIsComplete(tr_completion const* cp, tr_piece_index_
 
 void tr_cpBlockAdd(tr_completion* cp, tr_block_index_t i);
 
-static inline bool tr_cpBlockIsComplete(tr_completion const* cp, tr_block_index_t i)
+constexpr bool tr_cpBlockIsComplete(tr_completion const* cp, tr_block_index_t i)
 {
     return tr_bitfieldHas(&cp->blockBitfield, i);
 }
@@ -124,7 +124,7 @@ bool tr_cpFileIsComplete(tr_completion const* cp, tr_file_index_t);
 
 void* tr_cpCreatePieceBitfield(tr_completion const* cp, size_t* byte_count);
 
-static inline void tr_cpInvalidateDND(tr_completion* cp)
+constexpr void tr_cpInvalidateDND(tr_completion* cp)
 {
     cp->sizeWhenDoneIsDirty = true;
 }

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -175,7 +175,7 @@ void* tr_base64_decode_str(char const* input, size_t* output_length) TR_GNUC_MAL
 /**
  * @brief Wrapper around tr_binary_to_hex() for SHA_DIGEST_LENGTH.
  */
-static inline void tr_sha1_to_hex(void* hex, void const* sha1)
+constexpr void tr_sha1_to_hex(void* hex, void const* sha1)
 {
     tr_binary_to_hex(sha1, hex, SHA_DIGEST_LENGTH);
 }
@@ -183,7 +183,7 @@ static inline void tr_sha1_to_hex(void* hex, void const* sha1)
 /**
  * @brief Wrapper around tr_hex_to_binary() for SHA_DIGEST_LENGTH.
  */
-static inline void tr_hex_to_sha1(void* sha1, void const* hex)
+constexpr void tr_hex_to_sha1(void* sha1, void const* hex)
 {
     tr_hex_to_binary(hex, sha1, SHA_DIGEST_LENGTH);
 }

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -110,7 +110,7 @@ int tr_address_compare(tr_address const* a, tr_address const* b);
 
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);
 
-static inline bool tr_address_is_valid(tr_address const* a)
+constexpr bool tr_address_is_valid(tr_address const* a)
 {
     return a != nullptr && (a->type == TR_AF_INET || a->type == TR_AF_INET6);
 }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -132,7 +132,7 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io);
 
 #define PEER_IO_MAGIC_NUMBER 206745
 
-static inline bool tr_isPeerIo(tr_peerIo const* io)
+constexpr bool tr_isPeerIo(tr_peerIo const* io)
 {
     return io != nullptr && io->magicNumber == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 && tr_isBandwidth(&io->bandwidth) &&
         tr_address_is_valid(&io->addr);
@@ -142,37 +142,37 @@ static inline bool tr_isPeerIo(tr_peerIo const* io)
 ***
 **/
 
-static inline void tr_peerIoEnableFEXT(tr_peerIo* io, bool flag)
+constexpr void tr_peerIoEnableFEXT(tr_peerIo* io, bool flag)
 {
     io->fastExtensionSupported = flag;
 }
 
-static inline bool tr_peerIoSupportsFEXT(tr_peerIo const* io)
+constexpr bool tr_peerIoSupportsFEXT(tr_peerIo const* io)
 {
     return io->fastExtensionSupported;
 }
 
-static inline void tr_peerIoEnableLTEP(tr_peerIo* io, bool flag)
+constexpr void tr_peerIoEnableLTEP(tr_peerIo* io, bool flag)
 {
     io->extendedProtocolSupported = flag;
 }
 
-static inline bool tr_peerIoSupportsLTEP(tr_peerIo const* io)
+constexpr bool tr_peerIoSupportsLTEP(tr_peerIo const* io)
 {
     return io->extendedProtocolSupported;
 }
 
-static inline void tr_peerIoEnableDHT(tr_peerIo* io, bool flag)
+constexpr void tr_peerIoEnableDHT(tr_peerIo* io, bool flag)
 {
     io->dhtSupported = flag;
 }
 
-static inline bool tr_peerIoSupportsDHT(tr_peerIo const* io)
+constexpr bool tr_peerIoSupportsDHT(tr_peerIo const* io)
 {
     return io->dhtSupported;
 }
 
-static inline bool tr_peerIoSupportsUTP(tr_peerIo const* io)
+constexpr bool tr_peerIoSupportsUTP(tr_peerIo const* io)
 {
     return io->utpSupported;
 }
@@ -181,7 +181,7 @@ static inline bool tr_peerIoSupportsUTP(tr_peerIo const* io)
 ***
 **/
 
-static inline tr_session* tr_peerIoGetSession(tr_peerIo* io)
+constexpr tr_session* tr_peerIoGetSession(tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(io->session != nullptr);
@@ -201,7 +201,7 @@ void tr_peerIoSetTorrentHash(tr_peerIo* io, uint8_t const* hash);
 
 int tr_peerIoReconnect(tr_peerIo* io);
 
-static inline bool tr_peerIoIsIncoming(tr_peerIo const* io)
+constexpr bool tr_peerIoIsIncoming(tr_peerIo const* io)
 {
     return io->isIncoming;
 }
@@ -217,7 +217,7 @@ static inline int tr_peerIoGetAge(tr_peerIo const* io)
 
 void tr_peerIoSetPeersId(tr_peerIo* io, uint8_t const* peer_id);
 
-static inline uint8_t const* tr_peerIoGetPeersId(tr_peerIo const* io)
+constexpr uint8_t const* tr_peerIoGetPeersId(tr_peerIo const* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(io->peerIdIsSet);
@@ -245,14 +245,14 @@ void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData);
 ***
 **/
 
-static inline tr_crypto* tr_peerIoGetCrypto(tr_peerIo* io)
+constexpr tr_crypto* tr_peerIoGetCrypto(tr_peerIo* io)
 {
     return &io->crypto;
 }
 
 void tr_peerIoSetEncryption(tr_peerIo* io, tr_encryption_type encryption_type);
 
-static inline bool tr_peerIoIsEncrypted(tr_peerIo const* io)
+constexpr bool tr_peerIoIsEncrypted(tr_peerIo const* io)
 {
     return io != nullptr && io->encryption_type == PEER_ENCRYPTION_RC4;
 }
@@ -262,17 +262,17 @@ void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t hs);
 void evbuffer_add_uint32(struct evbuffer* outbuf, uint32_t hl);
 void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t hll);
 
-static inline void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
+constexpr void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
 {
     evbuffer_add_uint16(buf, val);
 }
 
-static inline void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
+constexpr void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
 {
     evbuffer_add_uint32(buf, val);
 }
 
-static inline void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
+constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
 }
@@ -281,7 +281,7 @@ void tr_peerIoReadBytesToBuf(tr_peerIo* io, struct evbuffer* inbuf, struct evbuf
 
 void tr_peerIoReadBytes(tr_peerIo* io, struct evbuffer* inbuf, void* bytes, size_t byteCount);
 
-static inline void tr_peerIoReadUint8(tr_peerIo* io, struct evbuffer* inbuf, uint8_t* setme)
+constexpr void tr_peerIoReadUint8(tr_peerIo* io, struct evbuffer* inbuf, uint8_t* setme)
 {
     tr_peerIoReadBytes(io, inbuf, setme, sizeof(uint8_t));
 }
@@ -298,7 +298,7 @@ void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byteCount);
 
 size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now);
 
-static inline void tr_peerIoSetParent(tr_peerIo* io, struct tr_bandwidth* parent)
+constexpr void tr_peerIoSetParent(tr_peerIo* io, struct tr_bandwidth* parent)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
@@ -307,12 +307,12 @@ static inline void tr_peerIoSetParent(tr_peerIo* io, struct tr_bandwidth* parent
 
 void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
 
-static inline bool tr_peerIoHasBandwidthLeft(tr_peerIo const* io, tr_direction dir)
+constexpr bool tr_peerIoHasBandwidthLeft(tr_peerIo const* io, tr_direction dir)
 {
     return tr_bandwidthClamp(&io->bandwidth, dir, 1024) > 0;
 }
 
-static inline unsigned int tr_peerIoGetPieceSpeed_Bps(tr_peerIo const* io, uint64_t now, tr_direction dir)
+constexpr unsigned int tr_peerIoGetPieceSpeed_Bps(tr_peerIo const* io, uint64_t now, tr_direction dir)
 {
     return tr_bandwidthGetPieceSpeed_Bps(&io->bandwidth, now, dir);
 }
@@ -331,7 +331,7 @@ int tr_peerIoFlushOutgoingProtocolMsgs(tr_peerIo* io);
 ***
 **/
 
-static inline struct evbuffer* tr_peerIoGetReadBuffer(tr_peerIo* io)
+constexpr struct evbuffer* tr_peerIoGetReadBuffer(tr_peerIo* io)
 {
     return io->inbuf;
 }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -29,8 +29,12 @@
  */
 
 struct UTPSocket;
+struct peer_atom;
+struct tr_peerIo;
 struct tr_peerMgr;
+struct tr_peerMsgs;
 struct tr_peer_stat;
+struct tr_swarm;
 struct tr_torrent;
 
 /* added_f's bitwise-or'ed flags */
@@ -56,12 +60,7 @@ struct tr_pex
     uint8_t flags;
 };
 
-struct peer_atom;
-struct tr_peerIo;
-struct tr_peerMsgs;
-struct tr_swarm;
-
-static inline bool tr_isPex(tr_pex const* pex)
+constexpr bool tr_isPex(tr_pex const* pex)
 {
     return pex && tr_address_is_valid(&pex->addr);
 }

--- a/libtransmission/ptrarray.h
+++ b/libtransmission/ptrarray.h
@@ -42,7 +42,7 @@ void tr_ptrArrayForeach(tr_ptrArray* array, PtrArrayForeachFunc func);
 
 /** @brief Return the nth item in a tr_ptrArray
     @return the nth item in a tr_ptrArray */
-static inline void* tr_ptrArrayNth(tr_ptrArray* array, int i)
+constexpr void* tr_ptrArrayNth(tr_ptrArray* array, int i)
 {
     TR_ASSERT(array != nullptr);
     TR_ASSERT(i >= 0);
@@ -59,14 +59,14 @@ void* tr_ptrArrayPop(tr_ptrArray* array);
 /** @brief Return the last item in a tr_ptrArray
     @return the last item in a tr_ptrArray, or nullptr if the array is empty
     @see tr_ptrArrayPop() */
-static inline void* tr_ptrArrayBack(tr_ptrArray* array)
+constexpr void* tr_ptrArrayBack(tr_ptrArray* array)
 {
     return array->n_items > 0 ? tr_ptrArrayNth(array, array->n_items - 1) : nullptr;
 }
 
 void tr_ptrArrayErase(tr_ptrArray* t, int begin, int end);
 
-static inline void tr_ptrArrayRemove(tr_ptrArray* t, int pos)
+constexpr void tr_ptrArrayRemove(tr_ptrArray* t, int pos)
 {
     tr_ptrArrayErase(t, pos, pos + 1);
 }
@@ -74,7 +74,7 @@ static inline void tr_ptrArrayRemove(tr_ptrArray* t, int pos)
 /** @brief Peek at the array pointer and its size, for easy iteration */
 void** tr_ptrArrayPeek(tr_ptrArray* array, int* size);
 
-static inline void tr_ptrArrayClear(tr_ptrArray* a)
+constexpr void tr_ptrArrayClear(tr_ptrArray* a)
 {
     a->n_items = 0;
 }
@@ -84,26 +84,26 @@ static inline void tr_ptrArrayClear(tr_ptrArray* a)
 int tr_ptrArrayInsert(tr_ptrArray* array, void* insertMe, int pos);
 
 /** @brief Append a pointer into the array */
-static inline int tr_ptrArrayAppend(tr_ptrArray* array, void* appendMe)
+constexpr int tr_ptrArrayAppend(tr_ptrArray* array, void* appendMe)
 {
     return tr_ptrArrayInsert(array, appendMe, -1);
 }
 
-static inline void** tr_ptrArrayBase(tr_ptrArray const* a)
+constexpr void** tr_ptrArrayBase(tr_ptrArray const* a)
 {
     return a->items;
 }
 
 /** @brief Return the number of items in the array
     @return the number of items in the array */
-static inline int tr_ptrArraySize(tr_ptrArray const* a)
+constexpr int tr_ptrArraySize(tr_ptrArray const* a)
 {
     return a->n_items;
 }
 
 /** @brief Return True if the array has no pointers
     @return True if the array has no pointers */
-static inline bool tr_ptrArrayEmpty(tr_ptrArray const* a)
+constexpr bool tr_ptrArrayEmpty(tr_ptrArray const* a)
 {
     return tr_ptrArraySize(a) == 0;
 }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -250,7 +250,7 @@ struct tr_session
     struct tr_bindinfo* bind_ipv6;
 };
 
-static inline tr_port tr_sessionGetPublicPeerPort(tr_session const* session)
+constexpr tr_port tr_sessionGetPublicPeerPort(tr_session const* session)
 {
     return session->public_peer_port;
 }
@@ -284,22 +284,22 @@ enum
     SESSION_MAGIC_NUMBER = 3845,
 };
 
-static inline bool tr_isSession(tr_session const* session)
+constexpr bool tr_isSession(tr_session const* session)
 {
     return session != nullptr && session->magicNumber == SESSION_MAGIC_NUMBER;
 }
 
-static inline bool tr_isPreallocationMode(tr_preallocation_mode m)
+constexpr bool tr_isPreallocationMode(tr_preallocation_mode m)
 {
     return m == TR_PREALLOCATE_NONE || m == TR_PREALLOCATE_SPARSE || m == TR_PREALLOCATE_FULL;
 }
 
-static inline bool tr_isEncryptionMode(tr_encryption_mode m)
+constexpr bool tr_isEncryptionMode(tr_encryption_mode m)
 {
     return m == TR_CLEAR_PREFERRED || m == TR_ENCRYPTION_PREFERRED || m == TR_ENCRYPTION_REQUIRED;
 }
 
-static inline bool tr_isPriority(tr_priority_t p)
+constexpr bool tr_isPriority(tr_priority_t p)
 {
     return p == TR_PRI_LOW || p == TR_PRI_NORMAL || p == TR_PRI_HIGH;
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -272,69 +272,69 @@ struct tr_torrent
 };
 
 /* what piece index is this block in? */
-static inline tr_piece_index_t tr_torBlockPiece(tr_torrent const* tor, tr_block_index_t const block)
+constexpr tr_piece_index_t tr_torBlockPiece(tr_torrent const* tor, tr_block_index_t const block)
 {
     return block / tor->blockCountInPiece;
 }
 
 /* how many bytes are in this piece? */
-static inline uint32_t tr_torPieceCountBytes(tr_torrent const* tor, tr_piece_index_t const piece)
+constexpr uint32_t tr_torPieceCountBytes(tr_torrent const* tor, tr_piece_index_t const piece)
 {
     return piece + 1 == tor->info.pieceCount ? tor->lastPieceSize : tor->info.pieceSize;
 }
 
 /* how many bytes are in this block? */
-static inline uint32_t tr_torBlockCountBytes(tr_torrent const* tor, tr_block_index_t const block)
+constexpr uint32_t tr_torBlockCountBytes(tr_torrent const* tor, tr_block_index_t const block)
 {
     return block + 1 == tor->blockCount ? tor->lastBlockSize : tor->blockSize;
 }
 
-static inline void tr_torrentLock(tr_torrent const* tor)
+constexpr void tr_torrentLock(tr_torrent const* tor)
 {
     tr_sessionLock(tor->session);
 }
 
-static inline bool tr_torrentIsLocked(tr_torrent const* tor)
+constexpr bool tr_torrentIsLocked(tr_torrent const* tor)
 {
     return tr_sessionIsLocked(tor->session);
 }
 
-static inline void tr_torrentUnlock(tr_torrent const* tor)
+constexpr void tr_torrentUnlock(tr_torrent const* tor)
 {
     tr_sessionUnlock(tor->session);
 }
 
-static inline bool tr_torrentExists(tr_session const* session, uint8_t const* torrentHash)
+constexpr bool tr_torrentExists(tr_session const* session, uint8_t const* torrentHash)
 {
     return tr_torrentFindFromHash((tr_session*)session, torrentHash) != nullptr;
 }
 
-static inline tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
+constexpr tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
 {
     return tor->completeness;
 }
 
-static inline bool tr_torrentIsSeed(tr_torrent const* tor)
+constexpr bool tr_torrentIsSeed(tr_torrent const* tor)
 {
     return tr_torrentGetCompleteness(tor) != TR_LEECH;
 }
 
-static inline bool tr_torrentIsPrivate(tr_torrent const* tor)
+constexpr bool tr_torrentIsPrivate(tr_torrent const* tor)
 {
     return tor != nullptr && tor->info.isPrivate;
 }
 
-static inline bool tr_torrentAllowsPex(tr_torrent const* tor)
+constexpr bool tr_torrentAllowsPex(tr_torrent const* tor)
 {
     return tor != nullptr && tor->session->isPexEnabled && !tr_torrentIsPrivate(tor);
 }
 
-static inline bool tr_torrentAllowsDHT(tr_torrent const* tor)
+constexpr bool tr_torrentAllowsDHT(tr_torrent const* tor)
 {
     return tor != nullptr && tr_sessionAllowsDHT(tor->session) && !tr_torrentIsPrivate(tor);
 }
 
-static inline bool tr_torrentAllowsLPD(tr_torrent const* tor)
+constexpr bool tr_torrentAllowsLPD(tr_torrent const* tor)
 {
     return tor != nullptr && tr_sessionAllowsLPD(tor->session) && !tr_torrentIsPrivate(tor);
 }
@@ -348,14 +348,14 @@ enum
     TORRENT_MAGIC_NUMBER = 95549
 };
 
-static inline bool tr_isTorrent(tr_torrent const* tor)
+constexpr bool tr_isTorrent(tr_torrent const* tor)
 {
     return tor != nullptr && tor->magicNumber == TORRENT_MAGIC_NUMBER && tr_isSession(tor->session);
 }
 
 /* set a flag indicating that the torrent's .resume file
  * needs to be saved when the torrent is closed */
-static inline void tr_torrentSetDirty(tr_torrent* tor)
+constexpr void tr_torrentSetDirty(tr_torrent* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
@@ -422,57 +422,57 @@ uint64_t tr_torrentGetCurrentSizeOnDisk(tr_torrent const* tor);
 
 unsigned char const* tr_torrentGetPeerId(tr_torrent* tor);
 
-static inline uint64_t tr_torrentGetLeftUntilDone(tr_torrent const* tor)
+constexpr uint64_t tr_torrentGetLeftUntilDone(tr_torrent const* tor)
 {
     return tr_cpLeftUntilDone(&tor->completion);
 }
 
-static inline bool tr_torrentHasAll(tr_torrent const* tor)
+constexpr bool tr_torrentHasAll(tr_torrent const* tor)
 {
     return tr_cpHasAll(&tor->completion);
 }
 
-static inline bool tr_torrentHasNone(tr_torrent const* tor)
+constexpr bool tr_torrentHasNone(tr_torrent const* tor)
 {
     return tr_cpHasNone(&tor->completion);
 }
 
-static inline bool tr_torrentPieceIsComplete(tr_torrent const* tor, tr_piece_index_t i)
+constexpr bool tr_torrentPieceIsComplete(tr_torrent const* tor, tr_piece_index_t i)
 {
     return tr_cpPieceIsComplete(&tor->completion, i);
 }
 
-static inline bool tr_torrentBlockIsComplete(tr_torrent const* tor, tr_block_index_t i)
+constexpr bool tr_torrentBlockIsComplete(tr_torrent const* tor, tr_block_index_t i)
 {
     return tr_cpBlockIsComplete(&tor->completion, i);
 }
 
-static inline size_t tr_torrentMissingBlocksInPiece(tr_torrent const* tor, tr_piece_index_t i)
+constexpr size_t tr_torrentMissingBlocksInPiece(tr_torrent const* tor, tr_piece_index_t i)
 {
     return tr_cpMissingBlocksInPiece(&tor->completion, i);
 }
 
-static inline size_t tr_torrentMissingBytesInPiece(tr_torrent const* tor, tr_piece_index_t i)
+constexpr size_t tr_torrentMissingBytesInPiece(tr_torrent const* tor, tr_piece_index_t i)
 {
     return tr_cpMissingBytesInPiece(&tor->completion, i);
 }
 
-static inline void* tr_torrentCreatePieceBitfield(tr_torrent const* tor, size_t* byte_count)
+constexpr void* tr_torrentCreatePieceBitfield(tr_torrent const* tor, size_t* byte_count)
 {
     return tr_cpCreatePieceBitfield(&tor->completion, byte_count);
 }
 
-static inline uint64_t tr_torrentHaveTotal(tr_torrent const* tor)
+constexpr uint64_t tr_torrentHaveTotal(tr_torrent const* tor)
 {
     return tr_cpHaveTotal(&tor->completion);
 }
 
-static inline bool tr_torrentIsQueued(tr_torrent const* tor)
+constexpr bool tr_torrentIsQueued(tr_torrent const* tor)
 {
     return tor->isQueued;
 }
 
-static inline tr_direction tr_torrentGetQueueDirection(tr_torrent const* tor)
+constexpr tr_direction tr_torrentGetQueueDirection(tr_torrent const* tor)
 {
     return tr_torrentIsSeed(tor) ? TR_UP : TR_DOWN;
 }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1222,7 +1222,7 @@ char* tr_torrentInfoGetMagnetLink(tr_info const* inf);
  * Returns a newly-allocated string with a magnet link of the torrent.
  * Use tr_free() to free the string when done.
  */
-static inline char* tr_torrentGetMagnetLink(tr_torrent const* tor)
+constexpr char* tr_torrentGetMagnetLink(tr_torrent const* tor)
 {
     return tr_torrentInfoGetMagnetLink(tr_torrentInfo(tor));
 }
@@ -1640,7 +1640,7 @@ struct tr_info
     bool isFolder;
 };
 
-static inline bool tr_torrentHasMetadata(tr_torrent const* tor)
+constexpr bool tr_torrentHasMetadata(tr_torrent const* tor)
 {
     tr_info const* const inf = tr_torrentInfo(tor);
     return (inf != nullptr) && (inf->fileCount > 0);
@@ -1885,7 +1885,7 @@ TR_DEPRECATED void tr_torrentSetDoneDate(tr_torrent* torrent, time_t doneDate);
 /** @} */
 
 /** @brief Sanity checker to test that the direction is TR_UP or TR_DOWN */
-static inline bool tr_isDirection(tr_direction d)
+constexpr bool tr_isDirection(tr_direction d)
 {
     return d == TR_UP || d == TR_DOWN;
 }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -202,7 +202,7 @@ char* tr_strdup(void const* in);
  */
 int tr_strcmp0(char const* str1, char const* str2);
 
-static inline bool tr_str_is_empty(char const* value)
+constexpr bool tr_str_is_empty(char const* value)
 {
     return value == nullptr || *value == '\0';
 }
@@ -354,7 +354,7 @@ static inline time_t tr_time(void)
 }
 
 /** @brief Private libtransmission function to update tr_time()'s counter */
-static inline void tr_timeUpdate(time_t now)
+constexpr void tr_timeUpdate(time_t now)
 {
     __tr_current_time = now;
 }

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <inttypes.h> /* int64_t */
+#include <cstddef> // size_t
+#include <inttypes.h> // int64_t
 
 #include "tr-macros.h"
 #include "quark.h"
@@ -122,12 +123,12 @@ int tr_variantFromBuf(
     char const* optional_source,
     char const** setme_end);
 
-static inline int tr_variantFromBenc(tr_variant* setme, void const* buf, size_t buflen)
+constexpr int tr_variantFromBenc(tr_variant* setme, void const* buf, size_t buflen)
 {
     return tr_variantFromBuf(setme, TR_VARIANT_FMT_BENC, buf, buflen, nullptr, nullptr);
 }
 
-static inline int tr_variantFromBencFull(
+constexpr int tr_variantFromBencFull(
     tr_variant* setme,
     void const* buf,
     size_t buflen,
@@ -137,7 +138,7 @@ static inline int tr_variantFromBencFull(
     return tr_variantFromBuf(setme, TR_VARIANT_FMT_BENC, buf, buflen, source, setme_end);
 }
 
-static inline int tr_variantFromJsonFull(
+constexpr int tr_variantFromJsonFull(
     tr_variant* setme,
     void const* buf,
     size_t buflen,
@@ -147,12 +148,12 @@ static inline int tr_variantFromJsonFull(
     return tr_variantFromBuf(setme, TR_VARIANT_FMT_JSON, buf, buflen, source, setme_end);
 }
 
-static inline int tr_variantFromJson(tr_variant* setme, void const* buf, size_t buflen)
+constexpr int tr_variantFromJson(tr_variant* setme, void const* buf, size_t buflen)
 {
     return tr_variantFromBuf(setme, TR_VARIANT_FMT_JSON, buf, buflen, nullptr, nullptr);
 }
 
-static inline bool tr_variantIsType(tr_variant const* b, int type)
+constexpr bool tr_variantIsType(tr_variant const* b, int type)
 {
     return b != nullptr && b->type == type;
 }
@@ -161,7 +162,7 @@ static inline bool tr_variantIsType(tr_variant const* b, int type)
 ****  Strings
 ***/
 
-static inline bool tr_variantIsString(tr_variant const* b)
+constexpr bool tr_variantIsString(tr_variant const* b)
 {
     return b != nullptr && b->type == TR_VARIANT_TYPE_STR;
 }
@@ -178,7 +179,7 @@ bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** raw_setme, size
 ****  Real Numbers
 ***/
 
-static inline bool tr_variantIsReal(tr_variant const* v)
+constexpr bool tr_variantIsReal(tr_variant const* v)
 {
     return v != nullptr && v->type == TR_VARIANT_TYPE_REAL;
 }
@@ -190,7 +191,7 @@ bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 ****  Booleans
 ***/
 
-static inline bool tr_variantIsBool(tr_variant const* v)
+constexpr bool tr_variantIsBool(tr_variant const* v)
 {
     return v != nullptr && v->type == TR_VARIANT_TYPE_BOOL;
 }
@@ -202,7 +203,7 @@ bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 ****  Ints
 ***/
 
-static inline bool tr_variantIsInt(tr_variant const* v)
+constexpr bool tr_variantIsInt(tr_variant const* v)
 {
     return v != nullptr && v->type == TR_VARIANT_TYPE_INT;
 }
@@ -214,7 +215,7 @@ bool tr_variantGetInt(tr_variant const* val, int64_t* setme);
 ****  Lists
 ***/
 
-static inline bool tr_variantIsList(tr_variant const* v)
+constexpr bool tr_variantIsList(tr_variant const* v)
 {
     return v != nullptr && v->type == TR_VARIANT_TYPE_LIST;
 }
@@ -240,7 +241,7 @@ size_t tr_variantListSize(tr_variant const* list);
 ****  Dictionaries
 ***/
 
-static inline bool tr_variantIsDict(tr_variant const* v)
+constexpr bool tr_variantIsDict(tr_variant const* v)
 {
     return v != nullptr && v->type == TR_VARIANT_TYPE_DICT;
 }


### PR DESCRIPTION
Another incremental C++ification PR. No functional changes.