### PR TITLE
web: fix sorting of renamed torrents by name

### DIFF
--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -124,6 +124,12 @@ export class Torrent extends EventTarget {
             changed |= this.setField(this.fields, key, value);
           }
           break;
+        case 'name':
+          if (this.setField(this.fields, key, data[key])) {
+            this.fields.collatedName = '';
+            changed = true;
+          }
+          break;
         default:
           changed |= this.setField(this.fields, key, value);
       }


### PR DESCRIPTION
> collatedName was not being recalculated on torrent renames, preserving the old ordering.

Submitted by @moben in #686, which was fine but the project didn't do anything with the patch so it fell out of sync with master. This PR is a resubmit that resolves those conflicts.