### PR TITLE
Don't set the path attribute when setting a cookie.

### DIFF
--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -67,7 +67,7 @@ export class Prefs extends EventTarget {
     const date = new Date();
     date.setFullYear(date.getFullYear() + 1);
     // eslint-disable-next-line unicorn/no-document-cookie
-    document.cookie = `${key}=${value}; SameSite=Strict; expires=${date.toGMTString()}; path=/`;
+    document.cookie = `${key}=${value}; SameSite=Strict; expires=${date.toGMTString()}`;
   }
 
   static _getCookie(key, fallback) {


### PR DESCRIPTION
> If you run several Transmission web servers behind a reverse proxy at a common public domain, the explicit cookie path attribute of "/" will cause the preferences set in one web client to take effect on all other web clients at that domain. I find this behaviour counter-intuitive. I see no reason why the path should not be left at the default, in which case each web client will have a private set of preferences.

Submitted by @RobCrowston in #942, which was fine but the project didn't do anything with the patch so it fell out of sync with master. This PR is a resubmit, that resolves those conflicts, keeping Rob as author.