### PR TITLE
fix: do not declare tr_peerMsgs as both a struct and a class

### DIFF
--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -33,7 +33,6 @@ struct UTPSocket;
 struct peer_atom;
 struct tr_peerIo;
 struct tr_peerMgr;
-struct tr_peerMsgs;
 struct tr_peer_stat;
 struct tr_swarm;
 struct tr_torrent;


### PR DESCRIPTION
Fix minor warning regression that was introduced in 83f21b8