### PR TITLE
Explain port-forwarding-enabled

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -534,7 +534,7 @@
    "pex-enabled"                    | boolean    | true means allow pex in public torrents
    "peer-port"                      | number     | port number
    "peer-port-random-on-start"      | boolean    | true means pick a random peer port on launch
-   "port-forwarding-enabled"        | boolean    | true means enabled
+   "port-forwarding-enabled"        | boolean    | true means ask upstream router to forward the configured peer port to transmission using UPnP or NAT-PMP
    "queue-stalled-enabled"          | boolean    | whether or not to consider idle torrents as stalled
    "queue-stalled-minutes"          | number     | torrents that are idle for N minuets aren't counted toward seed-queue-size or download-queue-size
    "rename-partial-files"           | boolean    | true means append ".part" to incomplete files


### PR DESCRIPTION
I'm basing this information on https://github.com/transmission/transmission/blob/454f55a9a27cac4195a46ca76b256732e1cc901b/gtk/tr-prefs.cc#L1185-L1186 which if I'm interpreting it right means that the same setting is labeled as "Use UPnP or NAT-PMP port forwarding from my router".