### PR TITLE
Bandwidth.cc bring naming closer to C++ style of code in qt/

### DIFF
--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -85,7 +85,7 @@ public:
      */
     void setPeer(tr_peerIo* newPeer)
     {
-        this->peer = newPeer;
+        this->peer_ = newPeer;
     }
 
     /**
@@ -124,7 +124,7 @@ public:
     {
         TR_ASSERT(tr_isDirection(dir));
 
-        return getSpeed_Bps(&this->band[dir].raw, HISTORY_MSEC, now);
+        return getSpeed_Bps(&this->band_[dir].raw_, HISTORY_MSEC, now);
     }
 
     /** @brief Get the number of piece data bytes read or sent by this bandwidth subtree. */
@@ -132,7 +132,7 @@ public:
     {
         TR_ASSERT(tr_isDirection(dir));
 
-        return getSpeed_Bps(&this->band[dir].piece, HISTORY_MSEC, now);
+        return getSpeed_Bps(&this->band_[dir].piece_, HISTORY_MSEC, now);
     }
 
     /**
@@ -142,7 +142,7 @@ public:
      */
     constexpr bool setDesiredSpeed_Bps(tr_direction dir, unsigned int desiredSpeed)
     {
-        unsigned int* value = &this->band[dir].desiredSpeed_Bps;
+        unsigned int* value = &this->band_[dir].desired_speed_bps_;
         bool const didChange = desiredSpeed != *value;
         *value = desiredSpeed;
         return didChange;
@@ -154,7 +154,7 @@ public:
      */
     [[nodiscard]] constexpr double getDesiredSpeed_Bps(tr_direction dir) const
     {
-        return this->band[dir].desiredSpeed_Bps;
+        return this->band_[dir].desired_speed_bps_;
     }
 
     /**
@@ -162,7 +162,7 @@ public:
      */
     constexpr bool setLimited(tr_direction dir, bool isLimited)
     {
-        bool* value = &this->band[dir].isLimited;
+        bool* value = &this->band_[dir].is_limited_;
         bool const didChange = isLimited != *value;
         *value = isLimited;
         return didChange;
@@ -173,7 +173,7 @@ public:
      */
     [[nodiscard]] constexpr bool isLimited(tr_direction dir) const
     {
-        return this->band[dir].isLimited;
+        return this->band_[dir].is_limited_;
     }
 
     /**
@@ -184,7 +184,7 @@ public:
      */
     constexpr bool honorParentLimits(tr_direction direction, bool isEnabled)
     {
-        bool* value = &this->band[direction].honorParentLimits;
+        bool* value = &this->band_[direction].honor_parent_limits_;
         bool const didChange = isEnabled != *value;
         *value = isEnabled;
         return didChange;
@@ -194,7 +194,7 @@ public:
     {
         TR_ASSERT(tr_isDirection(direction));
 
-        return this->band[direction].honorParentLimits;
+        return this->band_[direction].honor_parent_limits_;
     }
 
     static constexpr size_t HISTORY_MSEC = 2000U;
@@ -204,25 +204,25 @@ public:
 
     struct RateControl
     {
-        int newest;
+        int newest_;
         struct Transfer
         {
-            uint64_t date;
-            uint64_t size;
+            uint64_t date_;
+            uint64_t size_;
         };
-        std::array<Transfer, HISTORY_SIZE> transfers;
-        uint64_t cache_time;
-        unsigned int cache_val;
+        std::array<Transfer, HISTORY_SIZE> transfers_;
+        uint64_t cache_time_;
+        unsigned int cache_val_;
     };
 
     struct Band
     {
-        bool isLimited;
-        bool honorParentLimits;
-        unsigned int bytesLeft;
-        unsigned int desiredSpeed_Bps;
-        RateControl raw;
-        RateControl piece;
+        bool is_limited_;
+        bool honor_parent_limits_;
+        unsigned int bytes_left_;
+        unsigned int desired_speed_bps_;
+        RateControl raw_;
+        RateControl piece_;
     };
 
 private:
@@ -241,10 +241,10 @@ private:
         std::vector<tr_peerIo*>& peer_pool);
 
     tr_priority_t priority = 0;
-    std::array<Band, 2> band;
-    Bandwidth* parent;
-    std::unordered_set<Bandwidth*> children;
-    tr_peerIo* peer;
+    std::array<Band, 2> band_;
+    Bandwidth* parent_;
+    std::unordered_set<Bandwidth*> children_;
+    tr_peerIo* peer_;
 };
 
 /* @} */

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -643,7 +643,7 @@ static auto dummy_utp_function_table = UTPFunctionTable{
 
 static tr_peerIo* tr_peerIoNew(
     tr_session* session,
-    tr_bandwidth* parent,
+    Bandwidth* parent,
     tr_address const* addr,
     tr_port port,
     uint8_t const* torrentHash,
@@ -680,7 +680,7 @@ static tr_peerIo* tr_peerIoNew(
     io->timeCreated = tr_time();
     io->inbuf = evbuffer_new();
     io->outbuf = evbuffer_new();
-    io->bandwidth = new tr_bandwidth(parent);
+    io->bandwidth = new Bandwidth(parent);
     io->bandwidth->setPeer(io);
     dbgmsg(io, "bandwidth is %p; its parent is %p", (void*)&io->bandwidth, (void*)parent);
 
@@ -719,7 +719,7 @@ static tr_peerIo* tr_peerIoNew(
 
 tr_peerIo* tr_peerIoNewIncoming(
     tr_session* session,
-    tr_bandwidth* parent,
+    Bandwidth* parent,
     tr_address const* addr,
     tr_port port,
     struct tr_peer_socket const socket)
@@ -732,7 +732,7 @@ tr_peerIo* tr_peerIoNewIncoming(
 
 tr_peerIo* tr_peerIoNewOutgoing(
     tr_session* session,
-    tr_bandwidth* parent,
+    Bandwidth* parent,
     tr_address const* addr,
     tr_port port,
     uint8_t const* torrentHash,

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -26,7 +26,7 @@
 #include "utils.h" /* tr_time() */
 
 struct evbuffer;
-struct tr_bandwidth;
+struct Bandwidth;
 struct tr_datatype;
 struct tr_peerIo;
 
@@ -93,7 +93,7 @@ struct tr_peerIo
 
     // Changed to non-owning pointer temporarily till tr_peerIo becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct tr_bandwidth* bandwidth;
+    struct Bandwidth* bandwidth;
     tr_crypto crypto;
 
     struct evbuffer* inbuf;
@@ -110,7 +110,7 @@ struct tr_peerIo
 
 tr_peerIo* tr_peerIoNewOutgoing(
     tr_session* session,
-    struct tr_bandwidth* parent,
+    struct Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
     uint8_t const* torrentHash,
@@ -119,7 +119,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
 
 tr_peerIo* tr_peerIoNewIncoming(
     tr_session* session,
-    struct tr_bandwidth* parent,
+    struct Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
     struct tr_peer_socket const socket);
@@ -299,7 +299,7 @@ void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byteCount);
 
 size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now);
 
-static inline void tr_peerIoSetParent(tr_peerIo* io, struct tr_bandwidth* parent)
+static inline void tr_peerIoSetParent(tr_peerIo* io, struct Bandwidth* parent)
 {
     TR_ASSERT(tr_isPeerIo(io));
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -93,7 +93,7 @@ struct tr_peerIo
 
     // Changed to non-owning pointer temporarily till tr_peerIo becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct Bandwidth* bandwidth;
+    Bandwidth* bandwidth;
     tr_crypto crypto;
 
     struct evbuffer* inbuf;
@@ -110,7 +110,7 @@ struct tr_peerIo
 
 tr_peerIo* tr_peerIoNewOutgoing(
     tr_session* session,
-    struct Bandwidth* parent,
+    Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
     uint8_t const* torrentHash,
@@ -119,7 +119,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
 
 tr_peerIo* tr_peerIoNewIncoming(
     tr_session* session,
-    struct Bandwidth* parent,
+    Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
     struct tr_peer_socket const socket);
@@ -299,7 +299,7 @@ void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byteCount);
 
 size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now);
 
-static inline void tr_peerIoSetParent(tr_peerIo* io, struct Bandwidth* parent)
+static inline void tr_peerIoSetParent(tr_peerIo* io, Bandwidth* parent)
 {
     TR_ASSERT(tr_isPeerIo(io));
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -3183,7 +3183,7 @@ static int getRate(tr_torrent const* tor, struct peer_atom* atom, uint64_t now)
     return Bps;
 }
 
-static inline bool isBandwidthMaxedOut(tr_bandwidth const* b, uint64_t const now_msec, tr_direction dir)
+static inline bool isBandwidthMaxedOut(Bandwidth const* b, uint64_t const now_msec, tr_direction dir)
 {
     if (!b->isLimited(dir))
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -636,7 +636,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     session->cache = tr_cacheNew(1024 * 1024 * 2);
     session->magicNumber = SESSION_MAGIC_NUMBER;
     session->session_id = tr_session_id_new();
-    session->bandwidth = new tr_bandwidth(nullptr);
+    session->bandwidth = new Bandwidth(nullptr);
     tr_variantInitList(&session->removedTorrents, 0);
 
     /* nice to start logging at the very beginning */

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -242,7 +242,7 @@ struct tr_session
     /* monitors the "global pool" speeds */
     // Changed to non-owning pointer temporarily till tr_session becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct tr_bandwidth* bandwidth;
+    struct Bandwidth* bandwidth;
 
     float desiredRatio;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -242,7 +242,7 @@ struct tr_session
     /* monitors the "global pool" speeds */
     // Changed to non-owning pointer temporarily till tr_session becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct Bandwidth* bandwidth;
+    Bandwidth* bandwidth;
 
     float desiredRatio;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -881,7 +881,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         tor->incompleteDir = tr_strdup(dir);
     }
 
-    tor->bandwidth = new tr_bandwidth(session->bandwidth);
+    tor->bandwidth = new Bandwidth(session->bandwidth);
 
     tor->bandwidth->setPriority(tr_ctorGetBandwidthPriority(ctor));
     tor->error = TR_STAT_OK;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -259,7 +259,7 @@ struct tr_torrent
 
     // Changed to non-owning pointer temporarily till tr_torrent becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct tr_bandwidth* bandwidth;
+    struct Bandwidth* bandwidth;
 
     struct tr_swarm* swarm;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -260,7 +260,7 @@ struct tr_torrent
 
     // Changed to non-owning pointer temporarily till tr_torrent becomes C++-constructible and destructible
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    struct Bandwidth* bandwidth;
+    Bandwidth* bandwidth;
 
     tr_swarm* swarm;
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -109,7 +109,7 @@ public:
     tr_peer_callback const callback;
     void* const callback_data;
 
-    tr_bandwidth bandwidth;
+    Bandwidth bandwidth;
     std::set<tr_webseed_task*> tasks;
     struct event* timer = nullptr;
     int consecutive_failures = 0;


### PR DESCRIPTION
* Renamed `tr_bandwidth` to `Bandwidth`
* Renamed dependent structs to PascalCase and moved inside `Bandwidth`, they do not pollute global namespace anymore, but still remain in `Bandwidth`'s public section because other code refers to the fields internals.
* Moved dependent constants inside `Bandwidth`
* Renamed inner fields into `snake_case_` with trailing `_`
* Removed `struct` keyword in type names, it is unnecessary in C++.