### PR TITLE
refactor: make tr_swarm a class

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -23,7 +23,7 @@
  */
 
 class tr_peer;
-struct tr_swarm;
+class tr_swarm;
 struct peer_atom;
 
 /* This is the maximum size of a block request.
@@ -134,9 +134,9 @@ struct tr_swarm_stats
     int peerFromCount[TR_PEER_FROM__MAX];
 };
 
-void tr_swarmGetStats(struct tr_swarm const* swarm, tr_swarm_stats* setme);
+void tr_swarmGetStats(tr_swarm const* swarm, tr_swarm_stats* setme);
 
-void tr_swarmIncrementActivePeers(struct tr_swarm* swarm, tr_direction direction, bool is_active);
+void tr_swarmIncrementActivePeers(tr_swarm* swarm, tr_direction direction, bool is_active);
 
 /***
 ****

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -29,12 +29,12 @@
  */
 
 class tr_peerMsgs;
+class tr_swarm;
 struct UTPSocket;
 struct peer_atom;
 struct tr_peerIo;
 struct tr_peerMgr;
 struct tr_peer_stat;
-struct tr_swarm;
 struct tr_torrent;
 
 /* added_f's bitwise-or'ed flags */

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -22,6 +22,7 @@
 #include "tr-macros.h"
 #include "utils.h" /* TR_GNUC_PRINTF */
 
+class tr_swarm;
 struct tr_torrent_tiers;
 struct tr_magnet_info;
 
@@ -261,7 +262,7 @@ struct tr_torrent
     // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
     struct tr_bandwidth* bandwidth;
 
-    struct tr_swarm* swarm;
+    tr_swarm* swarm;
 
     float desiredRatio;
     tr_ratiolimit ratioLimitMode;


### PR DESCRIPTION
Another incremental PR to update some of libtransmission to C++.

This PR makes tr_swarm a class and uses new / delete for their lifecycle.

This a relatively small PR, but it's the first step needed for other work in peer-mgr.cc because swarm needed a constructor and destructor before its fields can be updated to std:: containers.