### PR TITLE
refactor: tr_peerMgrGetPeers() returns std::vector<tr_pex>

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -11,6 +11,7 @@
 #include <climits> /* INT_MAX */
 #include <cstdlib> /* qsort */
 #include <cstring> /* memcpy, memcmp, strstr */
+#include <iterator>
 #include <vector>
 
 #include <event2/event.h>

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2305,7 +2305,6 @@ static bool isAtomInteresting(tr_torrent const* tor, struct peer_atom* atom)
 std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t af, uint8_t list_mode, size_t max)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(setme_pex != nullptr);
     TR_ASSERT(af == TR_AF_INET || af == TR_AF_INET6);
     TR_ASSERT(list_mode == TR_PEERS_CONNECTED || list_mode == TR_PEERS_INTERESTING);
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <inttypes.h> /* uint16_t */
+#include <vector>
 
 #ifdef _WIN32
 #include <winsock2.h> /* struct in_addr */
@@ -117,12 +118,7 @@ enum
     TR_PEERS_INTERESTING
 };
 
-int tr_peerMgrGetPeers(
-    tr_torrent const* tor,
-    tr_pex** setme_pex,
-    uint8_t address_type,
-    uint8_t peer_list_mode,
-    int max_peer_count);
+std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t af, uint8_t list_mode, size_t max);
 
 void tr_peerMgrStartTorrent(tr_torrent* tor);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2470,40 +2470,38 @@ static void sendPex(tr_peerMsgsImpl* msgs)
     {
         PexDiffs diffs;
         PexDiffs diffs6;
-        tr_pex* newPex = nullptr;
-        tr_pex* newPex6 = nullptr;
-        int const newCount = tr_peerMgrGetPeers(msgs->torrent, &newPex, TR_AF_INET, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
-        int const newCount6 = tr_peerMgrGetPeers(msgs->torrent, &newPex6, TR_AF_INET6, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
+        auto const newPex = tr_peerMgrGetPeers(msgs->torrent, TR_AF_INET, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
+        auto const newPex6 = tr_peerMgrGetPeers(msgs->torrent, TR_AF_INET6, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
 
         /* build the diffs */
-        diffs.added = tr_new(tr_pex, newCount);
+        diffs.added = tr_new(tr_pex, std::size(newPex));
         diffs.addedCount = 0;
         diffs.dropped = tr_new(tr_pex, msgs->pexCount);
         diffs.droppedCount = 0;
-        diffs.elements = tr_new(tr_pex, newCount + msgs->pexCount);
+        diffs.elements = tr_new(tr_pex, std::size(newPex) + msgs->pexCount);
         diffs.elementCount = 0;
         tr_set_compare(
             msgs->pex,
             msgs->pexCount,
-            newPex,
-            newCount,
+            std::data(newPex),
+            std::size(newPex),
             tr_pexCompare,
             sizeof(tr_pex),
             pexDroppedCb,
             pexAddedCb,
             pexElementCb,
             &diffs);
-        diffs6.added = tr_new(tr_pex, newCount6);
+        diffs6.added = tr_new(tr_pex, std::size(newPex6));
         diffs6.addedCount = 0;
         diffs6.dropped = tr_new(tr_pex, msgs->pexCount6);
         diffs6.droppedCount = 0;
-        diffs6.elements = tr_new(tr_pex, newCount6 + msgs->pexCount6);
+        diffs6.elements = tr_new(tr_pex, std::size(newPex6) + msgs->pexCount6);
         diffs6.elementCount = 0;
         tr_set_compare(
             msgs->pex6,
             msgs->pexCount6,
-            newPex6,
-            newCount6,
+            std::data(newPex6),
+            std::size(newPex6),
             tr_pexCompare,
             sizeof(tr_pex),
             pexDroppedCb,
@@ -2512,11 +2510,11 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             &diffs6);
         dbgmsg(
             msgs,
-            "pex: old peer count %d+%d, new peer count %d+%d, added %d+%d, removed %d+%d",
+            "pex: old peer count %d+%d, new peer count %zu+%zu, added %d+%d, removed %d+%d",
             msgs->pexCount,
             msgs->pexCount6,
-            newCount,
-            newCount6,
+            std::size(newPex),
+            std::size(newPex6),
             diffs.addedCount,
             diffs6.addedCount,
             diffs.droppedCount,
@@ -2661,10 +2659,8 @@ static void sendPex(tr_peerMsgsImpl* msgs)
         /* cleanup */
         tr_free(diffs.added);
         tr_free(diffs.dropped);
-        tr_free(newPex);
         tr_free(diffs6.added);
         tr_free(diffs6.dropped);
-        tr_free(newPex6);
     }
 }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -45,26 +45,17 @@ static char* getResumeFilename(tr_torrent const* tor, enum tr_metainfo_basename_
 
 static void savePeers(tr_variant* dict, tr_torrent const* tor)
 {
-    int count;
-    tr_pex* pex;
-
-    count = tr_peerMgrGetPeers(tor, &pex, TR_AF_INET, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
-
-    if (count > 0)
+    auto pex = tr_peerMgrGetPeers(tor, TR_AF_INET, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
+    if (!std::empty(pex))
     {
-        tr_variantDictAddRaw(dict, TR_KEY_peers2, pex, sizeof(tr_pex) * count);
+        tr_variantDictAddRaw(dict, TR_KEY_peers2, std::data(pex), sizeof(tr_pex) * std::size(pex));
     }
 
-    tr_free(pex);
-
-    count = tr_peerMgrGetPeers(tor, &pex, TR_AF_INET6, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
-
-    if (count > 0)
+    pex = tr_peerMgrGetPeers(tor, TR_AF_INET6, TR_PEERS_INTERESTING, MAX_REMEMBERED_PEERS);
+    if (!std::empty(pex))
     {
-        tr_variantDictAddRaw(dict, TR_KEY_peers2_6, pex, sizeof(tr_pex) * count);
+        tr_variantDictAddRaw(dict, TR_KEY_peers2_6, std::data(pex), sizeof(tr_pex) * std::size(pex));
     }
-
-    tr_free(pex);
 }
 
 static size_t addPeers(tr_torrent* tor, uint8_t const* buf, size_t buflen)


### PR DESCRIPTION
Update tr_peerMgrGetPeers()

- refactor: use std::vector instead of raw pointers
- perf: use std::partial_sort to get the best N candidates instead of sorting the entire candidate list