### PR TITLE
Modernize/bitfield.cc: Make into C++

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -37,41 +37,41 @@ static constexpr int8_t const trueBitCount[256] = {
     4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8, //
 };
 
-static constexpr size_t countArray(tr_bitfield const* b)
+constexpr size_t tr_bitfield::countArray() const
 {
     size_t ret = 0;
-    size_t i = b->alloc_count;
+    size_t i = this->alloc_count;
 
     while (i > 0)
     {
-        ret += trueBitCount[b->bits[--i]];
+        ret += trueBitCount[this->bits[--i]];
     }
 
     return ret;
 }
 
-static constexpr size_t countRange(tr_bitfield const* b, size_t begin, size_t end)
+size_t tr_bitfield::countRangeImpl(size_t begin, size_t end) const
 {
     size_t ret = 0;
     size_t const first_byte = begin >> 3U;
     size_t const last_byte = (end - 1) >> 3U;
 
-    if (b->bit_count == 0)
+    if (this->bit_count == 0)
     {
         return 0;
     }
 
-    if (first_byte >= b->alloc_count)
+    if (first_byte >= this->alloc_count)
     {
         return 0;
     }
 
     TR_ASSERT(begin < end);
-    TR_ASSERT(b->bits != nullptr);
+    TR_ASSERT(this->bits != nullptr);
 
     if (first_byte == last_byte)
     {
-        uint8_t val = b->bits[first_byte];
+        uint8_t val = this->bits[first_byte];
 
         int i = begin - (first_byte * 8);
         val <<= i;
@@ -84,11 +84,11 @@ static constexpr size_t countRange(tr_bitfield const* b, size_t begin, size_t en
     }
     else
     {
-        size_t const walk_end = std::min(b->alloc_count, last_byte);
+        size_t const walk_end = std::min(this->alloc_count, last_byte);
 
         /* first byte */
         size_t const first_shift = begin - (first_byte * 8);
-        uint8_t val = b->bits[first_byte];
+        uint8_t val = this->bits[first_byte];
         val <<= first_shift;
         val >>= first_shift;
         ret += trueBitCount[val];
@@ -96,14 +96,14 @@ static constexpr size_t countRange(tr_bitfield const* b, size_t begin, size_t en
         /* middle bytes */
         for (size_t i = first_byte + 1; i < walk_end; ++i)
         {
-            ret += trueBitCount[b->bits[i]];
+            ret += trueBitCount[this->bits[i]];
         }
 
         /* last byte */
-        if (last_byte < b->alloc_count)
+        if (last_byte < this->alloc_count)
         {
             size_t const last_shift = (last_byte + 1) * 8 - end;
-            val = b->bits[last_byte];
+            val = this->bits[last_byte];
             val >>= last_shift;
             val <<= last_shift;
             ret += trueBitCount[val];
@@ -114,39 +114,24 @@ static constexpr size_t countRange(tr_bitfield const* b, size_t begin, size_t en
     return ret;
 }
 
-size_t tr_bitfieldCountRange(tr_bitfield const* b, size_t begin, size_t end)
+bool tr_bitfield::has(size_t n) const
 {
-    if (tr_bitfieldHasAll(b))
-    {
-        return end - begin;
-    }
-
-    if (tr_bitfieldHasNone(b))
-    {
-        return 0;
-    }
-
-    return countRange(b, begin, end);
-}
-
-bool tr_bitfieldHas(tr_bitfield const* b, size_t n)
-{
-    if (tr_bitfieldHasAll(b))
+    if (this->hasAll())
     {
         return true;
     }
 
-    if (tr_bitfieldHasNone(b))
+    if (this->hasNone())
     {
         return false;
     }
 
-    if (n >> 3U >= b->alloc_count)
+    if (n >> 3U >= this->alloc_count)
     {
         return false;
     }
 
-    return (b->bits[n >> 3U] << (n & 7U) & 0x80) != 0;
+    return (this->bits[n >> 3U] << (n & 7U) & 0x80) != 0;
 }
 
 /***
@@ -155,30 +140,24 @@ bool tr_bitfieldHas(tr_bitfield const* b, size_t n)
 
 #ifdef TR_ENABLE_ASSERTS
 
-static bool tr_bitfieldIsValid(tr_bitfield const* b)
+bool tr_bitfield::isValid() const
 {
-    TR_ASSERT(b != nullptr);
-    TR_ASSERT((b->alloc_count == 0) == (b->bits == nullptr));
-    TR_ASSERT(b->bits == nullptr || b->true_count == countArray(b));
+    TR_ASSERT((this->alloc_count == 0) == (this->bits == nullptr));
+    TR_ASSERT(this->bits == nullptr || this->true_count == this->countArray());
 
     return true;
 }
 
 #endif
 
-size_t tr_bitfieldCountTrueBits(tr_bitfield const* b)
+size_t tr_bitfield::countTrueBits() const
 {
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 
-    return b->true_count;
+    return this->true_count;
 }
 
-static constexpr size_t get_bytes_needed(size_t bit_count)
-{
-    return (bit_count >> 3) + ((bit_count & 7) != 0 ? 1 : 0);
-}
-
-static void set_all_true(uint8_t* array, size_t bit_count)
+void tr_bitfield::set_all_true(uint8_t* array, size_t bit_count)
 {
     uint8_t const val = 0xFF;
     size_t const n = get_bytes_needed(bit_count);
@@ -191,231 +170,230 @@ static void set_all_true(uint8_t* array, size_t bit_count)
     }
 }
 
-void* tr_bitfieldGetRaw(tr_bitfield const* b, size_t* byte_count)
+void* tr_bitfield::getRaw(size_t* byte_count) const
 {
-    TR_ASSERT(b->bit_count > 0);
+    TR_ASSERT(this->bit_count > 0);
 
-    size_t const n = get_bytes_needed(b->bit_count);
-    uint8_t* bits = tr_new0(uint8_t, n);
+    size_t const n = get_bytes_needed(this->bit_count);
+    uint8_t* newBits = tr_new0(uint8_t, n);
 
-    if (b->alloc_count != 0)
+    if (this->alloc_count != 0)
     {
-        TR_ASSERT(b->alloc_count <= n);
-        memcpy(bits, b->bits, b->alloc_count);
+        TR_ASSERT(this->alloc_count <= n);
+        std::memcpy(newBits, this->bits, this->alloc_count);
     }
-    else if (tr_bitfieldHasAll(b))
+    else if (this->hasAll())
     {
-        set_all_true(bits, b->bit_count);
+        set_all_true(newBits, this->bit_count);
     }
 
     *byte_count = n;
-    return bits;
+    return newBits;
 }
 
-static void tr_bitfieldEnsureBitsAlloced(tr_bitfield* b, size_t n)
+void tr_bitfield::ensureBitsAlloced(size_t n)
 {
     size_t bytes_needed;
-    bool const has_all = tr_bitfieldHasAll(b);
+    bool const has_all = this->hasAll();
 
     if (has_all)
     {
-        bytes_needed = get_bytes_needed(std::max(n, b->true_count));
+        bytes_needed = get_bytes_needed(std::max(n, this->true_count));
     }
     else
     {
         bytes_needed = get_bytes_needed(n);
     }
 
-    if (b->alloc_count < bytes_needed)
+    if (this->alloc_count < bytes_needed)
     {
-        b->bits = tr_renew(uint8_t, b->bits, bytes_needed);
-        memset(b->bits + b->alloc_count, 0, bytes_needed - b->alloc_count);
-        b->alloc_count = bytes_needed;
+        this->bits = tr_renew(uint8_t, this->bits, bytes_needed);
+        std::memset(this->bits + this->alloc_count, 0, bytes_needed - this->alloc_count);
+        this->alloc_count = bytes_needed;
 
         if (has_all)
         {
-            set_all_true(b->bits, b->true_count);
+            set_all_true(this->bits, this->true_count);
         }
     }
 }
 
-static bool tr_bitfieldEnsureNthBitAlloced(tr_bitfield* b, size_t nth)
+bool tr_bitfield::ensureNthBitAlloced(size_t nth)
 {
-    /* count is zero-based, so we need to allocate nth+1 bits before setting the nth */
+    // count is zero-based, so we need to allocate nth+1 bits before setting the nth
     if (nth == SIZE_MAX)
     {
         return false;
     }
 
-    tr_bitfieldEnsureBitsAlloced(b, nth + 1);
+    this->ensureBitsAlloced(nth + 1);
     return true;
 }
 
-static void tr_bitfieldFreeArray(tr_bitfield* b)
+void tr_bitfield::freeArray()
 {
-    tr_free(b->bits);
-    b->bits = nullptr;
-    b->alloc_count = 0;
+    tr_free(this->bits);
+    this->bits = nullptr;
+    this->alloc_count = 0;
 }
 
-static void tr_bitfieldSetTrueCount(tr_bitfield* b, size_t n)
+void tr_bitfield::setTrueCount(size_t n)
 {
-    TR_ASSERT(b->bit_count == 0 || n <= b->bit_count);
+    TR_ASSERT(this->bit_count == 0 || n <= this->bit_count);
 
-    b->true_count = n;
+    this->true_count = n;
 
-    if (tr_bitfieldHasAll(b) || tr_bitfieldHasNone(b))
+    if (this->hasAll() || this->hasNone())
     {
-        tr_bitfieldFreeArray(b);
+        this->freeArray();
     }
 
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 }
 
-static void tr_bitfieldRebuildTrueCount(tr_bitfield* b)
+void tr_bitfield::rebuildTrueCount()
 {
-    tr_bitfieldSetTrueCount(b, countArray(b));
+    this->setTrueCount(this->countArray());
 }
 
-static void tr_bitfieldIncTrueCount(tr_bitfield* b, size_t i)
+void tr_bitfield::incTrueCount(size_t i)
 {
-    TR_ASSERT(b->bit_count == 0 || i <= b->bit_count);
-    TR_ASSERT(b->bit_count == 0 || b->true_count <= b->bit_count - i);
+    TR_ASSERT(this->bit_count == 0 || i <= this->bit_count);
+    TR_ASSERT(this->bit_count == 0 || this->true_count <= this->bit_count - i);
 
-    tr_bitfieldSetTrueCount(b, b->true_count + i);
+    this->setTrueCount(this->true_count + i);
 }
 
-static void tr_bitfieldDecTrueCount(tr_bitfield* b, size_t i)
+void tr_bitfield::decTrueCount(size_t i)
 {
-    TR_ASSERT(b->bit_count == 0 || i <= b->bit_count);
-    TR_ASSERT(b->bit_count == 0 || b->true_count >= i);
+    TR_ASSERT(this->bit_count == 0 || i <= this->bit_count);
+    TR_ASSERT(this->bit_count == 0 || this->true_count >= i);
 
-    tr_bitfieldSetTrueCount(b, b->true_count - i);
+    this->setTrueCount(this->true_count - i);
 }
 
 /****
 *****
 ****/
 
-void tr_bitfieldConstruct(tr_bitfield* b, size_t bit_count)
+tr_bitfield::tr_bitfield(size_t bit_count)
 {
-    b->bit_count = bit_count;
-    b->true_count = 0;
-    b->bits = nullptr;
-    b->alloc_count = 0;
-    b->have_all_hint = false;
-    b->have_none_hint = false;
+    this->bit_count = bit_count;
+    this->true_count = 0;
+    this->bits = nullptr;
+    this->alloc_count = 0;
+    this->have_all_hint = false;
+    this->have_none_hint = false;
 
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 }
 
-void tr_bitfieldSetHasNone(tr_bitfield* b)
+void tr_bitfield::setHasNone()
 {
-    tr_bitfieldFreeArray(b);
-    b->true_count = 0;
-    b->have_all_hint = false;
-    b->have_none_hint = true;
+    this->freeArray();
+    this->true_count = 0;
+    this->have_all_hint = false;
+    this->have_none_hint = true;
 
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 }
 
-void tr_bitfieldSetHasAll(tr_bitfield* b)
+void tr_bitfield::setHasAll()
 {
-    tr_bitfieldFreeArray(b);
-    b->true_count = b->bit_count;
-    b->have_all_hint = true;
-    b->have_none_hint = false;
+    this->freeArray();
+    this->true_count = this->bit_count;
+    this->have_all_hint = true;
+    this->have_none_hint = false;
 
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 }
 
-void tr_bitfieldSetFromBitfield(tr_bitfield* b, tr_bitfield const* src)
+void tr_bitfield::setFromBitfield(tr_bitfield const* src)
 {
-    if (tr_bitfieldHasAll(src))
+    if (src->hasAll())
     {
-        tr_bitfieldSetHasAll(b);
+        this->setHasAll();
     }
-    else if (tr_bitfieldHasNone(src))
+    else if (src->hasNone())
     {
-        tr_bitfieldSetHasNone(b);
+        this->setHasNone();
     }
     else
     {
-        tr_bitfieldSetRaw(b, src->bits, src->alloc_count, true);
+        this->setRaw(src->bits, src->alloc_count, true);
     }
 }
 
-void tr_bitfieldSetRaw(tr_bitfield* b, void const* bits, size_t byte_count, bool bounded)
+void tr_bitfield::setRaw(void const* newBits, size_t byte_count, bool bounded)
 {
-    tr_bitfieldFreeArray(b);
-    b->true_count = 0;
+    this->freeArray();
+    this->true_count = 0;
 
     if (bounded)
     {
-        byte_count = std::min(byte_count, get_bytes_needed(b->bit_count));
+        byte_count = std::min(byte_count, get_bytes_needed(this->bit_count));
     }
 
-    b->bits = static_cast<uint8_t*>(tr_memdup(bits, byte_count));
-    b->alloc_count = byte_count;
+    this->bits = static_cast<uint8_t*>(tr_memdup(newBits, byte_count));
+    this->alloc_count = byte_count;
 
     if (bounded)
     {
-        /* ensure the excess bits are set to '0' */
-        int const excess_bit_count = byte_count * 8 - b->bit_count;
+        /* ensure the excess newBits are set to '0' */
+        int const excess_bit_count = byte_count * 8 - this->bit_count;
 
         TR_ASSERT(excess_bit_count >= 0);
         TR_ASSERT(excess_bit_count <= 7);
 
         if (excess_bit_count != 0)
         {
-            b->bits[b->alloc_count - 1] &= 0xff << excess_bit_count;
+            this->bits[this->alloc_count - 1] &= 0xff << excess_bit_count;
         }
     }
 
-    tr_bitfieldRebuildTrueCount(b);
+    this->rebuildTrueCount();
 }
 
-void tr_bitfieldSetFromFlags(tr_bitfield* b, bool const* flags, size_t n)
+void tr_bitfield::setFromFlags(bool const* flags, size_t n)
 {
     size_t trueCount = 0;
 
-    tr_bitfieldFreeArray(b);
-    tr_bitfieldEnsureBitsAlloced(b, n);
+    this->freeArray();
+    this->ensureBitsAlloced(n);
 
     for (size_t i = 0; i < n; ++i)
     {
-        if (flags[i] && b->bits != nullptr)
+        if (flags[i] && this->bits != nullptr)
         {
             ++trueCount;
-            b->bits[i >> 3U] |= (0x80 >> (i & 7U));
+            this->bits[i >> 3U] |= (0x80 >> (i & 7U));
         }
     }
 
-    tr_bitfieldSetTrueCount(b, trueCount);
+    this->setTrueCount(trueCount);
 }
 
-void tr_bitfieldAdd(tr_bitfield* b, size_t nth)
+void tr_bitfield::add(size_t nth)
 {
-    if (!tr_bitfieldHas(b, nth) && tr_bitfieldEnsureNthBitAlloced(b, nth))
+    if (!this->has(nth) && this->ensureNthBitAlloced(nth))
     {
         size_t const offset = nth >> 3U;
 
-        if ((b->bits != nullptr) && (offset < b->alloc_count))
+        if ((this->bits != nullptr) && (offset < this->alloc_count))
         {
-            b->bits[offset] |= 0x80 >> (nth & 7U);
-            tr_bitfieldIncTrueCount(b, 1);
+            this->bits[offset] |= 0x80 >> (nth & 7U);
+            this->incTrueCount(1);
         }
     }
 }
 
-/* Sets bit range [begin, end) to 1 */
-void tr_bitfieldAddRange(tr_bitfield* b, size_t begin, size_t end)
+void tr_bitfield::addRange(size_t begin, size_t end)
 {
     size_t sb;
     size_t eb;
     unsigned char sm;
     unsigned char em;
-    size_t const diff = (end - begin) - tr_bitfieldCountRange(b, begin, end);
+    size_t const diff = (end - begin) - this->countRange(begin, end);
 
     if (diff == 0)
     {
@@ -424,7 +402,7 @@ void tr_bitfieldAddRange(tr_bitfield* b, size_t begin, size_t end)
 
     end--;
 
-    if (end >= b->bit_count || begin > end)
+    if (end >= this->bit_count || begin > end)
     {
         return;
     }
@@ -434,48 +412,47 @@ void tr_bitfieldAddRange(tr_bitfield* b, size_t begin, size_t end)
     eb = end >> 3;
     em = 0xff << (7 - (end & 7));
 
-    if (!tr_bitfieldEnsureNthBitAlloced(b, end))
+    if (!this->ensureNthBitAlloced(end))
     {
         return;
     }
 
     if (sb == eb)
     {
-        b->bits[sb] |= sm & em;
+        this->bits[sb] |= sm & em;
     }
     else
     {
-        b->bits[sb] |= sm;
-        b->bits[eb] |= em;
+        this->bits[sb] |= sm;
+        this->bits[eb] |= em;
 
         if (++sb < eb)
         {
-            memset(b->bits + sb, 0xff, eb - sb);
+            std::memset(this->bits + sb, 0xff, eb - sb);
         }
     }
 
-    tr_bitfieldIncTrueCount(b, diff);
+    this->incTrueCount(diff);
 }
 
-void tr_bitfieldRem(tr_bitfield* b, size_t nth)
+void tr_bitfield::rem(size_t nth)
 {
-    TR_ASSERT(tr_bitfieldIsValid(b));
+    TR_ASSERT(this->isValid());
 
-    if (tr_bitfieldHas(b, nth) && tr_bitfieldEnsureNthBitAlloced(b, nth))
+    if (this->has(nth) && this->ensureNthBitAlloced(nth))
     {
-        b->bits[nth >> 3U] &= 0xff7f >> (nth & 7U);
-        tr_bitfieldDecTrueCount(b, 1);
+        this->bits[nth >> 3U] &= 0xff7f >> (nth & 7U);
+        this->decTrueCount(1);
     }
 }
 
-/* Clears bit range [begin, end) to 0 */
-void tr_bitfieldRemRange(tr_bitfield* b, size_t begin, size_t end)
+void tr_bitfield::remRange(size_t begin, size_t end)
 {
     size_t sb;
     size_t eb;
     unsigned char sm;
     unsigned char em;
-    size_t const diff = tr_bitfieldCountRange(b, begin, end);
+    size_t const diff = this->countRange(begin, end);
 
     if (diff == 0)
     {
@@ -484,7 +461,7 @@ void tr_bitfieldRemRange(tr_bitfield* b, size_t begin, size_t end)
 
     end--;
 
-    if (end >= b->bit_count || begin > end)
+    if (end >= this->bit_count || begin > end)
     {
         return;
     }
@@ -494,25 +471,25 @@ void tr_bitfieldRemRange(tr_bitfield* b, size_t begin, size_t end)
     eb = end >> 3;
     em = ~(0xff << (7 - (end & 7)));
 
-    if (!tr_bitfieldEnsureNthBitAlloced(b, end))
+    if (!this->ensureNthBitAlloced(end))
     {
         return;
     }
 
     if (sb == eb)
     {
-        b->bits[sb] &= sm | em;
+        this->bits[sb] &= sm | em;
     }
     else
     {
-        b->bits[sb] &= sm;
-        b->bits[eb] &= em;
+        this->bits[sb] &= sm;
+        this->bits[eb] &= em;
 
         if (++sb < eb)
         {
-            memset(b->bits + sb, 0, eb - sb);
+            std::memset(this->bits + sb, 0, eb - sb);
         }
     }
 
-    tr_bitfieldDecTrueCount(b, diff);
+    this->decTrueCount(diff);
 }

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -14,15 +14,115 @@
 
 #include "transmission.h"
 #include "tr-macros.h"
+#include "tr-assert.h"
 
-/** @brief Implementation of the BitTorrent spec's Bitfield array of bits */
+/// @brief Implementation of the BitTorrent spec's Bitfield array of bits
 struct tr_bitfield
 {
+public:
+    /***
+    ****  life cycle
+    ***/
+    explicit tr_bitfield(size_t bit_count);
+
+    tr_bitfield(): tr_bitfield(0) {}
+
+    ~tr_bitfield()
+    {
+        this->setHasNone();
+    }
+
+    /***
+    ****
+    ***/
+
+    void setHasAll();
+
+    void setHasNone();
+
+    void add(size_t bit);
+
+    /// @brief Sets bit range [begin, end) to 1
+    void addRange(size_t begin, size_t end);
+
+    void rem(size_t bit);
+
+    /// @brief Clears bit range [begin, end) to 0
+    void remRange(size_t begin, size_t end);
+
+    /***
+    ****
+    ***/
+
+    [[nodiscard]] size_t countRange(size_t begin, size_t end) const
+    {
+        if (this->hasAll())
+        {
+            return end - begin;
+        }
+
+        if (this->hasNone())
+        {
+            return 0;
+        }
+
+        return this->countRangeImpl(begin, end);
+    }
+
+    [[nodiscard]] size_t countTrueBits() const;
+
+    [[nodiscard]] constexpr bool hasAll() const
+    {
+        return this->bit_count != 0 ? (this->true_count == this->bit_count) : this->have_all_hint;
+    }
+
+    [[nodiscard]] constexpr bool hasNone() const
+    {
+        return this->bit_count != 0 ? (this->true_count == 0) : this->have_none_hint;
+    }
+
+    [[nodiscard]] bool has(size_t n) const;
+
+    /***
+    ****
+    ***/
+
+    void setFromFlags(bool const* bytes, size_t n);
+
+    void setFromBitfield(tr_bitfield const*);
+
+    void setRaw(void const* newBits, size_t byte_count, bool bounded);
+
+    void* getRaw(size_t* byte_count) const;
+
+    [[nodiscard]] size_t getBitCount() const
+    {
+        return bit_count;
+    }
+
+private:
+    [[nodiscard]] constexpr size_t countArray() const;
+    [[nodiscard]] size_t countRangeImpl(size_t begin, size_t end) const;
+    static void set_all_true(uint8_t* array, size_t bit_count);
+    static constexpr size_t get_bytes_needed(size_t bit_count)
+    {
+        return (bit_count >> 3) + ((bit_count & 7) != 0 ? 1 : 0);
+    }
+    void ensureBitsAlloced(size_t n);
+    bool ensureNthBitAlloced(size_t nth);
+    void freeArray();
+    void setTrueCount(size_t n);
+    void rebuildTrueCount();
+    void incTrueCount(size_t i);
+    void decTrueCount(size_t i);
+
+#ifdef TR_ENABLE_ASSERTS
+    [[nodiscard]] bool isValid() const;
+#endif
+
     uint8_t* bits = nullptr;
     size_t alloc_count = 0;
-
     size_t bit_count = 0;
-
     size_t true_count = 0;
 
     /* Special cases for when full or empty but we don't know the bitCount.
@@ -30,62 +130,3 @@ struct tr_bitfield
     bool have_all_hint = false;
     bool have_none_hint = false;
 };
-
-/***
-****
-***/
-
-void tr_bitfieldSetHasAll(tr_bitfield*);
-
-void tr_bitfieldSetHasNone(tr_bitfield*);
-
-void tr_bitfieldAdd(tr_bitfield*, size_t bit);
-
-void tr_bitfieldRem(tr_bitfield*, size_t bit);
-
-void tr_bitfieldAddRange(tr_bitfield*, size_t begin, size_t end);
-
-void tr_bitfieldRemRange(tr_bitfield*, size_t begin, size_t end);
-
-/***
-****  life cycle
-***/
-
-void tr_bitfieldConstruct(tr_bitfield*, size_t bit_count);
-
-static inline void tr_bitfieldDestruct(tr_bitfield* b)
-{
-    tr_bitfieldSetHasNone(b);
-}
-
-/***
-****
-***/
-
-void tr_bitfieldSetFromFlags(tr_bitfield*, bool const* bytes, size_t n);
-
-void tr_bitfieldSetFromBitfield(tr_bitfield*, tr_bitfield const*);
-
-void tr_bitfieldSetRaw(tr_bitfield*, void const* bits, size_t byte_count, bool bounded);
-
-void* tr_bitfieldGetRaw(tr_bitfield const* b, size_t* byte_count);
-
-/***
-****
-***/
-
-size_t tr_bitfieldCountRange(tr_bitfield const*, size_t begin, size_t end);
-
-size_t tr_bitfieldCountTrueBits(tr_bitfield const* b);
-
-constexpr bool tr_bitfieldHasAll(tr_bitfield const* b)
-{
-    return b->bit_count != 0 ? (b->true_count == b->bit_count) : b->have_all_hint;
-}
-
-constexpr bool tr_bitfieldHasNone(tr_bitfield const* b)
-{
-    return b->bit_count != 0 ? (b->true_count == 0) : b->have_none_hint;
-}
-
-bool tr_bitfieldHas(tr_bitfield const* b, size_t n);

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -21,13 +21,13 @@ static void tr_cpReset(tr_completion* cp)
     cp->sizeNow = 0;
     cp->sizeWhenDoneIsDirty = true;
     cp->haveValidIsDirty = true;
-    tr_bitfieldSetHasNone(&cp->blockBitfield);
+    cp->blockBitfield->setHasNone();
 }
 
 void tr_cpConstruct(tr_completion* cp, tr_torrent* tor)
 {
     cp->tor = tor;
-    tr_bitfieldConstruct(&cp->blockBitfield, tor->blockCount);
+    cp->blockBitfield = new tr_bitfield(tor->blockCount);
     tr_cpReset(cp);
 }
 
@@ -35,15 +35,15 @@ void tr_cpBlockInit(tr_completion* cp, tr_bitfield const* b)
 {
     tr_cpReset(cp);
 
-    /* set blockBitfield */
-    tr_bitfieldSetFromBitfield(&cp->blockBitfield, b);
+    // set blockBitfield
+    cp->blockBitfield->setFromBitfield(b);
 
-    /* set sizeNow */
-    cp->sizeNow = tr_bitfieldCountTrueBits(&cp->blockBitfield);
+    // set sizeNow
+    cp->sizeNow = cp->blockBitfield->countTrueBits();
     TR_ASSERT(cp->sizeNow <= cp->tor->blockCount);
     cp->sizeNow *= cp->tor->blockSize;
 
-    if (tr_bitfieldHas(b, cp->tor->blockCount - 1))
+    if (b->has(cp->tor->blockCount - 1))
     {
         cp->sizeNow -= (cp->tor->blockSize - cp->tor->lastBlockSize);
     }
@@ -93,7 +93,7 @@ void tr_cpPieceRem(tr_completion* cp, tr_piece_index_t piece)
 
     cp->haveValidIsDirty = true;
     cp->sizeWhenDoneIsDirty = true;
-    tr_bitfieldRemRange(&cp->blockBitfield, f, l + 1);
+    cp->blockBitfield->remRange(f, l + 1);
 }
 
 void tr_cpPieceAdd(tr_completion* cp, tr_piece_index_t piece)
@@ -116,7 +116,7 @@ void tr_cpBlockAdd(tr_completion* cp, tr_block_index_t block)
     {
         tr_piece_index_t const piece = tr_torBlockPiece(cp->tor, block);
 
-        tr_bitfieldAdd(&cp->blockBitfield, block);
+        cp->blockBitfield->add(block);
         cp->sizeNow += tr_torBlockCountBytes(tor, block);
 
         cp->haveValidIsDirty = true;
@@ -182,10 +182,10 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
                     tr_block_index_t l;
                     tr_torGetPieceBlockRange(cp->tor, p, &f, &l);
 
-                    n = tr_bitfieldCountRange(&cp->blockBitfield, f, l + 1);
+                    n = cp->blockBitfield->countRange(f, l + 1);
                     n *= cp->tor->blockSize;
 
-                    if (l == cp->tor->blockCount - 1 && tr_bitfieldHas(&cp->blockBitfield, l))
+                    if (l == cp->tor->blockCount - 1 && cp->blockBitfield->has(l))
                     {
                         n -= cp->tor->blockSize - cp->tor->lastBlockSize;
                     }
@@ -232,7 +232,7 @@ void tr_cpGetAmountDone(tr_completion const* cp, float* tab, int tabCount)
             tr_block_index_t l;
             tr_piece_index_t const piece = (tr_piece_index_t)i * interval;
             tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
-            tab[i] = tr_bitfieldCountRange(&cp->blockBitfield, f, l + 1) / (float)(l + 1 - f);
+            tab[i] = cp->blockBitfield->countRange(f, l + 1) / (float)(l + 1 - f);
         }
     }
 }
@@ -248,7 +248,7 @@ size_t tr_cpMissingBlocksInPiece(tr_completion const* cp, tr_piece_index_t piece
         tr_block_index_t f;
         tr_block_index_t l;
         tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
-        return (l + 1 - f) - tr_bitfieldCountRange(&cp->blockBitfield, f, l + 1);
+        return (l + 1 - f) - cp->blockBitfield->countRange(f, l + 1);
     }
 }
 
@@ -271,11 +271,11 @@ size_t tr_cpMissingBytesInPiece(tr_completion const* cp, tr_piece_index_t piece)
             /* nb: we don't pass the usual l+1 here to tr_bitfieldCountRange().
                It's faster to handle the last block separately because its size
                needs to be checked separately. */
-            haveBytes = tr_bitfieldCountRange(&cp->blockBitfield, f, l);
+            haveBytes = cp->blockBitfield->countRange(f, l);
             haveBytes *= cp->tor->blockSize;
         }
 
-        if (tr_bitfieldHas(&cp->blockBitfield, l)) /* handle the last block */
+        if (cp->blockBitfield->has(l)) /* handle the last block */
         {
             haveBytes += tr_torBlockCountBytes(cp->tor, l);
         }
@@ -296,7 +296,7 @@ bool tr_cpFileIsComplete(tr_completion const* cp, tr_file_index_t i)
         tr_block_index_t f;
         tr_block_index_t l;
         tr_torGetFileBlockRange(cp->tor, i, &f, &l);
-        return tr_bitfieldCountRange(&cp->blockBitfield, f, l + 1) == (l + 1 - f);
+        return cp->blockBitfield->countRange(f, l + 1) == (l + 1 - f);
     }
 }
 
@@ -306,14 +306,14 @@ void* tr_cpCreatePieceBitfield(tr_completion const* cp, size_t* byte_count)
 
     void* ret;
     tr_piece_index_t n;
-    tr_bitfield pieces;
 
     n = cp->tor->info.pieceCount;
-    tr_bitfieldConstruct(&pieces, n);
+
+    tr_bitfield pieces(n);
 
     if (tr_cpHasAll(cp))
     {
-        tr_bitfieldSetHasAll(&pieces);
+        pieces.setHasAll();
     }
     else if (!tr_cpHasNone(cp))
     {
@@ -324,12 +324,11 @@ void* tr_cpCreatePieceBitfield(tr_completion const* cp, size_t* byte_count)
             flags[i] = tr_cpPieceIsComplete(cp, i);
         }
 
-        tr_bitfieldSetFromFlags(&pieces, flags, n);
+        pieces.setFromFlags(flags, n);
         tr_free(flags);
     }
 
-    ret = tr_bitfieldGetRaw(&pieces, byte_count);
-    tr_bitfieldDestruct(&pieces);
+    ret = pieces.getRaw(byte_count);
     return ret;
 }
 

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -22,7 +22,7 @@ struct tr_completion
 
     // Changed to non-owning pointer temporarily till tr_completion becomes C++-constructible and destructible
     // TODO: remove * and own the value
-    tr_bitfield* blockBitfield;
+    Bitfield* blockBitfield;
 
     /* number of bytes we'll have when done downloading. [0..info.totalSize]
        DON'T access this directly; it's a lazy field.
@@ -50,7 +50,7 @@ struct tr_completion
 
 void tr_cpConstruct(tr_completion*, tr_torrent*);
 
-void tr_cpBlockInit(tr_completion* cp, tr_bitfield const* blocks);
+void tr_cpBlockInit(tr_completion* cp, Bitfield const& blocks);
 
 static inline void tr_cpDestruct(tr_completion* cp)
 {
@@ -115,7 +115,7 @@ void tr_cpBlockAdd(tr_completion* cp, tr_block_index_t i);
 
 static inline bool tr_cpBlockIsComplete(tr_completion const* cp, tr_block_index_t i)
 {
-    return cp->blockBitfield->has(i);
+    return cp->blockBitfield->readBit(i);
 }
 
 /***

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -57,7 +57,7 @@ struct tr_peer_event
     PeerEventType eventType;
 
     uint32_t pieceIndex; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
-    struct tr_bitfield* bitfield; /* for GOT_BITFIELD */
+    struct Bitfield* bitfield; /* for GOT_BITFIELD */
     uint32_t offset; /* for GOT_BLOCK */
     uint32_t length; /* for GOT_BLOCK + GOT_PIECE_DATA */
     int err; /* errno for GOT_ERROR */
@@ -103,8 +103,8 @@ public:
     /** how complete the peer's copy of the torrent is. [0.0...1.0] */
     float progress = 0.0f;
 
-    struct tr_bitfield blame;
-    struct tr_bitfield have;
+    struct Bitfield blame;
+    struct Bitfield have;
 
     /* the client name.
        For BitTorrent peers, this is the app name derived from the `v' string in LTEP's handshake dictionary */

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -103,8 +103,8 @@ public:
     /** how complete the peer's copy of the torrent is. [0.0...1.0] */
     float progress = 0.0f;
 
-    struct tr_bitfield blame = {};
-    struct tr_bitfield have = {};
+    struct tr_bitfield blame;
+    struct tr_bitfield have;
 
     /* the client name.
        For BitTorrent peers, this is the app name derived from the `v' string in LTEP's handshake dictionary */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -246,9 +246,9 @@ tr_peer::tr_peer(tr_torrent const* tor, peer_atom* atom_in)
     : session{ tor->session }
     , atom{ atom_in }
     , swarm{ tor->swarm }
+    , blame{ tor->blockCount }
+    , have{ tor->info.pieceCount }
 {
-    tr_bitfieldConstruct(&have, tor->info.pieceCount);
-    tr_bitfieldConstruct(&blame, tor->blockCount);
 }
 
 static void peerDeclinedAllRequests(tr_swarm*, tr_peer const*);
@@ -259,9 +259,6 @@ tr_peer::~tr_peer()
     {
         peerDeclinedAllRequests(swarm, this);
     }
-
-    tr_bitfieldDestruct(&have);
-    tr_bitfieldDestruct(&blame);
 
     if (atom != nullptr)
     {
@@ -416,7 +413,7 @@ static void replicationNew(tr_swarm* s)
         {
             auto const* const peer = static_cast<tr_peer const*>(tr_ptrArrayNth(&s->peers, peer_i));
 
-            if (tr_bitfieldHas(&peer->have, piece_i))
+            if (peer->have.has(piece_i))
             {
                 ++r;
             }
@@ -1205,7 +1202,7 @@ static void tr_incrReplicationFromBitfield(tr_swarm* s, tr_bitfield const* b)
 
     for (size_t i = 0, n = s->tor->info.pieceCount; i < n; ++i)
     {
-        if (tr_bitfieldHas(b, i))
+        if (b->has(i))
         {
             ++rep[i];
         }
@@ -1239,18 +1236,18 @@ static void tr_decrReplicationFromBitfield(tr_swarm* s, tr_bitfield const* b)
     TR_ASSERT(replicationExists(s));
     TR_ASSERT(s->pieceReplicationSize == s->tor->info.pieceCount);
 
-    if (tr_bitfieldHasAll(b))
+    if (b->hasAll())
     {
         for (size_t i = 0; i < s->pieceReplicationSize; ++i)
         {
             --s->pieceReplication[i];
         }
     }
-    else if (!tr_bitfieldHasNone(b))
+    else if (!b->hasNone())
     {
         for (size_t i = 0; i < s->pieceReplicationSize; ++i)
         {
-            if (tr_bitfieldHas(b, i))
+            if (b->has(i))
             {
                 --s->pieceReplication[i];
             }
@@ -1326,7 +1323,7 @@ void tr_peerMgrGetNextRequests(
         struct weighted_piece* p = pieces + i;
 
         /* if the peer has this piece that we want... */
-        if (tr_bitfieldHas(have, p->index))
+        if (have->has(p->index))
         {
             tr_block_index_t first;
             tr_block_index_t last;
@@ -1674,7 +1671,7 @@ void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t p)
 
         if (!pieceCameFromPeers)
         {
-            pieceCameFromPeers = tr_bitfieldHas(&peer->blame, p);
+            pieceCameFromPeers = peer->blame.has(p);
         }
     }
 
@@ -2239,7 +2236,7 @@ void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t pieceIndex)
     {
         auto* const peer = static_cast<tr_peer*>(tr_ptrArrayNth(&s->peers, i));
 
-        if (tr_bitfieldHas(&peer->blame, pieceIndex))
+        if (peer->blame.has(pieceIndex))
         {
             tordbg(
                 s,
@@ -2513,17 +2510,17 @@ void tr_peerUpdateProgress(tr_torrent* tor, tr_peer* peer)
 {
     tr_bitfield const* have = &peer->have;
 
-    if (tr_bitfieldHasAll(have))
+    if (have->hasAll())
     {
         peer->progress = 1.0;
     }
-    else if (tr_bitfieldHasNone(have))
+    else if (have->hasNone())
     {
         peer->progress = 0.0;
     }
     else
     {
-        float const true_count = tr_bitfieldCountTrueBits(have);
+        float const true_count = have->countTrueBits();
 
         if (tr_torrentHasMetadata(tor))
         {
@@ -2531,7 +2528,7 @@ void tr_peerUpdateProgress(tr_torrent* tor, tr_peer* peer)
         }
         else /* without pieceCount, this result is only a best guess... */
         {
-            peer->progress = true_count / (have->bit_count + 1);
+            peer->progress = true_count / static_cast<float>(have->getBitCount() + 1);
         }
     }
 
@@ -2606,7 +2603,7 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
             {
                 for (int j = 0; j < peerCount; ++j)
                 {
-                    if (tr_bitfieldHas(&peers[j]->have, piece))
+                    if (peers[j]->have.has(piece))
                     {
                         ++tab[i];
                     }
@@ -2895,7 +2892,7 @@ static bool isPeerInteresting(tr_torrent* const tor, bool const* const piece_is_
 
     for (tr_piece_index_t i = 0; i < tor->info.pieceCount; ++i)
     {
-        if (piece_is_interesting[i] && tr_bitfieldHas(&peer->have, i))
+        if (piece_is_interesting[i] && peer->have.has(i))
         {
             return true;
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -483,7 +483,7 @@ public:
         publish(e);
     }
 
-    void publishClientGotBitfield(tr_bitfield* bitfield)
+    void publishClientGotBitfield(Bitfield* bitfield)
     {
         auto e = tr_peer_event{};
         e.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
@@ -1679,9 +1679,9 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
         }
 
         /* a peer can send the same HAVE message twice... */
-        if (!msgs->have.has(ui32))
+        if (!msgs->have.readBit(ui32))
         {
-            msgs->have.add(ui32);
+            msgs->have.setBit(ui32);
             msgs->publishClientGotHave(ui32);
         }
 
@@ -1901,7 +1901,7 @@ static int clientGotBlock(tr_peerMsgsImpl* msgs, struct evbuffer* data, struct p
         return err;
     }
 
-    msgs->blame.add(req->index);
+    msgs->blame.setBit(req->index);
     msgs->publishGotBlock(req);
     return 0;
 }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1679,9 +1679,9 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
         }
 
         /* a peer can send the same HAVE message twice... */
-        if (!tr_bitfieldHas(&msgs->have, ui32))
+        if (!msgs->have.has(ui32))
         {
-            tr_bitfieldAdd(&msgs->have, ui32);
+            msgs->have.add(ui32);
             msgs->publishClientGotHave(ui32);
         }
 
@@ -1693,7 +1693,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
             uint8_t* tmp = tr_new(uint8_t, msglen);
             dbgmsg(msgs, "got a bitfield");
             tr_peerIoReadBytes(msgs->io, inbuf, tmp, msglen);
-            tr_bitfieldSetRaw(&msgs->have, tmp, msglen, tr_torrentHasMetadata(msgs->torrent));
+            msgs->have.setRaw(tmp, msglen, tr_torrentHasMetadata(msgs->torrent));
             msgs->publishClientGotBitfield(&msgs->have);
             updatePeerProgress(msgs);
             tr_free(tmp);
@@ -1787,8 +1787,8 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
 
         if (fext)
         {
-            tr_bitfieldSetHasAll(&msgs->have);
-            TR_ASSERT(tr_bitfieldHasAll(&msgs->have));
+            msgs->have.setHasAll();
+            TR_ASSERT(msgs->have.hasAll());
             msgs->publishClientGotHaveAll();
             updatePeerProgress(msgs);
         }
@@ -1805,7 +1805,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
 
         if (fext)
         {
-            tr_bitfieldSetHasNone(&msgs->have);
+            msgs->have.setHasNone();
             msgs->publishClientGotHaveNone();
             updatePeerProgress(msgs);
         }
@@ -1901,7 +1901,7 @@ static int clientGotBlock(tr_peerMsgsImpl* msgs, struct evbuffer* data, struct p
         return err;
     }
 
-    tr_bitfieldAdd(&msgs->blame, req->index);
+    msgs->blame.add(req->index);
     msgs->publishGotBlock(req);
     return 0;
 }

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -17,7 +17,7 @@
 
 class tr_peer;
 struct tr_address;
-struct tr_bitfield;
+struct Bitfield;
 struct tr_peerIo;
 struct tr_torrent;
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -472,7 +472,7 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
 ***/
 
 // TODO: Refactor this into a constructor for tr_variant
-static void bitfieldToBenc(tr_bitfield const* b, tr_variant* benc)
+static void bitfieldToBenc(Bitfield const* b, tr_variant* benc)
 {
     if (b->hasAll())
     {
@@ -662,7 +662,7 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
 
         err = nullptr;
 
-        tr_bitfield blocks(tor->blockCount);
+        Bitfield blocks(tor->blockCount);
 
         tr_variant const* const b = tr_variantDictFind(prog, TR_KEY_blocks);
         if (b != nullptr)
@@ -713,7 +713,7 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
         }
         else
         {
-            tr_cpBlockInit(&tor->completion, &blocks);
+            tr_cpBlockInit(&tor->completion, blocks);
         }
 
         ret = TR_FR_PROGRESS;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1508,9 +1508,7 @@ enum
 
 static void turtleUpdateTable(struct tr_turtle_info* t)
 {
-    tr_bitfield* b = &t->minutes;
-
-    tr_bitfieldSetHasNone(b);
+    t->minutes->setHasNone();
 
     for (int day = 0; day < 7; ++day)
     {
@@ -1526,7 +1524,7 @@ static void turtleUpdateTable(struct tr_turtle_info* t)
 
             for (time_t i = begin; i < end; ++i)
             {
-                tr_bitfieldAdd(b, (i + day * MINUTES_PER_DAY) % MINUTES_PER_WEEK);
+                t->minutes->add((i + day * MINUTES_PER_DAY) % MINUTES_PER_WEEK);
             }
         }
     }
@@ -1580,7 +1578,7 @@ static bool getInTurtleTime(struct tr_turtle_info const* t)
         minute_of_the_week = MINUTES_PER_WEEK - 1;
     }
 
-    return tr_bitfieldHas(&t->minutes, minute_of_the_week);
+    return t->minutes->has(minute_of_the_week);
 }
 
 static constexpr tr_auto_switch_state_t autoSwitchState(bool enabled)
@@ -1612,7 +1610,7 @@ static void turtleBootstrap(tr_session* session, struct tr_turtle_info* turtle)
     turtle->changedByUser = false;
     turtle->autoTurtleState = TR_AUTO_SWITCH_UNUSED;
 
-    tr_bitfieldConstruct(&turtle->minutes, MINUTES_PER_WEEK);
+    turtle->minutes = new tr_bitfield(MINUTES_PER_WEEK);
 
     turtleUpdateTable(turtle);
 
@@ -2113,7 +2111,7 @@ void tr_sessionClose(tr_session* session)
     /* free the session memory */
     tr_variantFree(&session->removedTorrents);
     delete session->bandwidth;
-    tr_bitfieldDestruct(&session->turtle.minutes);
+    delete session->turtle.minutes;
     tr_session_id_free(session->session_id);
     tr_lockFree(session->lock);
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1524,7 +1524,7 @@ static void turtleUpdateTable(struct tr_turtle_info* t)
 
             for (time_t i = begin; i < end; ++i)
             {
-                t->minutes->add((i + day * MINUTES_PER_DAY) % MINUTES_PER_WEEK);
+                t->minutes->setBit((i + day * MINUTES_PER_DAY) % MINUTES_PER_WEEK);
             }
         }
     }
@@ -1578,7 +1578,7 @@ static bool getInTurtleTime(struct tr_turtle_info const* t)
         minute_of_the_week = MINUTES_PER_WEEK - 1;
     }
 
-    return t->minutes->has(minute_of_the_week);
+    return t->minutes->readBit(minute_of_the_week);
 }
 
 static constexpr tr_auto_switch_state_t autoSwitchState(bool enabled)
@@ -1610,7 +1610,7 @@ static void turtleBootstrap(tr_session* session, struct tr_turtle_info* turtle)
     turtle->changedByUser = false;
     turtle->autoTurtleState = TR_AUTO_SWITCH_UNUSED;
 
-    turtle->minutes = new tr_bitfield(MINUTES_PER_WEEK);
+    turtle->minutes = new Bitfield(MINUTES_PER_WEEK);
 
     turtleUpdateTable(turtle);
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -97,7 +97,7 @@ struct tr_turtle_info
      * limits on or off at that given minute in the week. */
     // Changed to non-owning pointer temporarily till tr_turtle_info becomes C++-constructible and destructible
     // TODO: remove * and own the value
-    tr_bitfield* minutes;
+    Bitfield* minutes;
 
     /* recent action that was done by turtle's automatic switch */
     tr_auto_switch_state_t autoTurtleState;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -95,7 +95,9 @@ struct tr_turtle_info
     /* bitfield of all the minutes in a week.
      * Each bit's value indicates whether the scheduler wants turtle
      * limits on or off at that given minute in the week. */
-    tr_bitfield minutes;
+    // Changed to non-owning pointer temporarily till tr_turtle_info becomes C++-constructible and destructible
+    // TODO: remove * and own the value
+    tr_bitfield* minutes;
 
     /* recent action that was done by turtle's automatic switch */
     tr_auto_switch_state_t autoTurtleState;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1460,7 +1460,7 @@ static uint64_t countFileBytesCompleted(tr_torrent const* tor, tr_file_index_t i
             /* the middle blocks */
             if (first + 1 < last)
             {
-                uint64_t u = tr_bitfieldCountRange(&tor->completion.blockBitfield, first + 1, last);
+                uint64_t u = tor->completion.blockBitfield->countRange(first + 1, last);
                 u *= tor->blockSize;
                 total += u;
             }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -67,7 +67,7 @@ public:
         , bandwidth(tor->bandwidth)
     {
         // init parent bits
-        tr_bitfieldSetHasAll(&have);
+        have.setHasAll();
         tr_peerUpdateProgress(tor, this);
 
         file_urls.resize(tr_torrentInfo(tor)->fileCount);

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -22,12 +22,11 @@ TEST(Bitfield, countRange)
         int const bit_count = 100 + tr_rand_int_weak(1000);
 
         // generate a random bitfield
-        tr_bitfield bf;
-        tr_bitfieldConstruct(&bf, bit_count);
+        Bitfield bf(bit_count);
 
         for (int j = 0, n = tr_rand_int_weak(bit_count); j < n; ++j)
         {
-            tr_bitfieldAdd(&bf, tr_rand_int_weak(bit_count));
+            bf.setBit(tr_rand_int_weak(bit_count));
         }
 
         int begin = tr_rand_int_weak(bit_count);

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -48,169 +48,161 @@ TEST(Bitfield, countRange)
         unsigned long count1 = {};
         for (auto j = begin; j < end; ++j)
         {
-            if (tr_bitfieldHas(&bf, j))
+            if (bf.readBit(j))
             {
                 ++count1;
             }
         }
 
-        auto const count2 = tr_bitfieldCountRange(&bf, begin, end);
+        auto const count2 = bf.countRange(begin, end);
         EXPECT_EQ(count1, count2);
-
-        // cleanup
-        tr_bitfieldDestruct(&bf);
     }
 }
 
 TEST(Bitfields, bitfields)
 {
     unsigned int bitcount = 500;
-    tr_bitfield field;
+    Bitfield field(bitcount);
 
-    tr_bitfieldConstruct(&field, bitcount);
-
-    /* test tr_bitfieldAdd */
+    /* test Bitfield::setBit */
     for (unsigned int i = 0; i < bitcount; i++)
     {
         if (i % 7 == 0)
         {
-            tr_bitfieldAdd(&field, i);
+            field.setBit(i);
         }
     }
 
     for (unsigned int i = 0; i < bitcount; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (i % 7 == 0));
+        EXPECT_EQ(field.readBit(i), (i % 7 == 0));
     }
 
-    /* test tr_bitfieldAddRange */
-    tr_bitfieldAddRange(&field, 0, bitcount);
+    /* test Bitfield::setBitRange */
+    field.setBitRange(0, bitcount);
 
     for (unsigned int i = 0; i < bitcount; i++)
     {
-        EXPECT_TRUE(tr_bitfieldHas(&field, i));
+        EXPECT_TRUE(field.readBit(i));
     }
 
-    /* test tr_bitfieldRem */
+    /* test Bitfield::clearBit */
     for (unsigned int i = 0; i < bitcount; i++)
     {
         if (i % 7 != 0)
         {
-            tr_bitfieldRem(&field, i);
+            field.clearBit(i);
         }
     }
 
     for (unsigned int i = 0; i < bitcount; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (i % 7 == 0));
+        EXPECT_EQ(field.readBit(i), (i % 7 == 0));
     }
 
-    /* test tr_bitfieldRemRange in the middle of a boundary */
-    tr_bitfieldAddRange(&field, 0, 64);
-    tr_bitfieldRemRange(&field, 4, 21);
+    /* test Bitfield::clearBitRange in the middle of a boundary */
+    field.setBitRange(0, 64);
+    field.clearBitRange(4, 21);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (i < 4 || i >= 21));
+        EXPECT_EQ(field.readBit(i), (i < 4 || i >= 21));
     }
 
-    /* test tr_bitfieldRemRange on the boundaries */
-    tr_bitfieldAddRange(&field, 0, 64);
-    tr_bitfieldRemRange(&field, 8, 24);
+    /* test Bitfield::clearBitRange on the boundaries */
+    field.setBitRange(0, 64);
+    field.clearBitRange(8, 24);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (i < 8 || i >= 24));
+        EXPECT_EQ(field.readBit(i), (i < 8 || i >= 24));
     }
 
-    /* test tr_bitfieldRemRange when begin & end is on the same word */
-    tr_bitfieldAddRange(&field, 0, 64);
-    tr_bitfieldRemRange(&field, 4, 5);
+    /* test Bitfield::clearBitRange when begin & end is on the same word */
+    field.setBitRange(0, 64);
+    field.clearBitRange(4, 5);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (i < 4 || i >= 5));
+        EXPECT_EQ(field.readBit(i), (i < 4 || i >= 5));
     }
 
-    /* test tr_bitfieldAddRange */
-    tr_bitfieldRemRange(&field, 0, 64);
-    tr_bitfieldAddRange(&field, 4, 21);
+    /* test Bitfield::setBitRange */
+    field.clearBitRange(0, 64);
+    field.setBitRange(4, 21);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (4 <= i && i < 21));
+        EXPECT_EQ(field.readBit(i), (4 <= i && i < 21));
     }
 
-    /* test tr_bitfieldAddRange on the boundaries */
-    tr_bitfieldRemRange(&field, 0, 64);
-    tr_bitfieldAddRange(&field, 8, 24);
+    /* test Bitfield::setBitRange on the boundaries */
+    field.clearBitRange(0, 64);
+    field.setBitRange(8, 24);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (8 <= i && i < 24));
+        EXPECT_EQ(field.readBit(i), (8 <= i && i < 24));
     }
 
-    /* test tr_bitfieldAddRange when begin & end is on the same word */
-    tr_bitfieldRemRange(&field, 0, 64);
-    tr_bitfieldAddRange(&field, 4, 5);
+    /* test Bitfield::setBitRange when begin & end is on the same word */
+    field.clearBitRange(0, 64);
+    field.setBitRange(4, 5);
 
     for (unsigned int i = 0; i < 64; i++)
     {
-        EXPECT_EQ(tr_bitfieldHas(&field, i), (4 <= i && i < 5));
+        EXPECT_EQ(field.readBit(i), (4 <= i && i < 5));
     }
-
-    tr_bitfieldDestruct(&field);
 }
 
 TEST(Bitfields, hasAllNone)
 {
-    tr_bitfield field;
+    {
+        Bitfield field(3);
 
-    tr_bitfieldConstruct(&field, 3);
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(field.hasNone());
 
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(tr_bitfieldHasNone(&field));
+        field.setBit(0);
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
 
-    tr_bitfieldAdd(&field, 0);
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+        field.clearBit(0);
+        field.setBit(1);
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
 
-    tr_bitfieldRem(&field, 0);
-    tr_bitfieldAdd(&field, 1);
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+        field.clearBit(1);
+        field.setBit(2);
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
 
-    tr_bitfieldRem(&field, 1);
-    tr_bitfieldAdd(&field, 2);
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+        field.setBit(0);
+        field.setBit(1);
+        EXPECT_TRUE(field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
 
-    tr_bitfieldAdd(&field, 0);
-    tr_bitfieldAdd(&field, 1);
-    EXPECT_TRUE(tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+        field.setHasNone();
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(field.hasNone());
 
-    tr_bitfieldSetHasNone(&field);
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(tr_bitfieldHasNone(&field));
+        field.setHasAll();
+        EXPECT_TRUE(field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
+    }
 
-    tr_bitfieldSetHasAll(&field);
-    EXPECT_TRUE(tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+    {
+        Bitfield field(0);
 
-    tr_bitfieldDestruct(&field);
-    tr_bitfieldConstruct(&field, 0);
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
 
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
+        field.setHasNone();
+        EXPECT_TRUE(!field.hasAll());
+        EXPECT_TRUE(field.hasNone());
 
-    tr_bitfieldSetHasNone(&field);
-    EXPECT_TRUE(!tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(tr_bitfieldHasNone(&field));
-
-    tr_bitfieldSetHasAll(&field);
-    EXPECT_TRUE(tr_bitfieldHasAll(&field));
-    EXPECT_TRUE(!tr_bitfieldHasNone(&field));
-
-    tr_bitfieldDestruct(&field);
+        field.setHasAll();
+        EXPECT_TRUE(field.hasAll());
+        EXPECT_TRUE(!field.hasNone());
+    }
 }


### PR DESCRIPTION
* Renames: `tr_bitfield` becomes `Bitfield`, inner fields become private and `snake_case_`
* All/None flags become an Enum (a bit cleaner) but please review
* Test module for bitfield also updated
* Renamed some API functions

TODO:
* GetRaw - change from void* to owning pointer, update caller code
* SetRaw - change from pointer+size into a span (note std::span arrives in C++20 so for C++17 we have to be creative)
* C++ memory storage: change from `byte*` to a `vector` or `unique_ptr`