### PR TITLE
refactor: use maybe unused attribute

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -138,19 +138,14 @@ static char* tr_strlratio(char* buf, double ratio, size_t buflen)
 static bool waitingOnWeb;
 
 static void onTorrentFileDownloaded(
-    tr_session* session,
-    bool did_connect,
-    bool did_timeout,
-    long response_code,
+    [[maybe_unused]] tr_session* session,
+    [[maybe_unused]] bool did_connect,
+    [[maybe_unused]] bool did_timeout,
+    [[maybe_unused]] long response_code,
     void const* response,
     size_t response_byte_count,
     void* vctor)
 {
-    TR_UNUSED(session);
-    TR_UNUSED(did_connect);
-    TR_UNUSED(did_timeout);
-    TR_UNUSED(response_code);
-
     auto* ctor = static_cast<tr_ctor*>(vctor);
     tr_ctorSetMetainfo(ctor, response, response_byte_count);
     waitingOnWeb = false;

--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -72,10 +72,8 @@ static void send_signal_to_pipe(int sig)
     errno = old_errno;
 }
 
-static void* signal_handler_thread_main(void* arg)
+static void* signal_handler_thread_main([[maybe_unused]] void* arg)
 {
-    TR_UNUSED(arg);
-
     int sig;
 
     while (read(signal_pipe[0], &sig, sizeof(sig)) == sizeof(sig) && sig != 0)

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -72,10 +72,8 @@ static void do_log_system_error(char const* file, int line, tr_log_level level, 
 ****
 ***/
 
-static BOOL WINAPI handle_console_ctrl(DWORD control_type)
+static BOOL WINAPI handle_console_ctrl([[maybe_unused]] DWORD control_type)
 {
-    TR_UNUSED(control_type);
-
     callbacks->on_stop(callback_arg);
     return TRUE;
 }
@@ -147,12 +145,12 @@ static void stop_service(void)
     }
 }
 
-static DWORD WINAPI handle_service_ctrl(DWORD control_code, DWORD event_type, LPVOID event_data, LPVOID context)
+static DWORD WINAPI handle_service_ctrl(
+    DWORD control_code,
+    [[maybe_unused]] DWORD event_type,
+    [[maybe_unused]] LPVOID event_data,
+    [[maybe_unused]] LPVOID context)
 {
-    TR_UNUSED(event_type);
-    TR_UNUSED(event_data);
-    TR_UNUSED(context);
-
     switch (control_code)
     {
     case SERVICE_CONTROL_PRESHUTDOWN:
@@ -173,18 +171,13 @@ static DWORD WINAPI handle_service_ctrl(DWORD control_code, DWORD event_type, LP
     return ERROR_CALL_NOT_IMPLEMENTED;
 }
 
-static unsigned int __stdcall service_thread_main(void* context)
+static unsigned int __stdcall service_thread_main([[maybe_unused]] void* context)
 {
-    TR_UNUSED(context);
-
     return callbacks->on_start(callback_arg, false);
 }
 
-static VOID WINAPI service_main(DWORD argc, LPWSTR* argv)
+static VOID WINAPI service_main([[maybe_unused]] DWORD argc, [[maybe_unused]] LPWSTR* argv)
 {
-    TR_UNUSED(argc);
-    TR_UNUSED(argv);
-
     status_handle = RegisterServiceCtrlHandlerExW(service_name, &handle_service_ctrl, nullptr);
 
     if (status_handle == nullptr)

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -39,16 +39,12 @@
 
 #else
 
-static void sd_notify(int status, char const* str)
+static void sd_notify([[maybe_unused]] int status, [[maybe_unused]] char const* str)
 {
-    TR_UNUSED(status);
-    TR_UNUSED(str);
 }
 
-static void sd_notifyf(int status, char const* fmt, ...)
+static void sd_notifyf([[maybe_unused]] int status, [[maybe_unused]] char const* fmt, ...)
 {
-    TR_UNUSED(status);
-    TR_UNUSED(fmt);
 }
 
 #endif
@@ -282,7 +278,13 @@ static tr_watchdir_status onFileAdded(tr_watchdir_t dir, char const* name, void*
     return err == TR_PARSE_ERR ? TR_WATCHDIR_RETRY : TR_WATCHDIR_ACCEPT;
 }
 
-static void printMessage(tr_sys_file_t file, int level, char const* name, char const* message, char const* filename, int line)
+static void printMessage(
+    tr_sys_file_t file,
+    [[maybe_unused]] int level,
+    char const* name,
+    char const* message,
+    char const* filename,
+    int line)
 {
     if (file != TR_BAD_SYS_FILE)
     {
@@ -339,10 +341,6 @@ static void printMessage(tr_sys_file_t file, int level, char const* name, char c
         }
     }
 
-#else
-
-    TR_UNUSED(level);
-
 #endif
 }
 
@@ -378,26 +376,18 @@ static void reportStatus(void)
     }
 }
 
-static void periodicUpdate(evutil_socket_t fd, short what, void* context)
+static void periodicUpdate([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, [[maybe_unused]] void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-    TR_UNUSED(context);
-
     pumpLogMessages(logfile);
     reportStatus();
 }
 
 static tr_rpc_callback_status on_rpc_callback(
-    tr_session* session,
+    [[maybe_unused]] tr_session* session,
     tr_rpc_callback_type type,
-    struct tr_torrent* tor,
-    void* user_data)
+    [[maybe_unused]] struct tr_torrent* tor,
+    [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(session);
-    TR_UNUSED(tor);
-    TR_UNUSED(user_data);
-
     if (type == TR_RPC_SESSION_CLOSE)
     {
         event_base_loopexit(ev_base, nullptr);
@@ -621,10 +611,8 @@ struct daemon_data
     bool paused;
 };
 
-static void daemon_reconfigure(void* arg)
+static void daemon_reconfigure([[maybe_unused]] void* arg)
 {
-    TR_UNUSED(arg);
-
     if (mySession == nullptr)
     {
         tr_logAddInfo("Deferring reload until session is fully started.");
@@ -652,19 +640,13 @@ static void daemon_reconfigure(void* arg)
     }
 }
 
-static void daemon_stop(void* arg)
+static void daemon_stop([[maybe_unused]] void* arg)
 {
-    TR_UNUSED(arg);
-
     event_base_loopexit(ev_base, nullptr);
 }
 
-static int daemon_start(void* varg, bool foreground)
+static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
 {
-#ifndef HAVE_SYSLOG
-    TR_UNUSED(foreground);
-#endif
-
     bool boolVal;
     char const* pid_filename;
     bool pidfile_created = false;

--- a/gtk/actions.cc
+++ b/gtk/actions.cc
@@ -17,6 +17,7 @@
 #include "conf.h"
 #include "tr-core.h"
 #include "tr-prefs.h"
+#include "util.h"
 
 static TrCore* myCore = nullptr;
 static GtkActionGroup* myGroup = nullptr;

--- a/gtk/util.h
+++ b/gtk/util.h
@@ -54,6 +54,13 @@ extern char const* speed_T_str;
 
 #endif
 
+// http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
+#define TR_UNUSED(x) \
+    do \
+    { \
+        ((void)sizeof(x)); \
+    } while (0)
+
 enum
 {
     GTR_UNICODE_UP,

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1712,11 +1712,8 @@ static void scrapeAndAnnounceMore(tr_announcer* announcer)
     }
 }
 
-static void onUpkeepTimer(evutil_socket_t fd, short what, void* vannouncer)
+static void onUpkeepTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vannouncer)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* announcer = static_cast<tr_announcer*>(vannouncer);
     tr_session* session = announcer->session;
     bool const is_closing = session->isClosed;
@@ -1863,10 +1860,8 @@ tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerC
     return ret;
 }
 
-void tr_announcerStatsFree(tr_tracker_stat* trackers, int trackerCount)
+void tr_announcerStatsFree(tr_tracker_stat* trackers, [[maybe_unused]] int trackerCount)
 {
-    TR_UNUSED(trackerCount);
-
     tr_free(trackers);
 }
 
@@ -1920,10 +1915,8 @@ static void copy_tier_attributes(struct tr_torrent_tiers* tt, tr_tier const* src
     }
 }
 
-void tr_announcerResetTorrent(tr_announcer* announcer, tr_torrent* tor)
+void tr_announcerResetTorrent([[maybe_unused]] tr_announcer* announcer, tr_torrent* tor)
 {
-    TR_UNUSED(announcer);
-
     TR_ASSERT(tor->tiers != nullptr);
 
     time_t const now = tr_time();

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -250,9 +250,8 @@ constexpr void four_digit_formatter(char* buf, size_t buflen, std::string_view n
     buf_append(buf, buflen, name, ' ', charints[id[3]], '.', charints[id[4]], '.', charints[id[5]], '.', charints[id[6]]);
 }
 
-constexpr void no_version_formatter(char* buf, size_t buflen, std::string_view name, char const* id)
+constexpr void no_version_formatter(char* buf, size_t buflen, std::string_view name, [[maybe_unused]] char const* id)
 {
-    TR_UNUSED(id);
     buf_append(buf, buflen, name);
 }
 

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -204,10 +204,12 @@ void tr_dh_free(tr_dh_ctx_t raw_handle)
     tr_free(handle);
 }
 
-bool tr_dh_make_key(tr_dh_ctx_t raw_handle, size_t private_key_length, uint8_t* public_key, size_t* public_key_length)
+bool tr_dh_make_key(
+    tr_dh_ctx_t raw_handle,
+    [[maybe_unused]] size_t private_key_length,
+    uint8_t* public_key,
+    size_t* public_key_length)
 {
-    TR_UNUSED(private_key_length);
-
     TR_ASSERT(raw_handle != nullptr);
     TR_ASSERT(public_key != nullptr);
 

--- a/libtransmission/crypto-utils-fallback.cc
+++ b/libtransmission/crypto-utils-fallback.cc
@@ -76,32 +76,23 @@ void tr_dh_secret_free(tr_dh_secret_t handle)
 
 #ifdef TR_CRYPTO_X509_FALLBACK
 
-tr_x509_store_t tr_ssl_get_x509_store(tr_ssl_ctx_t handle)
+tr_x509_store_t tr_ssl_get_x509_store([[maybe_unused]] tr_ssl_ctx_t handle)
 {
-    TR_UNUSED(handle);
-
     return nullptr;
 }
 
-bool tr_x509_store_add(tr_x509_store_t handle, tr_x509_cert_t cert)
+bool tr_x509_store_add([[maybe_unused]] tr_x509_store_t handle, [[maybe_unused]] tr_x509_cert_t cert)
 {
-    TR_UNUSED(handle);
-    TR_UNUSED(cert);
-
     return false;
 }
 
-tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length)
+tr_x509_cert_t tr_x509_cert_new([[maybe_unused]] void const* der, [[maybe_unused]] size_t der_length)
 {
-    TR_UNUSED(der);
-    TR_UNUSED(der_length);
-
     return nullptr;
 }
 
-void tr_x509_cert_free(tr_x509_cert_t handle)
+void tr_x509_cert_free([[maybe_unused]] tr_x509_cert_t handle)
 {
-    TR_UNUSED(handle);
 }
 
 #endif /* TR_CRYPTO_X509_FALLBACK */

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -83,10 +83,8 @@ static bool check_polarssl_result(int result, int expected_result, char const* f
 ****
 ***/
 
-static int my_rand(void* context, unsigned char* buffer, size_t buffer_size)
+static int my_rand([[maybe_unused]] void* context, unsigned char* buffer, size_t buffer_size)
 {
-    TR_UNUSED(context);
-
     for (size_t i = 0; i < buffer_size; ++i)
     {
         buffer[i] = tr_rand_int_weak(256);

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -927,7 +927,12 @@ bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error** error)
     return ret;
 }
 
-bool tr_sys_file_advise(tr_sys_file_t handle, uint64_t offset, uint64_t size, tr_sys_file_advice_t advice, tr_error** error)
+bool tr_sys_file_advise(
+    [[maybe_unused]] tr_sys_file_t handle,
+    [[maybe_unused]] uint64_t offset,
+    [[maybe_unused]] uint64_t size,
+    [[maybe_unused]] tr_sys_file_advice_t advice,
+    [[maybe_unused]] tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
     TR_ASSERT(size > 0);
@@ -966,14 +971,6 @@ bool tr_sys_file_advise(tr_sys_file_t handle, uint64_t offset, uint64_t size, tr
             set_system_error(error, errno);
         }
     }
-
-#else
-
-    TR_UNUSED(handle);
-    TR_UNUSED(offset);
-    TR_UNUSED(size);
-    TR_UNUSED(advice);
-    TR_UNUSED(error);
 
 #endif
 
@@ -1046,9 +1043,8 @@ bool full_preallocate_posix(tr_sys_file_t handle, uint64_t size)
 
 } // unnamed namespace
 
-bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_error** error)
+bool tr_sys_file_preallocate(tr_sys_file_t handle, [[maybe_unused]] uint64_t size, int flags, tr_error** error)
 {
-    TR_UNUSED(size);
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
 
     using prealloc_func = bool (*)(tr_sys_file_t, uint64_t);
@@ -1134,7 +1130,7 @@ bool tr_sys_file_unmap(void const* address, uint64_t size, tr_error** error)
     return ret;
 }
 
-bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error** error)
+bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] int operation, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
     TR_ASSERT((operation & ~(TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB | TR_SYS_FILE_LOCK_UN)) == 0);
@@ -1204,9 +1200,6 @@ bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error** error)
     } while (!ret && errno == EINTR);
 
 #else
-
-    TR_UNUSED(handle);
-    TR_UNUSED(operation);
 
     errno = ENOSYS;
     ret = false;

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -260,10 +260,8 @@ static tr_sys_file_t open_file(char const* path, DWORD access, DWORD disposition
     return ret;
 }
 
-static bool create_dir(char const* path, int flags, int permissions, bool okay_if_exists, tr_error** error)
+static bool create_dir(char const* path, int flags, [[maybe_unused]] int permissions, bool okay_if_exists, tr_error** error)
 {
-    TR_UNUSED(permissions);
-
     TR_ASSERT(path != nullptr);
 
     bool ret;
@@ -877,10 +875,8 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
     return ret;
 }
 
-tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_error** error)
+tr_sys_file_t tr_sys_file_open(char const* path, int flags, [[maybe_unused]] int permissions, tr_error** error)
 {
-    TR_UNUSED(permissions);
-
     TR_ASSERT(path != nullptr);
     TR_ASSERT((flags & (TR_SYS_FILE_READ | TR_SYS_FILE_WRITE)) != 0);
 
@@ -1211,14 +1207,13 @@ bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error** error)
     return ret;
 }
 
-bool tr_sys_file_advise(tr_sys_file_t handle, uint64_t offset, uint64_t size, tr_sys_file_advice_t advice, tr_error** error)
+bool tr_sys_file_advise(
+    [[maybe_unused]] tr_sys_file_t handle,
+    [[maybe_unused]] uint64_t offset,
+    [[maybe_unused]] uint64_t size,
+    [[maybe_unused]] tr_sys_file_advice_t advice,
+    [[maybe_unused]] tr_error** error)
 {
-    TR_UNUSED(handle);
-    TR_UNUSED(offset);
-    TR_UNUSED(size);
-    TR_UNUSED(advice);
-    TR_UNUSED(error);
-
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
     TR_ASSERT(size > 0);
     TR_ASSERT(advice == TR_SYS_FILE_ADVICE_WILL_NEED || advice == TR_SYS_FILE_ADVICE_DONT_NEED);
@@ -1281,10 +1276,8 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
     return ret;
 }
 
-bool tr_sys_file_unmap(void const* address, uint64_t size, tr_error** error)
+bool tr_sys_file_unmap(void const* address, [[maybe_unused]] uint64_t size, tr_error** error)
 {
-    TR_UNUSED(size);
-
     TR_ASSERT(address != nullptr);
     TR_ASSERT(size > 0);
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1203,11 +1203,8 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
 ***
 **/
 
-static void handshakeTimeout(evutil_socket_t s, short type, void* handshake)
+static void handshakeTimeout([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, void* handshake)
 {
-    TR_UNUSED(s);
-    TR_UNUSED(type);
-
     tr_handshakeAbort(static_cast<tr_handshake*>(handshake));
 }
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -533,10 +533,8 @@ static tr_lock* getQueueLock(void)
     return lock;
 }
 
-static void makeMetaWorkerFunc(void* user_data)
+static void makeMetaWorkerFunc([[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(user_data);
-
     for (;;)
     {
         tr_metainfo_builder* builder = nullptr;

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -153,7 +153,7 @@ int tr_address_compare(tr_address const* a, tr_address const* b)
  * TCP sockets
  **********************************************************************/
 
-void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type)
+void tr_netSetTOS([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_address_type type)
 {
     if (type == TR_AF_INET)
     {
@@ -165,12 +165,6 @@ void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type)
             tr_net_strerror(err_buf, sizeof(err_buf), sockerrno);
             tr_logAddNamedInfo("Net", "Can't set TOS '%d': %s", tos, err_buf);
         }
-
-#else
-
-        TR_UNUSED(s);
-        TR_UNUSED(tos);
-
 #endif
     }
     else if (type == TR_AF_INET6)
@@ -182,12 +176,6 @@ void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type)
             tr_net_strerror(err_buf, sizeof(err_buf), sockerrno);
             tr_logAddNamedInfo("Net", "Can't set IPv6 QoS '%d': %s", tos, err_buf);
         }
-
-#else
-
-        TR_UNUSED(s);
-        TR_UNUSED(tos);
-
 #endif
     }
     else
@@ -197,7 +185,7 @@ void tr_netSetTOS(tr_socket_t s, int tos, tr_address_type type)
     }
 }
 
-void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm)
+void tr_netSetCongestionControl([[maybe_unused]] tr_socket_t s, [[maybe_unused]] char const* algorithm)
 {
 #ifdef TCP_CONGESTION
 
@@ -210,11 +198,6 @@ void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm)
             algorithm,
             tr_net_strerror(err_buf, sizeof(err_buf), sockerrno));
     }
-
-#else
-
-    TR_UNUSED(s);
-    TR_UNUSED(algorithm);
 
 #endif
 }
@@ -370,10 +353,12 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
     return ret;
 }
 
-struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed)
+struct tr_peer_socket tr_netOpenPeerUTPSocket(
+    tr_session* session,
+    tr_address const* addr,
+    tr_port port,
+    [[maybe_unused]] bool clientIsSeed)
 {
-    TR_UNUSED(clientIsSeed);
-
     auto ret = tr_peer_socket{};
 
     if (tr_address_is_valid_for_peers(addr, port))

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -263,10 +263,8 @@ static void canReadWrapper(tr_peerIo* io)
     tr_peerIoUnref(io);
 }
 
-static void event_read_cb(evutil_socket_t fd, short event, void* vio)
+static void event_read_cb(evutil_socket_t fd, [[maybe_unused]] short event, void* vio)
 {
-    TR_UNUSED(event);
-
     auto* io = static_cast<tr_peerIo*>(vio);
 
     TR_ASSERT(tr_isPeerIo(io));
@@ -356,10 +354,8 @@ static int tr_evbuffer_write(tr_peerIo* io, int fd, size_t howmuch)
     return n;
 }
 
-static void event_write_cb(evutil_socket_t fd, short event, void* vio)
+static void event_write_cb(evutil_socket_t fd, [[maybe_unused]] short event, void* vio)
 {
-    TR_UNUSED(event);
-
     auto* io = static_cast<tr_peerIo*>(vio);
 
     TR_ASSERT(tr_isPeerIo(io));
@@ -567,10 +563,8 @@ static void utp_on_error(void* vio, int errcode)
     }
 }
 
-static void utp_on_overhead(void* vio, bool send, size_t count, int type)
+static void utp_on_overhead(void* vio, bool send, size_t count, [[maybe_unused]] int type)
 {
-    TR_UNUSED(type);
-
     auto* io = static_cast<tr_peerIo*>(vio);
 
     TR_ASSERT(tr_isPeerIo(io));
@@ -588,51 +582,42 @@ static auto utp_function_table = UTPFunctionTable{
 /* We switch a UTP socket to use these after the associated peerIo has been
    destroyed -- see io_dtor. */
 
-static void dummy_read(void* closure, unsigned char const* buf, size_t buflen)
+static void dummy_read(
+    [[maybe_unused]] void* closure,
+    [[maybe_unused]] unsigned char const* buf,
+    [[maybe_unused]] size_t buflen)
 {
-    TR_UNUSED(closure);
-    TR_UNUSED(buf);
-    TR_UNUSED(buflen);
-
     /* This cannot happen, as far as I'm aware. */
     tr_logAddNamedError("UTP", "On_read called on closed socket");
 }
 
-static void dummy_write(void* closure, unsigned char* buf, size_t buflen)
+static void dummy_write([[maybe_unused]] void* closure, unsigned char* buf, size_t buflen)
 {
-    TR_UNUSED(closure);
-
     /* This can very well happen if we've shut down a peer connection that
        had unflushed buffers.  Complain and send zeroes. */
     tr_logAddNamedDbg("UTP", "On_write called on closed socket");
     memset(buf, 0, buflen);
 }
 
-static size_t dummy_get_rb_size(void* closure)
+static size_t dummy_get_rb_size([[maybe_unused]] void* closure)
 {
-    TR_UNUSED(closure);
-
     return 0;
 }
 
-static void dummy_on_state_change(void* closure, int state)
+static void dummy_on_state_change([[maybe_unused]] void* closure, [[maybe_unused]] int state)
 {
-    TR_UNUSED(closure);
-    TR_UNUSED(state);
 }
 
-static void dummy_on_error(void* closure, int errcode)
+static void dummy_on_error([[maybe_unused]] void* closure, [[maybe_unused]] int errcode)
 {
-    TR_UNUSED(closure);
-    TR_UNUSED(errcode);
 }
 
-static void dummy_on_overhead(void* closure, bool send, size_t count, int type)
+static void dummy_on_overhead(
+    [[maybe_unused]] void* closure,
+    [[maybe_unused]] bool send,
+    [[maybe_unused]] size_t count,
+    [[maybe_unused]] int type)
 {
-    TR_UNUSED(closure);
-    TR_UNUSED(send);
-    TR_UNUSED(count);
-    TR_UNUSED(type);
 }
 
 static auto dummy_utp_function_table = UTPFunctionTable{

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1446,11 +1446,8 @@ bool tr_peerMgrDidPeerRequest(tr_torrent const* tor, tr_peer const* peer, tr_blo
 }
 
 /* cancel requests that are too old */
-static void refillUpkeep(evutil_socket_t fd, short what, void* vmgr)
+static void refillUpkeep([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     time_t now;
     time_t too_old;
     int cancel_buflen = 0;
@@ -1550,10 +1547,12 @@ static void addStrike(tr_swarm* s, tr_peer* peer)
     }
 }
 
-static void peerSuggestedPiece(tr_swarm* s, tr_peer* peer, tr_piece_index_t pieceIndex, int isFastAllowed)
+static void peerSuggestedPiece(
+    [[maybe_unused]] tr_swarm* s,
+    [[maybe_unused]] tr_peer* peer,
+    [[maybe_unused]] tr_piece_index_t pieceIndex,
+    [[maybe_unused]] int isFastAllowed)
 {
-    TR_UNUSED(s);
-
 #if 0
 
     TR_ASSERT(t != nullptr);
@@ -1603,13 +1602,6 @@ static void peerSuggestedPiece(tr_swarm* s, tr_peer* peer, tr_piece_index_t piec
             }
         }
     }
-
-#else
-
-    TR_UNUSED(peer);
-    TR_UNUSED(pieceIndex);
-    TR_UNUSED(isFastAllowed);
-
 #endif
 }
 
@@ -3320,11 +3312,8 @@ static void rechokeUploads(tr_swarm* s, uint64_t const now)
     tr_free(choke);
 }
 
-static void rechokePulse(evutil_socket_t fd, short what, void* vmgr)
+static void rechokePulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     uint64_t const now = tr_time_msec();
 
@@ -3711,11 +3700,8 @@ static void enforceSessionPeerLimit(tr_session* session, uint64_t now)
 
 static void makeNewPeerConnections(tr_peerMgr* mgr, int const max);
 
-static void reconnectPulse(evutil_socket_t fd, short what, void* vmgr)
+static void reconnectPulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     time_t const now_sec = tr_time();
     uint64_t const now_msec = tr_time_msec();
@@ -3794,11 +3780,8 @@ static void queuePulse(tr_session* session, tr_direction dir)
     }
 }
 
-static void bandwidthPulse(evutil_socket_t fd, short what, void* vmgr)
+static void bandwidthPulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     tr_session* session = mgr->session;
     managerLock(mgr);
@@ -3904,11 +3887,8 @@ static int getMaxAtomCount(tr_torrent const* tor)
     return std::min(50, tor->maxConnectedPeers * 3);
 }
 
-static void atomPulse(evutil_socket_t fd, short what, void* vmgr)
+static void atomPulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     managerLock(mgr);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -878,10 +878,8 @@ size_t tr_generateAllowedSet(tr_piece_index_t* setmePieces, size_t desiredSetSiz
     return setSize;
 }
 
-static void updateFastSet(tr_peerMsgs* msgs)
+static void updateFastSet([[maybe_unused]] tr_peerMsgs* msgs)
 {
-    TR_UNUSED(msgs);
-
     bool const fext = tr_peerIoSupportsFEXT(msgs->io);
     bool const peerIsNeedy = msgs->peer->progress < 0.10;
 
@@ -2290,11 +2288,9 @@ static void peerPulse(void* vmsgs)
     }
 }
 
-static void gotError(tr_peerIo* io, short what, void* vmsgs)
+static void gotError([[maybe_unused]] tr_peerIo* io, short what, void* vmsgs)
 {
     auto* msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
-
-    TR_UNUSED(io);
 
     if ((what & BEV_EVENT_TIMEOUT) != 0)
     {
@@ -2668,11 +2664,8 @@ static void sendPex(tr_peerMsgsImpl* msgs)
     }
 }
 
-static void pexPulse(evutil_socket_t fd, short what, void* vmsgs)
+static void pexPulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmsgs)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
 
     sendPex(msgs);

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -435,7 +435,7 @@ static int64_t getxfsquota(char* device)
 
 #endif /* _WIN32 */
 
-static int64_t tr_getQuotaFreeSpace(struct tr_device_info const* info)
+static int64_t tr_getQuotaFreeSpace([[maybe_unused]] struct tr_device_info const* info)
 {
     int64_t ret = -1;
 
@@ -451,10 +451,6 @@ static int64_t tr_getQuotaFreeSpace(struct tr_device_info const* info)
     {
         ret = getquota(info->device);
     }
-
-#else /* _WIN32 */
-
-    TR_UNUSED(info);
 
 #endif /* _WIN32 */
 

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -479,7 +479,7 @@ static bool isWebClientDir(char const* path)
     return ret;
 }
 
-char const* tr_getWebClientDir(tr_session const* session)
+char const* tr_getWebClientDir([[maybe_unused]] tr_session const* session)
 {
     static char const* s = nullptr;
 
@@ -527,8 +527,6 @@ char const* tr_getWebClientDir(tr_session const* session)
             }
 
 #elif defined(_WIN32)
-
-            TR_UNUSED(session);
 
             /* Generally, Web interface should be stored in a Web subdir of
              * calling executable dir. */
@@ -582,8 +580,6 @@ char const* tr_getWebClientDir(tr_session const* session)
             }
 
 #else /* everyone else, follow the XDG spec */
-
-            TR_UNUSED(session);
 
             auto candidates = std::list<std::string>{};
 

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -143,11 +143,8 @@ static void set_evtimer_from_status(tr_shared* s)
     }
 }
 
-static void onTimer(evutil_socket_t fd, short what, void* vshared)
+static void onTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vshared)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* s = static_cast<tr_shared*>(vshared);
 
     TR_ASSERT(s != nullptr);

--- a/libtransmission/ptrarray.cc
+++ b/libtransmission/ptrarray.cc
@@ -241,17 +241,9 @@ static void* tr_ptrArrayRemoveSortedValue(tr_ptrArray* t, void const* ptr, tr_vo
 
 void tr_ptrArrayRemoveSortedPointer(tr_ptrArray* t, void const* ptr, tr_voidptr_compare_func compare)
 {
-    void const* removed = tr_ptrArrayRemoveSortedValue(t, ptr, compare);
-
-#ifndef TR_ENABLE_ASSERTS
-
-    TR_UNUSED(removed);
-
-#else
+    [[maybe_unused]] void const* removed = tr_ptrArrayRemoveSortedValue(t, ptr, compare);
 
     TR_ASSERT(removed != nullptr);
     TR_ASSERT(removed == ptr);
     TR_ASSERT(tr_ptrArrayFindSorted(t, ptr, compare) == nullptr);
-
-#endif
 }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -367,11 +367,8 @@ static void add_time_header(struct evkeyvalq* headers, char const* key, time_t v
     evhttp_add_header(headers, key, buf);
 }
 
-static void evbuffer_ref_cleanup_tr_free(void const* data, size_t datalen, void* extra)
+static void evbuffer_ref_cleanup_tr_free([[maybe_unused]] void const* data, [[maybe_unused]] size_t datalen, void* extra)
 {
-    TR_UNUSED(data);
-    TR_UNUSED(datalen);
-
     tr_free(extra);
 }
 
@@ -475,10 +472,8 @@ struct rpc_response_data
     struct tr_rpc_server* server;
 };
 
-static void rpc_response_func(tr_session* session, tr_variant* response, void* user_data)
+static void rpc_response_func([[maybe_unused]] tr_session* session, tr_variant* response, void* user_data)
 {
-    TR_UNUSED(session);
-
     auto* data = static_cast<struct rpc_response_data*>(user_data);
     struct evbuffer* response_buf = tr_variantToBuf(response, TR_VARIANT_FMT_JSON_LEAN);
     struct evbuffer* buf = evbuffer_new();
@@ -759,11 +754,8 @@ enum
 
 static void startServer(void* vserver);
 
-static void rpc_server_on_start_retry(evutil_socket_t fd, short type, void* context)
+static void rpc_server_on_start_retry([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     startServer(context);
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -210,12 +210,9 @@ static void notifyBatchQueueChange(tr_session* session, tr_torrent** torrents, i
 static char const* queueMoveTop(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
     int n;
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveTop(torrents, n);
@@ -227,12 +224,9 @@ static char const* queueMoveTop(
 static char const* queueMoveUp(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
     int n;
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveUp(torrents, n);
@@ -244,12 +238,9 @@ static char const* queueMoveUp(
 static char const* queueMoveDown(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
     int n;
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveDown(torrents, n);
@@ -261,12 +252,9 @@ static char const* queueMoveDown(
 static char const* queueMoveBottom(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
     int n;
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveBottom(torrents, n);
@@ -286,14 +274,9 @@ static int compareTorrentByQueuePosition(void const* va, void const* vb)
 static char const* torrentStart(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -317,14 +300,9 @@ static char const* torrentStart(
 static char const* torrentStartNow(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -348,14 +326,9 @@ static char const* torrentStartNow(
 static char const* torrentStop(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -377,14 +350,9 @@ static char const* torrentStop(
 static char const* torrentRemove(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     bool deleteFlag;
 
     if (!tr_variantDictFindBool(args_in, TR_KEY_delete_local_data, &deleteFlag))
@@ -415,14 +383,9 @@ static char const* torrentRemove(
 static char const* torrentReannounce(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -444,14 +407,9 @@ static char const* torrentReannounce(
 static char const* torrentVerify(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -982,12 +940,8 @@ static char const* torrentGet(
     tr_session* session,
     tr_variant* args_in,
     tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
     tr_variant* list = tr_variantDictAddList(args_out, TR_KEY_torrents, torrentCount + 1);
@@ -1402,14 +1356,9 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
 static char const* torrentSet(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     int torrentCount;
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
@@ -1545,14 +1494,9 @@ static char const* torrentSet(
 static char const* torrentSetLocation(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     char const* location = nullptr;
 
     if (!tr_variantDictFindStr(args_in, TR_KEY_location, &location, nullptr))
@@ -1614,11 +1558,9 @@ static void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char con
 static char const* torrentRenamePath(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
+    [[maybe_unused]] tr_variant* args_out,
     struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-
     char const* errmsg = nullptr;
 
     char const* oldpath = nullptr;
@@ -1647,18 +1589,14 @@ static char const* torrentRenamePath(
 ***/
 
 static void portTested(
-    tr_session* session,
-    bool did_connect,
-    bool did_timeout,
+    [[maybe_unused]] tr_session* session,
+    [[maybe_unused]] bool did_connect,
+    [[maybe_unused]] bool did_timeout,
     long response_code,
     void const* response,
     size_t response_byte_count,
     void* user_data)
 {
-    TR_UNUSED(session);
-    TR_UNUSED(did_connect);
-    TR_UNUSED(did_timeout);
-
     char result[1024];
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
 
@@ -1681,11 +1619,12 @@ static void portTested(
     tr_idle_function_done(data, result);
 }
 
-static char const* portTest(tr_session* session, tr_variant* args_in, tr_variant* args_out, struct tr_rpc_idle_data* idle_data)
+static char const* portTest(
+    tr_session* session,
+    [[maybe_unused]] tr_variant* args_in,
+    [[maybe_unused]] tr_variant* args_out,
+    struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_in);
-    TR_UNUSED(args_out);
-
     int const port = tr_sessionGetPeerPort(session);
     char* url = tr_strdup_printf("https://portcheck.transmissionbt.com/%d", port);
     tr_webRun(session, url, portTested, idle_data);
@@ -1699,16 +1638,13 @@ static char const* portTest(tr_session* session, tr_variant* args_in, tr_variant
 
 static void gotNewBlocklist(
     tr_session* session,
-    bool did_connect,
-    bool did_timeout,
+    [[maybe_unused]] bool did_connect,
+    [[maybe_unused]] bool did_timeout,
     long response_code,
     void const* response,
     size_t response_byte_count,
     void* user_data)
 {
-    TR_UNUSED(did_connect);
-    TR_UNUSED(did_timeout);
-
     char result[1024];
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
 
@@ -1809,13 +1745,10 @@ static void gotNewBlocklist(
 
 static char const* blocklistUpdate(
     tr_session* session,
-    tr_variant* args_in,
-    tr_variant* args_out,
+    [[maybe_unused]] tr_variant* args_in,
+    [[maybe_unused]] tr_variant* args_out,
     struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_in);
-    TR_UNUSED(args_out);
-
     tr_webRun(session, session->blocklist_url, gotNewBlocklist, idle_data);
     return nullptr;
 }
@@ -1882,18 +1815,14 @@ struct add_torrent_idle_data
 };
 
 static void gotMetadataFromURL(
-    tr_session* session,
-    bool did_connect,
-    bool did_timeout,
+    [[maybe_unused]] tr_session* session,
+    [[maybe_unused]] bool did_connect,
+    [[maybe_unused]] bool did_timeout,
     long response_code,
     void const* response,
     size_t response_byte_count,
     void* user_data)
 {
-    TR_UNUSED(session);
-    TR_UNUSED(did_connect);
-    TR_UNUSED(did_timeout);
-
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
     dbgmsg(
@@ -1955,11 +1884,9 @@ static tr_file_index_t* fileListFromList(tr_variant* list, tr_file_index_t* setm
 static char const* torrentAdd(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
+    [[maybe_unused]] tr_variant* args_out,
     struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-
     TR_ASSERT(idle_data != nullptr);
 
     char const* filename = nullptr;
@@ -2094,14 +2021,9 @@ static char const* torrentAdd(
 static char const* sessionSet(
     tr_session* session,
     tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     char const* download_dir = nullptr;
     char const* incomplete_dir = nullptr;
 
@@ -2359,15 +2281,10 @@ static char const* sessionSet(
 
 static char const* sessionStats(
     tr_session* session,
-    tr_variant* args_in,
+    [[maybe_unused]] tr_variant* args_in,
     tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_in);
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     auto currentStats = tr_session_stats{};
     auto cumulativeStats = tr_session_stats{};
 
@@ -2636,12 +2553,12 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
     }
 }
 
-static char const* sessionGet(tr_session* s, tr_variant* args_in, tr_variant* args_out, struct tr_rpc_idle_data* idle_data)
+static char const* sessionGet(
+    tr_session* s,
+    tr_variant* args_in,
+    tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(idle_data);
-
-    TR_ASSERT(idle_data == nullptr);
-
     tr_variant* fields;
 
     if (tr_variantDictFindList(args_in, TR_KEY_fields, &fields))
@@ -2678,10 +2595,12 @@ static char const* sessionGet(tr_session* s, tr_variant* args_in, tr_variant* ar
     return nullptr;
 }
 
-static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_variant* args_out, struct tr_rpc_idle_data* idle_data)
+static char const* freeSpace(
+    tr_session* session,
+    tr_variant* args_in,
+    tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(idle_data);
-
     int tmperr;
     char const* path = nullptr;
     char const* err = nullptr;
@@ -2725,14 +2644,10 @@ static char const* freeSpace(tr_session* session, tr_variant* args_in, tr_varian
 
 static char const* sessionClose(
     tr_session* session,
-    tr_variant* args_in,
-    tr_variant* args_out,
-    struct tr_rpc_idle_data* idle_data)
+    [[maybe_unused]] tr_variant* args_in,
+    [[maybe_unused]] tr_variant* args_out,
+    [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    TR_UNUSED(args_in);
-    TR_UNUSED(args_out);
-    TR_UNUSED(idle_data);
-
     notify(session, TR_RPC_SESSION_CLOSE, nullptr);
     return nullptr;
 }
@@ -2773,11 +2688,11 @@ static struct method
     { "queue-move-bottom", true, queueMoveBottom },
 };
 
-static void noop_response_callback(tr_session* session, tr_variant* response, void* user_data)
+static void noop_response_callback(
+    [[maybe_unused]] tr_session* session,
+    [[maybe_unused]] tr_variant* response,
+    [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(session);
-    TR_UNUSED(response);
-    TR_UNUSED(user_data);
 }
 
 void tr_rpc_request_exec_json(

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -166,10 +166,8 @@ static void free_incoming_peer_port(tr_session* session)
     session->bind_ipv6 = nullptr;
 }
 
-static void accept_incoming_peer(evutil_socket_t fd, short what, void* vsession)
+static void accept_incoming_peer(evutil_socket_t fd, [[maybe_unused]] short what, void* vsession)
 {
-    TR_UNUSED(what);
-
     tr_socket_t clientSocket;
     tr_port clientPort;
     tr_address clientAddr;
@@ -582,11 +580,8 @@ void tr_sessionSaveSettings(tr_session* session, char const* configDir, tr_varia
  * status has recently changed. This prevents loss of metadata
  * in the case of a crash, unclean shutdown, clumsy user, etc.
  */
-static void onSaveTimer(evutil_socket_t fd, short what, void* vsession)
+static void onSaveTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vsession)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* session = static_cast<tr_session*>(vsession);
 
     if (tr_cacheFlushDone(session->cache) != 0)
@@ -668,11 +663,8 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
 
 static void turtleCheckClock(tr_session* s, struct tr_turtle_info* t);
 
-static void onNowTimer(evutil_socket_t fd, short what, void* vsession)
+static void onNowTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vsession)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* session = static_cast<tr_session*>(vsession);
 
     TR_ASSERT(tr_isSession(session));
@@ -1989,11 +1981,8 @@ static void sessionCloseImplStart(tr_session* session)
 
 static void sessionCloseImplFinish(tr_session* session);
 
-static void sessionCloseImplWaitForIdleUdp(evutil_socket_t fd, short what, void* vsession)
+static void sessionCloseImplWaitForIdleUdp([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vsession)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* session = static_cast<tr_session*>(vsession);
 
     TR_ASSERT(tr_isSession(session));

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -22,10 +22,8 @@
 #include "tr-macros.h"
 #include "utils.h"
 
-static void handle_sigchld(int i)
+static void handle_sigchld([[maybe_unused]] int i)
 {
-    TR_UNUSED(i);
-
     int rc;
 
     do

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -532,10 +532,8 @@ static constexpr void tr_torrentClearError(tr_torrent* tor)
     tor->errorTracker[0] = '\0';
 }
 
-static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, void* user_data)
+static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(user_data);
-
     switch (event->messageType)
     {
     case TR_TRACKER_PEERS:
@@ -1502,10 +1500,8 @@ tr_file_stat* tr_torrentFiles(tr_torrent const* tor, tr_file_index_t* fileCount)
     return files;
 }
 
-void tr_torrentFilesFree(tr_file_stat* files, tr_file_index_t fileCount)
+void tr_torrentFilesFree(tr_file_stat* files, [[maybe_unused]] tr_file_index_t fileCount)
 {
-    TR_UNUSED(fileCount);
-
     tr_free(files);
 }
 
@@ -1527,10 +1523,8 @@ tr_peer_stat* tr_torrentPeers(tr_torrent const* tor, int* peerCount)
     return tr_peerMgrPeerStats(tor, peerCount);
 }
 
-void tr_torrentPeersFree(tr_peer_stat* peers, int peerCount)
+void tr_torrentPeersFree(tr_peer_stat* peers, [[maybe_unused]] int peerCount)
 {
-    TR_UNUSED(peerCount);
-
     tr_free(peers);
 }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -646,10 +646,13 @@ char const* tr_dhtPrintableStatus(int status)
     }
 }
 
-static void callback(void* ignore, int event, unsigned char const* info_hash, void const* data, size_t data_len)
+static void callback(
+    [[maybe_unused]] void* ignore,
+    int event,
+    unsigned char const* info_hash,
+    void const* data,
+    size_t data_len)
 {
-    TR_UNUSED(ignore);
-
     if (event == DHT_EVENT_VALUES || event == DHT_EVENT_VALUES6)
     {
         tr_torrent* tor;
@@ -829,11 +832,8 @@ void tr_dhtCallback(unsigned char* buf, int buflen, struct sockaddr* from, sockl
     tr_timerAdd(dht_timer, (int)tosleep, tr_rand_int_weak(1000000));
 }
 
-static void timer_callback(evutil_socket_t s, short type, void* session)
+static void timer_callback([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, void* session)
 {
-    TR_UNUSED(s);
-    TR_UNUSED(type);
-
     tr_dhtCallback(nullptr, 0, nullptr, 0, session);
 }
 
@@ -843,11 +843,8 @@ static void timer_callback(evutil_socket_t s, short type, void* session)
    free to add support to your private copy as long as you don't
    redistribute it. */
 
-int dht_blacklisted(struct sockaddr const* sa, int salen)
+int dht_blacklisted([[maybe_unused]] struct sockaddr const* sa, [[maybe_unused]] int salen)
 {
-    TR_UNUSED(sa);
-    TR_UNUSED(salen);
-
     return 0;
 }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -693,7 +693,7 @@ static void on_upkeep_timer([[maybe_unused]] evutil_socket_t s, [[maybe_unused]]
 * @brief Processing of timeout notifications and incoming data on the socket
 * @note maximum rate of read events is limited according to @a lpd_maxAnnounceCap
 * @see DoS */
-static void event_callback([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, void* user_data)
+static void event_callback([[maybe_unused]] evutil_socket_t s, short type, [[maybe_unused]] void* user_data)
 {
     TR_ASSERT(tr_isSession(session));
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -290,10 +290,8 @@ static void on_upkeep_timer(evutil_socket_t, short, void*);
 * @remark Since the LPD service does not use another protocol family yet, this code is
 * IPv4 only for the time being.
 */
-int tr_lpdInit(tr_session* ss, tr_address* tr_addr)
+int tr_lpdInit(tr_session* ss, [[maybe_unused]] tr_address* tr_addr)
 {
-    TR_UNUSED(tr_addr);
-
     /* if this check fails (i.e. the definition of hashString changed), update
      * string handling in tr_lpdSendAnnounce() and tr_lpdConsiderAnnounce().
      * However, the code should work as long as interfaces to the rest of
@@ -684,12 +682,8 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
     return announcesSent;
 }
 
-static void on_upkeep_timer(evutil_socket_t s, short type, void* user_data)
+static void on_upkeep_timer([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(s);
-    TR_UNUSED(type);
-    TR_UNUSED(user_data);
-
     time_t const now = tr_time();
     tr_lpdAnnounceMore(now, UPKEEP_INTERVAL_SECS);
     tr_timerAdd(upkeep_timer, UPKEEP_INTERVAL_SECS, 0);
@@ -699,11 +693,8 @@ static void on_upkeep_timer(evutil_socket_t s, short type, void* user_data)
 * @brief Processing of timeout notifications and incoming data on the socket
 * @note maximum rate of read events is limited according to @a lpd_maxAnnounceCap
 * @see DoS */
-static void event_callback(evutil_socket_t s, short type, void* user_data)
+static void event_callback([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, void* user_data)
 {
-    TR_UNUSED(s);
-    TR_UNUSED(user_data);
-
     TR_ASSERT(tr_isSession(session));
 
     /* do not allow announces to be processed if LPD is disabled */

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -52,17 +52,6 @@
 ****
 ***/
 
-// http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#define TR_UNUSED(x) \
-    do \
-    { \
-        ((void)sizeof(x)); \
-    } while (0)
-
-/***
-****
-***/
-
 #if __has_builtin(__builtin_expect) || TR_GNUC_CHECK_VERSION(3, 0)
 #define TR_LIKELY(x) __builtin_expect(!!(x), 1)
 #define TR_UNLIKELY(x) __builtin_expect(!!(x), 0)

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -239,10 +239,8 @@ FAIL:
     }
 }
 
-static void event_callback(evutil_socket_t s, short type, void* vsession)
+static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
 {
-    TR_UNUSED(type);
-
     TR_ASSERT(tr_isSession(static_cast<tr_session*>(vsession)));
     TR_ASSERT(type == EV_READ);
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -62,40 +62,37 @@ bool UTP_Write(struct UTPSocket* socket, size_t count)
     return false;
 }
 
-int tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, tr_session* ss)
+int tr_utpPacket(
+    [[maybe_unused]] unsigned char const* buf,
+    [[maybe_unused]] size_t buflen,
+    [[maybe_unused]] struct sockaddr const* from,
+    [[maybe_unused]] socklen_t fromlen,
+    [[maybe_unused]] tr_session* ss)
 {
-    TR_UNUSED(buf);
-    TR_UNUSED(buflen);
-    TR_UNUSED(from);
-    TR_UNUSED(fromlen);
-    TR_UNUSED(ss);
-
     return -1;
 }
 
-struct UTPSocket* UTP_Create(SendToProc* send_to_proc, void* send_to_userdata, struct sockaddr const* addr, socklen_t addrlen)
+struct UTPSocket* UTP_Create(
+    [[maybe_unused]] SendToProc* send_to_proc,
+    [[maybe_unused]] void* send_to_userdata,
+    [[maybe_unused]] struct sockaddr const* addr,
+    [[maybe_unused]] socklen_t addrlen)
 {
-    TR_UNUSED(send_to_proc);
-    TR_UNUSED(send_to_userdata);
-    TR_UNUSED(addr);
-    TR_UNUSED(addrlen);
-
     errno = ENOSYS;
     return nullptr;
 }
 
-void tr_utpClose(tr_session* ss)
+void tr_utpClose([[maybe_unused]] tr_session* ss)
 {
-    TR_UNUSED(ss);
 }
 
-void tr_utpSendTo(void* closure, unsigned char const* buf, size_t buflen, struct sockaddr const* to, socklen_t tolen)
+void tr_utpSendTo(
+    [[maybe_unused]] void* closure,
+    [[maybe_unused]] unsigned char const* buf,
+    [[maybe_unused]] size_t buflen,
+    [[maybe_unused]] struct sockaddr const* to,
+    [[maybe_unused]] socklen_t tolen)
 {
-    TR_UNUSED(closure);
-    TR_UNUSED(buf);
-    TR_UNUSED(buflen);
-    TR_UNUSED(to);
-    TR_UNUSED(tolen);
 }
 
 #else
@@ -169,11 +166,8 @@ static void reset_timer(tr_session* ss)
     tr_timerAdd(ss->utp_timer, sec, usec);
 }
 
-static void timer_callback(evutil_socket_t s, short type, void* vsession)
+static void timer_callback([[maybe_unused]] evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
 {
-    TR_UNUSED(s);
-    TR_UNUSED(type);
-
     auto* session = static_cast<tr_session*>(vsession);
     UTP_CheckTimeouts();
     reset_timer(session);

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -353,26 +353,20 @@ static void saveStringFunc(tr_variant const* v, void* vevbuf)
     evbuffer_add(evbuf, str, len);
 }
 
-static void saveDictBeginFunc(tr_variant const* val, void* vevbuf)
+static void saveDictBeginFunc([[maybe_unused]] tr_variant const* val, void* vevbuf)
 {
-    TR_UNUSED(val);
-
     auto* evbuf = static_cast<struct evbuffer*>(vevbuf);
     evbuffer_add(evbuf, "d", 1);
 }
 
-static void saveListBeginFunc(tr_variant const* val, void* vevbuf)
+static void saveListBeginFunc([[maybe_unused]] tr_variant const* val, void* vevbuf)
 {
-    TR_UNUSED(val);
-
     auto* evbuf = static_cast<struct evbuffer*>(vevbuf);
     evbuffer_add(evbuf, "l", 1);
 }
 
-static void saveContainerEndFunc(tr_variant const* val, void* vevbuf)
+static void saveContainerEndFunc([[maybe_unused]] tr_variant const* val, void* vevbuf)
 {
-    TR_UNUSED(val);
-
     auto* evbuf = static_cast<struct evbuffer*>(vevbuf);
     evbuffer_add(evbuf, "e", 1);
 }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -77,8 +77,8 @@ static tr_variant* get_node(struct jsonsl_st* jsn)
 
 static void error_handler(
     jsonsl_t jsn,
-    [[maybe_unused]] jsonsl_error_t error,
-    struct jsonsl_state_st* state,
+    jsonsl_error_t error,
+    [[maybe_unused]] struct jsonsl_state_st* state,
     jsonsl_char_t const* buf)
 {
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -75,10 +75,12 @@ static tr_variant* get_node(struct jsonsl_st* jsn)
     return node;
 }
 
-static void error_handler(jsonsl_t jsn, jsonsl_error_t error, struct jsonsl_state_st* state, jsonsl_char_t const* buf)
+static void error_handler(
+    jsonsl_t jsn,
+    [[maybe_unused]] jsonsl_error_t error,
+    struct jsonsl_state_st* state,
+    jsonsl_char_t const* buf)
 {
-    TR_UNUSED(state);
-
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
     if (data->source != nullptr)
@@ -104,11 +106,12 @@ static int error_callback(jsonsl_t jsn, jsonsl_error_t error, struct jsonsl_stat
     return 0; /* bail */
 }
 
-static void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t action, struct jsonsl_state_st* state, jsonsl_char_t const* buf)
+static void action_callback_PUSH(
+    jsonsl_t jsn,
+    [[maybe_unused]] jsonsl_action_t action,
+    struct jsonsl_state_st* state,
+    [[maybe_unused]] jsonsl_char_t const* buf)
 {
-    TR_UNUSED(action);
-    TR_UNUSED(buf);
-
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
     if ((state->type == JSONSL_T_LIST) || (state->type == JSONSL_T_OBJECT))
@@ -302,11 +305,12 @@ static char const* extract_string(jsonsl_t jsn, struct jsonsl_state_st* state, s
     return ret;
 }
 
-static void action_callback_POP(jsonsl_t jsn, jsonsl_action_t action, struct jsonsl_state_st* state, jsonsl_char_t const* buf)
+static void action_callback_POP(
+    jsonsl_t jsn,
+    [[maybe_unused]] jsonsl_action_t action,
+    struct jsonsl_state_st* state,
+    [[maybe_unused]] jsonsl_char_t const* buf)
 {
-    TR_UNUSED(action);
-    TR_UNUSED(buf);
-
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
     if (state->type == JSONSL_T_STRING)

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -894,23 +894,17 @@ void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkF
 *****
 ****/
 
-static void freeDummyFunc(tr_variant const* v, void* buf)
+static void freeDummyFunc([[maybe_unused]] tr_variant const* v, [[maybe_unused]] void* buf)
 {
-    TR_UNUSED(v);
-    TR_UNUSED(buf);
 }
 
-static void freeStringFunc(tr_variant const* v, void* user_data)
+static void freeStringFunc(tr_variant const* v, [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(user_data);
-
     tr_variant_string_clear(&((tr_variant*)v)->val.s);
 }
 
-static void freeContainerEndFunc(tr_variant const* v, void* user_data)
+static void freeContainerEndFunc(tr_variant const* v, [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(user_data);
-
     tr_free(v->val.l.vals);
 }
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -221,10 +221,8 @@ static tr_lock* getVerifyLock(void)
     return lock;
 }
 
-static void verifyThreadFunc(void* user_data)
+static void verifyThreadFunc([[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(user_data);
-
     for (;;)
     {
         bool changed = false;
@@ -328,10 +326,8 @@ void tr_verifyRemove(tr_torrent* tor)
     tr_lockUnlock(lock);
 }
 
-void tr_verifyClose(tr_session* session)
+void tr_verifyClose([[maybe_unused]] tr_session* session)
 {
-    TR_UNUSED(session);
-
     tr_lockLock(getVerifyLock());
 
     stopCurrent = true;

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -50,11 +50,8 @@ auto tr_watchdir_generic_interval = timeval{ 10, 0 };
 ****
 ***/
 
-static void tr_watchdir_generic_on_event(evutil_socket_t fd, short type, void* context)
+static void tr_watchdir_generic_on_event([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     auto const handle = static_cast<tr_watchdir_t>(context);
     tr_watchdir_generic* const backend = BACKEND_UPCAST(tr_watchdir_get_backend(handle));
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -55,11 +55,8 @@ struct tr_watchdir_inotify
 ****
 ***/
 
-static void tr_watchdir_inotify_on_first_scan(evutil_socket_t fd, short type, void* context)
+static void tr_watchdir_inotify_on_first_scan([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     auto const handle = static_cast<tr_watchdir_t>(context);
 
     tr_watchdir_scan(handle, nullptr);

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -62,11 +62,8 @@ struct tr_watchdir_kqueue
 ****
 ***/
 
-static void tr_watchdir_kqueue_on_event(evutil_socket_t fd, short type, void* context)
+static void tr_watchdir_kqueue_on_event([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     auto const handle = static_cast<tr_watchdir_t>(context);
     tr_watchdir_kqueue* const backend = BACKEND_UPCAST(tr_watchdir_get_backend(handle));
     struct kevent ke;

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -143,11 +143,8 @@ static unsigned int __stdcall tr_watchdir_win32_thread(void* context)
     return 0;
 }
 
-static void tr_watchdir_win32_on_first_scan(evutil_socket_t fd, short type, void* context)
+static void tr_watchdir_win32_on_first_scan([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     auto const handle = static_cast<tr_watchdir_t>(context);
 
     tr_watchdir_scan(handle, nullptr);

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -140,11 +140,8 @@ static int compare_retry_names(void const* a, void const* b)
 
 static void tr_watchdir_retry_free(tr_watchdir_retry* retry);
 
-static void tr_watchdir_on_retry_timer(evutil_socket_t fd, short type, void* context)
+static void tr_watchdir_on_retry_timer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short type, void* context)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(type);
-
     TR_ASSERT(context != nullptr);
 
     auto* const retry = static_cast<tr_watchdir_retry*>(context);

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -129,10 +129,8 @@ static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
 
 #ifdef USE_LIBCURL_SOCKOPT
 
-static int sockoptfunction(void* vtask, curl_socket_t fd, curlsocktype purpose)
+static int sockoptfunction(void* vtask, curl_socket_t fd, [[maybe_unused]] curlsocktype purpose)
 {
-    TR_UNUSED(purpose);
-
     auto* task = static_cast<struct tr_web_task*>(vtask);
     bool const isScrape = strstr(task->url, "scrape") != nullptr;
     bool const isAnnounce = strstr(task->url, "announce") != nullptr;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -154,11 +154,8 @@ static int sockoptfunction(void* vtask, curl_socket_t fd, curlsocktype purpose)
 
 #endif
 
-static CURLcode ssl_context_func(CURL* curl, void* ssl_ctx, void* user_data)
+static CURLcode ssl_context_func([[maybe_unused]] CURL* curl, void* ssl_ctx, [[maybe_unused]] void* user_data)
 {
-    TR_UNUSED(curl);
-    TR_UNUSED(user_data);
-
     tr_x509_store_t const cert_store = tr_ssl_get_x509_store(ssl_ctx);
     if (cert_store == nullptr)
     {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -409,18 +409,13 @@ static void on_idle(tr_webseed* w)
 
 static void web_response_func(
     tr_session* session,
-    bool did_connect,
-    bool did_timeout,
+    [[maybe_unused]] bool did_connect,
+    [[maybe_unused]] bool did_timeout,
     long response_code,
-    void const* response,
-    size_t response_byte_count,
+    [[maybe_unused]] void const* response,
+    [[maybe_unused]] size_t response_byte_count,
     void* vtask)
 {
-    TR_UNUSED(did_connect);
-    TR_UNUSED(did_timeout);
-    TR_UNUSED(response);
-    TR_UNUSED(response_byte_count);
-
     auto* t = static_cast<struct tr_webseed_task*>(vtask);
     bool const success = response_code == 206;
 
@@ -561,11 +556,8 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
 namespace
 {
 
-void webseed_timer_func(evutil_socket_t fd, short what, void* vw)
+void webseed_timer_func([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vw)
 {
-    TR_UNUSED(fd);
-    TR_UNUSED(what);
-
     auto* w = static_cast<tr_webseed*>(vw);
 
     if (w->retry_tickcount != 0)

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -131,19 +131,15 @@ typedef NS_ENUM(unsigned int, sortOrderTag) { //
 
 #define DONATE_NAG_TIME (60 * 60 * 24 * 7)
 
-static void altSpeedToggledCallback(tr_session* handle, bool active, bool byUser, void* controller)
+static void altSpeedToggledCallback([[maybe_unused]] tr_session* handle, bool active, bool byUser, void* controller)
 {
-    TR_UNUSED(handle);
-
     NSDictionary* dict = [[NSDictionary alloc] initWithObjects:@[ @(active), @(byUser) ] forKeys:@[ @"Active", @"ByUser" ]];
     [(__bridge Controller*)controller performSelectorOnMainThread:@selector(altSpeedToggledCallbackIsLimited:) withObject:dict
                                                     waitUntilDone:NO];
 }
 
-static tr_rpc_callback_status rpcCallback(tr_session* handle, tr_rpc_callback_type type, struct tr_torrent* torrentStruct, void* controller)
+static tr_rpc_callback_status rpcCallback([[maybe_unused]] tr_session* handle, tr_rpc_callback_type type, struct tr_torrent* torrentStruct, void* controller)
 {
-    TR_UNUSED(handle);
-
     [(__bridge Controller*)controller rpcCallback:type forTorrentStruct:torrentStruct];
     return TR_RPC_NOREMOVE; //we'll do the remove manually
 }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -51,11 +51,9 @@ protected:
         return test_dir;
     }
 
-    bool createSymlink(char const* dst_path, char const* src_path, bool dst_is_dir)
+    bool createSymlink(char const* dst_path, char const* src_path, [[maybe_unused]] bool dst_is_dir)
     {
 #ifndef _WIN32
-
-        TR_UNUSED(dst_is_dir);
 
         return symlink(src_path, dst_path) != -1;
 
@@ -138,7 +136,7 @@ protected:
         return true;
     }
 
-    bool validatePermissions(char const* path, unsigned int permissions)
+    bool validatePermissions([[maybe_unused]] char const* path, [[maybe_unused]] unsigned int permissions)
     {
 #ifndef _WIN32
 
@@ -146,9 +144,6 @@ protected:
         return stat(path, &sb) != -1 && (sb.st_mode & 0777) == permissions;
 
 #else
-
-        TR_UNUSED(path);
-        TR_UNUSED(permissions);
 
         /* No UNIX permissions on Windows */
         return true;

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -798,10 +798,8 @@ static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vbuf)
 }
 
 /* look for a session id in the header in case the server gives back a 409 */
-static size_t parseResponseHeader(void* ptr, size_t size, size_t nmemb, void* stream)
+static size_t parseResponseHeader(void* ptr, size_t size, size_t nmemb, [[maybe_unused]] void* stream)
 {
-    TR_UNUSED(stream);
-
     auto const* const line = static_cast<char const*>(ptr);
     size_t const line_len = size * nmemb;
     char const* key = TR_RPC_SESSION_ID_HEADER ": ";


### PR DESCRIPTION
A pretty straightforward PR: replace our `TR_UNUSED` macro with C++'s `[[maybe_unused]]` attribute instead.

No functional changes.

@mikedld I've left `gtk/` (mostly) unchanged since I know you've got a bigger branch in the works there.