### PR TITLE
refactor: run clang-tidy on bandwidth.h, .cc

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -23,7 +23,7 @@
 ****
 ***/
 
-unsigned int Bandwidth::getSpeedBps(RateControl& r, unsigned int interval_msec, uint64_t now)
+unsigned int Bandwidth::getSpeedBytesPerSecond(RateControl& r, unsigned int interval_msec, uint64_t now)
 {
     if (now == 0)
     {
@@ -259,8 +259,8 @@ unsigned int Bandwidth::clamp(uint64_t now, tr_direction dir, unsigned int byte_
                 now = tr_time_msec();
             }
 
-            current = this->getRawSpeedBps(now, TR_DOWN);
-            desired = this->getDesiredSpeedBps(TR_DOWN);
+            current = this->getRawSpeedBytesPerSecond(now, TR_DOWN);
+            desired = this->getDesiredSpeedBytesPerSecond(TR_DOWN);
             r = desired >= 1 ? current / desired : 0;
 
             if (r > 1.0)

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -125,19 +125,19 @@ public:
     }
 
     /** @brief Get the raw total of bytes read or sent by this bandwidth subtree. */
-    [[nodiscard]] unsigned int getRawSpeedBps(uint64_t const now, tr_direction const dir) const
+    [[nodiscard]] unsigned int getRawSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
     {
         TR_ASSERT(tr_isDirection(dir));
 
-        return getSpeedBps(this->band_[dir].raw_, HistoryMSec, now);
+        return getSpeedBytesPerSecond(this->band_[dir].raw_, HistoryMSec, now);
     }
 
     /** @brief Get the number of piece data bytes read or sent by this bandwidth subtree. */
-    [[nodiscard]] unsigned int getPieceSpeedBps(uint64_t const now, tr_direction const dir) const
+    [[nodiscard]] unsigned int getPieceSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
     {
         TR_ASSERT(tr_isDirection(dir));
 
-        return getSpeedBps(this->band_[dir].piece_, HistoryMSec, now);
+        return getSpeedBytesPerSecond(this->band_[dir].piece_, HistoryMSec, now);
     }
 
     /**
@@ -145,7 +145,7 @@ public:
      * @see Bandwidth::allocate
      * @see Bandwidth::getDesiredSpeed
      */
-    constexpr bool setDesiredSpeedBps(tr_direction dir, unsigned int desired_speed)
+    constexpr bool setDesiredSpeedBytesPerSecond(tr_direction dir, unsigned int desired_speed)
     {
         auto& value = this->band_[dir].desired_speed_bps_;
         bool const did_change = desired_speed != value;
@@ -157,7 +157,7 @@ public:
      * @brief Get the desired speed for the bandwidth subtree.
      * @see Bandwidth::setDesiredSpeed
      */
-    [[nodiscard]] constexpr double getDesiredSpeedBps(tr_direction dir) const
+    [[nodiscard]] constexpr double getDesiredSpeedBytesPerSecond(tr_direction dir) const
     {
         return this->band_[dir].desired_speed_bps_;
     }
@@ -231,7 +231,7 @@ public:
     };
 
 private:
-    static unsigned int getSpeedBps(RateControl& r, unsigned int interval_msec, uint64_t now);
+    static unsigned int getSpeedBytesPerSecond(RateControl& r, unsigned int interval_msec, uint64_t now);
 
     static void notifyBandwidthConsumedBytes(uint64_t now, RateControl* r, size_t size);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1067,7 +1067,7 @@ static unsigned int getDesiredOutputBufferSize(tr_peerIo const* io, uint64_t now
      * being large enough to hold the next 20 seconds' worth of input,
      * or a few blocks, whichever is bigger.
      * It's okay to tweak this as needed */
-    unsigned int const currentSpeed_Bps = io->bandwidth->getPieceSpeedBps(now, TR_UP);
+    unsigned int const currentSpeed_Bps = io->bandwidth->getPieceSpeedBytesPerSecond(now, TR_UP);
     unsigned int const period = 15U; /* arbitrary */
     /* the 3 is arbitrary; the .5 is to leave room for messages */
     static auto const ceiling = (unsigned int)(MAX_BLOCK_SIZE * 3.5);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -345,7 +345,7 @@ static inline bool tr_peerIoHasBandwidthLeft(tr_peerIo const* io, tr_direction d
 
 static inline unsigned int tr_peerIoGetPieceSpeed_Bps(tr_peerIo const* io, uint64_t now, tr_direction dir)
 {
-    return io->bandwidth->getPieceSpeedBps(now, dir);
+    return io->bandwidth->getPieceSpeedBytesPerSecond(now, dir);
 }
 
 /**

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -3181,8 +3181,8 @@ static inline bool isBandwidthMaxedOut(Bandwidth const* b, uint64_t const now_ms
     }
     else
     {
-        unsigned int const got = b->getPieceSpeedBps(now_msec, dir);
-        unsigned int const want = b->getDesiredSpeedBps(dir);
+        unsigned int const got = b->getPieceSpeedBytesPerSecond(now_msec, dir);
+        unsigned int const want = b->getDesiredSpeedBytesPerSecond(dir);
         return got >= want;
     }
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1488,7 +1488,7 @@ static void updateBandwidth(tr_session* session, tr_direction dir)
 
     session->bandwidth->setLimited(dir, isLimited && !zeroCase);
 
-    session->bandwidth->setDesiredSpeedBps(dir, limit_Bps);
+    session->bandwidth->setDesiredSpeedBytesPerSecond(dir, limit_Bps);
 }
 
 enum
@@ -1881,12 +1881,12 @@ bool tr_sessionGetDeleteSource(tr_session const* session)
 
 unsigned int tr_sessionGetPieceSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->bandwidth->getPieceSpeedBps(0, dir) : 0;
+    return tr_isSession(session) ? session->bandwidth->getPieceSpeedBytesPerSecond(0, dir) : 0;
 }
 
 static unsigned int tr_sessionGetRawSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->bandwidth->getRawSpeedBps(0, dir) : 0;
+    return tr_isSession(session) ? session->bandwidth->getRawSpeedBytesPerSecond(0, dir) : 0;
 }
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -196,7 +196,7 @@ void tr_torrentSetSpeedLimit_Bps(tr_torrent* tor, tr_direction dir, unsigned int
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    if (tor->bandwidth->setDesiredSpeedBps(dir, Bps))
+    if (tor->bandwidth->setDesiredSpeedBytesPerSecond(dir, Bps))
     {
         tr_torrentSetDirty(tor);
     }
@@ -212,7 +212,7 @@ unsigned int tr_torrentGetSpeedLimit_Bps(tr_torrent const* tor, tr_direction dir
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    return tor->bandwidth->getDesiredSpeedBps(dir);
+    return tor->bandwidth->getDesiredSpeedBytesPerSecond(dir);
 }
 
 unsigned int tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr_direction dir)
@@ -1294,10 +1294,10 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
         s->peersFrom[i] = swarm_stats.peerFromCount[i];
     }
 
-    s->rawUploadSpeed_KBps = toSpeedKBps(tor->bandwidth->getRawSpeedBps(now, TR_UP));
-    s->rawDownloadSpeed_KBps = toSpeedKBps(tor->bandwidth->getRawSpeedBps(now, TR_DOWN));
-    pieceUploadSpeed_Bps = tor->bandwidth->getPieceSpeedBps(now, TR_UP);
-    pieceDownloadSpeed_Bps = tor->bandwidth->getPieceSpeedBps(now, TR_DOWN);
+    s->rawUploadSpeed_KBps = toSpeedKBps(tor->bandwidth->getRawSpeedBytesPerSecond(now, TR_UP));
+    s->rawDownloadSpeed_KBps = toSpeedKBps(tor->bandwidth->getRawSpeedBytesPerSecond(now, TR_DOWN));
+    pieceUploadSpeed_Bps = tor->bandwidth->getPieceSpeedBytesPerSecond(now, TR_UP);
+    pieceDownloadSpeed_Bps = tor->bandwidth->getPieceSpeedBytesPerSecond(now, TR_DOWN);
     s->pieceUploadSpeed_KBps = toSpeedKBps(pieceUploadSpeed_Bps);
     s->pieceDownloadSpeed_KBps = toSpeedKBps(pieceDownloadSpeed_Bps);
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -93,7 +93,7 @@ public:
         if (direction == TR_DOWN)
         {
             is_active = !std::empty(tasks);
-            Bps = bandwidth.getPieceSpeedBps(now, direction);
+            Bps = bandwidth.getPieceSpeedBytesPerSecond(now, direction);
         }
 
         if (setme_Bps != nullptr)


### PR DESCRIPTION
No intentional functional changes.

This PR fixes all the warnings generated by clang-tidy when run on the refactored Bandwidth code.

- use `mutable` to avoid C-style cast in getSpeed_Bps()
- change function names, variable names, field names etc. to follow capitalization / underscore style settings
- omit unnecessary constructor initializer list items
- when range-looping through a collection of pointers, use `auto*` instead of `auto`
- add explicitly deleted assignment / move assignment / ctor / move ctor

One change needs explanation:

- Since underscores are disallowed in function names, I renamed `getFooSpeed_Bps()` as `getFooSpeedBytesPerSecond()`. This name is awkwardly prolix, but `getFooSpeedBps()` doesn't work because it's unclear whether `B` is a byte, or whether it's a bit that's been capitalized because of the naming scheme :dizzy_face: If / when we start using some speed unit types, maybe this could be revisited as simply `getFooSpeed()`
 
---

I ran clang-tidy manually this way:

```sh
$ clang-tidy --config-file=../qt/.clang-tidy -p ../build/compile_commands.json bandwidth.*
```

This is a pretty awful way to do this. Running qt/.clang-tidy on the entire libtransmission codebase generates an ocean of warnings, so we need a way to opt-in and whitelist files as they are modernized.

---

Hey @kvakvs I'd like to mark you as a reviewer for this since you've been in these two files so recently, but Github doesn't list you as a reviewer and I'm not sure if that's because you've never reviewed on the project before or if it's because of some project setting. _If_ you're interested in doing reviews, maybe try adding yourself as a reviewer on this PR so that next time around maybe Github will know you're an option?