### PR TITLE
refactor: fix cppcoreguidelines-init-variables warnings in libtransmission

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -1,0 +1,21 @@
+---
+# Many of these checks are disabled only because the code hasn't been
+# cleaned up yet. Pull requests welcomed.
+Checks: >
+  cppcoreguidelines-init-variables
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase,             value: camelBack  }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,            value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,      value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,               value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,    value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,             value: lower_case }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -41,8 +41,6 @@ static char const* get_event_string(tr_announce_request const* req)
 
 static char* announce_url_new(tr_session const* session, tr_announce_request const* req)
 {
-    char const* str;
-    unsigned char const* ipv6;
     struct evbuffer* buf = evbuffer_new();
     char escaped_info_hash[SHA_DIGEST_LENGTH * 3 + 1];
 
@@ -85,7 +83,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
         evbuffer_add_printf(buf, "&corrupt=%" PRIu64, req->corrupt);
     }
 
-    str = get_event_string(req);
+    char const* str = get_event_string(req);
 
     if (!tr_str_is_empty(str))
     {
@@ -108,8 +106,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
        announce twice. At any rate, we're already computing our IPv6
        address (for the LTEP handshake), so this comes for free. */
 
-    ipv6 = tr_globalIPv6();
-
+    unsigned char const* const ipv6 = tr_globalIPv6();
     if (ipv6 != nullptr)
     {
         char ipv6_readable[INET6_ADDRSTRLEN];
@@ -129,8 +126,6 @@ static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
 
     for (size_t i = 0; i < len; ++i)
     {
-        int64_t port;
-        char const* ip;
         tr_address addr;
         tr_variant* peer = tr_variantListChild(peerList, i);
 
@@ -139,6 +134,7 @@ static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
             continue;
         }
 
+        char const* ip = nullptr;
         if (!tr_variantDictFindStr(peer, TR_KEY_ip, &ip, nullptr))
         {
             continue;
@@ -149,6 +145,7 @@ static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
             continue;
         }
 
+        auto port = int64_t{};
         if (!tr_variantDictFindInt(peer, TR_KEY_port, &port))
         {
             continue;
@@ -207,10 +204,9 @@ static void on_announce_done(
     size_t msglen,
     void* vdata)
 {
-    tr_announce_response* response;
     auto* data = static_cast<struct announce_data*>(vdata);
 
-    response = &data->response;
+    tr_announce_response* const response = &data->response;
     response->did_connect = did_connect;
     response->did_timeout = did_timeout;
     dbgmsg(data->log_name, "Got announce response");
@@ -234,7 +230,7 @@ static void on_announce_done(
             }
             else
             {
-                size_t len;
+                auto len = size_t{};
                 char* str = tr_variantToStr(&benc, TR_VARIANT_FMT_JSON, &len);
                 fprintf(stderr, "%s", "Announce response:\n< ");
 
@@ -250,11 +246,11 @@ static void on_announce_done(
 
         if (variant_loaded && tr_variantIsDict(&benc))
         {
-            int64_t i;
-            size_t len;
-            tr_variant* tmp;
-            char const* str;
-            uint8_t const* raw;
+            auto i = int64_t{};
+            auto len = size_t{};
+            tr_variant* tmp = nullptr;
+            char const* str = nullptr;
+            uint8_t const* raw = nullptr;
 
             if (tr_variantDictFindStr(&benc, TR_KEY_failure_reason, &str, &len))
             {
@@ -329,10 +325,9 @@ void tr_tracker_http_announce(
     tr_announce_response_func response_func,
     void* response_func_user_data)
 {
-    struct announce_data* d;
     char* url = announce_url_new(session, request);
 
-    d = tr_new0(struct announce_data, 1);
+    auto* const d = tr_new0(struct announce_data, 1);
     d->response.seeders = -1;
     d->response.leechers = -1;
     d->response.downloads = -1;
@@ -398,9 +393,6 @@ static void on_scrape_done(
     else
     {
         tr_variant top;
-        int64_t intVal;
-        tr_variant* files;
-        tr_variant* flags;
         bool const variant_loaded = tr_variantFromBenc(&top, msg, msglen) == 0;
 
         if (tr_env_key_exists("TR_CURL_VERBOSE"))
@@ -411,7 +403,7 @@ static void on_scrape_done(
             }
             else
             {
-                size_t len;
+                auto len = size_t{};
                 char* str = tr_variantToStr(&top, TR_VARIANT_FMT_JSON, &len);
                 fprintf(stderr, "%s", "Scrape response:\n< ");
 
@@ -427,23 +419,26 @@ static void on_scrape_done(
 
         if (variant_loaded)
         {
-            size_t len;
-            char const* str;
+            auto len = size_t{};
+            char const* str = nullptr;
             if (tr_variantDictFindStr(&top, TR_KEY_failure_reason, &str, &len))
             {
                 response->errmsg = tr_strndup(str, len);
             }
 
+            tr_variant* flags = nullptr;
+            auto intVal = int64_t{};
             if (tr_variantDictFindDict(&top, TR_KEY_flags, &flags) &&
                 tr_variantDictFindInt(flags, TR_KEY_min_request_interval, &intVal))
             {
                 response->min_request_interval = intVal;
             }
 
+            tr_variant* files = nullptr;
             if (tr_variantDictFindDict(&top, TR_KEY_files, &files))
             {
-                tr_quark key;
-                tr_variant* val;
+                auto key = tr_quark{};
+                tr_variant* val = nullptr;
 
                 for (int i = 0; tr_variantDictChild(files, i, &key, &val); ++i)
                 {
@@ -489,11 +484,10 @@ static void on_scrape_done(
 
 static char* scrape_url_new(tr_scrape_request const* req)
 {
-    char delimiter;
     struct evbuffer* buf = evbuffer_new();
 
     evbuffer_add_printf(buf, "%s", req->url);
-    delimiter = strchr(req->url, '?') != nullptr ? '&' : '?';
+    char delimiter = strchr(req->url, '?') != nullptr ? '&' : '?';
 
     for (int i = 0; i < req->info_hash_count; ++i)
     {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -228,13 +228,16 @@ struct tr_tracker
 /* format: host+':'+ port */
 static char* getKey(char const* url)
 {
-    char* ret;
     char* scheme = nullptr;
     char* host = nullptr;
     int port = 0;
 
     tr_urlParse(url, TR_BAD_SIZE, &scheme, &host, &port, nullptr);
-    ret = tr_strdup_printf("%s://%s:%d", scheme != nullptr ? scheme : "invalid", host != nullptr ? host : "invalid", port);
+    char* const ret = tr_strdup_printf(
+        "%s://%s:%d",
+        scheme != nullptr ? scheme : "invalid",
+        host != nullptr ? host : "invalid",
+        port);
 
     tr_free(host);
     tr_free(scheme);
@@ -318,13 +321,13 @@ struct tr_tier
 
 static time_t get_next_scrape_time(tr_session const* session, tr_tier const* tier, int interval)
 {
-    time_t ret;
+    time_t ret = 0;
     time_t const now = tr_time();
 
     /* Maybe don't scrape paused torrents */
     if (!tier->isRunning && !session->scrapePausedTorrents)
     {
-        ret = 0;
+        // no-op
     }
     /* Add the interval, and then increment to the nearest 10th second.
      * The latter step is to increase the odds of several torrents coming
@@ -566,7 +569,6 @@ static int filter_trackers_compare_func(void const* va, void const* vb)
 static tr_tracker_info* filter_trackers(tr_tracker_info const* input, int input_count, int* setme_count)
 {
     int n = 0;
-    struct tr_tracker_info* ret;
     struct ann_tracker_info* tmp = tr_new0(struct ann_tracker_info, input_count);
 
     /* build a list of valid trackers */
@@ -574,10 +576,10 @@ static tr_tracker_info* filter_trackers(tr_tracker_info const* input, int input_
     {
         if (tr_urlIsValidTracker(input[i].announce))
         {
-            int port;
-            char* scheme;
-            char* host;
-            char* path;
+            int port = 0;
+            char* scheme = nullptr;
+            char* host = nullptr;
+            char* path = nullptr;
             bool is_duplicate = false;
             tr_urlParse(input[i].announce, TR_BAD_SIZE, &scheme, &host, &port, &path);
 
@@ -630,7 +632,7 @@ static tr_tracker_info* filter_trackers(tr_tracker_info const* input, int input_
 
     /* build the output */
     *setme_count = n;
-    ret = tr_new0(tr_tracker_info, n);
+    struct tr_tracker_info* const ret = tr_new0(tr_tracker_info, n);
 
     for (int i = 0; i < n; ++i)
     {
@@ -652,9 +654,7 @@ static tr_tracker_info* filter_trackers(tr_tracker_info const* input, int input_
 
 static void addTorrentToTier(tr_torrent_tiers* tt, tr_torrent* tor)
 {
-    int n;
-    int tier_count;
-    tr_tier* tier;
+    int n = 0;
     tr_tracker_info* infos = filter_trackers(tor->info.trackers, tor->info.trackerCount, &n);
 
     /* build the array of trackers */
@@ -667,8 +667,7 @@ static void addTorrentToTier(tr_torrent_tiers* tt, tr_torrent* tor)
     }
 
     /* count how many tiers there are */
-    tier_count = 0;
-
+    int tier_count = 0;
     for (int i = 0; i < n; ++i)
     {
         if (i == 0 || infos[i].tier != infos[i - 1].tier)
@@ -678,7 +677,7 @@ static void addTorrentToTier(tr_torrent_tiers* tt, tr_torrent* tor)
     }
 
     /* build the array of tiers */
-    tier = nullptr;
+    tr_tier* tier = nullptr;
     tt->tiers = tr_new0(tr_tier, tier_count);
     tt->tier_count = 0;
 
@@ -770,7 +769,6 @@ static void dbgmsg_tier_announce_queue(tr_tier const* tier)
     if (tr_logGetDeepEnabled())
     {
         char name[128];
-        char* message;
         struct evbuffer* buf = evbuffer_new();
 
         tier_build_log_name(tier, name, sizeof(name));
@@ -782,7 +780,7 @@ static void dbgmsg_tier_announce_queue(tr_tier const* tier)
             evbuffer_add_printf(buf, "[%d:%s]", i, str);
         }
 
-        message = evbuffer_free_to_str(buf, nullptr);
+        char* const message = evbuffer_free_to_str(buf, nullptr);
         tr_logAddDeep(__FILE__, __LINE__, name, "announce queue is %s", message);
         tr_free(message);
     }
@@ -1029,8 +1027,6 @@ struct announce_data
 
 static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e)
 {
-    int interval;
-
     /* increment the error count */
     if (tier->currentTracker != nullptr)
     {
@@ -1046,7 +1042,7 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
     tierIncrementTracker(tier);
 
     /* schedule a reannounce */
-    interval = getRetryInterval(tier->currentTracker);
+    int const interval = getRetryInterval(tier->currentTracker);
     dbgmsg(tier, "Retrying announce in %d seconds.", interval);
     tr_logAddTorInfo(tier->tor, "Retrying announce in %d seconds.", interval);
     tier_announce_event_push(tier, e, tr_time() + interval);
@@ -1062,8 +1058,6 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
     if (tier != nullptr)
     {
-        tr_tracker* tracker;
-
         dbgmsg(
             tier,
             "Got announce response: "
@@ -1121,8 +1115,6 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
         }
         else
         {
-            int i;
-            char const* str;
             int scrape_fields = 0;
             int seeders = 0;
             int leechers = 0;
@@ -1130,7 +1122,8 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
             publishErrorClear(tier);
 
-            if ((tracker = tier->currentTracker) != nullptr)
+            tr_tracker* const tracker = tier->currentTracker;
+            if (tracker != nullptr)
             {
                 tracker->consecutiveFailures = 0;
 
@@ -1152,14 +1145,15 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
                     ++scrape_fields;
                 }
 
-                if ((str = response->tracker_id_str) != nullptr)
+                if (response->tracker_id_str != nullptr)
                 {
                     tr_free(tracker->tracker_id_str);
-                    tracker->tracker_id_str = tr_strdup(str);
+                    tracker->tracker_id_str = tr_strdup(response->tracker_id_str);
                 }
             }
 
-            if ((str = response->warning) != nullptr)
+            char const* const str = response->warning;
+            if (str != nullptr)
             {
                 tr_strlcpy(tier->lastAnnounceStr, str, sizeof(tier->lastAnnounceStr));
                 dbgmsg(tier, "tracker gave \"%s\"", str);
@@ -1170,14 +1164,14 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
                 tr_strlcpy(tier->lastAnnounceStr, _("Success"), sizeof(tier->lastAnnounceStr));
             }
 
-            if ((i = response->min_interval) != 0)
+            if (response->min_interval != 0)
             {
-                tier->announceMinIntervalSec = i;
+                tier->announceMinIntervalSec = response->min_interval;
             }
 
-            if ((i = response->interval) != 0)
+            if (response->interval != 0)
             {
-                tier->announceIntervalSec = i;
+                tier->announceIntervalSec = response->interval;
             }
 
             if (response->pex_count > 0)
@@ -1228,7 +1222,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
             if (!isStopped && tier->announce_event_count == 0)
             {
                 /* the queue is empty, so enqueue a perodic update */
-                i = tier->announceIntervalSec;
+                int const i = tier->announceIntervalSec;
                 dbgmsg(tier, "Sending periodic reannounce in %d seconds", i);
                 tier_announce_event_push(tier, TR_ANNOUNCE_EVENT_NONE, now + i);
             }
@@ -1337,8 +1331,6 @@ static bool multiscrape_too_big(char const* errmsg)
 
 static void on_scrape_error(tr_session const* session, tr_tier* tier, char const* errmsg)
 {
-    int interval;
-
     /* increment the error count */
     if (tier->currentTracker != nullptr)
     {
@@ -1354,7 +1346,7 @@ static void on_scrape_error(tr_session const* session, tr_tier* tier, char const
     tierIncrementTracker(tier);
 
     /* schedule a rescrape */
-    interval = getRetryInterval(tier->currentTracker);
+    int const interval = getRetryInterval(tier->currentTracker);
     dbgmsg(tier, "Retrying scrape in %zu seconds.", (size_t)interval);
     tr_logAddTorInfo(tier->tor, "Retrying scrape in %zu seconds.", (size_t)interval);
     tier->lastScrapeSucceeded = false;
@@ -1490,7 +1482,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                 {
                     char* scheme = nullptr;
                     char* host = nullptr;
-                    int port;
+                    int port = 0;
                     if (tr_urlParse(std::data(url), std::size(url), &scheme, &host, &port, nullptr))
                     {
                         /* don't log the full URL, since that might have a personal announce id */

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -403,13 +403,9 @@ int tr_cacheFlushDone(tr_cache* cache)
 
     if (tr_ptrArraySize(&cache->blocks) > 0)
     {
-        int i;
-        int n;
-        struct run_info* runs;
-
-        runs = tr_new(struct run_info, tr_ptrArraySize(&cache->blocks));
-        i = 0;
-        n = calcRuns(cache, runs);
+        auto* const runs = tr_new(struct run_info, tr_ptrArraySize(&cache->blocks));
+        int i = 0;
+        int const n = calcRuns(cache, runs);
 
         while (i < n && (runs[i].is_piece_done || runs[i].is_multi_piece))
         {
@@ -425,16 +421,14 @@ int tr_cacheFlushDone(tr_cache* cache)
 
 int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
 {
-    int pos;
-    int err = 0;
-    tr_block_index_t first;
-    tr_block_index_t last;
-
+    auto first = tr_block_index_t{};
+    auto last = tr_block_index_t{};
     tr_torGetFileBlockRange(torrent, i, &first, &last);
-    pos = findBlockPos(cache, torrent, first);
+    int const pos = findBlockPos(cache, torrent, first);
     dbgmsg("flushing file %d from cache to disk: blocks [%zu...%zu]", (int)i, (size_t)first, (size_t)last);
 
     /* flush out all the blocks in that file */
+    int err = 0;
     while (err == 0 && pos < tr_ptrArraySize(&cache->blocks))
     {
         auto const* b = static_cast<struct cache_block const*>(tr_ptrArrayNth(&cache->blocks, pos));

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -77,10 +77,10 @@ tr_completeness tr_cpGetStatus(tr_completion const* cp)
 
 void tr_cpPieceRem(tr_completion* cp, tr_piece_index_t piece)
 {
-    tr_block_index_t f;
-    tr_block_index_t l;
     tr_torrent const* tor = cp->tor;
 
+    auto f = tr_block_index_t{};
+    auto l = tr_block_index_t{};
     tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
 
     for (tr_block_index_t i = f; i <= l; ++i)
@@ -98,8 +98,8 @@ void tr_cpPieceRem(tr_completion* cp, tr_piece_index_t piece)
 
 void tr_cpPieceAdd(tr_completion* cp, tr_piece_index_t piece)
 {
-    tr_block_index_t f;
-    tr_block_index_t l;
+    auto f = tr_block_index_t{};
+    auto l = tr_block_index_t{};
     tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
 
     for (tr_block_index_t i = f; i <= l; ++i)
@@ -133,7 +133,7 @@ uint64_t tr_cpHaveValid(tr_completion const* ccp)
     if (ccp->haveValidIsDirty)
     {
         uint64_t size = 0;
-        tr_completion* cp = (tr_completion*)ccp; /* mutable */
+        tr_completion* cp = const_cast<tr_completion*>(ccp); /* mutable */
         tr_torrent const* tor = ccp->tor;
         tr_info const* info = &tor->info;
 
@@ -159,7 +159,7 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
         uint64_t size = 0;
         tr_torrent const* tor = ccp->tor;
         tr_info const* inf = tr_torrentInfo(tor);
-        tr_completion* cp = (tr_completion*)ccp; /* mutable */
+        tr_completion* cp = const_cast<tr_completion*>(ccp); /* mutable */
 
         if (tr_cpHasAll(ccp))
         {
@@ -178,8 +178,8 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
                 }
                 else
                 {
-                    tr_block_index_t f;
-                    tr_block_index_t l;
+                    auto f = tr_block_index_t{};
+                    auto l = tr_block_index_t{};
                     tr_torGetPieceBlockRange(cp->tor, p, &f, &l);
 
                     n = cp->blockBitfield->countRange(f, l + 1);
@@ -228,8 +228,8 @@ void tr_cpGetAmountDone(tr_completion const* cp, float* tab, int tabCount)
         }
         else
         {
-            tr_block_index_t f;
-            tr_block_index_t l;
+            auto f = tr_block_index_t{};
+            auto l = tr_block_index_t{};
             tr_piece_index_t const piece = (tr_piece_index_t)i * interval;
             tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
             tab[i] = cp->blockBitfield->countRange(f, l + 1) / (float)(l + 1 - f);
@@ -245,8 +245,8 @@ size_t tr_cpMissingBlocksInPiece(tr_completion const* cp, tr_piece_index_t piece
     }
     else
     {
-        tr_block_index_t f;
-        tr_block_index_t l;
+        auto f = tr_block_index_t{};
+        auto l = tr_block_index_t{};
         tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
         return (l + 1 - f) - cp->blockBitfield->countRange(f, l + 1);
     }
@@ -261,8 +261,8 @@ size_t tr_cpMissingBytesInPiece(tr_completion const* cp, tr_piece_index_t piece)
     else
     {
         size_t haveBytes = 0;
-        tr_block_index_t f;
-        tr_block_index_t l;
+        auto f = tr_block_index_t{};
+        auto l = tr_block_index_t{};
         size_t const pieceByteSize = tr_torPieceCountBytes(cp->tor, piece);
         tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
 
@@ -293,8 +293,8 @@ bool tr_cpFileIsComplete(tr_completion const* cp, tr_file_index_t i)
     }
     else
     {
-        tr_block_index_t f;
-        tr_block_index_t l;
+        auto f = tr_block_index_t{};
+        auto l = tr_block_index_t{};
         tr_torGetFileBlockRange(cp->tor, i, &f, &l);
         return cp->blockBitfield->countRange(f, l + 1) == (l + 1 - f);
     }
@@ -304,10 +304,7 @@ void* tr_cpCreatePieceBitfield(tr_completion const* cp, size_t* byte_count)
 {
     TR_ASSERT(tr_torrentHasMetadata(cp->tor));
 
-    void* ret;
-    tr_piece_index_t n;
-
-    n = cp->tor->info.pieceCount;
+    tr_piece_index_t const n = cp->tor->info.pieceCount;
 
     Bitfield pieces(n);
 
@@ -328,7 +325,7 @@ void* tr_cpCreatePieceBitfield(tr_completion const* cp, size_t* byte_count)
         tr_free(flags);
     }
 
-    ret = pieces.getRaw(byte_count);
+    void* ret = pieces.getRaw(byte_count);
     return ret;
 }
 

--- a/libtransmission/crypto.cc
+++ b/libtransmission/crypto.cc
@@ -44,11 +44,9 @@ static void ensureKeyExists(tr_crypto* crypto)
 {
     if (crypto->dh == nullptr)
     {
-        size_t public_key_length;
-
         crypto->dh = tr_dh_new(dh_P, sizeof(dh_P), dh_G, sizeof(dh_G));
+        auto public_key_length = size_t{};
         tr_dh_make_key(crypto->dh, DH_PRIVKEY_LEN, crypto->myPublicKey, &public_key_length);
-
         TR_ASSERT(public_key_length == KEY_LEN);
     }
 }

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -23,12 +23,12 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
 
     bool ret = false;
     size_t offset = 0;
-    uint64_t bytes_read;
 
     while (buffer_size > 0)
     {
         size_t const bytes_needed = std::min(buffer_size, size_t{ 1024 });
 
+        auto bytes_read = uint64_t{};
         ret = tr_sys_file_read(handle, buffer + offset, bytes_needed, &bytes_read, error);
 
         if (!ret || (offset == 0 && bytes_read == 0))
@@ -103,11 +103,10 @@ bool tr_sys_file_write_fmt(tr_sys_file_t handle, char const* format, tr_error** 
     TR_ASSERT(format != nullptr);
 
     bool ret = false;
-    char* buffer;
     va_list args;
 
     va_start(args, error);
-    buffer = tr_strdup_vprintf(format, args);
+    char* const buffer = tr_strdup_vprintf(format, args);
     va_end(args);
 
     if (buffer != nullptr)

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -103,10 +103,9 @@ bool tr_logGetQueueEnabled(void)
 
 tr_log_message* tr_logGetQueue(void)
 {
-    tr_log_message* ret;
     tr_lockLock(getMessageLock());
 
-    ret = myQueue;
+    tr_log_message* const ret = myQueue;
     myQueue = nullptr;
     myQueueTail = &myQueue;
     myQueueLength = 0;
@@ -117,11 +116,9 @@ tr_log_message* tr_logGetQueue(void)
 
 void tr_logFreeQueue(tr_log_message* list)
 {
-    tr_log_message* next;
-
     while (list != nullptr)
     {
-        next = list->next;
+        tr_log_message* const next = list->next;
         tr_free(list->message);
         tr_free(list->name);
         tr_free(list);
@@ -211,14 +208,13 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 {
     int const err = errno; /* message logging shouldn't affect errno */
     char buf[1024];
-    int buf_len;
     va_list ap;
     tr_lockLock(getMessageLock());
 
     /* build the text message */
     *buf = '\0';
     va_start(ap, fmt);
-    buf_len = evutil_vsnprintf(buf, sizeof(buf), fmt, ap);
+    int const buf_len = evutil_vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
 
     if (buf_len < 0)
@@ -247,8 +243,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
     {
         if (tr_logGetQueueEnabled())
         {
-            tr_log_message* newmsg;
-            newmsg = tr_new0(tr_log_message, 1);
+            auto* const newmsg = tr_new0(tr_log_message, 1);
             newmsg->level = level;
             newmsg->when = tr_time();
             newmsg->message = tr_strdup(buf);
@@ -272,10 +267,9 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
         }
         else
         {
-            tr_sys_file_t fp;
             char timestr[64];
 
-            fp = tr_logGetFile();
+            tr_sys_file_t fp = tr_logGetFile();
 
             if (fp == TR_BAD_SYS_FILE)
             {

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -126,8 +126,8 @@ tr_magnet_info* tr_magnetParse(char const* uri)
             char const* delim = strchr(key, '=');
             char const* val = delim == nullptr ? nullptr : delim + 1;
             char const* next = strchr(delim == nullptr ? key : val, '&');
-            size_t keylen;
-            size_t vallen;
+            auto keylen = size_t{};
+            auto vallen = size_t{};
 
             if (delim != nullptr)
             {
@@ -179,7 +179,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
 
             if (vallen > 0 && trCount < MAX_TRACKERS)
             {
-                int i;
+                auto i = int{};
 
                 if (keylen == 2 && memcmp(key, "tr", 2) == 0)
                 {
@@ -253,7 +253,6 @@ void tr_magnetFree(tr_magnet_info* info)
 
 void tr_magnetCreateMetainfo(tr_magnet_info const* info, tr_variant* top)
 {
-    tr_variant* d;
     tr_variantInitDict(top, 4);
 
     /* announce list */
@@ -283,7 +282,7 @@ void tr_magnetCreateMetainfo(tr_magnet_info const* info, tr_variant* top)
     }
 
     /* nonstandard keys */
-    d = tr_variantDictAddDict(top, TR_KEY_magnet_info, 2);
+    tr_variant* const d = tr_variantDictAddDict(top, TR_KEY_magnet_info, 2);
     tr_variantDictAddRaw(d, TR_KEY_info_hash, info->hash, 20);
 
     if (info->displayName != nullptr)

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -86,9 +86,7 @@ static void logVal(char const* func, int ret)
 
 struct tr_natpmp* tr_natpmpInit(void)
 {
-    struct tr_natpmp* nat;
-
-    nat = tr_new0(struct tr_natpmp, 1);
+    auto* const nat = tr_new0(struct tr_natpmp, 1);
     nat->state = TR_NATPMP_DISCOVER;
     nat->public_port = 0;
     nat->private_port = 0;
@@ -117,8 +115,6 @@ static void setCommandTime(struct tr_natpmp* nat)
 
 tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, bool is_enabled, tr_port* public_port)
 {
-    tr_port_forwarding ret;
-
     if (is_enabled && nat->state == TR_NATPMP_DISCOVER)
     {
         int val = initnatpmp(&nat->natpmp, 0, 0);
@@ -237,24 +233,18 @@ tr_port_forwarding tr_natpmpPulse(struct tr_natpmp* nat, tr_port private_port, b
         return nat->is_mapped ? TR_PORT_MAPPED : TR_PORT_UNMAPPED;
 
     case TR_NATPMP_DISCOVER:
-        ret = TR_PORT_UNMAPPED;
-        break;
+        return TR_PORT_UNMAPPED;
 
     case TR_NATPMP_RECV_PUB:
     case TR_NATPMP_SEND_MAP:
     case TR_NATPMP_RECV_MAP:
-        ret = TR_PORT_MAPPING;
-        break;
+        return TR_PORT_MAPPING;
 
     case TR_NATPMP_SEND_UNMAP:
     case TR_NATPMP_RECV_UNMAP:
-        ret = TR_PORT_UNMAPPING;
-        break;
+        return TR_PORT_UNMAPPING;
 
     default:
-        ret = TR_PORT_ERROR;
-        break;
+        return TR_PORT_ERROR;
     }
-
-    return ret;
 }

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -302,11 +302,9 @@ static char const* getHomeDir(void)
 
 void tr_setConfigDir(tr_session* session, char const* configDir)
 {
-    char* path;
-
     session->configDir = tr_strdup(configDir);
 
-    path = tr_buildPath(configDir, RESUME_SUBDIR, nullptr);
+    char* path = tr_buildPath(configDir, RESUME_SUBDIR, nullptr);
     tr_sys_dir_create(path, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
     session->resumeDir = path;
 
@@ -388,27 +386,16 @@ char const* tr_getDefaultDownloadDir(void)
 
     if (user_dir == nullptr)
     {
-        char* config_home;
-        char* config_file;
-        char* content;
-        size_t content_len;
-
         /* figure out where to look for user-dirs.dirs */
-        config_home = tr_env_get_string("XDG_CONFIG_HOME", nullptr);
-
-        if (!tr_str_is_empty(config_home))
-        {
-            config_file = tr_buildPath(config_home, "user-dirs.dirs", nullptr);
-        }
-        else
-        {
-            config_file = tr_buildPath(getHomeDir(), ".config", "user-dirs.dirs", nullptr);
-        }
-
+        char* const config_home = tr_env_get_string("XDG_CONFIG_HOME", nullptr);
+        char* const config_file = !tr_str_is_empty(config_home) ?
+            tr_buildPath(config_home, "user-dirs.dirs", nullptr) :
+            tr_buildPath(getHomeDir(), ".config", "user-dirs.dirs", nullptr);
         tr_free(config_home);
 
         /* read in user-dirs.dirs and look for the download dir entry */
-        content = (char*)tr_loadFile(config_file, &content_len, nullptr);
+        auto content_len = size_t{};
+        auto* content = (char*)tr_loadFile(config_file, &content_len, nullptr);
 
         if (content != nullptr && content_len > 0)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -108,14 +108,15 @@ static void tr_idle_function_done(struct tr_rpc_idle_data* data, char const* res
 ****
 ***/
 
+// TODO: return a std:;vector<tr_torrent*>
 static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setmeCount)
 {
+    auto id = int64_t{};
     int torrentCount = 0;
-    int64_t id;
     tr_torrent** torrents = nullptr;
-    tr_variant* ids;
-    char const* str;
+    char const* str = nullptr;
 
+    tr_variant* ids = nullptr;
     if (tr_variantDictFindList(args, TR_KEY_ids, &ids))
     {
         size_t const n = tr_variantListSize(ids);
@@ -124,7 +125,7 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
 
         for (size_t i = 0; i < n; ++i)
         {
-            tr_torrent* tor;
+            tr_torrent* tor = nullptr;
             tr_variant const* const node = tr_variantListChild(ids, i);
 
             if (tr_variantGetInt(node, &id))
@@ -148,10 +149,10 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
     }
     else if (tr_variantDictFindInt(args, TR_KEY_ids, &id) || tr_variantDictFindInt(args, TR_KEY_id, &id))
     {
-        tr_torrent* tor;
         torrents = tr_new0(tr_torrent*, 1);
 
-        if ((tor = tr_torrentFindFromId(session, id)) != nullptr)
+        tr_torrent* const tor = tr_torrentFindFromId(session, id);
+        if (tor != nullptr)
         {
             torrents[torrentCount++] = tor;
         }
@@ -175,10 +176,10 @@ static tr_torrent** getTorrents(tr_session* session, tr_variant* args, int* setm
         }
         else
         {
-            tr_torrent* tor;
             torrents = tr_new0(tr_torrent*, 1);
 
-            if ((tor = tr_torrentFindFromHashString(session, str)) != nullptr)
+            tr_torrent* const tor = tr_torrentFindFromHashString(session, str);
+            if (tor != nullptr)
             {
                 torrents[torrentCount++] = tor;
             }
@@ -213,7 +214,7 @@ static char const* queueMoveTop(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int n;
+    auto n = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveTop(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
@@ -227,7 +228,7 @@ static char const* queueMoveUp(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int n;
+    auto n = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveUp(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
@@ -241,7 +242,7 @@ static char const* queueMoveDown(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int n;
+    auto n = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveDown(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
@@ -255,7 +256,7 @@ static char const* queueMoveBottom(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int n;
+    auto n = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &n);
     tr_torrentsQueueMoveBottom(torrents, n);
     notifyBatchQueueChange(session, torrents, n);
@@ -277,7 +278,7 @@ static char const* torrentStart(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     qsort(torrents, torrentCount, sizeof(tr_torrent*), compareTorrentByQueuePosition);
@@ -303,7 +304,7 @@ static char const* torrentStartNow(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     qsort(torrents, torrentCount, sizeof(tr_torrent*), compareTorrentByQueuePosition);
@@ -329,7 +330,7 @@ static char const* torrentStop(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     for (int i = 0; i < torrentCount; ++i)
@@ -353,8 +354,7 @@ static char const* torrentRemove(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    bool deleteFlag;
-
+    auto deleteFlag = bool{};
     if (!tr_variantDictFindBool(args_in, TR_KEY_delete_local_data, &deleteFlag))
     {
         deleteFlag = false;
@@ -362,7 +362,7 @@ static char const* torrentRemove(
 
     tr_rpc_callback_type type = deleteFlag ? TR_RPC_TORRENT_TRASHING : TR_RPC_TORRENT_REMOVING;
 
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     for (int i = 0; i < torrentCount; ++i)
@@ -386,7 +386,7 @@ static char const* torrentReannounce(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     for (int i = 0; i < torrentCount; ++i)
@@ -410,7 +410,7 @@ static char const* torrentVerify(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     for (int i = 0; i < torrentCount; ++i)
@@ -439,8 +439,9 @@ static void addLabels(tr_torrent const* tor, tr_variant* list)
 
 static void addFileStats(tr_torrent const* tor, tr_variant* list)
 {
-    tr_file_index_t n;
-    tr_info const* info = tr_torrentInfo(tor);
+    tr_info const* const info = tr_torrentInfo(tor);
+
+    auto n = tr_file_index_t{};
     tr_file_stat* files = tr_torrentFiles(tor, &n);
 
     for (tr_file_index_t i = 0; i < info->fileCount; ++i)
@@ -457,8 +458,9 @@ static void addFileStats(tr_torrent const* tor, tr_variant* list)
 
 static void addFiles(tr_torrent const* tor, tr_variant* list)
 {
-    tr_file_index_t n;
-    tr_info const* info = tr_torrentInfo(tor);
+    tr_info const* const info = tr_torrentInfo(tor);
+
+    auto n = tr_file_index_t{};
     tr_file_stat* files = tr_torrentFiles(tor, &n);
 
     for (tr_file_index_t i = 0; i < info->fileCount; ++i)
@@ -531,7 +533,7 @@ static void addTrackerStats(tr_tracker_stat const* st, int n, tr_variant* list)
 
 static void addPeers(tr_torrent* tor, tr_variant* list)
 {
-    int peerCount;
+    auto peerCount = int{};
     tr_peer_stat* peers = tr_torrentPeers(tor, &peerCount);
 
     tr_variantInitList(list, peerCount);
@@ -568,7 +570,7 @@ static void initField(
     tr_variant* const initme,
     tr_quark key)
 {
-    char* str;
+    char* str = nullptr;
 
     switch (key)
     {
@@ -855,7 +857,7 @@ static void initField(
 
     case TR_KEY_trackerStats:
         {
-            int n;
+            auto n = int{};
             tr_tracker_stat* s = tr_torrentTrackers(tor, &n);
             tr_variantInitList(initme, n);
             addTrackerStats(s, n, initme);
@@ -942,35 +944,30 @@ static char const* torrentGet(
     tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
     tr_variant* list = tr_variantDictAddList(args_out, TR_KEY_torrents, torrentCount + 1);
-    tr_variant* fields;
-    char const* strVal;
     char const* errmsg = nullptr;
-    tr_format format;
 
+    tr_format format = TR_FORMAT_OBJECT; // default value;
+    char const* strVal = nullptr;
     if (tr_variantDictFindStr(args_in, TR_KEY_format, &strVal, nullptr) && strcmp(strVal, "table") == 0)
     {
         format = TR_FORMAT_TABLE;
     }
-    else /* default value */
-    {
-        format = TR_FORMAT_OBJECT;
-    }
 
     if (tr_variantDictFindStr(args_in, TR_KEY_ids, &strVal, nullptr) && strcmp(strVal, "recently-active") == 0)
     {
-        int n = 0;
-        tr_variant* d;
+        auto n = int{};
         time_t const now = tr_time();
         int const interval = RECENTLY_ACTIVE_SECONDS;
         tr_variant* removed_out = tr_variantDictAddList(args_out, TR_KEY_removed, 0);
 
+        tr_variant* d = nullptr;
         while ((d = tr_variantListChild(&session->removedTorrents, n)) != nullptr)
         {
-            int64_t date;
-            int64_t id;
+            auto date = int64_t{};
+            auto id = int64_t{};
 
             if (tr_variantDictFindInt(d, TR_KEY_date, &date) && date >= now - interval &&
                 tr_variantDictFindInt(d, TR_KEY_id, &id))
@@ -982,6 +979,7 @@ static char const* torrentGet(
         }
     }
 
+    tr_variant* fields = nullptr;
     if (!tr_variantDictFindList(args_in, TR_KEY_fields, &fields))
     {
         errmsg = "no fields specified";
@@ -994,7 +992,7 @@ static char const* torrentGet(
         tr_quark* keys = tr_new(tr_quark, n);
         for (size_t i = 0; i < n; ++i)
         {
-            size_t len;
+            auto len = size_t{};
             if (tr_variantGetStr(tr_variantListChild(fields, i), &strVal, &len))
             {
                 keys[keyCount++] = tr_quark_new(strVal, len);
@@ -1034,8 +1032,8 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
     auto labels = tr_labels_t{};
     for (size_t i = 0; i < n; ++i)
     {
-        char const* str;
-        size_t str_len;
+        char const* str = nullptr;
+        auto str_len = size_t{};
         if (tr_variantGetStr(tr_variantListChild(list, i), &str, &str_len) && str != nullptr)
         {
             char* label = tr_strndup(str, str_len);
@@ -1075,7 +1073,7 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
 
 static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* list)
 {
-    int64_t tmp;
+    auto tmp = int64_t{};
     int fileCount = 0;
     size_t const n = tr_variantListSize(list);
     char const* errmsg = nullptr;
@@ -1117,7 +1115,7 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
 
 static char const* setFileDLs(tr_torrent* tor, bool do_download, tr_variant* list)
 {
-    int64_t tmp;
+    auto tmp = int64_t{};
     int fileCount = 0;
     size_t const n = tr_variantListSize(list);
     char const* errmsg = nullptr;
@@ -1205,23 +1203,18 @@ static void freeTrackers(tr_tracker_info* trackers, int n)
 
 static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
 {
-    int i;
-    int n;
-    int tier;
-    tr_tracker_info* trackers;
     bool changed = false;
-    tr_info const* inf = tr_torrentInfo(tor);
+    tr_info const* const inf = tr_torrentInfo(tor);
     char const* errmsg = nullptr;
 
     /* make a working copy of the existing announce list */
-    n = inf->trackerCount;
-    trackers = tr_new0(tr_tracker_info, n + tr_variantListSize(urls));
-    tier = copyTrackers(trackers, inf->trackers, n);
+    int n = inf->trackerCount;
+    tr_tracker_info* const trackers = tr_new0(tr_tracker_info, n + tr_variantListSize(urls));
+    int tier = copyTrackers(trackers, inf->trackers, n);
 
     /* and add the new ones */
-    i = 0;
-
-    tr_variant const* val;
+    auto i = int{};
+    tr_variant const* val = nullptr;
     while ((val = tr_variantListChild(urls, i)) != nullptr)
     {
         char const* announce = nullptr;
@@ -1253,22 +1246,21 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
 
 static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
 {
-    tr_tracker_info* trackers;
     bool changed = false;
-    tr_info const* inf = tr_torrentInfo(tor);
+    tr_info const* const inf = tr_torrentInfo(tor);
     int const n = inf->trackerCount;
     char const* errmsg = nullptr;
 
     /* make a working copy of the existing announce list */
-    trackers = tr_new0(tr_tracker_info, n);
+    tr_tracker_info* const trackers = tr_new0(tr_tracker_info, n);
     copyTrackers(trackers, inf->trackers, n);
 
     /* make the substitutions... */
     for (size_t i = 0, url_count = tr_variantListSize(urls); i + 1 < url_count; i += 2)
     {
-        size_t len;
-        int64_t pos;
-        char const* newval;
+        auto len = size_t{};
+        auto pos = int64_t{};
+        char const* newval = nullptr;
 
         if (tr_variantGetInt(tr_variantListChild(urls, i), &pos) &&
             tr_variantGetStr(tr_variantListChild(urls, i + 1), &newval, &len) && tr_urlIsValidTracker(newval) && pos < n &&
@@ -1305,10 +1297,10 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
     /* remove the ones specified in the urls list */
     int i = 0;
     int t = 0;
-    tr_variant const* val;
+    tr_variant const* val = nullptr;
     while ((val = tr_variantListChild(ids, i)) != nullptr)
     {
-        int64_t pos;
+        auto pos = int64_t{};
 
         if (tr_variantGetInt(val, &pos) && 0 <= pos && pos < n)
         {
@@ -1359,20 +1351,19 @@ static char const* torrentSet(
     [[maybe_unused]] tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int torrentCount;
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     char const* errmsg = nullptr;
 
     for (int i = 0; i < torrentCount; ++i)
     {
-        int64_t tmp;
-        double d;
-        tr_variant* tmp_variant;
-        bool boolVal;
-        tr_torrent* tor;
+        auto tmp = int64_t{};
+        auto d = double{};
+        tr_variant* tmp_variant = nullptr;
+        auto boolVal = bool{};
 
-        tor = torrents[i];
+        tr_torrent* const tor = torrents[i];
 
         if (tr_variantDictFindInt(args_in, TR_KEY_bandwidthPriority, &tmp))
         {
@@ -1509,8 +1500,8 @@ static char const* torrentSetLocation(
         return "new location path is not absolute";
     }
 
-    bool move;
-    int torrentCount;
+    auto move = bool{};
+    auto torrentCount = int{};
     tr_torrent** torrents = getTorrents(session, args_in, &torrentCount);
 
     if (!tr_variantDictFindBool(args_in, TR_KEY_move, &move))
@@ -1536,22 +1527,13 @@ static char const* torrentSetLocation(
 
 static void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char const* newname, int error, void* user_data)
 {
-    char const* result;
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
 
     tr_variantDictAddInt(data->args_out, TR_KEY_id, tr_torrentId(tor));
     tr_variantDictAddStr(data->args_out, TR_KEY_path, oldpath);
     tr_variantDictAddStr(data->args_out, TR_KEY_name, newname);
 
-    if (error == 0)
-    {
-        result = nullptr;
-    }
-    else
-    {
-        result = tr_strerror(error);
-    }
-
+    char const* const result = error == 0 ? nullptr : tr_strerror(error);
     tr_idle_function_done(data, result);
 }
 
@@ -1661,7 +1643,6 @@ static void gotNewBlocklist(
     }
     else /* successfully fetched the blocklist... */
     {
-        int err;
         z_stream stream;
         char const* configDir = tr_sessionGetConfigDir(session);
         size_t const buflen = 1024 * 128; /* 128 KiB buffer */
@@ -1688,6 +1669,7 @@ static void gotNewBlocklist(
             tr_error_clear(&error);
         }
 
+        auto err = int{};
         for (;;)
         {
             stream.next_out = static_cast<Bytef*>(buf);
@@ -1759,17 +1741,14 @@ static char const* blocklistUpdate(
 
 static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
 {
-    int err;
-    int duplicate_id;
-    char const* result;
-    tr_torrent* tor;
-    tr_quark key;
+    char const* result = nullptr;
 
-    err = 0;
-    duplicate_id = 0;
-    tor = tr_torrentNew(ctor, &err, &duplicate_id);
+    auto err = int{};
+    auto duplicate_id = int{};
+    tr_torrent* tor = tr_torrentNew(ctor, &err, &duplicate_id);
     tr_ctorFree(ctor);
 
+    auto key = tr_quark{};
     if (err == 0)
     {
         key = TR_KEY_torrent_added;
@@ -1861,6 +1840,7 @@ static bool isCurlURL(char const* filename)
     return strncmp(filename, "ftp://", 6) == 0 || strncmp(filename, "http://", 7) == 0 || strncmp(filename, "https://", 8) == 0;
 }
 
+// TODO: return a std::vector<tr_file_index_t>
 static tr_file_index_t* fileListFromList(tr_variant* list, tr_file_index_t* setmeCount)
 {
     size_t const childCount = tr_variantListSize(list);
@@ -1869,7 +1849,7 @@ static tr_file_index_t* fileListFromList(tr_variant* list, tr_file_index_t* setm
 
     for (size_t i = 0; i < childCount; ++i)
     {
-        int64_t intVal;
+        auto intVal = int64_t{};
 
         if (tr_variantGetInt(tr_variantListChild(list, i), &intVal))
         {
@@ -1907,9 +1887,9 @@ static char const* torrentAdd(
         return "download directory path is not absolute";
     }
 
-    int64_t i;
-    bool boolVal;
-    tr_variant* l;
+    auto i = int64_t{};
+    auto boolVal = bool{};
+    tr_variant* l = nullptr;
     tr_ctor* ctor = tr_ctorNew(session);
 
     /* set the optional arguments */
@@ -1939,7 +1919,7 @@ static char const* torrentAdd(
 
     if (tr_variantDictFindList(args_in, TR_KEY_files_unwanted, &l))
     {
-        tr_file_index_t fileCount;
+        auto fileCount = tr_file_index_t{};
         tr_file_index_t* files = fileListFromList(l, &fileCount);
         tr_ctorSetFilesWanted(ctor, files, fileCount, false);
         tr_free(files);
@@ -1947,7 +1927,7 @@ static char const* torrentAdd(
 
     if (tr_variantDictFindList(args_in, TR_KEY_files_wanted, &l))
     {
-        tr_file_index_t fileCount;
+        auto fileCount = tr_file_index_t{};
         tr_file_index_t* files = fileListFromList(l, &fileCount);
         tr_ctorSetFilesWanted(ctor, files, fileCount, true);
         tr_free(files);
@@ -1955,7 +1935,7 @@ static char const* torrentAdd(
 
     if (tr_variantDictFindList(args_in, TR_KEY_priority_low, &l))
     {
-        tr_file_index_t fileCount;
+        auto fileCount = tr_file_index_t{};
         tr_file_index_t* files = fileListFromList(l, &fileCount);
         tr_ctorSetFilePriorities(ctor, files, fileCount, TR_PRI_LOW);
         tr_free(files);
@@ -1963,7 +1943,7 @@ static char const* torrentAdd(
 
     if (tr_variantDictFindList(args_in, TR_KEY_priority_normal, &l))
     {
-        tr_file_index_t fileCount;
+        auto fileCount = tr_file_index_t{};
         tr_file_index_t* files = fileListFromList(l, &fileCount);
         tr_ctorSetFilePriorities(ctor, files, fileCount, TR_PRI_NORMAL);
         tr_free(files);
@@ -1971,7 +1951,7 @@ static char const* torrentAdd(
 
     if (tr_variantDictFindList(args_in, TR_KEY_priority_high, &l))
     {
-        tr_file_index_t fileCount;
+        auto fileCount = tr_file_index_t{};
         tr_file_index_t* files = fileListFromList(l, &fileCount);
         tr_ctorSetFilePriorities(ctor, files, fileCount, TR_PRI_HIGH);
         tr_free(files);
@@ -1992,7 +1972,7 @@ static char const* torrentAdd(
 
         if (fname == nullptr)
         {
-            size_t len;
+            auto len = size_t{};
             auto* metainfo = static_cast<char*>(tr_base64_decode_str(metainfo_base64, &len));
             tr_ctorSetMetainfo(ctor, (uint8_t*)metainfo, len);
             tr_free(metainfo);
@@ -2038,10 +2018,10 @@ static char const* sessionSet(
         return "incomplete torrents directory path is not absolute";
     }
 
-    int64_t i;
-    double d;
-    bool boolVal;
-    char const* str;
+    auto i = int64_t{};
+    auto d = double{};
+    auto boolVal = bool{};
+    char const* str = nullptr;
 
     if (tr_variantDictFindInt(args_in, TR_KEY_cache_size_mb, &i))
     {
@@ -2526,7 +2506,7 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
 
     case TR_KEY_encryption:
         {
-            char const* str;
+            char const* str = nullptr;
 
             switch (tr_sessionGetEncryption(s))
             {
@@ -2559,23 +2539,21 @@ static char const* sessionGet(
     tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    tr_variant* fields;
-
+    tr_variant* fields = nullptr;
     if (tr_variantDictFindList(args_in, TR_KEY_fields, &fields))
     {
         size_t const field_count = tr_variantListSize(fields);
 
         for (size_t i = 0; i < field_count; ++i)
         {
-            char const* field_name;
-            size_t field_name_len;
-            tr_quark field_id;
-
+            char const* field_name = nullptr;
+            auto field_name_len = size_t{};
             if (!tr_variantGetStr(tr_variantListChild(fields, i), &field_name, &field_name_len))
             {
                 continue;
             }
 
+            auto field_id = tr_quark{};
             if (!tr_quark_lookup(field_name, field_name_len, &field_id))
             {
                 continue;
@@ -2601,7 +2579,6 @@ static char const* freeSpace(
     tr_variant* args_out,
     [[maybe_unused]] struct tr_rpc_idle_data* idle_data)
 {
-    int tmperr;
     char const* path = nullptr;
     char const* err = nullptr;
     int64_t free_space = -1;
@@ -2617,7 +2594,7 @@ static char const* freeSpace(
     }
 
     /* get the free space */
-    tmperr = errno;
+    auto const tmperr = errno;
     errno = 0;
     free_space = tr_sessionGetDirFreeSpace(session, path);
 
@@ -2701,7 +2678,6 @@ void tr_rpc_request_exec_json(
     tr_rpc_response_func callback,
     void* callback_user_data)
 {
-    char const* str;
     tr_variant* const mutable_request = (tr_variant*)request;
     tr_variant* args_in = tr_variantDictFind(mutable_request, TR_KEY_arguments);
     char const* result = nullptr;
@@ -2713,6 +2689,7 @@ void tr_rpc_request_exec_json(
     }
 
     /* parse the request */
+    char const* str = nullptr;
     if (!tr_variantDictFindStr(mutable_request, TR_KEY_method, &str, nullptr))
     {
         result = "no method name";
@@ -2736,13 +2713,12 @@ void tr_rpc_request_exec_json(
     /* if we couldn't figure out which method to use, return an error */
     if (result != nullptr)
     {
-        int64_t tag;
         tr_variant response;
-
         tr_variantInitDict(&response, 3);
         tr_variantDictAddDict(&response, TR_KEY_arguments, 0);
         tr_variantDictAddStr(&response, TR_KEY_result, result);
 
+        auto tag = int64_t{};
         if (tr_variantDictFindInt(mutable_request, TR_KEY_tag, &tag))
         {
             tr_variantDictAddInt(&response, TR_KEY_tag, tag);
@@ -2754,12 +2730,9 @@ void tr_rpc_request_exec_json(
     }
     else if (method->immediate)
     {
-        int64_t tag;
         tr_variant response;
-        tr_variant* args_out;
-
         tr_variantInitDict(&response, 3);
-        args_out = tr_variantDictAddDict(&response, TR_KEY_arguments, 0);
+        tr_variant* const args_out = tr_variantDictAddDict(&response, TR_KEY_arguments, 0);
         result = (*method->func)(session, args_in, args_out, nullptr);
 
         if (result == nullptr)
@@ -2769,6 +2742,7 @@ void tr_rpc_request_exec_json(
 
         tr_variantDictAddStr(&response, TR_KEY_result, result);
 
+        auto tag = int64_t{};
         if (tr_variantDictFindInt(mutable_request, TR_KEY_tag, &tag))
         {
             tr_variantDictAddInt(&response, TR_KEY_tag, tag);
@@ -2780,12 +2754,12 @@ void tr_rpc_request_exec_json(
     }
     else
     {
-        int64_t tag;
         struct tr_rpc_idle_data* data = tr_new0(struct tr_rpc_idle_data, 1);
         data->session = session;
         data->response = tr_new0(tr_variant, 1);
         tr_variantInitDict(data->response, 3);
 
+        auto tag = int64_t{};
         if (tr_variantDictFindInt(mutable_request, TR_KEY_tag, &tag))
         {
             tr_variantDictAddInt(data->response, TR_KEY_tag, tag);
@@ -2844,15 +2818,12 @@ void tr_rpc_request_exec_uri(
     tr_rpc_response_func callback,
     void* callback_user_data)
 {
-    char const* pch;
     tr_variant top;
-    tr_variant* args;
-    char* request = tr_strndup(request_uri, request_uri_len);
-
     tr_variantInitDict(&top, 3);
-    args = tr_variantDictAddDict(&top, TR_KEY_arguments, 0);
+    tr_variant* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 0);
 
-    pch = strchr(request, '?');
+    char* request = tr_strndup(request_uri, request_uri_len);
+    char const* pch = strchr(request, '?');
 
     if (pch == nullptr)
     {

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -70,11 +70,13 @@ static tr_sys_file_t create_session_id_lock_file(char const* session_id)
     }
 
     char* lock_file_path = get_session_id_lock_file_path(session_id);
-    tr_sys_file_t lock_file;
     tr_error* error = nullptr;
 
-    lock_file = tr_sys_file_open(lock_file_path, TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, &error);
-
+    tr_sys_file_t lock_file = tr_sys_file_open(
+        lock_file_path,
+        TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE,
+        0600,
+        &error);
     if (lock_file != TR_BAD_SYS_FILE)
     {
         if (tr_sys_file_lock(lock_file, TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB, &error))
@@ -170,10 +172,9 @@ bool tr_session_id_is_local(char const* session_id)
     if (session_id != nullptr)
     {
         char* lock_file_path = get_session_id_lock_file_path(session_id);
-        tr_sys_file_t lock_file;
         tr_error* error = nullptr;
 
-        lock_file = tr_sys_file_open(lock_file_path, TR_SYS_FILE_READ, 0, &error);
+        tr_sys_file_t const lock_file = tr_sys_file_open(lock_file_path, TR_SYS_FILE_READ, 0, &error);
 
         if (lock_file == TR_BAD_SYS_FILE)
         {

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -40,11 +40,9 @@ static char* getFilename(tr_session const* session)
 static void loadCumulativeStats(tr_session const* session, tr_session_stats* setme)
 {
     tr_variant top;
-    char* filename;
-    bool loaded = false;
 
-    filename = getFilename(session);
-    loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_JSON, filename, nullptr);
+    char* filename = getFilename(session);
+    bool loaded = tr_variantFromFile(&top, TR_VARIANT_FMT_JSON, filename, nullptr);
     tr_free(filename);
 
     if (!loaded)
@@ -56,7 +54,7 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
 
     if (loaded)
     {
-        int64_t i;
+        auto i = int64_t{};
 
         if (tr_variantDictFindInt(&top, TR_KEY_downloaded_bytes, &i))
         {
@@ -89,7 +87,6 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
 
 static void saveCumulativeStats(tr_session const* session, tr_session_stats const* s)
 {
-    char* filename;
     tr_variant top;
 
     tr_variantInitDict(&top, 5);
@@ -99,7 +96,7 @@ static void saveCumulativeStats(tr_session const* session, tr_session_stats cons
     tr_variantDictAddInt(&top, TR_KEY_session_count, s->sessionCount);
     tr_variantDictAddInt(&top, TR_KEY_uploaded_bytes, s->uploadedBytes);
 
-    filename = getFilename(session);
+    char* const filename = getFilename(session);
     if (tr_logGetDeepEnabled())
     {
         tr_logAddDeep(__FILE__, __LINE__, nullptr, "Saving stats to \"%s\"", filename);
@@ -216,9 +213,8 @@ void tr_sessionClearStats(tr_session* session)
 
 void tr_statsAddUploaded(tr_session* session, uint32_t bytes)
 {
-    struct tr_stats_handle* s;
-
-    if ((s = getStats(session)) != nullptr)
+    auto* const s = getStats(session);
+    if (s != nullptr)
     {
         s->single.uploadedBytes += bytes;
         s->isDirty = true;
@@ -227,9 +223,8 @@ void tr_statsAddUploaded(tr_session* session, uint32_t bytes)
 
 void tr_statsAddDownloaded(tr_session* session, uint32_t bytes)
 {
-    struct tr_stats_handle* s;
-
-    if ((s = getStats(session)) != nullptr)
+    auto* const s = getStats(session);
+    if (s != nullptr)
     {
         s->single.downloadedBytes += bytes;
         s->isDirty = true;
@@ -238,10 +233,9 @@ void tr_statsAddDownloaded(tr_session* session, uint32_t bytes)
 
 void tr_statsFileCreated(tr_session* session)
 {
-    struct tr_stats_handle* s;
-
-    if ((s = getStats(session)) != nullptr)
+    auto* const s = getStats(session);
+    if (s != nullptr)
     {
-        s->single.filesAdded++;
+        ++s->single.filesAdded;
     }
 }

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -22,22 +22,17 @@ int tr_optind = 1;
 
 static char const* getArgName(tr_option const* opt)
 {
-    char const* arg;
-
     if (!opt->has_arg)
     {
-        arg = "";
-    }
-    else if (opt->argName != nullptr)
-    {
-        arg = opt->argName;
-    }
-    else
-    {
-        arg = "<args>";
+        return "";
     }
 
-    return arg;
+    if (opt->argName != nullptr)
+    {
+        return opt->argName;
+    }
+
+    return "<args>";
 }
 
 static size_t get_next_line_len(std::string_view description, size_t maxlen)
@@ -95,8 +90,6 @@ static void getopts_usage_line(tr_option const* opt, int longWidth, int shortWid
 
 static void maxWidth(struct tr_option const* o, size_t& longWidth, size_t& shortWidth, size_t& argWidth)
 {
-    char const* arg;
-
     if (o->longName != nullptr)
     {
         longWidth = std::max(longWidth, strlen(o->longName));
@@ -107,7 +100,8 @@ static void maxWidth(struct tr_option const* o, size_t& longWidth, size_t& short
         shortWidth = std::max(shortWidth, strlen(o->shortName));
     }
 
-    if ((arg = getArgName(o)) != nullptr)
+    char const* const arg = getArgName(o);
+    if (arg != nullptr)
     {
         argWidth = std::max(argWidth, strlen(arg));
     }

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -61,7 +61,7 @@ int tr_bencParseInt(void const* vbuf, void const* vbufend, uint8_t const** setme
     }
 
     errno = 0;
-    char* endptr;
+    char* endptr = nullptr;
     int64_t val = evutil_strtoll(static_cast<char const*>(begin), &endptr, 10);
 
     if (errno != 0 || endptr != end) /* incomplete parse */
@@ -102,7 +102,7 @@ int tr_bencParseStr(
         if (end != nullptr)
         {
             errno = 0;
-            char* ulend;
+            char* ulend = nullptr;
             size_t len = strtoul((char const*)buf, &ulend, 10);
 
             if (errno == 0 && ulend == end && len <= MAX_BENC_STR_LENGTH)
@@ -191,10 +191,8 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
         if (*buf == 'i') /* int */
         {
-            int64_t val;
-            uint8_t const* end;
-            tr_variant* v;
-
+            uint8_t const* end = nullptr;
+            auto val = int64_t{};
             if ((err = tr_bencParseInt(buf, bufend, &end, &val)) != 0)
             {
                 break;
@@ -202,6 +200,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
             buf = end;
 
+            tr_variant* v = nullptr;
             if ((v = get_node(stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitInt(v, val);
@@ -209,10 +208,9 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
         }
         else if (*buf == 'l') /* list */
         {
-            tr_variant* v;
-
             ++buf;
 
+            tr_variant* v = nullptr;
             if ((v = get_node(stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitList(v, 0);
@@ -221,10 +219,9 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
         }
         else if (*buf == 'd') /* dict */
         {
-            tr_variant* v;
-
             ++buf;
 
+            tr_variant* v = nullptr;
             if ((v = get_node(stack, &key, top, &err)) != nullptr)
             {
                 tr_variantInitDict(v, 0);
@@ -252,11 +249,9 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
         }
         else if (isdigit(*buf)) /* string? */
         {
-            tr_variant* v;
-            uint8_t const* end;
-            uint8_t const* str;
-            size_t str_len;
-
+            uint8_t const* end = nullptr;
+            uint8_t const* str = nullptr;
+            auto str_len = size_t{};
             if ((err = tr_bencParseStr(buf, bufend, &end, &str, &str_len)) != 0)
             {
                 break;
@@ -264,6 +259,7 @@ int tr_variantParseBenc(void const* buf_in, void const* bufend_in, tr_variant* t
 
             buf = end;
 
+            tr_variant* v = nullptr;
             if (key == 0 && !std::empty(stack) && tr_variantIsDict(stack.back()))
             {
                 key = tr_quark_new(str, str_len);
@@ -340,8 +336,8 @@ static void saveRealFunc(tr_variant const* val, void* vevbuf)
 
 static void saveStringFunc(tr_variant const* v, void* vevbuf)
 {
-    size_t len;
-    char const* str;
+    auto len = size_t{};
+    char const* str = nullptr;
     if (!tr_variantGetStr(v, &str, &len))
     {
         len = 0;

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -275,22 +275,17 @@ static char* extract_escaped_string(char const* in, size_t in_len, size_t* len, 
 
 static char const* extract_string(jsonsl_t jsn, struct jsonsl_state_st* state, size_t* len, struct evbuffer* buf)
 {
-    char const* ret;
-    char const* in_begin;
-    char const* in_end;
-    size_t in_len;
-
     /* figure out where the string is */
-    in_begin = jsn->base + state->pos_begin;
-
+    char const* in_begin = jsn->base + state->pos_begin;
     if (*in_begin == '"')
     {
         in_begin++;
     }
 
-    in_end = jsn->base + state->pos_cur;
-    in_len = in_end - in_begin;
+    char const* const in_end = jsn->base + state->pos_cur;
+    size_t const in_len = in_end - in_begin;
 
+    char const* ret = nullptr;
     if (memchr(in_begin, '\\', in_len) == nullptr)
     {
         /* it's not escaped */
@@ -315,7 +310,7 @@ static void action_callback_POP(
 
     if (state->type == JSONSL_T_STRING)
     {
-        size_t len;
+        auto len = size_t{};
         char const* str = extract_string(jsn, state, &len, data->strbuf);
         tr_variantInitStr(get_node(jsn), str, len);
         data->has_content = true;
@@ -365,11 +360,9 @@ static void action_callback_POP(
 
 int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* setme_variant, char const** setme_end)
 {
-    int error;
-    jsonsl_t jsn;
-    struct json_wrapper_data data;
+    auto data = json_wrapper_data{};
 
-    jsn = jsonsl_new(MAX_DEPTH);
+    jsonsl_t jsn = jsonsl_new(MAX_DEPTH);
     jsn->action_callback_PUSH = action_callback_PUSH;
     jsn->action_callback_POP = action_callback_POP;
     jsn->error_callback = error_callback;
@@ -405,7 +398,7 @@ int tr_jsonParse(char const* source, void const* vbuf, size_t len, tr_variant* s
     }
 
     /* cleanup */
-    error = data.error;
+    int const error = data.error;
     evbuffer_free(data.keybuf);
     evbuffer_free(data.strbuf);
     jsonsl_destroy(jsn);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -339,7 +339,6 @@ bool tr_variantGetRaw(tr_variant const* v, uint8_t const** setme_raw, size_t* se
 
 bool tr_variantGetBool(tr_variant const* v, bool* setme)
 {
-    char const* str;
     bool success = false;
 
     if (tr_variantIsBool(v))
@@ -354,6 +353,7 @@ bool tr_variantGetBool(tr_variant const* v, bool* setme)
         success = true;
     }
 
+    char const* str = nullptr;
     if ((!success) && tr_variantGetStr(v, &str, nullptr) && (strcmp(str, "true") == 0 || strcmp(str, "false") == 0))
     {
         *setme = strcmp(str, "true") == 0;
@@ -381,13 +381,11 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
 
     if (!success && tr_variantIsString(v))
     {
-        char* endptr;
-        struct locale_context locale_ctx;
-        double d;
-
         /* the json spec requires a '.' decimal point regardless of locale */
+        struct locale_context locale_ctx;
         use_numeric_locale(&locale_ctx, "C");
-        d = strtod(getStr(v), &endptr);
+        char* endptr = nullptr;
+        double const d = strtod(getStr(v), &endptr);
         restore_locale(&locale_ctx);
 
         if (getStr(v) != endptr && *endptr == '\0')
@@ -611,10 +609,9 @@ tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark const key)
 
 static tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark const key, int type)
 {
-    tr_variant* child;
-
     /* see if it already exists, and if so, try to reuse it */
-    if ((child = tr_variantDictFind(dict, key)) != nullptr)
+    tr_variant* child = tr_variantDictFind(dict, key);
+    if (child != nullptr)
     {
         if (!tr_variantIsType(child, type))
         {
@@ -812,7 +809,7 @@ void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkF
     while (!stack.empty())
     {
         auto& node = stack.top();
-        tr_variant const* v;
+        tr_variant const* v = nullptr;
 
         if (!node.is_visited)
         {
@@ -933,7 +930,7 @@ void tr_variantFree(tr_variant* v)
 static void tr_variantListCopy(tr_variant* target, tr_variant const* src)
 {
     int i = 0;
-    tr_variant const* val;
+    tr_variant const* val = nullptr;
 
     while ((val = tr_variantListChild((tr_variant*)src, i)) != nullptr)
     {
@@ -1011,9 +1008,9 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
 
     for (size_t i = 0; i < sourceCount; ++i)
     {
-        tr_quark key;
-        tr_variant* val;
-        tr_variant* t;
+        auto key = tr_quark{};
+        tr_variant* val = nullptr;
+        tr_variant* t = nullptr;
 
         if (tr_variantDictChild((tr_variant*)source, i, &key, &val))
         {
@@ -1212,11 +1209,9 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
 bool tr_variantFromFile(tr_variant* setme, tr_variant_fmt fmt, char const* filename, tr_error** error)
 {
     bool ret = false;
-    uint8_t* buf;
-    size_t buflen;
 
-    buf = tr_loadFile(filename, &buflen, error);
-
+    auto buflen = size_t{};
+    uint8_t* const buf = tr_loadFile(filename, &buflen, error);
     if (buf != nullptr)
     {
         if (tr_variantFromBuf(setme, fmt, buf, buflen, filename, nullptr) == 0)
@@ -1242,7 +1237,7 @@ int tr_variantFromBuf(
     char const* optional_source,
     char const** setme_end)
 {
-    int err;
+    auto err = int{};
     struct locale_context locale_ctx;
 
     /* parse with LC_NUMERIC="C" to ensure a "." decimal separator */

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -172,9 +172,7 @@ static void tr_watchdir_on_retry_timer([[maybe_unused]] evutil_socket_t fd, [[ma
 
 static tr_watchdir_retry* tr_watchdir_retry_new(tr_watchdir_t handle, char const* name)
 {
-    tr_watchdir_retry* retry;
-
-    retry = tr_new0(tr_watchdir_retry, 1);
+    auto* const retry = tr_new0(tr_watchdir_retry, 1);
     retry->handle = handle;
     retry->name = tr_strdup(name);
     retry->timer = evtimer_new(handle->event_base, &tr_watchdir_on_retry_timer, retry);
@@ -225,9 +223,7 @@ tr_watchdir_t tr_watchdir_new(
     struct event_base* event_base,
     bool force_generic)
 {
-    tr_watchdir_t handle;
-
-    handle = tr_new0(struct tr_watchdir, 1);
+    auto* handle = tr_new0(struct tr_watchdir, 1);
     handle->path = tr_strdup(path);
     handle->callback = callback;
     handle->callback_user_data = callback_user_data;
@@ -327,18 +323,18 @@ void tr_watchdir_process(tr_watchdir_t handle, char const* name)
 
 void tr_watchdir_scan(tr_watchdir_t handle, std::unordered_set<std::string>* dir_entries)
 {
-    tr_sys_dir_t dir;
-    char const* name;
     auto new_dir_entries = std::unordered_set<std::string>{};
     tr_error* error = nullptr;
 
-    if ((dir = tr_sys_dir_open(handle->path, &error)) == TR_BAD_SYS_DIR)
+    auto const dir = tr_sys_dir_open(handle->path, &error);
+    if (dir == TR_BAD_SYS_DIR)
     {
         log_error("Failed to open directory \"%s\" (%d): %s", handle->path, error->code, error->message);
         tr_error_free(error);
         return;
     }
 
+    char const* name = nullptr;
     while ((name = tr_sys_dir_read_name(dir, &error)) != nullptr)
     {
         if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)


### PR DESCRIPTION
Ensure that all variables are initialized.