### PR TITLE
fix: uninitialized variables pt 1/x: peer-mgr.cc

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -670,7 +670,7 @@ static void requestListAdd(tr_swarm* s, tr_block_index_t block, tr_peer* peer)
 
     /* insert the request to our array... */
     {
-        bool exact;
+        auto exact = bool{};
         int const
             pos = tr_lowerBound(&key, s->requests, s->requestCount, sizeof(struct block_request), compareReqByBlock, &exact);
         TR_ASSERT(!exact);
@@ -704,7 +704,7 @@ static auto getBlockRequestPeers(tr_swarm* s, tr_block_index_t block)
     auto peers = std::vector<tr_peer*>{};
 
     auto const key = block_request{ block, nullptr, 0 };
-    bool exact;
+    auto exact = bool{};
     int const pos = tr_lowerBound(&key, s->requests, s->requestCount, sizeof(struct block_request), compareReqByBlock, &exact);
 
     TR_ASSERT(!exact); /* shouldn't have a request with .peer == nullptr */
@@ -837,20 +837,16 @@ static int comparePieceByWeight(void const* va, void const* vb)
 {
     auto const* const a = static_cast<struct weighted_piece const*>(va);
     auto const* const b = static_cast<struct weighted_piece const*>(vb);
-    int ia;
-    int ib;
-    int missing;
-    int pending;
-    tr_torrent const* tor = weightTorrent;
-    uint16_t const* rep = weightReplication;
+    tr_torrent const* const tor = weightTorrent;
+    uint16_t const* const rep = weightReplication;
 
     /* primary key: weight */
-    missing = tr_torrentMissingBlocksInPiece(tor, a->index);
-    pending = a->requestCount;
-    ia = missing > pending ? missing - pending : tor->blockCountInPiece + pending;
+    int missing = tr_torrentMissingBlocksInPiece(tor, a->index);
+    int pending = a->requestCount;
+    int ia = missing > pending ? missing - pending : tor->blockCountInPiece + pending;
     missing = tr_torrentMissingBlocksInPiece(tor, b->index);
     pending = b->requestCount;
-    ib = missing > pending ? missing - pending : tor->blockCountInPiece + pending;
+    int ib = missing > pending ? missing - pending : tor->blockCountInPiece + pending;
 
     if (ia < ib)
     {
@@ -1016,16 +1012,12 @@ static void pieceListRebuild(tr_swarm* s)
 {
     if (!tr_torrentIsSeed(s->tor))
     {
-        tr_piece_index_t* pool;
-        tr_piece_index_t poolCount = 0;
-        tr_torrent const* tor = s->tor;
-        tr_info const* inf = tr_torrentInfo(tor);
-        struct weighted_piece* pieces;
-        int pieceCount;
+        tr_torrent const* const tor = s->tor;
+        tr_info const* const inf = tr_torrentInfo(tor);
 
         /* build the new list */
-        pool = tr_new(tr_piece_index_t, inf->pieceCount);
-
+        tr_piece_index_t poolCount = 0;
+        auto* const pool = tr_new(tr_piece_index_t, inf->pieceCount);
         for (tr_piece_index_t i = 0; i < inf->pieceCount; ++i)
         {
             if (!inf->pieces[i].dnd && !tr_torrentPieceIsComplete(tor, i))
@@ -1034,8 +1026,8 @@ static void pieceListRebuild(tr_swarm* s)
             }
         }
 
-        pieceCount = poolCount;
-        pieces = tr_new0(struct weighted_piece, pieceCount);
+        int const pieceCount = poolCount;
+        auto* const pieces = tr_new0(struct weighted_piece, pieceCount);
 
         for (tr_piece_index_t i = 0; i < poolCount; ++i)
         {
@@ -1087,9 +1079,8 @@ static void pieceListRebuild(tr_swarm* s)
 
 static void pieceListRemovePiece(tr_swarm* s, tr_piece_index_t piece)
 {
-    struct weighted_piece const* p;
-
-    if ((p = pieceListLookup(s, piece)) != nullptr)
+    weighted_piece const* const p = pieceListLookup(s, piece);
+    if (p != nullptr)
     {
         int const pos = p - s->pieces;
 
@@ -1106,17 +1097,16 @@ static void pieceListRemovePiece(tr_swarm* s, tr_piece_index_t piece)
 
 static void pieceListResortPiece(tr_swarm* s, struct weighted_piece* p)
 {
-    int pos;
-    bool isSorted = true;
-
     if (p == nullptr)
     {
         return;
     }
 
     /* is the torrent already sorted? */
-    pos = p - s->pieces;
+    int pos = p - s->pieces;
     setComparePieceByWeightTorrent(s);
+
+    bool isSorted = true;
 
     if (isSorted && pos > 0 && comparePieceByWeight(p - 1, p) > 0)
     {
@@ -1137,12 +1127,12 @@ static void pieceListResortPiece(tr_swarm* s, struct weighted_piece* p)
     /* if it's not sorted, move it around */
     if (!isSorted)
     {
-        bool exact;
         struct weighted_piece const tmp = *p;
 
         tr_removeElementFromArray(s->pieces, pos, sizeof(struct weighted_piece), s->pieceCount);
         --s->pieceCount;
 
+        auto exact = bool{};
         pos = tr_lowerBound(&tmp, s->pieces, s->pieceCount, sizeof(struct weighted_piece), comparePieceByWeight, &exact);
 
         memmove(&s->pieces[pos + 1], &s->pieces[pos], sizeof(struct weighted_piece) * (s->pieceCount - pos));
@@ -1156,10 +1146,10 @@ static void pieceListResortPiece(tr_swarm* s, struct weighted_piece* p)
 
 static void pieceListRemoveRequest(tr_swarm* s, tr_block_index_t block)
 {
-    struct weighted_piece* p;
     tr_piece_index_t const index = tr_torBlockPiece(s->tor, block);
 
-    if ((p = pieceListLookup(s, index)) != nullptr && p->requestCount > 0)
+    struct weighted_piece* const p = pieceListLookup(s, index);
+    if (p != nullptr && p->requestCount > 0)
     {
         --p->requestCount;
         pieceListResortPiece(s, p);
@@ -1283,11 +1273,10 @@ void tr_peerMgrGetNextRequests(
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(numwant > 0);
 
-    tr_swarm* s;
     Bitfield const* const have = &peer->have;
 
     /* walk through the pieces and find blocks that should be requested */
-    s = tor->swarm;
+    tr_swarm* const s = tor->swarm;
 
     /* prep the pieces list */
     if (s->pieces == nullptr)
@@ -1325,9 +1314,8 @@ void tr_peerMgrGetNextRequests(
         /* if the peer has this piece that we want... */
         if (have->readBit(p->index))
         {
-            tr_block_index_t first;
-            tr_block_index_t last;
-
+            auto first = tr_block_index_t{};
+            auto last = tr_block_index_t{};
             tr_torGetPieceBlockRange(tor, p->index, &first, &last);
 
             for (tr_block_index_t b = first; b <= last && (got < numwant || (get_intervals && setme[2 * got - 1] == b - 1));
@@ -1413,7 +1401,7 @@ void tr_peerMgrGetNextRequests(
 
         for (int i = checkedPieceCount - 1; i >= 0; --i)
         {
-            bool exact;
+            auto exact = bool{};
 
             /* relative position! */
             int const newpos = tr_lowerBound(
@@ -1445,15 +1433,13 @@ bool tr_peerMgrDidPeerRequest(tr_torrent const* tor, tr_peer const* peer, tr_blo
 /* cancel requests that are too old */
 static void refillUpkeep([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] short what, void* vmgr)
 {
-    time_t now;
-    time_t too_old;
     int cancel_buflen = 0;
     struct block_request* cancel = nullptr;
     auto* mgr = static_cast<tr_peerMgr*>(vmgr);
     managerLock(mgr);
 
-    now = tr_time();
-    too_old = now - REQUEST_TTL_SECS;
+    time_t const now = tr_time();
+    time_t const too_old = now - REQUEST_TTL_SECS;
 
     /* alloc the temporary "cancel" buffer */
     for (auto const* tor : mgr->session->torrents)
@@ -1952,8 +1938,6 @@ static bool myHandshakeDoneCB(
 
     bool ok = isConnected;
     bool success = false;
-    tr_port port;
-    tr_address const* addr;
     auto* manager = static_cast<tr_peerMgr*>(vmanager);
     tr_swarm* s = tr_peerIoHasTorrentHash(io) ? getExistingSwarm(manager, tr_peerIoGetTorrentHash(io)) : nullptr;
 
@@ -1971,7 +1955,8 @@ static bool myHandshakeDoneCB(
         swarmLock(s);
     }
 
-    addr = tr_peerIoGetAddress(io, &port);
+    auto port = tr_port{};
+    tr_address const* const addr = tr_peerIoGetAddress(io, &port);
 
     if (!ok || s == nullptr || !s->isRunning)
     {
@@ -2030,16 +2015,11 @@ static bool myHandshakeDoneCB(
             }
             else
             {
-                tr_quark client;
-                char buf[128];
-
+                tr_quark client = TR_KEY_NONE;
                 if (peer_id != nullptr)
                 {
+                    char buf[128];
                     client = tr_quark_new(tr_clientForId(buf, sizeof(buf), peer_id), TR_BAD_SIZE);
-                }
-                else
-                {
-                    client = TR_KEY_NONE;
                 }
 
                 /* this steals its refcount too, which is balanced by our unref in peerDelete() */
@@ -2103,12 +2083,8 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address* addr, tr_port port, 
     }
     else /* we don't have a connection to them yet... */
     {
-        tr_peerIo* io;
-        tr_handshake* handshake;
-
-        io = tr_peerIoNewIncoming(session, session->bandwidth, addr, port, socket);
-
-        handshake = tr_handshakeNew(io, session->encryptionMode, myHandshakeDoneCB, manager);
+        tr_peerIo* const io = tr_peerIoNewIncoming(session, session->bandwidth, addr, port, socket);
+        tr_handshake* const handshake = tr_handshakeNew(io, session->encryptionMode, myHandshakeDoneCB, manager);
 
         tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
 
@@ -2123,7 +2099,7 @@ void tr_peerMgrSetSwarmIsAllSeeds(tr_torrent* tor)
     tr_torrentLock(tor);
 
     tr_swarm* const swarm = tor->swarm;
-    int atomCount;
+    auto atomCount = int{};
     struct peer_atom** atoms = (struct peer_atom**)tr_ptrArrayPeek(&swarm->pool, &atomCount);
     for (int i = 0; i < atomCount; ++i)
     {
@@ -2251,7 +2227,7 @@ int tr_pexCompare(void const* va, void const* vb)
     TR_ASSERT(tr_isPex(a));
     TR_ASSERT(tr_isPex(b));
 
-    int i;
+    auto i = int{};
 
     if ((i = tr_address_compare(&a->addr, &b->addr)) != 0)
     {
@@ -2318,6 +2294,7 @@ static bool isAtomInteresting(tr_torrent const* tor, struct peer_atom* atom)
     return true;
 }
 
+// TODO: return a std::vector
 int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, uint8_t list_mode, int maxCount)
 {
     TR_ASSERT(tr_isTorrent(tor));
@@ -2325,20 +2302,15 @@ int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, ui
     TR_ASSERT(af == TR_AF_INET || af == TR_AF_INET6);
     TR_ASSERT(list_mode == TR_PEERS_CONNECTED || list_mode == TR_PEERS_INTERESTING);
 
-    int n;
-    int count = 0;
-    int atomCount = 0;
     tr_swarm const* s = tor->swarm;
-    struct peer_atom** atoms = nullptr;
-    tr_pex* pex;
-    tr_pex* walk;
-
     managerLock(s->manager);
 
     /**
     ***  build a list of atoms
     **/
 
+    int atomCount = 0;
+    struct peer_atom** atoms = nullptr;
     if (list_mode == TR_PEERS_CONNECTED) /* connected peers only */
     {
         tr_peer const** peers = (tr_peer const**)tr_ptrArrayBase(&s->peers);
@@ -2353,7 +2325,7 @@ int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, ui
     else /* TR_PEERS_INTERESTING */
     {
         struct peer_atom** atomBase = (struct peer_atom**)tr_ptrArrayBase(&s->pool);
-        n = tr_ptrArraySize(&s->pool);
+        int const n = tr_ptrArraySize(&s->pool);
         atoms = tr_new(struct peer_atom*, n);
 
         for (int i = 0; i < n; ++i)
@@ -2371,9 +2343,11 @@ int tr_peerMgrGetPeers(tr_torrent const* tor, tr_pex** setme_pex, uint8_t af, ui
     ***  add the first N of them into our return list
     **/
 
-    n = std::min(atomCount, maxCount);
-    pex = walk = tr_new0(tr_pex, n);
+    int const n = std::min(atomCount, maxCount);
+    tr_pex* const pex = tr_new0(tr_pex, n);
+    tr_pex* walk = pex;
 
+    auto count = int{};
     for (int i = 0; i < atomCount && count < n; ++i)
     {
         struct peer_atom const* atom = atoms[i];
@@ -2543,16 +2517,13 @@ void tr_peerUpdateProgress(tr_torrent* tor, tr_peer* peer)
 
 void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor)
 {
-    int peerCount;
-    tr_peer** peers;
-
     /* the webseed list may have changed... */
     rebuildWebseedArray(tor->swarm, tor);
 
     /* some peer_msgs' progress fields may not be accurate if we
        didn't have the metadata before now... so refresh them all... */
-    peerCount = tr_ptrArraySize(&tor->swarm->peers);
-    peers = (tr_peer**)tr_ptrArrayBase(&tor->swarm->peers);
+    int const peerCount = tr_ptrArraySize(&tor->swarm->peers);
+    tr_peer** const peers = (tr_peer**)tr_ptrArrayBase(&tor->swarm->peers);
 
     for (int i = 0; i < peerCount; ++i)
     {
@@ -2753,7 +2724,6 @@ struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setmeCount)
 
     for (int i = 0; i < size; ++i)
     {
-        char* pch;
         tr_peer* peer = peers[i];
         auto const* const msgs = dynamic_cast<tr_peerMsgs const*>(peer);
         struct peer_atom const* atom = peer->atom;
@@ -2785,7 +2755,7 @@ struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setmeCount)
         stat->pendingReqsToPeer = peer->pendingReqsToPeer;
         stat->pendingReqsToClient = peer->pendingReqsToClient;
 
-        pch = stat->flagStr;
+        char* pch = stat->flagStr;
 
         if (stat->isUTP)
         {
@@ -2945,7 +2915,6 @@ static void rechokeDownloads(tr_swarm* s)
     {
         int blocks = 0;
         int cancels = 0;
-        time_t timeSinceCancel;
 
         /* Count up how many blocks & cancels each peer has.
          *
@@ -2991,7 +2960,7 @@ static void rechokeDownloads(tr_swarm* s)
             s->lastCancel = now;
         }
 
-        timeSinceCancel = now - s->lastCancel;
+        time_t const timeSinceCancel = now - s->lastCancel;
 
         if (timeSinceCancel != 0)
         {
@@ -3023,12 +2992,11 @@ static void rechokeDownloads(tr_swarm* s)
 
     if (peerCount > 0)
     {
-        bool* piece_is_interesting;
         tr_torrent const* const tor = s->tor;
         int const n = tor->info.pieceCount;
 
         /* build a bitfield of interesting pieces... */
-        piece_is_interesting = tr_new(bool, n);
+        bool* const piece_is_interesting = tr_new(bool, n);
 
         for (int i = 0; i < n; ++i)
         {
@@ -3046,7 +3014,7 @@ static void rechokeDownloads(tr_swarm* s)
             }
             else
             {
-                tr_rechoke_state rechoke_state;
+                auto rechoke_state = tr_rechoke_state{};
                 auto const blocks = peer->blocksSentToClient.count(now, CANCEL_HISTORY_SEC);
                 auto const cancels = peer->cancelsSentToPeer.count(now, CANCEL_HISTORY_SEC);
 
@@ -3150,7 +3118,7 @@ static bool isNew(tr_peerMsgs const* msgs)
 /* get a rate for deciding which peers to choke and unchoke. */
 static int getRate(tr_torrent const* tor, struct peer_atom* atom, uint64_t now)
 {
-    unsigned int Bps;
+    auto Bps = unsigned{};
 
     if (tr_torrentIsSeed(tor))
     {
@@ -3381,14 +3349,16 @@ static bool shouldPeerBeClosed(tr_swarm const* s, tr_peer const* peer, int peerC
     return false;
 }
 
+// TODO: return std::vector
 static tr_peer** getPeersToClose(tr_swarm* s, time_t const now_sec, int* setmeSize)
 {
     TR_ASSERT(swarmIsLocked(s));
 
-    int peerCount;
-    int outsize = 0;
     tr_peer** ret = nullptr;
-    tr_peer** peers = (tr_peer**)tr_ptrArrayPeek(&s->peers, &peerCount);
+    int outsize = 0;
+
+    auto peerCount = int{};
+    tr_peer** const peers = (tr_peer**)tr_ptrArrayPeek(&s->peers, &peerCount);
 
     for (int i = 0; i < peerCount; ++i)
     {
@@ -3409,7 +3379,7 @@ static tr_peer** getPeersToClose(tr_swarm* s, time_t const now_sec, int* setmeSi
 
 static int getReconnectIntervalSecs(struct peer_atom const* atom, time_t const now)
 {
-    int sec;
+    auto sec = int{};
     bool const unreachable = (atom->flags2 & MYFLAG_UNREACHABLE) != 0;
 
     /* if we were recently connected to this peer and transferring piece
@@ -3530,10 +3500,8 @@ static void closeBadPeers(tr_swarm* s, time_t const now_sec)
 {
     if (!tr_ptrArrayEmpty(&s->peers))
     {
-        int peerCount;
-        tr_peer** peers;
-
-        peers = getPeersToClose(s, now_sec, &peerCount);
+        auto peerCount = int{};
+        tr_peer** const peers = getPeersToClose(s, now_sec, &peerCount);
 
         for (int i = 0; i < peerCount; ++i)
         {
@@ -3891,10 +3859,10 @@ static void atomPulse([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] shor
 
     for (auto* tor : mgr->session->torrents)
     {
-        int atomCount;
         tr_swarm* s = tor->swarm;
         int const maxAtomCount = getMaxAtomCount(tor);
-        struct peer_atom** atoms = (struct peer_atom**)tr_ptrArrayPeek(&s->pool, &atomCount);
+        auto atomCount = int{};
+        struct peer_atom** const atoms = (struct peer_atom**)tr_ptrArrayPeek(&s->pool, &atomCount);
 
         if (atomCount > maxAtomCount) /* we've got too many atoms... time to prune */
         {
@@ -4023,8 +3991,8 @@ static constexpr uint64_t addValToKey(uint64_t value, int width, uint64_t addme)
 /* smaller value is better */
 static uint64_t getPeerCandidateScore(tr_torrent const* tor, struct peer_atom const* atom, uint8_t salt)
 {
-    uint64_t i;
-    uint64_t score = 0;
+    auto i = uint64_t{};
+    auto score = uint64_t{};
     bool const failed = atom->lastConnectionAt < atom->lastConnectionAttemptAt;
 
     /* prefer peers we've connected to, or never tried, over peers we failed to connect to. */
@@ -4139,8 +4107,6 @@ static bool swarmIsAllSeeds(tr_swarm* swarm)
 /** @return an array of all the atoms we might want to connect to */
 static struct peer_candidate* getPeerCandidates(tr_session* session, int* candidateCount, int max)
 {
-    struct peer_candidate* candidates;
-    struct peer_candidate* walk;
     time_t const now = tr_time();
     uint64_t const now_msec = tr_time_msec();
     /* leave 5% of connection slots for incoming connections -- ticket #2609 */
@@ -4163,14 +4129,12 @@ static struct peer_candidate* getPeerCandidates(tr_session* session, int* candid
     }
 
     /* allocate an array of candidates */
-    walk = candidates = tr_new(struct peer_candidate, atomCount);
+    struct peer_candidate* const candidates = tr_new(struct peer_candidate, atomCount);
+    struct peer_candidate* walk = candidates;
 
     /* populate the candidate array */
     for (auto* tor : session->torrents)
     {
-        int nAtoms;
-        struct peer_atom** atoms;
-
         if (!tor->swarm->isRunning)
         {
             continue;
@@ -4196,7 +4160,8 @@ static struct peer_candidate* getPeerCandidates(tr_session* session, int* candid
             continue;
         }
 
-        atoms = (struct peer_atom**)tr_ptrArrayPeek(&tor->swarm->pool, &nAtoms);
+        auto nAtoms = int{};
+        peer_atom** atoms = (peer_atom**)tr_ptrArrayPeek(&tor->swarm->pool, &nAtoms);
 
         for (int i = 0; i < nAtoms; ++i)
         {
@@ -4230,7 +4195,6 @@ static struct peer_candidate* getPeerCandidates(tr_session* session, int* candid
 
 static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* atom)
 {
-    tr_peerIo* io;
     time_t const now = tr_time();
     bool utp = tr_sessionIsUTPEnabled(mgr->session) && !atom->utp_failed;
 
@@ -4244,7 +4208,7 @@ static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* a
 
     tordbg(s, "Starting an OUTGOING%s connection with %s", utp ? " µTP" : "", tr_atomAddrStr(atom));
 
-    io = tr_peerIoNewOutgoing(
+    tr_peerIo* const io = tr_peerIoNewOutgoing(
         mgr->session,
         mgr->session->bandwidth,
         &atom->addr,
@@ -4289,7 +4253,7 @@ static void initiateCandidateConnection(tr_peerMgr* mgr, struct peer_candidate* 
 
 static void makeNewPeerConnections(struct tr_peerMgr* mgr, int const max)
 {
-    int n;
+    auto n = int{};
     struct peer_candidate* candidates = getPeerCandidates(mgr->session, &n, max);
 
     for (int i = 0; i < n && i < max; ++i)


### PR DESCRIPTION
https://github.com/transmission/transmission/pull/1931 is entirely too big to review -- there are nearly **800** warnings that need to be resolved in libtransmission just to enable `cppcoreguidelines-init-variables`. So instead, I'm going to do a series of PRs in smaller, human-readable chunks.
 
This PR fixes the warnings in peer-mgr.cc, which accounts for about 50 warnings. At this rate this would be a series of 16 PRs. :dizzy:  :tada: 