### PR TITLE
Replace NULL back with nullptr (mistake after auto-rebase)

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -675,13 +675,13 @@ static void handle_request(struct evhttp_request* req, void* arg)
         server->loginattempts = 0;
 
         size_t const server_url_len = strlen(server->url);
-        char const* const location = strncmp(req->uri, server->url, server_url_len) == 0 ? req->uri + server_url_len : NULL;
+        char const* const location = strncmp(req->uri, server->url, server_url_len) == 0 ? req->uri + server_url_len : nullptr;
 
-        if (location == NULL || location[0] == '\0' || strcmp(location, "web") == 0)
+        if (location == nullptr || location[0] == '\0' || strcmp(location, "web") == 0)
         {
             char* new_location = tr_strdup_printf("%sweb/", server->url);
             evhttp_add_header(req->output_headers, "Location", new_location);
-            send_simple_response(req, HTTP_MOVEPERM, NULL);
+            send_simple_response(req, HTTP_MOVEPERM, nullptr);
             tr_free(new_location);
         }
         else if (strncmp(location, "web/", 4) == 0)


### PR DESCRIPTION
I have just noticed that in the previous pull-request (https://github.com/transmission/transmission/pull/857) some nullptrs were changed to NULL due to automatic rebase mistake.
Let's  fix it back.