### PR TITLE
refactor: add an enumeration of the script types

### DIFF
--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -1349,11 +1349,11 @@ static void on_prefs_changed(TrCore const* core, tr_quark const key, gpointer da
         break;
 
     case TR_KEY_script_torrent_done_enabled:
-        tr_sessionSetTorrentDoneScriptEnabled(tr, gtr_pref_flag_get(key));
+        tr_sessionSetScriptEnabled(tr, TR_SCRIPT_ON_TORRENT_DONE, gtr_pref_flag_get(key));
         break;
 
     case TR_KEY_script_torrent_done_filename:
-        tr_sessionSetTorrentDoneScript(tr, gtr_pref_string_get(key));
+        tr_sessionSetScript(tr, TR_SCRIPT_ON_TORRENT_DONE, gtr_pref_string_get(key));
         break;
 
     case TR_KEY_start_added_torrents:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2215,22 +2215,22 @@ static char const* sessionSet(
 
     if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_added_filename, &str, nullptr))
     {
-        tr_sessionSetTorrentAddedScript(session, str);
+        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_ADDED, str);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_script_torrent_added_enabled, &boolVal))
     {
-        tr_sessionSetTorrentAddedScriptEnabled(session, boolVal);
+        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
     }
 
     if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_done_filename, &str, nullptr))
     {
-        tr_sessionSetTorrentDoneScript(session, str);
+        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_DONE, str);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_script_torrent_done_enabled, &boolVal))
     {
-        tr_sessionSetTorrentDoneScriptEnabled(session, boolVal);
+        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_DONE, boolVal);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_trash_original_torrent_files, &boolVal))
@@ -2503,19 +2503,19 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_script_torrent_added_filename:
-        tr_variantDictAddStr(d, key, tr_sessionGetTorrentAddedScript(s));
+        tr_variantDictAddStr(d, key, tr_sessionGetScript(s, TR_SCRIPT_ON_TORRENT_ADDED));
         break;
 
     case TR_KEY_script_torrent_added_enabled:
-        tr_variantDictAddBool(d, key, tr_sessionIsTorrentAddedScriptEnabled(s));
+        tr_variantDictAddBool(d, key, tr_sessionIsScriptEnabled(s, TR_SCRIPT_ON_TORRENT_ADDED));
         break;
 
     case TR_KEY_script_torrent_done_filename:
-        tr_variantDictAddStr(d, key, tr_sessionGetTorrentDoneScript(s));
+        tr_variantDictAddStr(d, key, tr_sessionGetScript(s, TR_SCRIPT_ON_TORRENT_DONE));
         break;
 
     case TR_KEY_script_torrent_done_enabled:
-        tr_variantDictAddBool(d, key, tr_sessionIsTorrentDoneScriptEnabled(s));
+        tr_variantDictAddBool(d, key, tr_sessionIsScriptEnabled(s, TR_SCRIPT_ON_TORRENT_DONE));
         break;
 
     case TR_KEY_queue_stalled_enabled:

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -14,9 +14,11 @@
 
 #define TR_NAME "Transmission"
 
+#include <array>
 #include <cstring> // memcmp()
 #include <list>
 #include <map>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -129,8 +131,6 @@ struct tr_session
     bool isLPDEnabled;
     bool isBlocklistEnabled;
     bool isPrefetchEnabled;
-    bool isTorrentAddedScriptEnabled;
-    bool isTorrentDoneScriptEnabled;
     bool isClosing;
     bool isClosed;
     bool isIncompleteFileNamingEnabled;
@@ -140,6 +140,7 @@ struct tr_session
     bool pauseAddedTorrent;
     bool deleteSourceTorrent;
     bool scrapePausedTorrents;
+    std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled;
 
     uint8_t peer_id_ttl_hours;
 
@@ -206,8 +207,7 @@ struct tr_session
     std::map<uint8_t const*, tr_torrent*, CompareHash> torrentsByHash;
     std::map<char const*, tr_torrent*, CompareHashString> torrentsByHashString;
 
-    char* torrentAddedScript;
-    char* torrentDoneScript;
+    std::array<std::string, TR_SCRIPT_N_TYPES> scripts;
 
     char* configDir;
     char* resumeDir;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -699,21 +699,21 @@ tr_torrent** tr_sessionLoadTorrents(tr_session* session, tr_ctor* ctor, int* set
 ***
 **/
 
-bool tr_sessionIsTorrentAddedScriptEnabled(tr_session const*);
+enum TrScript
+{
+    TR_SCRIPT_ON_TORRENT_ADDED,
+    TR_SCRIPT_ON_TORRENT_DONE,
 
-void tr_sessionSetTorrentAddedScriptEnabled(tr_session*, bool isEnabled);
+    TR_SCRIPT_N_TYPES
+};
 
-char const* tr_sessionGetTorrentAddedScript(tr_session const*);
+void tr_sessionSetScript(tr_session*, TrScript, char const* script_filename);
 
-void tr_sessionSetTorrentAddedScript(tr_session*, char const* scriptFilename);
+char const* tr_sessionGetScript(tr_session const*, TrScript);
 
-bool tr_sessionIsTorrentDoneScriptEnabled(tr_session const*);
+void tr_sessionSetScriptEnabled(tr_session*, TrScript, bool enabled);
 
-void tr_sessionSetTorrentDoneScriptEnabled(tr_session*, bool isEnabled);
-
-char const* tr_sessionGetTorrentDoneScript(tr_session const*);
-
-void tr_sessionSetTorrentDoneScript(tr_session*, char const* scriptFilename);
+bool tr_sessionIsScriptEnabled(tr_session const*, TrScript);
 
 /** @} */
 


### PR DESCRIPTION
This simplifies the API by having a single set of functions that can be used for getting/setting all the script types.