### PR TITLE
build: have clang-tidy check for NULL in libtransmission

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -1,0 +1,7 @@
+---
+# Many of these checks are disabled only because the code hasn't been
+# cleaned up yet. Pull requests welcomed.
+Checks: >
+  modernize-use-nullptr,
+  modernize-use-override
+

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1140,7 +1140,7 @@ static void sessionSetImpl(void* vdata)
         tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_added_filename, &strVal, NULL))
+    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_added_filename, &strVal, nullptr))
     {
         tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_ADDED, strVal);
     }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -296,7 +296,7 @@ int tr_lpdInit(tr_session* ss, [[maybe_unused]] tr_address* tr_addr)
      * string handling in tr_lpdSendAnnounce() and tr_lpdConsiderAnnounce().
      * However, the code should work as long as interfaces to the rest of
      * libtransmission are compatible with char* strings. */
-    TR_STATIC_ASSERT(sizeof(((struct tr_info*)0)->hashString[0]) == sizeof(char), "");
+    TR_STATIC_ASSERT(sizeof(((struct tr_info*)nullptr)->hashString[0]) == sizeof(char), "");
 
     struct ip_mreq mcastReq;
     int const opt_on = 1;


### PR DESCRIPTION
Does what it says on the tin.