### PR TITLE
build: add clang-tidy check modernize-pass-by-value

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -2,6 +2,8 @@
 # Many of these checks are disabled only because the code hasn't been
 # cleaned up yet. Pull requests welcomed.
 Checks: >
+  modernize-pass-by-value,
+  modernize-use-default-member-init,
   modernize-use-nullptr,
   modernize-use-override
 

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -459,10 +459,10 @@ struct tau_tracker
     tr_ptrArray announces = {};
     tr_ptrArray scrapes = {};
 
-    tau_tracker(tr_session* session_in, std::string const& key_in, std::string const& host_in, int port_in)
+    tau_tracker(tr_session* session_in, std::string key_in, std::string host_in, int port_in)
         : session{ session_in }
-        , key{ key_in }
-        , host{ host_in }
+        , key{ std::move(key_in) }
+        , host{ std::move(host_in) }
         , port{ port_in }
     {
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -135,8 +135,8 @@ struct tr_scrape_info
 
     int multiscrape_max;
 
-    tr_scrape_info(std::string const& url_in, int const multiscrape_max_in)
-        : url{ url_in }
+    tr_scrape_info(std::string url_in, int const multiscrape_max_in)
+        : url{ std::move(url_in) }
         , multiscrape_max{ multiscrape_max_in }
     {
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -199,10 +199,8 @@ public:
     tr_peerMsgsImpl(tr_torrent* torrent_in, peer_atom* atom_in, tr_peerIo* io_in, tr_peer_callback callback, void* callbackData)
         : tr_peerMsgs{ torrent_in, atom_in }
         , outMessagesBatchPeriod{ LOW_PRIORITY_INTERVAL_SECS }
-        , state{ AWAITING_BT_LENGTH }
         , torrent{ torrent_in }
         , outMessages{ evbuffer_new() }
-        , outMessagesBatchedAt{ 0 }
         , io{ io_in }
         , callback_{ callback }
         , callbackData_{ callbackData }


### PR DESCRIPTION
Another minor clang-tidy PR. This one adds `modernize-pass-by-value` and `modernize-use-default-member-init` to libtransmission/ .
