### PR TITLE
fix runtime with wolfSSL and fastmath

### DIFF
--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -18,6 +18,7 @@
 #define API_VERSION_HEX LIBCYASSL_VERSION_HEX
 #endif
 
+#include API_HEADER(options.h)
 #include API_HEADER_CRYPT(dh.h)
 #include API_HEADER_CRYPT(error-crypt.h)
 #include API_HEADER_CRYPT(random.h)


### PR DESCRIPTION
wolfSSL's fastmath support requires options.h to be included before
anything else. Otherwise bad codepaths get taken and a crash occurs
during DH initialization.

Signed-off-by: Rosen Penev <rosenp@gmail.com>