### PR TITLE
refactor: use C++'s [[noreturn]] atrribute

### DIFF
--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -14,7 +14,7 @@
 
 #if !defined(NDEBUG) || defined(TR_FORCE_ASSERTIONS)
 
-bool tr_assert_report(char const* file, int line, char const* message_fmt, ...)
+[[noreturn]] bool tr_assert_report(char const* file, int line, char const* message_fmt, ...)
 {
     va_list args;
     va_start(args, message_fmt);

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -14,7 +14,7 @@
 
 #include "tr-macros.h"
 
-bool TR_NORETURN tr_assert_report(char const* file, int line, char const* message_fmt, ...) TR_GNUC_PRINTF(3, 4);
+[[noreturn]] bool tr_assert_report(char const* file, int line, char const* message_fmt, ...) TR_GNUC_PRINTF(3, 4);
 
 #define TR_ASSERT(x) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, "%s", #x)))
 #define TR_ASSERT_MSG(x, ...) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, __VA_ARGS__)))

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -64,14 +64,6 @@
 ****
 ***/
 
-#if __has_attribute(__noreturn__) || TR_GNUC_CHECK_VERSION(2, 5)
-#define TR_NORETURN __attribute__((__noreturn__))
-#elif defined(_MSC_VER)
-#define TR_NORETURN __declspec(noreturn)
-#else
-#define TR_NORETURN
-#endif
-
 #if __has_attribute(__deprecated__) || TR_GNUC_CHECK_VERSION(3, 1)
 #define TR_DEPRECATED __attribute__((__deprecated__))
 #elif defined(_MSC_VER)


### PR DESCRIPTION
Another PR to replace some custom code with built-in C++ code. This time, replace `TR_NORETURN` with the `[[noreturn]]` attribute.