### PR TITLE
refactor: tr_rpc_parse_list_str() takes a std::string_view

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2838,19 +2838,14 @@ void tr_rpc_request_exec_json(
  * - values that are all-digits or commas are number lists
  * - all other values are strings
  */
-void tr_rpc_parse_list_str(tr_variant* setme, char const* str, size_t len)
+void tr_rpc_parse_list_str(tr_variant* setme, std::string_view str)
 {
-    if (len == TR_BAD_SIZE)
-    {
-        len = strlen(str);
-    }
-
-    auto const values = tr_parseNumberRange(std::string_view{ str, len });
+    auto const values = tr_parseNumberRange(str);
     auto const valueCount = std::size(values);
 
     if (valueCount == 0)
     {
-        tr_variantInitStr(setme, str, len);
+        tr_variantInitStr(setme, std::data(str), std::size(str));
     }
     else if (valueCount == 1)
     {
@@ -2900,10 +2895,8 @@ void tr_rpc_request_exec_uri(
             bool isArg = key != "method" && key != "tag";
             tr_variant* parent = isArg ? args : &top;
 
-            tr_rpc_parse_list_str(
-                tr_variantDictAdd(parent, tr_quark_new(key)),
-                delim + 1,
-                next != nullptr ? (size_t)(next - (delim + 1)) : strlen(delim + 1));
+            auto const val = std::string_view{ delim + 1, next != nullptr ? (size_t)(next - (delim + 1)) : strlen(delim + 1) };
+            tr_rpc_parse_list_str(tr_variantDictAdd(parent, tr_quark_new(key)), val);
         }
 
         pch = next != nullptr ? next + 1 : nullptr;

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "transmission.h"
 #include "tr-macros.h"
 #include "variant.h"
@@ -33,4 +35,4 @@ void tr_rpc_request_exec_uri(
     tr_rpc_response_func callback,
     void* callback_user_data);
 
-void tr_rpc_parse_list_str(tr_variant* setme, char const* list_str, size_t list_str_len);
+void tr_rpc_parse_list_str(tr_variant* setme, std::string_view str);

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -16,7 +16,11 @@
 #include <algorithm>
 #include <array>
 #include <set>
+#include <string_view>
+#include <typeinfo>
 #include <vector>
+
+using namespace std::literals;
 
 namespace libtransmission
 {
@@ -33,19 +37,13 @@ TEST_F(RpcTest, list)
     char const* str;
     tr_variant top;
 
-    tr_rpc_parse_list_str(&top, "12", TR_BAD_SIZE);
+    tr_rpc_parse_list_str(&top, "12"sv);
     EXPECT_TRUE(tr_variantIsInt(&top));
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
     tr_variantFree(&top);
 
-    tr_rpc_parse_list_str(&top, "12", 1);
-    EXPECT_TRUE(tr_variantIsInt(&top));
-    EXPECT_TRUE(tr_variantGetInt(&top, &i));
-    EXPECT_EQ(1, i);
-    tr_variantFree(&top);
-
-    tr_rpc_parse_list_str(&top, "6,7", TR_BAD_SIZE);
+    tr_rpc_parse_list_str(&top, "6,7"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
     EXPECT_EQ(2, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
@@ -54,14 +52,14 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(7, i);
     tr_variantFree(&top);
 
-    tr_rpc_parse_list_str(&top, "asdf", TR_BAD_SIZE);
+    tr_rpc_parse_list_str(&top, "asdf"sv);
     EXPECT_TRUE(tr_variantIsString(&top));
     EXPECT_TRUE(tr_variantGetStr(&top, &str, &len));
     EXPECT_EQ(4, len);
     EXPECT_STREQ("asdf", str);
     tr_variantFree(&top);
 
-    tr_rpc_parse_list_str(&top, "1,3-5", TR_BAD_SIZE);
+    tr_rpc_parse_list_str(&top, "1,3-5"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
     EXPECT_EQ(4, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -601,7 +601,7 @@ static void addIdArg(tr_variant* args, char const* id_str, char const* fallback)
 
         if (isNum || isList)
         {
-            tr_rpc_parse_list_str(tr_variantDictAdd(args, TR_KEY_ids), id_str, strlen(id_str));
+            tr_rpc_parse_list_str(tr_variantDictAdd(args, TR_KEY_ids), id_str);
         }
         else
         {


### PR DESCRIPTION
A step towards replacing TR_BAD_SIZE (which is shorthand in libtransmission for saying "the receiving func needs to strlen() this char*") with std::string_view.

This PR updates the signature of tr_rpc_parse_list_str() to take a std::string_view instead of a char const* str + size_t length.

Previous: #1962