### PR TITLE
refactor: tr_utf8clean now takes a std::string_view

### DIFF
--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -227,7 +227,7 @@ static bool getfile(char** setme, bool* is_adjusted, char const* root, tr_varian
         char const* const buf_data = (char*)evbuffer_pullup(buf, -1);
         size_t const buf_len = evbuffer_get_length(buf);
 
-        *setme = tr_utf8clean(buf_data, buf_len);
+        *setme = tr_utf8clean(std::string_view{ buf_data, buf_len });
 
         if (!*is_adjusted)
         {
@@ -639,7 +639,7 @@ static char const* tr_metainfoParseImpl(
 
         tr_free(inf->name);
         tr_free(inf->originalName);
-        inf->name = tr_utf8clean(str, len);
+        inf->name = tr_utf8clean(std::string_view{ str, len });
         inf->originalName = tr_strdup(inf->name);
     }
 
@@ -653,7 +653,7 @@ static char const* tr_metainfoParseImpl(
     }
 
     tr_free(inf->comment);
-    inf->comment = tr_utf8clean(str, len);
+    inf->comment = tr_utf8clean(std::string_view{ str, len });
 
     /* created by */
     len = 0;
@@ -665,7 +665,7 @@ static char const* tr_metainfoParseImpl(
     }
 
     tr_free(inf->creator);
-    inf->creator = tr_utf8clean(str, len);
+    inf->creator = tr_utf8clean(std::string_view{ str, len });
 
     /* creation date */
     if (!tr_variantDictFindInt(meta, TR_KEY_creation_date, &i))

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1131,26 +1131,11 @@ static char* to_utf8(char const* in, size_t inlen)
     return ret;
 }
 
-char* tr_utf8clean(char const* str, size_t max_len)
+char* tr_utf8clean(std::string_view str)
 {
-    char* ret;
-    char const* end;
-
-    if (max_len == TR_BAD_SIZE)
-    {
-        max_len = strlen(str);
-    }
-
-    if (tr_utf8_validate(str, max_len, &end))
-    {
-        ret = tr_strndup(str, max_len);
-    }
-    else
-    {
-        ret = to_utf8(str, max_len);
-    }
-
-    TR_ASSERT(tr_utf8_validate(ret, TR_BAD_SIZE, nullptr));
+    char* const ret = tr_utf8_validate(std::data(str), std::size(str), nullptr) ? tr_strndup(std::data(str), std::size(str)) :
+                                                                                  to_utf8(std::data(str), std::size(str));
+    TR_ASSERT(tr_utf8_validate(ret, strlen(ret), nullptr));
     return ret;
 }
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -111,9 +111,8 @@ void tr_wait_msec(long int delay_milliseconds);
  * @brief make a copy of 'str' whose non-utf8 content has been corrected or stripped
  * @return a newly-allocated string that must be freed with tr_free()
  * @param str the string to make a clean copy of
- * @param len the length of the string to copy. If -1, the entire string is used.
  */
-char* tr_utf8clean(char const* str, size_t len) TR_GNUC_MALLOC;
+char* tr_utf8clean(std::string_view str) TR_GNUC_MALLOC;
 
 #ifdef _WIN32
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -82,35 +82,35 @@ TEST_F(UtilsTest, trBuildpath)
 
 TEST_F(UtilsTest, trUtf8clean)
 {
-    auto const* in = "hello world";
-    auto out = makeString(tr_utf8clean(in, TR_BAD_SIZE));
+    auto in = "hello world"sv;
+    auto out = makeString(tr_utf8clean(in));
     EXPECT_EQ(in, out);
 
-    in = "hello world";
-    out = makeString(tr_utf8clean(in, 5));
-    EXPECT_EQ("hello", out);
+    in = "hello world"sv;
+    out = makeString(tr_utf8clean(in.substr(0, 5)));
+    EXPECT_EQ("hello"sv, out);
 
     // this version is not utf-8 (but cp866)
-    in = "\x92\xE0\xE3\xA4\xAD\xAE \xA1\xEB\xE2\xEC \x81\xAE\xA3\xAE\xAC";
-    out = makeString(tr_utf8clean(in, 17));
-    EXPECT_TRUE(out.size() == 17 || out.size() == 33);
+    in = "\x92\xE0\xE3\xA4\xAD\xAE \xA1\xEB\xE2\xEC \x81\xAE\xA3\xAE\xAC"sv;
+    out = makeString(tr_utf8clean(in));
+    EXPECT_TRUE(std::size(out) == 17 || std::size(out) == 33);
     EXPECT_TRUE(tr_utf8_validate(out.c_str(), out.size(), nullptr));
 
     // same string, but utf-8 clean
-    in = "Трудно быть Богом";
-    out = makeString(tr_utf8clean(in, TR_BAD_SIZE));
+    in = "Трудно быть Богом"sv;
+    out = makeString(tr_utf8clean(in));
     EXPECT_NE(nullptr, out.data());
     EXPECT_TRUE(tr_utf8_validate(out.c_str(), out.size(), nullptr));
     EXPECT_EQ(in, out);
 
-    in = "\xF4\x00\x81\x82";
-    out = makeString(tr_utf8clean(in, 4));
+    in = "\xF4\x00\x81\x82"sv;
+    out = makeString(tr_utf8clean(in));
     EXPECT_NE(nullptr, out.data());
     EXPECT_TRUE(out.size() == 1 || out.size() == 2);
     EXPECT_TRUE(tr_utf8_validate(out.c_str(), out.size(), nullptr));
 
-    in = "\xF4\x33\x81\x82";
-    out = makeString(tr_utf8clean(in, 4));
+    in = "\xF4\x33\x81\x82"sv;
+    out = makeString(tr_utf8clean(in));
     EXPECT_NE(nullptr, out.data());
     EXPECT_TRUE(out.size() == 4 || out.size() == 7);
     EXPECT_TRUE(tr_utf8_validate(out.c_str(), out.size(), nullptr));


### PR DESCRIPTION
A step towards replacing TR_BAD_SIZE (which is shorthand in libtransmission for saying "the receiving func needs to strlen() this char*") with std::string_view.

This PR updates the signature of tr_utf8clean() to take a std::string_view instead of a char const* str + size_t length.

Previous: 1966