### PR TITLE
refactor: cppcoreguidelines-init-variables pt. 6

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -2,6 +2,7 @@
 # Many of these checks are disabled only because the code hasn't been
 # cleaned up yet. Pull requests welcomed.
 Checks: >
+  cppcoreguidelines-init-variables,
   modernize-loop-convert,
   modernize-pass-by-value,
   modernize-use-default-member-init,

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -133,7 +133,7 @@ uint64_t tr_cpHaveValid(tr_completion const* ccp)
     if (ccp->haveValidIsDirty)
     {
         uint64_t size = 0;
-        tr_completion* cp = (tr_completion*)ccp; /* mutable */
+        tr_completion* cp = const_cast<tr_completion*>(ccp); /* mutable */
         tr_torrent const* tor = ccp->tor;
         tr_info const* info = &tor->info;
 
@@ -159,7 +159,7 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
         uint64_t size = 0;
         tr_torrent const* tor = ccp->tor;
         tr_info const* inf = tr_torrentInfo(tor);
-        tr_completion* cp = (tr_completion*)ccp; /* mutable */
+        tr_completion* cp = const_cast<tr_completion*>(ccp); /* mutable */
 
         if (tr_cpHasAll(ccp))
         {

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -77,10 +77,10 @@ tr_completeness tr_cpGetStatus(tr_completion const* cp)
 
 void tr_cpPieceRem(tr_completion* cp, tr_piece_index_t piece)
 {
-    tr_block_index_t f;
-    tr_block_index_t l;
     tr_torrent const* tor = cp->tor;
 
+    auto f = tr_block_index_t{};
+    auto l = tr_block_index_t{};
     tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
 
     for (tr_block_index_t i = f; i <= l; ++i)
@@ -98,8 +98,8 @@ void tr_cpPieceRem(tr_completion* cp, tr_piece_index_t piece)
 
 void tr_cpPieceAdd(tr_completion* cp, tr_piece_index_t piece)
 {
-    tr_block_index_t f;
-    tr_block_index_t l;
+    auto f = tr_block_index_t{};
+    auto l = tr_block_index_t{};
     tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
 
     for (tr_block_index_t i = f; i <= l; ++i)
@@ -178,8 +178,8 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
                 }
                 else
                 {
-                    tr_block_index_t f;
-                    tr_block_index_t l;
+                    auto f = tr_block_index_t{};
+                    auto l = tr_block_index_t{};
                     tr_torGetPieceBlockRange(cp->tor, p, &f, &l);
 
                     n = cp->blockBitfield->countRange(f, l + 1);
@@ -228,9 +228,9 @@ void tr_cpGetAmountDone(tr_completion const* cp, float* tab, int tabCount)
         }
         else
         {
-            tr_block_index_t f;
-            tr_block_index_t l;
             tr_piece_index_t const piece = (tr_piece_index_t)i * interval;
+            auto f = tr_block_index_t{};
+            auto l = tr_block_index_t{};
             tr_torGetPieceBlockRange(cp->tor, piece, &f, &l);
             tab[i] = cp->blockBitfield->countRange(f, l + 1) / (float)(l + 1 - f);
         }
@@ -298,9 +298,7 @@ std::vector<uint8_t> tr_cpCreatePieceBitfield(tr_completion const* cp)
 {
     TR_ASSERT(tr_torrentHasMetadata(cp->tor));
 
-    tr_piece_index_t n;
-
-    n = cp->tor->info.pieceCount;
+    auto const n = cp->tor->info.pieceCount;
 
     Bitfield pieces(n);
 

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -126,9 +126,8 @@ tr_magnet_info* tr_magnetParse(char const* uri)
             char const* delim = strchr(key, '=');
             char const* val = delim == nullptr ? nullptr : delim + 1;
             char const* next = strchr(delim == nullptr ? key : val, '&');
-            size_t keylen;
-            size_t vallen;
 
+            auto keylen = size_t{};
             if (delim != nullptr)
             {
                 keylen = (size_t)(delim - key);
@@ -142,6 +141,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
                 keylen = strlen(key);
             }
 
+            auto vallen = size_t{};
             if (val == nullptr)
             {
                 vallen = 0;
@@ -179,7 +179,7 @@ tr_magnet_info* tr_magnetParse(char const* uri)
 
             if (vallen > 0 && trCount < MAX_TRACKERS)
             {
-                int i;
+                auto i = int{};
 
                 if (keylen == 2 && memcmp(key, "tr", 2) == 0)
                 {
@@ -253,7 +253,6 @@ void tr_magnetFree(tr_magnet_info* info)
 
 void tr_magnetCreateMetainfo(tr_magnet_info const* info, tr_variant* top)
 {
-    tr_variant* d;
     tr_variantInitDict(top, 4);
 
     /* announce list */
@@ -283,7 +282,7 @@ void tr_magnetCreateMetainfo(tr_magnet_info const* info, tr_variant* top)
     }
 
     /* nonstandard keys */
-    d = tr_variantDictAddDict(top, TR_KEY_magnet_info, 2);
+    auto* const d = tr_variantDictAddDict(top, TR_KEY_magnet_info, 2);
     tr_variantDictAddRaw(d, TR_KEY_info_hash, info->hash, 20);
 
     if (info->displayName != nullptr)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -88,8 +88,8 @@ static tr_port getRandomPort(tr_session* s)
    designates beta (Azureus-style) */
 void tr_peerIdInit(uint8_t* buf)
 {
-    int val;
     int total = 0;
+    // TODO: use a string_view
     char const* pool = "0123456789abcdefghijklmnopqrstuvwxyz";
     int const base = 36;
 
@@ -99,12 +99,12 @@ void tr_peerIdInit(uint8_t* buf)
 
     for (int i = 8; i < 19; ++i)
     {
-        val = buf[i] % base;
+        int const val = buf[i] % base;
         total += val;
         buf[i] = pool[val];
     }
 
-    val = total % base != 0 ? base - total % base : 0;
+    int const val = total % base != 0 ? base - total % base : 0;
     buf[19] = pool[val];
     buf[20] = '\0';
 }
@@ -168,12 +168,11 @@ static void free_incoming_peer_port(tr_session* session)
 
 static void accept_incoming_peer(evutil_socket_t fd, [[maybe_unused]] short what, void* vsession)
 {
-    tr_socket_t clientSocket;
-    tr_port clientPort;
-    tr_address clientAddr;
     auto* session = static_cast<tr_session*>(vsession);
 
-    clientSocket = tr_netAccept(session, fd, &clientAddr, &clientPort);
+    auto clientAddr = tr_address{};
+    auto clientPort = tr_port{};
+    auto const clientSocket = tr_netAccept(session, fd, &clientAddr, &clientPort);
 
     if (clientSocket != TR_BAD_SOCKET)
     {
@@ -196,10 +195,8 @@ static void accept_incoming_peer(evutil_socket_t fd, [[maybe_unused]] short what
 
 static void open_incoming_peer_port(tr_session* session)
 {
-    struct tr_bindinfo* b;
-
     /* bind an ipv4 port to listen for incoming peers... */
-    b = session->bind_ipv4;
+    auto* b = session->bind_ipv4;
     b->socket = tr_netBindTCP(&b->addr, session->private_peer_port, false);
 
     if (b->socket != TR_BAD_SOCKET)
@@ -224,8 +221,8 @@ static void open_incoming_peer_port(tr_session* session)
 
 tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_af_type, bool* is_default_value)
 {
-    char const* default_value;
-    struct tr_bindinfo const* bindinfo;
+    char const* default_value = "";
+    tr_bindinfo const* bindinfo = nullptr;
 
     switch (tr_af_type)
     {
@@ -240,8 +237,6 @@ tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_a
         break;
 
     default:
-        bindinfo = nullptr;
-        default_value = "";
         break;
     }
 
@@ -265,9 +260,6 @@ tr_address const* tr_sessionGetPublicAddress(tr_session const* session, int tr_a
 
 static int parse_tos(char const* tos)
 {
-    char* p;
-    int value;
-
     if (evutil_ascii_strcasecmp(tos, "") == 0)
     {
         return 0;
@@ -303,14 +295,9 @@ static int parse_tos(char const* tos)
         return TR_IPTOS_LOWDELAY;
     }
 
-    value = strtol(tos, &p, 0);
-
-    if (p == nullptr || p == tos)
-    {
-        return 0;
-    }
-
-    return value;
+    char* p = nullptr;
+    int const value = strtol(tos, &p, 0);
+    return p == nullptr || p == tos ? 0 : value;
 }
 
 static char const* format_tos(int value)
@@ -495,15 +482,9 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* configDir, char const*
 {
     TR_ASSERT(tr_variantIsDict(dict));
 
-    char* filename;
-    tr_variant oldDict;
-    tr_variant fileSettings;
-    bool success;
-    tr_error* error = nullptr;
-
     /* initializing the defaults: caller may have passed in some app-level defaults.
      * preserve those and use the session defaults to fill in any missing gaps. */
-    oldDict = *dict;
+    auto oldDict = *dict;
     tr_variantInitDict(dict, 0);
     tr_sessionGetDefaultSettings(dict);
     tr_variantMergeDicts(dict, &oldDict);
@@ -516,8 +497,10 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* configDir, char const*
     }
 
     /* file settings override the defaults */
-    filename = tr_buildPath(configDir, "settings.json", nullptr);
-
+    auto fileSettings = tr_variant{};
+    char* const filename = tr_buildPath(configDir, "settings.json", nullptr);
+    auto success = bool{};
+    tr_error* error = nullptr;
     if (tr_variantFromFile(&fileSettings, TR_VARIANT_FMT_JSON, filename, &error))
     {
         tr_variantMergeDicts(dict, &fileSettings);
@@ -622,9 +605,6 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
 {
     TR_ASSERT(tr_variantIsDict(clientSettings));
 
-    int64_t i;
-    struct init_data data;
-
     tr_timeUpdate(time(nullptr));
 
     /* initialize the bare skeleton of the session object */
@@ -639,6 +619,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     tr_variantInitList(&session->removedTorrents, 0);
 
     /* nice to start logging at the very beginning */
+    auto i = int64_t{};
     if (tr_variantDictFindInt(clientSettings, TR_KEY_message_level, &i))
     {
         tr_logSetLevel(tr_log_level(i));
@@ -650,6 +631,8 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     TR_ASSERT(session->events != nullptr);
 
     /* run the rest in the libtransmission thread */
+
+    auto data = init_data{};
     data.done = false;
     data.session = session;
     data.configDir = configDir;
@@ -674,10 +657,6 @@ static void onNowTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] sho
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(session->nowTimer != nullptr);
 
-    int usec;
-    int const min = 100;
-    int const max = 999999;
-    struct timeval tv;
     time_t const now = time(nullptr);
 
     /**
@@ -716,18 +695,11 @@ static void onNowTimer([[maybe_unused]] evutil_socket_t fd, [[maybe_unused]] sho
     **/
 
     /* schedule the next timer for right after the next second begins */
+    struct timeval tv;
     tr_gettimeofday(&tv);
-    usec = 1000000 - tv.tv_usec;
-
-    if (usec > max)
-    {
-        usec = max;
-    }
-
-    if (usec < min)
-    {
-        usec = min;
-    }
+    int constexpr Min = 100;
+    int constexpr Max = 999999;
+    int const usec = std::clamp(int(1000000 - tv.tv_usec), Min, Max);
 
     tr_timerAdd(session->nowTimer, 0, usec);
 }
@@ -819,12 +791,12 @@ static void sessionSetImpl(void* vdata)
     TR_ASSERT(tr_variantIsDict(settings));
     TR_ASSERT(tr_amInEventThread(session));
 
-    int64_t i;
-    double d;
-    bool boolVal;
-    char const* strVal;
-    struct tr_bindinfo b;
-    struct tr_turtle_info* turtle = &session->turtle;
+    auto b = tr_bindinfo{};
+    auto boolVal = bool{};
+    auto d = double{};
+    auto i = int64_t{};
+    char const* strVal = nullptr;
+    tr_turtle_info* const turtle = &session->turtle;
 
     if (tr_variantDictFindInt(settings, TR_KEY_message_level, &i))
     {
@@ -1228,18 +1200,8 @@ char const* tr_sessionGetDownloadDir(tr_session const* session)
 
 int64_t tr_sessionGetDirFreeSpace(tr_session* session, char const* dir)
 {
-    int64_t free_space;
-
-    if (tr_strcmp0(dir, tr_sessionGetDownloadDir(session)) == 0)
-    {
-        free_space = tr_device_info_get_disk_space(session->downloadDir).free;
-    }
-    else
-    {
-        free_space = tr_getDirSpace(dir).free;
-    }
-
-    return free_space;
+    return tr_strcmp0(dir, tr_sessionGetDownloadDir(session)) == 0 ? tr_device_info_get_disk_space(session->downloadDir).free :
+                                                                     tr_getDirSpace(dir).free;
 }
 
 /***
@@ -1571,13 +1533,11 @@ static void useAltSpeed(tr_session* s, struct tr_turtle_info* t, bool enabled, b
  */
 static bool getInTurtleTime(struct tr_turtle_info const* t)
 {
-    struct tm tm;
-    size_t minute_of_the_week;
     time_t const now = tr_time();
-
+    struct tm tm;
     tr_localtime_r(&now, &tm);
 
-    minute_of_the_week = tm.tm_wday * MINUTES_PER_DAY + tm.tm_hour * MINUTES_PER_HOUR + tm.tm_min;
+    size_t minute_of_the_week = tm.tm_wday * MINUTES_PER_DAY + tm.tm_hour * MINUTES_PER_HOUR + tm.tm_min;
 
     if (minute_of_the_week >= MINUTES_PER_WEEK) /* leap minutes? */
     {
@@ -2159,17 +2119,16 @@ static void sessionLoadTorrents(void* vdata)
     auto torrents = std::list<tr_torrent*>{};
     if (odir != TR_BAD_SYS_DIR)
     {
-        char const* name;
-
+        char const* name = nullptr;
         while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (tr_str_has_suffix(name, ".torrent"))
             {
-                tr_torrent* tor;
-                char* path = tr_buildPath(dirname, name, nullptr);
+                char* const path = tr_buildPath(dirname, name, nullptr);
                 tr_ctorSetMetainfoFromFile(data->ctor, path);
 
-                if ((tor = tr_torrentNew(data->ctor, nullptr, nullptr)) != nullptr)
+                tr_torrent* const tor = tr_torrentNew(data->ctor, nullptr, nullptr);
+                if (tor != nullptr)
                 {
                     torrents.push_back(tor);
                 }
@@ -2390,8 +2349,7 @@ static void setPortForwardingEnabled(void* vdata)
 
 void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled)
 {
-    struct port_forwarding_data* d;
-    d = tr_new0(struct port_forwarding_data, 1);
+    auto* const d = tr_new0(struct port_forwarding_data, 1);
     d->shared = session->shared;
     d->enabled = enabled;
     tr_runInEventThread(session, setPortForwardingEnabled, d);
@@ -2418,15 +2376,12 @@ static bool tr_stringEndsWith(char const* strval, char const* end)
 
 static void loadBlocklists(tr_session* session)
 {
-    tr_sys_dir_t odir;
-    char* dirname;
-    char const* name;
     auto loadme = std::unordered_set<std::string>{};
-    bool const isEnabled = session->isBlocklistEnabled;
+    auto const isEnabled = session->isBlocklistEnabled;
 
     /* walk the blocklist directory... */
-    dirname = tr_buildPath(session->configDir, "blocklists", nullptr);
-    odir = tr_sys_dir_open(dirname, nullptr);
+    char* const dirname = tr_buildPath(session->configDir, "blocklists", nullptr);
+    auto const odir = tr_sys_dir_open(dirname, nullptr);
 
     if (odir == TR_BAD_SYS_DIR)
     {
@@ -2434,9 +2389,9 @@ static void loadBlocklists(tr_session* session)
         return;
     }
 
+    char const* name = nullptr;
     while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
     {
-        char* path;
         char* load = nullptr;
 
         if (name[0] == '.') /* ignore dotfiles */
@@ -2444,7 +2399,7 @@ static void loadBlocklists(tr_session* session)
             continue;
         }
 
-        path = tr_buildPath(dirname, name, nullptr);
+        char* const path = tr_buildPath(dirname, name, nullptr);
 
         if (tr_stringEndsWith(path, ".bin"))
         {
@@ -2452,11 +2407,10 @@ static void loadBlocklists(tr_session* session)
         }
         else
         {
-            char* binname;
             tr_sys_path_info path_info;
             tr_sys_path_info binname_info;
 
-            binname = tr_strdup_printf("%s" TR_PATH_DELIMITER_STR "%s.bin", dirname, name);
+            char* const binname = tr_strdup_printf("%s" TR_PATH_DELIMITER_STR "%s.bin", dirname, name);
 
             if (!tr_sys_path_get_info(binname, 0, &binname_info, nullptr)) /* create it */
             {
@@ -2474,13 +2428,10 @@ static void loadBlocklists(tr_session* session)
                 tr_sys_path_get_info(path, 0, &path_info, nullptr) &&
                 path_info.last_modified_at >= binname_info.last_modified_at) /* update it */
             {
-                char* old;
-                tr_blocklistFile* b;
-
-                old = tr_strdup_printf("%s.old", binname);
+                char* const old = tr_strdup_printf("%s.old", binname);
                 tr_sys_path_remove(old, nullptr);
                 tr_sys_path_rename(binname, old, nullptr);
-                b = tr_blocklistFileNew(binname, isEnabled);
+                auto* const b = tr_blocklistFileNew(binname, isEnabled);
 
                 if (tr_blocklistFileSetContent(b, path) > 0)
                 {
@@ -2651,9 +2602,8 @@ static void metainfoLookupInit(tr_session* session)
         tr_ctor* ctor = tr_ctorNew(session);
         tr_ctorSetSave(ctor, false); /* since we already have them */
 
-        char const* name;
-
         /* walk through the directory and find the mappings */
+        char const* name = nullptr;
         while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
         {
             if (tr_str_has_suffix(name, ".torrent"))


### PR DESCRIPTION
part 6 of a series of PRs that applies clang-tidy's `cppcoreguidelines-init-variables` to libtransmission:

- move uninitialized variables to be declared as close as possible to where they are used
- prefer const
- prefer auto

This PR reduces the number of `cppcoreguidelines-init-variables` warnings to **443**

Previous part: #1970