### PR TITLE
refactor: clang-tidy --fix modernize-deprecated-headers

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -2,9 +2,14 @@
 # Many of these checks are disabled only because the code hasn't been
 # cleaned up yet. Pull requests welcomed.
 Checks: >
+  misc-static-assert,
+  modernize-deprecated-headers,
   modernize-loop-convert,
   modernize-pass-by-value,
+  modernize-return-braced-init-list,
   modernize-use-default-member-init,
+  modernize-use-emplace,
+  modernize-use-equals-default,
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <limits.h> /* USHRT_MAX */
-#include <stdio.h> /* fprintf() */
-#include <string.h> /* strchr(), memcmp(), memcpy() */
+#include <climits> /* USHRT_MAX */
+#include <cstdio> /* fprintf() */
+#include <cstring> /* strchr(), memcmp(), memcpy() */
 
 #include <event2/buffer.h>
 #include <event2/http.h> /* for HTTP_OK */

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <errno.h> /* errno, EAFNOSUPPORT */
-#include <string.h> /* memcpy(), memset() */
+#include <cerrno> /* errno, EAFNOSUPPORT */
+#include <cstring> /* memcpy(), memset() */
 #include <vector>
 
 #include <event2/buffer.h>

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -6,10 +6,10 @@
  *
  */
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h> /* bsearch(), qsort() */
-#include <string.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib> /* bsearch(), qsort() */
+#include <cstring>
 
 #include "transmission.h"
 #include "blocklist.h"

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <stdlib.h> /* qsort() */
+#include <cstdlib> /* qsort() */
 
 #include <event2/buffer.h>
 

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -13,9 +13,9 @@
 #include <iterator>
 #include <optional>
 #include <string_view>
-#include <ctype.h> /* isprint() */
-#include <stdlib.h> /* strtol() */
-#include <string.h>
+#include <cctype> /* isprint() */
+#include <cstdlib> /* strtol() */
+#include <cstring>
 #include <tuple>
 
 #include "transmission.h"

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <stdarg.h>
-#include <stdlib.h> /* abs(), srand(), rand() */
-#include <string.h> /* memcpy(), memmove(), memset(), strcmp(), strlen() */
+#include <cstdarg>
+#include <cstdlib> /* abs(), srand(), rand() */
+#include <cstring> /* memcpy(), memmove(), memset(), strcmp(), strlen() */
 
 #include <arc4.h>
 

--- a/libtransmission/crypto.cc
+++ b/libtransmission/crypto.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <string.h> /* memcpy(), memmove(), memset() */
+#include <cstring> /* memcpy(), memmove(), memset() */
 
 #include <arc4.h>
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <errno.h>
-#include <string.h> /* strcmp(), strlen(), strncmp() */
+#include <cerrno>
+#include <cstring> /* strcmp(), strlen(), strncmp() */
 
 #include <event2/buffer.h>
 #include <event2/event.h>

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 
 #include <event2/buffer.h>
 

--- a/libtransmission/magnet.cc
+++ b/libtransmission/magnet.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <string.h> /* strchr() */
-#include <stdio.h> /* sscanf() */
+#include <cstring> /* strchr() */
+#include <cstdio> /* sscanf() */
 
 #include "transmission.h"
 #include "crypto-utils.h" /* tr_hex_to_sha1() */

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -8,7 +8,7 @@
 
 #include <algorithm>
 #include <array>
-#include <string.h> /* strlen() */
+#include <cstring> /* strlen() */
 #include <string_view>
 #include <typeinfo>
 

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <errno.h>
-#include <time.h>
-#include <inttypes.h>
+#include <cerrno>
+#include <ctime>
+#include <cinttypes>
 
 #include <event2/util.h> /* evutil_inet_ntop() */
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -20,9 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
-#include <errno.h>
-#include <limits.h>
-#include <string.h>
+#include <cerrno>
+#include <climits>
+#include <cstring>
 
 #include <sys/types.h>
 
@@ -34,7 +34,7 @@
 
 #include <event2/util.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 #include "transmission.h"

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 
 #ifndef _WIN32
 #include <sys/stat.h>

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <errno.h>
-#include <signal.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <csignal>
+#include <cstdlib>
 
 #include <fcntl.h>
 #include <sys/types.h>

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <errno.h> /* EINVAL */
+#include <cerrno> /* EINVAL */
 
 #include "transmission.h"
 #include "file.h"

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -6,8 +6,8 @@
  *
  */
 
-#include <limits.h> /* INT_MAX */
-#include <string.h> /* memcpy(), memset(), memcmp() */
+#include <climits> /* INT_MAX */
+#include <cstring> /* memcpy(), memset(), memcmp() */
 
 #include <event2/buffer.h>
 

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 
 #include "tr-assert.h"
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -21,8 +21,8 @@ THE SOFTWARE.
 
 */
 
-#include <string.h> /* memcmp(), memcpy(), memset() */
-#include <stdlib.h> /* malloc(), free() */
+#include <cstring> /* memcmp(), memcpy(), memset() */
+#include <cstdlib> /* malloc(), free() */
 
 #ifdef _WIN32
 #include <io.h> /* dup2() */
@@ -32,7 +32,7 @@ THE SOFTWARE.
 
 #include <event2/event.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 #include "transmission.h"

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #include <event2/event.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <libutp/utp.h>
 
 #include "transmission.h"

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -6,10 +6,10 @@
  *
  */
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 
-#include <signal.h>
+#include <csignal>
 
 #ifdef _WIN32
 #include <winsock2.h>

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <errno.h>
+#include <cerrno>
 
 #ifdef SYSTEM_MINIUPNP
 #include <miniupnpc/miniupnpc.h>

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -6,11 +6,11 @@
  *
  */
 
-#include <ctype.h> /* isdigit() */
+#include <cctype> /* isdigit() */
 #include <deque>
-#include <errno.h>
-#include <stdlib.h> /* strtoul() */
-#include <string.h> /* strlen(), memchr() */
+#include <cerrno>
+#include <cstdlib> /* strtoul() */
+#include <cstring> /* strlen(), memchr() */
 #include <string_view>
 #include <optional>
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -7,12 +7,12 @@
  */
 
 #include <array>
-#include <ctype.h>
+#include <cctype>
 #include <deque>
-#include <errno.h> /* EILSEQ, EINVAL */
-#include <math.h> /* fabs() */
-#include <stdio.h>
-#include <string.h>
+#include <cerrno> /* EILSEQ, EINVAL */
+#include <cmath> /* fabs() */
+#include <cstdio>
+#include <cstring>
 
 #include <event2/buffer.h> /* evbuffer_add() */
 #include <event2/util.h> /* evutil_strtoll() */

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -16,17 +16,17 @@
 #endif
 
 #include <algorithm> // std::sort
-#include <errno.h>
+#include <cerrno>
 #include <stack>
-#include <stdlib.h> /* strtod() */
-#include <string.h>
+#include <cstdlib> /* strtod() */
+#include <cstring>
 #include <vector>
 
 #ifdef _WIN32
 #include <share.h>
 #endif
 
-#include <locale.h> /* setlocale() */
+#include <clocale> /* setlocale() */
 
 #if defined(HAVE_USELOCALE) && defined(HAVE_XLOCALE_H)
 #include <xlocale.h>

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <errno.h>
+#include <cerrno>
 #include <string>
 #include <unordered_set>
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include <errno.h>
-#include <limits.h> /* NAME_MAX */
-#include <stdlib.h> /* realloc() */
+#include <cerrno>
+#include <climits> /* NAME_MAX */
+#include <cstdlib> /* realloc() */
 
 #include <unistd.h> /* close() */
 

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <string.h> /* strcmp() */
+#include <cstring> /* strcmp() */
 
 #include <event2/event.h>
 #include <event2/util.h>


### PR DESCRIPTION
Another incremental libtransmission C++ification PR.

This PR changes code that includes deprecated headers to including the non-deprecated versions.