### PR TITLE
refactor: add performance-* to libt .clang-tidy

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -13,5 +13,6 @@ Checks: >
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,
+  performance-*,
   readability-avoid-const-params-in-decls,
   readability-else-after-return

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -1106,7 +1106,7 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
 
     void* ret = mmap(nullptr, size, PROT_READ, MAP_SHARED, handle, offset);
 
-    if (ret == MAP_FAILED)
+    if (ret == MAP_FAILED) // NOLINT(performance-no-int-to-ptr)
     {
         set_system_error(error, errno);
         ret = nullptr;

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -122,7 +122,7 @@ bool tr_spawn_async(char* const* cmd, char* const* env, char const* work_dir, tr
     if (!sigchld_handler_set)
     {
         /* FIXME: "The effects of signal() in a multithreaded process are unspecified." (c) man 2 signal */
-        if (signal(SIGCHLD, &handle_sigchld) == SIG_ERR)
+        if (signal(SIGCHLD, &handle_sigchld) == SIG_ERR) // NOLINT(performance-no-int-to-ptr)
         {
             set_system_error(error, errno, "Call to signal()");
             return false;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1108,7 +1108,7 @@ static char* to_utf8(char const* in, size_t inlen)
 
         iconv_t cd = iconv_open("UTF-8", test_encoding);
 
-        if (cd != (iconv_t)-1)
+        if (cd != (iconv_t)-1) // NOLINT(performance-no-int-to-ptr)
         {
             if (iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft) != (size_t)-1)
             {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -498,7 +498,7 @@ static std::string make_url(tr_webseed* w, tr_file const* file)
         tr_http_escape(buf, file->name, false);
     }
 
-    auto const url = std::string{ (char const*)evbuffer_pullup(buf, -1), evbuffer_get_length(buf) };
+    auto url = std::string{ (char const*)evbuffer_pullup(buf, -1), evbuffer_get_length(buf) };
     evbuffer_free(buf);
     return url;
 }


### PR DESCRIPTION
Barely a PR at all, since the net change was to add three `NOLINT` to disable pointer-to-int conversion when using POSIX-defined values, and one `const` removal to allow for move-return-value.

But still, the goal of these iterative .clang-tidy changes is to add helpful warnings on future code, so: this PR adds `performance-*` to the libtransmission clang-tidy checks.