### PR TITLE
build: silence new clang-tidy 13 warnings

### DIFF
--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -4,6 +4,8 @@
 Checks: >
   bugprone-*,
   -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-narrowing-conversions,
   cert-*,
   -cert-err58-cpp,
@@ -28,6 +30,7 @@ Checks: >
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -47,6 +50,7 @@ Checks: >
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   modernize-*,
+  -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type, # keep
   performance-*,
   readability-*,

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -65,9 +65,6 @@ Checks: >
   -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument
 
-WarningsAsErrors: >
-  *
-
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
   - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -4,6 +4,8 @@
 Checks: >
   bugprone-*,
   -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-narrowing-conversions,
   cert-*,
   -cert-dcl50-cpp,
@@ -46,8 +48,9 @@ Checks: >
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   modernize-*,
-  -modernize-raw-string-literal,
   -modernize-concat-nested-namespaces,
+  -modernize-raw-string-literal,
+  -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
   performance-*,
   -performance-no-int-to-ptr,
@@ -59,7 +62,8 @@ Checks: >
   -readability-magic-numbers,
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,
-  -readability-static-accessed-through-instance
+  -readability-static-accessed-through-instance,
+  -readability-suspicious-call-argument
 
 WarningsAsErrors: >
   *


### PR DESCRIPTION
No code changes, just fixing FTBFS when upgrading to clang 13 / clang-tidy 13.

Also, remove 'WarningsAsErrors' from tests/libtransmission/.clang-tidy since newly-introduced clang-tidy checks cause FTBFS on Ubuntu 21.10