### PR TITLE
refactor: fixup! tr_quark_new() now takes a std::string_view (#1961)

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -414,7 +414,7 @@ auto constexpr my_static = std::array<std::string_view, 391>{ ""sv,
                                                               "watch-dir"sv,
                                                               "watch-dir-enabled"sv,
                                                               "webseeds"sv,
-                                                              "webseedsSendingToUs" };
+                                                              "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
     []() constexpr


### PR DESCRIPTION
Missed a sv literal in #1961. HT @reardonia from https://github.com/transmission/transmission/pull/1961#issuecomment-945178281