### PR TITLE
fix: crash on torrent with 65536 blocks per piece

### DIFF
--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -183,8 +183,8 @@ struct tr_torrent
     uint32_t lastBlockSize;
     uint32_t lastPieceSize;
 
-    uint16_t blockCountInPiece;
-    uint16_t blockCountInLastPiece;
+    uint32_t blockCountInPiece;
+    uint32_t blockCountInLastPiece;
 
     struct tr_completion completion;
 


### PR DESCRIPTION
Fixes #1411.