### PR TITLE
refactor: cppcoreguidelines-init-variables pt. 8

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -2,7 +2,6 @@
 # Many of these checks are disabled only because the code hasn't been
 # cleaned up yet. Pull requests welcomed.
 Checks: >
-  cppcoreguidelines-init-variables,
   misc-static-assert,
   modernize-deprecated-headers,
   modernize-loop-convert,


### PR DESCRIPTION
part 8 of a series of PRs that applies clang-tidy's `cppcoreguidelines-init-variables` to libtransmission:

- move uninitialized variables to be declared as close as possible to where they are used
- prefer const
- prefer auto

This PR reduces the number of `cppcoreguidelines-init-variables` warnings to **323**

Previous part: #1989