### PR TITLE
refactor: cppcoreguidelines-init-variables pt. 9

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -639,7 +639,6 @@ static void myDebug(char const* file, int line, tr_peerMsgsImpl const* msgs, cha
         char addrstr[TR_ADDRSTRLEN];
         struct evbuffer* buf = evbuffer_new();
         char* base = tr_sys_path_basename(file, nullptr);
-        char* message;
 
         evbuffer_add_printf(
             buf,
@@ -653,7 +652,7 @@ static void myDebug(char const* file, int line, tr_peerMsgsImpl const* msgs, cha
         va_end(args);
         evbuffer_add_printf(buf, " (%s:%d)", base, line);
 
-        message = evbuffer_free_to_str(buf, nullptr);
+        char* const message = evbuffer_free_to_str(buf, nullptr);
         tr_sys_file_write_line(fp, message, nullptr);
 
         tr_free(base);
@@ -982,10 +981,7 @@ static bool requestIsValid(tr_peerMsgsImpl const* msgs, struct peer_request cons
 
 static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 {
-    tr_variant val;
-    bool allow_pex;
-    struct evbuffer* payload;
-    struct evbuffer* out = msgs->outMessages;
+    evbuffer* const out = msgs->outMessages;
     unsigned char const* ipv6 = tr_globalIPv6();
     static tr_quark version_quark = 0;
 
@@ -1006,6 +1002,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     bool const allow_metadata_xfer = !tr_torrentIsPrivate(msgs->torrent);
 
     /* decide if we want to advertise pex support */
+    auto allow_pex = bool{};
     if (!tr_torrentAllowsPex(msgs->torrent))
     {
         allow_pex = false;
@@ -1019,6 +1016,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
         allow_pex = true;
     }
 
+    auto val = tr_variant{};
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode != TR_CLEAR_PREFERRED);
 
@@ -1052,7 +1050,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
         }
     }
 
-    payload = tr_variantToBuf(&val, TR_VARIANT_FMT_BENC);
+    auto* const payload = tr_variantToBuf(&val, TR_VARIANT_FMT_BENC);
 
     evbuffer_add_uint32(out, 2 * sizeof(uint8_t) + evbuffer_get_length(payload));
     evbuffer_add_uint8(out, BT_LTEP);
@@ -1068,19 +1066,11 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
 static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuffer* inbuf)
 {
-    int64_t i;
-    tr_variant val;
-    tr_variant* sub;
-    uint8_t* tmp = tr_new(uint8_t, len);
-    uint8_t const* addr;
-    size_t addr_len;
-    tr_pex pex;
-
-    memset(&pex, 0, sizeof(tr_pex));
-
+    uint8_t* const tmp = tr_new(uint8_t, len);
     tr_peerIoReadBytes(msgs->io, inbuf, tmp, len);
     msgs->peerSentLtepHandshake = true;
 
+    auto val = tr_variant{};
     if (tr_variantFromBenc(&val, tmp, len) != 0 || !tr_variantIsDict(&val))
     {
         dbgmsg(msgs, "GET  extended-handshake, couldn't get dictionary");
@@ -1099,6 +1089,8 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
     }
 
     /* does the peer prefer encrypted connections? */
+    auto i = int64_t{};
+    auto pex = tr_pex{};
     if (tr_variantDictFindInt(&val, TR_KEY_e, &i))
     {
         msgs->encryption_preference = i != 0 ? ENCRYPTION_PREFERENCE_YES : ENCRYPTION_PREFERENCE_NO;
@@ -1113,6 +1105,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
     msgs->peerSupportsPex = false;
     msgs->peerSupportsMetadataXfer = false;
 
+    tr_variant* sub = nullptr;
     if (tr_variantDictFindDict(&val, TR_KEY_m, &sub))
     {
         if (tr_variantDictFindInt(sub, TR_KEY_ut_pex, &i))
@@ -1157,6 +1150,8 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
         dbgmsg(msgs, "peer's port is now %d", (int)i);
     }
 
+    uint8_t const* addr = nullptr;
+    auto addr_len = size_t{};
     if (tr_peerIoIsIncoming(msgs->io) && tr_variantDictFindRaw(&val, TR_KEY_ipv4, &addr, &addr_len) && addr_len == 4)
     {
         pex.addr.type = TR_AF_INET;
@@ -1191,8 +1186,8 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
     tr_peerIoReadBytes(msgs->io, inbuf, tmp, msglen);
     char const* const msg_end = (char const*)tmp + msglen;
 
-    tr_variant dict;
-    char const* benc_end;
+    auto dict = tr_variant{};
+    char const* benc_end = nullptr;
     if (tr_variantFromBencFull(&dict, tmp, msglen, nullptr, &benc_end) == 0)
     {
         (void)tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
@@ -1224,15 +1219,14 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
         }
         else
         {
-            tr_variant v;
-            struct evbuffer* payload;
-            struct evbuffer* out = msgs->outMessages;
+            evbuffer* const out = msgs->outMessages;
 
             /* build the rejection message */
+            auto v = tr_variant{};
             tr_variantInitDict(&v, 2);
             tr_variantDictAddInt(&v, TR_KEY_msg_type, METADATA_MSG_TYPE_REJECT);
             tr_variantDictAddInt(&v, TR_KEY_piece, piece);
-            payload = tr_variantToBuf(&v, TR_VARIANT_FMT_BENC);
+            evbuffer* const payload = tr_variantToBuf(&v, TR_VARIANT_FMT_BENC);
 
             /* write it out as a LTEP message to our outMessages buffer */
             evbuffer_add_uint32(out, 2 * sizeof(uint8_t) + evbuffer_get_length(payload));
@@ -1272,46 +1266,39 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
         return;
     }
 
-    uint8_t const* added;
-    size_t added_len;
-
+    uint8_t const* added = nullptr;
+    auto added_len = size_t{};
     if (tr_variantDictFindRaw(&val, TR_KEY_added, &added, &added_len))
     {
-        tr_pex* pex;
-        size_t n;
-        size_t added_f_len;
-        uint8_t const* added_f;
-
+        uint8_t const* added_f = nullptr;
+        auto added_f_len = size_t{};
         if (!tr_variantDictFindRaw(&val, TR_KEY_added_f, &added_f, &added_f_len))
         {
             added_f_len = 0;
             added_f = nullptr;
         }
 
-        pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
+        auto n = size_t{};
+        tr_pex* const pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
         n = std::min(n, size_t{ MAX_PEX_PEER_COUNT });
         tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
-
         tr_free(pex);
     }
 
     if (tr_variantDictFindRaw(&val, TR_KEY_added6, &added, &added_len))
     {
-        tr_pex* pex;
-        size_t n;
-        size_t added_f_len;
-        uint8_t const* added_f;
-
+        uint8_t const* added_f = nullptr;
+        auto added_f_len = size_t{};
         if (!tr_variantDictFindRaw(&val, TR_KEY_added6_f, &added_f, &added_f_len))
         {
             added_f_len = 0;
             added_f = nullptr;
         }
 
-        pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
+        auto n = size_t{};
+        tr_pex* const pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
         n = std::min(n, size_t{ MAX_PEX_PEER_COUNT });
         tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
-
         tr_free(pex);
     }
 
@@ -1324,8 +1311,7 @@ static void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* i
 {
     TR_ASSERT(msglen > 0);
 
-    uint8_t ltep_msgid;
-
+    auto ltep_msgid = uint8_t{};
     tr_peerIoReadUint8(msgs->io, inbuf, &ltep_msgid);
     msglen--;
 
@@ -1361,15 +1347,13 @@ static void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* i
 
 static ReadState readBtLength(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, size_t inlen)
 {
-    uint32_t len;
-
+    auto len = uint32_t{};
     if (inlen < sizeof(len))
     {
         return READ_LATER;
     }
 
     tr_peerIoReadUint32(msgs->io, inbuf, &len);
-
     if (len == 0) /* peer sent us a keepalive message */
     {
         dbgmsg(msgs, "got KeepAlive");
@@ -1387,13 +1371,12 @@ static ReadState readBtMessage(tr_peerMsgsImpl*, struct evbuffer*, size_t);
 
 static ReadState readBtId(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, size_t inlen)
 {
-    uint8_t id;
-
     if (inlen < sizeof(uint8_t))
     {
         return READ_LATER;
     }
 
+    auto id = uint8_t{};
     tr_peerIoReadUint8(msgs->io, inbuf, &id);
     msgs->incoming.id = id;
     dbgmsg(msgs, "msgs->incoming.id is now %d; msgs->incoming.length is %zu", id, (size_t)msgs->incoming.length);
@@ -1602,8 +1585,8 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
 #endif
     bool const fext = tr_peerIoSupportsFEXT(msgs->io);
 
-    uint32_t ui32;
-    uint32_t msglen = msgs->incoming.length;
+    auto ui32 = uint32_t{};
+    auto msglen = uint32_t{ msgs->incoming.length };
 
     TR_ASSERT(msglen > 0);
 
@@ -1850,7 +1833,6 @@ static int clientGotBlock(tr_peerMsgsImpl* msgs, struct evbuffer* data, struct p
     TR_ASSERT(msgs != nullptr);
     TR_ASSERT(req != nullptr);
 
-    int err;
     tr_torrent* tor = msgs->torrent;
     tr_block_index_t const block = _tr_block(tor, req->index, req->offset);
 
@@ -1884,7 +1866,8 @@ static int clientGotBlock(tr_peerMsgsImpl* msgs, struct evbuffer* data, struct p
     ***  Save the block
     **/
 
-    if ((err = tr_cacheWriteBlock(msgs->session->cache, tor, req->index, req->offset, req->length, data)) != 0)
+    int const err = tr_cacheWriteBlock(msgs->session->cache, tor, req->index, req->offset, req->length, data);
+    if (err != 0)
     {
         return err;
     }
@@ -1911,13 +1894,13 @@ static void didWrite(tr_peerIo* io, size_t bytesWritten, bool wasPieceData, void
 
 static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
 {
-    ReadState ret;
     auto* msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
     struct evbuffer* in = tr_peerIoGetReadBuffer(io);
     size_t const inlen = evbuffer_get_length(in);
 
     dbgmsg(msgs, "canRead: inlen is %zu, msgs->state is %d", inlen, msgs->state);
 
+    auto ret = ReadState{};
     if (inlen == 0)
     {
         ret = READ_LATER;
@@ -1972,23 +1955,20 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
     }
     else
     {
-        int estimatedBlocksInPeriod;
-        unsigned int rate_Bps;
-        unsigned int irate_Bps;
         int const floor = 4;
         int const seconds = REQUEST_BUF_SECS;
         uint64_t const now = tr_time_msec();
 
         /* Get the rate limit we should use.
          * FIXME: this needs to consider all the other peers as well... */
-        rate_Bps = tr_peerGetPieceSpeed_Bps(msgs, now, TR_PEER_TO_CLIENT);
-
+        auto rate_Bps = tr_peerGetPieceSpeed_Bps(msgs, now, TR_PEER_TO_CLIENT);
         if (tr_torrentUsesSpeedLimit(torrent, TR_PEER_TO_CLIENT))
         {
             rate_Bps = std::min(rate_Bps, tr_torrentGetSpeedLimit_Bps(torrent, TR_PEER_TO_CLIENT));
         }
 
         /* honor the session limits, if enabled */
+        auto irate_Bps = unsigned{};
         if (tr_torrentUsesSessionLimits(torrent) &&
             tr_sessionGetActiveSpeedLimit_Bps(torrent->session, TR_PEER_TO_CLIENT, &irate_Bps))
         {
@@ -1997,7 +1977,7 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
 
         /* use this desired rate to figure out how
          * many requests we should send to this peer */
-        estimatedBlocksInPeriod = (rate_Bps * seconds) / torrent->blockSize;
+        int const estimatedBlocksInPeriod = (rate_Bps * seconds) / torrent->blockSize;
         msgs->desiredRequestCount = std::max(floor, estimatedBlocksInPeriod);
 
         /* honor the peer's maximum request count, if specified */
@@ -2010,19 +1990,17 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
 
 static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
 {
-    int piece;
-
+    auto piece = int{};
     if (msgs->peerSupportsMetadataXfer && tr_torrentGetNextMetadataRequest(msgs->torrent, now, &piece))
     {
-        tr_variant tmp;
-        struct evbuffer* payload;
-        struct evbuffer* out = msgs->outMessages;
+        evbuffer* const out = msgs->outMessages;
 
         /* build the data message */
+        auto tmp = tr_variant{};
         tr_variantInitDict(&tmp, 3);
         tr_variantDictAddInt(&tmp, TR_KEY_msg_type, METADATA_MSG_TYPE_REQUEST);
         tr_variantDictAddInt(&tmp, TR_KEY_piece, piece);
-        payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
+        auto* const payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
 
         dbgmsg(msgs, "requesting metadata piece #%d", piece);
 
@@ -2048,11 +2026,10 @@ static void updateBlockRequests(tr_peerMsgsImpl* msgs)
         TR_ASSERT(msgs->is_client_interested());
         TR_ASSERT(!msgs->is_client_choked());
 
-        int n;
-        tr_block_index_t* blocks;
         int const numwant = msgs->desiredRequestCount - msgs->pendingReqsToPeer;
 
-        blocks = tr_new(tr_block_index_t, numwant);
+        auto* const blocks = tr_new(tr_block_index_t, numwant);
+        auto n = int{};
         tr_peerMgrGetNextRequests(msgs->torrent, msgs, numwant, blocks, &n, false);
 
         for (int i = 0; i < n; ++i)
@@ -2066,7 +2043,6 @@ static void updateBlockRequests(tr_peerMsgsImpl* msgs)
 
 static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
 {
-    int piece;
     size_t bytesWritten = 0;
     struct peer_request req;
     bool const haveMessages = evbuffer_get_length(msgs->outMessages) != 0;
@@ -2097,25 +2073,25 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
     ***  Metadata Pieces
     **/
 
+    auto piece = int{};
     if (tr_peerIoGetWriteBufferSpace(msgs->io, now) >= METADATA_PIECE_SIZE && popNextMetadataRequest(msgs, &piece))
     {
-        size_t dataLen;
-        bool ok = false;
+        auto ok = bool{ false };
 
+        auto dataLen = size_t{};
         auto* data = static_cast<char*>(tr_torrentGetMetadataPiece(msgs->torrent, piece, &dataLen));
 
         if (data != nullptr)
         {
-            tr_variant tmp;
-            struct evbuffer* payload;
-            struct evbuffer* out = msgs->outMessages;
+            evbuffer* const out = msgs->outMessages;
 
             /* build the data message */
+            auto tmp = tr_variant{};
             tr_variantInitDict(&tmp, 3);
             tr_variantDictAddInt(&tmp, TR_KEY_msg_type, METADATA_MSG_TYPE_DATA);
             tr_variantDictAddInt(&tmp, TR_KEY_piece, piece);
             tr_variantDictAddInt(&tmp, TR_KEY_total_size, msgs->torrent->infoDictLength);
-            payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
+            evbuffer* const payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
 
             /* write it out as a LTEP message to our outMessages buffer */
             evbuffer_add_uint32(out, 2 * sizeof(uint8_t) + evbuffer_get_length(payload) + dataLen);
@@ -2135,15 +2111,14 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
 
         if (!ok) /* send a rejection message */
         {
-            tr_variant tmp;
-            struct evbuffer* payload;
-            struct evbuffer* out = msgs->outMessages;
+            evbuffer* const out = msgs->outMessages;
 
             /* build the rejection message */
+            auto tmp = tr_variant{};
             tr_variantInitDict(&tmp, 2);
             tr_variantDictAddInt(&tmp, TR_KEY_msg_type, METADATA_MSG_TYPE_REJECT);
             tr_variantDictAddInt(&tmp, TR_KEY_piece, piece);
-            payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
+            evbuffer* const payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
 
             /* write it out as a LTEP message to our outMessages buffer */
             evbuffer_add_uint32(out, 2 * sizeof(uint8_t) + evbuffer_get_length(payload));
@@ -2168,12 +2143,10 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
 
         if (requestIsValid(msgs, &req) && tr_torrentPieceIsComplete(msgs->torrent, req.index))
         {
-            bool err;
             uint32_t const msglen = 4 + 1 + 4 + 4 + req.length;
-            struct evbuffer* out;
             struct evbuffer_iovec iovec[1];
 
-            out = evbuffer_new();
+            auto* const out = evbuffer_new();
             evbuffer_expand(out, msglen);
 
             evbuffer_add_uint32(out, sizeof(uint8_t) + 2 * sizeof(uint32_t) + req.length);
@@ -2182,13 +2155,13 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             evbuffer_add_uint32(out, req.offset);
 
             evbuffer_reserve_space(out, req.length, iovec, 1);
-            err = tr_cacheReadBlock(
-                      msgs->session->cache,
-                      msgs->torrent,
-                      req.index,
-                      req.offset,
-                      req.length,
-                      static_cast<uint8_t*>(iovec[0].iov_base)) != 0;
+            bool err = tr_cacheReadBlock(
+                           msgs->session->cache,
+                           msgs->torrent,
+                           req.index,
+                           req.offset,
+                           req.length,
+                           static_cast<uint8_t*>(iovec[0].iov_base)) != 0;
             iovec[0].iov_len = req.length;
             evbuffer_commit_space(out, iovec, 1);
 
@@ -2511,11 +2484,9 @@ static void sendPex(tr_peerMsgsImpl* msgs)
         }
         else
         {
-            tr_variant val;
-            uint8_t* tmp;
-            uint8_t* walk;
-            struct evbuffer* payload;
-            struct evbuffer* out = msgs->outMessages;
+            uint8_t* tmp = nullptr;
+            uint8_t* walk = nullptr;
+            evbuffer* const out = msgs->outMessages;
 
             /* update peer */
             tr_free(msgs->pex);
@@ -2526,6 +2497,7 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             msgs->pexCount6 = diffs6.elementCount;
 
             /* build the pex payload */
+            auto val = tr_variant{};
             tr_variantInitDict(&val, 3); /* ipv6 support: left as 3: speed vs. likelihood? */
 
             if (diffs.addedCount > 0)
@@ -2627,7 +2599,7 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             }
 
             /* write the pex message */
-            payload = tr_variantToBuf(&val, TR_VARIANT_FMT_BENC);
+            auto* const payload = tr_variantToBuf(&val, TR_VARIANT_FMT_BENC);
             evbuffer_add_uint32(out, 2 * sizeof(uint8_t) + evbuffer_get_length(payload));
             evbuffer_add_uint8(out, BT_LTEP);
             evbuffer_add_uint8(out, msgs->ut_pex_id);

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -113,22 +113,20 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
 
 static size_t findInfoDictOffset(tr_torrent const* tor)
 {
-    size_t fileLen;
-    uint8_t* fileContents;
     size_t offset = 0;
 
     /* load the file, and find the info dict's offset inside the file */
-    if ((fileContents = tr_loadFile(tor->info.torrent, &fileLen, nullptr)) != nullptr)
+    auto fileLen = size_t{};
+    uint8_t* const fileContents = tr_loadFile(tor->info.torrent, &fileLen, nullptr);
+    if (fileContents != nullptr)
     {
-        tr_variant top;
-
+        auto top = tr_variant{};
         if (tr_variantFromBenc(&top, fileContents, fileLen) == 0)
         {
-            tr_variant* infoDict;
-
+            tr_variant* infoDict = nullptr;
             if (tr_variantDictFindDict(&top, TR_KEY_info, &infoDict))
             {
-                size_t infoLen;
+                auto infoLen = size_t{};
                 char* infoContents = tr_variantToStr(infoDict, TR_VARIANT_FMT_BENC, &infoLen);
                 uint8_t const* i = (uint8_t const*)tr_memmem((char*)fileContents, fileLen, infoContents, infoLen);
                 offset = i != nullptr ? i - fileContents : 0;
@@ -165,14 +163,11 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 
     if (tr_torrentHasMetadata(tor))
     {
-        tr_sys_file_t fd;
-
         ensureInfoDictOffsetIsCached(tor);
 
         TR_ASSERT(tor->infoDictLength > 0);
 
-        fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, nullptr);
-
+        auto const fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, nullptr);
         if (fd != TR_BAD_SYS_FILE)
         {
             size_t const o = piece * METADATA_PIECE_SIZE;
@@ -184,7 +179,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
                 if (0 < l && l <= METADATA_PIECE_SIZE)
                 {
                     char* buf = tr_new(char, l);
-                    uint64_t n;
+                    auto n = uint64_t{};
 
                     if (tr_sys_file_read(fd, buf, l, &n, nullptr) && n == l)
                     {
@@ -296,10 +291,6 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
 
                 if (tr_variantFromFile(&newMetainfo, TR_VARIANT_FMT_BENC, path, nullptr))
                 {
-                    bool hasInfo;
-                    tr_info info;
-                    size_t infoDictLength;
-
                     /* remove any old .torrent and .resume files */
                     tr_sys_path_remove(path, nullptr);
                     tr_torrentRemoveResume(tor);
@@ -307,7 +298,9 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
                     dbgmsg(tor, "Saving completed metadata to \"%s\"", path);
                     tr_variantMergeDicts(tr_variantDictAddDict(&newMetainfo, TR_KEY_info, 0), &infoDict);
 
-                    memset(&info, 0, sizeof(tr_info));
+                    auto hasInfo = bool{};
+                    auto info = tr_info{};
+                    auto infoDictLength = size_t{};
                     success = tr_metainfoParse(tor->session, &newMetainfo, &info, &hasInfo, &infoDictLength);
 
                     if (success && tr_getBlockSize(info.pieceSize) == 0)
@@ -391,38 +384,23 @@ bool tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now, int* setme_pi
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor)
 {
-    double ret;
-
     if (tr_torrentHasMetadata(tor))
     {
-        ret = 1.0;
-    }
-    else
-    {
-        struct tr_incomplete_metadata const* m = tor->incompleteMetadata;
-
-        if (m == nullptr || m->pieceCount == 0)
-        {
-            ret = 0.0;
-        }
-        else
-        {
-            ret = (m->pieceCount - m->piecesNeededCount) / (double)m->pieceCount;
-        }
+        return 1.0;
     }
 
-    return ret;
+    auto const* const m = tor->incompleteMetadata;
+    return m == nullptr || m->pieceCount == 0 ? 0.0 : (m->pieceCount - m->piecesNeededCount) / (double)m->pieceCount;
 }
 
 /* TODO: this should be renamed tr_metainfoGetMagnetLink() and moved to metainfo.c for consistency */
 char* tr_torrentInfoGetMagnetLink(tr_info const* inf)
 {
-    char const* name;
-    struct evbuffer* s = evbuffer_new();
+    evbuffer* const s = evbuffer_new();
 
     evbuffer_add_printf(s, "magnet:?xt=urn:btih:%s", inf->hashString);
 
-    name = inf->name;
+    char const* const name = inf->name;
 
     if (!tr_str_is_empty(name))
     {

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -22,22 +22,17 @@ int tr_optind = 1;
 
 static char const* getArgName(tr_option const* opt)
 {
-    char const* arg;
-
     if (!opt->has_arg)
     {
-        arg = "";
-    }
-    else if (opt->argName != nullptr)
-    {
-        arg = opt->argName;
-    }
-    else
-    {
-        arg = "<args>";
+        return "";
     }
 
-    return arg;
+    if (opt->argName != nullptr)
+    {
+        return opt->argName;
+    }
+
+    return "<args>";
 }
 
 static size_t get_next_line_len(std::string_view description, size_t maxlen)
@@ -95,8 +90,6 @@ static void getopts_usage_line(tr_option const* opt, int longWidth, int shortWid
 
 static void maxWidth(struct tr_option const* o, size_t& longWidth, size_t& shortWidth, size_t& argWidth)
 {
-    char const* arg;
-
     if (o->longName != nullptr)
     {
         longWidth = std::max(longWidth, strlen(o->longName));
@@ -107,7 +100,8 @@ static void maxWidth(struct tr_option const* o, size_t& longWidth, size_t& short
         shortWidth = std::max(shortWidth, strlen(o->shortName));
     }
 
-    if ((arg = getArgName(o)) != nullptr)
+    char const* const arg = getArgName(o);
+    if (arg != nullptr)
     {
         argWidth = std::max(argWidth, strlen(arg));
     }


### PR DESCRIPTION
part 9 of a series of PRs that applies clang-tidy's `cppcoreguidelines-init-variables` to libtransmission:

- move uninitialized variables to be declared as close as possible to where they are used
- prefer const
- prefer auto

This PR reduces the number of `cppcoreguidelines-init-variables` warnings to **270**

Previous part: #1993