### PR TITLE
refactor: add tr_peer_id_t

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -15,7 +15,6 @@
 #include <string>
 
 #include "transmission.h" /* SHA_DIGEST_LENGTH */
-#include "session.h" /* PEER_ID_LEN */
 
 /***
 ****  SCRAPE
@@ -158,7 +157,7 @@ struct tr_announce_request
 
     /* the torrent's peer id.
      * this changes when a torrent is stopped -> restarted. */
-    char peer_id[PEER_ID_LEN];
+    tr_peer_id_t peer_id;
 
     /* the torrent's info_hash */
     uint8_t info_hash[SHA_DIGEST_LENGTH];

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -65,7 +65,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
         req->url,
         strchr(req->url, '?') != nullptr ? '&' : '?',
         escaped_info_hash,
-        TR_ARG_TUPLE(int(PEER_ID_LEN), int(PEER_ID_LEN), req->peer_id),
+        TR_ARG_TUPLE(int(std::size(req->peer_id)), int(std::size(req->peer_id)), std::data(req->peer_id)),
         req->port,
         req->up,
         req->down,

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -65,7 +65,7 @@ static char* announce_url_new(tr_session const* session, tr_announce_request con
         req->url,
         strchr(req->url, '?') != nullptr ? '&' : '?',
         escaped_info_hash,
-        TR_ARG_TUPLE(PEER_ID_LEN, PEER_ID_LEN, req->peer_id),
+        TR_ARG_TUPLE(int(PEER_ID_LEN), int(PEER_ID_LEN), req->peer_id),
         req->port,
         req->up,
         req->down,

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -24,6 +24,7 @@
 #include "peer-io.h"
 #include "peer-mgr.h" /* tr_peerMgrCompactToPex() */
 #include "ptrarray.h"
+#include "session.h"
 #include "tr-assert.h"
 #include "tr-udp.h"
 #include "utils.h"
@@ -317,7 +318,7 @@ static struct tau_announce_request* tau_announce_request_new(
     evbuffer_add_hton_32(buf, TAU_ACTION_ANNOUNCE);
     evbuffer_add_hton_32(buf, transaction_id);
     evbuffer_add(buf, in->info_hash, SHA_DIGEST_LENGTH);
-    evbuffer_add(buf, in->peer_id, PEER_ID_LEN);
+    evbuffer_add(buf, std::data(in->peer_id), std::size(in->peer_id));
     evbuffer_add_hton_64(buf, in->down);
     evbuffer_add_hton_64(buf, in->leftUntilComplete);
     evbuffer_add_hton_64(buf, in->up);

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -935,7 +935,7 @@ static tr_announce_request* announce_request_new(
     req->url = tr_strdup(tier->currentTracker->announce);
     req->tracker_id_str = tr_strdup(tier->currentTracker->tracker_id_str);
     memcpy(req->info_hash, tor->info.hash, SHA_DIGEST_LENGTH);
-    memcpy(req->peer_id, tr_torrentGetPeerId(tor), PEER_ID_LEN);
+    req->peer_id = tr_torrentGetPeerId(tor);
     req->up = tier->byteCounts[TR_ANN_UP];
     req->down = tier->byteCounts[TR_ANN_DOWN];
     req->corrupt = tier->byteCounts[TR_ANN_CORRUPT];

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -199,7 +199,7 @@ static bool buildHandshakeMessage(tr_handshake* handshake, uint8_t* buf)
         walk = std::copy_n(torrent_hash, SHA_DIGEST_LENGTH, walk);
 
         auto const& peer_id = tr_torrentGetPeerId(tor);
-        walk = std::copy_n(std::data(peer_id), std::size(peer_id), walk);
+        std::copy_n(std::data(peer_id), std::size(peer_id), walk);
 
         TR_ASSERT(walk + std::size(peer_id) - buf == HANDSHAKE_SIZE);
     }

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -12,6 +12,8 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <optional>
+
 #include "transmission.h"
 #include "net.h"
 
@@ -30,8 +32,8 @@ struct tr_handshake_result
     tr_peerIo* io;
     bool readAnythingFromPeer;
     bool isConnected;
-    uint8_t const* peerId;
     void* userData;
+    std::optional<tr_peer_id_t> peer_id;
 };
 
 /* returns true on success, false on error */

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -24,17 +24,25 @@ class tr_peerIo;
            freed when the handshake is completed. */
 struct tr_handshake;
 
-/* returns true on success, false on error */
-using handshakeDoneCB = bool (*)(
-    struct tr_handshake* handshake,
-    tr_peerIo* io,
-    bool readAnythingFromPeer,
-    bool isConnected,
-    uint8_t const* peerId,
-    void* userData);
+struct tr_handshake_result
+{
+    struct tr_handshake* handshake;
+    tr_peerIo* io;
+    bool readAnythingFromPeer;
+    bool isConnected;
+    uint8_t const* peerId;
+    void* userData;
+};
 
-/** @brief instantiate a new handshake */
-tr_handshake* tr_handshakeNew(tr_peerIo* io, tr_encryption_mode encryptionMode, handshakeDoneCB doneCB, void* doneUserData);
+/* returns true on success, false on error */
+using tr_handshake_done_func = bool (*)(tr_handshake_result const& result);
+
+/** @brief create a new handshake */
+tr_handshake* tr_handshakeNew(
+    tr_peerIo* io,
+    tr_encryption_mode encryption_mode,
+    tr_handshake_done_func when_done,
+    void* when_done_user_data);
 
 tr_address const* tr_handshakeGetAddr(struct tr_handshake const* handshake, tr_port* port);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1041,26 +1041,6 @@ bool tr_peerIoHasTorrentHash(tr_peerIo const* io)
 ***
 **/
 
-void tr_peerIoSetPeersId(tr_peerIo* io, uint8_t const* peer_id)
-{
-    TR_ASSERT(tr_isPeerIo(io));
-
-    if (peer_id == nullptr)
-    {
-        memset(io->peerId, '\0', sizeof(io->peerId));
-        io->peerIdIsSet = false;
-    }
-    else
-    {
-        memcpy(io->peerId, peer_id, sizeof(io->peerId));
-        io->peerIdIsSet = true;
-    }
-}
-
-/**
-***
-**/
-
 static unsigned int getDesiredOutputBufferSize(tr_peerIo const* io, uint64_t now)
 {
     /* this is all kind of arbitrary, but what seems to work well is

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -126,7 +126,6 @@ public:
     bool dhtSupported = false;
     bool extendedProtocolSupported = false;
     bool fastExtensionSupported = false;
-    bool isEncrypted = false;
     bool utpSupported = false;
 };
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -16,8 +16,6 @@
 ***
 **/
 
-#include <assert.h>
-
 #include <event2/buffer.h>
 
 #include "transmission.h"

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -116,9 +116,6 @@ public:
     // TODO: use std::shared_ptr instead of manual refcounting?
     int refCount = 1;
 
-    // TODO(ckerr): I think this can be moved to tr_handshake
-    uint8_t peerId[SHA_DIGEST_LENGTH] = {};
-
     short int pendingEvents = 0;
 
     tr_port const port;
@@ -130,8 +127,6 @@ public:
     bool extendedProtocolSupported = false;
     bool fastExtensionSupported = false;
     bool isEncrypted = false;
-    // TODO(ckerr): I think this can be moved to tr_handshake
-    bool peerIdIsSet = false;
     bool utpSupported = false;
 };
 
@@ -240,20 +235,6 @@ constexpr bool tr_peerIoIsIncoming(tr_peerIo const* io)
 static inline int tr_peerIoGetAge(tr_peerIo const* io)
 {
     return tr_time() - io->timeCreated;
-}
-
-/**
-***
-**/
-
-void tr_peerIoSetPeersId(tr_peerIo* io, uint8_t const* peer_id);
-
-constexpr uint8_t const* tr_peerIoGetPeersId(tr_peerIo const* io)
-{
-    TR_ASSERT(tr_isPeerIo(io));
-    TR_ASSERT(io->peerIdIsSet);
-
-    return io->peerId;
 }
 
 /**

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2015,10 +2015,11 @@ static bool on_handshake_done(tr_handshake_result const& result)
             else
             {
                 auto client = tr_quark{ TR_KEY_NONE };
-                if (result.peerId != nullptr)
+                if (result.peer_id)
                 {
-                    char buf[128];
-                    client = tr_quark_new(tr_clientForId(buf, sizeof(buf), result.peerId));
+                    char buf[128] = {};
+                    tr_clientForId(buf, sizeof(buf), std::data(*result.peer_id));
+                    client = tr_quark_new(buf);
                 }
 
                 /* this steals its refcount too, which is balanced by our unref in peerDelete() */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1931,28 +1931,22 @@ static void createBitTorrentPeer(tr_torrent* tor, tr_peerIo* io, struct peer_ato
 }
 
 /* FIXME: this is kind of a mess. */
-static bool myHandshakeDoneCB(
-    tr_handshake* handshake,
-    tr_peerIo* io,
-    bool readAnythingFromPeer,
-    bool isConnected,
-    uint8_t const* peer_id,
-    void* vmanager)
+static bool on_handshake_done(tr_handshake_result const& result)
 {
-    TR_ASSERT(io != nullptr);
+    TR_ASSERT(result.io != nullptr);
 
-    bool ok = isConnected;
+    bool ok = result.isConnected;
     bool success = false;
-    auto* manager = static_cast<tr_peerMgr*>(vmanager);
-    tr_swarm* s = tr_peerIoHasTorrentHash(io) ? getExistingSwarm(manager, tr_peerIoGetTorrentHash(io)) : nullptr;
+    auto* manager = static_cast<tr_peerMgr*>(result.userData);
+    tr_swarm* s = tr_peerIoHasTorrentHash(result.io) ? getExistingSwarm(manager, tr_peerIoGetTorrentHash(result.io)) : nullptr;
 
-    if (tr_peerIoIsIncoming(io))
+    if (tr_peerIoIsIncoming(result.io))
     {
-        tr_ptrArrayRemoveSortedPointer(&manager->incomingHandshakes, handshake, handshakeCompare);
+        tr_ptrArrayRemoveSortedPointer(&manager->incomingHandshakes, result.handshake, handshakeCompare);
     }
     else if (s != nullptr)
     {
-        tr_ptrArrayRemoveSortedPointer(&s->outgoingHandshakes, handshake, handshakeCompare);
+        tr_ptrArrayRemoveSortedPointer(&s->outgoingHandshakes, result.handshake, handshakeCompare);
     }
 
     if (s != nullptr)
@@ -1961,7 +1955,7 @@ static bool myHandshakeDoneCB(
     }
 
     auto port = tr_port{};
-    tr_address const* const addr = tr_peerIoGetAddress(io, &port);
+    tr_address const* const addr = tr_peerIoGetAddress(result.io, &port);
 
     if (!ok || s == nullptr || !s->isRunning)
     {
@@ -1973,7 +1967,7 @@ static bool myHandshakeDoneCB(
             {
                 ++atom->numFails;
 
-                if (!readAnythingFromPeer)
+                if (!result.readAnythingFromPeer)
                 {
                     tordbg(s, "marking peer %s as unreachable... numFails is %d", tr_atomAddrStr(atom), (int)atom->numFails);
                     atom->flags2 |= MyflagUnreachable;
@@ -1989,7 +1983,7 @@ static bool myHandshakeDoneCB(
         atom->piece_data_time = 0;
         atom->lastConnectionAt = tr_time();
 
-        if (!tr_peerIoIsIncoming(io))
+        if (!tr_peerIoIsIncoming(result.io))
         {
             atom->flags |= ADDED_F_CONNECTABLE;
             atom->flags2 &= ~MyflagUnreachable;
@@ -1997,7 +1991,7 @@ static bool myHandshakeDoneCB(
 
         /* In principle, this flag specifies whether the peer groks uTP,
            not whether it's currently connected over uTP. */
-        if (io->socket.type == TR_PEER_SOCKET_TYPE_UTP)
+        if (result.io->socket.type == TR_PEER_SOCKET_TYPE_UTP)
         {
             atom->flags |= ADDED_F_UTP_FLAGS;
         }
@@ -2006,7 +2000,7 @@ static bool myHandshakeDoneCB(
         {
             tordbg(s, "banned peer %s tried to reconnect", tr_atomAddrStr(atom));
         }
-        else if (tr_peerIoIsIncoming(io) && getPeerCount(s) >= getMaxPeerCount(s->tor))
+        else if (tr_peerIoIsIncoming(result.io) && getPeerCount(s) >= getMaxPeerCount(s->tor))
         {
             /* too many peers already */
         }
@@ -2021,14 +2015,14 @@ static bool myHandshakeDoneCB(
             else
             {
                 auto client = tr_quark{ TR_KEY_NONE };
-                if (peer_id != nullptr)
+                if (result.peerId != nullptr)
                 {
                     char buf[128];
-                    client = tr_quark_new(tr_clientForId(buf, sizeof(buf), peer_id));
+                    client = tr_quark_new(tr_clientForId(buf, sizeof(buf), result.peerId));
                 }
 
                 /* this steals its refcount too, which is balanced by our unref in peerDelete() */
-                tr_peerIo* stolen = tr_handshakeStealIO(handshake);
+                tr_peerIo* stolen = tr_handshakeStealIO(result.handshake);
                 tr_peerIoSetParent(stolen, s->tor->bandwidth);
                 createBitTorrentPeer(s->tor, stolen, atom, client);
 
@@ -2089,7 +2083,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address* addr, tr_port port, 
     else /* we don't have a connection to them yet... */
     {
         tr_peerIo* const io = tr_peerIoNewIncoming(session, session->bandwidth, addr, port, socket);
-        tr_handshake* const handshake = tr_handshakeNew(io, session->encryptionMode, myHandshakeDoneCB, manager);
+        tr_handshake* const handshake = tr_handshakeNew(io, session->encryptionMode, on_handshake_done, manager);
 
         tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
 
@@ -4216,7 +4210,7 @@ static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* a
     }
     else
     {
-        tr_handshake* handshake = tr_handshakeNew(io, mgr->session->encryptionMode, myHandshakeDoneCB, mgr);
+        tr_handshake* handshake = tr_handshakeNew(io, mgr->session->encryptionMode, on_handshake_done, mgr);
 
         TR_ASSERT(tr_peerIoGetTorrentHash(io));
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -45,11 +45,6 @@ enum tr_auto_switch_state_t
     TR_AUTO_SWITCH_OFF,
 };
 
-enum
-{
-    PEER_ID_LEN = 20
-};
-
 void tr_peerIdInit(uint8_t* setme);
 
 struct event_base;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -45,7 +45,7 @@ enum tr_auto_switch_state_t
     TR_AUTO_SWITCH_OFF,
 };
 
-void tr_peerIdInit(uint8_t* setme);
+tr_peer_id_t tr_peerIdInit();
 
 struct event_base;
 struct evdns_base;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -155,7 +155,7 @@ bool tr_torrentIsPieceTransferAllowed(tr_torrent const* tor, tr_direction direct
 ****
 ***/
 
-static constexpr void tr_torrentUnsetPeerId(tr_torrent* tor)
+static void tr_torrentUnsetPeerId(tr_torrent* tor)
 {
     // triggers a rebuild next time tr_torrentGetPeerId() is called
     tor->peer_id.reset();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -154,6 +154,7 @@ struct tr_torrent
      * peer_id that was registered by the peer. The peer_id from the tracker
      * and in the handshake are expected to match.
      */
+    // TODO(ckerr): use tr_peer_id_t
     unsigned char peer_id[PEER_ID_LEN + 1];
 
     time_t peer_id_creation_time;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -12,6 +12,7 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -154,8 +155,7 @@ struct tr_torrent
      * peer_id that was registered by the peer. The peer_id from the tracker
      * and in the handshake are expected to match.
      */
-    // TODO(ckerr): use tr_peer_id_t
-    unsigned char peer_id[PEER_ID_LEN + 1];
+    std::optional<tr_peer_id_t> peer_id;
 
     time_t peer_id_creation_time;
 
@@ -426,7 +426,7 @@ time_t tr_torrentGetFileMTime(tr_torrent const* tor, tr_file_index_t i);
 
 uint64_t tr_torrentGetCurrentSizeOnDisk(tr_torrent const* tor);
 
-unsigned char const* tr_torrentGetPeerId(tr_torrent* tor);
+tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 
 static inline uint64_t tr_torrentGetLeftUntilDone(tr_torrent const* tor)
 {

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -125,4 +125,8 @@
 
 auto inline constexpr PEER_ID_LEN = size_t{ 20 };
 
-using tr_peer_id_t = std::array<char, PEER_ID_LEN>;
+// https://www.bittorrent.org/beps/bep_0003.html
+// A string of length 20 which this downloader uses as its id. Each
+// downloader generates its own id at random at the start of a new
+// download. This value will also almost certainly have to be escaped.
+using tr_peer_id_t = std::array<char, 20>;

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 /***
 ****
 ***/
@@ -119,3 +122,7 @@
 
 // Mostly to enforce better formatting
 #define TR_ARG_TUPLE(...) __VA_ARGS__
+
+auto inline constexpr PEER_ID_LEN = size_t{ 20 };
+
+using tr_peer_id_t = std::array<char, PEER_ID_LEN>;

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -28,14 +28,10 @@ TEST(Session, peerId)
     for (int i = 0; i < 100000; ++i)
     {
         // get a new peer-id
-        auto buf = std::array<uint8_t, PEER_ID_LEN + 1>{};
-        tr_peerIdInit(buf.data());
-
-        // confirm that it has the right length
-        EXPECT_EQ(PEER_ID_LEN, strlen(reinterpret_cast<char const*>(buf.data())));
+        auto const buf = tr_peerIdInit();
 
         // confirm that it begins with peer_id_prefix
-        auto const peer_id = std::string(reinterpret_cast<char const*>(buf.data()), PEER_ID_LEN);
+        auto const peer_id = std::string_view(reinterpret_cast<char const*>(buf.data()), PEER_ID_LEN);
         EXPECT_EQ(peer_id_prefix, peer_id.substr(0, peer_id_prefix.size()));
 
         // confirm that its total is evenly divisible by 36


### PR DESCRIPTION
- Add a `tr_peer_id_t` using/typedef which is a `std::array<char, 20>`. This can be used to pass around peer-ids and manipulate them without using `memcmp`, `memcpy`, and `PEER_ID_LEN`.

- Remove now-unused global `PEER_ID_LEN`.

- This has some minor side-effects in handshake and peer-io: `tr_peerIo.peerId` and `tr_peerIo.isEncrypted` have been removed.