### PR TITLE
perf: remove redundant assertions

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -123,8 +123,6 @@ void Bandwidth::allocateBandwidth(
     unsigned int period_msec,
     std::vector<tr_peerIo*>& peer_pool)
 {
-    TR_ASSERT(tr_isDirection(dir));
-
     tr_priority_t const priority = std::max(parent_priority, this->priority_);
 
     /* set the available bandwidth */
@@ -181,10 +179,12 @@ void Bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
 
 void Bandwidth::allocate(tr_direction dir, unsigned int period_msec)
 {
-    std::vector<tr_peerIo*> tmp;
-    std::vector<tr_peerIo*> low;
-    std::vector<tr_peerIo*> normal;
-    std::vector<tr_peerIo*> high;
+    TR_ASSERT(tr_isDirection(dir));
+
+    auto high = std::vector<tr_peerIo*>{};
+    auto low = std::vector<tr_peerIo*>{};
+    auto normal = std::vector<tr_peerIo*>{};
+    auto tmp = std::vector<tr_peerIo*>{};
 
     /* allocateBandwidth () is a helper function with two purposes:
      * 1. allocate bandwidth to b and its subtree

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -179,8 +179,6 @@ private:
             bits_[byte_offset] |= bit_value;
             setTrueCount(true_count_ + 1);
         }
-
-        TR_ASSERT(isValid());
     }
 
     /// @brief Clear the bit
@@ -199,8 +197,6 @@ private:
             TR_ASSERT(true_count_ > 0);
             setTrueCount(true_count_ - 1);
         }
-
-        TR_ASSERT(isValid());
     }
 
     /// @brief Ensure that the memory is properly deallocated and size becomes zero

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -319,6 +319,7 @@ constexpr tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
     return tor->completeness;
 }
 
+// TODO(ckerr) this is confusingly-named. partial seeds return true here
 constexpr bool tr_torrentIsSeed(tr_torrent const* tor)
 {
     return tr_torrentGetCompleteness(tor) != TR_LEECH;


### PR DESCRIPTION
A pretty minor PR. The profiler showed that a couple of assertions were being called redundantly, i.e. called twice in a row in bitfield or called inside a loop in bandwidth.