### PR TITLE
fix: details dialog "available" percent can be off

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -488,7 +488,7 @@ void DetailsDialog::refreshUI()
                 have_verified += v;
                 size_when_done += t->sizeWhenDone();
                 left_until_done += t->leftUntilDone();
-                available += t->sizeWhenDone() - t->leftUntilDone() + t->desiredAvailable();
+                available += t->sizeWhenDone() - t->leftUntilDone() + t->haveUnverified() + t->desiredAvailable();
             }
         }
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -581,7 +581,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
         };
 
         // changing fields needed by the details dialog
-        static auto constexpr DetailStatKeys = std::array<tr_quark, 17>{
+        static auto constexpr DetailStatKeys = std::array<tr_quark, 18>{
             TR_KEY_activityDate, //
             TR_KEY_bandwidthPriority, //
             TR_KEY_corruptEver, //
@@ -590,6 +590,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
             TR_KEY_downloadLimit, //
             TR_KEY_downloadLimited, //
             TR_KEY_fileStats, //
+            TR_KEY_haveUnchecked, //
             TR_KEY_honorsSessionLimits, //
             TR_KEY_peer_limit, //
             TR_KEY_peers, //


### PR DESCRIPTION
It's often off by a little bit because it fails to account for blocks we've downloaded but haven't been verified yet. Copied the fix from the GTK client.

Bug is present in 3.00