### PR TITLE
refactor: cppcoreguidelines-init-variables pt. 15

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -287,16 +287,16 @@ static handshake_parse_err_t parseHandshake(tr_handshake* handshake, struct evbu
 /* 1 A->B: Diffie Hellman Ya, PadA */
 static void sendYa(tr_handshake* handshake)
 {
-    int len;
-    char outbuf[KEY_LEN + PadA_MAXLEN];
-    char* walk = outbuf;
-
     /* add our public key (Ya) */
+
+    int len = 0;
     uint8_t const* const public_key = tr_cryptoGetMyPublicKey(handshake->crypto, &len);
     TR_ASSERT(len == KEY_LEN);
     TR_ASSERT(public_key != nullptr);
-    memcpy(walk, public_key, len);
-    walk += len;
+
+    char outbuf[KEY_LEN + PadA_MAXLEN];
+    char* walk = outbuf;
+    walk = std::copy_n(public_key, len, walk);
 
     /* add some bullshit padding */
     len = tr_rand_int(PadA_MAXLEN);
@@ -512,8 +512,6 @@ static ReadState readVC(tr_handshake* handshake, struct evbuffer* inbuf)
 
 static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    uint16_t pad_d_len;
-    uint32_t crypto_select;
     static size_t const needlen = sizeof(uint32_t) + sizeof(uint16_t);
 
     if (evbuffer_get_length(inbuf) < needlen)
@@ -521,6 +519,7 @@ static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbu
         return READ_LATER;
     }
 
+    uint32_t crypto_select = 0;
     tr_peerIoReadUint32(handshake->io, inbuf, &crypto_select);
     handshake->crypto_select = crypto_select;
     dbgmsg(handshake, "crypto select is %d", (int)crypto_select);
@@ -531,6 +530,7 @@ static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbu
         return tr_handshakeDone(handshake, false);
     }
 
+    uint16_t pad_d_len = 0;
     tr_peerIoReadUint16(handshake->io, inbuf, &pad_d_len);
     dbgmsg(handshake, "pad_d_len is %d", (int)pad_d_len);
 
@@ -573,11 +573,6 @@ static ReadState readPadD(tr_handshake* handshake, struct evbuffer* inbuf)
 
 static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    uint8_t pstrlen;
-    uint8_t pstr[20];
-    uint8_t reserved[HANDSHAKE_FLAGS_LEN];
-    uint8_t hash[SHA_DIGEST_LENGTH];
-
     dbgmsg(handshake, "payload: need %d, got %zu", INCOMING_HANDSHAKE_LEN, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < INCOMING_HANDSHAKE_LEN)
@@ -587,7 +582,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
     handshake->haveReadAnythingFromPeer = true;
 
-    pstrlen = evbuffer_pullup(inbuf, 1)[0]; /* peek, don't read. We may be handing inbuf to AWAITING_YA */
+    uint8_t pstrlen = evbuffer_pullup(inbuf, 1)[0]; /* peek, don't read. We may be handing inbuf to AWAITING_YA */
 
     if (pstrlen == 19) /* unencrypted */
     {
@@ -623,6 +618,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
     /* pstr (BitTorrent) */
     TR_ASSERT(pstrlen == 19);
+    uint8_t pstr[20];
     tr_peerIoReadBytes(handshake->io, inbuf, pstr, pstrlen);
     pstr[pstrlen] = '\0';
 
@@ -632,6 +628,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
     }
 
     /* reserved bytes */
+    uint8_t reserved[HANDSHAKE_FLAGS_LEN];
     tr_peerIoReadBytes(handshake->io, inbuf, reserved, sizeof(reserved));
 
     /**
@@ -643,6 +640,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
     tr_peerIoEnableFEXT(handshake->io, HANDSHAKE_HAS_FASTEXT(reserved));
 
     /* torrent hash */
+    uint8_t hash[SHA_DIGEST_LENGTH];
     tr_peerIoReadBytes(handshake->io, inbuf, hash, sizeof(hash));
 
     if (tr_peerIoIsIncoming(handshake->io))
@@ -712,11 +710,6 @@ static ReadState readPeerId(tr_handshake* handshake, struct evbuffer* inbuf)
 
 static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    uint8_t ya[KEY_LEN];
-    uint8_t* walk;
-    uint8_t outbuf[KEY_LEN + PadB_MAXLEN];
-    int len;
-
     dbgmsg(handshake, "in readYa... need %d, have %zu", KEY_LEN, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < KEY_LEN)
@@ -725,6 +718,7 @@ static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
     }
 
     /* read the incoming peer's public key */
+    uint8_t ya[KEY_LEN];
     evbuffer_remove(inbuf, ya, KEY_LEN);
 
     if (!tr_cryptoComputeSecret(handshake->crypto, ya))
@@ -736,10 +730,11 @@ static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
 
     /* send our public key to the peer */
     dbgmsg(handshake, "sending B->A: Diffie Hellman Yb, PadB");
-    walk = outbuf;
+    uint8_t outbuf[KEY_LEN + PadB_MAXLEN];
+    uint8_t* walk = outbuf;
+    int len = 0;
     uint8_t const* const myKey = tr_cryptoGetMyPublicKey(handshake->crypto, &len);
-    memcpy(walk, myKey, len);
-    walk += len;
+    walk = std::copy_n(myKey, len, walk);
     len = tr_rand_int(PadB_MAXLEN);
     tr_rand_buffer(walk, len);
     walk += len;
@@ -844,7 +839,7 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
 
 static ReadState readPadC(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    uint16_t ia_len;
+    uint16_t ia_len = 0;
     size_t const needlen = handshake->pad_c_len + sizeof(uint16_t);
 
     if (evbuffer_get_length(inbuf) < needlen)
@@ -981,7 +976,6 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
-    ReadState ret;
     auto* handshake = static_cast<tr_handshake*>(vhandshake);
 
     struct evbuffer* inbuf = tr_peerIoGetReadBuffer(io);
@@ -992,6 +986,7 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
 
     dbgmsg(handshake, "handling canRead; state is [%s]", getStateName(handshake->state));
 
+    ReadState ret = READ_NOW;
     while (readyForMore)
     {
         switch (handshake->state)

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -24,7 +24,7 @@
 
 static void handle_sigchld(int /*i*/)
 {
-    int rc;
+    int rc = 0;
 
     do
     {
@@ -84,8 +84,8 @@ FAIL:
 
 static bool tr_spawn_async_in_parent(int pipe_fd, tr_error** error)
 {
-    int child_errno;
-    ssize_t count;
+    int child_errno = 0;
+    ssize_t count = 0;
 
     static_assert(sizeof(child_errno) == sizeof(errno), "");
 


### PR DESCRIPTION
part 15 of a series of PRs that applies clang-tidy's `cppcoreguidelines-init-variables` to libtransmission:

- move uninitialized variables to be declared as close as possible to where they are used
- prefer const
- prefer auto

This PR reduces the number of `cppcoreguidelines-init-variables` warnings to **10**

Previous part: #2043