### PR TITLE
refactor: remove tr_piece struct

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -113,7 +113,7 @@ void tr_cpBlockAdd(tr_completion* cp, tr_block_index_t block)
         cp->sizeNow += tr_torBlockCountBytes(tor, block);
 
         cp->haveValidIsDirty = true;
-        cp->sizeWhenDoneIsDirty = cp->sizeWhenDoneIsDirty || tor->isPieceDND(piece);
+        cp->sizeWhenDoneIsDirty = cp->sizeWhenDoneIsDirty || tor->pieceIsDnd(piece);
     }
 }
 
@@ -165,7 +165,7 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
                 uint64_t n = 0;
                 uint64_t const pieceSize = tr_torPieceCountBytes(tor, p);
 
-                if (!tor->isPieceDND(p))
+                if (!tor->pieceIsDnd(p))
                 {
                     n = pieceSize;
                 }

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -113,7 +113,7 @@ void tr_cpBlockAdd(tr_completion* cp, tr_block_index_t block)
         cp->sizeNow += tr_torBlockCountBytes(tor, block);
 
         cp->haveValidIsDirty = true;
-        cp->sizeWhenDoneIsDirty = cp->sizeWhenDoneIsDirty || tor->info.pieces[piece].dnd;
+        cp->sizeWhenDoneIsDirty = cp->sizeWhenDoneIsDirty || tor->isPieceDND(piece);
     }
 }
 
@@ -165,7 +165,7 @@ uint64_t tr_cpSizeWhenDone(tr_completion const* ccp)
                 uint64_t n = 0;
                 uint64_t const pieceSize = tr_torPieceCountBytes(tor, p);
 
-                if (!inf->pieces[p].dnd)
+                if (!tor->isPieceDND(p))
                 {
                     n = pieceSize;
                 }

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -265,7 +265,7 @@ static std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece
     auto buffer = std::vector<uint8_t>(tor->blockSize);
     auto bytes_left = size_t{ tr_torPieceCountBytes(tor, piece) };
     auto offset = uint32_t{};
-    auto sha = tr_sha1_ctx_t{};
+    auto sha = tr_sha1_init();
 
     tr_ioPrefetch(tor, piece, offset, bytes_left);
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -262,19 +262,19 @@ static std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece
     TR_ASSERT(tor != nullptr);
     TR_ASSERT(piece < tor->info.pieceCount);
 
-    auto buffer = std::vector<uint8_t>(tor->blockSize);
     auto bytes_left = size_t{ tr_torPieceCountBytes(tor, piece) };
     auto offset = uint32_t{};
-    auto sha = tr_sha1_init();
-
     tr_ioPrefetch(tor, piece, offset, bytes_left);
 
+    auto sha = tr_sha1_init();
+    auto buffer = std::vector<uint8_t>(tor->blockSize);
     while (bytes_left != 0)
     {
         size_t const len = std::min(bytes_left, std::size(buffer));
         auto const success = tr_cacheReadBlock(tor->session->cache, tor, piece, offset, len, std::data(buffer)) == 0;
         if (!success)
         {
+            tr_sha1_final(sha, nullptr);
             return {};
         }
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -10,6 +10,7 @@
 #include <cerrno>
 #include <cstdlib> /* bsearch() */
 #include <cstring> /* memcmp() */
+#include <optional>
 
 #include "transmission.h"
 #include "cache.h" /* tr_cacheReadBlock() */
@@ -256,49 +257,39 @@ int tr_ioWrite(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uin
 *****
 ****/
 
-static bool recalculateHash(tr_torrent* tor, tr_piece_index_t pieceIndex, uint8_t* setme)
+static std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_t piece)
 {
     TR_ASSERT(tor != nullptr);
-    TR_ASSERT(pieceIndex < tor->info.pieceCount);
-    TR_ASSERT(setme != nullptr);
+    TR_ASSERT(piece < tor->info.pieceCount);
 
-    uint32_t offset = 0;
-    bool success = true;
-    size_t const buflen = tor->blockSize;
-    void* const buffer = tr_malloc(buflen);
+    auto buffer = std::vector<uint8_t>(tor->blockSize);
+    auto bytes_left = size_t{ tr_torPieceCountBytes(tor, piece) };
+    auto offset = uint32_t{};
+    auto sha = tr_sha1_ctx_t{};
 
-    TR_ASSERT(buffer != nullptr);
-    TR_ASSERT(buflen > 0);
+    tr_ioPrefetch(tor, piece, offset, bytes_left);
 
-    tr_sha1_ctx_t sha = tr_sha1_init();
-    size_t bytesLeft = tr_torPieceCountBytes(tor, pieceIndex);
-
-    tr_ioPrefetch(tor, pieceIndex, offset, bytesLeft);
-
-    while (bytesLeft != 0)
+    while (bytes_left != 0)
     {
-        size_t const len = std::min(bytesLeft, buflen);
-        success = tr_cacheReadBlock(tor->session->cache, tor, pieceIndex, offset, len, static_cast<uint8_t*>(buffer)) == 0;
-
+        size_t const len = std::min(bytes_left, std::size(buffer));
+        auto const success = tr_cacheReadBlock(tor->session->cache, tor, piece, offset, len, std::data(buffer)) == 0;
         if (!success)
         {
-            break;
+            return {};
         }
 
-        tr_sha1_update(sha, buffer, len);
+        tr_sha1_update(sha, std::data(buffer), len);
         offset += len;
-        bytesLeft -= len;
+        bytes_left -= len;
     }
 
-    tr_sha1_final(sha, success ? setme : nullptr);
-
-    tr_free(buffer);
-    return success;
+    auto digest = tr_sha1_digest_t{};
+    tr_sha1_final(sha, std::data(digest));
+    return digest;
 }
 
 bool tr_ioTestPiece(tr_torrent* tor, tr_piece_index_t piece)
 {
-    uint8_t hash[SHA_DIGEST_LENGTH];
-
-    return recalculateHash(tor, piece, hash) && memcmp(hash, tor->info.pieces[piece].hash, SHA_DIGEST_LENGTH) == 0;
+    auto const hash = recalculateHash(tor, piece);
+    return hash && *hash == tor->info.pieces[piece];
 }

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -21,7 +21,6 @@
 #include "metainfo.h"
 #include "platform.h" /* tr_getTorrentDir() */
 #include "session.h"
-#include "torrent.h"
 #include "tr-assert.h"
 #include "utils.h"
 #include "variant.h"

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -711,12 +711,8 @@ static char const* tr_metainfoParseImpl(
         }
 
         inf->pieceCount = len / SHA_DIGEST_LENGTH;
-        inf->pieces = tr_new0(tr_piece, inf->pieceCount);
-
-        for (tr_piece_index_t pi = 0; pi < inf->pieceCount; ++pi)
-        {
-            memcpy(inf->pieces[pi].hash, &raw[pi * SHA_DIGEST_LENGTH], SHA_DIGEST_LENGTH);
-        }
+        inf->pieces = tr_new0(tr_sha1_digest_t, inf->pieceCount);
+        std::copy_n(raw, len, (uint8_t*)(inf->pieces));
     }
 
     /* files */

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -14,12 +14,14 @@
 #include <event2/buffer.h>
 
 #include "transmission.h"
+
 #include "crypto-utils.h" /* tr_sha1 */
 #include "file.h"
 #include "log.h"
 #include "metainfo.h"
 #include "platform.h" /* tr_getTorrentDir() */
 #include "session.h"
+#include "torrent.h"
 #include "tr-assert.h"
 #include "utils.h"
 #include "variant.h"

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -801,8 +801,8 @@ static int comparePieceByWeight(void const* va, void const* vb)
     }
 
     /* secondary key: higher priorities go first */
-    ia = tor->info.pieces[a->index].priority;
-    ib = tor->info.pieces[b->index].priority;
+    ia = tor->piecePriority(a->index);
+    ib = tor->piecePriority(b->index);
     if (ia != ib)
     {
         return ia > ib ? -1 : 1;
@@ -900,7 +900,7 @@ static void pieceListRebuild(tr_swarm* s)
         auto* const pool = tr_new(tr_piece_index_t, inf->pieceCount);
         for (tr_piece_index_t i = 0; i < inf->pieceCount; ++i)
         {
-            if (!inf->pieces[i].dnd && !tr_torrentPieceIsComplete(tor, i))
+            if (!tor->isPieceDND(i) && !tr_torrentPieceIsComplete(tor, i))
             {
                 pool[poolCount++] = i;
             }
@@ -2378,7 +2378,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
     for (size_t i = 0; i < n_pieces; ++i)
     {
-        if (!tor->info.pieces[i].dnd && have.at(i))
+        if (!tor->isPieceDND(i) && have.at(i))
         {
             desired_available += tr_torrentMissingBytesInPiece(tor, i);
         }
@@ -2706,7 +2706,7 @@ static void rechokeDownloads(tr_swarm* s)
 
         for (int i = 0; i < n; ++i)
         {
-            piece_is_interesting[i] = !tor->info.pieces[i].dnd && !tr_torrentPieceIsComplete(tor, i);
+            piece_is_interesting[i] = !tor->isPieceDND(i) && !tr_torrentPieceIsComplete(tor, i);
         }
 
         /* decide WHICH peers to be interested in (based on their cancel-to-block ratio) */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -900,7 +900,7 @@ static void pieceListRebuild(tr_swarm* s)
         auto* const pool = tr_new(tr_piece_index_t, inf->pieceCount);
         for (tr_piece_index_t i = 0; i < inf->pieceCount; ++i)
         {
-            if (!tor->isPieceDND(i) && !tr_torrentPieceIsComplete(tor, i))
+            if (!tor->pieceIsDnd(i) && !tr_torrentPieceIsComplete(tor, i))
             {
                 pool[poolCount++] = i;
             }
@@ -2378,7 +2378,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
     for (size_t i = 0; i < n_pieces; ++i)
     {
-        if (!tor->isPieceDND(i) && have.at(i))
+        if (!tor->pieceIsDnd(i) && have.at(i))
         {
             desired_available += tr_torrentMissingBytesInPiece(tor, i);
         }
@@ -2706,7 +2706,7 @@ static void rechokeDownloads(tr_swarm* s)
 
         for (int i = 0; i < n; ++i)
         {
-            piece_is_interesting[i] = !tor->isPieceDND(i) && !tr_torrentPieceIsComplete(tor, i);
+            piece_is_interesting[i] = !tor->pieceIsDnd(i) && !tr_torrentPieceIsComplete(tor, i);
         }
 
         /* decide WHICH peers to be interested in (based on their cancel-to-block ratio) */

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2216,10 +2216,9 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             evbuffer_commit_space(out, iovec, 1);
 
             /* check the piece if it needs checking... */
-            if (!err && tr_torrentPieceNeedsCheck(msgs->torrent, req.index))
+            if (!err)
             {
-                err = !tr_torrentCheckPiece(msgs->torrent, req.index);
-
+                err = !msgs->torrent->ensurePieceIsChecked(req.index);
                 if (err)
                 {
                     tr_torrentSetLocalError(

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -467,13 +467,13 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
 
 static void bitfieldToRaw(tr_bitfield const* b, tr_variant* benc)
 {
-    if (b->hasAll())
-    {
-        tr_variantInitStr(benc, "all"sv);
-    }
-    else if (b->hasNone())
+    if (b->hasNone() || std::size(*b) == 0)
     {
         tr_variantInitStr(benc, "none"sv);
+    }
+    else if (b->hasAll())
+    {
+        tr_variantInitStr(benc, "all"sv);
     }
     else
     {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -605,7 +605,7 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
                     {
                         int64_t piece_time = 0;
                         tr_variantGetInt(tr_variantListChild(b, i + 1), &piece_time);
-                        time_checked = std::min(time_checked, piece_time);
+                        time_checked = std::min(time_checked, time_t(piece_time));
                     }
                 }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -465,8 +465,6 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
 ****
 ***/
 
-#include <iostream>
-
 static void bitfieldToRaw(tr_bitfield const* b, tr_variant* benc)
 {
     if (b->hasAll())
@@ -486,19 +484,16 @@ static void bitfieldToRaw(tr_bitfield const* b, tr_variant* benc)
 
 static void rawToBitfield(tr_bitfield& bitfield, uint8_t const* raw, size_t rawlen)
 {
-    if (rawlen == 3 && memcmp(raw, "all", 3) == 0)
-    {
-        bitfield.setHasAll();
-    }
-    else if (rawlen == 4 && memcmp(raw, "none", 4) == 0)
+    if (raw == nullptr || rawlen == 0 || (rawlen == 4 && memcmp(raw, "none", 4) == 0))
     {
         bitfield.setHasNone();
     }
+    else if (rawlen == 3 && memcmp(raw, "all", 3) == 0)
+    {
+        bitfield.setHasAll();
+    }
     else
     {
-        std::cout << "bitfield size is " << std::size(bitfield) << std::endl;
-        std::cout << "first raw byte is " << *raw << std::endl;
-        std::cout << "rawlen len is " << rawlen << std::endl;
         bitfield.setRaw(raw, rawlen, true);
     }
 }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -465,8 +465,7 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
 ****
 ***/
 
-// TODO: Refactor this into a constructor for tr_variant
-static void bitfieldToBenc(tr_bitfield const* b, tr_variant* benc)
+static void bitfieldToRaw(tr_bitfield const* b, tr_variant* benc)
 {
     if (b->hasAll())
     {
@@ -483,75 +482,38 @@ static void bitfieldToBenc(tr_bitfield const* b, tr_variant* benc)
     }
 }
 
+static void rawToBitfield(tr_bitfield& bitfield, uint8_t const* raw, size_t rawlen)
+{
+    if (rawlen == 3 && memcmp(raw, "all", 3) == 0)
+    {
+        bitfield.setHasAll();
+    }
+    else if (rawlen == 4 && memcmp(raw, "none", 4) == 0)
+    {
+        bitfield.setHasNone();
+    }
+    else
+    {
+        bitfield.setRaw(raw, rawlen, true);
+    }
+}
+
 static void saveProgress(tr_variant* dict, tr_torrent* tor)
 {
     tr_info const* inf = tr_torrentInfo(tor);
-    time_t const now = tr_time();
 
-    tr_variant* const prog = tr_variantDictAddDict(dict, TR_KEY_progress, 3);
+    tr_variant* const prog = tr_variantDictAddDict(dict, TR_KEY_progress, 4);
 
-    /* add the file/piece check timestamps... */
-    tr_variant* const l = tr_variantDictAddList(prog, TR_KEY_time_checked, inf->fileCount);
-
-    for (tr_file_index_t fi = 0; fi < inf->fileCount; ++fi)
+    // add the mtimes
+    size_t n = inf->fileCount;
+    tr_variant* const l = tr_variantDictAddList(prog, TR_KEY_mtimes, n);
+    for (auto const *file = inf->files, *end = file + inf->fileCount; file != end; ++file)
     {
-        time_t oldest_nonzero = now;
-        time_t newest = 0;
-        bool has_zero = false;
-        time_t const mtime = tr_torrentGetFileMTime(tor, fi);
-        tr_file const* f = &inf->files[fi];
-
-        /* get the oldest and newest nonzero timestamps for pieces in this file */
-        for (tr_piece_index_t i = f->firstPiece; i <= f->lastPiece; ++i)
-        {
-            tr_piece const* const p = &inf->pieces[i];
-
-            if (p->timeChecked == 0)
-            {
-                has_zero = true;
-            }
-            else if (oldest_nonzero > p->timeChecked)
-            {
-                oldest_nonzero = p->timeChecked;
-            }
-
-            if (newest < p->timeChecked)
-            {
-                newest = p->timeChecked;
-            }
-        }
-
-        /* If some of a file's pieces have been checked more recently than
-           the file's mtime, and some less recently, then that file will
-           have a list containing timestamps for each piece.
-
-           However, the most common use case is that the file doesn't change
-           after it's downloaded. To reduce overhead in the .resume file,
-           only a single timestamp is saved for the file if *all* or *none*
-           of the pieces were tested more recently than the file's mtime. */
-
-        if (!has_zero && mtime <= oldest_nonzero) /* all checked */
-        {
-            tr_variantListAddInt(l, oldest_nonzero);
-        }
-        else if (newest < mtime) /* none checked */
-        {
-            tr_variantListAddInt(l, newest);
-        }
-        else /* some are checked, some aren't... so list piece by piece */
-        {
-            int const offset = oldest_nonzero - 1;
-            tr_variant* ll = tr_variantListAddList(l, 2 + f->lastPiece - f->firstPiece);
-            tr_variantListAddInt(ll, offset);
-
-            for (tr_piece_index_t i = f->firstPiece; i <= f->lastPiece; ++i)
-            {
-                tr_piece const* const p = &inf->pieces[i];
-
-                tr_variantListAddInt(ll, p->timeChecked != 0 ? p->timeChecked - offset : 0);
-            }
-        }
+        tr_variantListAddInt(l, file->mtime);
     }
+
+    // add the 'checked pieces' bitfield
+    bitfieldToRaw(&tor->checked_pieces_, tr_variantDictAdd(prog, TR_KEY_pieces));
 
     /* add the progress */
     if (tor->completeness == TR_SEED)
@@ -560,97 +522,109 @@ static void saveProgress(tr_variant* dict, tr_torrent* tor)
     }
 
     /* add the blocks bitfield */
-    bitfieldToBenc(tor->completion.blockBitfield, tr_variantDictAdd(prog, TR_KEY_blocks));
+    bitfieldToRaw(tor->completion.blockBitfield, tr_variantDictAdd(prog, TR_KEY_blocks));
 }
 
+/*
+ * This has gone through a couple of iterations to try and get it right.
+ * So the code has added complexity to support older approaches.
+ *
+ * Current approach: 'progress' is a dict with two entries:
+ * - 'pieces' a bitfield for whether each piece has been checked.
+ * - 'mtimes', an array of per-file timestamps
+ * On startup, 'pieces' is loaded. Then we check to see if the disk
+ * mtimes differ from the 'mtimes' list. Changed files have their
+ * pieces cleared from the bitset.
+ *
+ * Second approach (2.20 - 3.00): the 'progress' dict had a
+ * 'time_checked' entry which was a list with fileCount items.
+ * Each item was either a list of per-piece timestamps, or a
+ * single timestamp if either all or none of the pieces had been
+ * tested more recently than the file's mtime.
+ *
+ * First approach (pre-2.20) had an "mtimes" list identical to
+ * 3.10, but not the 'pieces' bitfield.
+ */
 static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
 {
     auto ret = uint64_t{};
     tr_info const* inf = tr_torrentInfo(tor);
 
-    for (size_t i = 0; i < inf->pieceCount; ++i)
-    {
-        inf->pieces[i].timeChecked = 0;
-    }
-
     tr_variant* prog = nullptr;
     if (tr_variantDictFindDict(dict, TR_KEY_progress, &prog))
     {
+        /// CHECKED PIECES
+
+        auto checked = tr_bitfield(inf->pieceCount);
+        auto mtimes = std::vector<time_t>{};
+        mtimes.reserve(inf->fileCount);
+
+        // try to load mtimes
         tr_variant* l = nullptr;
+        if (tr_variantDictFindList(prog, TR_KEY_mtimes, &l))
+        {
+            auto fi = size_t{};
+            auto t = int64_t{};
+            while (tr_variantGetInt(tr_variantListChild(l, fi++), &t))
+            {
+                mtimes.push_back(t);
+            }
+            if (std::size(mtimes) != tor->info.fileCount)
+            {
+                tr_logAddTorErr(tor, "got %zu mtimes; expected %zu", std::size(mtimes), size_t(tor->info.fileCount));
+                mtimes.resize(tor->info.fileCount);
+            }
+        }
+
+        // try to load the piece-checked bitfield
+        uint8_t const* raw = nullptr;
+        auto rawlen = size_t{};
+        if (tr_variantDictFindRaw(prog, TR_KEY_pieces, &raw, &rawlen))
+        {
+            rawToBitfield(checked, raw, rawlen);
+        }
+
+        // maybe it's a .resume file from [2.20 - 3.00] with the per-piece mtimes
         if (tr_variantDictFindList(prog, TR_KEY_time_checked, &l))
         {
-            /* per-piece timestamps were added in 2.20.
-
-               If some of a file's pieces have been checked more recently than
-               the file's mtime, and some lest recently, then that file will
-               have a list containing timestamps for each piece.
-
-               However, the most common use case is that the file doesn't change
-               after it's downloaded. To reduce overhead in the .resume file,
-               only a single timestamp is saved for the file if *all* or *none*
-               of the pieces were tested more recently than the file's mtime. */
-
             for (tr_file_index_t fi = 0; fi < inf->fileCount; ++fi)
             {
-                tr_variant* b = tr_variantListChild(l, fi);
-                tr_file const* f = &inf->files[fi];
+                tr_variant* const b = tr_variantListChild(l, fi);
+                tr_file* const f = &inf->files[fi];
+                auto time_checked = time_t{};
 
                 if (tr_variantIsInt(b))
                 {
                     auto t = int64_t{};
                     tr_variantGetInt(b, &t);
-
-                    for (tr_piece_index_t i = f->firstPiece; i <= f->lastPiece; ++i)
-                    {
-                        inf->pieces[i].timeChecked = (time_t)t;
-                    }
+                    time_checked = time_t(t);
                 }
                 else if (tr_variantIsList(b))
                 {
-                    int64_t offset = 0;
-                    int const pieces = f->lastPiece + 1 - f->firstPiece;
-
+                    auto offset = int64_t{};
                     tr_variantGetInt(tr_variantListChild(b, 0), &offset);
 
-                    for (int i = 0; i < pieces; ++i)
+                    time_checked = tr_time();
+                    size_t const pieces = f->lastPiece + 1 - f->firstPiece;
+                    for (size_t i = 0; i < pieces; ++i)
                     {
-                        int64_t t = 0;
-                        tr_variantGetInt(tr_variantListChild(b, i + 1), &t);
-                        inf->pieces[f->firstPiece + i].timeChecked = (time_t)(t != 0 ? t + offset : 0);
+                        int64_t piece_time = 0;
+                        tr_variantGetInt(tr_variantListChild(b, i + 1), &piece_time);
+                        time_checked = std::min(time_checked, piece_time);
                     }
                 }
+
+                f->mtime = time_checked;
             }
         }
-        else if (tr_variantDictFindList(prog, TR_KEY_mtimes, &l))
-        {
-            /* Before 2.20, we stored the files' mtimes in the .resume file.
-               When loading the .resume file, a torrent's file would be flagged
-               as untested if its stored mtime didn't match its real mtime. */
 
-            for (tr_file_index_t fi = 0; fi < inf->fileCount; ++fi)
-            {
-                auto t = int64_t{};
+        tor->initCheckedPieces(checked, std::data(mtimes));
 
-                if (tr_variantGetInt(tr_variantListChild(l, fi), &t))
-                {
-                    tr_file const* f = &inf->files[fi];
-                    time_t const mtime = tr_torrentGetFileMTime(tor, fi);
-                    time_t const timeChecked = mtime == t ? mtime : 0;
-
-                    for (tr_piece_index_t i = f->firstPiece; i <= f->lastPiece; ++i)
-                    {
-                        inf->pieces[i].timeChecked = timeChecked;
-                    }
-                }
-            }
-        }
+        /// COMPLETION
 
         auto blocks = tr_bitfield{ tor->blockCount };
-
-        auto rawlen = size_t{};
         char const* err = nullptr;
         char const* str = nullptr;
-        uint8_t const* raw = nullptr;
         tr_variant const* const b = tr_variantDictFind(prog, TR_KEY_blocks);
         if (b != nullptr)
         {
@@ -661,17 +635,9 @@ static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
             {
                 err = "Invalid value for \"blocks\"";
             }
-            else if (buflen == 3 && memcmp(buf, "all", 3) == 0)
-            {
-                blocks.setHasAll();
-            }
-            else if (buflen == 4 && memcmp(buf, "none", 4) == 0)
-            {
-                blocks.setHasNone();
-            }
             else
             {
-                blocks.setRaw(buf, buflen, true);
+                rawToBitfield(blocks, buf, buflen);
             }
         }
         else if (tr_variantDictFindStr(prog, TR_KEY_have, &str, nullptr))

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -505,7 +505,7 @@ static void saveProgress(tr_variant* dict, tr_torrent* tor)
     tr_variant* const prog = tr_variantDictAddDict(dict, TR_KEY_progress, 4);
 
     // add the mtimes
-    size_t n = inf->fileCount;
+    size_t const n = inf->fileCount;
     tr_variant* const l = tr_variantDictAddList(prog, TR_KEY_mtimes, n);
     for (auto const *file = inf->files, *end = file + inf->fileCount; file != end; ++file)
     {
@@ -526,8 +526,8 @@ static void saveProgress(tr_variant* dict, tr_torrent* tor)
 }
 
 /*
- * This has gone through a couple of iterations to try and get it right.
- * So the code has added complexity to support older approaches.
+ * Transmisison has iterated through a few strategies here, so the
+ * code has some added complexity to support older approaches.
  *
  * Current approach: 'progress' is a dict with two entries:
  * - 'pieces' a bitfield for whether each piece has been checked.

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1,5 +1,5 @@
 /*
- * This file Copyright (C) 2009-2014 Mnemosyne LLC
+ * This file Copyright (C) 2009-2021 Mnemosyne LLC
  *
  * It may be used under the GNU GPL versions 2 or 3
  * or any future license endorsed by Mnemosyne LLC.
@@ -163,6 +163,12 @@ struct tr_torrent
         if (priority == TR_PRI_NORMAL)
         {
             piece_priorities_.erase(piece);
+
+            if (std::empty(piece_priorities_))
+            {
+                // ensure we release piece_priorities_' internal memory
+                piece_priorities_ = decltype(piece_priorities_){};
+            }
         }
         else
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -210,12 +210,12 @@ struct tr_torrent
 
         for (size_t i = 0; i < info.fileCount; ++i)
         {
-            auto const mtime = mtimes[i];
+            auto const mtime = tr_torrentGetFileMTime(this, i);
 
             info.files[i].mtime = mtime;
 
             // if a file has changed, mark its pieces as unchecked
-            if (mtime != tr_torrentGetFileMTime(this, i))
+            if (mtime != mtimes[i])
             {
                 checked_pieces_.unsetRange(info.files[i].firstPiece, info.files[i].lastPiece);
             }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -143,16 +143,17 @@ struct tr_torrent
     char errorString[128];
     char errorTracker[128];
 
-    // dnd
+    /// DND
 
-    tr_bitfield dnd_pieces = tr_bitfield{ 0 };
+    tr_bitfield dnd_pieces_ = tr_bitfield{ 0 };
 
-    bool isPieceDND(tr_piece_index_t piece) const
+    bool pieceIsDnd(tr_piece_index_t piece) const
     {
-        return dnd_pieces.test(piece);
+        return dnd_pieces_.test(piece);
     }
 
-    // priorities
+    /// PRIORITIES
+
     // since 'TR_PRI_NORMAL' is by far the most common, save some
     // space by treating anything not in the map as normal
     std::unordered_map<tr_piece_index_t, tr_priority_t> piece_priorities_;
@@ -179,7 +180,7 @@ struct tr_torrent
         return it->second;
     }
 
-    // checksums
+    /// CHECKSUMS
 
     tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
@@ -221,7 +222,7 @@ struct tr_torrent
         }
     }
 
-    //
+    ///
 
     uint8_t obfuscatedHash[SHA_DIGEST_LENGTH];
 

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 /***
 ****
@@ -112,8 +113,6 @@
 /* Only use this macro to suppress false-positive alignment warnings */
 #define TR_DISCARD_ALIGN(ptr, type) ((type)(void*)(ptr))
 
-#define SHA_DIGEST_LENGTH 20
-
 #define TR_INET6_ADDRSTRLEN 46
 
 #define TR_ADDRSTRLEN 64
@@ -123,10 +122,16 @@
 // Mostly to enforce better formatting
 #define TR_ARG_TUPLE(...) __VA_ARGS__
 
-auto inline constexpr PEER_ID_LEN = size_t{ 20 };
-
 // https://www.bittorrent.org/beps/bep_0003.html
 // A string of length 20 which this downloader uses as its id. Each
 // downloader generates its own id at random at the start of a new
 // download. This value will also almost certainly have to be escaped.
-using tr_peer_id_t = std::array<char, 20>;
+auto inline constexpr PEER_ID_LEN = size_t{ 20 };
+using tr_peer_id_t = std::array<char, PEER_ID_LEN>;
+
+#define SHA_DIGEST_LENGTH 20
+
+// TODO #1: all arrays of SHA_DIGEST_LENGTH should be replaced with tr_sha1_digest
+// TODO #2: tr_peer_id_t, tr_sha1_digest_t should be moved into a new 'types.h' header
+// TODO #2: this should be an array of std::byte
+using tr_sha1_digest_t = std::array<uint8_t, 20>;

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -131,7 +131,7 @@ using tr_peer_id_t = std::array<char, PEER_ID_LEN>;
 
 #define SHA_DIGEST_LENGTH 20
 
-// TODO #1: all arrays of SHA_DIGEST_LENGTH should be replaced with tr_sha1_digest
+// TODO #1: all arrays of SHA_DIGEST_LENGTH should be replaced with tr_sha1_digest_t
 // TODO #2: tr_peer_id_t, tr_sha1_digest_t should be moved into a new 'types.h' header
-// TODO #2: this should be an array of std::byte
+// TODO #3: this should be an array of std::byte
 using tr_sha1_digest_t = std::array<uint8_t, 20>;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -37,7 +37,6 @@ using tr_port = uint16_t;
 struct tr_ctor;
 struct tr_error;
 struct tr_info;
-struct tr_piece;
 struct tr_session;
 struct tr_torrent;
 struct tr_variant;
@@ -1585,14 +1584,15 @@ void tr_torrentVerify(tr_torrent* torrent, tr_verify_done_func callback_func_or_
 /** @brief a part of tr_info that represents a single file of the torrent's content */
 struct tr_file
 {
+    time_t mtime;
     uint64_t length; /* Length of the file, in bytes */
+    uint64_t offset; /* file begins at the torrent's nth byte */
     char* name; /* Path to the file */
+    tr_piece_index_t firstPiece; /* We need pieces [firstPiece... */
+    tr_piece_index_t lastPiece; /* ...lastPiece] to dl this file */
     int8_t priority; /* TR_PRI_HIGH, _NORMAL, or _LOW */
     bool dnd; /* "do not download" flag */
     bool is_renamed; /* true if we're using a different path from the one in the metainfo; ie, if the user has renamed it */
-    tr_piece_index_t firstPiece; /* We need pieces [firstPiece... */
-    tr_piece_index_t lastPiece; /* ...lastPiece] to dl this file */
-    uint64_t offset; /* file begins at the torrent's nth byte */
 };
 
 /** @brief information about a torrent that comes from its metainfo file */
@@ -1619,8 +1619,9 @@ struct tr_info
     /* torrent's source. empty if not set. */
     char* source;
 
+    tr_sha1_digest_t* pieces;
+
     tr_file* files;
-    tr_piece* pieces;
 
     /* these trackers are sorted by tier */
     tr_tracker_info* trackers;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -37,6 +37,7 @@ using tr_port = uint16_t;
 struct tr_ctor;
 struct tr_error;
 struct tr_info;
+struct tr_piece;
 struct tr_session;
 struct tr_torrent;
 struct tr_variant;
@@ -1592,15 +1593,6 @@ struct tr_file
     tr_piece_index_t firstPiece; /* We need pieces [firstPiece... */
     tr_piece_index_t lastPiece; /* ...lastPiece] to dl this file */
     uint64_t offset; /* file begins at the torrent's nth byte */
-};
-
-/** @brief a part of tr_info that represents a single piece of the torrent's content */
-struct tr_piece
-{
-    time_t timeChecked; /* the last time we tested this piece */
-    uint8_t hash[SHA_DIGEST_LENGTH]; /* pieces hash */
-    int8_t priority; /* TR_PRI_HIGH, _NORMAL, or _LOW */
-    bool dnd; /* "do not download" flag */
 };
 
 /** @brief information about a torrent that comes from its metainfo file */

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1619,9 +1619,8 @@ struct tr_info
     /* torrent's source. empty if not set. */
     char* source;
 
-    tr_sha1_digest_t* pieces;
-
     tr_file* files;
+    tr_sha1_digest_t* pieces;
 
     /* these trackers are sorted by tier */
     tr_tracker_info* trackers;

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -46,7 +46,6 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
     tr_sha1_ctx_t sha = tr_sha1_init();
 
     tr_logAddTorDbg(tor, "%s", "verifying torrent...");
-    tr_torrentSetChecked(tor, 0);
 
     while (!*stopFlag && pieceIndex < tor->info.pieceCount)
     {
@@ -95,10 +94,9 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         /* if we're finishing a piece... */
         if (leftInPiece == 0)
         {
-            uint8_t hash[SHA_DIGEST_LENGTH];
-
-            tr_sha1_final(sha, hash);
-            bool const hasPiece = memcmp(hash, tor->info.pieces[pieceIndex].hash, SHA_DIGEST_LENGTH) == 0;
+            auto hash = tr_sha1_digest_t{};
+            tr_sha1_final(sha, std::data(hash));
+            bool const hasPiece = hash == tor->info.pieces[pieceIndex];
 
             if (hasPiece || hadPiece)
             {
@@ -106,7 +104,6 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
                 changed |= hasPiece != hadPiece;
             }
 
-            tr_torrentSetPieceChecked(tor, pieceIndex);
             time_t const now = tr_time();
             tor->anyDate = now;
 
@@ -119,7 +116,8 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
             }
 
             sha = tr_sha1_init();
-            pieceIndex++;
+            ++pieceIndex;
+            tor->verify_progress = pieceIndex / double(tor->info.pieceCount);
             piecePos = 0;
         }
 
@@ -143,6 +141,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         tr_sys_file_close(fd, nullptr);
     }
 
+    tor->verify_progress.reset();
     tr_sha1_final(sha, nullptr);
     free(buffer);
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -46,6 +46,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
     tr_sha1_ctx_t sha = tr_sha1_init();
 
     tr_logAddTorDbg(tor, "%s", "verifying torrent...");
+    tor->verify_progress = 0;
 
     while (!*stopFlag && pieceIndex < tor->info.pieceCount)
     {

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -442,7 +442,7 @@ void OptionsDialog::onTimeout()
     if (left_in_piece == 0)
     {
         QByteArray const result(verify_hash_.result());
-        bool const matches = memcmp(result.constData(), info_.pieces[verify_piece_index_].hash, SHA_DIGEST_LENGTH) == 0;
+        bool const matches = memcmp(result.constData(), std::data(info_.pieces[verify_piece_index_]), SHA_DIGEST_LENGTH) == 0;
         verify_flags_[verify_piece_index_] = matches;
         verify_piece_pos_ = 0;
         ++verify_piece_index_;


### PR DESCRIPTION
Fixes #2056.

tl;dr: in my permaseed testbed (~19,000 torrents) this cut 500 MB off of steady-state memory use

---

Even though the struct is only 32 bytes, it takes up the vast majority of memory allocation in a transmission-daemon session because there's one allocated for every piece in every torrent, so every byte get multiplied by a large factor.

This PR removes the `tr_piece` struct and replaces it with:

1. An array of sha1 digests, the checksum for each piece. (20 bytes per piece)

2. A per-torrent bitfield of do-not-download flags. When there are no flags marked as 'do not download', the bitfield is empty and only uses a few bytes per torrent.

3. An unordered_hash of piece priorities. This is more expensive than a bitfield, but it's only used while downloading and is cleared out after downloading is done. So the overall use in a permaseed setup is negligible.

4. The largest improvement, removing the per-piece time_t timestamp that was used to determine whether or not a piece had been checked more recently than the file's mtime. This has been replaced with two fields that serve the same purpose: A per-torrent bitfield of which pieces are tested, and a per-torrent array of mtimes for each file. On startup, the downloaded files' mtimes are compared to that array. For any file that has changed, the associated piece(s)' flags are removed from the bitfield.

All of these changes together bring the per-piece memory overhead from 32 bytes down to 20 bytes. That doesn't sound like a lot, but it lowered the overall cost of metainfo allocation in a 19k torrent test setup from 1.3 GB to 800 MB.