### PR TITLE
Fix clang warning in VDKQueue.m

### DIFF
--- a/macosx/VDKQueue/VDKQueue.m
+++ b/macosx/VDKQueue/VDKQueue.m
@@ -52,6 +52,7 @@ NSString * VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevokedNoti
     u_int            _subscriptionFlags;
 }
 
+- (instancetype) init NS_UNAVAILABLE;
 - (instancetype) initWithPath:(NSString*)inPath andSubscriptionFlags:(u_int)flags NS_DESIGNATED_INITIALIZER;
 
 @property (atomic, copy) NSString *path;


### PR DESCRIPTION
Fix warning `Method override for the designated
initializer of the superclass '-init' not found`
with `NS_UNAVAILABLE` marker.