### PR TITLE
refactor: use a std::vector for tr_session.removed_torrents

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -885,24 +885,17 @@ static char const* torrentGet(tr_session* session, tr_variant* args_in, tr_varia
 
     if (tr_variantDictFindStr(args_in, TR_KEY_ids, &strVal, nullptr) && strcmp(strVal, "recently-active") == 0)
     {
-        int n = 0;
         time_t const now = tr_time();
         int const interval = RECENTLY_ACTIVE_SECONDS;
-        tr_variant* removed_out = tr_variantDictAddList(args_out, TR_KEY_removed, 0);
 
-        tr_variant* d = nullptr;
-        while ((d = tr_variantListChild(&session->removedTorrents, n)) != nullptr)
+        auto const& removed = session->removed_torrents;
+        tr_variant* removed_out = tr_variantDictAddList(args_out, TR_KEY_removed, std::size(removed));
+        for (auto const& [id, time_removed] : removed)
         {
-            auto date = int64_t{};
-            auto id = int64_t{};
-
-            if (tr_variantDictFindInt(d, TR_KEY_date, &date) && date >= now - interval &&
-                tr_variantDictFindInt(d, TR_KEY_id, &id))
+            if (time_removed >= now - interval)
             {
                 tr_variantListAddInt(removed_out, id);
             }
-
-            ++n;
         }
     }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -616,7 +616,7 @@ tr_session* tr_sessionInit(char const* configDir, bool messageQueuingEnabled, tr
     session->magicNumber = SESSION_MAGIC_NUMBER;
     session->session_id = tr_session_id_new();
     session->bandwidth = new Bandwidth(nullptr);
-    tr_variantInitList(&session->removedTorrents, 0);
+    session->removed_torrents.clear();
 
     /* nice to start logging at the very beginning */
     auto i = int64_t{};
@@ -2069,7 +2069,6 @@ void tr_sessionClose(tr_session* session)
     }
 
     /* free the session memory */
-    tr_variantFree(&session->removedTorrents);
     delete session->bandwidth;
     delete session->turtle.minutes;
     tr_session_id_free(session->session_id);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -132,7 +132,8 @@ struct tr_session
 
     uint8_t peer_id_ttl_hours;
 
-    tr_variant removedTorrents;
+    // torrent id, time removed
+    std::vector<std::pair<int, time_t>> removed_torrents;
 
     bool stalledEnabled;
     bool queueEnabled[2];

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1910,9 +1910,7 @@ static void closeTorrent(void* vtor)
 
     TR_ASSERT(tr_isTorrent(tor));
 
-    tr_variant* d = tr_variantListAddDict(&tor->session->removedTorrents, 2);
-    tr_variantDictAddInt(d, TR_KEY_id, tor->uniqueId);
-    tr_variantDictAddInt(d, TR_KEY_date, tr_time());
+    tor->session->removed_torrents.emplace_back(tor->uniqueId, tr_time());
 
     tr_logAddTorInfo(tor, "%s", _("Removing torrent"));
 


### PR DESCRIPTION
Before this PR, it was a tr_variant for the sole reason that it was easier to use a tr_variant than roll a new data struct for this in C.