### PR TITLE
feat: new function tr_variantGetStrView()

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -365,10 +365,19 @@ bool tr_variantGetBool(tr_variant const* v, bool* setme)
     }
 
     auto sv = std::string_view{};
-    if (tr_variantGetStrView(v, &sv) && (sv == "true"sv || sv == "false"sv))
+    if (tr_variantGetStrView(v, &sv))
     {
-        *setme = sv == "true"sv;
-        return true;
+        if (sv == "true"sv)
+        {
+            *setme = true;
+            return true;
+        }
+
+        if (sv == "false"sv)
+        {
+            *setme = false;
+            return true;
+        }
     }
 
     return false;

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -168,6 +168,7 @@ constexpr bool tr_variantIsString(tr_variant const* b)
 }
 
 bool tr_variantGetStr(tr_variant const* variant, char const** setme_str, size_t* setme_len);
+bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
 void tr_variantInitStr(tr_variant* initme, std::string_view);
 void tr_variantInitQuark(tr_variant* initme, tr_quark const quark);
@@ -269,6 +270,7 @@ bool tr_variantDictFindInt(tr_variant* dict, tr_quark const key, int64_t* setme)
 bool tr_variantDictFindReal(tr_variant* dict, tr_quark const key, double* setme);
 bool tr_variantDictFindBool(tr_variant* dict, tr_quark const key, bool* setme);
 bool tr_variantDictFindStr(tr_variant* dict, tr_quark const key, char const** setme, size_t* len);
+bool tr_variantDictFindStrView(tr_variant* dict, tr_quark const key, std::string_view* setme);
 bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const** setme_raw, size_t* setme_len);
 
 /* this is only quasi-supported. don't rely on it too heavily outside of libT */

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -47,6 +47,43 @@ protected:
 #define STACK_SMASH_DEPTH (100 * 1000)
 #endif
 
+TEST_F(VariantTest, getType)
+{
+    auto i = int64_t{};
+    auto b = bool{};
+    auto d = double{};
+    auto sv = std::string_view{};
+    auto v = tr_variant{};
+
+    tr_variantInitInt(&v, 30);
+    EXPECT_TRUE(tr_variantGetInt(&v, &i));
+    EXPECT_EQ(30, i);
+    EXPECT_TRUE(tr_variantGetReal(&v, &d));
+    EXPECT_EQ(30, int(d));
+    EXPECT_FALSE(tr_variantGetBool(&v, &b));
+    EXPECT_FALSE(tr_variantGetStrView(&v, &sv));
+
+    auto strkey = "foo"sv;
+    tr_variantInitStr(&v, strkey);
+    EXPECT_FALSE(tr_variantGetBool(&v, &b));
+    EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
+    EXPECT_EQ(strkey, sv);
+
+    strkey = "true"sv;
+    tr_variantInitStr(&v, strkey);
+    EXPECT_TRUE(tr_variantGetBool(&v, &b));
+    EXPECT_TRUE(b);
+    EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
+    EXPECT_EQ(strkey, sv);
+
+    strkey = "false"sv;
+    tr_variantInitStr(&v, strkey);
+    EXPECT_TRUE(tr_variantGetBool(&v, &b));
+    EXPECT_FALSE(b);
+    EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
+    EXPECT_EQ(strkey, sv);
+}
+
 TEST_F(VariantTest, parseInt)
 {
     auto const in = std::string{ "i64e" };


### PR DESCRIPTION
This is similar to the prior sibling function `tr_variantGetStr(variant*, char const** setme_str, size_t* setme_len)` but puts the string into a std::string_view instead of taking separate string and len arguments.