### PR TITLE
fix: another piece priority fix

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -900,7 +900,7 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
     // Only load file priorities if we are actually downloading.
     // If we're a seed or partial seed, loading it is a waste of time.
     // NB: this is why loadProgress() comes before loadFilePriorities()
-    if (!tr_torrentIsSeed(tor) && (fieldsToLoad & TR_FR_FILE_PRIORITIES) != 0)
+    if ((tr_cpLeftUntilDone(&tor->completion) != 0) && (fieldsToLoad & TR_FR_FILE_PRIORITIES) != 0)
     {
         fieldsLoaded |= loadFilePriorities(&top, tor);
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -785,8 +785,6 @@ static void torrentInitFromInfo(tr_torrent* tor)
     tr_cpConstruct(&tor->completion, tor);
 
     tr_torrentInitFilePieces(tor);
-    tor->completeness = tr_cpGetStatus(&tor->completion);
-    tr_torrentInitPiecePriorities(tor);
 }
 
 static void tr_torrentFireMetadataCompleted(tr_torrent* tor);
@@ -909,6 +907,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
     tr_ctorInitTorrentPriorities(ctor, tor);
     tr_ctorInitTorrentWanted(ctor, tor);
+    tr_torrentInitPiecePriorities(tor);
 
     refreshCurrentDir(tor);
 


### PR DESCRIPTION
Move piece priority initialization to later in torrent construction so that we can correctly test whether the torrent is done or not.

The reason for this is because file/piece priorities are discarded iff the torrent is already done.