### PR TITLE
perf: recycle variant tree walking helpers

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -782,7 +782,6 @@ public:
     tr_variant v = {};
 
 protected:
-
     friend class VariantWalker;
 
     void assign(tr_variant const* v_in)


### PR DESCRIPTION
We walk a _lot_ of variant trees in Transmission -- parsing scrape results, loading .torrent files, loading .resume files, saving .resume files, parsing dht results, and so on.

This PR attempts to recycle the variant-walking helper objects by introducing a private `VariantWalker` class that encapsulates the recycling process.

Testing an 18k torrent testbed that with just starting + closing transmission-daemon, this saves about 1.4 million heap allocations.