### PR TITLE
Add MacStadum and SignPath sponsor links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-<p align="center">
- <a href="https://www.macstadium.com/opensource">
-  <img alt="[MacStadium]" src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" height="50"/>
- </a>
- &nbsp;&nbsp;&nbsp;
- <a href="https://signpath.org/">
-  <img alt="[SignPath]" src="https://avatars.githubusercontent.com/u/34448643" height="50"/>
- </a>
-</p>
-
 ## About
 
 Transmission is a fast, easy, and free BitTorrent client. It comes in several flavors:
@@ -86,3 +76,18 @@ If for some reason you are unwilling or unable to do so, there is a shell script
     or
     $ docker-compose build --pull
     $ docker-compose run --rm code_style
+
+## Sponsors
+
+<table>
+ <tbody>
+  <tr>
+   <td align="center"><img alt="[MacStadium]" src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" height="30"/></td>
+   <td>macOS CI builds are running on a M1 Mac Mini provided by <a href="https://www.macstadium.com/opensource">MacStadium</a></td>
+  </tr>
+  <tr>
+   <td align="center"><img alt="[SignPath]" src="https://avatars.githubusercontent.com/u/34448643" height="30"/></td>
+   <td>Free code signing on Windows provided by <a href="https://signpath.io/">SignPath.io</a>, certificate by <a href="https://signpath.org/">SignPath Foundation</a></td>
+  </tr>
+ </tbody>
+</table>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<p align="center">
+ <a href="https://www.macstadium.com/opensource">
+  <img alt="[MacStadium]" src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" height="50"/>
+ </a>
+ &nbsp;&nbsp;&nbsp;
+ <a href="https://signpath.org/">
+  <img alt="[SignPath]" src="https://avatars.githubusercontent.com/u/34448643" height="50"/>
+ </a>
+</p>
+
 ## About
 
 Transmission is a fast, easy, and free BitTorrent client. It comes in several flavors:


### PR DESCRIPTION
MacStadium asks to "put the MacStadium Open Source Developer logo on your landing page (either your GitHub page or website)". We're using Mac Mini M1 they provide for CI builds.

SignPath asks that "a code signing policy must be specified on the project’s home page". We're using the certificate provided by SignPath Foundation and the service provided by SignPath.io to sign release builds on Windows. The policy mention is already in place and the logo is not strictly necessary, but I value their support in this area and want to link back more prominently.