### PR TITLE
refactor: prefer tr_variantDictFindStrView() in tests

### DIFF
--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -52,13 +52,13 @@ TEST_P(JSONTest, testElements)
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
 
-    char const* str = {};
+    auto sv = std::string_view{};
     auto key = tr_quark_new("string"sv);
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key, &str, nullptr));
-    EXPECT_STREQ("hello world", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_EQ("hello world"sv, sv);
 
-    EXPECT_TRUE(tr_variantDictFindStr(&top, tr_quark_new("escaped"sv), &str, nullptr));
-    EXPECT_STREQ("bell \b formfeed \f linefeed \n carriage return \r tab \t", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("escaped"sv), &sv));
+    EXPECT_EQ("bell \b formfeed \f linefeed \n carriage return \r tab \t"sv, sv);
 
     auto i = int64_t{};
     EXPECT_TRUE(tr_variantDictFindInt(&top, tr_quark_new("int"sv), &i));
@@ -75,8 +75,8 @@ TEST_P(JSONTest, testElements)
     EXPECT_TRUE(tr_variantDictFindBool(&top, tr_quark_new("false"sv), &f));
     EXPECT_FALSE(f);
 
-    EXPECT_TRUE(tr_variantDictFindStr(&top, tr_quark_new("null"sv), &str, nullptr));
-    EXPECT_STREQ("", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("null"sv), &sv));
+    EXPECT_EQ(""sv, sv);
 
     if (err == 0)
     {
@@ -88,7 +88,7 @@ TEST_P(JSONTest, testUtf8)
 {
     auto in = std::string{ "{ \"key\": \"Letöltések\" }" };
     tr_variant top;
-    char const* str;
+    auto sv = std::string_view{};
     char* json;
     int err;
     tr_quark const key = tr_quark_new("key"sv);
@@ -96,8 +96,8 @@ TEST_P(JSONTest, testUtf8)
     err = tr_variantFromJson(&top, in.data(), in.size());
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key, &str, nullptr));
-    EXPECT_STREQ("Letöltések", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_EQ("Letöltések"sv, sv);
 
     if (err == 0)
     {
@@ -108,8 +108,8 @@ TEST_P(JSONTest, testUtf8)
     err = tr_variantFromJson(&top, in.data(), in.size());
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key, &str, nullptr));
-    EXPECT_STREQ("\\", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_EQ("\\"sv, sv);
 
     if (err == 0)
     {
@@ -128,8 +128,8 @@ TEST_P(JSONTest, testUtf8)
     err = tr_variantFromJson(&top, in.data(), in.size());
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key, &str, nullptr));
-    EXPECT_STREQ("Letöltések", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_EQ("Letöltések"sv, sv);
     json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON, nullptr);
 
     if (err == 0)
@@ -143,8 +143,8 @@ TEST_P(JSONTest, testUtf8)
     err = tr_variantFromJson(&top, json, strlen(json));
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key, &str, nullptr));
-    EXPECT_STREQ("Letöltések", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_EQ("Letöltések"sv, sv);
 
     if (err == 0)
     {
@@ -174,21 +174,21 @@ TEST_P(JSONTest, test1)
     tr_variant top;
     auto const err = tr_variantFromJson(&top, in.data(), in.size());
 
-    char const* str;
+    auto sv = std::string_view{};
     int64_t i;
     EXPECT_EQ(0, err);
     EXPECT_TRUE(tr_variantIsDict(&top));
     auto* headers = tr_variantDictFind(&top, tr_quark_new("headers"sv));
     EXPECT_NE(nullptr, headers);
     EXPECT_TRUE(tr_variantIsDict(headers));
-    EXPECT_TRUE(tr_variantDictFindStr(headers, tr_quark_new("type"sv), &str, nullptr));
-    EXPECT_STREQ("request", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(headers, tr_quark_new("type"sv), &sv));
+    EXPECT_EQ("request"sv, sv);
     EXPECT_TRUE(tr_variantDictFindInt(headers, TR_KEY_tag, &i));
     EXPECT_EQ(666, i);
     auto* body = tr_variantDictFind(&top, tr_quark_new("body"sv));
     EXPECT_NE(nullptr, body);
-    EXPECT_TRUE(tr_variantDictFindStr(body, TR_KEY_name, &str, nullptr));
-    EXPECT_STREQ("torrent-info", str);
+    EXPECT_TRUE(tr_variantDictFindStrView(body, TR_KEY_name, &sv));
+    EXPECT_EQ("torrent-info"sv, sv);
     auto* args = tr_variantDictFind(body, tr_quark_new("arguments"sv));
     EXPECT_NE(nullptr, args);
     EXPECT_TRUE(tr_variantIsDict(args));
@@ -230,9 +230,9 @@ TEST_P(JSONTest, test3)
     auto const err = tr_variantFromJson(&top, in.data(), in.size());
     EXPECT_EQ(0, err);
 
-    char const* str;
-    EXPECT_TRUE(tr_variantDictFindStr(&top, TR_KEY_errorString, &str, nullptr));
-    EXPECT_STREQ("torrent not registered with this tracker 6UHsVW'*C", str);
+    auto sv = std::string_view{};
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, TR_KEY_errorString, &sv));
+    EXPECT_EQ("torrent not registered with this tracker 6UHsVW'*C"sv, sv);
 
     tr_variantFree(&top);
 }
@@ -244,9 +244,9 @@ TEST_P(JSONTest, unescape)
     int const err = tr_variantFromJson(&top, in.data(), in.size());
     EXPECT_EQ(0, err);
 
-    char const* str;
-    EXPECT_TRUE(tr_variantDictFindStr(&top, tr_quark_new("string-1"sv), &str, nullptr));
-    EXPECT_STREQ("/usr/lib", str);
+    auto sv = std::string_view{};
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("string-1"sv), &sv));
+    EXPECT_EQ("/usr/lib"sv, sv);
 
     tr_variantFree(&top);
 }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -300,19 +300,18 @@ private:
         ensureFormattersInited();
 
         // download dir
-        size_t len;
-        char const* str;
+        auto sv = std::string_view{};
         auto q = TR_KEY_download_dir;
-        auto const download_dir = tr_variantDictFindStr(settings, q, &str, &len) ?
-            makeString(tr_strdup_printf("%s/%*.*s", sandboxDir().data(), TR_ARG_TUPLE((int)len, (int)len, str))) :
+        auto const download_dir = tr_variantDictFindStrView(settings, q, &sv) ?
+            makeString(tr_strdup_printf("%s/%" TR_PRIsv, sandboxDir().data(), TR_PRIsv_ARG(sv))) :
             makeString(tr_buildPath(sandboxDir().data(), "Downloads", nullptr));
         tr_sys_dir_create(download_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700, nullptr);
         tr_variantDictAddStr(settings, q, download_dir.data());
 
         // incomplete dir
         q = TR_KEY_incomplete_dir;
-        auto const incomplete_dir = tr_variantDictFindStr(settings, q, &str, &len) ?
-            makeString(tr_strdup_printf("%s/%*.*s", sandboxDir().data(), TR_ARG_TUPLE((int)len, (int)len, str))) :
+        auto const incomplete_dir = tr_variantDictFindStrView(settings, q, &sv) ?
+            makeString(tr_strdup_printf("%s/%" TR_PRIsv, sandboxDir().data(), TR_PRIsv_ARG(sv))) :
             makeString(tr_buildPath(sandboxDir().data(), "Incomplete", nullptr));
         tr_variantDictAddStr(settings, q, incomplete_dir.data());
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -451,20 +451,15 @@ TEST_F(VariantTest, merge)
     EXPECT_EQ(3, i);
     EXPECT_TRUE(tr_variantDictFindInt(&dest, i4, &i));
     EXPECT_EQ(-35, i);
-    size_t len;
-    char const* s;
-    EXPECT_TRUE(tr_variantDictFindStr(&dest, s5, &s, &len));
-    EXPECT_EQ(size_t{ 3 }, len);
-    EXPECT_STREQ("abc", s);
-    EXPECT_TRUE(tr_variantDictFindStr(&dest, s6, &s, &len));
-    EXPECT_EQ(size_t{ 3 }, len);
-    EXPECT_STREQ("xyz", s);
-    EXPECT_TRUE(tr_variantDictFindStr(&dest, s7, &s, &len));
-    EXPECT_EQ(size_t{ 9 }, len);
-    EXPECT_STREQ("127.0.0.1", s);
-    EXPECT_TRUE(tr_variantDictFindStr(&dest, s8, &s, &len));
-    EXPECT_EQ(size_t{ 3 }, len);
-    EXPECT_STREQ("ghi", s);
+    auto sv = std::string_view{};
+    EXPECT_TRUE(tr_variantDictFindStrView(&dest, s5, &sv));
+    EXPECT_EQ("abc"sv, sv);
+    EXPECT_TRUE(tr_variantDictFindStrView(&dest, s6, &sv));
+    EXPECT_EQ("xyz"sv, sv);
+    EXPECT_TRUE(tr_variantDictFindStrView(&dest, s7, &sv));
+    EXPECT_EQ("127.0.0.1"sv, sv);
+    EXPECT_TRUE(tr_variantDictFindStrView(&dest, s8, &sv));
+    EXPECT_EQ("ghi"sv, sv);
 
     tr_variantFree(&dest);
     tr_variantFree(&src);
@@ -554,18 +549,16 @@ TEST_F(VariantTest, dictFindType)
     tr_variantDictAddStr(&top, key_str, ExpectedStr.data());
 
     // look up the keys as strings
-    char const* str = {};
-    auto len = size_t{};
     auto sv = std::string_view{};
-    EXPECT_FALSE(tr_variantDictFindStr(&top, key_bool, &str, &len));
-    EXPECT_FALSE(tr_variantDictFindStr(&top, key_real, &str, &len));
-    EXPECT_FALSE(tr_variantDictFindStr(&top, key_int, &str, &len));
-    EXPECT_TRUE(tr_variantDictFindStr(&top, key_str, &str, &len));
-    EXPECT_EQ(ExpectedStr, std::string(str, len));
+    EXPECT_FALSE(tr_variantDictFindStrView(&top, key_bool, &sv));
+    EXPECT_FALSE(tr_variantDictFindStrView(&top, key_real, &sv));
+    EXPECT_FALSE(tr_variantDictFindStrView(&top, key_int, &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&top, key_str, &sv));
+    EXPECT_EQ(ExpectedStr, sv);
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key_str, &sv));
     EXPECT_EQ(ExpectedStr, sv);
     EXPECT_FALSE(tr_variantDictFindStrView(&top, key_unknown, &sv));
-    EXPECT_FALSE(tr_variantDictFindStr(&top, key_unknown, &str, &len));
+    EXPECT_FALSE(tr_variantDictFindStrView(&top, key_unknown, &sv));
 
     // look up the keys as bools
     auto b = bool{};

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -76,7 +76,7 @@ protected:
     auto createWatchDir(std::string const& path, tr_watchdir_cb cb, void* cb_data)
     {
         auto const force_generic = GetParam() == WatchMode::GENERIC;
-        return tr_watchdir_new(path, cb, cb_data, ev_base_.get(), force_generic);
+        return tr_watchdir_new(path.c_str(), cb, cb_data, ev_base_.get(), force_generic);
     }
 
     std::string createFile(std::string const& parent_dir, std::string const& name)

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -76,7 +76,7 @@ protected:
     auto createWatchDir(std::string const& path, tr_watchdir_cb cb, void* cb_data)
     {
         auto const force_generic = GetParam() == WatchMode::GENERIC;
-        return tr_watchdir_new(path.c_str(), cb, cb_data, ev_base_.get(), force_generic);
+        return tr_watchdir_new(path, cb, cb_data, ev_base_.get(), force_generic);
     }
 
     std::string createFile(std::string const& parent_dir, std::string const& name)


### PR DESCRIPTION
Prefer `tr_variantDictFindStrView()` to `tr_variantDictFindStr()` in tests