### PR TITLE
Include GTK client icon in resources once

### DIFF
--- a/gtk/transmission.gresource.xml
+++ b/gtk/transmission.gresource.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/transmissionbt/transmission">
-    <file alias="icons/scalable/panel/transmission-main-window-icon.svg" compressed="true" preprocess="xml-stripblanks">icons/hicolor_apps_scalable_transmission.svg</file>
-    <file alias="icons/scalable/panel/transmission-notification-icon.svg" compressed="true" preprocess="xml-stripblanks">icons/hicolor_apps_scalable_transmission.svg</file>
-    <file alias="icons/scalable/panel/transmission-tray-icon.svg" compressed="true" preprocess="xml-stripblanks">icons/hicolor_apps_scalable_transmission.svg</file>
+    <file alias="icons/scalable/apps/transmission.svg" compressed="true" preprocess="xml-stripblanks">icons/hicolor_apps_scalable_transmission.svg</file>
     <file alias="icons/16x16/actions/lock.png">icons/lock.png</file>
     <file alias="icons/16x16/status/ratio.png">icons/ratio.png</file>
     <file alias="icons/16x16/status/alt-speed-on.png">icons/turtle-blue.png</file>


### PR DESCRIPTION
There is a fallback mechanism in GTK: when looking for an icon named foo-a-b-c, it'll also try to find foo-a-b, foo-a, and foo, so the only icon necessary (if all of them default to the same one) is foo. Given that we're also installing this icon, including it in resources doesn't make a lot of sense, by I'm leaving it just in case anyway (useful when debugging without installing).