### PR TITLE
Fix torrent counts in tracker filter bar combo (GTK client)

### DIFF
--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -184,7 +184,7 @@ bool tracker_filter_model_update(Glib::RefPtr<Gtk::TreeStore> const& tracker_mod
 
             if (auto const count = hosts_hash.find(key); count == hosts_hash.end())
             {
-                hosts_hash.emplace(key, 1);
+                hosts_hash.emplace(key, 0);
                 hosts.push_back(key);
             }
 


### PR DESCRIPTION
Total count was correct, but per-tracker counts were 1 more than in reality.