### PR TITLE
refactor: tr_session.scripts

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1856,15 +1856,14 @@ static char const* sessionSet(
     tr_rpc_idle_data* /*idle_data*/)
 {
     auto download_dir = std::string_view{};
-    char const* incomplete_dir = nullptr;
+    auto incomplete_dir = std::string_view{};
 
     if (tr_variantDictFindStrView(args_in, TR_KEY_download_dir, &download_dir) && tr_sys_path_is_relative(download_dir))
     {
         return "download directory path is not absolute";
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_incomplete_dir, &incomplete_dir, nullptr) &&
-        tr_sys_path_is_relative(incomplete_dir))
+    if (tr_variantDictFindStrView(args_in, TR_KEY_incomplete_dir, &incomplete_dir) && tr_sys_path_is_relative(incomplete_dir))
     {
         return "incomplete torrents directory path is not absolute";
     }
@@ -1950,14 +1949,14 @@ static char const* sessionSet(
         tr_sessionSetQueueEnabled(session, TR_DOWN, boolVal);
     }
 
-    if (incomplete_dir != nullptr)
+    if (!std::empty(incomplete_dir))
     {
-        tr_sessionSetIncompleteDir(session, incomplete_dir);
+        session->setIncompleteDir(incomplete_dir);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_incomplete_dir_enabled, &boolVal))
     {
-        tr_sessionSetIncompleteDirEnabled(session, boolVal);
+        session->useIncompleteDir(boolVal);
     }
 
     if (tr_variantDictFindInt(args_in, TR_KEY_peer_limit_global, &i))

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2044,24 +2044,24 @@ static char const* sessionSet(
         tr_sessionSetQueueSize(session, TR_UP, (int)i);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_added_filename, &str, nullptr))
+    if (tr_variantDictFindStrView(args_in, TR_KEY_script_torrent_added_filename, &sv))
     {
-        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_ADDED, str);
+        session->setScript(TR_SCRIPT_ON_TORRENT_ADDED, sv);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_script_torrent_added_enabled, &boolVal))
     {
-        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
+        session->useScript(TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
     }
 
-    if (tr_variantDictFindStr(args_in, TR_KEY_script_torrent_done_filename, &str, nullptr))
+    if (tr_variantDictFindStrView(args_in, TR_KEY_script_torrent_done_filename, &sv))
     {
-        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_DONE, str);
+        session->setScript(TR_SCRIPT_ON_TORRENT_DONE, sv);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_script_torrent_done_enabled, &boolVal))
     {
-        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_DONE, boolVal);
+        session->useScript(TR_SCRIPT_ON_TORRENT_DONE, boolVal);
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_trash_original_torrent_files, &boolVal))

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1111,22 +1111,22 @@ static void sessionSetImpl(void* vdata)
 
     if (tr_variantDictFindBool(settings, TR_KEY_script_torrent_added_enabled, &boolVal))
     {
-        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
+        session->useScript(TR_SCRIPT_ON_TORRENT_ADDED, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_added_filename, &strVal, nullptr))
+    if (tr_variantDictFindStrView(settings, TR_KEY_script_torrent_added_filename, &sv))
     {
-        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_ADDED, strVal);
+        session->setScript(TR_SCRIPT_ON_TORRENT_ADDED, sv);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_script_torrent_done_enabled, &boolVal))
     {
-        tr_sessionSetScriptEnabled(session, TR_SCRIPT_ON_TORRENT_DONE, boolVal);
+        session->useScript(TR_SCRIPT_ON_TORRENT_DONE, boolVal);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_script_torrent_done_filename, &strVal, nullptr))
+    if (tr_variantDictFindStrView(settings, TR_KEY_script_torrent_done_filename, &sv))
     {
-        tr_sessionSetScript(session, TR_SCRIPT_ON_TORRENT_DONE, strVal);
+        session->setScript(TR_SCRIPT_ON_TORRENT_DONE, sv);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_scrape_paused_torrents_enabled, &boolVal))
@@ -2675,7 +2675,7 @@ void tr_sessionSetScriptEnabled(tr_session* session, TrScript type, bool enabled
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
-    session->scripts_enabled[type] = enabled;
+    session->useScript(type, enabled);
 }
 
 bool tr_sessionIsScriptEnabled(tr_session const* session, TrScript type)
@@ -2683,7 +2683,7 @@ bool tr_sessionIsScriptEnabled(tr_session const* session, TrScript type)
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
-    return session->scripts_enabled[type];
+    return session->useScript(type);
 }
 
 void tr_sessionSetScript(tr_session* session, TrScript type, char const* script)
@@ -2691,7 +2691,7 @@ void tr_sessionSetScript(tr_session* session, TrScript type, char const* script)
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
-    session->scripts[type].assign(script ? script : "");
+    session->setScript(type, script ? script : "");
 }
 
 char const* tr_sessionGetScript(tr_session const* session, TrScript type)
@@ -2699,7 +2699,7 @@ char const* tr_sessionGetScript(tr_session const* session, TrScript type)
     TR_ASSERT(tr_isSession(session));
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
-    return session->scripts[type].c_str();
+    return session->script(type).c_str();
 }
 
 /***

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -937,14 +937,14 @@ static void sessionSetImpl(void* vdata)
         session->setDownloadDir(sv);
     }
 
-    if (tr_variantDictFindStr(settings, TR_KEY_incomplete_dir, &strVal, nullptr))
+    if (tr_variantDictFindStrView(settings, TR_KEY_incomplete_dir, &sv))
     {
-        tr_sessionSetIncompleteDir(session, strVal);
+        session->setIncompleteDir(sv);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_incomplete_dir_enabled, &boolVal))
     {
-        tr_sessionSetIncompleteDirEnabled(session, boolVal);
+        session->useIncompleteDir(boolVal);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_rename_partial_files, &boolVal))
@@ -1211,33 +1211,28 @@ void tr_sessionSetIncompleteDir(tr_session* session, char const* dir)
 {
     TR_ASSERT(tr_isSession(session));
 
-    if (session->incompleteDir != dir)
-    {
-        tr_free(session->incompleteDir);
-
-        session->incompleteDir = tr_strdup(dir);
-    }
+    session->setIncompleteDir(dir ? dir : "");
 }
 
 char const* tr_sessionGetIncompleteDir(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->incompleteDir;
+    return session->incompleteDir().c_str();
 }
 
 void tr_sessionSetIncompleteDirEnabled(tr_session* session, bool b)
 {
     TR_ASSERT(tr_isSession(session));
 
-    session->isIncompleteDirEnabled = b;
+    session->useIncompleteDir(b);
 }
 
 bool tr_sessionIsIncompleteDirEnabled(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->isIncompleteDirEnabled;
+    return session->useIncompleteDir();
 }
 
 /***
@@ -2058,7 +2053,6 @@ void tr_sessionClose(tr_session* session)
     tr_free(session->configDir);
     tr_free(session->resumeDir);
     tr_free(session->torrentDir);
-    tr_free(session->incompleteDir);
     tr_free(session->blocklist_url);
     tr_free(session->peer_congestion_algorithm);
     delete session;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -161,6 +161,26 @@ public:
         incomplete_dir_enabled_ = enabled;
     }
 
+    void useScript(TrScript i, bool enabled)
+    {
+        scripts_enabled_[i] = enabled;
+    }
+
+    bool useScript(TrScript i) const
+    {
+        return scripts_enabled_[i];
+    }
+
+    void setScript(TrScript i, std::string_view path)
+    {
+        scripts_[i] = path;
+    }
+
+    std::string const& script(TrScript i) const
+    {
+        return scripts_[i];
+    }
+
 public:
     bool isPortRandom;
     bool isPexEnabled;
@@ -177,7 +197,6 @@ public:
     bool pauseAddedTorrent;
     bool deleteSourceTorrent;
     bool scrapePausedTorrents;
-    std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled;
 
     uint8_t peer_id_ttl_hours;
 
@@ -245,8 +264,6 @@ public:
     std::map<uint8_t const*, tr_torrent*, CompareHash> torrentsByHash;
     std::map<std::string_view, tr_torrent*, CaseInsensitiveStringCompare> torrentsByHashString;
 
-    std::array<std::string, TR_SCRIPT_N_TYPES> scripts;
-
     char* configDir;
     char* resumeDir;
     char* torrentDir;
@@ -289,9 +306,11 @@ public:
     struct tr_bindinfo* bind_ipv6;
 
 private:
+    std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
     std::string incomplete_dir_;
     std::string download_dir_;
 
+    std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_;
     bool incomplete_dir_enabled_ = false;
 };
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -141,6 +141,26 @@ public:
         download_dir_ = dir;
     }
 
+    std::string const& incompleteDir() const
+    {
+        return incomplete_dir_;
+    }
+
+    void setIncompleteDir(std::string_view dir)
+    {
+        incomplete_dir_ = dir;
+    }
+
+    bool useIncompleteDir() const
+    {
+        return incomplete_dir_enabled_;
+    }
+
+    void useIncompleteDir(bool enabled)
+    {
+        incomplete_dir_enabled_ = enabled;
+    }
+
 public:
     bool isPortRandom;
     bool isPexEnabled;
@@ -151,10 +171,9 @@ public:
     bool isPrefetchEnabled;
     bool isClosing;
     bool isClosed;
-    bool isIncompleteFileNamingEnabled;
     bool isRatioLimited;
     bool isIdleLimited;
-    bool isIncompleteDirEnabled;
+    bool isIncompleteFileNamingEnabled;
     bool pauseAddedTorrent;
     bool deleteSourceTorrent;
     bool scrapePausedTorrents;
@@ -231,7 +250,6 @@ public:
     char* configDir;
     char* resumeDir;
     char* torrentDir;
-    char* incompleteDir;
 
     char* blocklist_url;
 
@@ -271,7 +289,10 @@ public:
     struct tr_bindinfo* bind_ipv6;
 
 private:
+    std::string incomplete_dir_;
     std::string download_dir_;
+
+    bool incomplete_dir_enabled_ = false;
 };
 
 constexpr tr_port tr_sessionGetPublicPeerPort(tr_session const* session)

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -35,15 +35,15 @@ TEST_F(SessionTest, properties)
 
     // download dir
 
-    for (auto const& sv : { "foo"sv, "bar"sv, ""sv })
+    for (auto const& value : { "foo"sv, "bar"sv, ""sv })
     {
-        session->setDownloadDir(sv);
-        EXPECT_EQ(sv, session->downloadDir());
-        EXPECT_EQ(sv, tr_sessionGetDownloadDir(session));
+        session->setDownloadDir(value);
+        EXPECT_EQ(value, session->downloadDir());
+        EXPECT_EQ(value, tr_sessionGetDownloadDir(session));
 
-        tr_sessionSetDownloadDir(session, std::string(sv).c_str());
-        EXPECT_EQ(sv, session->downloadDir());
-        EXPECT_EQ(sv, tr_sessionGetDownloadDir(session));
+        tr_sessionSetDownloadDir(session, std::string(value).c_str());
+        EXPECT_EQ(value, session->downloadDir());
+        EXPECT_EQ(value, tr_sessionGetDownloadDir(session));
     }
 
     tr_sessionSetDownloadDir(session, nullptr);
@@ -52,32 +52,63 @@ TEST_F(SessionTest, properties)
 
     // incomplete dir
 
-    for (auto const& sv : { "foo"sv, "bar"sv, ""sv })
+    for (auto const& value : { "foo"sv, "bar"sv, ""sv })
     {
-        session->setIncompleteDir(sv);
-        EXPECT_EQ(sv, session->incompleteDir());
-        EXPECT_EQ(sv, tr_sessionGetIncompleteDir(session));
+        session->setIncompleteDir(value);
+        EXPECT_EQ(value, session->incompleteDir());
+        EXPECT_EQ(value, tr_sessionGetIncompleteDir(session));
 
-        tr_sessionSetIncompleteDir(session, std::string(sv).c_str());
-        EXPECT_EQ(sv, session->incompleteDir());
-        EXPECT_EQ(sv, tr_sessionGetIncompleteDir(session));
+        tr_sessionSetIncompleteDir(session, std::string(value).c_str());
+        EXPECT_EQ(value, session->incompleteDir());
+        EXPECT_EQ(value, tr_sessionGetIncompleteDir(session));
     }
 
     tr_sessionSetIncompleteDir(session, nullptr);
     EXPECT_EQ(""sv, session->incompleteDir());
     EXPECT_EQ(""sv, tr_sessionGetIncompleteDir(session));
 
+    // script
+
+    for (auto const& type : { TR_SCRIPT_ON_TORRENT_ADDED, TR_SCRIPT_ON_TORRENT_DONE })
+    {
+        for (auto const& value : { "foo"sv, "bar"sv, ""sv })
+        {
+            session->setScript(type, value);
+            EXPECT_EQ(value, session->script(type));
+            EXPECT_EQ(value, tr_sessionGetScript(session, type));
+
+            tr_sessionSetScript(session, type, std::string(value).c_str());
+            EXPECT_EQ(value, session->script(type));
+            EXPECT_EQ(value, tr_sessionGetScript(session, type));
+        }
+
+        tr_sessionSetScript(session, type, nullptr);
+        EXPECT_EQ(""sv, session->script(type));
+        EXPECT_EQ(""sv, tr_sessionGetScript(session, type));
+
+        for (auto const value : { true, false })
+        {
+            session->useScript(type, value);
+            EXPECT_EQ(value, session->useScript(type));
+            EXPECT_EQ(value, tr_sessionIsScriptEnabled(session, type));
+
+            tr_sessionSetScriptEnabled(session, type, value);
+            EXPECT_EQ(value, session->useScript(type));
+            EXPECT_EQ(value, tr_sessionIsScriptEnabled(session, type));
+        }
+    }
+
     // incomplete dir enabled
 
-    for (auto const b : { true, false })
+    for (auto const value : { true, false })
     {
-        session->useIncompleteDir(b);
-        EXPECT_EQ(b, session->useIncompleteDir());
-        EXPECT_EQ(b, tr_sessionIsIncompleteDirEnabled(session));
+        session->useIncompleteDir(value);
+        EXPECT_EQ(value, session->useIncompleteDir());
+        EXPECT_EQ(value, tr_sessionIsIncompleteDirEnabled(session));
 
-        tr_sessionSetIncompleteDirEnabled(session, b);
-        EXPECT_EQ(b, session->useIncompleteDir());
-        EXPECT_EQ(b, tr_sessionIsIncompleteDirEnabled(session));
+        tr_sessionSetIncompleteDirEnabled(session, value);
+        EXPECT_EQ(value, session->useIncompleteDir());
+        EXPECT_EQ(value, tr_sessionIsIncompleteDirEnabled(session));
     }
 }
 

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -12,7 +12,7 @@
 #include "utils.h"
 #include "version.h"
 
-#include "gtest/gtest.h"
+#include "test-fixtures.h"
 
 #include <algorithm>
 #include <array>
@@ -21,7 +21,67 @@
 #include <cstring>
 #include <string>
 
-TEST(Session, peerId)
+using namespace std::literals;
+
+namespace libtransmission
+{
+
+namespace test
+{
+
+TEST_F(SessionTest, properties)
+{
+    auto* const session = session_;
+
+    // download dir
+
+    for (auto const& sv : { "foo"sv, "bar"sv, ""sv })
+    {
+        session->setDownloadDir(sv);
+        EXPECT_EQ(sv, session->downloadDir());
+        EXPECT_EQ(sv, tr_sessionGetDownloadDir(session));
+
+        tr_sessionSetDownloadDir(session, std::string(sv).c_str());
+        EXPECT_EQ(sv, session->downloadDir());
+        EXPECT_EQ(sv, tr_sessionGetDownloadDir(session));
+    }
+
+    tr_sessionSetDownloadDir(session, nullptr);
+    EXPECT_EQ(""sv, session->downloadDir());
+    EXPECT_EQ(""sv, tr_sessionGetDownloadDir(session));
+
+    // incomplete dir
+
+    for (auto const& sv : { "foo"sv, "bar"sv, ""sv })
+    {
+        session->setIncompleteDir(sv);
+        EXPECT_EQ(sv, session->incompleteDir());
+        EXPECT_EQ(sv, tr_sessionGetIncompleteDir(session));
+
+        tr_sessionSetIncompleteDir(session, std::string(sv).c_str());
+        EXPECT_EQ(sv, session->incompleteDir());
+        EXPECT_EQ(sv, tr_sessionGetIncompleteDir(session));
+    }
+
+    tr_sessionSetIncompleteDir(session, nullptr);
+    EXPECT_EQ(""sv, session->incompleteDir());
+    EXPECT_EQ(""sv, tr_sessionGetIncompleteDir(session));
+
+    // incomplete dir enabled
+
+    for (auto const b : { true, false })
+    {
+        session->useIncompleteDir(b);
+        EXPECT_EQ(b, session->useIncompleteDir());
+        EXPECT_EQ(b, tr_sessionIsIncompleteDirEnabled(session));
+
+        tr_sessionSetIncompleteDirEnabled(session, b);
+        EXPECT_EQ(b, session->useIncompleteDir());
+        EXPECT_EQ(b, tr_sessionIsIncompleteDirEnabled(session));
+    }
+}
+
+TEST_F(SessionTest, peerId)
 {
     auto const peer_id_prefix = std::string{ PEERID_PREFIX };
 
@@ -47,7 +107,7 @@ TEST(Session, peerId)
     }
 }
 
-TEST(Session, sessionId)
+TEST_F(SessionTest, sessionId)
 {
 #ifdef __sun
     // FIXME: File locking doesn't work as expected
@@ -124,3 +184,7 @@ TEST(Session, sessionId)
     tr_free(const_cast<char*>(session_id_str_2));
     tr_free(const_cast<char*>(session_id_str_1));
 }
+
+} // namespace test
+
+} // namespace libtransmission


### PR DESCRIPTION
Add getters / setters for tr_session scripts, making the property values private fields.

Add tests for the related C++ and C API.