### PR TITLE
build: disable exit-time-destructor warnings in GTK client

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -181,8 +181,6 @@ target_link_libraries(${TR_NAME}-gtk
 )
 
 if(NOT MSVC)
-    # https://github.com/transmission/transmission/issues/1381 patches welcome
-    target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-deprecated-declarations)
     target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-exit-time-destructors)
 endif()
 

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -183,6 +183,7 @@ target_link_libraries(${TR_NAME}-gtk
 if(NOT MSVC)
     # https://github.com/transmission/transmission/issues/1381 patches welcome
     target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-deprecated-declarations)
+    target_compile_options(${TR_NAME}-gtk PRIVATE -Wno-exit-time-destructors)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
These were introduced during the gtkmm update.