### PR TITLE
refactor: remove tr_variantDictFindstr() from transmission-gtk

### DIFF
--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -220,9 +220,9 @@ std::vector<std::string> gtr_pref_strv_get(tr_quark const key)
 
 std::string gtr_pref_string_get(tr_quark const key)
 {
-    char const* str;
-
-    return tr_variantDictFindStr(getPrefs(), key, &str, nullptr) ? str : std::string();
+    auto sv = std::string_view{};
+    tr_variantDictFindStrView(getPrefs(), key, &sv);
+    return std::string{ sv };
 }
 
 void gtr_pref_string_set(tr_quark const key, std::string const& value)


### PR DESCRIPTION
More refactoring to not require zero-termination of strings taken from variants.

The final goal of this string of PRs is to make it safe to have inplace variant parsing (ie when we have the raw benc or json in memory, just take string_views of that raw memory instead of allocating copies of it).