### PR TITLE
refactor: remove tr_variantGetStr()

### DIFF
--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -206,11 +206,10 @@ std::vector<std::string> gtr_pref_strv_get(tr_quark const key)
 
         for (size_t i = 0; i < n; ++i)
         {
-            char const* str = nullptr;
-            size_t len = 0;
-            if (tr_variantGetStr(tr_variantListChild(list, i), &str, &len))
+            auto sv = std::string_view{};
+            if (tr_variantGetStrView(tr_variantListChild(list, i), &sv))
             {
-                ret.emplace_back(str, len);
+                ret.emplace_back(sv);
             }
         }
     }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -316,7 +316,7 @@ bool tr_variantGetStrView(tr_variant const* v, std::string_view* setme)
     return true;
 }
 
-bool tr_variantGetStr(tr_variant const* v, char const** setme, size_t* len)
+static bool tr_variantGetStr(tr_variant const* v, char const** setme, size_t* len)
 {
     auto sv = std::string_view{};
     if (!tr_variantGetStrView(v, &sv))

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -167,7 +167,6 @@ constexpr bool tr_variantIsString(tr_variant const* b)
     return b != nullptr && b->type == TR_VARIANT_TYPE_STR;
 }
 
-bool tr_variantGetStr(tr_variant const* variant, char const** setme_str, size_t* setme_len);
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
 void tr_variantInitStr(tr_variant* initme, std::string_view);

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -176,13 +176,12 @@ void TorrentModel::updateTorrents(tr_variant* torrents, bool is_complete_list)
     {
         // In 'table' format, the first entry in 'torrents' is an array of keys.
         // All the other entries are an array of the values for one torrent.
-        char const* str;
-        size_t len;
+        auto sv = std::string_view{};
         size_t i = 0;
         keys.reserve(tr_variantListSize(first_child));
-        while (tr_variantGetStr(tr_variantListChild(first_child, i++), &str, &len))
+        while (tr_variantGetStrView(tr_variantListChild(first_child, i++), &sv))
         {
-            keys.push_back(tr_quark_new(std::string_view(str, len)));
+            keys.push_back(tr_quark_new(sv));
         }
     }
     else if (first_child != nullptr)

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -77,11 +77,10 @@ template<typename T, typename std::enable_if<std::is_same_v<T, QString>>::type* 
 auto getValue(tr_variant const* variant)
 {
     std::optional<T> ret;
-    char const* str;
-    size_t len;
-    if (tr_variantGetStr(variant, &str, &len))
+    auto sv = std::string_view{};
+    if (tr_variantGetStrView(variant, &sv))
     {
-        ret = QString::fromUtf8(str, len);
+        ret = QString::fromUtf8(std::data(sv), std::size(sv));
     }
 
     return ret;
@@ -91,11 +90,10 @@ template<typename T, typename std::enable_if<std::is_same_v<T, std::string_view>
 auto getValue(tr_variant const* variant)
 {
     std::optional<T> ret;
-    char const* str;
-    size_t len;
-    if (tr_variantGetStr(variant, &str, &len))
+    auto sv = std::string_view{};
+    if (tr_variantGetStrView(variant, &sv))
     {
-        ret = std::string_view(str, len);
+        ret = std::string_view(std::data(sv), std::size(sv));
     }
 
     return ret;

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -31,9 +31,8 @@ using RpcTest = SessionTest;
 
 TEST_F(RpcTest, list)
 {
-    size_t len;
     int64_t i;
-    char const* str;
+    auto sv = std::string_view{};
     tr_variant top;
 
     tr_rpc_parse_list_str(&top, "12"sv);
@@ -53,9 +52,8 @@ TEST_F(RpcTest, list)
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
     EXPECT_TRUE(tr_variantIsString(&top));
-    EXPECT_TRUE(tr_variantGetStr(&top, &str, &len));
-    EXPECT_EQ(4, len);
-    EXPECT_STREQ("asdf", str);
+    EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
+    EXPECT_EQ("asdf"sv, sv);
     tr_variantFree(&top);
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);


### PR DESCRIPTION
More refactoring to not require zero-termination of strings taken from variants.

The final goal of this string of PRs is to make it safe to have inplace variant parsing (ie when we have the raw benc or json in memory, just take string_views of that raw memory instead of allocating copies of it).