### PR TITLE
refactor: remove tr_variantDictFindStr() from cli and daemon

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -237,6 +237,24 @@ static char const* getConfigDir(int argc, char const** argv)
     return configDir;
 }
 
+static bool ensurePathExists(std::string const& path)
+{
+    if (tr_sys_path_exists(path.c_str(), nullptr))
+    {
+        return true;
+    }
+
+    tr_error* error = nullptr;
+    if (!tr_sys_dir_create(path.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700, &error))
+    {
+        fprintf(stderr, "Unable to create download directory \"%s\": %s\n", path.c_str(), error->message);
+        tr_error_free(error);
+        return false;
+    }
+
+    return true;
+}
+
 int tr_main(int argc, char* argv[])
 {
     tr_session* h;
@@ -246,7 +264,7 @@ int tr_main(int argc, char* argv[])
     char const* configDir;
     uint8_t* fileContents;
     size_t fileLength;
-    char const* str;
+    auto sv = std::string_view{};
 
     tr_formatter_mem_init(MEM_K, MEM_K_STR, MEM_M_STR, MEM_G_STR, MEM_T_STR);
     tr_formatter_size_init(DISK_K, DISK_K_STR, DISK_M_STR, DISK_G_STR, DISK_T_STR);
@@ -284,16 +302,9 @@ int tr_main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (tr_variantDictFindStr(&settings, TR_KEY_download_dir, &str, nullptr) && !tr_sys_path_exists(str, nullptr))
+    if (tr_variantDictFindStrView(&settings, TR_KEY_download_dir, &sv) && !ensurePathExists(std::string{ sv }))
     {
-        tr_error* error = nullptr;
-
-        if (!tr_sys_dir_create(str, TR_SYS_DIR_CREATE_PARENTS, 0700, &error))
-        {
-            fprintf(stderr, "Unable to create download directory \"%s\": %s\n", str, error->message);
-            tr_error_free(error);
-            return EXIT_FAILURE;
-        }
+        return EXIT_FAILURE;
     }
 
     h = tr_sessionInit(configDir, false, &settings);

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -245,14 +245,14 @@ static bool ensurePathExists(std::string const& path)
     }
 
     tr_error* error = nullptr;
-    if (!tr_sys_dir_create(path.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700, &error))
+    if (tr_sys_dir_create(path.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700, &error))
     {
-        fprintf(stderr, "Unable to create download directory \"%s\": %s\n", path.c_str(), error->message);
-        tr_error_free(error);
-        return false;
+        return true;
     }
 
-    return true;
+    fprintf(stderr, "Unable to create download directory \"%s\": %s\n", path.c_str(), error->message);
+    tr_error_free(error);
+    return false;
 }
 
 int tr_main(int argc, char* argv[])

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -417,8 +417,7 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
-    []() constexpr
-    {
+    []() constexpr {
         for (size_t i = 1; i < std::size(my_static); ++i)
         {
             if (my_static[i - 1] >= my_static[i])


### PR DESCRIPTION
More refactoring to not require zero-termination of strings taken from variants.

The final goal of this string of PRs is to make it safe to have inplace variant parsing (ie when we have the raw benc or json in memory, just take string_views of that raw memory instead of allocating copies of it).