### PR TITLE
refactor: tr_torrent.setLocation

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1373,9 +1373,9 @@ static char const* torrentSetLocation(
     tr_variant* /*args_out*/,
     tr_rpc_idle_data* /*idle_data*/)
 {
-    char const* location = nullptr;
+    auto location = std::string_view{};
 
-    if (!tr_variantDictFindStr(args_in, TR_KEY_location, &location, nullptr))
+    if (!tr_variantDictFindStrView(args_in, TR_KEY_location, &location))
     {
         return "no location";
     }
@@ -1390,7 +1390,7 @@ static char const* torrentSetLocation(
 
     for (auto* tor : getTorrents(session, args_in))
     {
-        tr_torrentSetLocation(tor, location, move, nullptr, nullptr);
+        tor->setLocation(location, move, nullptr, nullptr);
         notify(session, TR_RPC_TORRENT_MOVED, tor);
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2123,7 +2123,7 @@ void tr_torrentRecheckCompleteness(tr_torrent* tor)
 
             if (tor->currentDir == tor->incompleteDir)
             {
-                tr_torrentSetLocation(tor, tor->downloadDir, true, nullptr, nullptr);
+                tor->setLocation(tor->downloadDir, true, nullptr, nullptr);
             }
         }
 
@@ -2946,14 +2946,16 @@ static void tr_torrentDeleteLocalData(tr_torrent* tor, tr_fileFunc func)
 
 struct LocationData
 {
-    bool move_from_old_location;
-    int volatile* setme_state;
-    double volatile* setme_progress;
-    char* location;
-    tr_torrent* tor;
+    std::string location;
+
+    tr_torrent* tor = nullptr;
+    double volatile* setme_progress = nullptr;
+    int volatile* setme_state = nullptr;
+
+    bool move_from_old_location = false;
 };
 
-static void setLocation(void* vdata)
+static void setLocationImpl(void* vdata)
 {
     auto* data = static_cast<struct LocationData*>(vdata);
     tr_torrent* tor = data->tor;
@@ -2964,14 +2966,18 @@ static void setLocation(void* vdata)
 
     bool err = false;
     bool const do_move = data->move_from_old_location;
-    char const* location = data->location;
+    auto const& location = data->location;
     double bytesHandled = 0;
 
-    tr_logAddDebug("Moving \"%s\" location from currentDir \"%s\" to \"%s\"", tr_torrentName(tor), tor->currentDir, location);
+    tr_logAddDebug(
+        "Moving \"%s\" location from currentDir \"%s\" to \"%s\"",
+        tr_torrentName(tor),
+        tor->currentDir,
+        location.c_str());
 
-    tr_sys_dir_create(location, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
+    tr_sys_dir_create(location.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
 
-    if (!tr_sys_path_is_same(location, tor->currentDir, nullptr))
+    if (!tr_sys_path_is_same(location.c_str(), tor->currentDir, nullptr))
     {
         /* bad idea to move files while they're being verified... */
         tr_verifyRemove(tor);
@@ -3031,7 +3037,7 @@ static void setLocation(void* vdata)
     if (!err)
     {
         /* set the new location and reverify */
-        tr_torrentSetDownloadDir(tor, location);
+        tr_torrentSetDownloadDir(tor, location.c_str());
 
         if (do_move)
         {
@@ -3048,19 +3054,15 @@ static void setLocation(void* vdata)
 
     /* cleanup */
     tr_torrentUnlock(tor);
-    tr_free(data->location);
-    tr_free(data);
+    delete data;
 }
 
-void tr_torrentSetLocation(
-    tr_torrent* tor,
-    char const* location,
+void tr_torrent::setLocation(
+    std::string_view location,
     bool move_from_old_location,
     double volatile* setme_progress,
     int volatile* setme_state)
 {
-    TR_ASSERT(tr_isTorrent(tor));
-
     if (setme_state != nullptr)
     {
         *setme_state = TR_LOC_MOVING;
@@ -3072,13 +3074,26 @@ void tr_torrentSetLocation(
     }
 
     /* run this in the libtransmission thread */
-    struct LocationData* data = tr_new(struct LocationData, 1);
-    data->tor = tor;
-    data->location = tr_strdup(location);
+    auto* const data = new LocationData{};
+    data->tor = this;
+    data->location = location;
     data->move_from_old_location = move_from_old_location;
     data->setme_state = setme_state;
     data->setme_progress = setme_progress;
-    tr_runInEventThread(tor->session, setLocation, data);
+    tr_runInEventThread(this->session, setLocationImpl, data);
+}
+
+void tr_torrentSetLocation(
+    tr_torrent* tor,
+    char const* location,
+    bool move_from_old_location,
+    double volatile* setme_progress,
+    int volatile* setme_state)
+{
+    TR_ASSERT(tr_isTorrent(tor));
+    TR_ASSERT(!tr_str_is_empty(location));
+
+    return tor->setLocation(location ? location : "", move_from_old_location, setme_progress, setme_state);
 }
 
 std::string_view tr_torrentPrimaryMimeType(tr_torrent const* tor)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -136,12 +136,12 @@ struct tr_incomplete_metadata;
 /** @brief Torrent object */
 struct tr_torrent
 {
-    tr_session* session;
-    tr_info info;
-
-    int magicNumber;
-
-    std::optional<double> verify_progress;
+public:
+    void setLocation(
+        std::string_view location,
+        bool move_from_current_location,
+        double volatile* setme_progress,
+        int volatile* setme_state);
 
     tr_sha1_digest_t pieceHash(tr_piece_index_t i) const
     {
@@ -149,7 +149,20 @@ struct tr_torrent
         return this->piece_checksums_[i];
     }
 
+    // these functions should become private when possible,
+    // but more refactoring is needed before that can happen
+    // because much of tr_torrent's impl is in the non-member C bindings
+    //
+    // private:
     void takeMetainfo(tr_metainfo_parsed&& parsed);
+
+public:
+    tr_session* session;
+    tr_info info;
+
+    int magicNumber;
+
+    std::optional<double> verify_progress;
 
     tr_stat_errtype error;
     char errorString[128];


### PR DESCRIPTION
Add a member version of tr_torrentSetLocation(). This member version takes a std::string_view.