### PR TITLE
refactor: tr_address_from_string() is now std::string_view-friendly

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -132,8 +132,8 @@ static tr_pex* listToPex(tr_variant* peerList, size_t* setme_len)
             continue;
         }
 
-        char const* ip = nullptr;
-        if (!tr_variantDictFindStr(peer, TR_KEY_ip, &ip, nullptr))
+        auto ip = std::string_view{};
+        if (!tr_variantDictFindStrView(peer, TR_KEY_ip, &ip))
         {
             continue;
         }

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -26,6 +26,8 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <string_view>
+
 #ifdef _WIN32
 #include <inttypes.h>
 #include <ws2tcpip.h>
@@ -103,6 +105,8 @@ char const* tr_address_to_string_with_buf(tr_address const* addr, char* buf, siz
 char const* tr_address_and_port_to_string(char* buf, size_t buflen, tr_address const* addr, tr_port port);
 
 bool tr_address_from_string(tr_address* setme, char const* string);
+
+bool tr_address_from_string(tr_address* dst, std::string_view src);
 
 bool tr_address_from_sockaddr_storage(tr_address* setme, tr_port* port, struct sockaddr_storage const* src);
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -941,8 +941,8 @@ static void sessionSetImpl(void* vdata)
 
     free_incoming_peer_port(session);
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv4, &strVal, nullptr) ||
-        !tr_address_from_string(&b.addr, strVal) || b.addr.type != TR_AF_INET)
+    if (!tr_variantDictFindStrView(settings, TR_KEY_bind_address_ipv4, &sv) || !tr_address_from_string(&b.addr, sv) ||
+        b.addr.type != TR_AF_INET)
     {
         b.addr = tr_inaddr_any;
     }
@@ -950,8 +950,8 @@ static void sessionSetImpl(void* vdata)
     b.socket = TR_BAD_SOCKET;
     session->bind_ipv4 = static_cast<struct tr_bindinfo*>(tr_memdup(&b, sizeof(struct tr_bindinfo)));
 
-    if (!tr_variantDictFindStr(settings, TR_KEY_bind_address_ipv6, &strVal, nullptr) ||
-        !tr_address_from_string(&b.addr, strVal) || b.addr.type != TR_AF_INET6)
+    if (!tr_variantDictFindStrView(settings, TR_KEY_bind_address_ipv6, &sv) || !tr_address_from_string(&b.addr, sv) ||
+        b.addr.type != TR_AF_INET6)
     {
         b.addr = tr_in6addr_any;
     }


### PR DESCRIPTION
Still chipping away at the last use cases for `tr_variantDictFindStr()` so that it can be removed.