### PR TITLE
refactor: add tr_torrent::renamePath()

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1421,15 +1421,15 @@ static char const* torrentRenamePath(
 {
     char const* errmsg = nullptr;
 
-    char const* oldpath = nullptr;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_path, &oldpath, nullptr);
-    char const* newname = nullptr;
-    (void)tr_variantDictFindStr(args_in, TR_KEY_name, &newname, nullptr);
+    auto oldpath = std::string_view{};
+    (void)tr_variantDictFindStrView(args_in, TR_KEY_path, &oldpath);
+    auto newname = std::string_view{};
+    (void)tr_variantDictFindStrView(args_in, TR_KEY_name, &newname);
 
     auto const torrents = getTorrents(session, args_in);
     if (std::size(torrents) == 1)
     {
-        tr_torrentRenamePath(torrents[0], oldpath, newname, torrentRenamePathDone, idle_data);
+        torrents[0]->renamePath(oldpath, newname, torrentRenamePathDone, idle_data);
     }
     else
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -784,7 +784,6 @@ static void sessionSetImpl(void* vdata)
     auto d = double{};
     auto i = int64_t{};
     auto sv = std::string_view{};
-    char const* strVal = nullptr;
     tr_turtle_info* const turtle = &session->turtle;
 
     if (tr_variantDictFindInt(settings, TR_KEY_message_level, &i))

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -143,6 +143,12 @@ public:
         double volatile* setme_progress,
         int volatile* setme_state);
 
+    void renamePath(
+        std::string_view oldpath,
+        std::string_view newname,
+        tr_torrent_rename_done_func callback,
+        void* callback_user_data);
+
     tr_sha1_digest_t pieceHash(tr_piece_index_t i) const
     {
         TR_ASSERT(i < std::size(this->piece_checksums_));


### PR DESCRIPTION
Nearing the end of the march toward removing `tr_variantDictFindStr()`