### PR TITLE
refactor: fix some msvc compiler warnings

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1757,7 +1757,8 @@ tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerC
             }
             else
             {
-                if ((st->hasScraped = tier->lastScrapeTime != 0))
+                st->hasScraped = tier->lastScrapeTime;
+                if (st->hasScraped != 0)
                 {
                     st->lastScrapeTime = tier->lastScrapeTime;
                     st->lastScrapeSucceeded = tier->lastScrapeSucceeded;
@@ -1785,7 +1786,8 @@ tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerC
 
                 st->lastAnnounceStartTime = tier->lastAnnounceStartTime;
 
-                if ((st->hasAnnounced = tier->lastAnnounceTime != 0))
+                st->hasAnnounced = tier->lastAnnounceTime;
+                if (st->hasAnnounced != 0)
                 {
                     st->lastAnnounceTime = tier->lastAnnounceTime;
                     tr_strlcpy(st->lastAnnounceResult, tier->lastAnnounceStr, sizeof(st->lastAnnounceResult));

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -306,7 +306,7 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     }
 
     /* file size should be able to fit into size_t */
-    if (sizeof(info.size) > sizeof(*size))
+    if constexpr (sizeof(info.size) > sizeof(*size))
     {
         TR_ASSERT(info.size <= SIZE_MAX);
     }

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -212,7 +212,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     // (while it's renamed: confirm that the .resume file remembers the changes)
     tr_torrentSaveResume(tor);
     sync();
-    loaded = tr_torrentLoadResume(tor, ~0, ctor, nullptr);
+    loaded = tr_torrentLoadResume(tor, ~uint64_t{}, ctor, nullptr);
     EXPECT_STREQ("foobar", tr_torrentName(tor));
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_NAME));
 
@@ -331,7 +331,7 @@ TEST_F(RenameTest, multifileTorrent)
     // this is a bit dodgy code-wise, but let's make sure the .resume file got the name
     tr_free(files[1].name);
     tor->info.files[1].name = tr_strdup("gabba gabba hey");
-    auto const loaded = tr_torrentLoadResume(tor, ~0, ctor, nullptr);
+    auto const loaded = tr_torrentLoadResume(tor, ~uint64_t{}, ctor, nullptr);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_FILENAMES));
     EXPECT_EQ(expected_files[0], files[0].name);
     EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", files[1].name);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -212,7 +212,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     // (while it's renamed: confirm that the .resume file remembers the changes)
     tr_torrentSaveResume(tor);
     sync();
-    loaded = tr_torrentLoadResume(tor, ~uint64_t{}, ctor, nullptr);
+    loaded = tr_torrentLoadResume(tor, ~0ULL, ctor, nullptr);
     EXPECT_STREQ("foobar", tr_torrentName(tor));
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_NAME));
 
@@ -331,7 +331,7 @@ TEST_F(RenameTest, multifileTorrent)
     // this is a bit dodgy code-wise, but let's make sure the .resume file got the name
     tr_free(files[1].name);
     tor->info.files[1].name = tr_strdup("gabba gabba hey");
-    auto const loaded = tr_torrentLoadResume(tor, ~uint64_t{}, ctor, nullptr);
+    auto const loaded = tr_torrentLoadResume(tor, ~0ULL, ctor, nullptr);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_FILENAMES));
     EXPECT_EQ(expected_files[0], files[0].name);
     EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", files[1].name);


### PR DESCRIPTION
no behavioral changes; just doing some cleanup.

- use 'if constexpr' to fix a conditional-value-known-at-compile-time C4127 warning
- break assignment/conditional statements into two separate statements to silence C4706 assignment-within-conditional warning
- fix int-implicitly-widened-to-uint64 warning in tests