### PR TITLE
perf: faster shutdown

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1838,7 +1838,7 @@ static void sessionCloseImplWaitForIdleUdp(evutil_socket_t fd, short what, void*
 
 static void sessionCloseImplStart(tr_session* session)
 {
-    session->isClosing = true;
+    session->is_closing_ = true;
 
     free_incoming_peer_port(session);
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -135,6 +135,11 @@ struct CaseInsensitiveStringCompare // case-insensitive string compare
 struct tr_session
 {
 public:
+    bool isClosing() const
+    {
+        return is_closing_;
+    }
+
     // download dir
 
     std::string const& downloadDir() const
@@ -261,7 +266,7 @@ public:
     bool isUTPEnabled;
     bool isLPDEnabled;
     bool isPrefetchEnabled;
-    bool isClosing;
+    bool is_closing_ = false;
     bool isClosed;
     bool isRatioLimited;
     bool isIdleLimited;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -887,8 +887,14 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
     torrentInitFromInfo(tor);
 
+    // tr_torrentLoadResume() calls a lot of tr_torrentSetFoo() methods
+    // that set things as dirty, but... these settings being loaded are
+    // the same ones that would be saved back again, so don't let them
+    // affect the 'is dirty' flag.
+    auto const was_dirty = tor->isDirty;
     bool didRenameResumeFileToHashOnlyName = false;
     auto const loaded = tr_torrentLoadResume(tor, ~(uint64_t)0, ctor, &didRenameResumeFileToHashOnlyName);
+    tor->isDirty = was_dirty;
 
     if (didRenameResumeFileToHashOnlyName)
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1517,17 +1517,21 @@ static void freeTorrent(tr_torrent* tor)
 
     tr_sessionRemoveTorrent(session, tor);
 
-    /* resequence the queue positions */
-    for (auto* t : session->torrents)
+    if (!session->isClosing())
     {
-        if (t->queuePosition > tor->queuePosition)
+        // "so you die, captain, and we all move up in rank."
+        // resequence the queue positions
+        for (auto* t : session->torrents)
         {
-            t->queuePosition--;
-            t->anyDate = now;
+            if (t->queuePosition > tor->queuePosition)
+            {
+                t->queuePosition--;
+                t->anyDate = now;
+            }
         }
-    }
 
-    TR_ASSERT(queueIsSequenced(session));
+        TR_ASSERT(queueIsSequenced(session));
+    }
 
     delete tor->bandwidth;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -340,7 +340,7 @@ static struct tr_web_task* tr_webRunImpl(
 {
     struct tr_web_task* task = nullptr;
 
-    if (!session->isClosing)
+    if (!session->isClosing())
     {
         if (session->web == nullptr)
         {


### PR DESCRIPTION
Fix a couple of warts that were making a tr_session shutdown slower than it needed to be:

- Don't let tr_torrentLoadResume() affect a torrent's 'torrent settings are dirty & need to be saved' flag.

- When a torrent is removed from a session, _usually_ we want to re-sequence all the other torrents' queue positions. Don't do this during shutdown because it can be expensive and those changes are all irrelevant during shutdown.