### PR TITLE
refactor: make Bandwidth.children a std::vector

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -94,22 +94,37 @@ Bandwidth::Bandwidth(Bandwidth* new_parent)
 ****
 ***/
 
+static void remove_child(std::vector<Bandwidth*>& v, Bandwidth* remove_me)
+{
+    auto it = std::find(std::begin(v), std::end(v), remove_me);
+    if (it == std::end(v))
+    {
+        return;
+    }
+
+    // the list isn't sorted -- so instead of erase()ing `it`,
+    // do the cheaper option of overwriting it with the final item
+    *it = v.back();
+    v.resize(v.size() - 1);
+}
+
 void Bandwidth::setParent(Bandwidth* new_parent)
 {
     TR_ASSERT(this != new_parent);
 
     if (this->parent_ != nullptr)
     {
-        this->parent_->children_.erase(this);
+        remove_child(this->parent_->children_, this);
         this->parent_ = nullptr;
     }
 
     if (new_parent != nullptr)
     {
         TR_ASSERT(new_parent->parent_ != this);
-        TR_ASSERT(new_parent->children_.find(this) == new_parent->children_.end()); // does not exist
+        auto& children = new_parent->children_;
+        TR_ASSERT(std::find(std::begin(children), std::end(children), this) == std::end(children)); // not already there
 
-        new_parent->children_.insert(this);
+        new_parent->children_.push_back(this);
         this->parent_ = new_parent;
     }
 }

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -13,7 +13,6 @@
 #endif
 
 #include <array>
-#include <unordered_set>
 #include <vector>
 
 #include "transmission.h"
@@ -247,7 +246,7 @@ private:
 
     mutable std::array<Band, 2> band_ = {};
     Bandwidth* parent_ = nullptr;
-    std::unordered_set<Bandwidth*> children_;
+    std::vector<Bandwidth*> children_;
     tr_peerIo* peer_ = nullptr;
     tr_priority_t priority_ = 0;
 };


### PR DESCRIPTION
These items don't get added / removed very often but the tree gets walked very frequently, so it's overall cheaper to use a std::vector and just use `std::find()` for those cases where we do need to remove.