### PR TITLE
gtk: Disable torrent actions that override text entry field actions

### DIFF
--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -62,36 +62,39 @@ std::array<std::string_view, 6> const pref_toggle_entries = {
     "show-toolbar"sv, //
 };
 
-std::array<std::string_view, 29> const entries = {
+std::array<std::string_view, 12> const window_entries = {
+    "open-torrent-from-url"sv, //
+    "open-torrent"sv, //
+    "show-stats"sv, //
+    "donate"sv, //
+    "pause-all-torrents"sv, //
+    "start-all-torrents"sv, //
+    "new-torrent"sv, //
+    "quit"sv, //
+    "edit-preferences"sv, //
+    "show-about-dialog"sv, //
+    "help"sv, //
+    "present-main-window"sv, //
+};
+
+std::array<std::string_view, 17> const torrent_entries = {
     "copy-magnet-link-to-clipboard"sv,
-    "open-torrent-from-url"sv,
-    "open-torrent"sv,
     "torrent-start"sv,
     "torrent-start-now"sv,
-    "show-stats"sv,
-    "donate"sv,
     "torrent-verify"sv,
     "torrent-stop"sv,
-    "pause-all-torrents"sv,
-    "start-all-torrents"sv,
     "relocate-torrent"sv,
     "remove-torrent"sv,
     "delete-torrent"sv,
-    "new-torrent"sv,
-    "quit"sv,
     "select-all"sv,
     "deselect-all"sv,
-    "edit-preferences"sv,
     "show-torrent-properties"sv,
     "open-torrent-folder"sv,
-    "show-about-dialog"sv,
-    "help"sv,
     "torrent-reannounce"sv,
     "queue-move-top"sv,
     "queue-move-up"sv,
     "queue-move-down"sv,
     "queue-move-bottom"sv,
-    "present-main-window"sv,
 };
 
 Gtk::Builder* myBuilder = nullptr;
@@ -105,7 +108,9 @@ void gtr_actions_set_core(Glib::RefPtr<Session> const& core)
     myCore = gtr_get_ptr(core);
 }
 
-Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init(Glib::RefPtr<Gtk::Builder> const& builder, gpointer callback_user_data)
+Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init_window(
+    Glib::RefPtr<Gtk::Builder> const& builder,
+    gpointer callback_user_data)
 {
     myBuilder = gtr_get_ptr(builder);
 
@@ -142,7 +147,24 @@ Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init(Glib::RefPtr<Gtk::Builder>
         key_to_action.try_emplace(action_name, action);
     }
 
-    for (auto const& action_name_view : entries)
+    for (auto const& action_name_view : window_entries)
+    {
+        auto const action_name = Glib::ustring(std::string(action_name_view));
+        auto const action = Gio::SimpleAction::create(action_name);
+        action->signal_activate().connect([a = gtr_get_ptr(action), callback_user_data](auto const& /*value*/)
+                                          { action_cb(*a, callback_user_data); });
+        action_group->add_action(action);
+        key_to_action.try_emplace(action_name, action);
+    }
+
+    return action_group;
+}
+
+Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init_torrent(gpointer callback_user_data)
+{
+    auto const action_group = Gio::SimpleActionGroup::create();
+
+    for (auto const& action_name_view : torrent_entries)
     {
         auto const action_name = Glib::ustring(std::string(action_name_view));
         auto const action = Gio::SimpleAction::create(action_name);

--- a/gtk/Actions.h
+++ b/gtk/Actions.h
@@ -11,7 +11,10 @@
 
 class Session;
 
-Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init(Glib::RefPtr<Gtk::Builder> const& builder, gpointer callback_user_data);
+Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init_window(
+    Glib::RefPtr<Gtk::Builder> const& builder,
+    gpointer callback_user_data);
+Glib::RefPtr<Gio::SimpleActionGroup> gtr_actions_init_torrent(gpointer callback_user_data);
 void gtr_actions_set_core(Glib::RefPtr<Session> const& core);
 void gtr_actions_handler(Glib::ustring const& action_name, gpointer user_data);
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -562,12 +562,13 @@ void Application::Impl::on_startup()
 
     /* init the ui manager */
     ui_builder_ = Gtk::Builder::create_from_resource(gtr_get_full_resource_path("transmission-ui.xml"s));
-    auto const actions = gtr_actions_init(ui_builder_, this);
+    auto const actions_window = gtr_actions_init_window(ui_builder_, this);
+    auto const actions_torrent = gtr_actions_init_torrent(this);
 
     app_.set_menubar(gtr_action_get_object<Gio::Menu>("main-window-menu"));
 
     /* create main window now to be a parent to any error dialogs */
-    wind_ = MainWindow::create(app_, actions, core_);
+    wind_ = MainWindow::create(app_, actions_window, actions_torrent, core_);
     wind_->signal_size_allocate().connect(sigc::mem_fun(*this, &Impl::on_main_window_size_allocated));
     app_.hold();
     app_setup();

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -24,7 +24,11 @@
 class MainWindow::Impl
 {
 public:
-    Impl(MainWindow& window, Glib::RefPtr<Gio::ActionGroup> const& actions, Glib::RefPtr<Session> const& core);
+    Impl(
+        MainWindow& window,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
+        Glib::RefPtr<Session> const& core);
     ~Impl();
 
     TR_DISABLE_COPY_MOVE(Impl)
@@ -36,7 +40,7 @@ public:
     void prefsChanged(tr_quark key);
 
 private:
-    Gtk::TreeView* makeview(Glib::RefPtr<Gtk::TreeModel> const& model);
+    Gtk::TreeView* makeview(Glib::RefPtr<Gtk::TreeModel> const& model, Glib::RefPtr<Gio::ActionGroup> const& actions_torrent);
 
     Gtk::Menu* createOptionsMenu();
     Gtk::Menu* createSpeedMenu(tr_direction dir);
@@ -118,7 +122,9 @@ bool tree_view_search_equal_func(
 
 } // namespace
 
-Gtk::TreeView* MainWindow::Impl::makeview(Glib::RefPtr<Gtk::TreeModel> const& model)
+Gtk::TreeView* MainWindow::Impl::makeview(
+    Glib::RefPtr<Gtk::TreeModel> const& model,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_torrent)
 {
     auto* view = Gtk::make_managed<Gtk::TreeView>();
     view->set_search_column(torrent_cols.name_collated);
@@ -154,6 +160,16 @@ Gtk::TreeView* MainWindow::Impl::makeview(Glib::RefPtr<Gtk::TreeModel> const& mo
                                                 { return on_tree_view_button_released(view, event); });
     view->signal_row_activated().connect([](auto const& /*path*/, auto* /*column*/)
                                          { gtr_action_activate("show-torrent-properties"); });
+    view->signal_state_flags_changed().connect(
+        [this, view, actions_torrent](Gtk::StateFlags previous)
+        {
+            Gtk::StateFlags changed = previous ^ view->get_state_flags();
+            if (changed & Gtk::StateFlags::STATE_FLAG_FOCUSED)
+            {
+                view->has_focus() ? window_.insert_action_group("torrent", actions_torrent) :
+                                    window_.remove_action_group("torrent");
+            }
+        });
 
     view->set_model(model);
 
@@ -392,22 +408,31 @@ void MainWindow::Impl::onOptionsClicked(Gtk::Button* button)
 
 std::unique_ptr<MainWindow> MainWindow::create(
     Gtk::Application& app,
-    Glib::RefPtr<Gio::ActionGroup> const& actions,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
     Glib::RefPtr<Session> const& core)
 {
-    return std::unique_ptr<MainWindow>(new MainWindow(app, actions, core));
+    return std::unique_ptr<MainWindow>(new MainWindow(app, actions_window, actions_torrent, core));
 }
 
-MainWindow::MainWindow(Gtk::Application& app, Glib::RefPtr<Gio::ActionGroup> const& actions, Glib::RefPtr<Session> const& core)
+MainWindow::MainWindow(
+    Gtk::Application& app,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
+    Glib::RefPtr<Session> const& core)
     : Gtk::ApplicationWindow()
-    , impl_(std::make_unique<Impl>(*this, actions, core))
+    , impl_(std::make_unique<Impl>(*this, actions_window, actions_torrent, core))
 {
     app.add_window(*this);
 }
 
 MainWindow::~MainWindow() = default;
 
-MainWindow::Impl::Impl(MainWindow& window, Glib::RefPtr<Gio::ActionGroup> const& actions, Glib::RefPtr<Session> const& core)
+MainWindow::Impl::Impl(
+    MainWindow& window,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+    Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
+    Glib::RefPtr<Session> const& core)
     : window_(window)
     , core_(core)
 {
@@ -433,7 +458,8 @@ MainWindow::Impl::Impl(MainWindow& window, Glib::RefPtr<Gio::ActionGroup> const&
         window.maximize();
     }
 
-    window.insert_action_group("win", actions);
+    window.insert_action_group("win", actions_window);
+    window.insert_action_group("torrent", actions_torrent);
     /* Add style provider to the window. */
     /* Please move it to separate .css file if you’re adding more styles here. */
     auto const* style = ".tr-workarea.frame {border-left-width: 0; border-right-width: 0; border-radius: 0;}";
@@ -529,7 +555,7 @@ MainWindow::Impl::Impl(MainWindow& window, Glib::RefPtr<Gio::ActionGroup> const&
     *** Workarea
     **/
 
-    view_ = makeview(filter_->get_filter_model());
+    view_ = makeview(filter_->get_filter_model(), actions_torrent);
     scroll_ = Gtk::make_managed<Gtk::ScrolledWindow>();
     scroll_->set_policy(Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
     scroll_->set_shadow_type(Gtk::SHADOW_OUT);

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -22,7 +22,8 @@ public:
 
     static std::unique_ptr<MainWindow> create(
         Gtk::Application& app,
-        Glib::RefPtr<Gio::ActionGroup> const& actions,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
         Glib::RefPtr<Session> const& core);
 
     Glib::RefPtr<Gtk::TreeSelection> get_selection() const;
@@ -31,7 +32,11 @@ public:
     void refresh();
 
 protected:
-    MainWindow(Gtk::Application& app, Glib::RefPtr<Gio::ActionGroup> const& actions, Glib::RefPtr<Session> const& core);
+    MainWindow(
+        Gtk::Application& app,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_window,
+        Glib::RefPtr<Gio::ActionGroup> const& actions_torrent,
+        Glib::RefPtr<Session> const& core);
 
 private:
     class Impl;

--- a/gtk/transmission-ui.xml
+++ b/gtk/transmission-ui.xml
@@ -54,13 +54,13 @@
       <attribute name="label" translatable="true">_Edit</attribute>
       <section>
         <item>
-          <attribute name="action">win.select-all</attribute>
+          <attribute name="action">torrent.select-all</attribute>
           <attribute name="icon">edit-select-all</attribute>
           <attribute name="label" translatable="yes">Select _All</attribute>
           <attribute name="accel">&lt;control&gt;A</attribute>
         </item>
         <item>
-          <attribute name="action">win.deselect-all</attribute>
+          <attribute name="action">torrent.deselect-all</attribute>
           <attribute name="label" translatable="yes">Dese_lect All</attribute>
           <attribute name="accel">&lt;shift&gt;&lt;control&gt;A</attribute>
         </item>
@@ -77,14 +77,14 @@
       <attribute name="label" translatable="true">_Torrent</attribute>
       <section>
         <item>
-          <attribute name="action">win.show-torrent-properties</attribute>
+          <attribute name="action">torrent.show-torrent-properties</attribute>
           <attribute name="icon">document-properties</attribute>
           <attribute name="label" translatable="yes">_Properties</attribute>
           <attribute name="accel">&lt;alt&gt;Return</attribute>
           <attribute name="tooltip" translatable="yes">Torrent properties</attribute>
         </item>
         <item>
-          <attribute name="action">win.open-torrent-folder</attribute>
+          <attribute name="action">torrent.open-torrent-folder</attribute>
           <attribute name="icon">document-open</attribute>
           <attribute name="label" translatable="yes">Open Fold_er</attribute>
           <attribute name="accel">&lt;control&gt;E</attribute>
@@ -92,21 +92,21 @@
       </section>
       <section>
         <item>
-          <attribute name="action">win.torrent-start</attribute>
+          <attribute name="action">torrent.torrent-start</attribute>
           <attribute name="icon">media-playback-start</attribute>
           <attribute name="label" translatable="yes">_Start</attribute>
           <attribute name="accel">&lt;control&gt;S</attribute>
           <attribute name="tooltop" translatable="yes">Start torrent</attribute>
         </item>
         <item>
-          <attribute name="action">win.torrent-start-now</attribute>
+          <attribute name="action">torrent.torrent-start-now</attribute>
           <attribute name="icon">media-playback-start</attribute>
           <attribute name="label" translatable="yes">Start _Now</attribute>
           <attribute name="accel">&lt;shift&gt;&lt;control&gt;S</attribute>
           <attribute name="tooltop" translatable="yes">Start torrent now</attribute>
         </item>
         <item>
-          <attribute name="action">win.torrent-reannounce</attribute>
+          <attribute name="action">torrent.torrent-reannounce</attribute>
           <attribute name="icon">network-workgroup</attribute>
           <attribute name="label" translatable="yes">Ask Tracker for _More Peers</attribute>
         </item>
@@ -114,29 +114,29 @@
           <attribute name="label" translatable="true">_Queue</attribute>
           <section>
             <item>
-              <attribute name="action">win.queue-move-top</attribute>
+              <attribute name="action">torrent.queue-move-top</attribute>
               <attribute name="icon">go-top</attribute>
               <attribute name="label" translatable="yes">Move to _Top</attribute>
             </item>
             <item>
-              <attribute name="action">win.queue-move-up</attribute>
+              <attribute name="action">torrent.queue-move-up</attribute>
               <attribute name="icon">go-up</attribute>
               <attribute name="label" translatable="yes">Move _Up</attribute>
             </item>
             <item>
-              <attribute name="action">win.queue-move-down</attribute>
+              <attribute name="action">torrent.queue-move-down</attribute>
               <attribute name="icon">go-down</attribute>
               <attribute name="label" translatable="yes">Move _Down</attribute>
             </item>
             <item>
-              <attribute name="action">win.queue-move-bottom</attribute>
+              <attribute name="action">torrent.queue-move-bottom</attribute>
               <attribute name="icon">go-bottom</attribute>
               <attribute name="label" translatable="yes">Move to _Bottom</attribute>
             </item>
           </section>
         </submenu>
         <item>
-          <attribute name="action">win.torrent-stop</attribute>
+          <attribute name="action">torrent.torrent-stop</attribute>
           <attribute name="icon">media-playback-pause</attribute>
           <attribute name="label" translatable="yes">_Pause</attribute>
           <attribute name="accel">&lt;control&gt;P</attribute>
@@ -145,29 +145,29 @@
       </section>
       <section>
         <item>
-          <attribute name="action">win.relocate-torrent</attribute>
+          <attribute name="action">torrent.relocate-torrent</attribute>
           <attribute name="label" translatable="yes">Set _Location…</attribute>
         </item>
         <item>
-          <attribute name="action">win.torrent-verify</attribute>
+          <attribute name="action">torrent.torrent-verify</attribute>
           <attribute name="label" translatable="yes">_Verify Local Data</attribute>
           <attribute name="accel">&lt;control&gt;V</attribute>
         </item>
         <item>
-          <attribute name="action">win.copy-magnet-link-to-clipboard</attribute>
+          <attribute name="action">torrent.copy-magnet-link-to-clipboard</attribute>
           <attribute name="icon">edit-copy</attribute>
           <attribute name="label" translatable="yes">Copy _Magnet Link to Clipboard</attribute>
         </item>
       </section>
       <section>
         <item>
-          <attribute name="action">win.remove-torrent</attribute>
+          <attribute name="action">torrent.remove-torrent</attribute>
           <attribute name="icon">list-remove</attribute>
           <attribute name="label" translatable="yes">Remove torrent</attribute>
           <attribute name="accel">Delete</attribute>
         </item>
         <item>
-          <attribute name="action">win.delete-torrent</attribute>
+          <attribute name="action">torrent.delete-torrent</attribute>
           <attribute name="icon">edit-delete</attribute>
           <attribute name="label" translatable="yes">_Delete Files and Remove</attribute>
           <attribute name="accel">&lt;shift&gt;Delete</attribute>
@@ -309,7 +309,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="tooltip-text" translatable="yes">Start torrent</property>
-        <property name="action-name">win.torrent-start</property>
+        <property name="action-name">torrent.torrent-start</property>
         <property name="label" translatable="yes">_Start</property>
         <property name="use-underline">True</property>
         <property name="icon-name">media-playback-start</property>
@@ -324,7 +324,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="tooltip-text" translatable="yes">Pause torrent</property>
-        <property name="action-name">win.torrent-stop</property>
+        <property name="action-name">torrent.torrent-stop</property>
         <property name="label" translatable="yes">_Pause</property>
         <property name="use-underline">True</property>
         <property name="icon-name">media-playback-pause</property>
@@ -338,7 +338,7 @@
       <object class="GtkToolButton">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="action-name">win.remove-torrent</property>
+        <property name="action-name">torrent.remove-torrent</property>
         <property name="label" translatable="yes">Remove torrent</property>
         <property name="use-underline">True</property>
         <property name="icon-name">list-remove</property>
@@ -364,7 +364,7 @@
         <property name="can-focus">False</property>
         <property name="tooltip-text" translatable="yes">Torrent properties</property>
         <property name="is-important">True</property>
-        <property name="action-name">win.show-torrent-properties</property>
+        <property name="action-name">torrent.show-torrent-properties</property>
         <property name="label" translatable="yes">_Properties</property>
         <property name="use-underline">True</property>
         <property name="icon-name">document-properties</property>
@@ -379,14 +379,14 @@
   <menu id="main-window-popup">
     <section>
       <item>
-        <attribute name="action">win.show-torrent-properties</attribute>
+        <attribute name="action">torrent.show-torrent-properties</attribute>
         <attribute name="icon">document-properties</attribute>
         <attribute name="label" translatable="yes">_Properties</attribute>
         <attribute name="accel">&lt;alt&gt;Return</attribute>
         <attribute name="tooltip" translatable="yes">Torrent properties</attribute>
       </item>
       <item>
-        <attribute name="action">win.open-torrent-folder</attribute>
+        <attribute name="action">torrent.open-torrent-folder</attribute>
         <attribute name="icon">document-open</attribute>
         <attribute name="label" translatable="yes">Open Fold_er</attribute>
         <attribute name="accel">&lt;control&gt;E</attribute>
@@ -452,21 +452,21 @@
     </section>
     <section>
       <item>
-        <attribute name="action">win.torrent-start</attribute>
+        <attribute name="action">torrent.torrent-start</attribute>
         <attribute name="icon">media-playback-start</attribute>
         <attribute name="label" translatable="yes">_Start</attribute>
         <attribute name="accel">&lt;control&gt;S</attribute>
         <attribute name="tooltop" translatable="yes">Start torrent</attribute>
       </item>
       <item>
-        <attribute name="action">win.torrent-start-now</attribute>
+        <attribute name="action">torrent.torrent-start-now</attribute>
         <attribute name="icon">media-playback-start</attribute>
         <attribute name="label" translatable="yes">Start _Now</attribute>
         <attribute name="accel">&lt;shift&gt;&lt;control&gt;S</attribute>
         <attribute name="tooltop" translatable="yes">Start torrent now</attribute>
       </item>
       <item>
-        <attribute name="action">win.torrent-reannounce</attribute>
+        <attribute name="action">torrent.torrent-reannounce</attribute>
         <attribute name="icon">network-workgroup</attribute>
         <attribute name="label" translatable="yes">Ask Tracker for _More Peers</attribute>
       </item>
@@ -474,29 +474,29 @@
         <attribute name="label" translatable="true">_Queue</attribute>
         <section>
           <item>
-            <attribute name="action">win.queue-move-top</attribute>
+            <attribute name="action">torrent.queue-move-top</attribute>
             <attribute name="icon">go-top</attribute>
             <attribute name="label" translatable="yes">Move to _Top</attribute>
           </item>
           <item>
-            <attribute name="action">win.queue-move-up</attribute>
+            <attribute name="action">torrent.queue-move-up</attribute>
             <attribute name="icon">go-up</attribute>
             <attribute name="label" translatable="yes">Move _Up</attribute>
           </item>
           <item>
-            <attribute name="action">win.queue-move-down</attribute>
+            <attribute name="action">torrent.queue-move-down</attribute>
             <attribute name="icon">go-down</attribute>
             <attribute name="label" translatable="yes">Move _Down</attribute>
           </item>
           <item>
-            <attribute name="action">win.queue-move-bottom</attribute>
+            <attribute name="action">torrent.queue-move-bottom</attribute>
             <attribute name="icon">go-bottom</attribute>
             <attribute name="label" translatable="yes">Move to _Bottom</attribute>
           </item>
         </section>
       </submenu>
       <item>
-        <attribute name="action">win.torrent-stop</attribute>
+        <attribute name="action">torrent.torrent-stop</attribute>
         <attribute name="icon">media-playback-pause</attribute>
         <attribute name="label" translatable="yes">_Pause</attribute>
         <attribute name="accel">&lt;control&gt;P</attribute>
@@ -505,29 +505,29 @@
     </section>
     <section>
       <item>
-        <attribute name="action">win.relocate-torrent</attribute>
+        <attribute name="action">torrent.relocate-torrent</attribute>
         <attribute name="label" translatable="yes">Set _Location…</attribute>
       </item>
       <item>
-        <attribute name="action">win.torrent-verify</attribute>
+        <attribute name="action">torrent.torrent-verify</attribute>
         <attribute name="label" translatable="yes">_Verify Local Data</attribute>
         <attribute name="accel">&lt;control&gt;V</attribute>
       </item>
       <item>
-        <attribute name="action">win.copy-magnet-link-to-clipboard</attribute>
+        <attribute name="action">torrent.copy-magnet-link-to-clipboard</attribute>
         <attribute name="icon">edit-copy</attribute>
         <attribute name="label" translatable="yes">Copy _Magnet Link to Clipboard</attribute>
       </item>
     </section>
     <section>
       <item>
-        <attribute name="action">win.remove-torrent</attribute>
+        <attribute name="action">torrent.remove-torrent</attribute>
         <attribute name="icon">list-remove</attribute>
         <attribute name="label" translatable="yes">Remove torrent</attribute>
         <attribute name="accel">Delete</attribute>
       </item>
       <item>
-        <attribute name="action">win.delete-torrent</attribute>
+        <attribute name="action">torrent.delete-torrent</attribute>
         <attribute name="icon">edit-delete</attribute>
         <attribute name="label" translatable="yes">_Delete Files and Remove</attribute>
         <attribute name="accel">&lt;shift&gt;Delete</attribute>


### PR DESCRIPTION
This is a draft of the changes discussed with @mikedld in https://github.com/transmission/transmission/pull/1759.

The current state is that the actions have been split into window actions, like "win.quit" and "win.alt-speed-enabled", and torrent actions, like "torrent.show-torrent-properties" and "torrent.torrent-start".

What's left to do is to actually disable the torrent action group when the torrent list is not focused. I don't know how to do that. I tried using `gtk_action_group_set_sensitive` but that is deprecated. I also tried inserting the action group into widgets related to the torrent list but that doesn't seem to work. Another thing I tried is setting all the actions' sensitivity in the view's focus events but these events don't seem to fire reliably.

I hope that somebody more familiar with GTK can explain what needs to be done to attach the torrent action group to the torrent list.

Closes https://github.com/transmission/transmission/issues/1758
Closes https://github.com/transmission/transmission/issues/153