### PR TITLE
perf: preallocate list space during benc parsing

### DIFF
--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -200,7 +200,8 @@ int tr_variantParseBenc(tr_variant& top, int parse_opts, std::string_view benc, 
                 tr_variant* const v = get_node(stack, key, &top, &err);
                 if (v != nullptr)
                 {
-                    tr_variantInitList(v, 0);
+                    auto constexpr ArbitraryInitSize = size_t{ 32 };
+                    tr_variantInitList(v, ArbitraryInitSize);
                     stack.push_back(v);
                 }
                 break;


### PR DESCRIPTION
This codepath has a disproportionate amount of heap allocations, so preallocate an initial list size to cut down on the reallocs.