### PR TITLE
man pages: remove commas in option listings

### DIFF
--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -51,9 +51,9 @@ Enable peer blocklists. Transmission understands the bluetack blocklist file for
 New blocklists can be added by copying them into the config-dir's "blocklists" subdirectory.
 .It Fl B Fl -no-blocklist
 Disable blocklists.
-.It Fl d, -downlimit Ar number
+.It Fl d -downlimit Ar number
 Set the maximum download speed in KB/s
-.It Fl D, -no-downlimit
+.It Fl D -no-downlimit
 Don't limit the download speed
 .It Fl er Fl -encryption-required
 Encrypt all peer connections.
@@ -61,22 +61,22 @@ Encrypt all peer connections.
 Prefer encrypted peer connections.
 .It Fl et Fl -encryption-tolerated
 Prefer unencrypted peer connections.
-.It Fl f, -finish Ar script
+.It Fl f -finish Ar script
 Set a script to run when the torrent finishes
-.It Fl g, Fl -config-dir Ar directory
+.It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
 See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
-.It Fl h, Fl -help
+.It Fl h Fl -help
 Prints a short usage summary.
-.It Fl m, Fl -portmap
+.It Fl m Fl -portmap
 Enable portmapping via NAT-PMP or UPnP
-.It Fl M, Fl -no-portmap
+.It Fl M Fl -no-portmap
 Disable portmapping
-.It Fl n, Fl -new Ar sourcefile
+.It Fl n Fl -new Ar sourcefile
 Create torrent from the specified file or directory
-.It Fl p, -port Ar port
+.It Fl p -port Ar port
 Set the port to listen for incoming peers. (Default: 51413)
-.It Fl t, -tos Ar tos
+.It Fl t -tos Ar tos
 Set the peer socket TOS for local router-based traffic shaping.
 Valid values are
 .Pp
@@ -87,13 +87,13 @@ Valid values are
 .Dq lowdelay ,
 .Pp
 a decimal value 0-255 or a hexidecimal value 0x00-0xff)
-.It Fl u, -uplimit Ar number
+.It Fl u -uplimit Ar number
 Set the maximum upload speed in KB/s
-.It Fl U, -no-uplimit
+.It Fl U -no-uplimit
 Don't limit the upload speed
-.It Fl v, Fl -verify
+.It Fl v Fl -verify
 Verify the torrent's downloaded data.
-.It Fl w, Fl -download-dir Ar directory
+.It Fl w Fl -download-dir Ar directory
 Where to save downloaded data.
 .El
 .Sh SIGNALS

--- a/gtk/transmission-gtk.1
+++ b/gtk/transmission-gtk.1
@@ -45,7 +45,7 @@ Show help options
 Start with all torrents paused
 .It Fl m Fl -minimized
 Start minimized in notification area
-.It Fl g, Fl -config-dir Ar directory
+.It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
 See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .El

--- a/qt/transmission-qt.1
+++ b/qt/transmission-qt.1
@@ -21,20 +21,20 @@ information on the BitTorrent protocol see http://www.bittorrent.org/
 .Bl -tag -width Ds
 .It Fl h Fl -help
 Show help options
-.It Fl g, Fl -config-dir Ar directory
+.It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
 See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .It Fl m Fl -minimized
 Start minimized in notification area
-.It Fl p, Fl -port Ar port
+.It Fl p Fl -port Ar port
 Port to use when connecting to an existing session
-.It Fl r, Fl -remote Ar host
+.It Fl r Fl -remote Ar host
 Connect to an existing session at the specified hostname
-.It Fl u, Fl -username Ar username
+.It Fl u Fl -username Ar username
 Username to use when connecting to an existing session
-.It Fl v, Fl -version
+.It Fl v Fl -version
 Show version number and exit
-.It Fl w, Fl -password Ar password
+.It Fl w Fl -password Ar password
 Password to use when connecting to an existing session
 .El
 .Pp


### PR DESCRIPTION
they were quite distracting
most of them seem to occur in options that take arguments
but that's not consistently so, so i removed them all