### PR TITLE
fixup! refactor: use std mutex/lock intead of bespoke (#2194)

### DIFF
--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -265,7 +265,7 @@ static void libeventThreadFunc(void* veh)
     /* shut down the thread */
     event_base_free(base);
     eh->session->events = nullptr;
-    tr_free(eh);
+    delete eh;
     tr_logAddDebug("Closing libevent thread");
 }
 


### PR DESCRIPTION
Fix a memory management issue introduced last week in #2194.