### PR TITLE
fixup: crash after completing magnet link metainfo

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -274,6 +274,10 @@ tr_cache* tr_cacheNew(int64_t max_bytes)
 
 void tr_cacheFree(tr_cache* cache)
 {
+    // FIXME(ckerr): this assertion isn't _always_ going to be true,
+    // e.g. if writing to disk failed due to disk full / permission error etc
+    // then there is still going to be data sitting in the cache on shutdown.
+    // Make this assertion smarter or remove it.
     TR_ASSERT(tr_ptrArrayEmpty(&cache->blocks));
 
     tr_ptrArrayDestruct(&cache->blocks, nullptr);

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -305,9 +305,8 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
 
                     if (success)
                     {
-                        /* keep the new info */
-                        std::swap(tor->info, info->info);
-                        std::swap(tor->infoDictLength, info->info_dict_length);
+                        /* tor should keep this metainfo */
+                        tor->swapMetainfo(*info);
 
                         /* save the new .torrent file */
                         tr_variantToFile(&newMetainfo, TR_VARIANT_FMT_BENC, tor->info.torrent);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -989,7 +989,7 @@ tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_dupl
     }
 
     auto* tor = new tr_torrent{};
-    tor->takeMetainfo(std::move(*parsed));
+    tor->swapMetainfo(*parsed);
     torrentInit(tor, ctor);
     return tor;
 }
@@ -3604,7 +3604,7 @@ void tr_torrentRenamePath(
     tor->renamePath(oldpath, newname, callback, callback_user_data);
 }
 
-void tr_torrent::takeMetainfo(tr_metainfo_parsed&& parsed)
+void tr_torrent::swapMetainfo(tr_metainfo_parsed& parsed)
 {
     std::swap(this->info, parsed.info);
     std::swap(this->piece_checksums_, parsed.pieces);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -151,7 +151,7 @@ public:
     // because much of tr_torrent's impl is in the non-member C bindings
     //
     // private:
-    void takeMetainfo(tr_metainfo_parsed&& parsed);
+    void swapMetainfo(tr_metainfo_parsed& parsed);
 
 public:
     auto unique_lock() const


### PR DESCRIPTION
When adding a magnet torrent's newly-fetched metainfo, ensure that the piece checksums are initialized.

This is Yet Another Fixup of d1f8c28 from #2130. :3rd_place_medal: 