### PR TITLE
fix: crash on corrupt dht.dat file

### DIFF
--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -324,14 +324,14 @@ int tr_dhtInit(tr_session* ss)
     size_t len6 = 0;
     if (ok)
     {
-        uint8_t const* raw = nullptr;
-        have_id = tr_variantDictFindRaw(&benc, TR_KEY_id, &raw, &len);
-
-        if (have_id && len == 20)
+        auto sv = std::string_view{};
+        have_id = tr_variantDictFindStrView(&benc, TR_KEY_id, &sv);
+        if (have_id && std::size(sv) == 20)
         {
-            memcpy(myid, raw, len);
+            std::copy(std::begin(sv), std::end(sv), myid);
         }
 
+        uint8_t const* raw = nullptr;
         if (ss->udp_socket != TR_BAD_SOCKET && tr_variantDictFindRaw(&benc, TR_KEY_nodes, &raw, &len) && len % 6 == 0)
         {
             nodes = static_cast<uint8_t*>(tr_memdup(raw, len));


### PR DESCRIPTION
This bug is present in 3.00 as well but I hadn't experienced before the recent regression introduced a corrupt dht.dat file to my system.

Re-use of the local variable `len` in `tr_dhtInit()` could cause the data passed to `dht_bootstrap()` to indicate that there were > 0 nodes available even when the nodes array was nullptr.