### PR TITLE
minor norwegian correction

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -2104,7 +2104,7 @@ msgstr "Denne mangetlenka ser ut til å være laget for noe annet enn BitTorrent
 #: ../gtk/util.c:725
 #, c-format
 msgid "%s free"
-msgstr "%s gratis"
+msgstr "%s ledig"
 
 #: ../libtransmission/announcer-http.c:215 ../libtransmission/announcer-http.c:383
 #, c-format


### PR DESCRIPTION
Gratis in norwegian can only be used when you are talking about price. correct word is ledig for instance "2.45 TB ledig"  word Ledig is specific to space
I noticed this grammar error when adding a torrent. "2.45 TB Gratis" this would mean that you are getting 2.45TB for free 
the rest looks good!