### PR TITLE
fix: crash when renaming top-level folder in qt

### DIFF
--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -91,9 +91,9 @@ public:
 } // namespace
 
 FileTreeModel::FileTreeModel(QObject* parent, bool is_editable)
-    : QAbstractItemModel(parent)
-    , root_item_(new FileTreeItem)
-    , is_editable_(is_editable)
+    : QAbstractItemModel{ parent }
+    , root_item_{ new FileTreeItem }
+    , is_editable_{ is_editable }
 {
 }
 
@@ -320,6 +320,8 @@ void FileTreeModel::clear()
 {
     beginResetModel();
     clearSubtree(QModelIndex());
+    delete root_item_;
+    root_item_ = new FileTreeItem{};
     endResetModel();
 
     assert(index_cache_.isEmpty());


### PR DESCRIPTION
Also present in 3.00, not just a recent regression.

This one's been bothering me for a long time; happy to finally have tracked this down.

Fixes #1764.