### PR TITLE
Mac client uses freed memory

### DIFF
--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -24,13 +24,5 @@
 
 int main(int argc, char** argv)
 {
-    if (argc > 1 && strncmp(argv[1], "-v", 2) == 0)
-    {
-        char* level;
-        int debug = atoi(&argv[1][2]);
-        asprintf(&level, "%d", debug);
-        setenv("TR_DEBUG", level, 1);
-        free(level);
-    }
     return NSApplicationMain(argc, (char const**)argv);
 }

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -26,11 +26,11 @@ int main(int argc, char** argv)
 {
     if (argc > 1 && strncmp(argv[1], "-v", 2) == 0)
     {
-        char* env;
+        char* level;
         int debug = atoi(&argv[1][2]);
-        asprintf(&env, "TR_DEBUG=%d", debug);
-        putenv(env);
-        free(env);
+        asprintf(&level, "%d", debug);
+        setenv("TR_DEBUG", level, 1);
+        free(level);
     }
     return NSApplicationMain(argc, (char const**)argv);
 }


### PR DESCRIPTION
Fixes #2219

Not changing the logic of the code (which means that `-v` is treated as `-v0`, which is probably surprising to users). But fixing the use-after-free issue.