### PR TITLE
refactor: add file-piece-map

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -9,7 +9,8 @@
 /* Begin PBXBuildFile section */
 		0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A6169A50FE5C9A200C66CE6 /* bitfield.cc */; };
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.h */; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.h */; };
 		35F373030C2DA89000DAA8F2 /* FilePriorityCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */; };
 		3C7A11970D0B2EE300B5701F /* getgateway.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11910D0B2EE300B5701F /* getgateway.c */; };
 		3C7A11980D0B2EE300B5701F /* getgateway.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11920D0B2EE300B5701F /* getgateway.h */; };
@@ -363,7 +364,6 @@
 		C1FEE57B1C3223CC00D62832 /* watchdir.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5761C3223CC00D62832 /* watchdir.h */; };
 		CAB35C64252F6F5E00552A55 /* mime-types.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB35C62252F6F5E00552A55 /* mime-types.h */; };
 		E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */ = {isa = PBXBuildFile; fileRef = E138A9760C04D88F00C5426C /* ProgressGradients.mm */; };
-		5FDA439AB6609C092593F98B /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5FDA439AB6609C092593F98B /* file-piece-map.cc */; };
 		ED8A163F2735A8AA000D61F9 /* peer-mgr-active-requests.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163B2735A8AA000D61F9 /* peer-mgr-active-requests.h */; };
 		ED8A16402735A8AA000D61F9 /* peer-mgr-active-requests.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED8A163C2735A8AA000D61F9 /* peer-mgr-active-requests.cc */; };
 		ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163D2735A8AA000D61F9 /* peer-mgr-wishlist.h */; };
@@ -494,6 +494,8 @@
 /* Begin PBXFileReference section */
 		0A6169A50FE5C9A200C66CE6 /* bitfield.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bitfield.cc; sourceTree = "<group>"; };
 		0A6169A60FE5C9A200C66CE6 /* bitfield.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitfield.h; sourceTree = "<group>"; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = file-piece-map.cc; sourceTree = "<group>"; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file-piece-map.h; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		13E42FB307B3F0F600E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
@@ -544,7 +546,6 @@
 		4DFBC2DD09C0970D00D5C571 /* Torrent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Torrent.h; sourceTree = "<group>"; };
 		4DFBC2DE09C0970D00D5C571 /* Torrent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Torrent.mm; sourceTree = "<group>"; };
 		55869925257074EC00F77A43 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
-		5FDA439AB6609C092593F98B /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-piece-map.cc"; sourceTree = "<group>"; };
 		6A044CBD8C049AFCBD4DB411 /* block-info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "block-info.h"; path = "block-info.h"; sourceTree = SOURCE_ROOT; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1037,7 +1038,6 @@
 		ED8A163E2735A8AA000D61F9 /* peer-mgr-wishlist.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "peer-mgr-wishlist.cc"; sourceTree = "<group>"; };
 		EDBDFA9D25AFCCA60093D9C1 /* evutil_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evutil_time.c; sourceTree = "<group>"; };
 		F63480621E1D7274005B9E09 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images/Images.xcassets; sourceTree = "<group>"; };
-		F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "file-piece-map.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1400,6 +1400,8 @@
 				4D8017E910BBC073008A4AF2 /* torrent-magnet.h */,
 				0A6169A50FE5C9A200C66CE6 /* bitfield.cc */,
 				0A6169A60FE5C9A200C66CE6 /* bitfield.h */,
+				1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */,
+				1BB44E07B1B52E28291B4E3F /* file-piece-map.h */,
 				C1425B321EE9C5EA001DB85F /* tr-assert.cc */,
 				C1425B331EE9C5EA001DB85F /* tr-assert.h */,
 				A22CFCA60FC24ED80009BD3E /* tr-dht.cc */,
@@ -1887,6 +1889,7 @@
 				A21FBBAB0EDA78C300BC3C51 /* bandwidth.h in Headers */,
 				A22CFCA90FC24ED80009BD3E /* tr-dht.h in Headers */,
 				0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */,
+				1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */,
 				A25964A7106D73A800453B31 /* announcer.h in Headers */,
 				ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */,
 				4D8017EB10BBC073008A4AF2 /* torrent-magnet.h in Headers */,
@@ -1909,7 +1912,6 @@
 				A2AF23C916B44FA0003BC59E /* log.h in Headers */,
 				A23FAE55178BC2950053DC5B /* platform-quota.h in Headers */,
 				F11545ACA7C4D7A464F703AB /* block-info.h in Headers */,
-				1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2484,6 +2486,7 @@
 				C1033E081A3279B800EF44D8 /* crypto-utils-ccrypto.cc in Sources */,
 				A22CFCA80FC24ED80009BD3E /* tr-dht.cc in Sources */,
 				0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */,
+				1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */,
 				A25964A6106D73A800453B31 /* announcer.cc in Sources */,
 				4D8017EA10BBC073008A4AF2 /* torrent-magnet.cc in Sources */,
 				4D80185910BBC0B0008A4AF2 /* magnet-metainfo.cc in Sources */,
@@ -2506,7 +2509,6 @@
 				A2AF23C816B44FA0003BC59E /* log.cc in Sources */,
 				A23FAE54178BC2950053DC5B /* platform-quota.cc in Sources */,
 				62F644738FE3D8788EBF73A9 /* block-info.cc in Sources */,
-				5FDA439AB6609C092593F98B /* file-piece-map.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A6169A50FE5C9A200C66CE6 /* bitfield.cc */; };
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.h */; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */; };
 		1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.h */; };
 		35F373030C2DA89000DAA8F2 /* FilePriorityCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */; };
 		3C7A11970D0B2EE300B5701F /* getgateway.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11910D0B2EE300B5701F /* getgateway.c */; };

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 		C1FEE57B1C3223CC00D62832 /* watchdir.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5761C3223CC00D62832 /* watchdir.h */; };
 		CAB35C64252F6F5E00552A55 /* mime-types.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB35C62252F6F5E00552A55 /* mime-types.h */; };
 		E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */ = {isa = PBXBuildFile; fileRef = E138A9760C04D88F00C5426C /* ProgressGradients.mm */; };
-		E3184BABAB4709196ED64773 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5FDA439AB6609C092593F98B /* file-piece-map.cc */; };
+		5FDA439AB6609C092593F98B /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5FDA439AB6609C092593F98B /* file-piece-map.cc */; };
 		ED8A163F2735A8AA000D61F9 /* peer-mgr-active-requests.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163B2735A8AA000D61F9 /* peer-mgr-active-requests.h */; };
 		ED8A16402735A8AA000D61F9 /* peer-mgr-active-requests.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED8A163C2735A8AA000D61F9 /* peer-mgr-active-requests.cc */; };
 		ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163D2735A8AA000D61F9 /* peer-mgr-wishlist.h */; };
@@ -2506,7 +2506,7 @@
 				A2AF23C816B44FA0003BC59E /* log.cc in Sources */,
 				A23FAE54178BC2950053DC5B /* platform-quota.cc in Sources */,
 				62F644738FE3D8788EBF73A9 /* block-info.cc in Sources */,
-				E3184BABAB4709196ED64773 /* file-piece-map.cc in Sources */,
+				5FDA439AB6609C092593F98B /* file-piece-map.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A6169A50FE5C9A200C66CE6 /* bitfield.cc */; };
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
+		1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */; };
 		35F373030C2DA89000DAA8F2 /* FilePriorityCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */; };
 		3C7A11970D0B2EE300B5701F /* getgateway.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11910D0B2EE300B5701F /* getgateway.c */; };
 		3C7A11980D0B2EE300B5701F /* getgateway.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11920D0B2EE300B5701F /* getgateway.h */; };
@@ -362,6 +363,7 @@
 		C1FEE57B1C3223CC00D62832 /* watchdir.h in Headers */ = {isa = PBXBuildFile; fileRef = C1FEE5761C3223CC00D62832 /* watchdir.h */; };
 		CAB35C64252F6F5E00552A55 /* mime-types.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB35C62252F6F5E00552A55 /* mime-types.h */; };
 		E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */ = {isa = PBXBuildFile; fileRef = E138A9760C04D88F00C5426C /* ProgressGradients.mm */; };
+		E3184BABAB4709196ED64773 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5FDA439AB6609C092593F98B /* file-piece-map.cc */; };
 		ED8A163F2735A8AA000D61F9 /* peer-mgr-active-requests.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163B2735A8AA000D61F9 /* peer-mgr-active-requests.h */; };
 		ED8A16402735A8AA000D61F9 /* peer-mgr-active-requests.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED8A163C2735A8AA000D61F9 /* peer-mgr-active-requests.cc */; };
 		ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163D2735A8AA000D61F9 /* peer-mgr-wishlist.h */; };
@@ -542,6 +544,7 @@
 		4DFBC2DD09C0970D00D5C571 /* Torrent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Torrent.h; sourceTree = "<group>"; };
 		4DFBC2DE09C0970D00D5C571 /* Torrent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Torrent.mm; sourceTree = "<group>"; };
 		55869925257074EC00F77A43 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
+		5FDA439AB6609C092593F98B /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "file-piece-map.cc"; path = "file-piece-map.cc"; sourceTree = "<group>"; };
 		6A044CBD8C049AFCBD4DB411 /* block-info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "block-info.h"; path = "block-info.h"; sourceTree = SOURCE_ROOT; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1034,6 +1037,7 @@
 		ED8A163E2735A8AA000D61F9 /* peer-mgr-wishlist.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "peer-mgr-wishlist.cc"; sourceTree = "<group>"; };
 		EDBDFA9D25AFCCA60093D9C1 /* evutil_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evutil_time.c; sourceTree = "<group>"; };
 		F63480621E1D7274005B9E09 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images/Images.xcassets; sourceTree = "<group>"; };
+		F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "file-piece-map.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1302,6 +1306,8 @@
 				4DDBB71509E16B3F00284745 /* Libraries */,
 				A2F35BBA15C5A0A100EBF632 /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
+				F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */,
+				5FDA439AB6609C092593F98B /* file-piece-map.cc */,
 			);
 			name = Transmission;
 			sourceTree = "<group>";
@@ -1905,6 +1911,7 @@
 				A2AF23C916B44FA0003BC59E /* log.h in Headers */,
 				A23FAE55178BC2950053DC5B /* platform-quota.h in Headers */,
 				F11545ACA7C4D7A464F703AB /* block-info.h in Headers */,
+				1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2501,6 +2508,7 @@
 				A2AF23C816B44FA0003BC59E /* log.cc in Sources */,
 				A23FAE54178BC2950053DC5B /* platform-quota.cc in Sources */,
 				62F644738FE3D8788EBF73A9 /* block-info.cc in Sources */,
+				E3184BABAB4709196ED64773 /* file-piece-map.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 		4DFBC2DD09C0970D00D5C571 /* Torrent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Torrent.h; sourceTree = "<group>"; };
 		4DFBC2DE09C0970D00D5C571 /* Torrent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Torrent.mm; sourceTree = "<group>"; };
 		55869925257074EC00F77A43 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
-		5FDA439AB6609C092593F98B /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "file-piece-map.cc"; path = "file-piece-map.cc"; sourceTree = "<group>"; };
+		5FDA439AB6609C092593F98B /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-piece-map.cc"; sourceTree = "<group>"; };
 		6A044CBD8C049AFCBD4DB411 /* block-info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "block-info.h"; path = "block-info.h"; sourceTree = SOURCE_ROOT; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1306,8 +1306,6 @@
 				4DDBB71509E16B3F00284745 /* Libraries */,
 				A2F35BBA15C5A0A100EBF632 /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
-				F800495C9966DCCBF1E6D5D4 /* file-piece-map.h */,
-				5FDA439AB6609C092593F98B /* file-piece-map.cc */,
 			);
 			name = Transmission;
 			sourceTree = "<group>";

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A6169A50FE5C9A200C66CE6 /* bitfield.cc */; };
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E3F /* file-piece-map.h */; };
+		1BB44E07B1B52E28291B4E32 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */; };
+		1BB44E07B1B52E28291B4E33 /* file-piece-map.h in Headers */ =  {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E31 /* file-piece-map.h */; };
 		35F373030C2DA89000DAA8F2 /* FilePriorityCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */; };
 		3C7A11970D0B2EE300B5701F /* getgateway.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11910D0B2EE300B5701F /* getgateway.c */; };
 		3C7A11980D0B2EE300B5701F /* getgateway.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11920D0B2EE300B5701F /* getgateway.h */; };
@@ -494,8 +494,8 @@
 /* Begin PBXFileReference section */
 		0A6169A50FE5C9A200C66CE6 /* bitfield.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bitfield.cc; sourceTree = "<group>"; };
 		0A6169A60FE5C9A200C66CE6 /* bitfield.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitfield.h; sourceTree = "<group>"; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = file-piece-map.cc; sourceTree = "<group>"; };
-		1BB44E07B1B52E28291B4E3F /* file-piece-map.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file-piece-map.h; sourceTree = "<group>"; };
+		1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = file-piece-map.cc; sourceTree = "<group>"; };
+		1BB44E07B1B52E28291B4E31 /* file-piece-map.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = file-piece-map.h; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		13E42FB307B3F0F600E4EEF1 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
@@ -1400,8 +1400,8 @@
 				4D8017E910BBC073008A4AF2 /* torrent-magnet.h */,
 				0A6169A50FE5C9A200C66CE6 /* bitfield.cc */,
 				0A6169A60FE5C9A200C66CE6 /* bitfield.h */,
-				1BB44E07B1B52E28291B4E3F /* file-piece-map.cc */,
-				1BB44E07B1B52E28291B4E3F /* file-piece-map.h */,
+				1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */,
+				1BB44E07B1B52E28291B4E31 /* file-piece-map.h */,
 				C1425B321EE9C5EA001DB85F /* tr-assert.cc */,
 				C1425B331EE9C5EA001DB85F /* tr-assert.h */,
 				A22CFCA60FC24ED80009BD3E /* tr-dht.cc */,
@@ -1889,7 +1889,7 @@
 				A21FBBAB0EDA78C300BC3C51 /* bandwidth.h in Headers */,
 				A22CFCA90FC24ED80009BD3E /* tr-dht.h in Headers */,
 				0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */,
-				1BB44E07B1B52E28291B4E3F /* file-piece-map.h in Headers */,
+				1BB44E07B1B52E28291B4E33 /* file-piece-map.h in Headers */,
 				A25964A7106D73A800453B31 /* announcer.h in Headers */,
 				ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */,
 				4D8017EB10BBC073008A4AF2 /* torrent-magnet.h in Headers */,
@@ -2486,7 +2486,7 @@
 				C1033E081A3279B800EF44D8 /* crypto-utils-ccrypto.cc in Sources */,
 				A22CFCA80FC24ED80009BD3E /* tr-dht.cc in Sources */,
 				0A6169A70FE5C9A200C66CE6 /* bitfield.cc in Sources */,
-				1BB44E07B1B52E28291B4E3F /* file-piece-map.cc in Sources */,
+				1BB44E07B1B52E28291B4E32 /* file-piece-map.cc in Sources */,
 				A25964A6106D73A800453B31 /* announcer.cc in Sources */,
 				4D8017EA10BBC073008A4AF2 /* torrent-magnet.cc in Sources */,
 				4D80185910BBC0B0008A4AF2 /* magnet-metainfo.cc in Sources */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PROJECT_FILES
   crypto.cc
   error.cc
   fdlimit.cc
+  file-piece-map.cc
   file-posix.cc
   file-win32.cc
   file.cc
@@ -156,6 +157,7 @@ set(${PROJECT_NAME}_PRIVATE_HEADERS
     crypto-utils.h
     crypto.h
     fdlimit.h
+    file-piece-map.h
     handshake.h
     history.h
     inout.h

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -59,7 +59,7 @@ uint64_t tr_completion::computeSizeWhenDone() const
     auto size = size_t{ 0 };
     for (tr_piece_index_t piece = 0; piece < block_info_->n_pieces; ++piece)
     {
-        if (!tor_->pieceIsDnd(piece))
+        if (tor_->pieceIsWanted(piece))
         {
             size += block_info_->pieceSize(piece);
         }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -29,7 +29,7 @@ struct tr_completion
 {
     struct torrent_view
     {
-        virtual bool pieceIsDnd(tr_piece_index_t piece) const = 0;
+        virtual bool pieceIsWanted(tr_piece_index_t piece) const = 0;
 
         virtual ~torrent_view() = default;
     };

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -15,7 +15,7 @@
 #include "block-info.h"
 #include "file-piece-map.h"
 
-void tr_file_piece_map::init(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
 {
     files_.resize(n_files);
     files_.shrink_to_fit();
@@ -41,17 +41,12 @@ void tr_file_piece_map::init(tr_block_info const& block_info, uint64_t const* fi
     }
 }
 
-tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
-{
-    init(block_info, file_sizes, n_files);
-}
-
-tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, tr_info const& info)
+void tr_file_piece_map::reset(tr_info const& info)
 {
     tr_file_index_t const n = info.fileCount;
     auto file_sizes = std::vector<uint64_t>(n);
     std::transform(info.files, info.files + n, std::begin(file_sizes), [](tr_file const& file) { return file.length; });
-    init(block_info, std::data(file_sizes), std::size(file_sizes));
+    reset({ info.totalSize, info.pieceSize }, std::data(file_sizes), std::size(file_sizes));
 }
 
 tr_file_piece_map::piece_span_t tr_file_piece_map::pieceSpan(tr_file_index_t file) const
@@ -103,10 +98,16 @@ tr_file_piece_map::file_span_t tr_file_piece_map::fileSpan(tr_piece_index_t piec
 ****
 ***/
 
-tr_file_priorities::tr_file_priorities(tr_file_piece_map const& fpm)
-    : fpm_{ fpm }
+tr_file_priorities::tr_file_priorities(tr_file_piece_map const* fpm)
 {
-    auto const n = std::size(fpm);
+    reset(fpm);
+}
+
+void tr_file_priorities::reset(tr_file_piece_map const* fpm)
+{
+    fpm_ = fpm;
+
+    auto const n = std::size(*fpm_);
     priorities_.resize(n);
     priorities_.shrink_to_fit();
     std::fill_n(std::begin(priorities_), n, TR_PRI_NORMAL);
@@ -132,7 +133,7 @@ tr_priority_t tr_file_priorities::filePriority(tr_file_index_t file) const
 
 tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
 {
-    auto const [begin_idx, end_idx] = fpm_.fileSpan(piece);
+    auto const [begin_idx, end_idx] = fpm_->fileSpan(piece);
     auto const begin = std::begin(priorities_) + begin_idx;
     auto const end = std::begin(priorities_) + end_idx;
     auto const it = std::max_element(begin, end);

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -148,10 +148,10 @@ tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
 ****
 ***/
 
-tr_files_wanted::tr_files_wanted(tr_file_piece_map const& fpm)
-    : fpm_{ fpm }
-    , wanted_{ std::size(fpm) }
+void tr_files_wanted::reset(tr_file_piece_map const* fpm)
 {
+    fpm_ = fpm;
+    wanted_ = tr_bitfield{ std::size(*fpm) };
     wanted_.setHasAll(); // by default we want all files
 }
 
@@ -168,13 +168,13 @@ void tr_files_wanted::set(tr_file_index_t const* files, size_t n, bool wanted)
     }
 }
 
-tr_priority_t tr_files_wanted::fileWanted(tr_file_index_t file) const
+bool tr_files_wanted::fileWanted(tr_file_index_t file) const
 {
     return wanted_.test(file);
 }
 
-tr_priority_t tr_files_wanted::pieceWanted(tr_piece_index_t piece) const
+bool tr_files_wanted::pieceWanted(tr_piece_index_t piece) const
 {
-    auto const [begin, end] = fpm_.fileSpan(piece);
+    auto const [begin, end] = fpm_->fileSpan(piece);
     return wanted_.count(begin, end) != 0;
 }

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -1,0 +1,179 @@
+/*
+ * This file Copyright (C) Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+#include "transmission.h"
+
+#include "block-info.h"
+#include "file-piece-map.h"
+
+void tr_file_piece_map::init(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+{
+    files_.resize(n_files);
+    files_.shrink_to_fit();
+
+    uint64_t offset = 0;
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        auto const file_size = file_sizes[i];
+        auto const begin_piece = block_info.pieceOf(offset);
+        tr_piece_index_t end_piece = 0;
+        if (file_size != 0)
+        {
+            auto const last_byte = offset + file_size - 1;
+            auto const final_piece = block_info.pieceOf(last_byte);
+            end_piece = final_piece + 1;
+        }
+        else
+        {
+            end_piece = begin_piece + 1;
+        }
+        files_[i] = piece_span_t{ begin_piece, end_piece };
+        offset += file_size;
+    }
+}
+
+tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+{
+    init(block_info, file_sizes, n_files);
+}
+
+tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, tr_info const& info)
+{
+    tr_file_index_t const n = info.fileCount;
+    auto file_sizes = std::vector<uint64_t>(n);
+    std::transform(info.files, info.files + n, std::begin(file_sizes), [](tr_file const& file) { return file.length; });
+    init(block_info, std::data(file_sizes), std::size(file_sizes));
+}
+
+tr_file_piece_map::piece_span_t tr_file_piece_map::pieceSpan(tr_file_index_t file) const
+{
+    return files_[file];
+}
+
+tr_file_piece_map::file_span_t tr_file_piece_map::fileSpan(tr_piece_index_t piece) const
+{
+    struct Compare
+    {
+        int compare(tr_piece_index_t piece, piece_span_t span) const // <=>
+        {
+            if (piece < span.begin)
+            {
+                return -1;
+            }
+
+            if (piece >= span.end)
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+
+        bool operator()(tr_piece_index_t piece, piece_span_t span) const // <
+        {
+            return compare(piece, span) < 0;
+        }
+
+        int compare(piece_span_t span, tr_piece_index_t piece) const // <=>
+        {
+            return -compare(piece, span);
+        }
+
+        bool operator()(piece_span_t span, tr_piece_index_t piece) const // <
+        {
+            return compare(span, piece) < 0;
+        }
+    };
+
+    auto const begin = std::begin(files_);
+    auto const pair = std::equal_range(begin, std::end(files_), piece, Compare{});
+    return { tr_piece_index_t(std::distance(begin, pair.first)), tr_piece_index_t(std::distance(begin, pair.second)) };
+}
+
+/***
+****
+***/
+
+tr_file_priorities::tr_file_priorities(tr_file_piece_map const& fpm)
+    : fpm_{ fpm }
+{
+    auto const n = std::size(fpm);
+    priorities_.resize(n);
+    priorities_.shrink_to_fit();
+    std::fill_n(std::begin(priorities_), n, TR_PRI_NORMAL);
+}
+
+void tr_file_priorities::set(tr_file_index_t file, tr_priority_t priority)
+{
+    priorities_[file] = priority;
+}
+
+void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority_t priority)
+{
+    for (size_t i = 0; i < n; ++i)
+    {
+        set(files[i], priority);
+    }
+}
+
+tr_priority_t tr_file_priorities::filePriority(tr_file_index_t file) const
+{
+    return priorities_[file];
+}
+
+tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
+{
+    auto const [begin_idx, end_idx] = fpm_.fileSpan(piece);
+    auto const begin = std::begin(priorities_) + begin_idx;
+    auto const end = std::begin(priorities_) + end_idx;
+    auto const it = std::max_element(begin, end);
+    if (it == end)
+    {
+        return TR_PRI_NORMAL;
+    }
+    return *it;
+}
+
+/***
+****
+***/
+
+tr_files_wanted::tr_files_wanted(tr_file_piece_map const& fpm)
+    : fpm_{ fpm }
+    , wanted_{ std::size(fpm) }
+{
+    wanted_.setHasAll(); // by default we want all files
+}
+
+void tr_files_wanted::set(tr_file_index_t file, bool wanted)
+{
+    wanted_.set(file, wanted);
+}
+
+void tr_files_wanted::set(tr_file_index_t const* files, size_t n, bool wanted)
+{
+    for (size_t i = 0; i < n; ++i)
+    {
+        set(files[i], wanted);
+    }
+}
+
+tr_priority_t tr_files_wanted::fileWanted(tr_file_index_t file) const
+{
+    return wanted_.test(file);
+}
+
+tr_priority_t tr_files_wanted::pieceWanted(tr_piece_index_t piece) const
+{
+    auto const [begin, end] = fpm_.fileSpan(piece);
+    return wanted_.count(begin, end) != 0;
+}

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -32,8 +32,17 @@ public:
     using file_span_t = index_span_t<tr_file_index_t>;
     using piece_span_t = index_span_t<tr_piece_index_t>;
 
-    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
-    tr_file_piece_map(tr_block_info const& block_info, tr_info const& info);
+    tr_file_piece_map(tr_info const& info)
+    {
+        reset(info);
+    }
+    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+    {
+        reset(block_info, file_sizes, n_files);
+    }
+    void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
+    void reset(tr_info const& info);
+
     [[nodiscard]] piece_span_t pieceSpan(tr_file_index_t file) const;
     [[nodiscard]] file_span_t fileSpan(tr_piece_index_t piece) const;
     [[nodiscard]] size_t size() const
@@ -42,14 +51,14 @@ public:
     }
 
 private:
-    void init(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
     std::vector<piece_span_t> files_;
 };
 
 class tr_file_priorities
 {
 public:
-    explicit tr_file_priorities(tr_file_piece_map const& fpm);
+    explicit tr_file_priorities(tr_file_piece_map const* fpm);
+    void reset(tr_file_piece_map const*);
     void set(tr_file_index_t file, tr_priority_t priority);
     void set(tr_file_index_t const* files, size_t n, tr_priority_t priority);
 
@@ -57,7 +66,7 @@ public:
     [[nodiscard]] tr_priority_t piecePriority(tr_piece_index_t piece) const;
 
 private:
-    tr_file_piece_map const& fpm_;
+    tr_file_piece_map const* fpm_;
     std::vector<tr_priority_t> priorities_;
 };
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -73,14 +73,20 @@ private:
 class tr_files_wanted
 {
 public:
-    explicit tr_files_wanted(tr_file_piece_map const& fpm);
+    explicit tr_files_wanted(tr_file_piece_map const* fpm)
+        : wanted_(std::size(*fpm))
+    {
+        reset(fpm);
+    }
+    void reset(tr_file_piece_map const* fpm);
+
     void set(tr_file_index_t file, bool wanted);
     void set(tr_file_index_t const* files, size_t n, bool wanted);
 
-    [[nodiscard]] tr_priority_t fileWanted(tr_file_index_t file) const;
-    [[nodiscard]] tr_priority_t pieceWanted(tr_piece_index_t piece) const;
+    [[nodiscard]] bool fileWanted(tr_file_index_t file) const;
+    [[nodiscard]] bool pieceWanted(tr_piece_index_t piece) const;
 
 private:
-    tr_file_piece_map const& fpm_;
+    tr_file_piece_map const* fpm_;
     tr_bitfield wanted_;
 };

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -1,0 +1,77 @@
+/*
+ * This file Copyright (C) Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <vector>
+
+#include "transmission.h"
+
+#include "bitfield.h"
+
+struct tr_block_info;
+
+class tr_file_piece_map
+{
+public:
+    template<typename T>
+    struct index_span_t
+    {
+        T begin;
+        T end;
+    };
+    using file_span_t = index_span_t<tr_file_index_t>;
+    using piece_span_t = index_span_t<tr_piece_index_t>;
+
+    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
+    tr_file_piece_map(tr_block_info const& block_info, tr_info const& info);
+    [[nodiscard]] piece_span_t pieceSpan(tr_file_index_t file) const;
+    [[nodiscard]] file_span_t fileSpan(tr_piece_index_t piece) const;
+    [[nodiscard]] size_t size() const
+    {
+        return std::size(files_);
+    }
+
+private:
+    void init(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
+    std::vector<piece_span_t> files_;
+};
+
+class tr_file_priorities
+{
+public:
+    explicit tr_file_priorities(tr_file_piece_map const& fpm);
+    void set(tr_file_index_t file, tr_priority_t priority);
+    void set(tr_file_index_t const* files, size_t n, tr_priority_t priority);
+
+    [[nodiscard]] tr_priority_t filePriority(tr_file_index_t file) const;
+    [[nodiscard]] tr_priority_t piecePriority(tr_piece_index_t piece) const;
+
+private:
+    tr_file_piece_map const& fpm_;
+    std::vector<tr_priority_t> priorities_;
+};
+
+class tr_files_wanted
+{
+public:
+    explicit tr_files_wanted(tr_file_piece_map const& fpm);
+    void set(tr_file_index_t file, bool wanted);
+    void set(tr_file_index_t const* files, size_t n, bool wanted);
+
+    [[nodiscard]] tr_priority_t fileWanted(tr_file_index_t file) const;
+    [[nodiscard]] tr_priority_t pieceWanted(tr_piece_index_t piece) const;
+
+private:
+    tr_file_piece_map const& fpm_;
+    tr_bitfield wanted_;
+};

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -53,7 +53,7 @@ static int readOrWriteBytes(
     bool const doWrite = ioMode >= TR_IO_WRITE;
 
     TR_ASSERT(fileIndex < tr_torrentFileCount(tor));
-    auto const file = tr_torrentFile(tor, fileIndex);
+    auto const& file = tor->info.files[fileIndex];
     TR_ASSERT(file.length == 0 || fileOffset < file.length);
     TR_ASSERT(fileOffset + buflen <= file.length);
 
@@ -91,8 +91,9 @@ static int readOrWriteBytes(
         {
             /* open (and maybe create) the file */
             auto const filename = tr_strvPath(base, subpath);
-            tr_preallocation_mode const prealloc = (!file.wanted || !doWrite) ? TR_PREALLOCATE_NONE :
-                                                                                tor->session->preallocationMode;
+            tr_preallocation_mode const prealloc = (!doWrite || !tor->fileIsWanted(fileIndex)) ?
+                TR_PREALLOCATE_NONE :
+                tor->session->preallocationMode;
 
             fd = tr_fdFileCheckout(session, tor->uniqueId, fileIndex, filename.c_str(), doWrite, prealloc, file.length);
             if (fd == TR_BAD_SYS_FILE)

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -577,7 +577,7 @@ std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_p
 
         bool clientCanRequestPiece(tr_piece_index_t piece) const override
         {
-            return !torrent_->pieceIsDnd(piece) && peer_->have.test(piece);
+            return torrent_->pieceIsWanted(piece) && peer_->have.test(piece);
         }
 
         bool isEndgame() const override
@@ -1694,7 +1694,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
 
     for (size_t i = 0; i < n_pieces; ++i)
     {
-        if (!tor->pieceIsDnd(i) && have.at(i))
+        if (tor->pieceIsWanted(i) && have.at(i))
         {
             desired_available += tor->countMissingBytesInPiece(i);
         }
@@ -2022,7 +2022,7 @@ static void rechokeDownloads(tr_swarm* s)
 
         for (int i = 0; i < n; ++i)
         {
-            piece_is_interesting[i] = !tor->pieceIsDnd(i) && !tor->hasPiece(i);
+            piece_is_interesting[i] = tor->pieceIsWanted(i) && !tor->hasPiece(i);
         }
 
         /* decide WHICH peers to be interested in (based on their cancel-to-block ratio) */
@@ -2703,7 +2703,7 @@ static void bandwidthPulse(evutil_socket_t /*fd*/, short /*what*/, void* vmgr)
         if (tor->swarm->needsCompletenessCheck)
         {
             tor->swarm->needsCompletenessCheck = false;
-            tr_torrentRecheckCompleteness(tor);
+            tor->recheckCompleteness();
         }
 
         /* stop torrents that are ready to stop, but couldn't be stopped

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -417,8 +417,7 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
-    []() constexpr
-    {
+    []() constexpr {
         for (size_t i = 1; i < std::size(my_static); ++i)
         {
             if (my_static[i - 1] >= my_static[i])

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -417,7 +417,8 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
-    []() constexpr {
+    []() constexpr
+    {
         for (size_t i = 1; i < std::size(my_static); ++i)
         {
             if (my_static[i - 1] >= my_static[i])

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -232,7 +232,7 @@ static uint64_t loadFilePriorities(tr_variant* dict, tr_torrent* tor)
             auto priority = int64_t{};
             if (tr_variantGetInt(tr_variantListChild(list, i), &priority))
             {
-                tr_torrentInitFilePriority(tor, i, priority);
+                tor->setFilePriority(i, priority);
             }
         }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -983,11 +983,11 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
 
 static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* list)
 {
-    int fileCount = 0;
-    size_t const n = tr_variantListSize(list);
     char const* errmsg = nullptr;
-    tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
+    auto files = std::vector<tr_file_index_t>{};
+    files.reserve(tr_torrentFileCount(tor));
 
+    size_t const n = tr_variantListSize(list);
     if (n != 0)
     {
         for (size_t i = 0; i < n; ++i)
@@ -997,7 +997,7 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
             {
                 if (0 <= tmp && tmp < tor->info.fileCount)
                 {
-                    files[fileCount++] = tmp;
+                    files.push_back(tmp);
                 }
                 else
                 {
@@ -1006,20 +1006,16 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
             }
         }
     }
-    else /* if empty set, apply to all */
+    else // if empty set, apply to all
     {
         for (tr_file_index_t t = 0; t < tor->info.fileCount; ++t)
         {
-            files[fileCount++] = t;
+            files.push_back(t);
         }
     }
 
-    if (fileCount != 0)
-    {
-        tr_torrentSetFilePriorities(tor, files, fileCount, priority);
-    }
+    tor->setFilePriorities(std::data(files), std::size(files), priority);
 
-    tr_free(files);
     return errmsg;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -13,6 +13,7 @@
 #include <cstdlib> /* strtol */
 #include <cstring> /* strcmp */
 #include <iterator>
+#include <numeric>
 #include <string_view>
 #include <vector>
 
@@ -1019,24 +1020,26 @@ static char const* setFilePriorities(tr_torrent* tor, int priority, tr_variant* 
     return errmsg;
 }
 
-static char const* setFileDLs(tr_torrent* tor, bool do_download, tr_variant* list)
+static char const* setFileDLs(tr_torrent* tor, bool wanted, tr_variant* list)
 {
     char const* errmsg = nullptr;
 
-    int fileCount = 0;
-    size_t const n = tr_variantListSize(list);
-    tr_file_index_t* files = tr_new0(tr_file_index_t, tor->info.fileCount);
+    auto const n_files = tr_torrentFileCount(tor);
+    size_t const n_items = tr_variantListSize(list);
 
-    if (n != 0) /* if argument list, process them */
+    auto files = std::vector<tr_file_index_t>{};
+    files.reserve(n_files);
+
+    if (n_items != 0) // if argument list, process them
     {
-        for (size_t i = 0; i < n; ++i)
+        for (size_t i = 0; i < n_items; ++i)
         {
             auto tmp = int64_t{};
             if (tr_variantGetInt(tr_variantListChild(list, i), &tmp))
             {
                 if (0 <= tmp && tmp < tor->info.fileCount)
                 {
-                    files[fileCount++] = tmp;
+                    files.push_back(tmp);
                 }
                 else
                 {
@@ -1045,20 +1048,14 @@ static char const* setFileDLs(tr_torrent* tor, bool do_download, tr_variant* lis
             }
         }
     }
-    else /* if empty set, apply to all */
+    else // if empty set, apply to all
     {
-        for (tr_file_index_t t = 0; t < tor->info.fileCount; ++t)
-        {
-            files[fileCount++] = t;
-        }
+        files.resize(n_files);
+        std::iota(std::begin(files), std::end(files), 0);
     }
 
-    if (fileCount != 0)
-    {
-        tr_torrentSetFileDLs(tor, files, fileCount, do_download);
-    }
+    tor->setFilesWanted(std::data(files), std::size(files), wanted);
 
-    tr_free(files);
     return errmsg;
 }
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -188,20 +188,9 @@ void tr_ctorSetFilePriorities(tr_ctor* ctor, tr_file_index_t const* files, tr_fi
 
 void tr_ctorInitTorrentPriorities(tr_ctor const* ctor, tr_torrent* tor)
 {
-    for (auto file_index : ctor->low)
-    {
-        tr_torrentInitFilePriority(tor, file_index, TR_PRI_LOW);
-    }
-
-    for (auto file_index : ctor->normal)
-    {
-        tr_torrentInitFilePriority(tor, file_index, TR_PRI_NORMAL);
-    }
-
-    for (auto file_index : ctor->high)
-    {
-        tr_torrentInitFilePriority(tor, file_index, TR_PRI_HIGH);
-    }
+    tor->setFilePriorities(std::data(ctor->low), std::size(ctor->low), TR_PRI_LOW);
+    tor->setFilePriorities(std::data(ctor->normal), std::size(ctor->normal), TR_PRI_NORMAL);
+    tor->setFilePriorities(std::data(ctor->high), std::size(ctor->high), TR_PRI_HIGH);
 }
 
 void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t fileCount, bool wanted)

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -46,8 +46,8 @@ struct tr_ctor
 
     std::string incomplete_dir;
 
-    std::vector<tr_file_index_t> want;
-    std::vector<tr_file_index_t> not_want;
+    std::vector<tr_file_index_t> wanted;
+    std::vector<tr_file_index_t> unwanted;
     std::vector<tr_file_index_t> low;
     std::vector<tr_file_index_t> normal;
     std::vector<tr_file_index_t> high;
@@ -195,14 +195,14 @@ void tr_ctorInitTorrentPriorities(tr_ctor const* ctor, tr_torrent* tor)
 
 void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t fileCount, bool wanted)
 {
-    auto& indices = wanted ? ctor->want : ctor->not_want;
+    auto& indices = wanted ? ctor->wanted : ctor->unwanted;
     indices.assign(files, files + fileCount);
 }
 
 void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor)
 {
-    tr_torrentInitFileDLs(tor, std::data(ctor->not_want), std::size(ctor->not_want), false);
-    tr_torrentInitFileDLs(tor, std::data(ctor->want), std::size(ctor->want), true);
+    tor->initFilesWanted(std::data(ctor->unwanted), std::size(ctor->unwanted), false);
+    tor->initFilesWanted(std::data(ctor->wanted), std::size(ctor->wanted), true);
 }
 
 /***

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -26,6 +26,7 @@
 #include "block-info.h"
 #include "completion.h"
 #include "file.h"
+#include "file-piece-map.h"
 #include "quark.h"
 #include "session.h"
 #include "tr-assert.h"
@@ -490,6 +491,10 @@ public:
     tr_labels_t labels;
 
     static auto constexpr MagicNumber = int{ 95549 };
+
+    tr_file_piece_map fpm_ = tr_file_piece_map{ *this, info };
+    tr_file_priorities file_priorities_{ fpm_ };
+    tr_files_wanted files_wanted_{ fpm_ };
 
 private:
     mutable std::vector<tr_sha1_digest_t> piece_checksums_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1594,9 +1594,6 @@ struct tr_file_priv
 {
     uint64_t offset; // file begins at the torrent's nth byte
     time_t mtime;
-    tr_piece_index_t firstPiece; // We need pieces [firstPiece...
-    tr_piece_index_t lastPiece; // ...lastPiece] to dl this file
-    bool dnd; // "do not download" flag
     bool is_renamed; // true if we're using a different path from the one in the metainfo; ie, if the user has renamed it */
 };
 /** @brief a part of tr_info that represents a single file of the torrent's content */

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1188,15 +1188,6 @@ void tr_torrentSetFilePriorities(
     tr_file_index_t fileCount,
     tr_priority_t priority);
 
-/**
- * @brief Get this torrent's file priorities.
- *
- * @return A malloc()ed array of tor->info.fileCount items,
- *         each holding a TR_PRI_NORMAL, TR_PRI_HIGH, or TR_PRI_LOW.
- *         It's the caller's responsibility to free() this.
- */
-tr_priority_t* tr_torrentGetFilePriorities(tr_torrent const* torrent);
-
 /** @brief Set a batch of files to be downloaded or not. */
 void tr_torrentSetFileDLs(tr_torrent* torrent, tr_file_index_t const* files, tr_file_index_t fileCount, bool do_download);
 
@@ -1605,7 +1596,6 @@ struct tr_file_priv
     time_t mtime;
     tr_piece_index_t firstPiece; // We need pieces [firstPiece...
     tr_piece_index_t lastPiece; // ...lastPiece] to dl this file
-    int8_t priority; // TR_PRI_HIGH, _NORMAL, or _LOW
     bool dnd; // "do not download" flag
     bool is_renamed; // true if we're using a different path from the one in the metainfo; ie, if the user has renamed it */
 };

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(libtransmission-test
     crypto-test.cc
     error-test.cc
     file-test.cc
+    file-piece-map-test.cc
     getopt-test.cc
     history-test.cc
     json-test.cc

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -27,9 +27,9 @@ struct TestTorrent : public tr_completion::torrent_view
 {
     std::set<tr_piece_index_t> dnd_pieces;
 
-    [[nodiscard]] bool pieceIsDnd(tr_piece_index_t piece) const final
+    [[nodiscard]] bool pieceIsWanted(tr_piece_index_t piece) const final
     {
-        return dnd_pieces.count(piece) != 0;
+        return dnd_pieces.count(piece) == 0;
     }
 };
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -1,0 +1,335 @@
+/*
+ * This file Copyright (C) Mnemosyne LLC
+ *
+ * It may be used under the GNU GPL versions 2 or 3
+ * or any future license endorsed by Mnemosyne LLC.
+ *
+ */
+
+#include <array>
+#include <numeric>
+#include <cstdint>
+
+#include "transmission.h"
+
+#include "block-info.h"
+#include "file-piece-map.h"
+
+#include "gtest/gtest.h"
+
+class FilePieceMapTest : public ::testing::Test
+{
+protected:
+    static constexpr size_t TotalSize{ 1001 };
+    static constexpr size_t PieceSize{ 100 };
+    tr_block_info const block_info_{ TotalSize, PieceSize };
+
+    static constexpr std::array<uint64_t, 17> FileSizes{
+        500, // [offset 0] begins and ends on a piece boundary
+        0, // [offset 500] zero-sized files
+        0,   0, 0,
+        50, // [offset 500] begins on a piece boundary
+        100, // [offset 550] neither begins nor ends on a piece boundary, spans >1 piece
+        10, // [offset 650] small files all contained in a single piece
+        9,   8, 7, 6,
+        311, // [offset 690] ends end-of-torrent
+        0, // [offset 1001] zero-sized files at the end-of-torrent
+        0,   0, 0,
+        // sum is 1001 == TotalSize
+    };
+
+    void SetUp() override
+    {
+        EXPECT_EQ(11, block_info_.n_pieces);
+        EXPECT_EQ(PieceSize, block_info_.piece_size);
+        EXPECT_EQ(TotalSize, block_info_.total_size);
+        EXPECT_EQ(TotalSize, std::accumulate(std::begin(FileSizes), std::end(FileSizes), uint64_t{ 0 }));
+    }
+};
+
+TEST_F(FilePieceMapTest, pieceSpan)
+{
+    // Note to reviewers: it's easy to see a nonexistent fencepost error here.
+    // Remember everything is zero-indexed, so the 11 valid pieces are [0..10]
+    // and that last piece #10 has one byte in it. Piece #11 is the 'end' iterator position.
+    auto constexpr ExpectedPieceSpans = std::array<tr_file_piece_map::piece_span_t, 17>{ {
+        { 0, 5 },
+        { 5, 6 },
+        { 5, 6 },
+        { 5, 6 },
+        { 5, 6 },
+        { 5, 6 },
+        { 5, 7 },
+        { 6, 7 },
+        { 6, 7 },
+        { 6, 7 },
+        { 6, 7 },
+        { 6, 7 },
+        { 6, 11 },
+        { 10, 11 },
+        { 10, 11 },
+        { 10, 11 },
+        { 10, 11 },
+    } };
+    EXPECT_EQ(std::size(FileSizes), std::size(ExpectedPieceSpans));
+
+    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    tr_file_index_t const n = std::size(fpm);
+    EXPECT_EQ(std::size(FileSizes), n);
+    uint64_t offset = 0;
+    for (tr_file_index_t file = 0; file < n; ++file)
+    {
+        EXPECT_EQ(ExpectedPieceSpans[file].begin, fpm.pieceSpan(file).begin);
+        EXPECT_EQ(ExpectedPieceSpans[file].end, fpm.pieceSpan(file).end);
+        offset += FileSizes[file];
+    }
+    EXPECT_EQ(TotalSize, offset);
+    EXPECT_EQ(block_info_.n_pieces, fpm.pieceSpan(std::size(FileSizes) - 1).end);
+}
+
+TEST_F(FilePieceMapTest, priorities)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto file_priorities = tr_file_priorities(fpm);
+    tr_file_index_t const n_files = std::size(FileSizes);
+
+    // make a helper to compare file & piece priorities
+    auto expected_file_priorities = std::vector<tr_priority_t>(n_files, TR_PRI_NORMAL);
+    auto expected_piece_priorities = std::vector<tr_priority_t>(block_info_.n_pieces, TR_PRI_NORMAL);
+    auto const compare_to_expected = [&, this]()
+    {
+        for (tr_file_index_t i = 0; i < n_files; ++i)
+        {
+            EXPECT_EQ(int(expected_file_priorities[i]), int(file_priorities.filePriority(i)));
+        }
+        for (tr_piece_index_t i = 0; i < block_info_.n_pieces; ++i)
+        {
+            EXPECT_EQ(int(expected_piece_priorities[i]), int(file_priorities.piecePriority(i)));
+        }
+    };
+
+    // check default priority is normal
+    compare_to_expected();
+
+    // set the first file as high priority.
+    // since this begins and ends on a piece boundary,
+    // this shouldn't affect any other files' pieces
+    auto pri = TR_PRI_HIGH;
+    file_priorities.set(0, pri);
+    expected_file_priorities[0] = pri;
+    for (size_t i = 0; i < 5; ++i)
+    {
+        expected_piece_priorities[i] = pri;
+    }
+    compare_to_expected();
+
+    // This file shares a piece with another file.
+    // If _either_ is set to high, the piece's priority should be high.
+    // file #5: byte [500..550) piece [5, 6)
+    // file #6: byte [550..650) piece [5, 7)
+    //
+    // first test setting file #5...
+    pri = TR_PRI_HIGH;
+    file_priorities.set(5, pri);
+    expected_file_priorities[5] = pri;
+    expected_piece_priorities[5] = pri;
+    compare_to_expected();
+    // ...and that shared piece should still be the same when both are high...
+    file_priorities.set(6, pri);
+    expected_file_priorities[6] = pri;
+    expected_piece_priorities[5] = pri;
+    expected_piece_priorities[6] = pri;
+    compare_to_expected();
+    // ...and that shared piece should still be the same when only 6 is high...
+    pri = TR_PRI_NORMAL;
+    file_priorities.set(5, pri);
+    expected_file_priorities[5] = pri;
+    compare_to_expected();
+
+    // setup for the next test: set all files to low priority
+    pri = TR_PRI_LOW;
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        file_priorities.set(i, pri);
+    }
+    std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
+    std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    compare_to_expected();
+
+    // Raise the priority of a small 1-piece file.
+    // Since it's the highest priority in the piece, piecePriority() should return its value.
+    // file #8: byte [650, 659) piece [6, 7)
+    pri = TR_PRI_NORMAL;
+    file_priorities.set(8, pri);
+    expected_file_priorities[8] = pri;
+    expected_piece_priorities[6] = pri;
+    compare_to_expected();
+    // Raise the priority of another small 1-piece file in the same piece.
+    // Since _it_ now has the highest priority in the piece, piecePriority should return _its_ value.
+    // file #9: byte [659, 667) piece [6, 7)
+    pri = TR_PRI_HIGH;
+    file_priorities.set(9, pri);
+    expected_file_priorities[9] = pri;
+    expected_piece_priorities[6] = pri;
+    compare_to_expected();
+
+    // Prep for the next test: set all files to normal priority
+    pri = TR_PRI_NORMAL;
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        file_priorities.set(i, pri);
+    }
+    std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
+    std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    compare_to_expected();
+
+    // *Sigh* OK what happens to piece priorities if you set the priority
+    // of a zero-byte file. Arguably nothing should happen since you can't
+    // download an empty file. But that would complicate the code for a
+    // pretty stupid use case, and treating 0-sized files the same as any
+    // other does no real harm. Let's KISS.
+    //
+    // Check that even zero-sized files can change a piece's priority
+    // file #1: byte [500, 500) piece [5, 6)
+    pri = TR_PRI_HIGH;
+    file_priorities.set(1, pri);
+    expected_file_priorities[1] = pri;
+    expected_piece_priorities[5] = pri;
+    compare_to_expected();
+    // Check that zero-sized files at the end of a torrent change the last piece's priority.
+    // file #16 byte [1001, 1001) piece [10, 11)
+    file_priorities.set(16, pri);
+    expected_file_priorities[16] = pri;
+    expected_piece_priorities[10] = pri;
+    compare_to_expected();
+
+    // test the batch API
+    auto file_indices = std::vector<tr_file_index_t>(n_files);
+    std::iota(std::begin(file_indices), std::end(file_indices), 0);
+    pri = TR_PRI_HIGH;
+    file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
+    std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
+    std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    compare_to_expected();
+    pri = TR_PRI_LOW;
+    file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
+    std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
+    std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    compare_to_expected();
+}
+
+TEST_F(FilePieceMapTest, wanted)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto files_wanted = tr_files_wanted(fpm);
+    tr_file_index_t const n_files = std::size(FileSizes);
+
+    // make a helper to compare file & piece priorities
+    auto expected_files_wanted = tr_bitfield(n_files);
+    auto expected_pieces_wanted = tr_bitfield(block_info_.n_pieces);
+    auto const compare_to_expected = [&, this]()
+    {
+        for (tr_file_index_t i = 0; i < n_files; ++i)
+        {
+            EXPECT_EQ(int(expected_files_wanted.test(i)), int(files_wanted.fileWanted(i)));
+        }
+        for (tr_piece_index_t i = 0; i < block_info_.n_pieces; ++i)
+        {
+            EXPECT_EQ(int(expected_pieces_wanted.test(i)), int(files_wanted.pieceWanted(i)));
+        }
+    };
+
+    // check everything is wanted by default
+    expected_files_wanted.setHasAll();
+    expected_pieces_wanted.setHasAll();
+    compare_to_expected();
+
+    // set the first file as not wanted.
+    // since this begins and ends on a piece boundary,
+    // this shouldn't affect any other files' pieces
+    bool wanted = false;
+    files_wanted.set(0, wanted);
+    expected_files_wanted.set(0, wanted);
+    expected_pieces_wanted.setSpan(0, 5, wanted);
+    compare_to_expected();
+
+    // now test when a piece has >1 file.
+    // if *any* file in that piece is wanted, then we want the piece too.
+    // file #1: byte [100..100) piece [5, 6) (zero-byte file)
+    // file #2: byte [100..100) piece [5, 6) (zero-byte file)
+    // file #3: byte [100..100) piece [5, 6) (zero-byte file)
+    // file #4: byte [100..100) piece [5, 6) (zero-byte file)
+    // file #5: byte [500..550) piece [5, 6)
+    // file #6: byte [550..650) piece [5, 7)
+    //
+    // first test setting file #5...
+    files_wanted.set(5, false);
+    expected_files_wanted.unset(5);
+    compare_to_expected();
+    // marking all the files in the piece as unwanted
+    // should cause the piece to become unwanted
+    files_wanted.set(1, false);
+    files_wanted.set(2, false);
+    files_wanted.set(3, false);
+    files_wanted.set(4, false);
+    files_wanted.set(5, false);
+    files_wanted.set(6, false);
+    expected_files_wanted.setSpan(1, 7, false);
+    expected_pieces_wanted.unset(5);
+    compare_to_expected();
+    // but as soon as any of them is turned back to wanted,
+    // the piece should pop back.
+    files_wanted.set(6, true);
+    expected_files_wanted.set(6, true);
+    expected_pieces_wanted.set(5);
+    compare_to_expected();
+    files_wanted.set(5, true);
+    files_wanted.set(6, false);
+    expected_files_wanted.set(5);
+    expected_files_wanted.unset(6);
+    compare_to_expected();
+    files_wanted.set(4, true);
+    files_wanted.set(5, false);
+    expected_files_wanted.set(4);
+    expected_files_wanted.unset(5);
+    compare_to_expected();
+
+    // Prep for the next test: set all files to unwanted priority
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        files_wanted.set(i, false);
+    }
+    expected_files_wanted.setHasNone();
+    expected_pieces_wanted.setHasNone();
+    compare_to_expected();
+
+    // *Sigh* OK what happens to files_wanted if you say the only
+    // file you want is a zero-byte file? Arguably nothing should happen
+    // since you can't download a zero-byte file. But that would complicate
+    // the coe for a stupid use case, so let's KISS.
+    //
+    // Check that even zero-sized files can change a file's 'wanted' state
+    // file #1: byte [500, 500) piece [5, 6)
+    files_wanted.set(1, true);
+    expected_files_wanted.set(1);
+    expected_pieces_wanted.set(5);
+    compare_to_expected();
+    // Check that zero-sized files at the end of a torrent change the last piece's state.
+    // file #16 byte [1001, 1001) piece [10, 11)
+    files_wanted.set(16, true);
+    expected_files_wanted.set(16);
+    expected_pieces_wanted.set(10);
+    compare_to_expected();
+
+    // test the batch API
+    auto file_indices = std::vector<tr_file_index_t>(n_files);
+    std::iota(std::begin(file_indices), std::end(file_indices), 0);
+    files_wanted.set(std::data(file_indices), std::size(file_indices), true);
+    expected_files_wanted.setHasAll();
+    expected_pieces_wanted.setHasAll();
+    compare_to_expected();
+    files_wanted.set(std::data(file_indices), std::size(file_indices), false);
+    expected_files_wanted.setHasNone();
+    expected_pieces_wanted.setHasNone();
+    compare_to_expected();
+}

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -221,7 +221,7 @@ TEST_F(FilePieceMapTest, priorities)
 TEST_F(FilePieceMapTest, wanted)
 {
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
-    auto files_wanted = tr_files_wanted(fpm);
+    auto files_wanted = tr_files_wanted(&fpm);
     tr_file_index_t const n_files = std::size(FileSizes);
 
     // make a helper to compare file & piece priorities

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -90,7 +90,7 @@ TEST_F(FilePieceMapTest, pieceSpan)
 TEST_F(FilePieceMapTest, priorities)
 {
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
-    auto file_priorities = tr_file_priorities(fpm);
+    auto file_priorities = tr_file_priorities(&fpm);
     tr_file_index_t const n_files = std::size(FileSizes);
 
     // make a helper to compare file & piece priorities


### PR DESCRIPTION
Add small classes that handle mapping files to pieces.

This decouples the file wanted/priority tracking features from the rest of tr_torrent and makes them easier to test.