### PR TITLE
refactor: use strf to format numbers when serializing json/benc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,7 @@
 [submodule "third-party/googletest"]
 	path = third-party/googletest
 	url = https://github.com/google/googletest.git
+[submodule "third-party/strf"]
+	path = third-party/strf
+	url = https://github.com/transmission/strf.git
+	branch = v0.15.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ if(WIN32)
     endforeach()
 endif()
 
+find_package(Strf)
 find_package(Threads)
 find_package(PkgConfig QUIET)
 

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 		A22CFB820FB66EF30009BD3E /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFB810FB66EF30009BD3E /* Carbon.framework */; };
 		A22CFCA80FC24ED80009BD3E /* tr-dht.cc in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCA60FC24ED80009BD3E /* tr-dht.cc */; };
 		A22CFCA90FC24ED80009BD3E /* tr-dht.h in Headers */ = {isa = PBXBuildFile; fileRef = A22CFCA70FC24ED80009BD3E /* tr-dht.h */; };
-		4C027923C7C292AD6F509232 /* strf.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C027923C7C292AD6F509231 /* strf.h */; };
 		A22CFCC20FC24F890009BD3E /* dht.h in Headers */ = {isa = PBXBuildFile; fileRef = A22CFCC00FC24F890009BD3E /* dht.h */; };
 		A22CFCC30FC24F890009BD3E /* dht.c in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCC10FC24F890009BD3E /* dht.c */; };
 		A22CFCCB0FC24FDA0009BD3E /* libdht.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFCBA0FC24F710009BD3E /* libdht.a */; };
@@ -668,7 +667,6 @@
 		A22CFCA60FC24ED80009BD3E /* tr-dht.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-dht.cc"; sourceTree = "<group>"; };
 		A22CFCA70FC24ED80009BD3E /* tr-dht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tr-dht.h"; sourceTree = "<group>"; };
 		A22CFCBA0FC24F710009BD3E /* libdht.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libdht.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4C027923C7C292AD6F509231 /* strf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = strf.h; sourceTree = "<group>"; };
 		A22CFCC00FC24F890009BD3E /* dht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dht.h; sourceTree = "<group>"; };
 		A22CFCC10FC24F890009BD3E /* dht.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dht.c; sourceTree = "<group>"; };
 		A22F1E540E7DA8030065DB9D /* sparkle_dsa_pub.pem */ = {isa = PBXFileReference; lastKnownFileType = text; path = sparkle_dsa_pub.pem; sourceTree = "<group>"; };
@@ -1300,7 +1298,6 @@
 				C15E58AC219A37C600AB292F /* utils */,
 				C1A7518626ED04EC0038B90A /* arc4 */,
 				A22CFCB50FC24F630009BD3E /* dht */,
-				4C027923C7C292AD6F509230 /* strf */,
 				A2E384BF130DFA49001F501B /* libutp */,
 				BE75C3570C72A0D600DBEFE0 /* libevent */,
 				BE1183410CE15DF00002D0F3 /* libminiupnp */,
@@ -1553,15 +1550,6 @@
 			);
 			name = CLI;
 			path = cli;
-			sourceTree = "<group>";
-		};
-		4C027923C7C292AD6F509230 /* strf */ = {
-			isa = PBXGroup;
-			children = (
-				4C027923C7C292AD6F509231 /* strf.h */,
-			);
-			name = strf;
-			path = "third-party/strf";
 			sourceTree = "<group>";
 		};
 		A22CFCB50FC24F630009BD3E /* dht */ = {
@@ -3046,6 +3034,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3239,6 +3228,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3489,6 +3479,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		A22CFB820FB66EF30009BD3E /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFB810FB66EF30009BD3E /* Carbon.framework */; };
 		A22CFCA80FC24ED80009BD3E /* tr-dht.cc in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCA60FC24ED80009BD3E /* tr-dht.cc */; };
 		A22CFCA90FC24ED80009BD3E /* tr-dht.h in Headers */ = {isa = PBXBuildFile; fileRef = A22CFCA70FC24ED80009BD3E /* tr-dht.h */; };
+		4C027923C7C292AD6F509232 /* strf.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C027923C7C292AD6F509231 /* strf.h */; };
 		A22CFCC20FC24F890009BD3E /* dht.h in Headers */ = {isa = PBXBuildFile; fileRef = A22CFCC00FC24F890009BD3E /* dht.h */; };
 		A22CFCC30FC24F890009BD3E /* dht.c in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCC10FC24F890009BD3E /* dht.c */; };
 		A22CFCCB0FC24FDA0009BD3E /* libdht.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFCBA0FC24F710009BD3E /* libdht.a */; };
@@ -667,6 +668,7 @@
 		A22CFCA60FC24ED80009BD3E /* tr-dht.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-dht.cc"; sourceTree = "<group>"; };
 		A22CFCA70FC24ED80009BD3E /* tr-dht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tr-dht.h"; sourceTree = "<group>"; };
 		A22CFCBA0FC24F710009BD3E /* libdht.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libdht.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C027923C7C292AD6F509231 /* strf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = strf.h; sourceTree = "<group>"; };
 		A22CFCC00FC24F890009BD3E /* dht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dht.h; sourceTree = "<group>"; };
 		A22CFCC10FC24F890009BD3E /* dht.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dht.c; sourceTree = "<group>"; };
 		A22F1E540E7DA8030065DB9D /* sparkle_dsa_pub.pem */ = {isa = PBXFileReference; lastKnownFileType = text; path = sparkle_dsa_pub.pem; sourceTree = "<group>"; };
@@ -1298,6 +1300,7 @@
 				C15E58AC219A37C600AB292F /* utils */,
 				C1A7518626ED04EC0038B90A /* arc4 */,
 				A22CFCB50FC24F630009BD3E /* dht */,
+				4C027923C7C292AD6F509230 /* strf */,
 				A2E384BF130DFA49001F501B /* libutp */,
 				BE75C3570C72A0D600DBEFE0 /* libevent */,
 				BE1183410CE15DF00002D0F3 /* libminiupnp */,
@@ -1550,6 +1553,16 @@
 			);
 			name = CLI;
 			path = cli;
+			sourceTree = "<group>";
+		};
+		4C027923C7C292AD6F509230 /* strf */ = {
+			isa = PBXGroup;
+			children = (
+			mmm
+				4C027923C7C292AD6F509231 /* strf.h */,
+			);
+			name = strf;
+			path = "third-party/strf";
 			sourceTree = "<group>";
 		};
 		A22CFCB50FC24F630009BD3E /* dht */ = {

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3034,6 +3034,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3227,6 +3228,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3477,6 +3479,7 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
+					"third-party/strf/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1558,7 +1558,6 @@
 		4C027923C7C292AD6F509230 /* strf */ = {
 			isa = PBXGroup;
 			children = (
-			mmm
 				4C027923C7C292AD6F509231 /* strf.h */,
 			);
 			name = strf;

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3034,7 +3034,6 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
-					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3228,7 +3227,6 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
-					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3479,7 +3477,6 @@
 					"third-party/libb64/include",
 					"third-party/libevent/include",
 					"third-party/libutp",
-					"third-party/strf",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/cmake/FindStrf.cmake
+++ b/cmake/FindStrf.cmake
@@ -1,0 +1,1 @@
+set(STRF_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/third-party/strf/include)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -244,6 +244,7 @@ include_directories(
 
 include_directories(
     SYSTEM
+    ${STRF_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
     ${CRYPTO_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}


### PR DESCRIPTION
as discussed [here](https://github.com/transmission/transmission/issues/612#issuecomment-981198736), try using [strf](https://github.com/robhz786/strf) when serializing numbers for json.

My first choice was `std::to_chars()` for this, since it would require no new dependencies. However that's not available on all the older systems that Transmission supports (e.g. it's not feature-complete in Ubuntu 20.04 LTS), so who knows when that will be a realistic option. Moreover, strf has utf8/utf32 conversion utilities that dovetail nicely with #612.

- [x] fork into `transmission/strf` as a safeguard against upstream churn / repo deletion
- [x] add submodule in `transmission/transmission` third-party/ and pin against latest stable of strf
- [x] use strf instead of evbuffer_printf() when serializing integral types to json and benc
- [ ] Update xcode project to add third-party/strf/include to include path
- [x] replace ConvertUTF use in variant-json.cc with strf
- [ ] reimplement tr_utf8_validate using strf -- e.g. we could convert to a discarded_destination with an invalid_seq_notifier that sets an error flag?
- [ ] reimplement tr_utf8clean() using strf::sani() 
- [ ] maybe reimplement tr_truncd() using strf? (is tr_truncd still needed?)

*edit:* https://github.com/transmission/transmission/pull/2251 uses utfcpp for the 32<->8 conversion / verification, so perhaps just using strf for faster formatting when serializing json.