### PR TITLE
fixup! fix: sonarcloud warnings (#2260)

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -729,7 +729,8 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
 
     std::string const filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
 
-    if (auto buf = std::vector<char>{}; !tr_loadFile(buf, filename.c_str(), &error) ||
+    auto buf = std::vector<char>{};
+    if (!tr_loadFile(buf, filename.c_str(), &error) ||
         !tr_variantFromBuf(
             &top,
             TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE,


### PR DESCRIPTION
the scope of the buf variable was narrowed too far.