### PR TITLE
refactor: add tr_saveFile()

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -243,8 +243,6 @@ int tr_main(int argc, char* argv[])
     tr_torrent* tor = nullptr;
     tr_variant settings;
     char const* configDir;
-    uint8_t* fileContents;
-    size_t fileLength;
 
     tr_formatter_mem_init(MEM_K, MEM_K_STR, MEM_M_STR, MEM_G_STR, MEM_T_STR);
     tr_formatter_size_init(DISK_K, DISK_K_STR, DISK_M_STR, DISK_G_STR, DISK_T_STR);
@@ -304,12 +302,11 @@ int tr_main(int argc, char* argv[])
 
     ctor = tr_ctorNew(h);
 
-    fileContents = tr_loadFile(torrentPath, &fileLength, nullptr);
     tr_ctorSetPaused(ctor, TR_FORCE, false);
 
-    if (fileContents != nullptr)
+    if (tr_sys_path_exists(torrentPath, nullptr))
     {
-        tr_ctorSetMetainfo(ctor, fileContents, fileLength);
+        tr_ctorSetMetainfoFromFile(ctor, torrentPath);
     }
     else if (memcmp(torrentPath, "magnet:?", 8) == 0)
     {
@@ -333,8 +330,6 @@ int tr_main(int argc, char* argv[])
         tr_sessionClose(h);
         return EXIT_FAILURE;
     }
-
-    tr_free(fileContents);
 
     tor = tr_torrentNew(ctor, nullptr, nullptr);
     tr_ctorFree(ctor);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1148,7 +1148,7 @@ void Session::Impl::add_file_async_callback(
         {
             g_message(_("Couldn't read \"%s\""), file->get_parse_name().c_str());
         }
-        else if (tr_ctorSetMetainfo(ctor, (uint8_t const*)contents, length) == 0)
+        else if (tr_ctorSetMetainfo(ctor, contents, length) == 0)
         {
             add_ctor(ctor, do_prompt, do_notify);
         }

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -172,7 +172,7 @@ bool tr_ctorSaveContents(tr_ctor const* ctor, char const* filename, tr_error** e
 
     if (std::empty(ctor->contents))
     {
-        tr_error_set_literal(error, ENODATA, "torrent ctor has no contents to save");
+        tr_error_set_literal(error, EINVAL, "torrent ctor has no contents to save");
         return false;
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -763,17 +763,12 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     /* maybe save our own copy of the metainfo */
     if (tr_ctorGetSave(ctor))
     {
-        tr_variant const* val = nullptr;
-        if (tr_ctorGetMetainfo(ctor, &val))
+        tr_error* error = nullptr;
+        if (!tr_ctorSaveContents(ctor, tor->info.torrent, &error))
         {
-            char const* path = tor->info.torrent;
-            int const err = tr_variantToFile(val, TR_VARIANT_FMT_BENC, path);
-
-            if (err != 0)
-            {
-                tr_torrentSetLocalError(tor, "Unable to save torrent file: %s", tr_strerror(err));
-            }
+            tr_torrentSetLocalError(tor, "Unable to save torrent file: %s (%d)", error->message, error->code);
         }
+        tr_error_clear(&error);
     }
 
     tor->tiers = tr_announcerAddTorrent(tor, onTrackerResponse, nullptr);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -248,7 +248,7 @@ public:
 
     /// WANTED
 
-    bool pieceIsWanted(tr_piece_index_t piece) const final
+    bool pieceIsWanted(tr_piece_index_t piece) const final override
     {
         return files_wanted_.pieceWanted(piece);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -52,6 +52,14 @@ void tr_ctorInitTorrentPriorities(tr_ctor const* ctor, tr_torrent* tor);
 
 void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 
+bool tr_ctorSaveContents(tr_ctor const* ctor, char const* filename, tr_error** error);
+
+bool tr_ctorGetMetainfo(tr_ctor const* ctor, tr_variant const** setme);
+
+tr_session* tr_ctorGetSession(tr_ctor const* ctor);
+
+bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDir);
+
 /**
 ***
 **/

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -860,7 +860,7 @@ void tr_ctorSetDeleteSource(tr_ctor* ctor, bool doDelete);
 int tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, char const* magnet);
 
 /** @brief Set the constructor's metainfo from a raw benc already in memory */
-int tr_ctorSetMetainfo(tr_ctor* ctor, void const* metainfo, size_t len);
+int tr_ctorSetMetainfo(tr_ctor* ctor, char const* metainfo, size_t len);
 
 /** @brief Set the constructor's metainfo from a local .torrent file */
 int tr_ctorSetMetainfoFromFile(tr_ctor* ctor, char const* filename);
@@ -902,17 +902,8 @@ bool tr_ctorGetPaused(tr_ctor const* ctor, tr_ctorMode mode, bool* setmeIsPaused
 /** @brief Get the download path from this peer constructor */
 bool tr_ctorGetDownloadDir(tr_ctor const* ctor, tr_ctorMode mode, char const** setmeDownloadDir);
 
-/** @brief Get the incomplete directory from this peer constructor */
-bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDir);
-
-/** @brief Get the metainfo from this peer constructor */
-bool tr_ctorGetMetainfo(tr_ctor const* ctor, struct tr_variant const** setme);
-
 /** @brief Get the "delete .torrent file" flag from this peer constructor */
 bool tr_ctorGetDeleteSource(tr_ctor const* ctor, bool* setmeDoDelete);
-
-/** @brief Get the tr_session poiner from this peer constructor */
-tr_session* tr_ctorGetSession(tr_ctor const* ctor);
 
 /** @brief Get the .torrent file that this ctor's metainfo came from,
            or nullptr if tr_ctorSetMetainfoFromFile() wasn't used */

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -81,6 +81,8 @@ uint8_t* tr_loadFile(char const* filename, size_t* size, struct tr_error** error
 
 bool tr_loadFile(std::vector<char>& setme, char const* filename, tr_error** error = nullptr);
 
+bool tr_saveFile(char const* filename_in, std::string_view contents, tr_error** error = nullptr);
+
 /** @brief build a filename from a series of elements using the
            platform's correct directory separator. */
 char* tr_buildPath(char const* first_element, ...) TR_GNUC_NULL_TERMINATED TR_GNUC_MALLOC;

--- a/tests/libtransmission/metainfo-test.cc
+++ b/tests/libtransmission/metainfo-test.cc
@@ -196,7 +196,7 @@ TEST(Metainfo, ctorSaveContents)
     tr_error* error = nullptr;
     EXPECT_FALSE(tr_ctorSaveContents(ctor, tgt_filename.c_str(), &error));
     ASSERT_NE(nullptr, error);
-    EXPECT_EQ(ENODATA, error->code);
+    EXPECT_EQ(EINVAL, error->code);
     tr_error_clear(&error);
 
     // now try saving _with_ metainfo

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -73,7 +73,7 @@ protected:
         auto* metainfo = static_cast<char*>(tr_base64_decode_str(metainfo_base64, &metainfo_len));
         EXPECT_NE(nullptr, metainfo);
         EXPECT_LT(size_t(0), metainfo_len);
-        tr_ctorSetMetainfo(ctor, reinterpret_cast<uint8_t const*>(metainfo), metainfo_len);
+        tr_ctorSetMetainfo(ctor, metainfo, metainfo_len);
         tr_ctorSetPaused(ctor, TR_FORCE, true);
 
         // create the torrent

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -374,11 +374,11 @@ protected:
 
         // create the torrent ctor
         auto metainfo_len = size_t{};
-        auto* metainfo = tr_base64_decode_str(metainfo_base64, &metainfo_len);
+        auto* const metainfo = tr_base64_decode_str(metainfo_base64, &metainfo_len);
         EXPECT_NE(nullptr, metainfo);
         EXPECT_LT(size_t{ 0 }, metainfo_len);
         auto* ctor = tr_ctorNew(session_);
-        tr_ctorSetMetainfo(ctor, reinterpret_cast<uint8_t*>(metainfo), metainfo_len);
+        tr_ctorSetMetainfo(ctor, static_cast<char const*>(metainfo), metainfo_len);
         tr_ctorSetPaused(ctor, TR_FORCE, true);
         tr_free(metainfo);
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -509,6 +509,6 @@ TEST_F(UtilsTest, saveFile)
     filename = "/this/path/does/not/exist/foo.txt";
     EXPECT_FALSE(tr_saveFile(filename.c_str(), contents, &error));
     ASSERT_NE(nullptr, error);
-    EXPECT_EQ(ENOENT, error->code);
+    EXPECT_NE(0, error->code);
     tr_error_clear(&error);
 }


### PR DESCRIPTION
This lays groundwork for the upcoming metainfo refactor:

- add `tr_saveFile()`, whose implementation is extracted from `tr_variantToFile()`.
- add new tests for `tr_saveFile()`
- finish the extract-method step by reimplementing `tr_variantToFile()` as a wrapper around `tr_saveFiile()`

And then  use it:

- add `tr_ctorSaveContents()`, which saves the constructor's metainfo to a file.
- add new tests for `tr_ctorSaveContents()`
- use `tr_ctorSaveContents()` in `torrentInit()`

Why? Because `torrentInit()` previously serialized ctor's variant to save the contents, but the upcoming metainfo refactor no longer exposes a variant. To reduce the size & complexity of the metainfo refactor, this piece is being PR'ed as a standalone refactor.