### PR TITLE
refactor: add tr_torrent::fileCount()

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -52,7 +52,7 @@ static int readOrWriteBytes(
     int err = 0;
     bool const doWrite = ioMode >= TR_IO_WRITE;
 
-    TR_ASSERT(fileIndex < tr_torrentFileCount(tor));
+    TR_ASSERT(fileIndex < tor->fileCount());
     auto const& file = tor->info.files[fileIndex];
     TR_ASSERT(file.length == 0 || fileOffset < file.length);
     TR_ASSERT(fileOffset + buflen <= file.length);
@@ -180,15 +180,16 @@ void tr_ioFindFileLocation(
     uint64_t const offset = tr_pieceOffset(tor, pieceIndex, pieceOffset, 0);
     TR_ASSERT(offset < tor->info.totalSize);
 
+    auto const n_files = tor->fileCount();
     auto const* file = static_cast<tr_file const*>(
-        bsearch(&offset, tor->info.files, tor->info.fileCount, sizeof(tr_file), compareOffsetToFile));
+        bsearch(&offset, tor->info.files, n_files, sizeof(tr_file), compareOffsetToFile));
     TR_ASSERT(file != nullptr);
 
     if (file != nullptr)
     {
         *fileIndex = file - tor->info.files;
         *fileOffset = offset - file->priv.offset;
-        TR_ASSERT(*fileIndex < tor->info.fileCount);
+        TR_ASSERT(*fileIndex < n_files);
         TR_ASSERT(*fileOffset < file->length);
         TR_ASSERT(tor->info.files[*fileIndex].priv.offset + *fileOffset == offset);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -314,7 +314,7 @@ public:
         checked_pieces_ = checked;
 
         auto filename = std::string{};
-        for (size_t i = 0; i < info.fileCount; ++i)
+        for (size_t i = 0, n = this->fileCount(); i < n; ++i)
         {
             auto const found = this->findFile(filename, i);
             auto const mtime = found ? found->last_modified_at : 0;
@@ -330,7 +330,12 @@ public:
         }
     }
 
-    /// FINDING FILES
+    /// FILES
+
+    tr_file_index_t fileCount() const
+    {
+        return info.fileCount;
+    }
 
     struct tr_found_file_t : public tr_sys_path_info
     {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1083,7 +1083,7 @@ char const* tr_torrentName(tr_torrent const*);
  *         when done) that gives the location of this file on disk,
  *         or nullptr if no file exists yet.
  * @param tor the torrent whose file we're looking for
- * @param fileNum the fileIndex, in [0...tr_info.fileCount)
+ * @param fileNum the fileIndex, in [0...tr_torrentFileCount())
  */
 char* tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t fileNum);
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -73,7 +73,7 @@ public:
         have.setHasAll();
         tr_peerUpdateProgress(tor, this);
 
-        file_urls.resize(tr_torrentInfo(tor)->fileCount);
+        file_urls.resize(tor->fileCount());
 
         timer = evtimer_new(session->event_base, webseed_timer_func, this);
         tr_timerAddMsec(timer, TR_IDLE_TIMER_MSEC);


### PR DESCRIPTION
Provide an accessor to get a torrent's file count.

This is an incremental step towards making tr_torrent's impl private.