### PR TITLE
refactor: add tr_torrent::file()

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -52,7 +52,7 @@ static int readOrWriteBytes(
     int err = 0;
     bool const doWrite = ioMode >= TR_IO_WRITE;
 
-    TR_ASSERT(fileIndex < tr_torrentFileCount(tor));
+    TR_ASSERT(fileIndex < tor->fileCount());
     auto const& file = tor->info.files[fileIndex];
     TR_ASSERT(file.length == 0 || fileOffset < file.length);
     TR_ASSERT(fileOffset + buflen <= file.length);
@@ -180,15 +180,16 @@ void tr_ioFindFileLocation(
     uint64_t const offset = tr_pieceOffset(tor, pieceIndex, pieceOffset, 0);
     TR_ASSERT(offset < tor->info.totalSize);
 
+    auto const n_files = tor->fileCount();
     auto const* file = static_cast<tr_file const*>(
-        bsearch(&offset, tor->info.files, tor->info.fileCount, sizeof(tr_file), compareOffsetToFile));
+        bsearch(&offset, tor->info.files, n_files, sizeof(tr_file), compareOffsetToFile));
     TR_ASSERT(file != nullptr);
 
     if (file != nullptr)
     {
         *fileIndex = file - tor->info.files;
         *fileOffset = offset - file->priv.offset;
-        TR_ASSERT(*fileIndex < tor->info.fileCount);
+        TR_ASSERT(*fileIndex < n_files);
         TR_ASSERT(*fileOffset < file->length);
         TR_ASSERT(tor->info.files[*fileIndex].priv.offset + *fileOffset == offset);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -289,6 +289,44 @@ public:
         setDirty();
     }
 
+    /// FILES
+
+    tr_file_index_t fileCount() const
+    {
+        return info.fileCount;
+    }
+
+    auto& file(tr_file_index_t i)
+    {
+        TR_ASSERT(i < this->fileCount());
+
+        return info.files[i];
+    }
+
+    auto const& file(tr_file_index_t i) const
+    {
+        TR_ASSERT(i < this->fileCount());
+
+        return info.files[i];
+    }
+
+    struct tr_found_file_t : public tr_sys_path_info
+    {
+        std::string& filename; // /home/foo/Downloads/torrent/01-file-one.txt
+        std::string_view base; // /home/foo/Downloads
+        std::string_view subpath; // /torrent/01-file-one.txt
+
+        tr_found_file_t(tr_sys_path_info info, std::string& f, std::string_view b)
+            : tr_sys_path_info{ info }
+            , filename{ f }
+            , base{ b }
+            , subpath{ f.c_str() + std::size(b) + 1 }
+        {
+        }
+    };
+
+    std::optional<tr_found_file_t> findFile(std::string& filename, tr_file_index_t i) const;
+
     /// CHECKSUMS
 
     bool ensurePieceIsChecked(tr_piece_index_t piece)
@@ -319,7 +357,7 @@ public:
             auto const found = this->findFile(filename, i);
             auto const mtime = found ? found->last_modified_at : 0;
 
-            info.files[i].priv.mtime = mtime;
+            this->file(i).priv.mtime = mtime;
 
             // if a file has changed, mark its pieces as unchecked
             if (mtime == 0 || mtime != mtimes[i])
@@ -329,30 +367,6 @@ public:
             }
         }
     }
-
-    /// FILES
-
-    tr_file_index_t fileCount() const
-    {
-        return info.fileCount;
-    }
-
-    struct tr_found_file_t : public tr_sys_path_info
-    {
-        std::string& filename; // /home/foo/Downloads/torrent/01-file-one.txt
-        std::string_view base; // /home/foo/Downloads
-        std::string_view subpath; // /torrent/01-file-one.txt
-
-        tr_found_file_t(tr_sys_path_info info, std::string& f, std::string_view b)
-            : tr_sys_path_info{ info }
-            , filename{ f }
-            , base{ b }
-            , subpath{ f.c_str() + std::size(b) + 1 }
-        {
-        }
-    };
-
-    std::optional<tr_found_file_t> findFile(std::string& filename, tr_file_index_t i) const;
 
     tr_info info = {};
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -314,7 +314,7 @@ public:
         checked_pieces_ = checked;
 
         auto filename = std::string{};
-        for (size_t i = 0; i < info.fileCount; ++i)
+        for (size_t i = 0, n = this->fileCount(); i < n; ++i)
         {
             auto const found = this->findFile(filename, i);
             auto const mtime = found ? found->last_modified_at : 0;
@@ -330,7 +330,12 @@ public:
         }
     }
 
-    /// FINDING FILES
+    /// FILES
+
+    tr_file_index_t fileCount() const
+    {
+        return info.fileCount;
+    }
 
     struct tr_found_file_t : public tr_sys_path_info
     {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -999,12 +999,12 @@ using tr_torrent_rename_done_func = void (*)( //
  * EXAMPLES
  *
  *   Consider a tr_torrent where its
- *   info.files[0].name is "frobnitz-linux/checksum" and
- *   info.files[1].name is "frobnitz-linux/frobnitz.iso".
+ *   tr_torrentFile(tor, 0).name is "frobnitz-linux/checksum" and
+ *   tr_torrentFile(tor, 1).name is "frobnitz-linux/frobnitz.iso".
  *
  *   1. tr_torrentRenamePath(tor, "frobnitz-linux", "foo") will rename
- *      the "frotbnitz-linux" folder as "foo", and update both info.name
- *      and info.files[*].name.
+ *      the "frotbnitz-linux" folder as "foo", and update both
+ *      tr_torrentName(tor) and tr_torrentFile(tor, *).name.
  *
  *   2. tr_torrentRenamePath(tor, "frobnitz-linux/checksum", "foo") will
  *      rename the "frobnitz-linux/checksum" file as "foo" and update
@@ -1513,34 +1513,19 @@ void tr_torrentTrackersFree(tr_tracker_stat* trackerStats, int trackerCount);
  */
 double* tr_torrentWebSpeeds_KBps(tr_torrent const* torrent);
 
+/*
+ * This view structure is intended for short-term use. Its pointers are owned
+ * by the torrent and may be invalidated if the torrent is edited or removed.
+ */
 struct tr_file_view
 {
-    // This file's name. Includes the full subpath in the torrent.
-    char const* name;
-
-    // the current size of the file, i.e. how much we've downloaded
-    uint64_t have;
-
-    // the total size of the file
-    uint64_t length;
-
-    // have / length
-    double progress;
-
-    // the file's priority
-    tr_priority_t priority;
-
-    // do we want to download this file?
-    bool wanted;
+    char const* name; // This file's name. Includes the full subpath in the torrent.
+    uint64_t have; // the current size of the file, i.e. how much we've downloaded
+    uint64_t length; // the total size of the file
+    double progress; // have / length
+    tr_priority_t priority; // the file's priority
+    bool wanted; // do we want to download this file?
 };
-
-/**
- * Returns a tr_file_view containing information about a file.
- *
- * This view structure is intended for short-term use. Pointers in it are
- * owned and managed by the torrent. Callers who want to keep this info
- * must make their own copy.
- */
 tr_file_view tr_torrentFile(tr_torrent const* torrent, tr_file_index_t file);
 
 size_t tr_torrentFileCount(tr_torrent const* torrent);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1083,7 +1083,7 @@ char const* tr_torrentName(tr_torrent const*);
  *         when done) that gives the location of this file on disk,
  *         or nullptr if no file exists yet.
  * @param tor the torrent whose file we're looking for
- * @param fileNum the fileIndex, in [0...tr_info.fileCount)
+ * @param fileNum the fileIndex, in [0...tr_torrentFileCount())
  */
 char* tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t fileNum);
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -51,7 +51,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
 
     while (!*stopFlag && piece < tor->info.pieceCount)
     {
-        auto const file_length = tor->info.files[fileIndex].length;
+        auto const file_length = tor->file(fileIndex).length;
 
         /* if we're starting a new piece... */
         if (piecePos == 0)

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -73,7 +73,7 @@ public:
         have.setHasAll();
         tr_peerUpdateProgress(tor, this);
 
-        file_urls.resize(tr_torrentInfo(tor)->fileCount);
+        file_urls.resize(tor->fileCount());
 
         timer = evtimer_new(session->event_base, webseed_timer_func, this);
         tr_timerAddMsec(timer, TR_IDLE_TIMER_MSEC);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -518,7 +518,7 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
         auto file_offset = uint64_t{};
         tr_ioFindFileLocation(tor, step_piece, step_piece_offset, &file_index, &file_offset);
 
-        auto const& file = inf->files[file_index];
+        auto const& file = tor->file(file_index);
         uint64_t this_pass = std::min(remain, file.length - file_offset);
 
         if (std::empty(urls[file_index]))


### PR DESCRIPTION
A sibling to https://github.com/transmission/transmission/pull/2273, this PR provides an accessor to a torrent's file structures.

This is another incremental step towards making tr_torrent's impl private.