### PR TITLE
fixup! refactor: make parts of tr file private (#2241)

### DIFF
--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -425,7 +425,7 @@ void buildTree(FileRowNode& node, build_data& build)
 
     auto const mime_type = isLeaf ? gtr_get_mime_type_from_filename(child_data.name) : DIRECTORY_MIME_TYPE;
     auto const icon = gtr_get_mime_type_icon(mime_type, Gtk::ICON_SIZE_MENU, *build.w);
-    auto const file = tr_torrentFile(build.tor, child_data.index);
+    auto const file = isLeaf ? tr_torrentFile(build.tor, child_data.index) : tr_file_view{};
     int const priority = isLeaf ? file.priority : 0;
     bool const enabled = isLeaf ? file.wanted : true;
     auto name_esc = Glib::Markup::escape_text(child_data.name);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -375,6 +375,12 @@ static uint64_t loadName(tr_variant* dict, tr_torrent* tor)
         return 0;
     }
 
+    name = tr_strvDup(name);
+    if (std::empty(name))
+    {
+        return 0;
+    }
+
     if (name != tr_torrentName(tor))
     {
         tr_free(tor->info.name);


### PR DESCRIPTION
fix: crash regression in GTK client details dialog