### PR TITLE
refactor: add tr_torrentTrackers()

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -2253,19 +2253,18 @@ std::string get_editable_tracker_list(tr_torrent const* tor)
 {
     std::ostringstream gstr;
     int tier = 0;
-    tr_info const* inf = tr_torrentInfo(tor);
 
-    for (unsigned int i = 0; i < inf->trackerCount; ++i)
+    for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
     {
-        tr_tracker_info const* t = &inf->trackers[i];
+        auto const tracker = tr_torrentTracker(tor, i);
 
-        if (tier != t->tier)
+        if (tier != tracker.tier)
         {
-            tier = t->tier;
+            tier = tracker.tier;
             gstr << '\n';
         }
 
-        gstr << t->announce << '\n';
+        gstr << tracker.announce << '\n';
     }
 
     auto str = gstr.str();
@@ -2628,8 +2627,7 @@ void DetailsDialog::Impl::set_torrents(std::vector<int> const& ids)
     {
         int const id = ids.front();
         auto const* tor = core_->find_torrent(id);
-        auto const* inf = tr_torrentInfo(tor);
-        title = gtr_sprintf(_("%s Properties"), inf->name);
+        title = gtr_sprintf(_("%s Properties"), tr_torrentName(tor));
 
         file_list_->set_torrent(id);
         file_list_->show();

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -456,15 +456,9 @@ int compare_by_activity(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::itera
 
 int compare_by_age(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator const& b)
 {
-    int ret = 0;
-
     auto* const ta = static_cast<tr_torrent*>(a->get_value(torrent_cols.torrent));
     auto* const tb = static_cast<tr_torrent*>(b->get_value(torrent_cols.torrent));
-
-    if (ret == 0)
-    {
-        ret = compare_time(tr_torrentStatCached(ta)->addedDate, tr_torrentStatCached(tb)->addedDate);
-    }
+    int ret = compare_time(tr_torrentStatCached(ta)->addedDate, tr_torrentStatCached(tb)->addedDate);
 
     if (ret == 0)
     {
@@ -476,15 +470,9 @@ int compare_by_age(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator c
 
 int compare_by_size(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator const& b)
 {
-    int ret = 0;
-
-    auto const* const ia = tr_torrentInfo(static_cast<tr_torrent*>(a->get_value(torrent_cols.torrent)));
-    auto const* const ib = tr_torrentInfo(static_cast<tr_torrent*>(b->get_value(torrent_cols.torrent)));
-
-    if (ret == 0)
-    {
-        ret = compare_uint64(ia->totalSize, ib->totalSize);
-    }
+    auto const size_a = tr_torrentInfo(static_cast<tr_torrent*>(a->get_value(torrent_cols.torrent)))->totalSize;
+    auto const size_b = tr_torrentInfo(static_cast<tr_torrent*>(b->get_value(torrent_cols.torrent)))->totalSize;
+    int ret = compare_uint64(size_a, size_b);
 
     if (ret == 0)
     {
@@ -496,15 +484,9 @@ int compare_by_size(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator 
 
 int compare_by_progress(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator const& b)
 {
-    int ret = 0;
-
     auto const* const sa = tr_torrentStatCached(static_cast<tr_torrent*>(a->get_value(torrent_cols.torrent)));
     auto const* const sb = tr_torrentStatCached(static_cast<tr_torrent*>(b->get_value(torrent_cols.torrent)));
-
-    if (ret == 0)
-    {
-        ret = compare_double(sa->percentComplete, sb->percentComplete);
-    }
+    int ret = compare_double(sa->percentComplete, sb->percentComplete);
 
     if (ret == 0)
     {
@@ -521,15 +503,9 @@ int compare_by_progress(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::itera
 
 int compare_by_eta(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator const& b)
 {
-    int ret = 0;
-
     auto const* const sa = tr_torrentStatCached(static_cast<tr_torrent*>(a->get_value(torrent_cols.torrent)));
     auto const* const sb = tr_torrentStatCached(static_cast<tr_torrent*>(b->get_value(torrent_cols.torrent)));
-
-    if (ret == 0)
-    {
-        ret = compare_eta(sa->eta, sb->eta);
-    }
+    int ret = compare_eta(sa->eta, sb->eta);
 
     if (ret == 0)
     {
@@ -541,15 +517,9 @@ int compare_by_eta(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator c
 
 int compare_by_state(Gtk::TreeModel::iterator const& a, Gtk::TreeModel::iterator const& b)
 {
-    int ret = 0;
-
     auto const sa = a->get_value(torrent_cols.activity);
     auto const sb = b->get_value(torrent_cols.activity);
-
-    if (ret == 0)
-    {
-        ret = compare_int(sa, sb);
-    }
+    int ret = compare_int(sa, sb);
 
     if (ret == 0)
     {
@@ -893,8 +863,7 @@ namespace
 
 Glib::ustring get_collated_name(tr_torrent const* tor)
 {
-    auto const* const inf = tr_torrentInfo(tor);
-    return gtr_sprintf("%s\t%s", Glib::ustring(tr_torrentName(tor)).lowercase(), inf->hashString);
+    return gtr_sprintf("%s\t%s", Glib::ustring(tr_torrentName(tor)).lowercase(), tr_torrentInfo(tor)->hashString);
 }
 
 struct metadata_callback_data
@@ -951,14 +920,13 @@ namespace
 
 unsigned int build_torrent_trackers_hash(tr_torrent* tor)
 {
-    uint64_t hash = 0;
-    tr_info const* const inf = tr_torrentInfo(tor);
+    auto hash = uint64_t{};
 
-    for (unsigned int i = 0; i < inf->trackerCount; ++i)
+    for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
     {
-        for (char const* pch = inf->trackers[i].announce; *pch != '\0'; ++pch)
+        for (auto const ch : std::string_view{ tr_torrentTracker(tor, i).announce })
         {
-            hash = (hash << 4) ^ (hash >> 28) ^ *pch;
+            hash = (hash << 4) ^ (hash >> 28) ^ ch;
         }
     }
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1720,10 +1720,12 @@ static tr_tracker_view trackerView(tr_torrent const& tor, int tier_index, tr_tie
 
     view.host = tr_quark_get_string(tracker.key);
     view.announce = tr_quark_get_string(tracker.announce_url);
+    view.scrape = tracker.scrape_info == nullptr ? "" : tr_quark_get_string(tracker.scrape_info->scrape_url);
+
+    view.id = tracker.id;
     view.tier = tier_index;
     view.isBackup = &tracker != tier.currentTracker;
     view.lastScrapeStartTime = tier.lastScrapeStartTime;
-    view.scrape = tracker.scrape_info == nullptr ? "" : tr_quark_get_string(tracker.scrape_info->scrape_url);
     view.seederCount = tracker.seederCount;
     view.leecherCount = tracker.leecherCount;
     view.downloadCount = tracker.downloadCount;
@@ -1743,7 +1745,7 @@ static tr_tracker_view trackerView(tr_torrent const& tor, int tier_index, tr_tie
             view.lastScrapeTime = tier.lastScrapeTime;
             view.lastScrapeSucceeded = tier.lastScrapeSucceeded;
             view.lastScrapeTimedOut = tier.lastScrapeTimedOut;
-            view.lastScrapeResult = tier.lastScrapeStr;
+            tr_strlcpy(view.lastScrapeResult, tier.lastScrapeStr, sizeof(view.lastScrapeResult));
         }
 
         if (tier.isScraping)
@@ -1770,10 +1772,10 @@ static tr_tracker_view trackerView(tr_torrent const& tor, int tier_index, tr_tie
         if (view.hasAnnounced != 0)
         {
             view.lastAnnounceTime = tier.lastAnnounceTime;
-            view.lastAnnounceResult = tier.lastAnnounceStr;
             view.lastAnnounceSucceeded = tier.lastAnnounceSucceeded;
             view.lastAnnounceTimedOut = tier.lastAnnounceTimedOut;
             view.lastAnnouncePeerCount = tier.lastAnnouncePeerCount;
+            tr_strlcpy(view.lastAnnounceResult, tier.lastAnnounceStr, sizeof(view.lastAnnounceResult));
         }
 
         if (tier.isAnnouncing)

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1713,115 +1713,118 @@ static void onUpkeepTimer(evutil_socket_t /*fd*/, short /*what*/, void* vannounc
 ****
 ***/
 
-tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerCount)
+static tr_tracker_view trackerView(tr_torrent const& tor, int tier_index, tr_tier const& tier, tr_tracker const& tracker)
 {
-    TR_ASSERT(tr_isTorrent(torrent));
+    auto const now = tr_time();
+    auto view = tr_tracker_view{};
 
-    time_t const now = tr_time();
+    view.host = tr_quark_get_string(tracker.key);
+    view.announce = tr_quark_get_string(tracker.announce_url);
+    view.tier = tier_index;
+    view.isBackup = &tracker != tier.currentTracker;
+    view.lastScrapeStartTime = tier.lastScrapeStartTime;
+    view.scrape = tracker.scrape_info == nullptr ? "" : tr_quark_get_string(tracker.scrape_info->scrape_url);
+    view.seederCount = tracker.seederCount;
+    view.leecherCount = tracker.leecherCount;
+    view.downloadCount = tracker.downloadCount;
 
-    int out = 0;
-    struct tr_torrent_tiers const* const tt = torrent->tiers;
-
-    /* alloc the stats */
-    *setmeTrackerCount = tt->tracker_count;
-    tr_tracker_stat* const ret = tr_new0(tr_tracker_stat, tt->tracker_count);
-
-    /* populate the stats */
-    for (int i = 0; i < tt->tier_count; ++i)
+    if (view.isBackup)
     {
-        tr_tier const* const tier = &tt->tiers[i];
-
-        for (int j = 0; j < tier->tracker_count; ++j)
+        view.scrapeState = TR_TRACKER_INACTIVE;
+        view.announceState = TR_TRACKER_INACTIVE;
+        view.nextScrapeTime = 0;
+        view.nextAnnounceTime = 0;
+    }
+    else
+    {
+        view.hasScraped = tier.lastScrapeTime;
+        if (view.hasScraped != 0)
         {
-            tr_tracker const* const tracker = &tier->trackers[j];
-            tr_tracker_stat* st = &ret[out++];
+            view.lastScrapeTime = tier.lastScrapeTime;
+            view.lastScrapeSucceeded = tier.lastScrapeSucceeded;
+            view.lastScrapeTimedOut = tier.lastScrapeTimedOut;
+            view.lastScrapeResult = tier.lastScrapeStr;
+        }
 
-            st->id = tracker->id;
-            st->host = tr_quark_get_string(tracker->key);
-            st->announce = tr_quark_get_string(tracker->announce_url);
-            st->tier = i;
-            st->isBackup = tracker != tier->currentTracker;
-            st->lastScrapeStartTime = tier->lastScrapeStartTime;
-            st->scrape = tracker->scrape_info == nullptr ? "" : tr_quark_get_string(tracker->scrape_info->scrape_url);
-            st->seederCount = tracker->seederCount;
-            st->leecherCount = tracker->leecherCount;
-            st->downloadCount = tracker->downloadCount;
+        if (tier.isScraping)
+        {
+            view.scrapeState = TR_TRACKER_ACTIVE;
+        }
+        else if (tier.scrapeAt == 0)
+        {
+            view.scrapeState = TR_TRACKER_INACTIVE;
+        }
+        else if (tier.scrapeAt > now)
+        {
+            view.scrapeState = TR_TRACKER_WAITING;
+            view.nextScrapeTime = tier.scrapeAt;
+        }
+        else
+        {
+            view.scrapeState = TR_TRACKER_QUEUED;
+        }
 
-            if (st->isBackup)
-            {
-                st->scrapeState = TR_TRACKER_INACTIVE;
-                st->announceState = TR_TRACKER_INACTIVE;
-                st->nextScrapeTime = 0;
-                st->nextAnnounceTime = 0;
-            }
-            else
-            {
-                st->hasScraped = tier->lastScrapeTime;
-                if (st->hasScraped != 0)
-                {
-                    st->lastScrapeTime = tier->lastScrapeTime;
-                    st->lastScrapeSucceeded = tier->lastScrapeSucceeded;
-                    st->lastScrapeTimedOut = tier->lastScrapeTimedOut;
-                    tr_strlcpy(st->lastScrapeResult, tier->lastScrapeStr, sizeof(st->lastScrapeResult));
-                }
+        view.lastAnnounceStartTime = tier.lastAnnounceStartTime;
 
-                if (tier->isScraping)
-                {
-                    st->scrapeState = TR_TRACKER_ACTIVE;
-                }
-                else if (tier->scrapeAt == 0)
-                {
-                    st->scrapeState = TR_TRACKER_INACTIVE;
-                }
-                else if (tier->scrapeAt > now)
-                {
-                    st->scrapeState = TR_TRACKER_WAITING;
-                    st->nextScrapeTime = tier->scrapeAt;
-                }
-                else
-                {
-                    st->scrapeState = TR_TRACKER_QUEUED;
-                }
+        view.hasAnnounced = tier.lastAnnounceTime;
+        if (view.hasAnnounced != 0)
+        {
+            view.lastAnnounceTime = tier.lastAnnounceTime;
+            view.lastAnnounceResult = tier.lastAnnounceStr;
+            view.lastAnnounceSucceeded = tier.lastAnnounceSucceeded;
+            view.lastAnnounceTimedOut = tier.lastAnnounceTimedOut;
+            view.lastAnnouncePeerCount = tier.lastAnnouncePeerCount;
+        }
 
-                st->lastAnnounceStartTime = tier->lastAnnounceStartTime;
-
-                st->hasAnnounced = tier->lastAnnounceTime;
-                if (st->hasAnnounced != 0)
-                {
-                    st->lastAnnounceTime = tier->lastAnnounceTime;
-                    tr_strlcpy(st->lastAnnounceResult, tier->lastAnnounceStr, sizeof(st->lastAnnounceResult));
-                    st->lastAnnounceSucceeded = tier->lastAnnounceSucceeded;
-                    st->lastAnnounceTimedOut = tier->lastAnnounceTimedOut;
-                    st->lastAnnouncePeerCount = tier->lastAnnouncePeerCount;
-                }
-
-                if (tier->isAnnouncing)
-                {
-                    st->announceState = TR_TRACKER_ACTIVE;
-                }
-                else if (!torrent->isRunning || tier->announceAt == 0)
-                {
-                    st->announceState = TR_TRACKER_INACTIVE;
-                }
-                else if (tier->announceAt > now)
-                {
-                    st->announceState = TR_TRACKER_WAITING;
-                    st->nextAnnounceTime = tier->announceAt;
-                }
-                else
-                {
-                    st->announceState = TR_TRACKER_QUEUED;
-                }
-            }
+        if (tier.isAnnouncing)
+        {
+            view.announceState = TR_TRACKER_ACTIVE;
+        }
+        else if (!tor.isRunning || tier.announceAt == 0)
+        {
+            view.announceState = TR_TRACKER_INACTIVE;
+        }
+        else if (tier.announceAt > now)
+        {
+            view.announceState = TR_TRACKER_WAITING;
+            view.nextAnnounceTime = tier.announceAt;
+        }
+        else
+        {
+            view.announceState = TR_TRACKER_QUEUED;
         }
     }
 
-    return ret;
+    TR_ASSERT(0 <= view.tier);
+    TR_ASSERT(view.tier < tor.tiers->tier_count);
+    return view;
 }
 
-void tr_announcerStatsFree(tr_tracker_stat* trackers, int /*trackerCount*/)
+tr_tracker_view tr_announcerTracker(tr_torrent const* tor, size_t nth)
 {
-    tr_free(trackers);
+    TR_ASSERT(tr_isTorrent(tor));
+    TR_ASSERT(tor->tiers != nullptr);
+
+    // find the nth tracker
+    struct tr_torrent_tiers const* const tt = tor->tiers;
+    if (nth >= size_t(tt->tracker_count))
+    {
+        return {};
+    }
+    auto const& tracker = tt->trackers[nth];
+    for (int i = 0; i < tt->tier_count; ++i)
+    {
+        tr_tier const& tier = tt->tiers[i];
+
+        for (int j = 0; j < tier.tracker_count; ++j)
+        {
+            if (&tier.trackers[j] == &tracker)
+            {
+                return trackerView(*tor, i, tier, tracker);
+            }
+        }
+    }
+    return {};
 }
 
 /***

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -93,9 +93,7 @@ void tr_announcerAddBytes(tr_torrent*, int up_down_or_corrupt, uint32_t byteCoun
 
 time_t tr_announcerNextManualAnnounce(tr_torrent const*);
 
-tr_tracker_stat* tr_announcerStats(tr_torrent const* torrent, int* setmeTrackerCount);
-
-void tr_announcerStatsFree(tr_tracker_stat* trackers, int trackerCount);
+tr_tracker_view tr_announcerTracker(tr_torrent const* torrent, size_t i);
 
 /***
 ****

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -128,6 +128,8 @@ void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority
 
 tr_priority_t tr_file_priorities::filePriority(tr_file_index_t file) const
 {
+    TR_ASSERT(file < std::size(priorities_));
+
     return priorities_[file];
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -426,39 +426,35 @@ static void addTrackers(tr_info const* info, tr_variant* trackers)
     }
 }
 
-static void addTrackerStats(tr_tracker_stat const* st, int n, tr_variant* list)
+static void addTrackerStats(tr_tracker_view const& tracker, tr_variant* list)
 {
-    for (int i = 0; i < n; ++i)
-    {
-        tr_tracker_stat const* s = &st[i];
-        tr_variant* d = tr_variantListAddDict(list, 26);
-        tr_variantDictAddStr(d, TR_KEY_announce, s->announce);
-        tr_variantDictAddInt(d, TR_KEY_announceState, s->announceState);
-        tr_variantDictAddInt(d, TR_KEY_downloadCount, s->downloadCount);
-        tr_variantDictAddBool(d, TR_KEY_hasAnnounced, s->hasAnnounced);
-        tr_variantDictAddBool(d, TR_KEY_hasScraped, s->hasScraped);
-        tr_variantDictAddStr(d, TR_KEY_host, s->host);
-        tr_variantDictAddInt(d, TR_KEY_id, s->id);
-        tr_variantDictAddBool(d, TR_KEY_isBackup, s->isBackup);
-        tr_variantDictAddInt(d, TR_KEY_lastAnnouncePeerCount, s->lastAnnouncePeerCount);
-        tr_variantDictAddStr(d, TR_KEY_lastAnnounceResult, s->lastAnnounceResult);
-        tr_variantDictAddInt(d, TR_KEY_lastAnnounceStartTime, s->lastAnnounceStartTime);
-        tr_variantDictAddBool(d, TR_KEY_lastAnnounceSucceeded, s->lastAnnounceSucceeded);
-        tr_variantDictAddInt(d, TR_KEY_lastAnnounceTime, s->lastAnnounceTime);
-        tr_variantDictAddBool(d, TR_KEY_lastAnnounceTimedOut, s->lastAnnounceTimedOut);
-        tr_variantDictAddStr(d, TR_KEY_lastScrapeResult, s->lastScrapeResult);
-        tr_variantDictAddInt(d, TR_KEY_lastScrapeStartTime, s->lastScrapeStartTime);
-        tr_variantDictAddBool(d, TR_KEY_lastScrapeSucceeded, s->lastScrapeSucceeded);
-        tr_variantDictAddInt(d, TR_KEY_lastScrapeTime, s->lastScrapeTime);
-        tr_variantDictAddBool(d, TR_KEY_lastScrapeTimedOut, s->lastScrapeTimedOut);
-        tr_variantDictAddInt(d, TR_KEY_leecherCount, s->leecherCount);
-        tr_variantDictAddInt(d, TR_KEY_nextAnnounceTime, s->nextAnnounceTime);
-        tr_variantDictAddInt(d, TR_KEY_nextScrapeTime, s->nextScrapeTime);
-        tr_variantDictAddStr(d, TR_KEY_scrape, s->scrape);
-        tr_variantDictAddInt(d, TR_KEY_scrapeState, s->scrapeState);
-        tr_variantDictAddInt(d, TR_KEY_seederCount, s->seederCount);
-        tr_variantDictAddInt(d, TR_KEY_tier, s->tier);
-    }
+    auto* const d = tr_variantListAddDict(list, 26);
+    tr_variantDictAddStr(d, TR_KEY_announce, tracker.announce);
+    tr_variantDictAddInt(d, TR_KEY_announceState, tracker.announceState);
+    tr_variantDictAddInt(d, TR_KEY_downloadCount, tracker.downloadCount);
+    tr_variantDictAddBool(d, TR_KEY_hasAnnounced, tracker.hasAnnounced);
+    tr_variantDictAddBool(d, TR_KEY_hasScraped, tracker.hasScraped);
+    tr_variantDictAddStr(d, TR_KEY_host, tracker.host);
+    tr_variantDictAddInt(d, TR_KEY_id, tracker.id);
+    tr_variantDictAddBool(d, TR_KEY_isBackup, tracker.isBackup);
+    tr_variantDictAddInt(d, TR_KEY_lastAnnouncePeerCount, tracker.lastAnnouncePeerCount);
+    tr_variantDictAddStr(d, TR_KEY_lastAnnounceResult, tracker.lastAnnounceResult);
+    tr_variantDictAddInt(d, TR_KEY_lastAnnounceStartTime, tracker.lastAnnounceStartTime);
+    tr_variantDictAddBool(d, TR_KEY_lastAnnounceSucceeded, tracker.lastAnnounceSucceeded);
+    tr_variantDictAddInt(d, TR_KEY_lastAnnounceTime, tracker.lastAnnounceTime);
+    tr_variantDictAddBool(d, TR_KEY_lastAnnounceTimedOut, tracker.lastAnnounceTimedOut);
+    tr_variantDictAddStr(d, TR_KEY_lastScrapeResult, tracker.lastScrapeResult);
+    tr_variantDictAddInt(d, TR_KEY_lastScrapeStartTime, tracker.lastScrapeStartTime);
+    tr_variantDictAddBool(d, TR_KEY_lastScrapeSucceeded, tracker.lastScrapeSucceeded);
+    tr_variantDictAddInt(d, TR_KEY_lastScrapeTime, tracker.lastScrapeTime);
+    tr_variantDictAddBool(d, TR_KEY_lastScrapeTimedOut, tracker.lastScrapeTimedOut);
+    tr_variantDictAddInt(d, TR_KEY_leecherCount, tracker.leecherCount);
+    tr_variantDictAddInt(d, TR_KEY_nextAnnounceTime, tracker.nextAnnounceTime);
+    tr_variantDictAddInt(d, TR_KEY_nextScrapeTime, tracker.nextScrapeTime);
+    tr_variantDictAddStr(d, TR_KEY_scrape, tracker.scrape);
+    tr_variantDictAddInt(d, TR_KEY_scrapeState, tracker.scrapeState);
+    tr_variantDictAddInt(d, TR_KEY_seederCount, tracker.seederCount);
+    tr_variantDictAddInt(d, TR_KEY_tier, tracker.tier);
 }
 
 static void addPeers(tr_torrent* tor, tr_variant* list)
@@ -791,11 +787,13 @@ static void initField(
 
     case TR_KEY_trackerStats:
         {
-            auto n = int{};
-            tr_tracker_stat* s = tr_torrentTrackers(tor, &n);
+            auto const n = tr_torrentTrackerCount(tor);
             tr_variantInitList(initme, n);
-            addTrackerStats(s, n, initme);
-            tr_torrentTrackersFree(s, n);
+            for (size_t i = 0; i < n; ++i)
+            {
+                auto const& tracker = tr_torrentTracker(tor, i);
+                addTrackerStats(tracker, initme);
+            }
             break;
         }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1253,6 +1253,16 @@ size_t tr_torrentWebseedCount(tr_torrent const* tor)
     return tor->webseedCount();
 }
 
+tr_tracker_view tr_torrentTracker(tr_torrent const* tor, size_t i)
+{
+    return tr_announcerTracker(tor, i);
+}
+
+size_t tr_torrentTrackerCount(tr_torrent const* tor)
+{
+    return tor->trackerCount();
+}
+
 /***
 ****
 ***/
@@ -1267,18 +1277,6 @@ tr_peer_stat* tr_torrentPeers(tr_torrent const* tor, int* peerCount)
 void tr_torrentPeersFree(tr_peer_stat* peers, int /*peerCount*/)
 {
     tr_free(peers);
-}
-
-tr_tracker_stat* tr_torrentTrackers(tr_torrent const* tor, int* setmeTrackerCount)
-{
-    TR_ASSERT(tr_isTorrent(tor));
-
-    return tr_announcerStats(tor, setmeTrackerCount);
-}
-
-void tr_torrentTrackersFree(tr_tracker_stat* trackers, int trackerCount)
-{
-    tr_announcerStatsFree(trackers, trackerCount);
 }
 
 void tr_torrentAvailability(tr_torrent const* tor, int8_t* tab, int size)
@@ -1822,20 +1820,15 @@ static std::string buildTrackersString(tr_torrent const* tor)
 {
     auto buf = std::stringstream{};
 
-    int n = 0;
-    tr_tracker_stat* stats = tr_torrentTrackers(tor, &n);
-    for (int i = 0; i < n;)
+    for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
     {
-        tr_tracker_stat const* s = &stats[i];
-
-        buf << s->host;
+        buf << tr_torrentTracker(tor, i).host;
 
         if (++i < n)
         {
             buf << ',';
         }
     }
-    tr_torrentTrackersFree(stats, n);
 
     return buf.str();
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -348,6 +348,13 @@ public:
         return info.webseeds[i];
     }
 
+    /// TRACKERS
+
+    auto trackerCount() const
+    {
+        return info.trackerCount;
+    }
+
     /// CHECKSUMS
 
     bool ensurePieceIsChecked(tr_piece_index_t piece)

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1404,17 +1404,17 @@ enum tr_tracker_state
 };
 
 /*
- * This view structure is intended for short-term use. Its pointers are owned
- * by the torrent and may be invalidated if the torrent is edited or removed.
+ * Unlike other _view structs, it is safe to keep a tr_tracker_view copy.
+ * The announce, scrape, and host strings are interned & never go out-of-scope.
  */
 struct tr_tracker_view
 {
     char const* announce; // full announce URL
-    char const* host; // human-readable tracker name. (`${host}:${port}`)
     char const* scrape; // full scrape URL
+    char const* host; // human-readable tracker name. (`${host}:${port}`)
 
-    char const* lastAnnounceResult; // if hasAnnounced, the human-readable result of latest announce
-    char const* lastScrapeResult; // if hasScraped, the human-readable result of the latest scrape
+    char lastAnnounceResult[128]; // if hasAnnounced, the human-readable result of latest announce
+    char lastScrapeResult[128]; // if hasScraped, the human-readable result of the latest scrape
 
     time_t lastAnnounceStartTime; // if hasAnnounced, when the latest announce request was sent
     time_t lastAnnounceTime; // if hasAnnounced, when the latest announce reply was received

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -754,7 +754,7 @@ bool trashDataFile(char const* filename, tr_error** error)
             [trackers addObject:@{ @"Tier" : @(tracker.tier + 1), @"Name" : self.name }];
         }
 
-        auto* tracker_node = [[TrackerNode alloc] initWithTrackerStat:&stats[i] torrent:self];
+        auto* tracker_node = [[TrackerNode alloc] initWithTrackerView:tracker torrent:self];
         [trackers addObject:tracker_node];
     }
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -754,7 +754,7 @@ bool trashDataFile(char const* filename, tr_error** error)
             [trackers addObject:@{ @"Tier" : @(tracker.tier + 1), @"Name" : self.name }];
         }
 
-        auto* tracker_node = [[TrackerNode alloc] initWithTrackerView:tracker torrent:self];
+        auto* tracker_node = [[TrackerNode alloc] initWithTrackerView:&tracker torrent:self];
         [trackers addObject:tracker_node];
     }
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1551,7 +1551,7 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (NSInteger)fileCount
 {
-    return fInfo->fileCount;
+    return tr_torrentFileCount(fHandle);
 }
 
 - (CGFloat)fileProgress:(FileListNode*)node

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -20,7 +20,10 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
+#include <optional>
+
 #include <libtransmission/transmission.h>
+
 #include <libtransmission/error.h>
 #include <libtransmission/log.h>
 #include <libtransmission/utils.h> // tr_new()
@@ -736,25 +739,25 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (NSMutableArray*)allTrackerStats
 {
-    int count;
-    tr_tracker_stat* stats = tr_torrentTrackers(fHandle, &count);
+    auto const count = tr_torrentTrackerCount(fHandle);
+    auto tier = std::optional<int>{};
 
-    NSMutableArray* trackers = [NSMutableArray arrayWithCapacity:(count > 0 ? count + (stats[count - 1].tier + 1) : 0)];
+    NSMutableArray* trackers = [NSMutableArray arrayWithCapacity:count * 2];
 
-    int prevTier = -1;
-    for (int i = 0; i < count; ++i)
+    for (size_t i = 0; i < count; ++i)
     {
-        if (stats[i].tier != prevTier)
+        auto const tracker = tr_torrentTracker(fHandle, i);
+
+        if (!tier || tier != tracker.tier)
         {
-            [trackers addObject:@{ @"Tier" : @(stats[i].tier + 1), @"Name" : self.name }];
-            prevTier = stats[i].tier;
+            tier = tracker.tier;
+            [trackers addObject:@{ @"Tier" : @(tracker.tier + 1), @"Name" : self.name }];
         }
 
-        TrackerNode* tracker = [[TrackerNode alloc] initWithTrackerStat:&stats[i] torrent:self];
-        [trackers addObject:tracker];
+        auto* tracker_node = [[TrackerNode alloc] initWithTrackerStat:&stats[i] torrent:self];
+        [trackers addObject:tracker_node];
     }
 
-    tr_torrentTrackersFree(stats, count);
     return trackers;
 }
 
@@ -1792,21 +1795,19 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (NSString*)trackerSortKey
 {
-    int count;
-    tr_tracker_stat* stats = tr_torrentTrackers(fHandle, &count);
-
     NSString* best = nil;
 
-    for (int i = 0; i < count; ++i)
+    for (size_t i = 0, n = tr_torrentTrackerCount(fHandle); i < n; ++i)
     {
-        NSString* tracker = @(stats[i].host);
-        if (!best || [tracker localizedCaseInsensitiveCompare:best] == NSOrderedAscending)
+        auto const tracker = tr_torrentTracker(fHandle, i);
+
+        NSString* host = @(tracker.host);
+        if (!best || [host localizedCaseInsensitiveCompare:best] == NSOrderedAscending)
         {
-            best = tracker;
+            best = host;
         }
     }
 
-    tr_torrentTrackersFree(stats, count);
     return best;
 }
 

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -30,7 +30,7 @@
 
 @property(nonatomic, weak, readonly) Torrent* torrent;
 
-- (instancetype)initWithTrackerView:(tr_tracker_view*)stat torrent:(Torrent*)torrent;
+- (instancetype)initWithTrackerView:(tr_tracker_view const*)stat torrent:(Torrent*)torrent;
 
 - (BOOL)isEqual:(id)object;
 

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -30,7 +30,7 @@
 
 @property(nonatomic, weak, readonly) Torrent* torrent;
 
-- (instancetype)initWithTrackerStat:(tr_tracker_stat*)stat torrent:(Torrent*)torrent;
+- (instancetype)initWithTrackerView:(tr_tracker_view*)stat torrent:(Torrent*)torrent;
 
 - (BOOL)isEqual:(id)object;
 

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -26,7 +26,7 @@
 
 @implementation TrackerNode
 {
-    tr_tracker_stat fStat;
+    tr_tracker_view fStat;
 }
 
 - (instancetype)initWithTrackerView:(tr_tracker_view*)stat torrent:(Torrent*)torrent

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -29,7 +29,7 @@
     tr_tracker_view fStat;
 }
 
-- (instancetype)initWithTrackerView:(tr_tracker_view*)stat torrent:(Torrent*)torrent
+- (instancetype)initWithTrackerView:(tr_tracker_view const*)stat torrent:(Torrent*)torrent
 {
     if ((self = [super init]))
     {

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -29,7 +29,7 @@
     tr_tracker_stat fStat;
 }
 
-- (instancetype)initWithTrackerStat:(tr_tracker_stat*)stat torrent:(Torrent*)torrent
+- (instancetype)initWithTrackerView:(tr_tracker_view*)stat torrent:(Torrent*)torrent
 {
     if ((self = [super init]))
     {


### PR DESCRIPTION
Replace `tr_torrentTrackers()`  and `tr_torrentTrackersFree()` with `tr_torrentTracker()`, a view accessor similar to `tr_torrentFile()` and `tr_torrentWebseed()`.