### PR TITLE
multiple tracker-add

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2753,9 +2753,15 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 addLabels(args, optarg ? optarg : "");
                 break;
 
-            case 712:
-                tr_variantListAddInt(tr_variantDictAddList(args, TR_KEY_trackerRemove, 1), atoi(optarg));
+            case 712: {
+                tr_variant *list;
+                if (!tr_variantDictFindList(args, TR_KEY_trackerRemove, &list))
+                {
+                    list = tr_variantDictAddList(args, TR_KEY_trackerRemove, 1);
+                }
+                tr_variantListAddInt(list, atoi(optarg));
                 break;
+            }
 
             case 950:
                 tr_variantDictAddReal(args, TR_KEY_seedRatioLimit, atof(optarg));
@@ -2830,9 +2836,15 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 tr_variantDictAddInt(args, TR_KEY_bandwidthPriority, -1);
                 break;
 
-            case 710:
-                tr_variantListAddStr(tr_variantDictAddList(args, TR_KEY_trackerAdd, 1), optarg);
+            case 710: {
+                tr_variant *list;
+                if (!tr_variantDictFindList(args, TR_KEY_trackerAdd, &list ))
+                {
+                    list = tr_variantDictAddList(args, TR_KEY_trackerAdd, 1);
+                }
+                tr_variantListAddStr(list, optarg);
                 break;
+            }
 
             default:
                 assert("unhandled value" && 0);


### PR DESCRIPTION
simple patch allowing multiple declaration in transmission-remote
passing several --tracker-add will result in extending list
passed to the transmission-deamon by each subsequent call