### PR TITLE
fix: non-portable strftime() fmt string

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1844,7 +1844,7 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
     struct tm tm;
     char ctime_str[32];
     tr_localtime_r(&now, &tm);
-    strftime(ctime_str, sizeof(ctime_str), "%a %b %2e %T %Y%n", &tm); /* ctime equiv */
+    strftime(ctime_str, sizeof(ctime_str), "%a %b %d %T %Y%n", &tm); /* ctime equiv */
 
     char* const torrent_dir = tr_sys_path_native_separators(tr_strdup(tor->currentDir));
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -934,7 +934,7 @@ static char* format_date(char* buf, size_t buflen, time_t now)
 {
     struct tm tm;
     tr_localtime_r(&now, &tm);
-    strftime(buf, buflen, "%a %b %2e %T %Y%n", &tm); /* ctime equiv */
+    strftime(buf, buflen, "%a %b %d %T %Y%n", &tm); /* ctime equiv */
     return buf;
 }
 


### PR DESCRIPTION
Sibling to the fix in #2212. I found the same non-portable fmt string in two other places.