### PR TITLE
Add sort by ETA for macOS

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -95,6 +95,7 @@ typedef NS_ENUM(unsigned int, toolbarGroupTag) { //
 #define SORT_ORDER @"Order"
 #define SORT_ACTIVITY @"Activity"
 #define SORT_SIZE @"Size"
+#define SORT_ETA @"ETA"
 
 typedef NS_ENUM(unsigned int, sortTag) {
     SORT_ORDER_TAG = 0,
@@ -104,7 +105,8 @@ typedef NS_ENUM(unsigned int, sortTag) {
     SORT_STATE_TAG = 4,
     SORT_TRACKER_TAG = 5,
     SORT_ACTIVITY_TAG = 6,
-    SORT_SIZE_TAG = 7
+    SORT_SIZE_TAG = 7,
+    SORT_ETA_TAG = 8
 };
 
 typedef NS_ENUM(unsigned int, sortOrderTag) { //
@@ -2499,6 +2501,9 @@ static void removeKeRangerRansomware()
     case SORT_SIZE_TAG:
         sortType = SORT_SIZE;
         break;
+    case SORT_ETA_TAG:
+        sortType = SORT_ETA;
+        break;
     default:
         NSAssert1(NO, @"Unknown sort tag received: %ld", senderMenuItem.tag);
         return;
@@ -2588,6 +2593,11 @@ static void removeKeRangerRansomware()
     else if ([sortType isEqualToString:SORT_NAME])
     {
         descriptors = @[ nameDescriptor ];
+    }
+    else if ([sortType isEqualToString:SORT_ETA])
+    {
+        NSSortDescriptor* etaDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"eta" ascending:asc];
+        descriptors = @[ etaDescriptor, nameDescriptor];
     }
     else
     {
@@ -4747,6 +4757,9 @@ static void removeKeRangerRansomware()
             break;
         case SORT_SIZE_TAG:
             sortType = SORT_SIZE;
+            break;
+        case SORT_ETA_TAG:
+            sortType = SORT_ETA;
             break;
         default:
             NSAssert1(NO, @"Unknown sort tag received: %ld", [menuItem tag]);

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -133,6 +133,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
               withName:(NSString*)newName
      completionHandler:(void (^)(BOOL didRename))completionHandler;
 
+@property(nonatomic, readonly) NSInteger eta;
 @property(nonatomic, readonly) CGFloat progress;
 @property(nonatomic, readonly) CGFloat progressDone;
 @property(nonatomic, readonly) CGFloat progressLeft;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -2178,6 +2178,23 @@ bool trashDataFile(char const* filename, tr_error** error)
     completionHandler(success);
 }
 
+- (NSInteger)eta
+{
+    if (fStat->eta != TR_ETA_NOT_AVAIL && fStat->eta != TR_ETA_UNKNOWN)
+    {
+        return fStat->eta;
+    }
+    else if (fStat->etaIdle != TR_ETA_NOT_AVAIL && fStat->etaIdle < ETA_IDLE_DISPLAY_SEC)
+    {
+        return fStat->etaIdle;
+    }
+
+    // We have to return something valid. Returning 0 or -1 or some other indicator value
+    // will cause problems if this is used for sorting. So we return INT_MAX which acts
+    // like an infinite amount of time remaining if we're sorting by ETA.
+    return INT_MAX;
+}
+
 - (BOOL)shouldShowEta
 {
     if (fStat->activity == TR_STATUS_DOWNLOAD)

--- a/macosx/da.lproj/MainMenu.xib
+++ b/macosx/da.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Navn" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/de.lproj/MainMenu.xib
+++ b/macosx/de.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Name" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/en.lproj/MainMenu.xib
+++ b/macosx/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Name" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>
@@ -698,6 +703,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="140" y="340"/>
         </menu>
         <customObject id="206" userLabel="Controller" customClass="Controller">
             <connections>

--- a/macosx/es.lproj/MainMenu.xib
+++ b/macosx/es.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Nombre" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/fr.lproj/MainMenu.xib
+++ b/macosx/fr.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Nom" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/it.lproj/MainMenu.xib
+++ b/macosx/it.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Nome" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/nl.lproj/MainMenu.xib
+++ b/macosx/nl.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Naam" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>
@@ -697,6 +702,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139" y="-56"/>
         </menu>
         <customObject id="206" userLabel="Controller" customClass="Controller">
             <connections>

--- a/macosx/pt_PT.lproj/MainMenu.xib
+++ b/macosx/pt_PT.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Nome" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>

--- a/macosx/ru.lproj/MainMenu.xib
+++ b/macosx/ru.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -408,6 +408,11 @@
                                         <menuItem title="Дате добавления" tag="1" id="1900">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1904"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Имени" tag="2" id="1902">

--- a/macosx/tr.lproj/MainMenu.xib
+++ b/macosx/tr.lproj/MainMenu.xib
@@ -410,6 +410,11 @@
                                                 <action selector="setSort:" target="206" id="1904"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="8f9-Jp-K00">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="W08-H8-Rjg"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Ad" tag="2" id="1902">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="1905"/>


### PR DESCRIPTION
The ability to sort downloads by their ETA is present in the Qt client but missing from the native macOS client. This PR adds that ability to the macOS client.

This was mentioned as missing in issue https://github.com/transmission/transmission/issues/2279

Also, I haven't touched macOS development in over a decade so apologies in advance if I went about things in weird way 😬