### PR TITLE
refactor: tweak qt client about dialog text

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -417,8 +417,7 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
-    []() constexpr
-    {
+    []() constexpr {
         for (size_t i = 1; i < std::size(my_static); ++i)
         {
             if (my_static[i - 1] >= my_static[i])

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -417,7 +417,8 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "webseedsSendingToUs"sv };
 
 size_t constexpr quarks_are_sorted = ( //
-    []() constexpr {
+    []() constexpr
+    {
         for (size_t i = 1; i < std::size(my_static); ++i)
         {
             if (my_static[i - 1] >= my_static[i])

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -37,9 +37,9 @@ AboutDialog::AboutDialog(Session& session, QWidget* parent)
         QString title = QStringLiteral(
             "<div style='font-size:x-large; font-weight: bold; text-align: center'>Transmission</div>");
         title += QStringLiteral("<div style='text-align: center'>%1: %2</div>")
-                     .arg(tr("This GUI"))
+                     .arg(tr("Client"))
                      .arg(QStringLiteral(LONG_VERSION_STRING));
-        title += QStringLiteral("<div style='text-align: center'>%1: %2</div>").arg(tr("Remote")).arg(session.sessionVersion());
+        title += QStringLiteral("<div style='text-align: center'>%1: %2</div>").arg(tr("Server")).arg(session.sessionVersion());
         ui_.titleLabel->setText(title);
     }
 


### PR DESCRIPTION
No functional changes; just changing the text a little bit.

The motivation here is the word "remote" referring to the remote server could be confusing since in transmission-remote, the word 'remote' refers to the client.

The new text uses 'client' / 'server' terminology