### PR TITLE
[macOS] Use old icon name for Square Grid to support older macOS

### DIFF
--- a/macosx/InfoWindow.xib
+++ b/macosx/InfoWindow.xib
@@ -68,7 +68,7 @@
                             <font key="font" metaFont="system"/>
                             <segments>
                                 <segment image="info.circle" catalog="system" selected="YES"/>
-                                <segment image="square.grid.3x3.square" catalog="system" tag="1"/>
+                                <segment image="square.grid.3x3.fill.square" catalog="system" tag="1"/>
                                 <segment image="antenna.radiowaves.left.and.right" catalog="system" tag="2"/>
                                 <segment image="person.2" catalog="system" tag="3"/>
                                 <segment image="doc.on.doc" catalog="system" tag="4"/>
@@ -107,6 +107,6 @@
         <image name="gearshape" catalog="system" width="16" height="16"/>
         <image name="info.circle" catalog="system" width="15" height="15"/>
         <image name="person.2" catalog="system" width="21" height="14"/>
-        <image name="square.grid.3x3.square" catalog="system" width="15" height="14"/>
+        <image name="square.grid.3x3.fill.square" catalog="system" width="15" height="14"/>
     </resources>
 </document>

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -101,7 +101,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
     [fTabs setImage:[NSImage systemSymbol:@"info.circle"
                              withFallback:@"InfoGeneral"]
          forSegment:TAB_GENERAL_TAG];
-    [fTabs setImage:[NSImage systemSymbol:@"square.grid.3x3.square"
+    [fTabs setImage:[NSImage systemSymbol:@"square.grid.3x3.fill.square"
                              withFallback:@"InfoActivity"]
          forSegment:TAB_ACTIVITY_TAG];
     [fTabs setImage:[NSImage systemSymbol:@"antenna.radiowaves.left.and.right"


### PR DESCRIPTION
`square.grid.3x3.fill.square` is deprecated name for `square.grid.3x3.square`.
The former is available on macOS 11.0+, while the latter is for macOS 12.0+.
They are the same visually.

Fixes this report https://github.com/transmission/transmission/pull/2269#issuecomment-991980368