### PR TITLE
refactor: make some tr_torrentFoo() methods member functions

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2126,7 +2126,7 @@ static int getRate(tr_torrent const* tor, struct peer_atom* atom, uint64_t now)
     }
     /* downloading a private torrent... take upload speed into account
      * because there may only be a small window of opportunity to share */
-    else if (tr_torrentIsPrivate(tor))
+    else if (tor->isPrivate())
     {
         Bps = tr_peerGetPieceSpeed_Bps(atom->peer, now, TR_PEER_TO_CLIENT) +
             tr_peerGetPieceSpeed_Bps(atom->peer, now, TR_CLIENT_TO_PEER);
@@ -2319,7 +2319,7 @@ static bool shouldPeerBeClosed(tr_swarm const* s, tr_peer const* peer, int peerC
     /* disconnect if we're both seeds and enough time has passed for PEX */
     if (tr_torrentIsSeed(tor) && tr_peerIsSeed(peer))
     {
-        return !tr_torrentAllowsPex(tor) || now - atom->time >= 30;
+        return !tor->allowsPex() || now - atom->time >= 30;
     }
 
     /* disconnect if it's been too long since piece data has been transferred.
@@ -3004,7 +3004,7 @@ static std::vector<peer_candidate> getPeerCandidates(tr_session* session, size_t
         /* if everyone in the swarm is seeds and pex is disabled because
          * the torrent is private, then don't initiate connections */
         bool const seeding = tr_torrentIsSeed(tor);
-        if (seeding && swarmIsAllSeeds(tor->swarm) && tr_torrentIsPrivate(tor))
+        if (seeding && swarmIsAllSeeds(tor->swarm) && tor->isPrivate())
         {
             continue;
         }
@@ -3100,7 +3100,7 @@ static void initiateCandidateConnection(tr_peerMgr* mgr, peer_candidate& c)
 #if 0
 
     fprintf(stderr, "Starting an OUTGOING connection with %s - [%s] %s, %s\n", tr_atomAddrStr(c->atom),
-        tr_torrentName(c->tor), tr_torrentIsPrivate(c->tor) ? "private" : "public",
+        tr_torrentName(c->tor), c->tor->isPrivate() ? "private" : "public",
         tr_torrentIsSeed(c->tor) ? "seed" : "downloader");
 
 #endif

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -606,7 +606,7 @@ static void initField(
         break;
 
     case TR_KEY_isPrivate:
-        tr_variantInitBool(initme, tr_torrentIsPrivate(tor));
+        tr_variantInitBool(initme, tor->isPrivate());
         break;
 
     case TR_KEY_isStalled:

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -184,7 +184,7 @@ static int peerIdTTL(tr_torrent const* tor)
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor)
 {
     bool const needs_new_peer_id = !tor->peer_id || // doesn't have one
-        (!tr_torrentIsPrivate(tor) && (peerIdTTL(tor) <= 0)); // has one but it's expired
+        (tor->isPublic() && (peerIdTTL(tor) <= 0)); // has one but it's expired
 
     if (needs_new_peer_id)
     {
@@ -550,7 +550,7 @@ static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, vo
         break;
 
     case TR_TRACKER_COUNTS:
-        if (tr_torrentIsPrivate(tor) && (event->leechers == 0))
+        if (tor->isPrivate() && (event->leechers == 0))
         {
             tr_peerMgrSetSwarmIsAllSeeds(tor);
         }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -290,7 +290,7 @@ public:
         setDirty();
     }
 
-    /// FILES
+    /// METAINFO - FILES
 
     tr_file_index_t fileCount() const
     {
@@ -328,7 +328,7 @@ public:
 
     std::optional<tr_found_file_t> findFile(std::string& filename, tr_file_index_t i) const;
 
-    /// TRACKERS
+    /// METAINFO - TRACKERS
 
     auto trackerCount() const
     {
@@ -345,7 +345,7 @@ public:
         return info.announce_list->tiers();
     }
 
-    /// WEBSEEDS
+    /// METAINFO - WEBSEEDS
 
     auto webseedCount() const
     {
@@ -366,7 +366,7 @@ public:
         return info.webseeds[i];
     }
 
-    /// CHECKSUMS
+    /// METAINFO - CHECKSUMS
 
     bool ensurePieceIsChecked(tr_piece_index_t piece)
     {
@@ -405,6 +405,35 @@ public:
                 checked_pieces_.unsetSpan(begin, end);
             }
         }
+    }
+
+    /// METAINFO - OTHER
+
+    auto isPrivate() const
+    {
+        return this->info.isPrivate;
+    }
+
+    auto isPublic() const
+    {
+        return !this->isPrivate();
+    }
+
+    ///
+
+    auto allowsPex() const
+    {
+        return this->isPublic() && this->session->isPexEnabled;
+    }
+
+    auto allowsDht() const
+    {
+        return this->isPublic() && tr_sessionAllowsDHT(this->session);
+    }
+
+    auto allowsLpd() const // local peer discovery
+    {
+        return this->isPublic() && tr_sessionAllowsLPD(this->session);
     }
 
     tr_info info = {};
@@ -594,26 +623,6 @@ constexpr tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
 constexpr bool tr_torrentIsSeed(tr_torrent const* tor)
 {
     return tr_torrentGetCompleteness(tor) != TR_LEECH;
-}
-
-constexpr bool tr_torrentIsPrivate(tr_torrent const* tor)
-{
-    return tor != nullptr && tor->info.isPrivate;
-}
-
-constexpr bool tr_torrentAllowsPex(tr_torrent const* tor)
-{
-    return tor != nullptr && tor->session->isPexEnabled && !tr_torrentIsPrivate(tor);
-}
-
-constexpr bool tr_torrentAllowsDHT(tr_torrent const* tor)
-{
-    return tor != nullptr && tr_sessionAllowsDHT(tor->session) && !tr_torrentIsPrivate(tor);
-}
-
-constexpr bool tr_torrentAllowsLPD(tr_torrent const* tor)
-{
-    return tor != nullptr && tr_sessionAllowsLPD(tor->session) && !tr_torrentIsPrivate(tor);
 }
 
 /***

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -624,7 +624,7 @@ static void callback(void* /*ignore*/, int event, unsigned char const* info_hash
         auto const lock = session_->unique_lock();
 
         tr_torrent* const tor = tr_torrentFindFromHash(session_, info_hash);
-        if (tor != nullptr && tr_torrentAllowsDHT(tor))
+        if (tor != nullptr && tor->allowsDht())
         {
             size_t n = 0;
             tr_pex* const pex = event == DHT_EVENT_VALUES ? tr_peerMgrCompactToPex(data, data_len, nullptr, 0, &n) :
@@ -665,7 +665,7 @@ enum class AnnounceResult
 
 static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
 {
-    if (!tr_torrentAllowsDHT(tor))
+    if (!tor->allowsDht())
     {
         return AnnounceResult::INVALID;
     }
@@ -727,7 +727,7 @@ void tr_dhtUpkeep(tr_session* session)
 
     for (auto* tor : session->torrents)
     {
-        if (!tor->isRunning || !tr_torrentAllowsDHT(tor))
+        if (!tor->isRunning || !tor->allowsDht())
         {
             continue;
         }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -559,7 +559,7 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
 
         tor = tr_torrentFindFromHashString(session, hashString);
 
-        if (tr_isTorrent(tor) && tr_torrentAllowsLPD(tor))
+        if (tr_isTorrent(tor) && tor->allowsLpd())
         {
             /* we found a suitable peer, add it to the torrent */
             tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, peer, 1);
@@ -604,7 +604,7 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
         {
             int announcePrio = 0;
 
-            if (!tr_torrentAllowsLPD(tor))
+            if (!tor->allowsLpd())
             {
                 continue;
             }


### PR DESCRIPTION
Changing some libtransmission-visible functions from `tr_torrentFoo()` to `tr_torrent::foo()`