### PR TITLE
refactor: add tr_info accessors to tr_torrent

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -818,7 +818,7 @@ static tr_announce_request* announce_request_new(
     req->up = tier->byteCounts[TR_ANN_UP];
     req->down = tier->byteCounts[TR_ANN_DOWN];
     req->corrupt = tier->byteCounts[TR_ANN_CORRUPT];
-    req->leftUntilComplete = tr_torrentHasMetadata(tor) ? tor->info.totalSize - tor->hasTotal() : INT64_MAX;
+    req->leftUntilComplete = tr_torrentHasMetadata(tor) ? tor->totalSize() - tor->hasTotal() : INT64_MAX;
     req->event = event;
     req->numwant = event == TR_ANNOUNCE_EVENT_STOPPED ? 0 : Numwant;
     req->key = announcer->key;

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -147,11 +147,11 @@ private:
 
     tr_bitfield blocks_{ 0 };
 
-    // Number of bytes we'll have when done downloading. [0..info.totalSize]
+    // Number of bytes we'll have when done downloading. [0..totalSize]
     // Mutable because lazy-calculated
     mutable std::optional<uint64_t> size_when_done_;
 
-    // Number of verified bytes we have right now. [0..info.totalSize]
+    // Number of verified bytes we have right now. [0..totalSize]
     // Mutable because lazy-calculated
     mutable std::optional<uint64_t> has_valid_;
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -178,7 +178,7 @@ void tr_ioFindFileLocation(
     TR_ASSERT(tr_isTorrent(tor));
 
     uint64_t const offset = tr_pieceOffset(tor, pieceIndex, pieceOffset, 0);
-    TR_ASSERT(offset < tor->info.totalSize);
+    TR_ASSERT(offset < tor->totalSize());
 
     auto const n_files = tor->fileCount();
     auto const* file = static_cast<tr_file const*>(
@@ -206,7 +206,7 @@ static int readOrWritePiece(
 {
     int err = 0;
 
-    if (pieceIndex >= tor->info.pieceCount)
+    if (pieceIndex >= tor->pieceCount())
     {
         return EINVAL;
     }
@@ -258,7 +258,7 @@ int tr_ioWrite(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uin
 static std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_t piece)
 {
     TR_ASSERT(tor != nullptr);
-    TR_ASSERT(piece < tor->info.pieceCount);
+    TR_ASSERT(piece < tor->pieceCount());
 
     auto bytes_left = size_t{ tor->pieceSize(piece) };
     auto offset = uint32_t{};

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -226,7 +226,7 @@ tr_peer::tr_peer(tr_torrent const* tor, peer_atom* atom_in)
     , atom{ atom_in }
     , swarm{ tor->swarm }
     , blame{ tor->n_blocks }
-    , have{ tor->info.pieceCount }
+    , have{ tor->pieceCount() }
 {
 }
 
@@ -602,7 +602,7 @@ std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_p
 
         tr_piece_index_t countAllPieces() const override
         {
-            return torrent_->info.pieceCount;
+            return torrent_->pieceCount();
         }
 
         tr_priority_t priority(tr_piece_index_t piece) const override
@@ -700,7 +700,7 @@ static void peerSuggestedPiece(tr_swarm* /*s*/, tr_peer* /*peer*/, tr_piece_inde
     TR_ASSERT(peer->msgs != nullptr);
 
     /* is this a valid piece? */
-    if (pieceIndex >= t->tor->info.pieceCount)
+    if (pieceIndex >= t->tor->pieceCount())
     {
         return;
     }
@@ -1532,7 +1532,7 @@ void tr_peerUpdateProgress(tr_torrent* tor, tr_peer* peer)
 
         if (tr_torrentHasMetadata(tor))
         {
-            peer->progress = true_count / tor->info.pieceCount;
+            peer->progress = true_count / tor->pieceCount();
         }
         else /* without pieceCount, this result is only a best guess... */
         {
@@ -1584,7 +1584,7 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
     {
         int const peerCount = tr_ptrArraySize(&tor->swarm->peers);
         tr_peer const** peers = (tr_peer const**)tr_ptrArrayBase(&tor->swarm->peers);
-        float const interval = tor->info.pieceCount / (float)tabCount;
+        float const interval = tor->pieceCount() / (float)tabCount;
         bool const isSeed = tr_torrentGetCompleteness(tor) == TR_SEED;
 
         for (tr_piece_index_t i = 0; i < tabCount; ++i)
@@ -1677,7 +1677,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
     // do it the hard way
 
     auto desired_available = uint64_t{};
-    auto const n_pieces = tor->info.pieceCount;
+    auto const n_pieces = tor->pieceCount();
     auto have = std::vector<bool>(n_pieces);
 
     for (size_t i = 0; i < n_peers; ++i)
@@ -1700,7 +1700,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
         }
     }
 
-    TR_ASSERT(desired_available <= tor->info.totalSize);
+    TR_ASSERT(desired_available <= tor->totalSize());
     return desired_available;
 }
 
@@ -1860,7 +1860,7 @@ static bool isPeerInteresting(tr_torrent* const tor, bool const* const piece_is_
         return true;
     }
 
-    for (tr_piece_index_t i = 0; i < tor->info.pieceCount; ++i)
+    for (tr_piece_index_t i = 0; i < tor->pieceCount(); ++i)
     {
         if (piece_is_interesting[i] && peer->have.test(i))
         {
@@ -1993,7 +1993,7 @@ static void rechokeDownloads(tr_swarm* s)
     if (peerCount > 0)
     {
         tr_torrent const* const tor = s->tor;
-        int const n = tor->info.pieceCount;
+        int const n = tor->pieceCount();
 
         /* build a bitfield of interesting pieces... */
         bool* const piece_is_interesting = tr_new(bool, n);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1534,7 +1534,7 @@ static bool messageLengthIsCorrect(tr_peerMsgsImpl const* msg, uint8_t id, uint3
     case BtBitfield:
         if (tr_torrentHasMetadata(msg->torrent))
         {
-            return len == (msg->torrent->info.pieceCount >> 3) + ((msg->torrent->info.pieceCount & 7) != 0 ? 1 : 0) + 1U;
+            return len == (msg->torrent->pieceCount() >> 3) + ((msg->torrent->pieceCount() & 7) != 0 ? 1 : 0) + 1U;
         }
 
         /* we don't know the piece count yet,
@@ -1694,7 +1694,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
         tr_peerIoReadUint32(msgs->io, inbuf, &ui32);
         dbgmsg(msgs, "got Have: %u", ui32);
 
-        if (tr_torrentHasMetadata(msgs->torrent) && ui32 >= msgs->torrent->info.pieceCount)
+        if (tr_torrentHasMetadata(msgs->torrent) && ui32 >= msgs->torrent->pieceCount())
         {
             msgs->publishError(ERANGE);
             return READ_ERR;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1076,7 +1076,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->info.torrent);
+    tor->announceList().save(tor->torrentFile());
     return nullptr;
 }
 
@@ -1101,7 +1101,7 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->info.torrent);
+    tor->announceList().save(tor->torrentFile());
     return nullptr;
 }
 
@@ -1126,7 +1126,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->info.torrent);
+    tor->announceList().save(tor->torrentFile());
     return nullptr;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -415,7 +415,7 @@ static void addWebseeds(tr_info const* info, tr_variant* webseeds)
 
 static void addTrackers(tr_torrent const* tor, tr_variant* trackers)
 {
-    for (auto const& tracker : *tor->info.announce_list)
+    for (auto const& tracker : tor->announceList())
     {
         tr_variant* d = tr_variantListAddDict(trackers, 4);
         tr_variantDictAddQuark(d, TR_KEY_announce, tracker.announce_interned);
@@ -578,7 +578,7 @@ static void initField(
         break;
 
     case TR_KEY_hashString:
-        tr_variantInitStrView(initme, tor->info.hashString);
+        tr_variantInitStrView(initme, tor->hashString());
         break;
 
     case TR_KEY_haveUnchecked:
@@ -1068,7 +1068,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
             continue;
         }
 
-        tor->info.announce_list->add(tor->info.announce_list->nextTier(), announce);
+        tor->announceList().add(tor->announceList().nextTier(), announce);
     }
 
     if (tor->trackerCount() == old_size)
@@ -1076,7 +1076,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->info.announce_list->save(tor->info.torrent);
+    tor->announceList().save(tor->info.torrent);
     return nullptr;
 }
 
@@ -1092,7 +1092,7 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
         if (tr_variantGetInt(tr_variantListChild(urls, i), &id) &&
             tr_variantGetStrView(tr_variantListChild(urls, i + 1), &newval))
         {
-            changed |= tor->info.announce_list->replace(id, newval);
+            changed |= tor->announceList().replace(id, newval);
         }
     }
 
@@ -1101,7 +1101,7 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->info.announce_list->save(tor->info.torrent);
+    tor->announceList().save(tor->info.torrent);
     return nullptr;
 }
 
@@ -1118,7 +1118,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
             continue;
         }
 
-        tor->info.announce_list->remove(id);
+        tor->announceList().remove(id);
     }
 
     if (tor->trackerCount() == old_size)
@@ -1126,7 +1126,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         return "error setting announce list";
     }
 
-    tor->info.announce_list->save(tor->info.torrent);
+    tor->announceList().save(tor->info.torrent);
     return nullptr;
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2821,7 +2821,7 @@ void tr_sessionAddTorrent(tr_session* session, tr_torrent* tor)
     session->torrents.insert(tor);
     session->torrentsById.insert_or_assign(tor->uniqueId, tor);
     session->torrentsByHash.insert_or_assign(tor->info.hash, tor);
-    session->torrentsByHashString.insert_or_assign(tor->info.hashString, tor);
+    session->torrentsByHashString.insert_or_assign(tor->hashString(), tor);
 }
 
 void tr_sessionRemoveTorrent(tr_session* session, tr_torrent* tor)
@@ -2829,5 +2829,5 @@ void tr_sessionRemoveTorrent(tr_session* session, tr_torrent* tor)
     session->torrents.erase(tor);
     session->torrentsById.erase(tor->uniqueId);
     session->torrentsByHash.erase(tor->info.hash);
-    session->torrentsByHashString.erase(tor->info.hashString);
+    session->torrentsByHashString.erase(tor->hashString());
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -115,7 +115,7 @@ static size_t findInfoDictOffset(tr_torrent const* tor)
 
     /* load the file, and find the info dict's offset inside the file */
     auto fileLen = size_t{};
-    uint8_t* const fileContents = tr_loadFile(tor->info.torrent, &fileLen, nullptr);
+    uint8_t* const fileContents = tr_loadFile(tor->torrentFile(), &fileLen, nullptr);
     if (fileContents != nullptr)
     {
         auto top = tr_variant{};
@@ -166,7 +166,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 
         TR_ASSERT(tor->infoDictLength > 0);
 
-        auto const fd = tr_sys_file_open(tor->info.torrent, TR_SYS_FILE_READ, 0, nullptr);
+        auto const fd = tr_sys_file_open(tor->torrentFile(), TR_SYS_FILE_READ, 0, nullptr);
         if (fd != TR_BAD_SYS_FILE)
         {
             size_t const o = piece * METADATA_PIECE_SIZE;
@@ -284,7 +284,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
             {
                 /* yay we have bencoded metainfo... merge it into our .torrent file */
                 tr_variant newMetainfo;
-                char* path = tr_strdup(tor->info.torrent);
+                char* path = tr_strdup(tor->torrentFile());
 
                 if (tr_variantFromFile(&newMetainfo, TR_VARIANT_PARSE_BENC, path, nullptr))
                 {
@@ -309,7 +309,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
                         tor->swapMetainfo(*info);
 
                         /* save the new .torrent file */
-                        tr_variantToFile(&newMetainfo, TR_VARIANT_FMT_BENC, tor->info.torrent);
+                        tr_variantToFile(&newMetainfo, TR_VARIANT_FMT_BENC, tor->torrentFile());
                         tr_torrentGotNewInfoDict(tor);
                         tr_torrentSetDirty(tor);
                     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -758,13 +758,13 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tr_sessionAddTorrent(session, tor);
 
     /* if we don't have a local .torrent file already, assume the torrent is new */
-    bool const isNewTorrent = !tr_sys_path_exists(tor->info.torrent, nullptr);
+    bool const isNewTorrent = !tr_sys_path_exists(tor->torrentFile(), nullptr);
 
     /* maybe save our own copy of the metainfo */
     if (tr_ctorGetSave(ctor))
     {
         tr_error* error = nullptr;
-        if (!tr_ctorSaveContents(ctor, tor->info.torrent, &error))
+        if (!tr_ctorSaveContents(ctor, tor->torrentFile(), &error))
         {
             tr_torrentSetLocalError(tor, "Unable to save torrent file: %s (%d)", error->message, error->code);
         }
@@ -1271,7 +1271,7 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     auto ret = tr_torrent_view{};
     ret.name = tor->info.name;
     ret.hash_string = tor->hashString();
-    ret.torrent_filename = tor->info.torrent;
+    ret.torrent_filename = tor->torrentFile();
     ret.comment = tor->info.comment;
     ret.creator = tor->info.creator;
     ret.source = tor->info.source;
@@ -1279,7 +1279,7 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.date_created = tor->info.dateCreated;
     ret.piece_size = tor->pieceSize();
     ret.n_pieces = tor->pieceCount();
-    ret.is_private = tor->info.isPrivate;
+    ret.is_private = tor->isPrivate();
     ret.is_folder = tor->info.isFolder;
 
     return ret;
@@ -2172,7 +2172,7 @@ bool tr_torrentSetAnnounceList(tr_torrent* tor, char const* const* announce_urls
     auto const lock = tor->unique_lock();
 
     auto announce_list = tr_announce_list();
-    if (!announce_list.set(announce_urls, tiers, n) || !announce_list.save(tor->info.torrent))
+    if (!announce_list.set(announce_urls, tiers, n) || !announce_list.save(tor->torrentFile()))
     {
         return false;
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -81,7 +81,7 @@ uint64_t tr_torrentTotalSize(tr_torrent const* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    return tor->info.totalSize;
+    return tor->totalSize();
 }
 
 int tr_torrentId(tr_torrent const* tor)
@@ -592,7 +592,7 @@ static void tr_torrentFireMetadataCompleted(tr_torrent* tor);
 
 static void torrentInitFromInfoDict(tr_torrent* tor)
 {
-    tor->initSizes(tor->info.totalSize, tor->info.pieceSize);
+    tor->initSizes(tor->totalSize(), tor->pieceSize());
     tor->completion = tr_completion{ tor, tor };
     tr_sha1(tor->obfuscatedHash, "req2", 4, tor->info.hash, SHA_DIGEST_LENGTH, nullptr);
 
@@ -609,7 +609,7 @@ static void torrentInitFromInfoDict(tr_torrent* tor)
     tor->file_priorities_.reset(&tor->fpm_);
     tor->files_wanted_.reset(&tor->fpm_);
 
-    tor->checked_pieces_ = tr_bitfield{ tor->info.pieceCount };
+    tor->checked_pieces_ = tr_bitfield{ tor->pieceCount() };
 }
 
 void tr_torrentGotNewInfoDict(tr_torrent* tor)
@@ -1159,7 +1159,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     }
 
     /* test some of the constraints */
-    TR_ASSERT(s->sizeWhenDone <= tor->info.totalSize);
+    TR_ASSERT(s->sizeWhenDone <= tor->totalSize());
     TR_ASSERT(s->leftUntilDone <= s->sizeWhenDone);
     TR_ASSERT(s->desiredAvailable <= s->leftUntilDone);
 
@@ -1270,15 +1270,15 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
 
     auto ret = tr_torrent_view{};
     ret.name = tor->info.name;
-    ret.hash_string = tor->info.hashString;
+    ret.hash_string = tor->hashString();
     ret.torrent_filename = tor->info.torrent;
     ret.comment = tor->info.comment;
     ret.creator = tor->info.creator;
     ret.source = tor->info.source;
-    ret.total_size = tor->info.totalSize;
+    ret.total_size = tor->totalSize();
     ret.date_created = tor->info.dateCreated;
-    ret.piece_size = tor->info.pieceSize;
-    ret.n_pieces = tor->info.pieceCount;
+    ret.piece_size = tor->pieceSize();
+    ret.n_pieces = tor->pieceCount();
     ret.is_private = tor->info.isPrivate;
     ret.is_folder = tor->info.isFolder;
 
@@ -1883,7 +1883,7 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
         { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
         { "TR_TIME_LOCALTIME"sv, ctime_str },
         { "TR_TORRENT_DIR"sv, torrent_dir },
-        { "TR_TORRENT_HASH"sv, tor->info.hashString },
+        { "TR_TORRENT_HASH"sv, tor->hashString() },
         { "TR_TORRENT_ID"sv, id_str },
         { "TR_TORRENT_LABELS"sv, labels_str },
         { "TR_TORRENT_NAME"sv, tr_torrentName(tor) },
@@ -2072,8 +2072,8 @@ void tr_torrentGetBlockLocation(
 {
     uint64_t pos = block;
     pos *= tor->block_size;
-    *piece = pos / tor->info.pieceSize;
-    uint64_t piece_begin = tor->info.pieceSize;
+    *piece = pos / tor->pieceSize();
+    uint64_t piece_begin = tor->pieceSize();
     piece_begin *= *piece;
     *offset = pos - piece_begin;
     *length = tor->blockSize(block);
@@ -2085,7 +2085,7 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
 
     int err = 0;
 
-    if (index >= tor->info.pieceCount)
+    if (index >= tor->pieceCount())
     {
         err = 1;
     }
@@ -2101,7 +2101,7 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
     {
         err = 4;
     }
-    else if (tr_pieceOffset(tor, index, offset, length) > tor->info.totalSize)
+    else if (tr_pieceOffset(tor, index, offset, length) > tor->totalSize())
     {
         err = 5;
     }
@@ -2126,7 +2126,7 @@ uint64_t tr_pieceOffset(tr_torrent const* tor, tr_piece_index_t index, uint32_t 
     TR_ASSERT(tr_isTorrent(tor));
 
     auto ret = uint64_t{};
-    ret = tor->info.pieceSize;
+    ret = tor->pieceSize();
     ret *= index;
     ret += offset;
     ret += length;
@@ -2188,8 +2188,8 @@ bool tr_torrentSetAnnounceList(tr_torrent* tor, char const* const* announce_urls
         auto const error_url = tor->error_announce_url;
 
         if (std::any_of(
-                std::begin(*tor->info.announce_list),
-                std::end(*tor->info.announce_list),
+                std::begin(tor->announceList()),
+                std::end(tor->announceList()),
                 [error_url](auto const& tracker) { return tracker.announce_interned == error_url; }))
         {
             tr_torrentClearError(tor);
@@ -2584,7 +2584,7 @@ static void setLocationImpl(void* vdata)
             if (data->setme_progress != nullptr)
             {
                 bytesHandled += file_length;
-                *data->setme_progress = bytesHandled / tor->info.totalSize;
+                *data->setme_progress = bytesHandled / tor->totalSize();
             }
         }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -413,6 +413,11 @@ public:
         return *this->info.announce_list;
     }
 
+    auto const& torrentFile() const
+    {
+        return this->info.torrent;
+    }
+
     /// METAINFO - CHECKSUMS
 
     bool ensurePieceIsChecked(tr_piece_index_t piece)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -366,11 +366,58 @@ public:
         return info.webseeds[i];
     }
 
+    /// METAINFO - OTHER
+
+    auto isPrivate() const
+    {
+        return this->info.isPrivate;
+    }
+
+    auto isPublic() const
+    {
+        return !this->isPrivate();
+    }
+
+    auto pieceCount() const
+    {
+        return this->info.pieceCount;
+    }
+
+    auto pieceSize() const
+    {
+        return this->info.pieceSize;
+    }
+
+    auto pieceSize(tr_piece_index_t i) const
+    {
+        return tr_block_info::pieceSize(i);
+    }
+
+    auto totalSize() const
+    {
+        return this->info.totalSize;
+    }
+
+    auto hashString() const
+    {
+        return this->info.hashString;
+    }
+
+    auto const& announceList() const
+    {
+        return *this->info.announce_list;
+    }
+
+    auto& announceList()
+    {
+        return *this->info.announce_list;
+    }
+
     /// METAINFO - CHECKSUMS
 
     bool ensurePieceIsChecked(tr_piece_index_t piece)
     {
-        TR_ASSERT(piece < info.pieceCount);
+        TR_ASSERT(piece < this->pieceCount());
 
         if (checked_pieces_.test(piece))
         {
@@ -387,7 +434,7 @@ public:
 
     void initCheckedPieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/)
     {
-        TR_ASSERT(std::size(checked) == info.pieceCount);
+        TR_ASSERT(std::size(checked) == this->pieceCount());
         checked_pieces_ = checked;
 
         auto filename = std::string{};
@@ -405,18 +452,6 @@ public:
                 checked_pieces_.unsetSpan(begin, end);
             }
         }
-    }
-
-    /// METAINFO - OTHER
-
-    auto isPrivate() const
-    {
-        return this->info.isPrivate;
-    }
-
-    auto isPublic() const
-    {
-        return !this->isPrivate();
     }
 
     ///

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -473,9 +473,10 @@ bool tr_lpdSendAnnounce(tr_torrent const* t)
     }
 
     /* make sure the hash string is normalized, just in case */
+    auto const* const sourceHashString = t->hashString();
     for (size_t i = 0; i < TR_N_ELEMENTS(hashString); ++i)
     {
-        hashString[i] = toupper(t->info.hashString[i]);
+        hashString[i] = toupper(sourceHashString[i]);
     }
 
     /* prepare a zero-terminated announce message */

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -49,7 +49,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
     tr_logAddTorDbg(tor, "%s", "verifying torrent...");
     tor->verify_progress = 0;
 
-    while (!*stopFlag && piece < tor->info.pieceCount)
+    while (!*stopFlag && piece < tor->pieceCount())
     {
         auto const file_length = tor->file(fileIndex).length;
 
@@ -118,7 +118,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
 
             sha = tr_sha1_init();
             ++piece;
-            tor->verify_progress = piece / double(tor->info.pieceCount);
+            tor->verify_progress = piece / double(tor->pieceCount());
             piecePos = 0;
         }
 
@@ -152,8 +152,8 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
         tor,
         "Verification is done. It took %d seconds to verify %" PRIu64 " bytes (%" PRIu64 " bytes per second)",
         (int)(end - begin),
-        tor->info.totalSize,
-        (uint64_t)(tor->info.totalSize / (1 + (end - begin))));
+        tor->totalSize(),
+        (uint64_t)(tor->totalSize() / (1 + (end - begin))));
 
     return changed;
 }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -385,7 +385,7 @@ static void on_idle(tr_webseed* w)
             task->webseed = w;
             task->block = begin;
             task->piece_index = tor->pieceForBlock(begin);
-            task->piece_offset = tor->block_size * begin - tor->info.pieceSize * task->piece_index;
+            task->piece_offset = tor->block_size * begin - tor->pieceSize() * task->piece_index;
             task->length = (end - 1 - begin) * tor->block_size + tor->blockSize(end - 1);
             task->blocks_done = 0;
             task->response_code = 0;

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -54,7 +54,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
         makeString(tr_strdup_printf("%s/%s.part", incomplete_dir, tr_torrentFile(tor, 0).name)),
         makeString(tr_torrentFindFile(tor, 0)));
     EXPECT_EQ(tr_strvPath(incomplete_dir, tr_torrentFile(tor, 1).name), makeString(tr_torrentFindFile(tor, 1)));
-    EXPECT_EQ(tor->info.pieceSize, tr_torrentStat(tor)->leftUntilDone);
+    EXPECT_EQ(tor->pieceSize(), tr_torrentStat(tor)->leftUntilDone);
 
     // auto constexpr completeness_unset = tr_completeness { -1 };
     // auto completeness = completeness_unset;

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -115,7 +115,7 @@ protected:
         EXPECT_EQ(TR_STAT_OK, tst->error);
         EXPECT_EQ(total_size, tst->sizeWhenDone);
         EXPECT_EQ(total_size, tst->leftUntilDone);
-        EXPECT_EQ(total_size, tor->info.totalSize);
+        EXPECT_EQ(total_size, tor->totalSize());
         EXPECT_EQ(0, tst->haveValid);
     }
 
@@ -274,7 +274,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     // sanity check the info
     EXPECT_STREQ("Felidae", tor->info.name);
-    EXPECT_EQ(TotalSize, tor->info.totalSize);
+    EXPECT_EQ(TotalSize, tor->totalSize());
     EXPECT_EQ(tr_file_index_t{ 4 }, tor->info.fileCount);
 
     for (tr_file_index_t i = 0; i < 4; ++i)
@@ -488,9 +488,9 @@ TEST_F(RenameTest, partialFile)
 
     auto* tor = zeroTorrentInit();
     auto const& files = tor->info.files;
-    EXPECT_EQ(TotalSize, tor->info.totalSize);
-    EXPECT_EQ(PieceSize, tor->info.pieceSize);
-    EXPECT_EQ(PieceCount, tor->info.pieceCount);
+    EXPECT_EQ(TotalSize, tor->totalSize());
+    EXPECT_EQ(PieceSize, tor->pieceSize());
+    EXPECT_EQ(PieceCount, tor->pieceCount());
     EXPECT_STREQ("files-filled-with-zeroes/1048576", files[0].name);
     EXPECT_STREQ("files-filled-with-zeroes/4096", files[1].name);
     EXPECT_STREQ("files-filled-with-zeroes/512", files[2].name);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -412,7 +412,7 @@ protected:
 
             for (uint64_t j = 0; j < file.length; ++j)
             {
-                tr_sys_file_write(fd, (!complete && i == 0 && j < tor->info.pieceSize) ? "\1" : "\0", 1, nullptr, nullptr);
+                tr_sys_file_write(fd, (!complete && i == 0 && j < tor->pieceSize()) ? "\1" : "\0", 1, nullptr, nullptr);
             }
 
             tr_sys_file_close(fd, nullptr);
@@ -432,7 +432,7 @@ protected:
         }
         else
         {
-            EXPECT_EQ(tor->info.pieceSize, tr_torrentStat(tor)->leftUntilDone);
+            EXPECT_EQ(tor->pieceSize(), tr_torrentStat(tor)->leftUntilDone);
         }
     }
 


### PR DESCRIPTION
More prepwork for replacing tr_info. This PR adds accessor methods to tr_torrent so that the aggregated struct doesn't have to be referred to directly.

For example:

```diff
- tor->info.totalSize()
+ tor->totalSize()
```