### PR TITLE
refactor: more prefer tr_strv*()

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -260,10 +260,10 @@ static void on_scrape_response(struct tau_scrape_request* request, tau_action_t 
     else
     {
         size_t const buflen = evbuffer_get_length(buf);
-        char* const errmsg = action == TAU_ACTION_ERROR && buflen > 0 ? tr_strndup(evbuffer_pullup(buf, -1), buflen) :
-                                                                        tr_strdup(_("Unknown error"));
+        auto const errmsg = action == TAU_ACTION_ERROR && buflen > 0 ?
+            std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(buf, -1)), buflen } :
+            _("Unknown error");
         tau_scrape_request_fail(request, true, false, errmsg);
-        tr_free(errmsg);
     }
 }
 

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -224,7 +224,7 @@ static char const* parseFiles(tr_info* inf, tr_variant* files, tr_variant const*
         inf->isFolder = false;
         inf->fileCount = 1;
         inf->files = tr_new0(tr_file, 1);
-        inf->files[0].name = tr_strndup(root_name.c_str(), std::size(root_name));
+        inf->files[0].name = tr_strvDup(root_name);
         inf->files[0].length = len;
         inf->files[0].priv.is_renamed = is_root_adjusted;
         inf->totalSize += len;

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -16,7 +16,7 @@
 #include "transmission.h"
 #include "quark.h"
 #include "tr-assert.h"
-#include "utils.h" // tr_strndup()
+#include "utils.h" // tr_strvDup()
 
 using namespace std::literals;
 
@@ -466,7 +466,7 @@ tr_quark tr_quark_new(std::string_view str)
     }
 
     auto const ret = TR_N_KEYS + std::size(my_runtime);
-    my_runtime.emplace_back(tr_strndup(std::data(str), std::size(str)), std::size(str));
+    my_runtime.emplace_back(tr_strvDup(str), std::size(str));
     return ret;
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1088,7 +1088,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
             tor->etaDLSpeedCalculatedAt = now;
         }
 
-        if (s->leftUntilDone > s->desiredAvailable && tor->info.webseedCount < 1)
+        if (s->leftUntilDone > s->desiredAvailable && tor->webseedCount() < 1)
         {
             s->eta = TR_ETA_NOT_AVAIL;
         }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2844,7 +2844,7 @@ bool tr_torrentFindFile2(tr_torrent const* tor, tr_file_index_t fileNum, char co
 
     if (subpath != nullptr)
     {
-        *subpath = tr_strndup(std::data(found->subpath), std::size(found->subpath));
+        *subpath = tr_strvDup(found->subpath);
     }
 
     if (mtime != nullptr)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1619,7 +1619,7 @@ char* tr_env_get_string(char const* key, char const* default_value)
         value = default_value;
     }
 
-    return value != nullptr ? tr_strdup(value) : nullptr;
+    return value != nullptr ? tr_strvDup(value) : nullptr;
 
 #endif
 }

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -155,7 +155,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     auto const& files = tor->info.files;
 
     // sanity check the info
-    EXPECT_EQ(tr_file_index_t{ 1 }, tor->info.fileCount);
+    EXPECT_EQ(tr_file_index_t{ 1 }, tor->fileCount());
     EXPECT_STREQ("hello-world.txt", files[0].name);
     EXPECT_FALSE(files[0].priv.is_renamed);
 
@@ -275,7 +275,7 @@ TEST_F(RenameTest, multifileTorrent)
     // sanity check the info
     EXPECT_STREQ("Felidae", tor->info.name);
     EXPECT_EQ(TotalSize, tor->totalSize());
-    EXPECT_EQ(tr_file_index_t{ 4 }, tor->info.fileCount);
+    EXPECT_EQ(tr_file_index_t{ 4 }, tor->fileCount());
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -279,7 +279,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {
-        EXPECT_EQ(expected_files[i], files[i].name);
+        EXPECT_EQ(expected_files[i], tr_torrentFile(tor, i).name);
     }
 
     // sanity check the (empty) stats
@@ -306,20 +306,20 @@ TEST_F(RenameTest, multifileTorrent)
 
     // rename a leaf...
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/catus/Kyphi", "placeholder"));
-    EXPECT_STREQ("Felidae/Felinae/Felis/catus/placeholder", files[1].name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/catus/placeholder", tr_torrentFile(tor, 1).name);
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 1, "Inquisitive\n"));
 
     // ...and back again
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/catus/placeholder", "Kyphi"));
-    EXPECT_STREQ("Felidae/Felinae/Felis/catus/Kyphi", files[1].name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/catus/Kyphi", tr_torrentFile(tor, 1).name);
     testFileExistsAndConsistsOfThisString(tor, 1, "Inquisitive\n");
 
     // rename a branch...
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/catus", "placeholder"));
-    EXPECT_EQ(expected_files[0], files[0].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", files[1].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Saffron", files[2].name);
-    EXPECT_EQ(expected_files[3], files[3].name);
+    EXPECT_EQ(expected_files[0], tr_torrentFile(tor, 0).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", tr_torrentFile(tor, 1).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Saffron", tr_torrentFile(tor, 2).name);
+    EXPECT_EQ(expected_files[3], tr_torrentFile(tor, 3).name);
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 1, expected_contents[1]));
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 2, expected_contents[2]));
     EXPECT_FALSE(files[0].priv.is_renamed);
@@ -334,17 +334,17 @@ TEST_F(RenameTest, multifileTorrent)
     files[1].name = tr_strdup("gabba gabba hey");
     auto const loaded = tr_torrentLoadResume(tor, ~0ULL, ctor, nullptr);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_FILENAMES));
-    EXPECT_EQ(expected_files[0], files[0].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", files[1].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Saffron", files[2].name);
-    EXPECT_EQ(expected_files[3], files[3].name);
+    EXPECT_EQ(expected_files[0], tr_torrentFile(tor, 0).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", tr_torrentFile(tor, 1).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Saffron", tr_torrentFile(tor, 2).name);
+    EXPECT_EQ(expected_files[3], tr_torrentFile(tor, 3).name);
 
     // ...and back again
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/placeholder", "catus"));
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {
-        EXPECT_EQ(expected_files[i], files[i].name);
+        EXPECT_EQ(expected_files[i], tr_torrentFile(tor, i).name);
         EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, i, expected_contents[i]));
     }
 
@@ -384,17 +384,17 @@ TEST_F(RenameTest, multifileTorrent)
 
     // rename a branch...
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/catus", "foo"));
-    EXPECT_EQ(expected_files[0], files[0].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/foo/Kyphi", files[1].name);
-    EXPECT_STREQ("Felidae/Felinae/Felis/foo/Saffron", files[2].name);
-    EXPECT_EQ(expected_files[3], files[3].name);
+    EXPECT_EQ(expected_files[0], tr_torrentFile(tor, 0).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/foo/Kyphi", tr_torrentFile(tor, 1).name);
+    EXPECT_STREQ("Felidae/Felinae/Felis/foo/Saffron", tr_torrentFile(tor, 2).name);
+    EXPECT_EQ(expected_files[3], tr_torrentFile(tor, 3).name);
 
     // ...and back again
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/foo", "catus"));
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {
-        EXPECT_EQ(expected_files[i], files[i].name);
+        EXPECT_EQ(expected_files[i], tr_torrentFile(tor, i).name);
     }
 
     EXPECT_EQ(0, torrentRenameAndWait(tor, "Felidae", "gabba"));
@@ -406,7 +406,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {
-        EXPECT_STREQ(strings[i], files[i].name);
+        EXPECT_STREQ(strings[i], tr_torrentFile(tor, i).name);
         testFileExistsAndConsistsOfThisString(tor, i, expected_contents[i]);
     }
 
@@ -421,7 +421,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     for (tr_file_index_t i = 0; i < 4; ++i)
     {
-        EXPECT_STREQ(strings[i], files[i].name);
+        EXPECT_STREQ(strings[i], tr_torrentFile(tor, i).name);
         testFileExistsAndConsistsOfThisString(tor, i, expected_contents[i]);
     }
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -205,7 +205,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     EXPECT_TRUE(files[0].priv.is_renamed); // confirm the file's 'renamed' flag is set
     EXPECT_STREQ("foobar", tr_torrentName(tor)); // confirm the torrent's name is now 'foobar'
     EXPECT_STREQ("foobar", files[0].name); // confirm the file's name is now 'foobar' in our struct
-    EXPECT_STREQ(nullptr, strstr(tor->info.torrent, "foobar")); // confirm the name in the .torrent file hasn't changed
+    EXPECT_STREQ(nullptr, strstr(tr_torrentView(tor).torrent_filename, "foobar")); // confirm .torrent file hasn't changed
     tmpstr = tr_strvPath(tor->currentDir, "foobar");
     EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the file's name is now 'foobar' on the disk
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 0, "hello, world!\n")); // confirm the contents are right

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -200,7 +200,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     auto tmpstr = tr_strvPath(tor->currentDir, "hello-world.txt");
     EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
     EXPECT_STREQ("hello-world.txt", tr_torrentName(tor));
-    EXPECT_EQ(0, torrentRenameAndWait(tor, tor->info.name, "foobar"));
+    EXPECT_EQ(0, torrentRenameAndWait(tor, tr_torrentName(tor), "foobar"));
     EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the old filename can't be found
     EXPECT_TRUE(files[0].priv.is_renamed); // confirm the file's 'renamed' flag is set
     EXPECT_STREQ("foobar", tr_torrentName(tor)); // confirm the torrent's name is now 'foobar'
@@ -273,7 +273,7 @@ TEST_F(RenameTest, multifileTorrent)
     auto* files = tor->info.files;
 
     // sanity check the info
-    EXPECT_STREQ("Felidae", tor->info.name);
+    EXPECT_STREQ("Felidae", tr_torrentName(tor));
     EXPECT_EQ(TotalSize, tor->totalSize());
     EXPECT_EQ(tr_file_index_t{ 4 }, tor->fileCount());
 
@@ -448,7 +448,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     // rename prefix of top
     EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "Feli", "FelidaeX"));
-    EXPECT_STREQ("Felidae", tor->info.name);
+    EXPECT_STREQ("Felidae", tr_torrentName(tor));
     EXPECT_FALSE(files[0].priv.is_renamed);
     EXPECT_FALSE(files[1].priv.is_renamed);
     EXPECT_FALSE(files[2].priv.is_renamed);
@@ -456,7 +456,7 @@ TEST_F(RenameTest, multifileTorrent)
 
     // rename false path
     EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "Felidae/FelinaeX", "Genus Felinae"));
-    EXPECT_STREQ("Felidae", tor->info.name);
+    EXPECT_STREQ("Felidae", tr_torrentName(tor));
     EXPECT_FALSE(files[0].priv.is_renamed);
     EXPECT_FALSE(files[1].priv.is_renamed);
     EXPECT_FALSE(files[2].priv.is_renamed);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -395,9 +395,9 @@ protected:
 
     void zeroTorrentPopulate(tr_torrent* tor, bool complete)
     {
-        for (tr_file_index_t i = 0; i < tor->info.fileCount; ++i)
+        for (size_t i = 0, n = tr_torrentFileCount(tor); i < n; ++i)
         {
-            auto const& file = tor->info.files[i];
+            auto const file = tr_torrentFile(tor, i);
 
             auto path = (!complete && i == 0) ? tr_strvJoin(tor->currentDir, TR_PATH_DELIMITER_STR, file.name, ".part") :
                                                 tr_strvJoin(tor->currentDir, TR_PATH_DELIMITER_STR, file.name);


### PR DESCRIPTION
Similar to the previous refactor -- prefer memory-managed `tr_strv*()` methods over the raw C pointer functions e.g. `tr_strdup_printf()`