### PR TITLE
refactor: tr_torrent housekeeping

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -823,7 +823,7 @@ static tr_announce_request* announce_request_new(
     req->event = event;
     req->numwant = event == TR_ANNOUNCE_EVENT_STOPPED ? 0 : Numwant;
     req->key = announcer->key;
-    req->partial_seed = tr_torrentGetCompleteness(tor) == TR_PARTIAL_SEED;
+    req->partial_seed = tor->isPartialSeed();
     tier_build_log_name(tier, req->log_name, sizeof(req->log_name));
     return req;
 }

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -12,6 +12,7 @@
 
 #include "error.h"
 #include "tr-assert.h"
+#include "tr-macros.h"
 #include "utils.h"
 
 tr_error* tr_error_new_literal(int code, char const* message)
@@ -24,6 +25,8 @@ tr_error* tr_error_new_literal(int code, char const* message)
 
     return error;
 }
+
+static tr_error* tr_error_new_valist(int code, char const* message_format, va_list args) TR_GNUC_PRINTF(2, 0);
 
 static tr_error* tr_error_new_valist(int code, char const* message_format, va_list args)
 {

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -38,18 +38,19 @@ using namespace std::literals;
 
 std::string tr_buildTorrentFilename(
     std::string_view dirname,
-    tr_info const* inf,
+    std::string_view name,
+    std::string_view info_hash_string,
     enum tr_metainfo_basename_format format,
     std::string_view suffix)
 {
     return format == TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH ?
-        tr_strvJoin(dirname, "/"sv, inf->name, "."sv, std::string_view{ inf->hashString, 16 }, suffix) :
-        tr_strvJoin(dirname, "/"sv, inf->hashString, suffix);
+        tr_strvJoin(dirname, "/"sv, name, "."sv, info_hash_string.substr(0, 16), suffix) :
+        tr_strvJoin(dirname, "/"sv, info_hash_string, suffix);
 }
 
 static std::string getTorrentFilename(tr_session const* session, tr_info const* inf, enum tr_metainfo_basename_format format)
 {
-    return tr_buildTorrentFilename(tr_getTorrentDir(session), inf, format, ".torrent"sv);
+    return tr_buildTorrentFilename(tr_getTorrentDir(session), inf->name, inf->hashString, format, ".torrent"sv);
 }
 
 /***

--- a/libtransmission/metainfo.h
+++ b/libtransmission/metainfo.h
@@ -62,7 +62,8 @@ void tr_metainfoRemoveSaved(tr_session const* session, tr_info const* info);
 
 std::string tr_buildTorrentFilename(
     std::string_view dirname,
-    tr_info const* inf,
+    std::string_view name,
+    std::string_view info_hash_string,
     enum tr_metainfo_basename_format format,
     std::string_view suffix);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1585,7 +1585,7 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
         int const peerCount = tr_ptrArraySize(&tor->swarm->peers);
         tr_peer const** peers = (tr_peer const**)tr_ptrArrayBase(&tor->swarm->peers);
         float const interval = tor->pieceCount() / (float)tabCount;
-        bool const isSeed = tr_torrentGetCompleteness(tor) == TR_SEED;
+        auto const isSeed = tor->isSeed();
 
         for (tr_piece_index_t i = 0; i < tabCount; ++i)
         {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2017,7 +2017,7 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
         auto rate_Bps = tr_peerGetPieceSpeed_Bps(msgs, now, TR_PEER_TO_CLIENT);
         if (tr_torrentUsesSpeedLimit(torrent, TR_PEER_TO_CLIENT))
         {
-            rate_Bps = std::min(rate_Bps, tr_torrentGetSpeedLimit_Bps(torrent, TR_PEER_TO_CLIENT));
+            rate_Bps = std::min(rate_Bps, torrent->speedLimitBps(TR_PEER_TO_CLIENT));
         }
 
         /* honor the session limits, if enabled */

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -240,7 +240,7 @@ static uint64_t loadFilePriorities(tr_variant* dict, tr_torrent* tor)
 static void saveSingleSpeedLimit(tr_variant* d, tr_torrent* tor, tr_direction dir)
 {
     tr_variantDictReserve(d, 3);
-    tr_variantDictAddInt(d, TR_KEY_speed_Bps, tr_torrentGetSpeedLimit_Bps(tor, dir));
+    tr_variantDictAddInt(d, TR_KEY_speed_Bps, tor->speedLimitBps(dir));
     tr_variantDictAddBool(d, TR_KEY_use_global_speed_limit, tr_torrentUsesSessionLimits(tor));
     tr_variantDictAddBool(d, TR_KEY_use_speed_limit, tr_torrentUsesSpeedLimit(tor, dir));
 }
@@ -272,11 +272,11 @@ static void loadSingleSpeedLimit(tr_variant* d, tr_direction dir, tr_torrent* to
 
     if (tr_variantDictFindInt(d, TR_KEY_speed_Bps, &i))
     {
-        tr_torrentSetSpeedLimit_Bps(tor, dir, i);
+        tor->setSpeedLimitBps(dir, i);
     }
     else if (tr_variantDictFindInt(d, TR_KEY_speed, &i))
     {
-        tr_torrentSetSpeedLimit_Bps(tor, dir, i * 1024);
+        tor->setSpeedLimitBps(dir, i * 1024);
     }
 
     if (tr_variantDictFindBool(d, TR_KEY_use_speed_limit, &boolVal))

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -690,7 +690,7 @@ void tr_torrentSaveResume(tr_torrent* tor)
     tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->uploadedPrev + tor->uploadedCur);
     tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->maxConnectedPeers);
     tr_variantDictAddInt(&top, TR_KEY_bandwidth_priority, tr_torrentGetPriority(tor));
-    tr_variantDictAddBool(&top, TR_KEY_paused, !tor->isRunning && !tor->isQueued);
+    tr_variantDictAddBool(&top, TR_KEY_paused, !tor->isRunning && !tor->isQueued());
     savePeers(&top, tor);
 
     if (tr_torrentHasMetadata(tor))

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -38,7 +38,7 @@ constexpr int MAX_REMEMBERED_PEERS = 200;
 
 static std::string getResumeFilename(tr_torrent const* tor, enum tr_metainfo_basename_format format)
 {
-    return tr_buildTorrentFilename(tr_getResumeDir(tor->session), tr_torrentInfo(tor), format, ".resume"sv);
+    return tr_buildTorrentFilename(tr_getResumeDir(tor->session), tr_torrentName(tor), tor->hashString(), format, ".resume"sv);
 }
 
 /***
@@ -529,13 +529,12 @@ static void saveProgress(tr_variant* dict, tr_torrent* tor)
 static uint64_t loadProgress(tr_variant* dict, tr_torrent* tor)
 {
     auto ret = uint64_t{};
-    tr_info const* inf = tr_torrentInfo(tor);
 
     if (tr_variant* prog = nullptr; tr_variantDictFindDict(dict, TR_KEY_progress, &prog))
     {
         /// CHECKED PIECES
 
-        auto checked = tr_bitfield(inf->pieceCount);
+        auto checked = tr_bitfield(tor->pieceCount());
         auto mtimes = std::vector<time_t>{};
         auto const n_files = tor->fileCount();
         mtimes.reserve(n_files);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -302,7 +302,7 @@ static char const* torrentStop(
 {
     for (auto* tor : getTorrents(session, args_in))
     {
-        if (tor->isRunning || tr_torrentIsQueued(tor))
+        if (tor->isRunning || tor->isQueued())
         {
             tor->isStopping = true;
             notify(session, TR_RPC_TORRENT_STOPPED, tor);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -406,11 +406,11 @@ static void addFiles(tr_torrent const* tor, tr_variant* list)
     }
 }
 
-static void addWebseeds(tr_info const* info, tr_variant* webseeds)
+static void addWebseeds(tr_torrent const* tor, tr_variant* webseeds)
 {
-    for (unsigned int i = 0; i < info->webseedCount; ++i)
+    for (size_t i = 0, n = tor->webseedCount(); i < n; ++i)
     {
-        tr_variantListAddStr(webseeds, info->webseeds[i]);
+        tr_variantListAddStr(webseeds, tor->webseed(i));
     }
 }
 
@@ -491,7 +491,7 @@ static void addPeers(tr_torrent* tor, tr_variant* list)
 
 static void initField(
     tr_torrent* const tor,
-    tr_info const* const inf,
+    tr_torrent_view const* view,
     tr_stat const* const st,
     tr_variant* const initme,
     tr_quark key)
@@ -513,7 +513,7 @@ static void initField(
         break;
 
     case TR_KEY_comment:
-        tr_variantInitStr(initme, std::string_view{ inf->comment != nullptr ? inf->comment : "" });
+        tr_variantInitStr(initme, std::string_view{ view->comment != nullptr ? view->comment : "" });
         break;
 
     case TR_KEY_corruptEver:
@@ -521,11 +521,11 @@ static void initField(
         break;
 
     case TR_KEY_creator:
-        tr_variantInitStr(initme, std::string_view{ inf->creator != nullptr ? inf->creator : "" });
+        tr_variantInitStr(initme, std::string_view{ view->creator != nullptr ? view->creator : "" });
         break;
 
     case TR_KEY_dateCreated:
-        tr_variantInitInt(initme, inf->dateCreated);
+        tr_variantInitInt(initme, view->date_created);
         break;
 
     case TR_KEY_desiredAvailable:
@@ -698,11 +698,11 @@ static void initField(
         break;
 
     case TR_KEY_pieceCount:
-        tr_variantInitInt(initme, inf->pieceCount);
+        tr_variantInitInt(initme, view->n_pieces);
         break;
 
     case TR_KEY_pieceSize:
-        tr_variantInitInt(initme, inf->pieceSize);
+        tr_variantInitInt(initme, view->piece_size);
         break;
 
     case TR_KEY_primary_mime_type:
@@ -761,7 +761,7 @@ static void initField(
         break;
 
     case TR_KEY_source:
-        tr_variantDictAddStr(initme, key, inf->source);
+        tr_variantDictAddStr(initme, key, view->source ? view->source : "");
         break;
 
     case TR_KEY_startDate:
@@ -798,11 +798,11 @@ static void initField(
         }
 
     case TR_KEY_torrentFile:
-        tr_variantInitStr(initme, inf->torrent);
+        tr_variantInitStr(initme, view->torrent_filename);
         break;
 
     case TR_KEY_totalSize:
-        tr_variantInitInt(initme, inf->totalSize);
+        tr_variantInitInt(initme, view->total_size);
         break;
 
     case TR_KEY_uploadedEver:
@@ -833,8 +833,8 @@ static void initField(
         break;
 
     case TR_KEY_webseeds:
-        tr_variantInitList(initme, inf->webseedCount);
-        addWebseeds(inf, initme);
+        tr_variantInitList(initme, tor->webseedCount());
+        addWebseeds(tor, initme);
         break;
 
     case TR_KEY_webseedsSendingToUs:
@@ -859,14 +859,14 @@ static void addTorrentInfo(tr_torrent* tor, tr_format format, tr_variant* entry,
 
     if (fieldCount > 0)
     {
-        tr_info const* const inf = tr_torrentInfo(tor);
+        auto const torrent_view = tr_torrentView(tor);
         tr_stat const* const st = tr_torrentStat(tor);
 
         for (size_t i = 0; i < fieldCount; ++i)
         {
             tr_variant* child = format == TR_FORMAT_TABLE ? tr_variantListAdd(entry) : tr_variantDictAdd(entry, fields[i]);
 
-            initField(tor, inf, st, child, fields[i]);
+            initField(tor, &torrent_view, st, child, fields[i]);
         }
     }
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2774,7 +2774,7 @@ std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr
     candidates.reserve(tr_sessionCountTorrents(session));
     for (auto* tor : session->torrents)
     {
-        if (tr_torrentIsQueued(tor) && (direction == tor->queueDirection()))
+        if (tor->isQueued() && (direction == tor->queueDirection()))
         {
             candidates.push_back(tor);
         }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -418,5 +418,5 @@ char* tr_torrentInfoGetMagnetLink(tr_info const* inf)
 
 char* tr_torrentGetMagnetLink(tr_torrent const* tor)
 {
-    return tr_torrentInfoGetMagnetLink(tr_torrentInfo(tor));
+    return tr_torrentInfoGetMagnetLink(&tor->info);
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -151,7 +151,7 @@ bool tr_torrentIsPieceTransferAllowed(tr_torrent const* tor, tr_direction direct
 
     bool allowed = true;
 
-    if (tr_torrentUsesSpeedLimit(tor, direction) && tr_torrentGetSpeedLimit_Bps(tor, direction) <= 0)
+    if (tr_torrentUsesSpeedLimit(tor, direction) && tor->speedLimitBps(direction) <= 0)
     {
         allowed = false;
     }
@@ -202,28 +202,26 @@ tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor)
 ****  PER-TORRENT UL / DL SPEEDS
 ***/
 
-void tr_torrentSetSpeedLimit_Bps(tr_torrent* tor, tr_direction dir, unsigned int Bps)
+void tr_torrent::setSpeedLimitBps(tr_direction dir, unsigned int Bps)
 {
-    TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    if (tor->bandwidth->setDesiredSpeedBytesPerSecond(dir, Bps))
+    if (this->bandwidth->setDesiredSpeedBytesPerSecond(dir, Bps))
     {
-        tor->setDirty();
+        this->setDirty();
     }
 }
 
 void tr_torrentSetSpeedLimit_KBps(tr_torrent* tor, tr_direction dir, unsigned int KBps)
 {
-    tr_torrentSetSpeedLimit_Bps(tor, dir, tr_toSpeedBytes(KBps));
+    tor->setSpeedLimitBps(dir, tr_toSpeedBytes(KBps));
 }
 
-unsigned int tr_torrentGetSpeedLimit_Bps(tr_torrent const* tor, tr_direction dir)
+unsigned int tr_torrent::speedLimitBps(tr_direction dir) const
 {
-    TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    return tor->bandwidth->getDesiredSpeedBytesPerSecond(dir);
+    return this->bandwidth->getDesiredSpeedBytesPerSecond(dir);
 }
 
 unsigned int tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr_direction dir)
@@ -231,7 +229,7 @@ unsigned int tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr_direction di
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    return tr_toSpeedKBps(tr_torrentGetSpeedLimit_Bps(tor, dir));
+    return tr_toSpeedKBps(tor->speedLimitBps(dir));
 }
 
 void tr_torrentUseSpeedLimit(tr_torrent* tor, tr_direction dir, bool do_use)
@@ -740,9 +738,9 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     if ((loaded & TR_FR_SPEEDLIMIT) == 0)
     {
         tr_torrentUseSpeedLimit(tor, TR_UP, false);
-        tr_torrentSetSpeedLimit_Bps(tor, TR_UP, tr_sessionGetSpeedLimit_Bps(tor->session, TR_UP));
+        tor->setSpeedLimitBps(TR_UP, tr_sessionGetSpeedLimit_Bps(tor->session, TR_UP));
         tr_torrentUseSpeedLimit(tor, TR_DOWN, false);
-        tr_torrentSetSpeedLimit_Bps(tor, TR_DOWN, tr_sessionGetSpeedLimit_Bps(tor->session, TR_DOWN));
+        tor->setSpeedLimitBps(TR_DOWN, tr_sessionGetSpeedLimit_Bps(tor->session, TR_DOWN));
         tr_torrentUseSessionLimits(tor, true);
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1414,27 +1414,6 @@ static void torrentStartImpl(void* vtor)
     tr_peerMgrStartTorrent(tor);
 }
 
-uint64_t tr_torrentGetCurrentSizeOnDisk(tr_torrent const* tor)
-{
-    uint64_t byte_count = 0;
-    auto const n = tor->fileCount();
-
-    for (tr_file_index_t i = 0; i < n; ++i)
-    {
-        tr_sys_path_info info;
-        char* filename = tr_torrentFindFile(tor, i);
-
-        if (filename != nullptr && tr_sys_path_get_info(filename, 0, &info, nullptr))
-        {
-            byte_count += info.size;
-        }
-
-        tr_free(filename);
-    }
-
-    return byte_count;
-}
-
 static bool torrentShouldQueue(tr_torrent const* tor)
 {
     tr_direction const dir = tor->queueDirection();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -930,11 +930,6 @@ bool tr_torrentCanManualUpdate(tr_torrent const* tor)
     return tr_isTorrent(tor) && tor->isRunning && tr_announcerCanManualAnnounce(tor);
 }
 
-tr_info const* tr_torrentInfo(tr_torrent const* tor)
-{
-    return tr_isTorrent(tor) ? &tor->info : nullptr;
-}
-
 tr_stat const* tr_torrentStatCached(tr_torrent* tor)
 {
     time_t const now = tr_time();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -969,7 +969,7 @@ tr_torrent_activity tr_torrentGetActivity(tr_torrent const* tor)
     {
         ret = is_seed ? TR_STATUS_SEED : TR_STATUS_DOWNLOAD;
     }
-    else if (tr_torrentIsQueued(tor))
+    else if (tor->isQueued())
     {
         if (is_seed && tr_sessionGetQueueEnabled(tor->session, TR_UP))
         {
@@ -3004,7 +3004,7 @@ static void torrentSetQueued(tr_torrent* tor, bool queued)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tr_torrentIsQueued(tor) != queued)
+    if (tor->isQueued() != queued)
     {
         tor->isQueued = queued;
         tor->markChanged();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -3006,7 +3006,7 @@ static void torrentSetQueued(tr_torrent* tor, bool queued)
 
     if (tor->isQueued() != queued)
     {
-        tor->isQueued = queued;
+        tor->is_queued = queued;
         tor->markChanged();
         tor->setDirty();
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -481,7 +481,7 @@ public:
 
     [[nodiscard]] auto isQueued() const
     {
-        return this->isQueued;
+        return this->is_queued;
     }
 
     [[nodiscard]] constexpr auto queueDirection() const
@@ -619,7 +619,7 @@ public:
 
     bool isDeleting = false;
     bool isDirty = false;
-    bool isQueued = false;
+    bool is_queued = false;
     bool isRunning = false;
     bool isStopping = false;
     bool startAfterVerify = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -479,6 +479,11 @@ public:
 
     ///
 
+    [[nodiscard]] auto isQueued() const
+    {
+        return this->isQueued;
+    }
+
     [[nodiscard]] constexpr auto queueDirection() const
     {
         return this->isDone() ? TR_UP : TR_DOWN;
@@ -720,10 +725,5 @@ char* tr_torrentBuildPartial(tr_torrent const*, tr_file_index_t fileNo);
 void tr_torrentGotNewInfoDict(tr_torrent* tor);
 
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
-
-constexpr bool tr_torrentIsQueued(tr_torrent const* tor)
-{
-    return tor->isQueued;
-}
 
 tr_info const* tr_torrentInfo(tr_torrent const* torrent);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -228,6 +228,16 @@ public:
         return completeness != TR_LEECH;
     }
 
+    [[nodiscard]] constexpr bool isSeed() const
+    {
+        return completeness == TR_SEED;
+    }
+
+    [[nodiscard]] constexpr bool isPartialSeed() const
+    {
+        return completeness == TR_PARTIAL_SEED;
+    }
+
     [[nodiscard]] tr_bitfield const& blocks() const
     {
         return completion.blocks();
@@ -668,11 +678,6 @@ private:
 static inline bool tr_torrentExists(tr_session const* session, uint8_t const* torrentHash)
 {
     return tr_torrentFindFromHash((tr_session*)session, torrentHash) != nullptr;
-}
-
-constexpr tr_completeness tr_torrentGetCompleteness(tr_torrent const* tor)
-{
-    return tor->completeness;
 }
 
 /***

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -711,14 +711,6 @@ void tr_torrentGotNewInfoDict(tr_torrent* tor);
 void tr_torrentSetSpeedLimit_Bps(tr_torrent*, tr_direction, unsigned int Bps);
 unsigned int tr_torrentGetSpeedLimit_Bps(tr_torrent const*, tr_direction);
 
-/**
- * @brief Test a piece against its info dict checksum
- * @return true if the piece's passes the checksum test
- */
-bool tr_torrentCheckPiece(tr_torrent* tor, tr_piece_index_t pieceIndex);
-
-uint64_t tr_torrentGetCurrentSizeOnDisk(tr_torrent const* tor);
-
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 
 constexpr bool tr_torrentIsQueued(tr_torrent const* tor)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -244,19 +244,19 @@ public:
 
     /// FILE <-> PIECE
 
-    auto piecesInFile(tr_file_index_t file) const
+    [[nodiscard]] auto piecesInFile(tr_file_index_t file) const
     {
         return fpm_.pieceSpan(file);
     }
 
     /// WANTED
 
-    bool pieceIsWanted(tr_piece_index_t piece) const final
+    [[nodiscard]] bool pieceIsWanted(tr_piece_index_t piece) const final
     {
         return files_wanted_.pieceWanted(piece);
     }
 
-    bool fileIsWanted(tr_file_index_t file) const
+    [[nodiscard]] bool fileIsWanted(tr_file_index_t file) const
     {
         return files_wanted_.fileWanted(file);
     }
@@ -275,7 +275,7 @@ public:
 
     /// PRIORITIES
 
-    tr_priority_t piecePriority(tr_piece_index_t piece) const
+    [[nodiscard]] tr_priority_t piecePriority(tr_piece_index_t piece) const
     {
         return file_priorities_.piecePriority(piece);
     }
@@ -294,19 +294,19 @@ public:
 
     /// METAINFO - FILES
 
-    tr_file_index_t fileCount() const
+    [[nodiscard]] tr_file_index_t fileCount() const
     {
         return info.fileCount;
     }
 
-    auto& file(tr_file_index_t i)
+    [[nodiscard]] auto& file(tr_file_index_t i)
     {
         TR_ASSERT(i < this->fileCount());
 
         return info.files[i];
     }
 
-    auto const& file(tr_file_index_t i) const
+    [[nodiscard]] auto const& file(tr_file_index_t i) const
     {
         TR_ASSERT(i < this->fileCount());
 
@@ -332,36 +332,36 @@ public:
 
     /// METAINFO - TRACKERS
 
-    auto trackerCount() const
+    [[nodiscard]] auto trackerCount() const
     {
         return std::size(*info.announce_list);
     }
 
-    auto const& tracker(size_t i) const
+    [[nodiscard]] auto const& tracker(size_t i) const
     {
         return info.announce_list->at(i);
     }
 
-    auto tiers() const
+    [[nodiscard]] auto tiers() const
     {
         return info.announce_list->tiers();
     }
 
     /// METAINFO - WEBSEEDS
 
-    auto webseedCount() const
+    [[nodiscard]] auto webseedCount() const
     {
         return info.webseedCount;
     }
 
-    auto const& webseed(size_t i) const
+    [[nodiscard]] auto const& webseed(size_t i) const
     {
         TR_ASSERT(i < webseedCount());
 
         return info.webseeds[i];
     }
 
-    auto& webseed(size_t i)
+    [[nodiscard]] auto& webseed(size_t i)
     {
         TR_ASSERT(i < webseedCount());
 
@@ -370,59 +370,59 @@ public:
 
     /// METAINFO - OTHER
 
-    auto isPrivate() const
+    [[nodiscard]] auto isPrivate() const
     {
         return this->info.isPrivate;
     }
 
-    auto isPublic() const
+    [[nodiscard]] auto isPublic() const
     {
         return !this->isPrivate();
     }
 
-    auto pieceCount() const
+    [[nodiscard]] auto pieceCount() const
     {
         return this->info.pieceCount;
     }
 
-    auto pieceSize() const
+    [[nodiscard]] auto pieceSize() const
     {
         return this->info.pieceSize;
     }
 
-    auto pieceSize(tr_piece_index_t i) const
+    [[nodiscard]] auto pieceSize(tr_piece_index_t i) const
     {
         return tr_block_info::pieceSize(i);
     }
 
-    auto totalSize() const
+    [[nodiscard]] auto totalSize() const
     {
         return this->info.totalSize;
     }
 
-    auto hashString() const
+    [[nodiscard]] auto hashString() const
     {
         return this->info.hashString;
     }
 
-    auto const& announceList() const
+    [[nodiscard]] auto const& announceList() const
     {
         return *this->info.announce_list;
     }
 
-    auto& announceList()
+    [[nodiscard]] auto& announceList()
     {
         return *this->info.announce_list;
     }
 
-    auto const& torrentFile() const
+    [[nodiscard]] auto const& torrentFile() const
     {
         return this->info.torrent;
     }
 
     /// METAINFO - CHECKSUMS
 
-    bool ensurePieceIsChecked(tr_piece_index_t piece)
+    [[nodiscard]] bool ensurePieceIsChecked(tr_piece_index_t piece)
     {
         TR_ASSERT(piece < this->pieceCount());
 
@@ -463,22 +463,22 @@ public:
 
     ///
 
-    constexpr auto queueDirection() const
+    [[nodiscard]] constexpr auto queueDirection() const
     {
         return this->isDone() ? TR_UP : TR_DOWN;
     }
 
-    auto allowsPex() const
+    [[nodiscard]] auto allowsPex() const
     {
         return this->isPublic() && this->session->isPexEnabled;
     }
 
-    auto allowsDht() const
+    [[nodiscard]] auto allowsDht() const
     {
         return this->isPublic() && tr_sessionAllowsDHT(this->session);
     }
 
-    auto allowsLpd() const // local peer discovery
+    [[nodiscard]] auto allowsLpd() const // local peer discovery
     {
         return this->isPublic() && tr_sessionAllowsLPD(this->session);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -725,5 +725,3 @@ char* tr_torrentBuildPartial(tr_torrent const*, tr_file_index_t fileNo);
 void tr_torrentGotNewInfoDict(tr_torrent* tor);
 
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
-
-tr_info const* tr_torrentInfo(tr_torrent const* torrent);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -170,6 +170,12 @@ public:
         return session->unique_lock();
     }
 
+    /// SPEED LIMIT
+
+    void setSpeedLimitBps(tr_direction, unsigned int Bps);
+
+    unsigned int speedLimitBps(tr_direction) const;
+
     /// COMPLETION
 
     [[nodiscard]] uint64_t leftUntilDone() const
@@ -707,9 +713,6 @@ char* tr_torrentBuildPartial(tr_torrent const*, tr_file_index_t fileNo);
 /* for when the info dict has been fundamentally changed wrt files,
  * piece size, etc. such as in BEP 9 where peers exchange metadata */
 void tr_torrentGotNewInfoDict(tr_torrent* tor);
-
-void tr_torrentSetSpeedLimit_Bps(tr_torrent*, tr_direction, unsigned int Bps);
-unsigned int tr_torrentGetSpeedLimit_Bps(tr_torrent const*, tr_direction);
 
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -254,7 +254,7 @@ void tr_verifyAdd(tr_torrent* tor, tr_verify_done_func callback_func, void* call
     node.torrent = tor;
     node.callback_func = callback_func;
     node.callback_data = callback_data;
-    node.current_size = tr_torrentGetCurrentSizeOnDisk(tor);
+    node.current_size = tor->hasTotal();
 
     auto const lock = std::lock_guard(verify_mutex_);
     tr_torrentSetVerifyState(tor, TR_VERIFY_WAIT);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -521,12 +521,12 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
     {
         auto& urls = t->webseed->file_urls;
 
-        tr_info const* inf = tr_torrentInfo(tor);
+        auto const piece_size = tor->pieceSize();
         uint64_t const remain = t->length - t->blocks_done * tor->block_size - evbuffer_get_length(t->content);
 
         uint64_t const total_offset = tr_pieceOffset(tor, t->piece_index, t->piece_offset, t->length - remain);
-        tr_piece_index_t const step_piece = total_offset / inf->pieceSize;
-        uint64_t const step_piece_offset = total_offset - (uint64_t)inf->pieceSize * step_piece;
+        tr_piece_index_t const step_piece = total_offset / piece_size;
+        uint64_t const step_piece_offset = total_offset - uint64_t(piece_size) * step_piece;
 
         auto file_index = tr_file_index_t{};
         auto file_offset = uint64_t{};


### PR DESCRIPTION
Migrate more tr_torrent use to new accessor methods. This has a dual goal:

- reduce the number of references to the `tr_info` data structure to make it easier to refactor
- reduce the number of C-style accessors, e.g. migrating `tr_torrentGetFoo()` to `tor->foo()`