### PR TITLE
refactor: move tr_ioFindFileLocation() to tr_file_piece_manager

### DIFF
--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -38,14 +38,4 @@ int tr_ioWrite(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t off
  */
 bool tr_ioTestPiece(tr_torrent* tor, tr_piece_index_t piece);
 
-/**
- * Converts a piece index + offset into a file index + offset.
- */
-void tr_ioFindFileLocation(
-    tr_torrent const* tor,
-    tr_piece_index_t pieceIndex,
-    uint32_t pieceOffset,
-    tr_file_index_t* fileIndex,
-    uint64_t* fileOffset);
-
 /* @} */

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -242,6 +242,16 @@ public:
         return fpm_.pieceSpan(file);
     }
 
+    [[nodiscard]] auto fileOffset(uint64_t offset) const
+    {
+        return fpm_.fileOffset(offset);
+    }
+
+    [[nodiscard]] auto fileOffset(tr_piece_index_t piece, uint32_t piece_offset) const
+    {
+        return fpm_.fileOffset(this->offset(piece, piece_offset));
+    }
+
     /// WANTED
 
     [[nodiscard]] bool pieceIsWanted(tr_piece_index_t piece) const final

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -36,6 +36,7 @@ using tr_block_index_t = uint32_t;
 using tr_port = uint16_t;
 using tr_tracker_tier_t = uint32_t;
 using tr_tracker_id_t = uint32_t;
+using tr_byte_index_t = uint64_t;
 
 #include "announce-list.h"
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -18,7 +18,6 @@
 
 #include "bandwidth.h"
 #include "cache.h"
-#include "inout.h" /* tr_ioFindFileLocation() */
 #include "peer-mgr.h"
 #include "torrent.h"
 #include "trevent.h" /* tr_runInEventThread() */
@@ -271,9 +270,7 @@ static void connection_succeeded(void* vdata)
 
         if (tor != nullptr)
         {
-            auto file_index = tr_file_index_t{};
-            auto file_offset = uint64_t{};
-            tr_ioFindFileLocation(tor, data->piece_index, data->piece_offset, &file_index, &file_offset);
+            auto const file_index = tor->fileOffset(data->piece_index, data->piece_offset).index;
             w->file_urls[file_index].assign(data->real_url);
         }
     }
@@ -527,10 +524,7 @@ static void task_request_next_chunk(struct tr_webseed_task* t)
         tr_piece_index_t const step_piece = total_offset / piece_size;
         uint64_t const step_piece_offset = total_offset - uint64_t(piece_size) * step_piece;
 
-        auto file_index = tr_file_index_t{};
-        auto file_offset = uint64_t{};
-        tr_ioFindFileLocation(tor, step_piece, step_piece_offset, &file_index, &file_offset);
-
+        auto const [file_index, file_offset] = tor->fileOffset(step_piece, step_piece_offset);
         auto const& file = tor->file(file_index);
         uint64_t this_pass = std::min(remain, file.length - file_offset);
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -47,6 +47,35 @@ protected:
     }
 };
 
+TEST_F(FilePieceMapTest, fileOffset)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+
+    // first byte of the first file
+    auto file_offset = fpm.fileOffset(0);
+    EXPECT_EQ(0, file_offset.index);
+    EXPECT_EQ(0, file_offset.offset);
+
+    // final byte of the first file
+    file_offset = fpm.fileOffset(FileSizes[0] - 1);
+    EXPECT_EQ(0, file_offset.index);
+    EXPECT_EQ(FileSizes[0] - 1, file_offset.offset);
+
+    // first byte of the second file
+    // NB: this is an edge case, second file is 0 bytes.
+    // The second nonzero file is file #5
+    file_offset = fpm.fileOffset(FileSizes[0]);
+    EXPECT_EQ(5, file_offset.index);
+    EXPECT_EQ(0, file_offset.offset);
+
+    // the last byte of in the torrent.
+    // NB: reverse of previous edge case, since
+    // the final 4 files in the torrent are all 0 bytes
+    file_offset = fpm.fileOffset(TotalSize - 1);
+    EXPECT_EQ(12, file_offset.index);
+    EXPECT_EQ(FileSizes[12] - 1, file_offset.offset);
+}
+
 TEST_F(FilePieceMapTest, pieceSpan)
 {
     // Note to reviewers: it's easy to see a nonexistent fencepost error here.


### PR DESCRIPTION
This is a relatively small change to reduce dependency on `tr_info.file` and its `priv.offset` field, since that's going away in the metainfo refactor. This change could be folded into the larger metainfo refactor PR, but doing it here as a standalone makes for simpler / more focused PRs.

Since we already have file-piece-map, migrating tr_ioFindFileLocation() to that class is relatively easy. Better yet, we can use file-piece-map's existing test code to add tests while migrating the feature.