### PR TITLE
refactor: take string_view in tr_loadFile(), tr_saveFile()

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -205,7 +205,7 @@ bool tr_announce_list::canAdd(tr_url_parsed_t const& announce)
     return std::none_of(std::begin(trackers_), std::end(trackers_), is_same);
 }
 
-bool tr_announce_list::save(char const* torrent_file, tr_error** error) const
+bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) const
 {
     // load the .torrent file
     auto metainfo = tr_variant{};

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -105,7 +105,7 @@ public:
         return trackers_.clear();
     }
 
-    bool save(char const* torrent_file, tr_error** error = nullptr) const;
+    bool save(std::string_view torrent_file, tr_error** error = nullptr) const;
 
     static std::optional<std::string> announceToScrape(std::string_view announce);
     static tr_quark announceToScrape(tr_quark announce);

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -312,7 +312,7 @@ static std::string getUserDirsFilename()
 static std::string getXdgEntryFromUserDirs(std::string_view key)
 {
     auto content = std::vector<char>{};
-    if (!tr_loadFile(content, getUserDirsFilename().c_str()) && std::empty(content))
+    if (!tr_loadFile(content, getUserDirsFilename()) && std::empty(content))
     {
         return {};
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -736,7 +736,7 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
     std::string const filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
 
     auto buf = std::vector<char>{};
-    if (!tr_loadFile(buf, filename.c_str(), &error) ||
+    if (!tr_loadFile(buf, filename, &error) ||
         !tr_variantFromBuf(
             &top,
             TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE,

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -166,10 +166,10 @@ int tr_ctorSetMetainfoFromFile(tr_ctor* ctor, char const* filename)
     return 0;
 }
 
-bool tr_ctorSaveContents(tr_ctor const* ctor, char const* filename, tr_error** error)
+bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_error** error)
 {
     TR_ASSERT(ctor != nullptr);
-    TR_ASSERT(filename != nullptr);
+    TR_ASSERT(!std::empty(filename));
 
     if (std::empty(ctor->contents))
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -57,7 +57,7 @@ void tr_ctorInitTorrentPriorities(tr_ctor const* ctor, tr_torrent* tor);
 
 void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 
-bool tr_ctorSaveContents(tr_ctor const* ctor, char const* filename, tr_error** error);
+bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_error** error);
 
 bool tr_ctorGetMetainfo(tr_ctor const* ctor, tr_variant const** setme);
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -79,9 +79,9 @@ bool tr_wildmat(char const* text, char const* pattern) TR_GNUC_NONNULL(1, 2);
  */
 uint8_t* tr_loadFile(char const* filename, size_t* size, struct tr_error** error) TR_GNUC_MALLOC TR_GNUC_NONNULL(1);
 
-bool tr_loadFile(std::vector<char>& setme, char const* filename, tr_error** error = nullptr);
+bool tr_loadFile(std::vector<char>& setme, std::string_view filename, tr_error** error = nullptr);
 
-bool tr_saveFile(char const* filename_in, std::string_view contents, tr_error** error = nullptr);
+bool tr_saveFile(std::string_view filename, std::string_view contents, tr_error** error = nullptr);
 
 /** @brief build a filename from a series of elements using the
            platform's correct directory separator. */

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1206,7 +1206,7 @@ char* tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt, size_t* len)
     return evbuffer_free_to_str(buf, len);
 }
 
-int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filename)
+int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view filename)
 {
     auto error_code = int{ 0 };
     auto contents_len = size_t{};
@@ -1216,7 +1216,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, char const* filena
     tr_saveFile(filename, { contents, contents_len }, &error);
     if (error != nullptr)
     {
-        tr_logAddError(_("Error saving \"%s\": %s (%d)"), filename, error->message, error->code);
+        tr_logAddError(_("Error saving \"%" TR_PRIsv "\": %s (%d)"), TR_PRIsv_ARG(filename), error->message, error->code);
         error_code = error->code;
         tr_error_clear(&error);
     }
@@ -1253,7 +1253,7 @@ bool tr_variantFromBuf(tr_variant* setme, int opts, std::string_view buf, char c
     return true;
 }
 
-bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, char const* filename, tr_error** error)
+bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, std::string_view filename, tr_error** error)
 {
     // can't do inplace when this function is allocating & freeing the memory...
     TR_ASSERT((opts & TR_VARIANT_PARSE_INPLACE) == 0);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -106,7 +106,7 @@ enum tr_variant_fmt
     TR_VARIANT_FMT_JSON_LEAN /* saves bandwidth by omitting all whitespace. */
 };
 
-int tr_variantToFile(tr_variant const* variant, tr_variant_fmt fmt, char const* filename);
+int tr_variantToFile(tr_variant const* variant, tr_variant_fmt fmt, std::string_view filename);
 
 char* tr_variantToStr(tr_variant const* variant, tr_variant_fmt fmt, size_t* len);
 
@@ -119,7 +119,11 @@ enum tr_variant_parse_opts
     TR_VARIANT_PARSE_INPLACE = (1 << 2)
 };
 
-bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, char const* filename, struct tr_error** error = nullptr);
+bool tr_variantFromFile(
+    tr_variant* setme,
+    tr_variant_parse_opts opts,
+    std::string_view filename,
+    struct tr_error** error = nullptr);
 
 bool tr_variantFromBuf(
     tr_variant* setme,


### PR DESCRIPTION
Change the filename argument type in `tr_loadFile()` and `tr_saveFile()` from a `char const*` to a `std::string_view` so those functions can more easily service both c strings and std::strings