### PR TITLE
refactor: further decouple tr_torrent and tr_info

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -809,7 +809,7 @@ static tr_announce_request* announce_request_new(
     req->port = tr_sessionGetPublicPeerPort(announcer->session);
     req->announce_url = tier->currentTracker->announce_url;
     req->tracker_id_str = tr_strdup(tier->currentTracker->tracker_id_str);
-    req->info_hash = tor->hash();
+    req->info_hash = tor->infoHash();
     req->peer_id = tr_torrentGetPeerId(tor);
     req->up = tier->byteCounts[TR_ANN_UP];
     req->down = tier->byteCounts[TR_ANN_DOWN];
@@ -1420,7 +1420,7 @@ static void multiscrape(tr_announcer* announcer, std::vector<tr_tier*> const& ti
                 continue;
             }
 
-            req->info_hash[req->info_hash_count] = tier->tor->hash();
+            req->info_hash[req->info_hash_count] = tier->tor->infoHash();
             ++req->info_hash_count;
             tier->isScraping = true;
             tier->lastScrapeStartTime = now;
@@ -1434,7 +1434,7 @@ static void multiscrape(tr_announcer* announcer, std::vector<tr_tier*> const& ti
             req->scrape_url = scrape_info->scrape_url;
             tier_build_log_name(tier, req->log_name, sizeof(req->log_name));
 
-            req->info_hash[req->info_hash_count] = tier->tor->hash();
+            req->info_hash[req->info_hash_count] = tier->tor->infoHash();
             ++req->info_hash_count;
             tier->isScraping = true;
             tier->lastScrapeStartTime = now;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -198,7 +198,7 @@ static bool buildHandshakeMessage(tr_handshake* handshake, uint8_t* buf)
         }
         walk += HANDSHAKE_FLAGS_LEN;
 
-        walk = std::copy_n(reinterpret_cast<char const*>(std::data(tor->hash())), std::size(tor->hash()), walk);
+        walk = std::copy_n(reinterpret_cast<char const*>(std::data(tor->infoHash())), std::size(tor->infoHash()), walk);
 
         auto const& peer_id = tr_torrentGetPeerId(tor);
         std::copy_n(std::data(peer_id), std::size(peer_id), walk);
@@ -825,7 +825,7 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
         bool const clientIsSeed = tor->isDone();
         bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, tr_peerIoGetAddress(handshake->io, nullptr));
         dbgmsg(handshake, "got INCOMING connection's encrypted handshake for torrent [%s]", tr_torrentName(tor));
-        tr_peerIoSetTorrentHash(handshake->io, tor->info.hash);
+        tr_peerIoSetTorrentHash(handshake->io, tor->infoHash());
 
         if (clientIsSeed && peerIsSeed)
         {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -3067,7 +3067,7 @@ static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* a
         mgr->session->bandwidth,
         &atom->addr,
         atom->port,
-        s->tor->info.hash,
+        s->tor->infoHash(),
         s->tor->completeness == TR_SEED,
         utp);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -349,17 +349,15 @@ static void peerCallbackFunc(tr_peer*, tr_peer_event const*, void*);
 
 static void rebuildWebseedArray(tr_swarm* s, tr_torrent* tor)
 {
-    tr_info const* inf = &tor->info;
-
     /* clear the array */
     tr_ptrArrayDestruct(&s->webseeds, [](void* peer) { delete static_cast<tr_peer*>(peer); });
     s->webseeds = {};
     s->stats.activeWebseedCount = 0;
 
     /* repopulate it */
-    for (unsigned int i = 0; i < inf->webseedCount; ++i)
+    for (size_t i = 0, n = tor->webseedCount(); i < n; ++i)
     {
-        tr_peer* w = tr_webseedNew(tor, inf->webseeds[i], peerCallbackFunc, s);
+        auto* const w = tr_webseedNew(tor, tor->webseed(i), peerCallbackFunc, s);
         tr_ptrArrayAppend(&s->webseeds, w);
     }
 }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1059,9 +1059,10 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     // It also adds "metadata_size" to the handshake message (not the
     // "m" dictionary) specifying an integer value of the number of
     // bytes of the metadata.
-    if (allow_metadata_xfer && msgs->torrent->hasMetadata() && msgs->torrent->infoDictLength > 0)
+    auto const info_dict_length = msgs->torrent->infoDictLength();
+    if (allow_metadata_xfer && msgs->torrent->hasMetadata() && info_dict_length > 0)
     {
-        tr_variantDictAddInt(&val, TR_KEY_metadata_size, msgs->torrent->infoDictLength);
+        tr_variantDictAddInt(&val, TR_KEY_metadata_size, info_dict_length);
     }
 
     // http://bittorrent.org/beps/bep_0010.html
@@ -2150,7 +2151,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             tr_variantInitDict(&tmp, 3);
             tr_variantDictAddInt(&tmp, TR_KEY_msg_type, METADATA_MSG_TYPE_DATA);
             tr_variantDictAddInt(&tmp, TR_KEY_piece, piece);
-            tr_variantDictAddInt(&tmp, TR_KEY_total_size, msgs->torrent->infoDictLength);
+            tr_variantDictAddInt(&tmp, TR_KEY_total_size, msgs->torrent->infoDictLength());
             evbuffer* const payload = tr_variantToBuf(&tmp, TR_VARIANT_FMT_BENC);
 
             /* write it out as a LTEP message to our outMessages buffer */

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -38,7 +38,12 @@ constexpr int MAX_REMEMBERED_PEERS = 200;
 
 static std::string getResumeFilename(tr_torrent const* tor, enum tr_metainfo_basename_format format)
 {
-    return tr_buildTorrentFilename(tr_getResumeDir(tor->session), tr_torrentName(tor), tor->hashString(), format, ".resume"sv);
+    return tr_buildTorrentFilename(
+        tr_getResumeDir(tor->session),
+        tr_torrentName(tor),
+        tor->infoHashString(),
+        format,
+        ".resume"sv);
 }
 
 /***
@@ -383,11 +388,7 @@ static uint64_t loadName(tr_variant* dict, tr_torrent* tor)
         return 0;
     }
 
-    if (name != tr_torrentName(tor))
-    {
-        tr_free(tor->info.name);
-        tor->info.name = tr_strvDup(name);
-    }
+    tor->setName(name);
 
     return TR_FR_NAME;
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -574,7 +574,7 @@ static void initField(
         break;
 
     case TR_KEY_hashString:
-        tr_variantInitStrView(initme, tor->hashString());
+        tr_variantInitStrView(initme, tor->infoHashString());
         break;
 
     case TR_KEY_haveUnchecked:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2834,12 +2834,12 @@ void tr_sessionAddTorrent(tr_session* session, tr_torrent* tor)
 {
     session->torrents.insert(tor);
     session->torrentsById.insert_or_assign(tor->uniqueId, tor);
-    session->torrentsByHash.insert_or_assign(tor->info.hash, tor);
+    session->torrentsByHash.insert_or_assign(tor->infoHash(), tor);
 }
 
 void tr_sessionRemoveTorrent(tr_session* session, tr_torrent* tor)
 {
     session->torrents.erase(tor);
     session->torrentsById.erase(tor->uniqueId);
-    session->torrentsByHash.erase(tor->info.hash);
+    session->torrentsByHash.erase(tor->infoHash());
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -166,7 +166,8 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
     {
         ensureInfoDictOffsetIsCached(tor);
 
-        TR_ASSERT(tor->infoDictLength > 0);
+        auto const info_dict_length = tor->infoDictLength();
+        TR_ASSERT(info_dict_length > 0);
 
         auto const fd = tr_sys_file_open(tor->torrentFile(), TR_SYS_FILE_READ, 0, nullptr);
         if (fd != TR_BAD_SYS_FILE)
@@ -175,7 +176,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent* tor, int piece, size_t* len)
 
             if (tr_sys_file_seek(fd, tor->infoDictOffset + o, TR_SEEK_SET, nullptr, nullptr))
             {
-                size_t const l = o + METADATA_PIECE_SIZE <= tor->infoDictLength ? METADATA_PIECE_SIZE : tor->infoDictLength - o;
+                size_t const l = o + METADATA_PIECE_SIZE <= info_dict_length ? METADATA_PIECE_SIZE : info_dict_length - o;
 
                 if (0 < l && l <= METADATA_PIECE_SIZE)
                 {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -273,7 +273,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
         /* we've got a complete set of metainfo... see if it passes the checksum test */
         dbgmsg(tor, "metainfo piece %d was the last one", piece);
         auto const sha1 = tr_sha1(std::string_view{ m->metadata, m->metadata_size });
-        bool const checksum_passed = sha1 && *sha1 == tor->info.hash;
+        bool const checksum_passed = sha1 && *sha1 == tor->infoHash();
         if (checksum_passed)
         {
             /* checksum passed; now try to parse it as benc */

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -3177,7 +3177,7 @@ void tr_torrent::swapMetainfo(tr_metainfo_parsed& parsed)
 {
     std::swap(this->info, parsed.info);
     std::swap(this->piece_checksums_, parsed.pieces);
-    std::swap(this->infoDictLength, parsed.info_dict_length);
+    std::swap(this->info_dict_length, parsed.info_dict_length);
 }
 
 void tr_torrentSetFilePriorities(

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -552,7 +552,7 @@ static void torrentInitFromInfoDict(tr_torrent* tor)
 {
     tor->initSizes(tor->totalSize(), tor->pieceSize());
     tor->completion = tr_completion{ tor, tor };
-    auto const obfuscated = tr_sha1("req2"sv, tor->info.hash);
+    auto const obfuscated = tr_sha1("req2"sv, tor->infoHash());
     if (obfuscated)
     {
         tor->obfuscated_hash = *obfuscated;
@@ -1229,8 +1229,8 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     TR_ASSERT(tr_isTorrent(tor));
 
     auto ret = tr_torrent_view{};
-    ret.name = tor->info.name;
-    ret.hash_string = tor->hashString();
+    ret.name = tr_torrentName(tor);
+    ret.hash_string = tor->infoHashString();
     ret.torrent_filename = tor->torrentFile();
     ret.comment = tor->info.comment;
     ret.creator = tor->info.creator;
@@ -1818,7 +1818,7 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
         { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
         { "TR_TIME_LOCALTIME"sv, ctime_str },
         { "TR_TORRENT_DIR"sv, torrent_dir.c_str() },
-        { "TR_TORRENT_HASH"sv, tor->hashString() },
+        { "TR_TORRENT_HASH"sv, tor->infoHashString() },
         { "TR_TORRENT_ID"sv, id_str },
         { "TR_TORRENT_LABELS"sv, labels_str },
         { "TR_TORRENT_NAME"sv, tr_torrentName(tor) },
@@ -3115,8 +3115,7 @@ static void torrentRenamePath(void* vdata)
                 /* update tr_info.name if user changed the toplevel */
                 if (n == tor->fileCount() && strchr(oldpath, '/') == nullptr)
                 {
-                    tr_free(tor->info.name);
-                    tor->info.name = tr_strdup(newname);
+                    tor->setName(newname);
                 }
 
                 tor->markEdited();
@@ -3214,4 +3213,15 @@ void tr_torrent::setDateActive(time_t t)
 void tr_torrent::setBlocks(tr_bitfield blocks)
 {
     this->completion.setBlocks(std::move(blocks));
+}
+
+void tr_torrent::setName(std::string_view name)
+{
+    if (name == this->info.name)
+    {
+        return;
+    }
+
+    tr_free(this->info.name);
+    this->info.name = tr_strvDup(name);
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -390,7 +390,9 @@ public:
 
     /// METAINFO - OTHER
 
-    [[nodiscard]] auto const& hash() const
+    void setName(std::string_view name);
+
+    [[nodiscard]] auto const& infoHash() const
     {
         return this->info.hash;
     }
@@ -425,7 +427,7 @@ public:
         return this->info.totalSize;
     }
 
-    [[nodiscard]] auto hashString() const
+    [[nodiscard]] auto infoHashString() const
     {
         return this->info.hashString;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -452,6 +452,11 @@ public:
         return fileCount() > 0;
     }
 
+    [[nodiscard]] auto infoDictLength() const
+    {
+        return this->info_dict_length;
+    }
+
     /// METAINFO - CHECKSUMS
 
     [[nodiscard]] bool ensurePieceIsChecked(tr_piece_index_t piece)
@@ -605,7 +610,7 @@ public:
     tr_interned_string current_dir;
 
     /* Length, in bytes, of the "info" dict in the .torrent file. */
-    uint64_t infoDictLength = 0;
+    uint64_t info_dict_length = 0;
 
     /* Offset, in bytes, of the beginning of the "info" dict in the .torrent file.
      *

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -690,7 +690,7 @@ static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
         return AnnounceResult::FAILED;
     }
 
-    auto const* dht_hash = reinterpret_cast<unsigned char const*>(std::data(tor->info.hash));
+    auto const* dht_hash = reinterpret_cast<unsigned char const*>(std::data(tor->infoHash()));
     int const rc = dht_search(dht_hash, announce ? tr_sessionGetPeerPort(session_) : 0, af, callback, nullptr);
     if (rc < 0)
     {

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -152,12 +152,10 @@ TEST_F(RenameTest, singleFilenameTorrent)
         "OmhlbGxvLXdvcmxkLnR4dDEyOnBpZWNlIGxlbmd0aGkzMjc2OGU2OnBpZWNlczIwOukboJcrkFUY"
         "f6LvqLXBVvSHqCk6Nzpwcml2YXRlaTBlZWU=");
     EXPECT_TRUE(tr_isTorrent(tor));
-    auto const& files = tor->info.files;
 
     // sanity check the info
     EXPECT_EQ(tr_file_index_t{ 1 }, tor->fileCount());
-    EXPECT_STREQ("hello-world.txt", files[0].name);
-    EXPECT_FALSE(files[0].priv.is_renamed);
+    EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
 
     // sanity check the (empty) stats
     blockingTorrentVerify(tor);
@@ -189,9 +187,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "hello-world.txt", ".."));
     EXPECT_EQ(0, torrentRenameAndWait(tor, "hello-world.txt", "hello-world.txt"));
     EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "hello-world.txt", "hello/world.txt"));
-
-    EXPECT_FALSE(files[0].priv.is_renamed);
-    EXPECT_STREQ("hello-world.txt", files[0].name);
+    EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
 
     /***
     ****  Now try a rename that should succeed
@@ -202,9 +198,8 @@ TEST_F(RenameTest, singleFilenameTorrent)
     EXPECT_STREQ("hello-world.txt", tr_torrentName(tor));
     EXPECT_EQ(0, torrentRenameAndWait(tor, tr_torrentName(tor), "foobar"));
     EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the old filename can't be found
-    EXPECT_TRUE(files[0].priv.is_renamed); // confirm the file's 'renamed' flag is set
     EXPECT_STREQ("foobar", tr_torrentName(tor)); // confirm the torrent's name is now 'foobar'
-    EXPECT_STREQ("foobar", files[0].name); // confirm the file's name is now 'foobar' in our struct
+    EXPECT_STREQ("foobar", tr_torrentFile(tor, 0).name); // confirm the file's name is now 'foobar'
     EXPECT_STREQ(nullptr, strstr(tr_torrentView(tor).torrent_filename, "foobar")); // confirm .torrent file hasn't changed
     tmpstr = tr_strvPath(tor->currentDir().sv(), "foobar");
     EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the file's name is now 'foobar' on the disk
@@ -225,9 +220,8 @@ TEST_F(RenameTest, singleFilenameTorrent)
     EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
     EXPECT_EQ(0, torrentRenameAndWait(tor, "foobar", "hello-world.txt"));
     EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
-    EXPECT_TRUE(files[0].priv.is_renamed);
-    EXPECT_STREQ("hello-world.txt", files[0].name);
     EXPECT_STREQ("hello-world.txt", tr_torrentName(tor));
+    EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 0, "hello, world!\n"));
 
     // cleanup


### PR DESCRIPTION
The `tr_info` struct is going away, but `tr_torrent` currently aggregates it.

Loosen coupling between the two by adding accessor methods to `tr_torrent`. Client code can call the accessors instead of using `tor->info` directly, making it easier to swap `tr_info` out with replacement code.