### PR TITLE
refactor: change tr torrent new() args

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -236,7 +236,6 @@ int tr_main(int argc, char* argv[])
 {
     tr_session* h;
     tr_ctor* ctor;
-    tr_torrent* tor = nullptr;
     tr_variant settings;
     char const* configDir;
 
@@ -327,9 +326,8 @@ int tr_main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    tor = tr_torrentNew(ctor, nullptr, nullptr);
+    tr_torrent* tor = tr_torrentNew(ctor, nullptr);
     tr_ctorFree(ctor);
-
     if (tor == nullptr)
     {
         fprintf(stderr, "Failed opening torrent file `%s'\n", torrentPath);

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -233,11 +233,9 @@ static tr_watchdir_status onFileAdded(tr_watchdir_t dir, char const* name, void*
 
     if (err == 0)
     {
-        tr_torrentNew(ctor, &err, nullptr);
-
-        if (err == TR_PARSE_ERR)
+        if (tr_torrentNew(ctor, nullptr) == nullptr)
         {
-            tr_logAddError("Error parsing .torrent file \"%s\"", name);
+            tr_logAddError("Unable to add .torrent file \"%s\"", name);
         }
         else
         {

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -188,10 +188,7 @@ void OptionsDialog::Impl::sourceChanged(Gtk::FileChooserButton* b)
     /* maybe instantiate a torrent */
     if (!filename.empty() || tor_ == nullptr)
     {
-        int err = 0;
         bool new_file = false;
-        int duplicate_id = 0;
-        tr_torrent* torrent;
 
         if (!filename.empty() && (filename_.empty() || !tr_sys_path_is_same(filename.c_str(), filename_.c_str(), nullptr)))
         {
@@ -204,15 +201,15 @@ void OptionsDialog::Impl::sourceChanged(Gtk::FileChooserButton* b)
         tr_ctorSetPaused(ctor_.get(), TR_FORCE, true);
         tr_ctorSetDeleteSource(ctor_.get(), false);
 
-        if (torrent = tr_torrentNew(ctor_.get(), &err, &duplicate_id); torrent != nullptr)
+        tr_torrent* duplicate_of = nullptr;
+        if (tr_torrent* const torrent = tr_torrentNew(ctor_.get(), &duplicate_of); torrent != nullptr)
         {
             removeOldTorrent();
             tor_ = torrent;
         }
         else if (new_file)
         {
-            tr_torrent* tor = duplicate_id != 0 ? core_->find_torrent(duplicate_id) : nullptr;
-            gtr_add_torrent_error_dialog(*b, err, tor, filename_);
+            gtr_add_torrent_error_dialog(*b, duplicate_of, filename_);
         }
 
         updateTorrent();

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1016,7 +1016,7 @@ tr_torrent* Session::Impl::create_new_torrent(tr_ctor* ctor)
      * doesn't have any concept of the glib trash API */
     tr_ctorGetDeleteSource(ctor, &do_trash);
     tr_ctorSetDeleteSource(ctor, false);
-    tr_torrent* const tor = tr_torrentNew(ctor, nullptr, nullptr);
+    tr_torrent* const tor = tr_torrentNew(ctor, nullptr);
 
     if (tor != nullptr && do_trash)
     {

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -219,16 +219,12 @@ Gtk::Window* getWindow(Gtk::Widget* w)
 
 } // namespace
 
-void gtr_add_torrent_error_dialog(Gtk::Widget& child, int err, tr_torrent* duplicate_torrent, std::string const& filename)
+void gtr_add_torrent_error_dialog(Gtk::Widget& child, tr_torrent* duplicate_torrent, std::string const& filename)
 {
     Glib::ustring secondary;
     auto* win = getWindow(&child);
 
-    if (err == TR_PARSE_ERR)
-    {
-        secondary = gtr_sprintf(_("The torrent file \"%s\" contains invalid data."), filename);
-    }
-    else if (err == TR_PARSE_DUPLICATE)
+    if (duplicate_torrent != nullptr)
     {
         secondary = gtr_sprintf(
             _("The torrent file \"%s\" is already in use by \"%s.\""),
@@ -237,7 +233,7 @@ void gtr_add_torrent_error_dialog(Gtk::Widget& child, int err, tr_torrent* dupli
     }
     else
     {
-        secondary = gtr_sprintf(_("The torrent file \"%s\" encountered an unknown error."), filename);
+        secondary = gtr_sprintf(_("Unable to add torrent file \"%s\"."), filename);
     }
 
     auto w = std::make_shared<Gtk::MessageDialog>(

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -107,11 +107,7 @@ void gtr_combo_box_set_active_enum(Gtk::ComboBox&, int value);
 
 void gtr_unrecognized_url_dialog(Gtk::Widget& parent, Glib::ustring const& url);
 
-void gtr_add_torrent_error_dialog(
-    Gtk::Widget& window_or_child,
-    int err,
-    tr_torrent* duplicate_torrent,
-    std::string const& filename);
+void gtr_add_torrent_error_dialog(Gtk::Widget& window_or_child, tr_torrent* duplicate_torrent, std::string const& filename);
 
 /* pop up the context menu if a user right-clicks.
    if the row they right-click on isn't selected, select it. */

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1506,21 +1506,20 @@ static char const* blocklistUpdate(
 
 static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
 {
-    auto err = int{};
-    auto duplicate_id = int{};
-    tr_torrent* tor = tr_torrentNew(ctor, &err, &duplicate_id);
+    tr_torrent* duplicate_of = nullptr;
+    tr_torrent* tor = tr_torrentNew(ctor, &duplicate_of);
     tr_ctorFree(ctor);
 
     auto key = tr_quark{};
     char const* result = "invalid or corrupt torrent file";
-    if (err == 0)
+    if (tor != nullptr)
     {
         key = TR_KEY_torrent_added;
         result = nullptr;
     }
-    else if (err == TR_PARSE_DUPLICATE)
+    else if (duplicate_of != nullptr)
     {
-        tor = tr_torrentFindFromId(data->session, duplicate_id);
+        tor = duplicate_of;
         key = TR_KEY_torrent_duplicate;
         result = "duplicate torrent";
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2044,8 +2044,7 @@ static void sessionLoadTorrents(void* vdata)
                 tr_buildBuf(path, dirname_sv, "/", name);
                 tr_ctorSetMetainfoFromFile(data->ctor, path.c_str());
 
-                tr_torrent* const tor = tr_torrentNew(data->ctor, nullptr, nullptr);
-                if (tor != nullptr)
+                if (tr_torrent* const tor = tr_torrentNew(data->ctor, nullptr); tor != nullptr)
                 {
                     torrents.push_back(tor);
                 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -788,7 +788,7 @@ tr_parse_result tr_torrentParse(tr_ctor const* ctor, tr_info* setmeInfo)
     return TR_PARSE_OK;
 }
 
-tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_duplicate_id)
+tr_torrent* tr_torrentNew(tr_ctor const* ctor, tr_torrent** setme_duplicate_of)
 {
     TR_ASSERT(ctor != nullptr);
     auto* const session = tr_ctorGetSession(ctor);
@@ -799,25 +799,15 @@ tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_dupl
     auto parsed = tr_metainfoParse(session, metainfo, nullptr);
     if (!parsed)
     {
-        if (setme_error != nullptr)
-        {
-            *setme_error = TR_PARSE_ERR;
-        }
-
         return nullptr;
     }
 
-    tr_torrent const* const dupe = session->getTorrent(parsed->info.hash);
-    if (dupe != nullptr)
+    auto* const duplicate_of = session->getTorrent(parsed->info.hash);
+    if (duplicate_of != nullptr)
     {
-        if (setme_duplicate_id != nullptr)
+        if (setme_duplicate_of != nullptr)
         {
-            *setme_duplicate_id = tr_torrentId(dupe);
-        }
-
-        if (setme_error != nullptr)
-        {
-            *setme_error = TR_PARSE_DUPLICATE;
+            *setme_duplicate_of = duplicate_of;
         }
 
         return nullptr;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -953,13 +953,10 @@ void tr_metainfoFree(tr_info* inf);
  * Returns a pointer to the torrent on success, or nullptr on failure.
  *
  * @param ctor               the builder struct
- * @param setme_error        TR_PARSE_ERR if the parsing failed.
- *                           TR_PARSE_OK if parsing succeeded and it's not a duplicate.
- *                           TR_PARSE_DUPLICATE if parsing succeeded but it's a duplicate.
- * @param setme_duplicate_id when setmeError is TR_PARSE_DUPLICATE,
- *                           this field is set to the duplicate torrent's id.
+ * @param setme_duplicate_of If the torrent couldn't be created because it's a duplicate,
+ *                           this is set to point to the original torrent.
  */
-tr_torrent* tr_torrentNew(tr_ctor const* ctor, int* setme_error, int* setme_duplicate_id);
+tr_torrent* tr_torrentNew(tr_ctor const* ctor, tr_torrent** setme_duplicate_of);
 
 /** @} */
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1862,7 +1862,7 @@ bool trashDataFile(char const* filename, tr_error** error)
 
         if (result == TR_PARSE_OK)
         {
-            fHandle = tr_torrentNew(ctor, NULL, NULL);
+            fHandle = tr_torrentNew(ctor, NULL);
         }
 
         tr_ctorFree(ctor);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -77,9 +77,8 @@ protected:
         tr_ctorSetPaused(ctor, TR_FORCE, true);
 
         // create the torrent
-        auto err = int{};
-        auto* tor = tr_torrentNew(ctor, &err, nullptr);
-        EXPECT_EQ(0, err);
+        auto* const tor = tr_torrentNew(ctor, nullptr);
+        EXPECT_NE(nullptr, tor);
 
         // cleanup
         tr_free(metainfo);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -384,9 +384,8 @@ protected:
         tr_free(metainfo);
 
         // create the torrent
-        auto err = int{};
-        auto* tor = tr_torrentNew(ctor, &err, nullptr);
-        EXPECT_EQ(0, err);
+        auto* const tor = tr_torrentNew(ctor, nullptr);
+        EXPECT_NE(nullptr, tor);
 
         // cleanup
         tr_ctorFree(ctor);


### PR DESCRIPTION
If the torrent couldn't be created because it's a duplicate, provide a way to get the pointer to the original torrent.