### PR TITLE
fix: exit time dtor warnings

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1020,8 +1020,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
                 }
             }
 
-            auto const& warning = response->warning;
-            if (!std::empty(warning))
+            if (auto const& warning = response->warning; !std::empty(warning))
             {
                 tr_strlcpy(tier->lastAnnounceStr, warning.c_str(), sizeof(tier->lastAnnounceStr));
                 dbgmsg(tier, "tracker gave \"%s\"", warning.c_str());

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -96,7 +96,7 @@ public:
         return std::rend(this->sv());
     }
 
-    [[nodiscard]] int compare(tr_interned_string const& that) const // <=>
+    [[nodiscard]] auto compare(tr_interned_string const& that) const // <=>
     {
         return this->quark() - that.quark();
     }

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -227,13 +227,13 @@ QIcon IconCache::getThemeIcon(
     QString const& fallbackName,
     std::optional<QStyle::StandardPixmap> const& fallbackPixmap) const
 {
-    static auto const RtlSuffix = qApp->layoutDirection() == Qt::RightToLeft ? QStringLiteral("-rtl") : QString();
+    auto const rtl_suffix = qApp->layoutDirection() == Qt::RightToLeft ? QStringLiteral("-rtl") : QString();
 
-    auto icon = QIcon::fromTheme(name + RtlSuffix);
+    auto icon = QIcon::fromTheme(name + rtl_suffix);
 
     if (icon.isNull())
     {
-        icon = QIcon::fromTheme(fallbackName + RtlSuffix);
+        icon = QIcon::fromTheme(fallbackName + rtl_suffix);
     }
 
     if (icon.isNull() && fallbackPixmap.has_value())

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -556,7 +556,7 @@ static int getOptMode(int val)
 static bool debug = false;
 static char* auth = nullptr;
 static char* netrc = nullptr;
-static std::string session_id;
+static char* session_id = nullptr;
 static bool UseSSL = false;
 
 static char* getEncodedMetainfo(char const* filename)
@@ -810,7 +810,7 @@ static size_t parseResponseHeader(void* ptr, size_t size, size_t nmemb, void* /*
             ++end;
         }
 
-        session_id.assign(begin, end);
+        session_id = tr_strvDup(std::string_view{ begin, size_t(end - begin) });
     }
 
     return line_len;
@@ -2166,7 +2166,7 @@ static CURL* tr_curl_easy_init(struct evbuffer* writebuf)
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0); /* since most certs will be self-signed, do not verify against CA */
     }
 
-    if (!std::empty(session_id))
+    if (!tr_str_is_empty(session_id))
     {
         auto const h = tr_strvJoin(TR_RPC_SESSION_ID_HEADER, ": "sv, session_id);
         auto* const custom_headers = curl_slist_append(nullptr, h.c_str());


### PR DESCRIPTION
fix a pair of exit-time-dtor warnings in the Qt client and transmission-remote.