### PR TITLE
refactor: use tr_torrent_metainfo in transmission-show

### DIFF
--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#ifndef __TRANSMISSION__
-#error only libtransmission should #include this header.
-#endif
-
 #include "transmission.h"
 
 struct tr_block_info

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#ifndef __TRANSMISSION__
-#error only libtransmission should #include this header.
-#endif
-
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
Replace `tr_info` with `tr_torrent_metainfo` in the `transmission-show` utility.