### PR TITLE
refactor: use tr_torrent_metainfo in transmission-qt

### DIFF
--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -12,7 +12,9 @@
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/crypto-utils.h> // tr_base64_encode()
+#include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/utils.h>
+#include <libtransmission/error.h>
 
 #include "AddData.h"
 #include "Utils.h"
@@ -20,22 +22,16 @@
 namespace
 {
 
-QString getNameFromMetainfo(QByteArray const& metainfo)
+QString getNameFromMetainfo(QByteArray const& benc)
 {
-    QString name;
-
-    tr_ctor* ctor = tr_ctorNew(nullptr);
-    tr_ctorSetMetainfo(ctor, metainfo.constData(), metainfo.size());
-
-    auto inf = tr_info{};
-    if (tr_torrentParse(ctor, &inf) == TR_PARSE_OK)
+    auto metainfo = tr_torrent_metainfo{};
+    if (metainfo.parseBenc({ benc.constData(), size_t(benc.size()) }))
     {
-        name = QString::fromUtf8(inf.name); // metainfo is required to be UTF-8
-        tr_metainfoFree(&inf);
+        auto const& mname = metainfo.name();
+        return QString::fromUtf8(std::data(mname), std::size(mname));
     }
 
-    tr_ctorFree(ctor);
-    return name;
+    return {};
 }
 
 } // namespace

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include <QDir>
@@ -22,6 +23,10 @@
 #include "BaseDialog.h"
 #include "Torrent.h" // FileList
 #include "ui_OptionsDialog.h"
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/torrent-metainfo.h>
 
 class Prefs;
 class Session;
@@ -66,7 +71,6 @@ private:
     std::vector<int> priorities_;
     Session& session_;
     Ui::OptionsDialog ui_ = {};
-    tr_info info_ = {};
-    bool have_info_ = {};
+    std::optional<tr_torrent_metainfo> metainfo_;
     bool is_local_ = {};
 };

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -117,6 +117,11 @@ public:
     {
     }
 
+    explicit TorrentHash(tr_sha1_digest_t const& data)
+        : data_{ data }
+    {
+    }
+
     explicit TorrentHash(char const* str)
     {
         data_ = tr_sha1_from_string(str != nullptr ? str : "");

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -12,6 +12,8 @@
 
 #include <libtransmission/transmission.h>
 
+#include <libtransmission/torrent-metainfo.h>
+
 #include "Prefs.h"
 #include "TorrentModel.h"
 #include "WatchDir.h"
@@ -31,35 +33,18 @@ WatchDir::WatchDir(TorrentModel const& model)
 
 int WatchDir::metainfoTest(QString const& filename) const
 {
-    int ret;
-    auto inf = tr_info{};
-    tr_ctor* ctor = tr_ctorNew(nullptr);
-
-    // parse
-    tr_ctorSetMetainfoFromFile(ctor, filename.toUtf8().constData());
-    int const err = tr_torrentParse(ctor, &inf);
-
-    if (err != 0)
+    auto metainfo = tr_torrent_metainfo();
+    if (!metainfo.parseTorrentFile(filename.toUtf8().constData()))
     {
-        ret = ERROR;
-    }
-    else if (model_.hasTorrent(TorrentHash(inf.hashString)))
-    {
-        ret = DUPLICATE;
-    }
-    else
-    {
-        ret = OK;
+        return ERROR;
     }
 
-    // cleanup
-    if (err == 0)
+    if (model_.hasTorrent(TorrentHash{ metainfo.infoHash() }))
     {
-        tr_metainfoFree(&inf);
+        return DUPLICATE;
     }
 
-    tr_ctorFree(ctor);
-    return ret;
+    return OK;
 }
 
 void WatchDir::onTimeout()


### PR DESCRIPTION
Replace `tr_info` with `tr_torrent_metainfo` in the `transmission-qt` app.