### PR TITLE
refactor: remove tr_file.offset

### DIFF
--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -128,6 +128,8 @@ struct tr_completion
         size_when_done_.reset();
     }
 
+    [[nodiscard]] uint64_t countHasBytesInSpan(tr_byte_span_t) const;
+
 private:
     [[nodiscard]] constexpr bool hasMetainfo() const
     {
@@ -136,7 +138,7 @@ private:
 
     [[nodiscard]] uint64_t computeHasValid() const;
     [[nodiscard]] uint64_t computeSizeWhenDone() const;
-    [[nodiscard]] uint64_t countHasBytesInSpan(tr_block_span_t) const;
+    [[nodiscard]] uint64_t countHasBytesInBlocks(tr_block_span_t) const;
 
     torrent_view const* tor_;
     tr_block_info const* block_info_;

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -63,8 +63,15 @@ public:
         return std::size(file_pieces_);
     }
 
+    // TODO(ckerr) minor wart here, two identical span types
+    [[nodiscard]] tr_byte_span_t byteSpan(tr_file_index_t file) const
+    {
+        auto const& span = file_bytes_.at(file);
+        return tr_byte_span_t{ span.begin, span.end };
+    }
+
 private:
-    using byte_span_t = index_span_t<tr_byte_index_t>;
+    using byte_span_t = index_span_t<uint64_t>;
     std::vector<byte_span_t> file_bytes_;
 
     std::vector<piece_span_t> file_pieces_;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1118,47 +1118,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 static uint64_t countFileBytesCompleted(tr_torrent const* tor, tr_file_index_t index)
 {
     tr_file const& f = tor->file(index);
-    if (f.length == 0)
-    {
-        return 0;
-    }
-
-    auto const [begin, end] = tr_torGetFileBlockSpan(tor, index);
-    auto const n = end - begin;
-
-    if (n == 0)
-    {
-        return 0;
-    }
-
-    if (n == 1)
-    {
-        return tor->hasBlock(begin) ? f.length : 0;
-    }
-
-    auto total = uint64_t{};
-
-    // the first block
-    if (tor->hasBlock(begin))
-    {
-        total += tor->block_size - f.priv.offset % tor->block_size;
-    }
-
-    // the middle blocks
-    if (end - begin > 2)
-    {
-        uint64_t u = tor->completion.blocks().count(begin + 1, end - 1);
-        u *= tor->block_size;
-        total += u;
-    }
-
-    // the last block
-    if (tor->hasBlock(end - 1))
-    {
-        total += f.priv.offset + f.length - (uint64_t)tor->block_size * (end - 1);
-    }
-
-    return total;
+    return tor->completion.countHasBytesInBytes({ f.offset, f.offset + f.length });
 }
 
 tr_file_view tr_torrentFile(tr_torrent const* torrent, tr_file_index_t i)

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -46,6 +46,12 @@ struct tr_block_span_t
     tr_block_index_t end;
 };
 
+struct tr_byte_span_t
+{
+    uint64_t begin;
+    uint64_t end;
+};
+
 struct tr_ctor;
 struct tr_error;
 struct tr_file;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1501,7 +1501,6 @@ void tr_torrentVerify(tr_torrent* torrent, tr_verify_done_func callback_func_or_
 
 struct tr_file_priv
 {
-    uint64_t offset; // file begins at the torrent's nth byte
     time_t mtime;
     bool is_renamed; // true if we're using a different path from the one in the metainfo; ie, if the user has renamed it */
 };


### PR DESCRIPTION
A quick side-trip in the `tr_metainfo` refactor to continue hollowing out `tr_info` before its removal.

This PR removes `tr_file.priv.offset` and adds a public `tr_completion.getHasBytesInSpan()` function that works on a span of bytes rather than a span of blocks. Tests are added for `tr_completion.getHasBytesInSpan()`.