### PR TITLE
refactor: use std::string in tr_variantToStr()

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -857,9 +857,8 @@ static bool init_daemon_data(int argc, char* argv[], struct daemon_data* data, b
 
     if (dumpSettings)
     {
-        char* str = tr_variantToStr(&data->settings, TR_VARIANT_FMT_JSON, nullptr);
-        fprintf(stderr, "%s", str);
-        tr_free(str);
+        auto const str = tr_variantToStr(&data->settings, TR_VARIANT_FMT_JSON);
+        fprintf(stderr, "%s", str.c_str());
         goto EXIT_EARLY;
     }
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -450,11 +450,9 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, int torre
                 }
                 else
                 {
-                    char* a = tr_variantToStr(oldval, TR_VARIANT_FMT_BENC, nullptr);
-                    char* b = tr_variantToStr(newval, TR_VARIANT_FMT_BENC, nullptr);
-                    changed = g_strcmp0(a, b) != 0;
-                    tr_free(b);
-                    tr_free(a);
+                    auto const a = tr_variantToStr(oldval, TR_VARIANT_FMT_BENC);
+                    auto const b = tr_variantToStr(newval, TR_VARIANT_FMT_BENC);
+                    changed = a != b;
                 }
 
                 if (changed)

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -250,10 +250,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
     }
 
     // save it
-    auto contents_len = size_t{};
-    auto* const contents = tr_variantToStr(&metainfo, TR_VARIANT_FMT_BENC, &contents_len);
+    auto const contents = tr_variantToStr(&metainfo, TR_VARIANT_FMT_BENC);
     tr_variantFree(&metainfo);
-    auto const success = tr_saveFile(torrent_file, { contents, contents_len }, error);
-    tr_free(contents);
-    return success;
+    return tr_saveFile(torrent_file, contents, error);
 }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -649,9 +649,8 @@ static void dbgmsg_tier_announce_queue(tr_tier const* tier)
             evbuffer_add_printf(buf, "[%d:%s]", i, str);
         }
 
-        char* const message = evbuffer_free_to_str(buf, nullptr);
-        tr_logAddDeep(__FILE__, __LINE__, name, "announce queue is %s", message);
-        tr_free(message);
+        auto const message = evbuffer_free_to_str(buf);
+        tr_logAddDeep(__FILE__, __LINE__, name, "announce queue is %" TR_PRIsv, TR_PRIsv_ARG(message));
     }
 }
 

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -81,12 +81,11 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
     return ret;
 }
 
-bool tr_sys_file_write_line(tr_sys_file_t handle, char const* buffer, tr_error** error)
+bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(buffer != nullptr);
 
-    bool ret = tr_sys_file_write(handle, buffer, strlen(buffer), nullptr, error);
+    bool ret = tr_sys_file_write(handle, std::data(buffer), std::size(buffer), nullptr, error);
 
     if (ret)
     {

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -578,13 +578,13 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
  * should already be in UTF-8 encoding, or whichever else you expect.
  *
  * @param[in]  handle Valid file descriptor.
- * @param[in]  buffer Zero-terminated string to write.
+ * @param[in]  buffer String to write.
  * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
  *                    are not interested in error details.
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_write_line(tr_sys_file_t handle, char const* buffer, struct tr_error** error);
+bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, struct tr_error** error);
 
 /**
  * @brief Portability wrapper for `fprintf()`.

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -177,7 +177,7 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
         auto const message = evbuffer_free_to_str(buf);
 
 #ifdef _WIN32
-        OutputDebugStringA(message);
+        OutputDebugStringA(message.c(str());
 #endif
 
         if (fp != TR_BAD_SYS_FILE)

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -174,8 +174,7 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
         va_end(args);
         evbuffer_add_printf(buf, " (%s:%d)" TR_NATIVE_EOL_STR, base, line);
 
-        size_t message_len = 0;
-        char* const message = evbuffer_free_to_str(buf, &message_len);
+        auto const message = evbuffer_free_to_str(buf);
 
 #ifdef _WIN32
         OutputDebugStringA(message);
@@ -183,10 +182,9 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
 
         if (fp != TR_BAD_SYS_FILE)
         {
-            tr_sys_file_write(fp, message, message_len, nullptr, nullptr);
+            tr_sys_file_write(fp, std::data(message), std::size(message), nullptr, nullptr);
         }
 
-        tr_free(message);
         tr_free(base);
     }
 }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -177,7 +177,7 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
         auto const message = evbuffer_free_to_str(buf);
 
 #ifdef _WIN32
-        OutputDebugStringA(message.c(str());
+        OutputDebugStringA(message.c_str());
 #endif
 
         if (fp != TR_BAD_SYS_FILE)

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -387,11 +387,8 @@ static char const* tr_metainfoParseImpl(
     }
     else
     {
-        size_t blen = 0;
-        char* bstr = tr_variantToStr(infoDict, TR_VARIANT_FMT_BENC, &blen);
-        auto const hash = tr_sha1(std::string_view{ bstr, blen });
-        tr_free(bstr);
-
+        auto const benc = tr_variantToStr(infoDict, TR_VARIANT_FMT_BENC);
+        auto const hash = tr_sha1(benc);
         if (!hash)
         {
             return "hash";
@@ -402,7 +399,7 @@ static char const* tr_metainfoParseImpl(
 
         if (infoDictLength != nullptr)
         {
-            *infoDictLength = blen;
+            *infoDictLength = std::size(benc);
         }
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -682,11 +682,10 @@ static void myDebug(char const* file, int line, tr_peerMsgsImpl const* msgs, cha
         va_end(args);
         evbuffer_add_printf(buf, " (%s:%d)", base, line);
 
-        char* const message = evbuffer_free_to_str(buf, nullptr);
+        auto const message = evbuffer_free_to_str(buf);
         tr_sys_file_write_line(fp, message, nullptr);
 
         tr_free(base);
-        tr_free(message);
     }
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -467,7 +467,17 @@ tr_disk_space tr_dirSpace(std::string_view dir)
 *****
 ****/
 
-char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len)
+std::string evbuffer_free_to_str(evbuffer* buf)
+{
+    auto const n = evbuffer_get_length(buf);
+    auto ret = std::string{};
+    ret.resize(n);
+    evbuffer_copyout(buf, std::data(ret), n);
+    evbuffer_free(buf);
+    return ret;
+}
+
+static char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len)
 {
     size_t const n = evbuffer_get_length(buf);
     auto* const ret = tr_new(char, n + 1);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -228,7 +228,7 @@ constexpr bool tr_str_is_empty(char const* value)
     return value == nullptr || *value == '\0';
 }
 
-char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len);
+std::string evbuffer_free_to_str(evbuffer* buf);
 
 /**
  * @brief sprintf() a string into a newly-allocated buffer large enough to hold it

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1200,20 +1200,18 @@ struct evbuffer* tr_variantToBuf(tr_variant const* v, tr_variant_fmt fmt)
     return buf;
 }
 
-char* tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt, size_t* len)
+std::string tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt)
 {
-    struct evbuffer* buf = tr_variantToBuf(v, fmt);
-    return evbuffer_free_to_str(buf, len);
+    return evbuffer_free_to_str(tr_variantToBuf(v, fmt));
 }
 
 int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view filename)
 {
     auto error_code = int{ 0 };
-    auto contents_len = size_t{};
-    auto* const contents = tr_variantToStr(v, fmt, &contents_len);
+    auto const contents = tr_variantToStr(v, fmt);
 
     tr_error* error = nullptr;
-    tr_saveFile(filename, { contents, contents_len }, &error);
+    tr_saveFile(filename, { std::data(contents), std::size(contents) }, &error);
     if (error != nullptr)
     {
         tr_logAddError(_("Error saving \"%" TR_PRIsv "\": %s (%d)"), TR_PRIsv_ARG(filename), error->message, error->code);
@@ -1221,7 +1219,6 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view f
         tr_error_clear(&error);
     }
 
-    tr_free(contents);
     return error_code;
 }
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -108,7 +108,7 @@ enum tr_variant_fmt
 
 int tr_variantToFile(tr_variant const* variant, tr_variant_fmt fmt, std::string_view filename);
 
-char* tr_variantToStr(tr_variant const* variant, tr_variant_fmt fmt, size_t* len);
+std::string tr_variantToStr(tr_variant const* variant, tr_variant_fmt fmt);
 
 struct evbuffer* tr_variantToBuf(tr_variant const* variant, tr_variant_fmt fmt);
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -144,11 +144,7 @@ void RpcClient::sendNetworkRequest(TrVariantPtr json, QFutureInterface<RpcRespon
         request_ = request;
     }
 
-    size_t raw_json_data_length;
-    auto* raw_json_data = tr_variantToStr(json.get(), TR_VARIANT_FMT_JSON_LEAN, &raw_json_data_length);
-    QByteArray json_data(raw_json_data, raw_json_data_length);
-    tr_free(raw_json_data);
-
+    auto const json_data = QByteArray::fromStdString(tr_variantToStr(json.get(), TR_VARIANT_FMT_JSON_LEAN));
     QNetworkReply* reply = networkAccessManager()->post(*request_, json_data);
     reply->setProperty(RequestDataPropertyKey, QVariant::fromValue(json));
     reply->setProperty(RequestFutureinterfacePropertyKey, QVariant::fromValue(promise));

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -85,7 +85,6 @@ TEST_P(JSONTest, testUtf8)
     auto in = "{ \"key\": \"Letöltések\" }"sv;
     tr_variant top;
     auto sv = std::string_view{};
-    char* json;
     tr_quark const key = tr_quark_new("key"sv);
 
     EXPECT_TRUE(tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, in));
@@ -114,19 +113,17 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON, nullptr);
+    auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON);
     tr_variantFree(&top);
 
-    EXPECT_NE(nullptr, json);
-    EXPECT_NE(nullptr, strstr(json, "\\u00f6"));
-    EXPECT_NE(nullptr, strstr(json, "\\u00e9"));
+    EXPECT_FALSE(std::empty(json));
+    EXPECT_NE(std::string::npos, json.find("\\u00f6"));
+    EXPECT_NE(std::string::npos, json.find("\\u00e9"));
     EXPECT_TRUE(tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, json));
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     tr_variantFree(&top);
-
-    tr_free(json);
 }
 
 TEST_P(JSONTest, test1)

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -229,12 +229,7 @@ TEST_F(VariantTest, parse)
     EXPECT_EQ(32, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&val, 2), &i));
     EXPECT_EQ(16, i);
-
-    auto len = size_t{};
-    auto* saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &len);
-    EXPECT_EQ(std::size(benc), len);
-    EXPECT_EQ(benc, saved);
-    tr_free(saved);
+    EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
     tr_variantFree(&val);
     end = nullptr;
@@ -248,10 +243,7 @@ TEST_F(VariantTest, parse)
     EXPECT_TRUE(tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end));
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
 
-    saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &len);
-    EXPECT_EQ(std::size(benc), len);
-    EXPECT_EQ(benc, saved);
-    tr_free(saved);
+    EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
     tr_variantFree(&val);
 }
 
@@ -284,10 +276,7 @@ TEST_F(VariantTest, bencParseAndReencode)
         if (is_good)
         {
             EXPECT_EQ(test.benc.data() + test.benc.size(), end);
-            auto saved_len = size_t{};
-            auto* saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &saved_len);
-            EXPECT_EQ(test.benc, std::string(saved, saved_len));
-            tr_free(saved);
+            EXPECT_EQ(test.benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
             tr_variantFree(&val);
         }
     }
@@ -303,12 +292,7 @@ TEST_F(VariantTest, bencSortWhenSerializing)
     auto const ok = tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, In, &end);
     EXPECT_TRUE(ok);
     EXPECT_EQ(std::data(In) + std::size(In), end);
-
-    auto len = size_t{};
-    auto* saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &len);
-    auto sv = std::string_view{ saved, len };
-    EXPECT_EQ(ExpectedOut, sv);
-    tr_free(saved);
+    EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
     tr_variantFree(&val);
 }
@@ -323,12 +307,7 @@ TEST_F(VariantTest, bencMalformedTooManyEndings)
     auto const ok = tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, In, &end);
     EXPECT_TRUE(ok);
     EXPECT_EQ(std::data(In) + std::size(ExpectedOut), end);
-
-    auto len = size_t{};
-    auto* saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &len);
-    auto sv = std::string_view{ saved, len };
-    EXPECT_EQ(ExpectedOut, sv);
-    tr_free(saved);
+    EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
     tr_variantFree(&val);
 }
@@ -369,10 +348,8 @@ TEST_F(VariantTest, bencToJson)
         tr_variant top;
         tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, test.benc);
 
-        auto len = size_t{};
-        auto* str = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN, &len);
-        EXPECT_EQ(test.expected, stripWhitespace(std::string(str, len)));
-        tr_free(str);
+        auto const str = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
+        EXPECT_EQ(test.expected, stripWhitespace(str));
         tr_variantFree(&top);
     }
 }
@@ -447,11 +424,7 @@ TEST_F(VariantTest, stackSmash)
     EXPECT_EQ(in.data() + in.size(), end);
 
     // confirm that we can serialize it back again
-    size_t len;
-    auto* saved = tr_variantToStr(&val, TR_VARIANT_FMT_BENC, &len);
-    EXPECT_NE(nullptr, saved);
-    EXPECT_EQ(in, std::string(saved, len));
-    tr_free(saved);
+    EXPECT_EQ(in, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
     tr_variantFree(&val);
 }


### PR DESCRIPTION
`tr_variantToStr()` now returns a `std::string`. Previously it was a C-style function that returned a `char*` and the length was obtained by passing in a pointer to a `size_t`.