### PR TITLE
refactor: avoid referencing tr_file struct directly

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -403,7 +403,7 @@ static void saveFilenames(tr_variant* dict, tr_torrent const* tor)
     tr_variant* const list = tr_variantDictAddList(dict, TR_KEY_files, n);
     for (tr_file_index_t i = 0; i < n; ++i)
     {
-        tr_variantListAddStrView(list, tor->file(i).name);
+        tr_variantListAddStrView(list, tor->fileSubpath(i));
     }
 }
 
@@ -420,11 +420,9 @@ static uint64_t loadFilenames(tr_variant* dict, tr_torrent* tor)
     for (size_t i = 0; i < n_files && i < n_list; ++i)
     {
         auto sv = std::string_view{};
-        auto& file = tor->file(i);
-        if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv) && sv != file.name)
+        if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv))
         {
-            tr_free(file.name);
-            file.name = tr_strvDup(sv);
+            tor->setFileSubpath(i, sv);
         }
     }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -317,19 +317,21 @@ public:
         return info.fileCount;
     }
 
-    [[nodiscard]] auto& file(tr_file_index_t i)
+    [[nodiscard]] char const* fileSubpath(tr_file_index_t i) const
     {
         TR_ASSERT(i < this->fileCount());
 
-        return info.files[i];
+        return info.files[i].name ? info.files[i].name : "";
     }
 
-    [[nodiscard]] auto const& file(tr_file_index_t i) const
+    [[nodiscard]] auto fileSize(tr_file_index_t i) const
     {
         TR_ASSERT(i < this->fileCount());
 
-        return info.files[i];
+        return info.files[i].length;
     }
+
+    void setFileSubpath(tr_file_index_t i, std::string_view subpath);
 
     struct tr_found_file_t : public tr_sys_path_info
     {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -54,7 +54,6 @@ struct tr_byte_span_t
 
 struct tr_ctor;
 struct tr_error;
-struct tr_file;
 struct tr_info;
 struct tr_session;
 struct tr_torrent;

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -50,7 +50,7 @@ static bool verifyTorrent(tr_torrent* tor, bool* stopFlag)
 
     while (!*stopFlag && piece < tor->pieceCount())
     {
-        auto const file_length = tor->file(fileIndex).length;
+        auto const file_length = tor->fileSize(fileIndex);
 
         /* if we're starting a new piece... */
         if (piecePos == 0)


### PR DESCRIPTION
yes, another incremental PR on the replace-`tr_info`-with-`tr_torrent_metainfo` chain.

This step avoids directly referring to the `tr_file` struct aggregated by `tr_info` to reduce code shear when we make the jump.