### PR TITLE
refactor: make tr_buildPath() private

### DIFF
--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <string>
+#include <string_view>
 
 /**
  * @addtogroup tr_session Session
@@ -25,7 +26,7 @@
  * @see tr_getTorrentDir()
  * @see tr_getWebClientDir()
  */
-void tr_setConfigDir(tr_session* session, char const* configDir);
+void tr_setConfigDir(tr_session* session, std::string_view config_dir);
 
 /** @brief return the directory where .resume files are stored */
 char const* tr_getResumeDir(tr_session const*);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -321,9 +321,9 @@ public:
     std::map<int, tr_torrent*> torrentsById;
     std::map<tr_sha1_digest_t, tr_torrent*> torrentsByHash;
 
-    char* configDir;
-    char* resumeDir;
-    char* torrentDir;
+    std::string config_dir;
+    std::string resume_dir;
+    std::string torrent_dir;
 
     std::list<tr_blocklistFile*> blocklists;
     struct tr_peerMgr* peerMgr;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -751,7 +751,7 @@ void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t blockIndex);
 /**
  * @brief Like tr_torrentFindFile(), but splits the filename into base and subpath.
  *
- * If the file is found, "tr_buildPath(base, subpath, nullptr)"
+ * If the file is found, "tr_strvPath(base, subpath, nullptr)"
  * will generate the complete filename.
  *
  * @return true if the file is found, false otherwise.

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -218,7 +218,7 @@ static void dht_bootstrap(void* closure)
 
     if (!bootstrap_done(cl->session, 0))
     {
-        auto const bootstrap_file = tr_strvPath(cl->session->configDir, "dht.bootstrap");
+        auto const bootstrap_file = tr_strvPath(cl->session->config_dir, "dht.bootstrap");
 
         tr_sys_file_t const f = tr_sys_file_open(bootstrap_file.c_str(), TR_SYS_FILE_READ, 0, nullptr);
 
@@ -314,7 +314,7 @@ int tr_dhtInit(tr_session* ss)
         dht_debug = stderr;
     }
 
-    auto const dat_file = tr_strvPath(ss->configDir, "dht.dat"sv);
+    auto const dat_file = tr_strvPath(ss->config_dir, "dht.dat"sv);
     auto benc = tr_variant{};
     auto const ok = tr_variantFromFile(&benc, TR_VARIANT_PARSE_BENC, dat_file);
 
@@ -465,7 +465,7 @@ void tr_dhtUninit(tr_session* ss)
             tr_variantDictAddRaw(&benc, TR_KEY_nodes6, compact6, out6 - compact6);
         }
 
-        auto const dat_file = tr_strvPath(ss->configDir, "dht.dat");
+        auto const dat_file = tr_strvPath(ss->config_dir, "dht.dat");
         tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file);
         tr_variantFree(&benc);
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -401,51 +401,6 @@ bool tr_saveFile(std::string_view filename_in, std::string_view contents, tr_err
     return true;
 }
 
-char* tr_buildPath(char const* first_element, ...)
-{
-
-    /* pass 1: allocate enough space for the string */
-    va_list vl;
-    va_start(vl, first_element);
-    auto bufLen = size_t{};
-    for (char const* element = first_element; element != nullptr;)
-    {
-        bufLen += strlen(element) + 1;
-        element = va_arg(vl, char const*);
-    }
-    va_end(vl);
-    char* const buf = tr_new(char, bufLen);
-    if (buf == nullptr)
-    {
-        return nullptr;
-    }
-
-    /* pass 2: build the string piece by piece */
-    char* pch = buf;
-    va_start(vl, first_element);
-    for (char const* element = first_element; element != nullptr;)
-    {
-        size_t const elementLen = strlen(element);
-        pch = std::copy_n(element, elementLen, pch);
-        *pch++ = TR_PATH_DELIMITER;
-        element = va_arg(vl, char const*);
-    }
-    va_end(vl);
-
-    // if nonempty, eat the unwanted trailing slash
-    if (pch != buf)
-    {
-        --pch;
-    }
-
-    // zero-terminate the string
-    *pch++ = '\0';
-
-    /* sanity checks & return */
-    TR_ASSERT(pch - buf == (ptrdiff_t)bufLen);
-    return buf;
-}
-
 tr_disk_space tr_dirSpace(std::string_view dir)
 {
     if (std::empty(dir))

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -82,10 +82,6 @@ bool tr_loadFile(std::vector<char>& setme, std::string_view filename, tr_error**
 
 bool tr_saveFile(std::string_view filename, std::string_view contents, tr_error** error = nullptr);
 
-/** @brief build a filename from a series of elements using the
-           platform's correct directory separator. */
-char* tr_buildPath(char const* first_element, ...) TR_GNUC_NULL_TERMINATED TR_GNUC_MALLOC;
-
 template<typename... T, typename std::enable_if_t<(std::is_convertible_v<T, std::string_view> && ...), bool> = true>
 std::string& tr_buildBuf(std::string& setme, T... args)
 {

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -424,7 +424,7 @@ static void tr_webThreadFunc(void* vsession)
         tr_logAddNamedInfo("web", "NB: invalid certs will show up as 'Could not connect to tracker' like many other errors");
     }
 
-    auto const str = tr_strvPath(session->configDir, "cookies.txt");
+    auto const str = tr_strvPath(session->config_dir, "cookies.txt");
     if (tr_sys_path_exists(str.c_str(), nullptr))
     {
         web->cookie_filename = tr_strvDup(str);

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -146,15 +146,6 @@ TEST_F(UtilsTest, trStrvDup)
     tr_free(str);
 }
 
-TEST_F(UtilsTest, trBuildpath)
-{
-    auto out = makeString(tr_buildPath("foo", "bar", nullptr));
-    EXPECT_EQ("foo" TR_PATH_DELIMITER_STR "bar", out);
-
-    out = makeString(tr_buildPath("", "foo", "bar", nullptr));
-    EXPECT_EQ(TR_PATH_DELIMITER_STR "foo" TR_PATH_DELIMITER_STR "bar", out);
-}
-
 TEST_F(UtilsTest, trStrvPath)
 {
     EXPECT_EQ("foo" TR_PATH_DELIMITER_STR "bar", tr_strvPath("foo", "bar"));


### PR DESCRIPTION
`tr_buildPath()` is only used in platform.cc, so make it visible only to that file.