### PR TITLE
Fix integer overflow when calculating `sizeWhenDone`

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -56,7 +56,7 @@ uint64_t tr_completion::computeSizeWhenDone() const
     }
 
     // count bytes that we want or that we already have
-    auto size = size_t{ 0 };
+    auto size = uint64_t{ 0 };
     for (tr_piece_index_t piece = 0; piece < block_info_->n_pieces; ++piece)
     {
         if (tor_->pieceIsWanted(piece))


### PR DESCRIPTION
Fix integer overflow when calculating `sizeWhenDone`.
While the function correctly returns a `uint64_t`, internally a `size_t` variable is used to calculate the accumulated size.
On 32-bit systems (e.g. Raspbian) `size_t` is only 32-bit wide, causing overflow for torrents > 4GB.

On my Raspberry Pi 4 running Raspberry Pi OS 'Buster', this bug caused strange behavior with torrents > 4GB:
* Torrents were shown as complete after downloading the first 4GB (while downloading the rest continued)
* Re-adding the torrent after everything was downloaded showed a "Done" percentage > 100%
* `transmission-remote -t<id> -i` showed this after adding a torrent > 4GB (but not starting it):
```
1100101@raspi2:~$ transmission-remote -t8 -i
NAME
  Id: 8
  Name: xxxx
  Hash: xxx
  Magnet: xxx

TRANSFER
  State: Stopped
  Location: xxx
  Percent Done: 0.0%
  ETA: 0 seconds (0 seconds)
  Download Speed: 0 kB/s
  Upload Speed: 0 kB/s
  Have: None (None verified)
  Availability: 0.0%
  Total size: 12.67 GB (4.08 GB wanted)
  Downloaded: None
  Uploaded: None
  Ratio: None
  Corrupt DL: None
  Peers: connected to 0, uploading to 0, downloading from 0
```

(Somewhat related to #2029)