### PR TITLE
refactor: base64 utils

### DIFF
--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -137,7 +137,7 @@ bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext)
 ****
 ***/
 
-char* tr_base64_encode(char const* input, size_t input_length, size_t* output_length)
+static char* tr_base64_encode(char const* input, size_t input_length, size_t* output_length)
 {
     char* ret = nullptr;
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -189,7 +189,7 @@ std::string tr_base64_encode_str(std::string_view input)
     return str;
 }
 
-char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length)
+static char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length)
 {
     char* ret = nullptr;
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -157,50 +157,13 @@ std::string tr_base64_encode_str(std::string_view input)
     return std::string{ std::data(buf), len };
 }
 
-static char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length)
-{
-    char* ret = nullptr;
-
-    if (input != nullptr)
-    {
-        if (input_length != 0)
-        {
-            size_t ret_length = input_length / 4 * 3;
-            base64_decodestate state;
-
-            ret = tr_new(char, ret_length + 8);
-
-            base64_init_decodestate(&state);
-            ret_length = base64_decode_block(static_cast<char const*>(input), input_length, ret, &state);
-
-            if (output_length != nullptr)
-            {
-                *output_length = ret_length;
-            }
-
-            ret[ret_length] = '\0';
-
-            return ret;
-        }
-
-        ret = tr_strdup("");
-    }
-
-    if (output_length != nullptr)
-    {
-        *output_length = 0;
-    }
-
-    return ret;
-}
-
 std::string tr_base64_decode_str(std::string_view input)
 {
-    auto len = size_t{};
-    auto* tmp = tr_base64_decode(std::data(input), std::size(input), &len);
-    auto str = std::string{ tmp, len };
-    tr_free(tmp);
-    return str;
+    auto buf = std::vector<char>(std::size(input) + 8);
+    auto state = base64_decodestate{};
+    base64_init_decodestate(&state);
+    size_t const len = base64_decode_block(std::data(input), std::size(input), std::data(buf), &state);
+    return std::string{ std::data(buf), len };
 }
 
 /***

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -147,7 +147,7 @@ static size_t base64_alloc_size(std::string_view input)
     return ret_length * 8;
 }
 
-std::string tr_base64_encode_str(std::string_view input)
+std::string tr_base64_encode(std::string_view input)
 {
     auto buf = std::vector<char>(base64_alloc_size(input));
     auto state = base64_encodestate{};
@@ -157,7 +157,7 @@ std::string tr_base64_encode_str(std::string_view input)
     return std::string{ std::data(buf), len };
 }
 
-std::string tr_base64_decode_str(std::string_view input)
+std::string tr_base64_decode(std::string_view input)
 {
     auto buf = std::vector<char>(std::size(input) + 8);
     auto state = base64_decodestate{};

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -8,8 +8,9 @@
 
 #include <algorithm>
 #include <array>
-#include <cstring> /* memmove(), memset(), strlen() */
-#include <random> /* random_device, mt19937, uniform_int_distribution*/
+#include <cstring> // memmove(), memset()
+#include <iterator>
+#include <random>
 #include <string>
 #include <string_view>
 
@@ -154,7 +155,13 @@ std::string tr_base64_encode(std::string_view input)
     base64_init_encodestate(&state);
     size_t len = base64_encode_block(std::data(input), std::size(input), std::data(buf), &state);
     len += base64_encode_blockend(std::data(buf) + len, &state);
-    return std::string{ std::data(buf), len };
+    auto str = std::string{};
+    std::copy_if(
+        std::data(buf),
+        std::data(buf) + len,
+        std::back_inserter(str),
+        [](auto ch) { return !tr_strvContains("\r\n"sv, ch); });
+    return str;
 }
 
 std::string tr_base64_decode(std::string_view input)

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -222,11 +222,6 @@ void* tr_base64_decode(void const* input, size_t input_length, size_t* output_le
     return ret;
 }
 
-void* tr_base64_decode_str(char const* input, size_t* output_length)
-{
-    return tr_base64_decode(input, input == nullptr ? 0 : strlen(input), output_length);
-}
-
 std::string tr_base64_decode_str(std::string_view input)
 {
     auto len = size_t{};

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -137,7 +137,7 @@ bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext)
 ****
 ***/
 
-void* tr_base64_encode(void const* input, size_t input_length, size_t* output_length)
+char* tr_base64_encode(char const* input, size_t input_length, size_t* output_length)
 {
     char* ret = nullptr;
 
@@ -183,13 +183,13 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
 std::string tr_base64_encode_str(std::string_view input)
 {
     auto len = size_t{};
-    auto* buf = tr_base64_encode(std::data(input), std::size(input), &len);
-    auto str = std::string{ reinterpret_cast<char const*>(buf), len };
-    tr_free(buf);
+    char* const tmp = tr_base64_encode(std::data(input), std::size(input), &len);
+    auto str = std::string{ tmp, len };
+    tr_free(tmp);
     return str;
 }
 
-void* tr_base64_decode(void const* input, size_t input_length, size_t* output_length)
+char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length)
 {
     char* ret = nullptr;
 
@@ -229,9 +229,9 @@ void* tr_base64_decode(void const* input, size_t input_length, size_t* output_le
 std::string tr_base64_decode_str(std::string_view input)
 {
     auto len = size_t{};
-    auto* buf = tr_base64_decode(std::data(input), std::size(input), &len);
-    auto str = std::string{ reinterpret_cast<char const*>(buf), len };
-    tr_free(buf);
+    auto* tmp = tr_base64_decode(std::data(input), std::size(input), &len);
+    auto str = std::string{ tmp, len };
+    tr_free(tmp);
     return str;
 }
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -180,9 +180,13 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
     return ret;
 }
 
-void* tr_base64_encode_str(char const* input, size_t* output_length)
+std::string tr_base64_encode_str(std::string_view input)
 {
-    return tr_base64_encode(input, input == nullptr ? 0 : strlen(input), output_length);
+    auto len = size_t{};
+    auto* buf = tr_base64_encode(std::data(input), std::size(input), &len);
+    auto str = std::string{ reinterpret_cast<char const*>(buf), len };
+    tr_free(buf);
+    return str;
 }
 
 void* tr_base64_decode(void const* input, size_t input_length, size_t* output_length)

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -175,13 +175,13 @@ bool tr_ssha1_matches(std::string_view ssha1, std::string_view plain_text);
  * @brief Translate null-terminated string into base64.
  * @return a new std::string with the encoded contents
  */
-std::string tr_base64_encode_str(std::string_view input);
+std::string tr_base64_encode(std::string_view input);
 
 /**
  * @brief Translate a character range from base64 into raw form.
  * @return a new std::string with the decoded contents.
  */
-std::string tr_base64_decode_str(std::string_view input);
+std::string tr_base64_decode(std::string_view input);
 
 /**
  * @brief Generate an ascii hex string for a sha1 digest.

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -172,12 +172,6 @@ bool tr_ssha1_test(std::string_view text);
 bool tr_ssha1_matches(std::string_view ssha1, std::string_view plain_text);
 
 /**
- * @brief Translate a block of bytes into base64.
- * @return a newly-allocated null-terminated string that can be freed with tr_free()
- */
-char* tr_base64_encode(char const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
-
-/**
  * @brief Translate null-terminated string into base64.
  * @return a new std::string with the encoded contents
  */

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -175,7 +175,7 @@ bool tr_ssha1_matches(std::string_view ssha1, std::string_view plain_text);
  * @brief Translate a block of bytes into base64.
  * @return a newly-allocated null-terminated string that can be freed with tr_free()
  */
-void* tr_base64_encode(void const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
+char* tr_base64_encode(char const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
 
 /**
  * @brief Translate null-terminated string into base64.
@@ -187,7 +187,7 @@ std::string tr_base64_encode_str(std::string_view input);
  * @brief Translate a block of bytes from base64 into raw form.
  * @return a newly-allocated null-terminated string that can be freed with tr_free()
  */
-void* tr_base64_decode(void const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
+char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
 
 /**
  * @brief Translate a character range from base64 into raw form.

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -179,9 +179,9 @@ void* tr_base64_encode(void const* input, size_t input_length, size_t* output_le
 
 /**
  * @brief Translate null-terminated string into base64.
- * @return a newly-allocated null-terminated string that can be freed with tr_free()
+ * @return a new std::string with the encoded contents
  */
-void* tr_base64_encode_str(char const* input, size_t* output_length) TR_GNUC_MALLOC;
+std::string tr_base64_encode_str(std::string_view input);
 
 /**
  * @brief Translate a block of bytes from base64 into raw form.

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -190,12 +190,6 @@ void* tr_base64_encode_str(char const* input, size_t* output_length) TR_GNUC_MAL
 void* tr_base64_decode(void const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
 
 /**
- * @brief Translate null-terminated string from base64 into raw form.
- * @return a newly-allocated null-terminated string that can be freed with tr_free()
- */
-void* tr_base64_decode_str(char const* input, size_t* output_length) TR_GNUC_MALLOC;
-
-/**
  * @brief Translate a character range from base64 into raw form.
  * @return a new std::string with the decoded contents.
  */

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -184,12 +184,6 @@ char* tr_base64_encode(char const* input, size_t input_length, size_t* output_le
 std::string tr_base64_encode_str(std::string_view input);
 
 /**
- * @brief Translate a block of bytes from base64 into raw form.
- * @return a newly-allocated null-terminated string that can be freed with tr_free()
- */
-char* tr_base64_decode(char const* input, size_t input_length, size_t* output_length) TR_GNUC_MALLOC;
-
-/**
  * @brief Translate a character range from base64 into raw form.
  * @return a new std::string with the decoded contents.
  */

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -198,7 +198,7 @@ static void handle_upload(struct evhttp_request* req, tr_rpc_server* server)
                 }
                 else if (tr_variantFromBuf(&test, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, body))
                 {
-                    tr_variantDictAddStrView(args, TR_KEY_metainfo, tr_base64_encode_str(body));
+                    tr_variantDictAddStrView(args, TR_KEY_metainfo, tr_base64_encode(body));
                     have_source = true;
                 }
 
@@ -582,7 +582,7 @@ static bool isAuthorized(tr_rpc_server const* server, char const* auth_header)
     }
 
     auth.remove_prefix(std::size(Prefix));
-    auto const decoded_str = tr_base64_decode_str(auth);
+    auto const decoded_str = tr_base64_decode(auth);
     auto decoded = std::string_view{ decoded_str };
     auto const username = tr_strvSep(&decoded, ':');
     auto const password = decoded;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -681,7 +681,7 @@ static void initField(
         if (tor->hasMetadata())
         {
             auto const bytes = tor->createPieceBitfield();
-            auto* enc = static_cast<char*>(tr_base64_encode(bytes.data(), std::size(bytes), nullptr));
+            auto* enc = tr_base64_encode(reinterpret_cast<char const*>(bytes.data()), std::size(bytes), nullptr);
             tr_variantInitStr(initme, enc != nullptr ? std::string_view{ enc } : ""sv);
             tr_free(enc);
         }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -681,9 +681,8 @@ static void initField(
         if (tor->hasMetadata())
         {
             auto const bytes = tor->createPieceBitfield();
-            auto* enc = tr_base64_encode(reinterpret_cast<char const*>(bytes.data()), std::size(bytes), nullptr);
-            tr_variantInitStr(initme, enc != nullptr ? std::string_view{ enc } : ""sv);
-            tr_free(enc);
+            auto const enc = tr_base64_encode_str({ reinterpret_cast<char const*>(std::data(bytes)), std::size(bytes) });
+            tr_variantInitStrView(initme, enc);
         }
         else
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -681,7 +681,7 @@ static void initField(
         if (tor->hasMetadata())
         {
             auto const bytes = tor->createPieceBitfield();
-            auto const enc = tr_base64_encode_str({ reinterpret_cast<char const*>(std::data(bytes)), std::size(bytes) });
+            auto const enc = tr_base64_encode({ reinterpret_cast<char const*>(std::data(bytes)), std::size(bytes) });
             tr_variantInitStrView(initme, enc);
         }
         else
@@ -1707,7 +1707,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
     {
         if (std::empty(filename))
         {
-            std::string const metainfo = tr_base64_decode_str(metainfo_base64);
+            auto const metainfo = tr_base64_decode(metainfo_base64);
             tr_ctorSetMetainfo(ctor, std::data(metainfo), std::size(metainfo), nullptr);
         }
         else

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -11,7 +11,6 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/crypto-utils.h> // tr_base64_encode()
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/error.h>
@@ -64,13 +63,10 @@ int AddData::set(QString const& key)
     }
     else
     {
-        size_t len;
-        void* raw = tr_base64_decode(key.toUtf8().constData(), key.toUtf8().size(), &len);
-
-        if (raw != nullptr)
+        auto raw = QByteArray::fromBase64(key.toUtf8());
+        if (!raw.isEmpty())
         {
-            metainfo.append(static_cast<char const*>(raw), int(len));
-            tr_free(raw);
+            metainfo.append(raw);
             type = METAINFO;
         }
         else
@@ -84,17 +80,7 @@ int AddData::set(QString const& key)
 
 QByteArray AddData::toBase64() const
 {
-    QByteArray ret;
-
-    if (!metainfo.isEmpty())
-    {
-        size_t len;
-        void* b64 = tr_base64_encode(metainfo.constData(), metainfo.size(), &len);
-        ret = QByteArray(static_cast<char const*>(b64), int(len));
-        tr_free(b64);
-    }
-
-    return ret;
+    return metainfo.toBase64();
 }
 
 QString AddData::readableName() const

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -56,10 +56,8 @@
 #define tr_ssha1_matches tr_ssha1_matches_
 #define tr_ssha1_test tr_ssha1_test_
 #define tr_base64_encode tr_base64_encode_
-#define tr_base64_encode_str tr_base64_encode_str_
 #define tr_base64_encode_impl tr_base64_encode_impl_
 #define tr_base64_decode tr_base64_decode_
-#define tr_base64_decode_str tr_base64_decode_str_
 #define tr_base64_decode_impl tr_base64_decode_impl_
 #define tr_sha1_to_string tr_sha1_to_string_
 #define tr_sha1_from_string tr_sha1_from_string_
@@ -116,10 +114,8 @@
 #undef tr_ssha1_matches
 #undef tr_ssha1_test
 #undef tr_base64_encode
-#undef tr_base64_encode_str
 #undef tr_base64_encode_impl
 #undef tr_base64_decode
-#undef tr_base64_decode_str
 #undef tr_base64_decode_impl
 #undef tr_sha1_to_string
 #undef tr_sha1_from_string
@@ -169,10 +165,8 @@
 #define tr_ssha1_matches_ tr_ssha1_matches
 #define tr_ssha1_test_ tr_ssha1_test
 #define tr_base64_encode_ tr_base64_encode
-#define tr_base64_encode_str_ tr_base64_encode_str
 #define tr_base64_encode_impl_ tr_base64_encode_impl
 #define tr_base64_decode_ tr_base64_decode
-#define tr_base64_decode_str_ tr_base64_decode_str
 #define tr_base64_decode_impl_ tr_base64_decode_impl
 #define tr_sha1_to_string_ tr_sha1_to_string
 #define tr_sha1_from_string_ tr_sha1_from_string

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -206,12 +206,12 @@ TEST(Crypto, random)
 TEST(Crypto, base64)
 {
     auto raw = std::string_view{ "YOYO!"sv };
-    auto encoded = tr_base64_encode_str(raw);
+    auto encoded = tr_base64_encode(raw);
     EXPECT_EQ("WU9ZTyE="sv, encoded);
-    EXPECT_EQ(raw, tr_base64_decode_str(encoded));
+    EXPECT_EQ(raw, tr_base64_decode(encoded));
 
-    EXPECT_EQ(""sv, tr_base64_encode_str(""sv));
-    EXPECT_EQ(""sv, tr_base64_decode_str(""sv));
+    EXPECT_EQ(""sv, tr_base64_encode(""sv));
+    EXPECT_EQ(""sv, tr_base64_decode(""sv));
 
     static auto constexpr MaxBufSize = size_t{ 1024 };
     for (size_t i = 1; i <= MaxBufSize; ++i)
@@ -221,13 +221,13 @@ TEST(Crypto, base64)
         {
             buf += char(tr_rand_int_weak(256));
         }
-        EXPECT_EQ(buf, tr_base64_decode_str(tr_base64_encode_str(buf)));
+        EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
 
         buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
             buf += char(1 + tr_rand_int_weak(255));
         }
-        EXPECT_EQ(buf, tr_base64_decode_str(tr_base64_encode_str(buf)));
+        EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
     }
 }

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -203,11 +203,42 @@ TEST(Crypto, random)
     }
 }
 
+static bool base64Eq(std::string_view a, std::string_view b)
+{
+    auto constexpr IgnoreChars = "\r\n"sv;
+
+    while (!std::empty(a) && !std::empty(b))
+    {
+        if (tr_strvContains(IgnoreChars, a.front()))
+        {
+            a.remove_prefix(1);
+            continue;
+        }
+
+        if (tr_strvContains(IgnoreChars, b.front()))
+        {
+            b.remove_prefix(1);
+            continue;
+        }
+
+        if (a.front() == b.front())
+        {
+            a.remove_prefix(1);
+            b.remove_prefix(1);
+            continue;
+        }
+
+        return false;
+    }
+
+    return std::empty(a) == std::empty(b);
+}
+
 TEST(Crypto, base64)
 {
     auto raw = std::string_view{ "YOYO!"sv };
     auto encoded = tr_base64_encode(raw);
-    EXPECT_EQ("WU9ZTyE="sv, encoded);
+    EXPECT_TRUE(base64Eq("WU9ZTyE="sv, encoded));
     EXPECT_EQ(raw, tr_base64_decode(encoded));
 
     EXPECT_EQ(""sv, tr_base64_encode(""sv));

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -211,19 +211,19 @@ TEST(Crypto, base64)
     EXPECT_EQ(raw, tr_base64_decode_str(encoded));
 
     size_t len = 0;
-    char* out = static_cast<char*>(tr_base64_encode("", 0, &len));
+    char* out = tr_base64_encode("", 0, &len);
     EXPECT_EQ(size_t{}, len);
     EXPECT_STREQ("", out);
     tr_free(out);
-    out = static_cast<char*>(tr_base64_decode("", 0, &len));
+    out = tr_base64_decode("", 0, &len);
     EXPECT_EQ(0, len);
     EXPECT_STREQ("", out);
     tr_free(out);
 
-    out = static_cast<char*>(tr_base64_encode(nullptr, 0, &len));
+    out = tr_base64_encode(nullptr, 0, &len);
     EXPECT_EQ(0, len);
     EXPECT_EQ(nullptr, out);
-    out = static_cast<char*>(tr_base64_decode(nullptr, 0, &len));
+    out = tr_base64_decode(nullptr, 0, &len);
     EXPECT_EQ(0, len);
     EXPECT_EQ(nullptr, out);
 
@@ -236,7 +236,7 @@ TEST(Crypto, base64)
             buf += char(tr_rand_int_weak(256));
         }
 
-        out = static_cast<char*>(tr_base64_encode(std::data(buf), std::size(buf), &len));
+        out = tr_base64_encode(std::data(buf), std::size(buf), &len);
         EXPECT_EQ(strlen(out), len);
         EXPECT_EQ(buf, tr_base64_decode_str(out));
         tr_free(out);

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -203,42 +203,11 @@ TEST(Crypto, random)
     }
 }
 
-static bool base64Eq(std::string_view a, std::string_view b)
-{
-    auto constexpr IgnoreChars = "\r\n"sv;
-
-    while (!std::empty(a) && !std::empty(b))
-    {
-        if (tr_strvContains(IgnoreChars, a.front()))
-        {
-            a.remove_prefix(1);
-            continue;
-        }
-
-        if (tr_strvContains(IgnoreChars, b.front()))
-        {
-            b.remove_prefix(1);
-            continue;
-        }
-
-        if (a.front() == b.front())
-        {
-            a.remove_prefix(1);
-            b.remove_prefix(1);
-            continue;
-        }
-
-        return false;
-    }
-
-    return std::empty(a) == std::empty(b);
-}
-
 TEST(Crypto, base64)
 {
     auto raw = std::string_view{ "YOYO!"sv };
     auto encoded = tr_base64_encode(raw);
-    EXPECT_TRUE(base64Eq("WU9ZTyE="sv, encoded));
+    EXPECT_EQ("WU9ZTyE="sv, encoded);
     EXPECT_EQ(raw, tr_base64_decode(encoded));
 
     EXPECT_EQ(""sv, tr_base64_encode(""sv));

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -210,20 +210,11 @@ TEST(Crypto, base64)
     EXPECT_EQ("WU9ZTyE="sv, encoded);
     EXPECT_EQ(raw, tr_base64_decode_str(encoded));
 
-    size_t len = 0;
-    char* out = tr_base64_encode("", 0, &len);
-    EXPECT_EQ(size_t{}, len);
-    EXPECT_STREQ("", out);
-    tr_free(out);
-    out = tr_base64_decode("", 0, &len);
-    EXPECT_EQ(0, len);
-    EXPECT_STREQ("", out);
-    tr_free(out);
+    EXPECT_EQ(""sv, tr_base64_encode_str(""sv));
+    EXPECT_EQ(""sv, tr_base64_decode_str(""sv));
 
-    out = tr_base64_encode(nullptr, 0, &len);
-    EXPECT_EQ(0, len);
-    EXPECT_EQ(nullptr, out);
-    out = tr_base64_decode(nullptr, 0, &len);
+    size_t len = 0;
+    char* out = tr_base64_encode(nullptr, 0, &len);
     EXPECT_EQ(0, len);
     EXPECT_EQ(nullptr, out);
 

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -203,39 +203,15 @@ TEST(Crypto, random)
     }
 }
 
-static bool base64Eq(char const* a, char const* b)
-{
-    for (;; ++a, ++b)
-    {
-        while (*a == '\r' || *a == '\n')
-        {
-            ++a;
-        }
-
-        while (*b == '\r' || *b == '\n')
-        {
-            ++b;
-        }
-
-        if (*a == '\0' || *b == '\0' || *a != *b)
-        {
-            break;
-        }
-    }
-
-    return *a == *b;
-}
-
 TEST(Crypto, base64)
 {
-    auto len = size_t{};
-    auto* out = static_cast<char*>(tr_base64_encode_str("YOYO!", &len));
-    EXPECT_EQ(strlen(out), len);
-    EXPECT_TRUE(base64Eq("WU9ZTyE=", out));
-    EXPECT_EQ("YOYO!", tr_base64_decode_str(std::string_view{ out, len }));
-    tr_free(out);
+    auto raw = std::string_view{ "YOYO!"sv };
+    auto encoded = tr_base64_encode_str(raw);
+    EXPECT_EQ("WU9ZTyE="sv, encoded);
+    EXPECT_EQ(raw, tr_base64_decode_str(encoded));
 
-    out = static_cast<char*>(tr_base64_encode("", 0, &len));
+    size_t len = 0;
+    char* out = static_cast<char*>(tr_base64_encode("", 0, &len));
     EXPECT_EQ(size_t{}, len);
     EXPECT_STREQ("", out);
     tr_free(out);
@@ -271,9 +247,6 @@ TEST(Crypto, base64)
             buf += char(1 + tr_rand_int_weak(255));
         }
 
-        out = static_cast<char*>(tr_base64_encode_str(std::data(buf), &len));
-        EXPECT_EQ(strlen(out), len);
-        EXPECT_EQ(buf, tr_base64_decode_str(out));
-        tr_free(out);
+        EXPECT_EQ(buf, tr_base64_decode_str(tr_base64_encode_str(buf)));
     }
 }

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -213,11 +213,6 @@ TEST(Crypto, base64)
     EXPECT_EQ(""sv, tr_base64_encode_str(""sv));
     EXPECT_EQ(""sv, tr_base64_decode_str(""sv));
 
-    size_t len = 0;
-    char* out = tr_base64_encode(nullptr, 0, &len);
-    EXPECT_EQ(0, len);
-    EXPECT_EQ(nullptr, out);
-
     static auto constexpr MaxBufSize = size_t{ 1024 };
     for (size_t i = 1; i <= MaxBufSize; ++i)
     {
@@ -226,18 +221,13 @@ TEST(Crypto, base64)
         {
             buf += char(tr_rand_int_weak(256));
         }
-
-        out = tr_base64_encode(std::data(buf), std::size(buf), &len);
-        EXPECT_EQ(strlen(out), len);
-        EXPECT_EQ(buf, tr_base64_decode_str(out));
-        tr_free(out);
+        EXPECT_EQ(buf, tr_base64_decode_str(tr_base64_encode_str(buf)));
 
         buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
             buf += char(1 + tr_rand_int_weak(255));
         }
-
         EXPECT_EQ(buf, tr_base64_decode_str(tr_base64_encode_str(buf)));
     }
 }

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -69,12 +69,10 @@ protected:
     tr_torrent* createTorrentFromBase64Metainfo(tr_ctor* ctor, char const* benc_base64)
     {
         // create the torrent ctor
-        size_t benc_len;
-        auto* benc = static_cast<char*>(tr_base64_decode_str(benc_base64, &benc_len));
-        EXPECT_NE(nullptr, benc);
-        EXPECT_LT(size_t(0), benc_len);
+        auto const benc = tr_base64_decode_str(benc_base64);
+        EXPECT_LT(0, std::size(benc));
         tr_error* error = nullptr;
-        EXPECT_TRUE(tr_ctorSetMetainfo(ctor, benc, benc_len, &error));
+        EXPECT_TRUE(tr_ctorSetMetainfo(ctor, std::data(benc), std::size(benc), &error));
         EXPECT_EQ(nullptr, error);
         tr_ctorSetPaused(ctor, TR_FORCE, true);
 
@@ -83,7 +81,6 @@ protected:
         EXPECT_NE(nullptr, tor);
 
         // cleanup
-        tr_free(benc);
         return tor;
     }
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -69,7 +69,7 @@ protected:
     tr_torrent* createTorrentFromBase64Metainfo(tr_ctor* ctor, char const* benc_base64)
     {
         // create the torrent ctor
-        auto const benc = tr_base64_decode_str(benc_base64);
+        auto const benc = tr_base64_decode(benc_base64);
         EXPECT_LT(0, std::size(benc));
         tr_error* error = nullptr;
         EXPECT_TRUE(tr_ctorSetMetainfo(ctor, std::data(benc), std::size(benc), &error));

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <thread>
 
-#include "crypto-utils.h" // tr_base64_decode_str()
+#include "crypto-utils.h" // tr_base64_decode()
 #include "error.h"
 #include "file.h" // tr_sys_file_*()
 #include "platform.h" // TR_PATH_DELIMITER
@@ -374,7 +374,7 @@ protected:
             "OnByaXZhdGVpMGVlZQ==";
 
         // create the torrent ctor
-        auto const metainfo = tr_base64_decode_str(metainfo_base64);
+        auto const metainfo = tr_base64_decode(metainfo_base64);
         EXPECT_LT(0, std::size(metainfo));
         auto* ctor = tr_ctorNew(session_);
         tr_error* error = nullptr;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -374,16 +374,13 @@ protected:
             "OnByaXZhdGVpMGVlZQ==";
 
         // create the torrent ctor
-        auto metainfo_len = size_t{};
-        auto* const metainfo = tr_base64_decode_str(metainfo_base64, &metainfo_len);
-        EXPECT_NE(nullptr, metainfo);
-        EXPECT_LT(size_t{ 0 }, metainfo_len);
+        auto const metainfo = tr_base64_decode_str(metainfo_base64);
+        EXPECT_LT(0, std::size(metainfo));
         auto* ctor = tr_ctorNew(session_);
         tr_error* error = nullptr;
-        EXPECT_TRUE(tr_ctorSetMetainfo(ctor, static_cast<char const*>(metainfo), metainfo_len, &error));
+        EXPECT_TRUE(tr_ctorSetMetainfo(ctor, std::data(metainfo), std::size(metainfo), &error));
         EXPECT_EQ(nullptr, error);
         tr_ctorSetPaused(ctor, TR_FORCE, true);
-        tr_free(metainfo);
 
         // create the torrent
         auto* const tor = tr_torrentNew(ctor, nullptr);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -544,17 +544,15 @@ static char* netrc = nullptr;
 static char* session_id = nullptr;
 static bool UseSSL = false;
 
-static char* getEncodedMetainfo(char const* filename)
+static std::string getEncodedMetainfo(char const* filename)
 {
-    char* b64 = nullptr;
-
     auto contents = std::vector<char>{};
     if (tr_loadFile(contents, filename))
     {
-        b64 = tr_base64_encode(std::data(contents), std::size(contents), nullptr);
+        return tr_base64_encode_str({ std::data(contents), std::size(contents) });
     }
 
-    return b64;
+    return {};
 }
 
 static void addIdArg(tr_variant* args, char const* id_str, char const* fallback)
@@ -2354,18 +2352,16 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 if (tadd != nullptr)
                 {
                     tr_variant* args = tr_variantDictFind(tadd, Arguments);
-                    char* tmp = getEncodedMetainfo(optarg);
+                    std::string const tmp = getEncodedMetainfo(optarg);
 
-                    if (tmp != nullptr)
+                    if (!std::empty(tmp))
                     {
-                        tr_variantDictAddStr(args, TR_KEY_metainfo, tmp);
+                        tr_variantDictAddStrView(args, TR_KEY_metainfo, tmp);
                     }
                     else
                     {
                         tr_variantDictAddStr(args, TR_KEY_filename, optarg);
                     }
-
-                    tr_free(tmp);
                 }
                 else
                 {

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -549,7 +549,7 @@ static std::string getEncodedMetainfo(char const* filename)
     auto contents = std::vector<char>{};
     if (tr_loadFile(contents, filename))
     {
-        return tr_base64_encode_str({ std::data(contents), std::size(contents) });
+        return tr_base64_encode({ std::data(contents), std::size(contents) });
     }
 
     return {};
@@ -1360,7 +1360,7 @@ static void printPeers(tr_variant* top)
 
 static void printPiecesImpl(std::string_view raw, size_t piece_count)
 {
-    auto const str = tr_base64_decode_str(raw);
+    auto const str = tr_base64_decode(raw);
     printf("  ");
 
     size_t piece = 0;


### PR DESCRIPTION
Update `tr_base64_encode()` and `tr_base64_decode()` to use C++ memory-managed API