### PR TITLE
refactor: use std::string in tr_info

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -484,12 +484,7 @@ static void addPeers(tr_torrent const* tor, tr_variant* list)
     tr_torrentPeersFree(peers, peerCount);
 }
 
-static void initField(
-    tr_torrent* const tor,
-    tr_torrent_view const* view,
-    tr_stat const* const st,
-    tr_variant* const initme,
-    tr_quark key)
+static void initField(tr_torrent* const tor, tr_stat const* const st, tr_variant* const initme, tr_quark key)
 {
     char* str = nullptr;
 
@@ -508,7 +503,7 @@ static void initField(
         break;
 
     case TR_KEY_comment:
-        tr_variantInitStr(initme, std::string_view{ view->comment != nullptr ? view->comment : "" });
+        tr_variantInitStr(initme, tor->comment());
         break;
 
     case TR_KEY_corruptEver:
@@ -516,11 +511,11 @@ static void initField(
         break;
 
     case TR_KEY_creator:
-        tr_variantInitStr(initme, std::string_view{ view->creator != nullptr ? view->creator : "" });
+        tr_variantInitStrView(initme, tor->creator());
         break;
 
     case TR_KEY_dateCreated:
-        tr_variantInitInt(initme, view->date_created);
+        tr_variantInitInt(initme, tor->dateCreated());
         break;
 
     case TR_KEY_desiredAvailable:
@@ -692,11 +687,11 @@ static void initField(
         break;
 
     case TR_KEY_pieceCount:
-        tr_variantInitInt(initme, view->n_pieces);
+        tr_variantInitInt(initme, tor->pieceCount());
         break;
 
     case TR_KEY_pieceSize:
-        tr_variantInitInt(initme, view->piece_size);
+        tr_variantInitInt(initme, tor->pieceSize());
         break;
 
     case TR_KEY_primary_mime_type:
@@ -755,7 +750,7 @@ static void initField(
         break;
 
     case TR_KEY_source:
-        tr_variantDictAddStr(initme, key, view->source ? view->source : "");
+        tr_variantInitStrView(initme, tor->source());
         break;
 
     case TR_KEY_startDate:
@@ -792,11 +787,11 @@ static void initField(
         }
 
     case TR_KEY_torrentFile:
-        tr_variantInitStr(initme, view->torrent_filename);
+        tr_variantInitStrView(initme, tor->torrentFile());
         break;
 
     case TR_KEY_totalSize:
-        tr_variantInitInt(initme, view->total_size);
+        tr_variantInitInt(initme, tor->totalSize());
         break;
 
     case TR_KEY_uploadedEver:
@@ -853,14 +848,13 @@ static void addTorrentInfo(tr_torrent* tor, tr_format format, tr_variant* entry,
 
     if (fieldCount > 0)
     {
-        auto const torrent_view = tr_torrentView(tor);
         tr_stat const* const st = tr_torrentStat(tor);
 
         for (size_t i = 0; i < fieldCount; ++i)
         {
             tr_variant* child = format == TR_FORMAT_TABLE ? tr_variantListAdd(entry) : tr_variantDictAdd(entry, fields[i]);
 
-            initField(tor, &torrent_view, st, child, fields[i]);
+            initField(tor, st, child, fields[i]);
         }
     }
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -86,7 +86,7 @@ void tr_torrentGetBlockLocation(
     uint32_t* offset,
     uint32_t* length);
 
-tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t const file);
+tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file);
 
 void tr_torrentCheckSeedLimit(tr_torrent* tor);
 
@@ -449,9 +449,14 @@ public:
 
     void setName(std::string_view name);
 
+    [[nodiscard]] auto const& name() const
+    {
+        return this->info.name();
+    }
+
     [[nodiscard]] auto const& infoHash() const
     {
-        return this->info.hash;
+        return this->info.infoHash();
     }
 
     [[nodiscard]] auto isPrivate() const
@@ -464,14 +469,34 @@ public:
         return !this->isPrivate();
     }
 
-    [[nodiscard]] auto infoHashString() const
+    [[nodiscard]] auto const& infoHashString() const
     {
-        return this->info.hashString;
+        return this->info.infoHashString();
+    }
+
+    [[nodiscard]] auto dateCreated() const
+    {
+        return this->info.dateCreated();
     }
 
     [[nodiscard]] auto const& torrentFile() const
     {
-        return this->info.torrent;
+        return this->info.torrentFile();
+    }
+
+    [[nodiscard]] auto const& comment() const
+    {
+        return this->info.comment();
+    }
+
+    [[nodiscard]] auto const& creator() const
+    {
+        return this->info.creator();
+    }
+
+    [[nodiscard]] auto const& source() const
+    {
+        return this->info.source();
     }
 
     [[nodiscard]] auto hasMetadata() const

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -21,6 +21,8 @@
 ***/
 
 #include <memory>
+#include <string_view>
+
 #include <stdbool.h> /* bool */
 #include <stddef.h> /* size_t */
 #include <stdint.h> /* uintN_t */
@@ -1502,8 +1504,8 @@ void tr_torrentVerify(tr_torrent* torrent, tr_verify_done_func callback_func_or_
 struct tr_file
 {
     // public
-    std::string subpath; /* Path to the file */
-    uint64_t size; /* Length of the file, in bytes */
+    std::string subpath_; /* Path to the file */
+    uint64_t size_; /* Length of the file, in bytes */
 };
 
 /** @brief information about a torrent that comes from its metainfo file */
@@ -1513,18 +1515,53 @@ struct tr_info
     uint64_t totalSize;
 
     /* The torrent's name. */
-    char* name;
+    std::string name_;
 
     /* Path to torrent Transmission's internal copy of the .torrent file. */
-    char* torrent;
+    std::string torrent_file_;
 
     char** webseeds;
 
-    char* comment;
-    char* creator;
+    std::string comment_;
+    std::string creator_;
 
     /* torrent's source. empty if not set. */
-    char* source;
+    std::string source_;
+
+    auto const& torrentFile() const
+    {
+        return torrent_file_;
+    }
+
+    auto const& name() const
+    {
+        return name_;
+    }
+
+    auto const& creator() const
+    {
+        return creator_;
+    }
+
+    auto const& comment() const
+    {
+        return comment_;
+    }
+
+    auto const& source() const
+    {
+        return source_;
+    }
+
+    auto const& infoHash() const
+    {
+        return hash_;
+    }
+
+    void setName(std::string_view name)
+    {
+        name_ = name;
+    }
 
     // Private.
     // Use tr_torrentFile() and tr_torrentFileCount() instead.
@@ -1537,27 +1574,42 @@ struct tr_info
 
     std::string const& fileSubpath(tr_file_index_t i) const
     {
-        return files[i].subpath;
+        return files[i].subpath_;
+    }
+
+    void setFileSubpath(tr_file_index_t i, std::string_view subpath)
+    {
+        files[i].subpath_ = subpath;
     }
 
     auto fileSize(tr_file_index_t i) const
     {
-        return files[i].size;
+        return files[i].size_;
+    }
+
+    auto const& infoHashString() const
+    {
+        return info_hash_string_;
+    }
+
+    auto dateCreated() const
+    {
+        return date_created_;
     }
 
     // TODO(ckerr) aggregate this directly, rather than  using a shared_ptr, when tr_info is private
     std::shared_ptr<tr_announce_list> announce_list;
 
     /* Torrent info */
-    time_t dateCreated;
+    time_t date_created_;
 
     unsigned int webseedCount;
     uint32_t pieceSize;
     tr_piece_index_t pieceCount;
 
     /* General info */
-    tr_sha1_digest_t hash;
-    char hashString[2 * SHA_DIGEST_LENGTH + 1];
+    tr_sha1_digest_t hash_;
+    std::string info_hash_string_;
 
     /* Flags */
     bool isPrivate;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -820,13 +820,6 @@ static char* to_utf8(std::string_view sv)
     return strip_non_utf8(sv);
 }
 
-char* tr_utf8clean(std::string_view sv)
-{
-    char* const ret = tr_utf8_validate(sv, nullptr) ? tr_strvDup(sv) : to_utf8(sv);
-    TR_ASSERT(tr_utf8_validate(ret, nullptr));
-    return ret;
-}
-
 std::string tr_strvUtf8Clean(std::string_view sv)
 {
     if (tr_utf8_validate(sv, nullptr))

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -164,13 +164,6 @@ std::optional<T> tr_parseNum(std::string_view& sv)
 
 #endif // #if defined(__GNUC__) && !__has_include(<charconv>)
 
-/**
- * @brief make a copy of 'str' whose non-utf8 content has been corrected or stripped
- * @return a newly-allocated string that must be freed with tr_free()
- * @param str the string to make a clean copy of
- */
-char* tr_utf8clean(std::string_view str) TR_GNUC_MALLOC;
-
 bool tr_utf8_validate(std::string_view sv, char const** endptr);
 
 #ifdef _WIN32

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -300,6 +300,14 @@ std::string tr_strlower(T in)
     return out;
 }
 
+template<typename T>
+std::string tr_strupper(T in)
+{
+    auto out = std::string{ in };
+    std::for_each(std::begin(out), std::end(out), [](char& ch) { ch = std::toupper(ch); });
+    return out;
+}
+
 /***
 ****  std::string_view utils
 ***/

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -387,9 +387,9 @@ TEST_F(AnnounceListTest, save)
     tr_variantFree(&metainfo);
 
     // test that non-announce parts of the metainfo are the same
-    EXPECT_STREQ(original->info.name, saved->info.name);
+    EXPECT_EQ(original->info.name(), saved->info.name());
     EXPECT_EQ(original->info.fileCount(), saved->info.fileCount());
-    EXPECT_EQ(original->info.dateCreated, saved->info.dateCreated);
+    EXPECT_EQ(original->info.dateCreated(), saved->info.dateCreated());
     EXPECT_EQ(original->pieces, saved->pieces);
 
     // test that the saved version has the updated announce list

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -264,7 +264,6 @@ TEST_F(RenameTest, multifileTorrent)
         "MjpwaWVjZSBsZW5ndGhpMzI3NjhlNjpwaWVjZXMyMDp27buFkmy8ICfNX4nsJmt0Ckm2Ljc6cHJp"
         "dmF0ZWkwZWVl");
     EXPECT_TRUE(tr_isTorrent(tor));
-    auto& files = tor->info.files;
 
     // sanity check the info
     EXPECT_STREQ("Felidae", tr_torrentName(tor));
@@ -320,7 +319,7 @@ TEST_F(RenameTest, multifileTorrent)
     // (while the branch is renamed: confirm that the .resume file remembers the changes)
     tr_torrentSaveResume(tor);
     // this is a bit dodgy code-wise, but let's make sure the .resume file got the name
-    files[1].subpath = "gabba gabba hey";
+    tor->setFileSubpath(1, "gabba gabba hey"sv);
     auto const loaded = tr_torrentLoadResume(tor, ~0ULL, ctor, nullptr);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & TR_FR_FILENAMES));
     EXPECT_EQ(expected_files[0], tr_torrentFile(tor, 0).name);

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -158,42 +158,6 @@ TEST_F(UtilsTest, trStrvPath)
         tr_strvPath("foo"sv, "bar", std::string{ "baz" }, "mum"sv));
 }
 
-TEST_F(UtilsTest, trUtf8clean)
-{
-    auto in = "hello world"sv;
-    auto out = makeString(tr_utf8clean(in));
-    EXPECT_EQ(in, out);
-
-    in = "hello world"sv;
-    out = makeString(tr_utf8clean(in.substr(0, 5)));
-    EXPECT_EQ("hello"sv, out);
-
-    // this version is not utf-8 (but cp866)
-    in = "\x92\xE0\xE3\xA4\xAD\xAE \xA1\xEB\xE2\xEC \x81\xAE\xA3\xAE\xAC"sv;
-    out = makeString(tr_utf8clean(in));
-    EXPECT_TRUE(std::size(out) == 17 || std::size(out) == 33);
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
-
-    // same string, but utf-8 clean
-    in = "Трудно быть Богом"sv;
-    out = makeString(tr_utf8clean(in));
-    EXPECT_NE(nullptr, out.data());
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
-    EXPECT_EQ(in, out);
-
-    in = "\xF4\x00\x81\x82"sv;
-    out = makeString(tr_utf8clean(in));
-    EXPECT_NE(nullptr, out.data());
-    EXPECT_TRUE(out.size() == 1 || out.size() == 2);
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
-
-    in = "\xF4\x33\x81\x82"sv;
-    out = makeString(tr_utf8clean(in));
-    EXPECT_NE(nullptr, out.data());
-    EXPECT_TRUE(out.size() == 4 || out.size() == 7);
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
-}
-
 TEST_F(UtilsTest, trStrvUtf8Clean)
 {
     auto in = "hello world"sv;


### PR DESCRIPTION
Another incremental PR to reduce shear between the master (`tr_info`) branch and the `tr_torrent_metainfo` branch.