### PR TITLE
refactor: migrate makeFilename() to tr_magnet_metainfo

### DIFF
--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -260,3 +260,16 @@ void tr_magnet_metainfo::toVariant(tr_variant* top) const
         tr_variantDictAddStr(d, TR_KEY_display_name, this->name());
     }
 }
+
+std::string tr_magnet_metainfo::makeFilename(
+    std::string_view dirname,
+    std::string_view name,
+    std::string_view info_hash_string,
+    BasenameFormat format,
+    std::string_view suffix)
+{
+    // `${dirname}/${name}.${info_hash}${suffix}`
+    // `${dirname}/${info_hash}${suffix}`
+    return format == BasenameFormat::Hash ? tr_strvJoin(dirname, "/"sv, info_hash_string, suffix) :
+                                            tr_strvJoin(dirname, "/"sv, name, "."sv, info_hash_string.substr(0, 16), suffix);
+}

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -63,6 +63,29 @@ public:
 
     void toVariant(tr_variant* top) const;
 
+    enum class BasenameFormat
+    {
+        Hash,
+        NameAndPartialHash
+    };
+
+    static std::string makeFilename(
+        std::string_view dirname,
+        std::string_view name,
+        std::string_view info_hash_string,
+        BasenameFormat format,
+        std::string_view suffix);
+
+    std::string makeFilename(std::string_view dirname, BasenameFormat format, std::string_view suffix) const
+    {
+        return makeFilename(dirname, name(), infoHashString(), format, suffix);
+    }
+
+    std::string makeTorrentFilename(std::string_view dirname, BasenameFormat format) const
+    {
+        return makeFilename(dirname, format, std::string_view{ ".torrent" });
+    }
+
 protected:
     tr_announce_list announce_list_;
     std::vector<std::string> webseed_urls_;

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -81,11 +81,6 @@ public:
         return makeFilename(dirname, name(), infoHashString(), format, suffix);
     }
 
-    std::string makeTorrentFilename(std::string_view dirname, BasenameFormat format) const
-    {
-        return makeFilename(dirname, format, std::string_view{ ".torrent" });
-    }
-
 protected:
     tr_announce_list announce_list_;
     std::vector<std::string> webseed_urls_;

--- a/libtransmission/metainfo.cc
+++ b/libtransmission/metainfo.cc
@@ -538,22 +538,3 @@ void tr_metainfoFree(tr_info* inf)
 
     inf->announce_list.reset();
 }
-
-void tr_metainfoMigrateFile(
-    tr_session const* session,
-    tr_info const* info,
-    tr_magnet_metainfo::BasenameFormat old_format,
-    tr_magnet_metainfo::BasenameFormat new_format)
-{
-    auto const old_filename = getTorrentFilename(session, info, old_format);
-    auto const new_filename = getTorrentFilename(session, info, new_format);
-
-    if (tr_sys_path_rename(old_filename.c_str(), new_filename.c_str(), nullptr))
-    {
-        tr_logAddNamedError(
-            info->name().c_str(),
-            "Migrated torrent file from \"%s\" to \"%s\"",
-            old_filename.c_str(),
-            new_filename.c_str());
-    }
-}

--- a/libtransmission/metainfo.h
+++ b/libtransmission/metainfo.h
@@ -22,7 +22,6 @@
 #include "transmission.h"
 
 #include "bitfield.h"
-#include "magnet-metainfo.h"
 #include "torrent.h"
 #include "tr-macros.h"
 

--- a/libtransmission/metainfo.h
+++ b/libtransmission/metainfo.h
@@ -22,17 +22,12 @@
 #include "transmission.h"
 
 #include "bitfield.h"
+#include "magnet-metainfo.h"
 #include "torrent.h"
 #include "tr-macros.h"
 
 struct tr_error;
 struct tr_variant;
-
-enum tr_metainfo_basename_format
-{
-    TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH,
-    TR_METAINFO_BASENAME_HASH
-};
 
 struct tr_metainfo_parsed
 {
@@ -62,20 +57,11 @@ struct tr_metainfo_parsed
 
 std::optional<tr_metainfo_parsed> tr_metainfoParse(tr_session const* session, tr_variant const* variant, tr_error** error);
 
-void tr_metainfoRemoveSaved(tr_session const* session, tr_info const* info);
-
-std::string tr_buildTorrentFilename(
-    std::string_view dirname,
-    std::string_view name,
-    std::string_view info_hash_string,
-    enum tr_metainfo_basename_format format,
-    std::string_view suffix);
-
 void tr_metainfoMigrateFile(
     tr_session const* session,
     tr_info const* info,
-    enum tr_metainfo_basename_format old_format,
-    enum tr_metainfo_basename_format new_format);
+    tr_magnet_metainfo::BasenameFormat old_format,
+    tr_magnet_metainfo::BasenameFormat new_format);
 
 /** @brief Private function that's exposed here only for unit tests */
 bool tr_metainfoAppendSanitizedPathComponent(std::string& out, std::string_view in);

--- a/libtransmission/metainfo.h
+++ b/libtransmission/metainfo.h
@@ -57,11 +57,5 @@ struct tr_metainfo_parsed
 
 std::optional<tr_metainfo_parsed> tr_metainfoParse(tr_session const* session, tr_variant const* variant, tr_error** error);
 
-void tr_metainfoMigrateFile(
-    tr_session const* session,
-    tr_info const* info,
-    tr_magnet_metainfo::BasenameFormat old_format,
-    tr_magnet_metainfo::BasenameFormat new_format);
-
 /** @brief Private function that's exposed here only for unit tests */
 bool tr_metainfoAppendSanitizedPathComponent(std::string& out, std::string_view in);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -36,9 +36,9 @@ constexpr int MAX_REMEMBERED_PEERS = 200;
 
 } // unnamed namespace
 
-static std::string getResumeFilename(tr_torrent const* tor, enum tr_metainfo_basename_format format)
+static std::string getResumeFilename(tr_torrent const* tor, tr_magnet_metainfo::BasenameFormat format)
 {
-    return tr_buildTorrentFilename(
+    return tr_magnet_metainfo::makeFilename(
         tr_getResumeDir(tor->session),
         tr_torrentName(tor),
         tor->infoHashString(),
@@ -692,8 +692,8 @@ void tr_torrentSaveResume(tr_torrent* tor)
     saveName(&top, tor);
     saveLabels(&top, tor);
 
-    std::string const filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
-    int const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, filename.c_str());
+    auto const filename = getResumeFilename(tor, tr_magnet_metainfo::BasenameFormat::Hash);
+    auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, filename.c_str());
     if (err != 0)
     {
         tor->setLocalError(tr_strvJoin("Unable to save resume file: ", tr_strerror(err)));
@@ -719,7 +719,7 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
         *didRenameToHashOnlyName = false;
     }
 
-    std::string const filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
+    std::string const filename = getResumeFilename(tor, tr_magnet_metainfo::BasenameFormat::Hash);
 
     auto buf = std::vector<char>{};
     if (!tr_loadFile(buf, filename, &error) ||
@@ -733,7 +733,7 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* didRe
         tr_logAddTorDbg(tor, "Couldn't read \"%s\": %s", filename.c_str(), error->message);
         tr_error_clear(&error);
 
-        std::string const old_filename = getResumeFilename(tor, TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH);
+        std::string const old_filename = getResumeFilename(tor, tr_magnet_metainfo::BasenameFormat::NameAndPartialHash);
 
         if (!tr_variantFromFile(&top, TR_VARIANT_PARSE_BENC, old_filename.c_str(), &error))
         {
@@ -969,9 +969,9 @@ uint64_t tr_torrentLoadResume(tr_torrent* tor, uint64_t fieldsToLoad, tr_ctor co
 
 void tr_torrentRemoveResume(tr_torrent const* tor)
 {
-    std::string filename = getResumeFilename(tor, TR_METAINFO_BASENAME_HASH);
+    std::string filename = getResumeFilename(tor, tr_magnet_metainfo::BasenameFormat::Hash);
     tr_sys_path_remove(filename.c_str(), nullptr);
 
-    filename = getResumeFilename(tor, TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH);
+    filename = getResumeFilename(tor, tr_magnet_metainfo::BasenameFormat::NameAndPartialHash);
     tr_sys_path_remove(filename.c_str(), nullptr);
 }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -17,6 +17,7 @@
 #include "error.h"
 #include "file.h"
 #include "log.h"
+#include "magnet-metainfo.h"
 #include "metainfo.h" /* tr_metainfoGetBasename() */
 #include "peer-mgr.h" /* pex */
 #include "platform.h" /* tr_getResumeDir() */

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -196,20 +196,6 @@ void tr_metainfoDestruct(tr_info* inf)
     memset(inf, '\0', sizeof(tr_info));
 }
 
-static std::string getTorrentFilename(tr_session const* session, tr_info const* inf, enum tr_metainfo_basename_format format)
-{
-    return tr_buildTorrentFilename(tr_getTorrentDir(session), inf, format, ".torrent"sv);
-}
-
-void tr_metainfoRemoveSaved(tr_session const* session, tr_torrent_metainfo const& metainfo)
-{
-    auto filename = getTorrentFilename(session, inf, tr_torrent_metainfo::FilenameFormat::FullHash);
-    tr_sys_path_remove(filename.c_str(), nullptr);
-
-    filename = getTorrentFilename(session, inf, tr_torrent_metainfo::FilenameFormat::NameAndParitalHash);
-    tr_sys_path_remove(filename.c_str(), nullptr);
-}
-
 void tr_metainfoMigrateFile(
     tr_session const* session,
     tr_info const* info,

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -36,17 +36,6 @@ tr_piece_index_t getBytePiece(tr_torrent_metainfo const& tm, uint64_t byte_offse
 }
 #endif
 
-#if 0
-std::string tr_new_magnet_metainfo::makeFilename(std::string_view dirname, FilenameFormat format, std::string_view suffix) const
-{
-    // `${dirname}/${name}.${info_hash}${suffix}`
-    // `${dirname}/${info_hash}${suffix}`
-    return format == FilenameFormat::NameAndParitalHash ?
-        tr_strvJoin(dirname, "/"sv, this->name, "."sv, this->infoHashString().substr(0, 16), suffix) :
-        tr_strvJoin(dirname, "/"sv, this->infoHashString(), suffix);
-}
-#endif
-
 /// tr_torrent_metainfo
 
 //// C BINDINGS
@@ -194,25 +183,6 @@ void tr_metainfoDestruct(tr_info* inf)
     tr_free(inf->trackers);
 
     memset(inf, '\0', sizeof(tr_info));
-}
-
-void tr_metainfoMigrateFile(
-    tr_session const* session,
-    tr_info const* info,
-    enum tr_metainfo_basename_format old_format,
-    enum tr_metainfo_basename_format new_format)
-{
-    auto const old_filename = getTorrentFilename(session, info, old_format);
-    auto const new_filename = getTorrentFilename(session, info, new_format);
-
-    if (tr_sys_path_rename(old_filename.c_str(), new_filename.c_str(), nullptr))
-    {
-        tr_logAddNamedError(
-            info->name,
-            "Migrated torrent file from \"%s\" to \"%s\"",
-            old_filename.c_str(),
-            new_filename.c_str());
-    }
 }
 #endif
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -28,21 +28,11 @@
 
 using namespace std::literals;
 
-#if 0
-tr_piece_index_t getBytePiece(tr_torrent_metainfo const& tm, uint64_t byte_offset)
-{
-    // handle 0-byte files at the end of a torrent
-    return byte_offset == tm.total_size ? tm.n_pieces - 1 : byte_offset / tm.piece_size;
-}
-#endif
-
-/// tr_torrent_metainfo
-
 //// C BINDINGS
 
+#if 0
 /// Lifecycle
 
-#if 0
 tr_torrent_metainfo* tr_torrentMetainfoNewFromData(char const* data, size_t data_len, struct tr_error** error)
 {
     auto* tm = new tr_torrent_metainfo{};
@@ -54,9 +44,7 @@ tr_torrent_metainfo* tr_torrentMetainfoNewFromData(char const* data, size_t data
 
     return tm;
 }
-#endif
 
-#if 0
 tr_torrent_metainfo* tr_torrentMetainfoNewFromFile(char const* filename, struct tr_error** error)
 {
     auto* tm = new tr_torrent_metainfo{};
@@ -68,27 +56,21 @@ tr_torrent_metainfo* tr_torrentMetainfoNewFromFile(char const* filename, struct 
 
     return tm;
 }
-#endif
 
-#if 0
 void tr_torrentMetainfoFree(tr_torrent_metainfo* tm)
 {
     delete tm;
 }
-#endif
 
 ////  Accessors
 
-#if 0
 char* tr_torrentMetainfoMagnet(struct tr_torrent_metainfo const* tm)
 {
     return tr_strvDup(tm->magnet());
 }
-#endif
 
 /// Info
 
-#if 0
 tr_torrent_metainfo_info* tr_torrentMetainfoGet(tr_torrent_metainfo const* tm, tr_torrent_metainfo_info* setme)
 {
     setme->comment = tm->comment.c_str();
@@ -103,18 +85,14 @@ tr_torrent_metainfo_info* tr_torrentMetainfoGet(tr_torrent_metainfo const* tm, t
     setme->total_size = tm->total_size;
     return setme;
 }
-#endif
 
 /// Files
 
-#if 0
 size_t tr_torrentMetainfoFileCount(tr_torrent_metainfo const* tm)
 {
     return std::size(tm->files);
 }
-#endif
 
-#if 0
 tr_torrent_metainfo_file_info* tr_torrentMetainfoFile(
     tr_torrent_metainfo const* tm,
     size_t n,
@@ -125,18 +103,14 @@ tr_torrent_metainfo_file_info* tr_torrentMetainfoFile(
     setme->size = file.size;
     return setme;
 }
-#endif
 
 /// Trackers
 
-#if 0
 size_t tr_torrentMetainfoTrackerCount(tr_torrent_metainfo const* tm)
 {
     return std::size(tm->trackers);
 }
-#endif
 
-#if 0
 tr_torrent_metainfo_tracker_info* tr_torrentMetainfoTracker(
     tr_torrent_metainfo const* tm,
     size_t n,
@@ -149,40 +123,6 @@ tr_torrent_metainfo_tracker_info* tr_torrentMetainfoTracker(
     setme->scrape_url = tr_quark_get_string(tracker.scrape_url);
     setme->tier = tracker.tier;
     return setme;
-}
-#endif
-
-#if 0
-void tr_metainfoDestruct(tr_info* inf)
-{
-    for (unsigned int i = 0; i < inf->webseedCount; i++)
-    {
-        tr_free(inf->webseeds[i]);
-    }
-
-    for (tr_file_index_t ff = 0; ff < inf->fileCount; ff++)
-    {
-        tr_free(inf->files[ff].name);
-    }
-
-    tr_free(inf->webseeds);
-    tr_free(inf->files);
-    tr_free(inf->comment);
-    tr_free(inf->creator);
-    tr_free(inf->source);
-    tr_free(inf->torrent);
-    tr_free(inf->originalName);
-    tr_free(inf->name);
-
-    for (unsigned int i = 0; i < inf->trackerCount; i++)
-    {
-        tr_free(inf->trackers[i].announce);
-        tr_free(inf->trackers[i].scrape);
-    }
-
-    tr_free(inf->trackers);
-
-    memset(inf, '\0', sizeof(tr_info));
 }
 #endif
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1183,15 +1183,15 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.name = tr_torrentName(tor);
     ret.hash_string = tor->infoHashString().c_str();
     ret.torrent_filename = tor->torrentFile().c_str();
-    ret.comment = tor->info.comment().c_str();
-    ret.creator = tor->info.creator().c_str();
-    ret.source = tor->info.source().c_str();
+    ret.comment = tor->comment().c_str();
+    ret.creator = tor->creator().c_str();
+    ret.source = tor->source().c_str();
     ret.total_size = tor->totalSize();
     ret.date_created = tor->dateCreated();
     ret.piece_size = tor->pieceSize();
     ret.n_pieces = tor->pieceCount();
     ret.is_private = tor->isPrivate();
-    ret.is_folder = tor->info.isFolder;
+    ret.is_folder = tor->fileCount() > 1;
 
     return ret;
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -689,7 +689,11 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     if (didRenameResumeFileToHashOnlyName)
     {
         /* Rename torrent file as well */
-        tr_metainfoMigrateFile(session, &tor->info, TR_METAINFO_BASENAME_NAME_AND_PARTIAL_HASH, TR_METAINFO_BASENAME_HASH);
+        tr_metainfoMigrateFile(
+            session,
+            &tor->info,
+            tr_magnet_metainfo::BasenameFormat::NameAndPartialHash,
+            tr_magnet_metainfo::BasenameFormat::Hash);
     }
 
     tor->completeness = tor->completion.status();
@@ -1550,7 +1554,7 @@ static void closeTorrent(void* vtor)
 
     if (tor->isDeleting)
     {
-        tr_metainfoRemoveSaved(tor->session, &tor->info);
+        tr_sys_path_remove(tor->torrentFile().c_str(), nullptr);
         tr_torrentRemoveResume(tor);
     }
 


### PR DESCRIPTION
`tr_metainfo` is going away, but its function `tr_buildTorrentFilename()` will live on, so migrate that function to another part of libtransmission.