### PR TITLE
refactor: use std::vector in tr_info

### DIFF
--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -16,7 +16,7 @@
 
 #include "transmission.h"
 
-#include "quark.h"
+#include "interned-string.h"
 
 struct tr_announcer;
 struct tr_announcer_tiers;

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -59,7 +59,7 @@ void tr_file_piece_map::reset(tr_info const& info)
     {
         file_sizes[i] = info.fileSize(i);
     }
-    reset({ info.totalSize, info.pieceSize }, std::data(file_sizes), std::size(file_sizes));
+    reset({ info.totalSize(), info.pieceSize() }, std::data(file_sizes), std::size(file_sizes));
 }
 
 tr_file_piece_map::piece_span_t tr_file_piece_map::pieceSpan(tr_file_index_t file) const

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -239,14 +239,14 @@ void tr_magnet_metainfo::toVariant(tr_variant* top) const
     }
 
     // webseeds
-    n = std::size(this->webseeds());
+    n = this->webseedCount();
     if (n != 0)
     {
         tr_variant* list = tr_variantDictAddList(top, TR_KEY_url_list, n);
 
-        for (auto& url : this->webseeds())
+        for (size_t i = 0; i < n; ++i)
         {
-            tr_variantListAddStr(list, url);
+            tr_variantListAddStr(list, this->webseed(i));
         }
     }
 

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -34,9 +34,15 @@ public:
     {
         return name_;
     }
-    auto const& webseeds() const
+
+    auto webseedCount() const
     {
-        return webseed_urls_;
+        return std::size(webseed_urls_);
+    }
+
+    auto const& webseed(size_t i) const
+    {
+        return webseed_urls_[i];
     }
 
     auto& announceList()

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -13,9 +13,10 @@
 #endif
 
 #include "transmission.h"
+
 #include "bitfield.h"
 #include "history.h"
-#include "quark.h"
+#include "interned-string.h"
 
 /**
  * @addtogroup peers Peers

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -302,7 +302,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
 
                     auto info = tr_metainfoParse(tor->session, &newMetainfo, nullptr);
                     success = !!info;
-                    if (info && tr_block_info::bestBlockSize(info->info.pieceSize) == 0)
+                    if (info && tr_block_info::bestBlockSize(info->info.pieceSize()) == 0)
                     {
                         tor->setLocalError(_("Magnet torrent's metadata is not usable"));
                         success = false;
@@ -409,10 +409,10 @@ char* tr_torrentInfoGetMagnetLink(tr_info const* inf)
         tr_http_escape(buf, inf->announce_list->at(i).announce.full, true);
     }
 
-    for (unsigned int i = 0; i < inf->webseedCount; i++)
+    for (size_t i = 0, n = inf->webseedCount(); i < n; ++i)
     {
         buf += "&ws="sv;
-        tr_http_escape(buf, inf->webseeds[i], true);
+        tr_http_escape(buf, inf->webseed(i), true);
     }
 
     return tr_strvDup(buf);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -561,7 +561,7 @@ static void tr_torrentFireMetadataCompleted(tr_torrent* tor);
 
 static void torrentInitFromInfoDict(tr_torrent* tor)
 {
-    tor->block_info.initSizes(tor->info.totalSize, tor->info.pieceSize);
+    tor->block_info.initSizes(tor->info.totalSize(), tor->info.pieceSize());
     tor->completion = tr_completion{ tor, &tor->block_info };
     auto const obfuscated = tr_sha1("req2"sv, tor->infoHash());
     if (obfuscated)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -109,7 +109,7 @@ struct tr_torrent : public tr_completion::torrent_view
 {
 public:
     explicit tr_torrent(tr_info const& inf)
-        : block_info{ inf.totalSize, inf.pieceSize }
+        : block_info{ inf.totalSize(), inf.pieceSize() }
         , completion{ this, &this->block_info }
     {
     }
@@ -435,14 +435,12 @@ public:
 
     [[nodiscard]] auto webseedCount() const
     {
-        return info.webseedCount;
+        return info.webseedCount();
     }
 
     [[nodiscard]] auto const& webseed(size_t i) const
     {
-        TR_ASSERT(i < webseedCount());
-
-        return info.webseeds[i];
+        return info.webseed(i);
     }
 
     /// METAINFO - OTHER
@@ -461,7 +459,7 @@ public:
 
     [[nodiscard]] auto isPrivate() const
     {
-        return this->info.isPrivate;
+        return this->info.isPrivate();
     }
 
     [[nodiscard]] auto isPublic() const

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -133,7 +133,7 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
 
     NSMutableArray* lists = [NSMutableArray array];
 
-    auto const n_webseeds = std::size(metainfo.webseeds());
+    auto const n_webseeds = metainfo.webseedCount();
     if (n_webseeds > 0)
     {
         NSMutableString* listSection = [NSMutableString string];
@@ -145,9 +145,9 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
                                        [NSString formattedUInteger:n_webseeds]];
         [listSection appendFormat:@"<tr><th>%@</th></tr>", headerTitleString];
 
-        for (auto const& url : metainfo.webseeds())
+        for (size_t i = 0; i < n_webseeds; ++i)
         {
-            [listSection appendFormat:@"<tr><td>%s<td></tr>", url.c_str()];
+            [listSection appendFormat:@"<tr><td>%s<td></tr>", metainfo.webseed(i).c_str()];
         }
 
         [listSection appendString:@"</table>"];

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -55,8 +55,8 @@ TEST(MagnetMetainfo, magnetParse)
         EXPECT_EQ(1, it->tier);
         EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce.full);
         EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape.full);
-        EXPECT_EQ(1, std::size(mm.webseeds()));
-        EXPECT_EQ("http://server.webseed.org/path/to/file"sv, mm.webseeds().front());
+        EXPECT_EQ(1, mm.webseedCount());
+        EXPECT_EQ("http://server.webseed.org/path/to/file"sv, mm.webseed(0));
         EXPECT_EQ("Display Name"sv, mm.name());
         EXPECT_EQ(ExpectedHash, mm.infoHash());
     }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -160,13 +160,14 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
     ***
     **/
 
-    if (auto const& webseeds = metainfo.webseeds(); !std::empty(webseeds))
+    auto const n_webseeds = metainfo.webseedCount();
+    if (n_webseeds > 0)
     {
         printf("\nWEBSEEDS\n\n");
 
-        for (auto const& webseed : webseeds)
+        for (size_t i = 0; i < n_webseeds; ++i)
         {
-            printf("  %s\n", webseed.c_str());
+            printf("  %s\n", metainfo.webseed(i).c_str());
         }
     }
 


### PR DESCRIPTION
Reduce code shear between master (`tr_info`) and `tr_torrent_metainfo` branches.