### PR TITLE
fix: potential infinite loop when parsing benc

### DIFF
--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -235,6 +235,7 @@ int tr_variantParseBenc(tr_variant& top, int parse_opts, std::string_view benc, 
                 auto const sv = tr_bencParseStr(&benc);
                 if (!sv)
                 {
+                    benc.remove_prefix(1);
                     break;
                 }
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -242,9 +242,14 @@ TEST_F(VariantTest, parse)
     benc = "le"sv;
     EXPECT_TRUE(tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end));
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
-
     EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
     tr_variantFree(&val);
+
+    benc = "d20:"sv;
+    end = nullptr;
+    ok = tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end);
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(nullptr, end);
 }
 
 TEST_F(VariantTest, bencParseAndReencode)


### PR DESCRIPTION
Work on magnet / metainfo is still chugging along, but I hit this unrelated benc parsing error today so this PR adds a fix and regression test.