### PR TITLE
fix: parse utorrent peer-id version components as hex

### DIFF
--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -442,7 +442,7 @@ void transmission_formatter(char* buf, size_t buflen, std::string_view name, tr_
     }
 }
 
-constexpr void utorrent_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
+void utorrent_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
 {
     if (id[7] == '-')
     {

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -92,12 +92,12 @@ auto constexpr charints = std::array<std::string_view, 256>{
       "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x",  "x" }
 };
 
-int strint(void const* pch, int span)
+int strint(void const* pch, int span, int base = 0)
 {
     char tmp[64];
     memcpy(tmp, pch, span);
     tmp[span] = '\0';
-    return strtol(tmp, nullptr, 0);
+    return strtol(tmp, nullptr, base);
 }
 
 constexpr std::string_view getMnemonicEnd(uint8_t ch)
@@ -446,11 +446,31 @@ constexpr void utorrent_formatter(char* buf, size_t buflen, std::string_view nam
 {
     if (id[7] == '-')
     {
-        buf_append(buf, buflen, name, ' ', id[3], '.', id[4], '.', id[5], getMnemonicEnd(id[6]));
+        buf_append(
+            buf,
+            buflen,
+            name,
+            ' ',
+            strint(&id[3], 1, 16),
+            '.',
+            strint(&id[4], 1, 16),
+            '.',
+            strint(&id[5], 1, 16),
+            getMnemonicEnd(id[6]));
     }
     else // uTorrent replaces the trailing dash with an extra digit for longer version numbers
     {
-        buf_append(buf, buflen, name, ' ', id[3], '.', id[4], '.', id[5], id[6], getMnemonicEnd(id[6]));
+        buf_append(
+            buf,
+            buflen,
+            name,
+            ' ',
+            strint(&id[3], 1, 16),
+            '.',
+            strint(&id[4], 1, 16),
+            '.',
+            strint(&id[5], 2, 10),
+            getMnemonicEnd(id[7]));
     }
 }
 

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -25,7 +25,7 @@ TEST(Client, clientForId)
         std::string_view expected_client;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 37>{
+    auto constexpr Tests = std::array<LocalTest, 38>{
         { { "-AZ8421-"sv, "Azureus / Vuze 8.4.2.1"sv },
           { "-BC0241-"sv, "BitComet 2.41"sv }, // two major, two minor
           { "-BI2300-"sv, "BiglyBT 2.3.0.0"sv },
@@ -50,6 +50,7 @@ TEST(Client, clientForId)
           { "-TR0072-"sv, "Transmission 0.72"sv },
           { "-TR111Z-"sv, "Transmission 1.11+"sv },
           { "-UT341\0-"sv, "\xc2\xb5Torrent 3.4.1"sv },
+          { "-UT7a5\0-"sv, "\xc2\xb5Torrent 7.10.5"sv },
           { "-UW110Q-"sv, "\xc2\xb5Torrent Web 1.1.0"sv },
           { "-UW1110Q"sv, "\xc2\xb5Torrent Web 1.1.10"sv }, // wider version
           { "-WS1000-"sv, "HTTP Seed"sv },
@@ -73,6 +74,6 @@ TEST(Client, clientForId)
 
         auto buf = std::array<char, 128>{};
         tr_clientForId(buf.data(), buf.size(), peer_id);
-        EXPECT_EQ(test.expected_client, buf.data());
+        EXPECT_EQ(test.expected_client, std::string_view{ buf.data() });
     }
 }


### PR DESCRIPTION
Fixes #2406