### PR TITLE
fix: calculate seed ratio by torrent size.

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -334,34 +334,33 @@ bool tr_torrentGetSeedRatio(tr_torrent const* tor, double* ratio)
 
 /* returns true if the seed ratio applies --
  * it applies if the torrent's a seed AND it has a seed ratio set */
-static bool tr_torrentGetSeedRatioBytes(tr_torrent const* tor, uint64_t* setmeLeft, uint64_t* setmeGoal)
+static bool tr_torrentGetSeedRatioBytes(tr_torrent const* tor, uint64_t* setme_left, uint64_t* setme_goal)
 {
-    bool seedRatioApplies = false;
+    bool seed_ratio_applies = false;
 
     TR_ASSERT(tr_isTorrent(tor));
 
-    auto seedRatio = double{};
-    if (tr_torrentGetSeedRatio(tor, &seedRatio))
+    auto seed_ratio = double{};
+    if (tr_torrentGetSeedRatio(tor, &seed_ratio))
     {
-        uint64_t const u = tor->uploadedCur + tor->uploadedPrev;
-        uint64_t const d = tor->downloadedCur + tor->downloadedPrev;
-        uint64_t const baseline = d != 0 ? d : tor->completion.sizeWhenDone();
-        uint64_t const goal = baseline * seedRatio;
+        auto const uploaded = tor->uploadedCur + tor->uploadedPrev;
+        auto const baseline = tor->totalSize();
+        auto const goal = baseline * seed_ratio;
 
-        if (setmeLeft != nullptr)
+        if (setme_left != nullptr)
         {
-            *setmeLeft = goal > u ? goal - u : 0;
+            *setme_left = goal > uploaded ? goal - uploaded : 0;
         }
 
-        if (setmeGoal != nullptr)
+        if (setme_goal != nullptr)
         {
-            *setmeGoal = goal;
+            *setme_goal = goal;
         }
 
-        seedRatioApplies = tor->isDone();
+        seed_ratio_applies = tor->isDone();
     }
 
-    return seedRatioApplies;
+    return seed_ratio_applies;
 }
 
 static bool tr_torrentIsSeedRatioDone(tr_torrent const* tor)
@@ -996,7 +995,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->haveUnchecked = tor->hasTotal() - s->haveValid;
     s->desiredAvailable = tr_peerMgrGetDesiredAvailable(tor);
 
-    s->ratio = tr_getRatio(s->uploadedEver, s->downloadedEver != 0 ? s->downloadedEver : s->haveValid);
+    s->ratio = tr_getRatio(s->uploadedEver, tor->totalSize());
 
     auto seedRatioBytesLeft = uint64_t{};
     auto seedRatioBytesGoal = uint64_t{};

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -76,6 +76,9 @@ enum tr_encryption_mode
     TR_ENCRYPTION_REQUIRED
 };
 
+#define TR_RATIO_NA -1
+#define TR_RATIO_INF -2
+
 /***
 ****
 ****  Startup & Shutdown
@@ -1660,9 +1663,9 @@ struct tr_stat
         or 0 if you can't */
     time_t manualAnnounceTime;
 
-#define TR_RATIO_NA -1
-#define TR_RATIO_INF -2
-    /** TR_RATIO_INF, TR_RATIO_NA, or a regular ratio */
+    /** Total uploaded bytes / total torrent size.
+        NB: In Transmission 3.00 and earlier, this was total upload / download,
+        which caused edge cases when total download was less than the total size. */
     float ratio;
 
     /** When the torrent was first added. */

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -388,7 +388,7 @@ std::string& tr_strvUtf8Clean(std::string_view cleanme, std::string& setme);
 ****
 ***/
 
-/** @brief return TR_RATIO_NA, TR_RATIO_INF, or a number in [0..1]
+/** @brief return TR_RATIO_NA or a number in [0..1]
     @return TR_RATIO_NA, TR_RATIO_INF, or a number in [0..1] */
 double tr_getRatio(uint64_t numerator, uint64_t denominator);
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -388,7 +388,7 @@ std::string& tr_strvUtf8Clean(std::string_view cleanme, std::string& setme);
 ****
 ***/
 
-/** @brief return TR_RATIO_NA or a number in [0..1]
+/** @brief return TR_RATIO_NA, TR_RATIO_INF, or a number in [0..1]
     @return TR_RATIO_NA, TR_RATIO_INF, or a number in [0..1] */
 double tr_getRatio(uint64_t numerator, uint64_t denominator);
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -100,29 +100,28 @@
 + (NSString*)stringForRatio:(CGFloat)ratio
 {
     //N/A is different than libtransmission's
+
     if ((int)ratio == TR_RATIO_NA)
     {
         return NSLocalizedString(@"N/A", "No Ratio");
     }
-    else if ((int)ratio == TR_RATIO_INF)
+
+    if ((int)ratio == TR_RATIO_INF)
     {
         return @"\xE2\x88\x9E";
     }
-    else
+
+    if (ratio < 10.0)
     {
-        if (ratio < 10.0)
-        {
-            return [NSString localizedStringWithFormat:@"%.2f", tr_truncd(ratio, 2)];
-        }
-        else if (ratio < 100.0)
-        {
-            return [NSString localizedStringWithFormat:@"%.1f", tr_truncd(ratio, 1)];
-        }
-        else
-        {
-            return [NSString localizedStringWithFormat:@"%.0f", tr_truncd(ratio, 0)];
-        }
+        return [NSString localizedStringWithFormat:@"%.2f", tr_truncd(ratio, 2)];
     }
+
+    if (ratio < 100.0)
+    {
+        return [NSString localizedStringWithFormat:@"%.1f", tr_truncd(ratio, 1)];
+    }
+
+    return [NSString localizedStringWithFormat:@"%.0f", tr_truncd(ratio, 0)];
 }
 
 + (NSString*)percentString:(CGFloat)progress longDecimals:(BOOL)longDecimals


### PR DESCRIPTION
fix: calculate seedratio by torrent size
    
Fixes #276.
    
Previously was calculated by number of bytes downloaded, which caused edge cases when those two numbers were not the same, e.g. if the user already had part of the torrent from another source and only downloaded a small part. When this happened, the ratio could be very large and use of seedratio would behave in a way that most people would not expect.
    
Note, the old behavior has been around for a VERY LONG TIME. Even though this is a bugfix, it does change semantics. I don't think there is any third-party code that depends on the old behavior but this is arguably a breaking change.
