### PR TITLE
fix: torrents re-added due to unremoved cfg files

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -682,7 +682,7 @@ void tr_torrentSaveResume(tr_torrent* tor)
     saveName(&top, tor);
     saveLabels(&top, tor);
 
-    auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, tor->makeResumeFilename());
+    auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, tor->resumeFilename());
     if (err != 0)
     {
         tor->setLocalError(tr_strvJoin("Unable to save resume file: ", tr_strerror(err)));
@@ -702,7 +702,7 @@ static uint64_t loadFromFile(tr_torrent* tor, uint64_t fieldsToLoad, bool* did_m
         *did_migrate_filename = migrated;
     }
 
-    std::string const filename = tor->makeResumeFilename();
+    std::string const filename = tor->resumeFilename();
 
     auto buf = std::vector<char>{};
     tr_error* error = nullptr;
@@ -937,9 +937,4 @@ uint64_t tr_torrentLoadResume(tr_torrent* tor, uint64_t fieldsToLoad, tr_ctor co
     ret |= useFallbackFields(tor, fieldsToLoad, ctor);
 
     return ret;
-}
-
-void tr_torrentRemoveResume(tr_torrent const* tor)
-{
-    tr_sys_path_remove(tor->makeResumeFilename().c_str(), nullptr);
 }

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -50,7 +50,3 @@ enum
 uint64_t tr_torrentLoadResume(tr_torrent* tor, uint64_t fieldsToLoad, tr_ctor const* ctor, bool* didRenameToHashOnlyName);
 
 void tr_torrentSaveResume(tr_torrent* tor);
-
-void tr_torrentRemoveResume(tr_torrent const* tor);
-
-int tr_torrentRenameResume(tr_torrent const* tor, char const* newname);

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -277,7 +277,7 @@ static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_
     }
 
     // save it
-    auto const filename = tor->makeTorrentFilename();
+    auto const filename = tor->torrentFilename();
     if (!tr_saveFile(filename, benc, error))
     {
         return false;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -575,7 +575,7 @@ bool tr_torrent_metainfo::migrateFile(
     std::string_view dirname,
     std::string_view name,
     std::string_view info_hash_string,
-    std::string_view suffix)
+    std::string_view suffix) const
 {
     auto const old_filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
     auto const old_filename_exists = tr_sys_path_exists(old_filename.c_str(), nullptr);
@@ -605,6 +605,19 @@ bool tr_torrent_metainfo::migrateFile(
     }
 
     return false; // neither file exists
+}
+
+void tr_torrent_metainfo::removeFile(
+    std::string_view dirname,
+    std::string_view name,
+    std::string_view info_hash_string,
+    std::string_view suffix)
+{
+    auto filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
+    tr_sys_path_remove(filename.c_str(), nullptr);
+
+    filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
+    tr_sys_path_remove(filename.c_str(), nullptr);
 }
 
 std::string const& tr_torrent_metainfo::fileSubpath(tr_file_index_t i) const

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -155,17 +155,23 @@ public:
         return info_dict_offset_;
     }
 
-    std::string makeTorrentFilename(std::string_view torrent_dir) const
+    std::string torrentFilename(std::string_view torrent_dir) const
     {
         return makeFilename(torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");
     }
 
-    std::string makeResumeFilename(std::string_view resume_dir) const
+    std::string resumeFilename(std::string_view resume_dir) const
     {
         return makeFilename(resume_dir, name(), infoHashString(), BasenameFormat::Hash, ".resume");
     }
 
     bool migrateFile(
+        std::string_view dirname,
+        std::string_view name,
+        std::string_view info_hash_string,
+        std::string_view suffix) const;
+
+    void removeFile(
         std::string_view dirname,
         std::string_view name,
         std::string_view info_hash_string,

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -723,7 +723,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tr_sessionAddTorrent(session, tor);
 
     // if we don't have a local .torrent file already, assume the torrent is new
-    auto filename = tor->makeTorrentFilename();
+    auto filename = tor->torrentFilename();
     bool const is_new_torrent = !tr_sys_path_exists(filename.c_str(), nullptr);
     if (is_new_torrent)
     {
@@ -1542,8 +1542,8 @@ static void closeTorrent(void* vtor)
 
     if (tor->isDeleting)
     {
-        tr_sys_path_remove(tor->torrentFile().c_str(), nullptr);
-        tr_torrentRemoveResume(tor);
+        tor->metainfo_.removeFile(tor->session->torrent_dir, tor->name(), tor->infoHashString(), ".torrent"sv);
+        tor->metainfo_.removeFile(tor->session->resume_dir, tor->name(), tor->infoHashString(), ".resume"sv);
     }
 
     tor->isRunning = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -516,14 +516,14 @@ public:
         return metainfo_.infoDictOffset();
     }
 
-    [[nodiscard]] auto makeTorrentFilename() const
+    [[nodiscard]] auto torrentFilename() const
     {
-        return metainfo_.makeTorrentFilename(this->session->torrent_dir);
+        return metainfo_.torrentFilename(this->session->torrent_dir);
     }
 
-    [[nodiscard]] auto makeResumeFilename() const
+    [[nodiscard]] auto resumeFilename() const
     {
-        return metainfo_.makeResumeFilename(this->session->resume_dir);
+        return metainfo_.resumeFilename(this->session->resume_dir);
     }
 
     /// METAINFO - CHECKSUMS


### PR DESCRIPTION
Fixes #2430.

When removing a torrent, try to remove config filenames under both old and new filename formats. This prevents torrents from being incorrectly re-added when old-format files aren't removed.