### PR TITLE
chore: disable ssl verification when using libcurl

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -247,22 +247,8 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
     curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, task);
 #endif
 
-    if (web->curl_ssl_verify)
-    {
-        if (web->curl_ca_bundle != nullptr)
-        {
-            curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
-        }
-        else
-        {
-            curl_easy_setopt(e, CURLOPT_SSL_CTX_FUNCTION, ssl_context_func);
-        }
-    }
-    else
-    {
-        curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
-        curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
-    }
+    curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
 
     curl_easy_setopt(e, CURLOPT_TIMEOUT, task->timeout_secs);
     curl_easy_setopt(e, CURLOPT_URL, task->url.c_str());


### PR DESCRIPTION
EXPERIMENTAL COMMIT DO NOT MERGE

This is a test to see if disabling ssl verification in curl resolves the problems that the system install of libcurl has on older macOS systems. https://blog.bytesguy.com/resolving-lets-encrypt-issues-with-curl-on-macos has some background context on the issue.

Issue discussion at https://github.com/transmission/transmission/issues/2429