### PR TITLE
fix: explicitly use unsigned char when checking isprint()

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -574,7 +574,7 @@ static void jsonStringFunc(tr_variant const* val, void* vdata)
             break;
 
         default:
-            if (isprint(sv.front()))
+            if (isprint((unsigned char)sv.front()))
             {
                 *outwalk++ = sv.front();
             }


### PR DESCRIPTION
Fixes a follow-up issue reported in https://github.com/transmission/transmission/issues/2106#issuecomment-1015797781