### PR TITLE
chore: update copyright years, make notices consistent

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -1,4 +1,4 @@
-// This file Copyright © Transmission authors and contributors
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstdio> /* fprintf () */

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -1,4 +1,4 @@
-// This file Copyright (c) Transmission authors and contributors
+// This file Copyright © Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -1,5 +1,5 @@
 .\"
-.\"  Copyright (c) Deanna Phillips <deanna@sdf.lonestar.org>
+.\"  Copyright © Deanna Phillips <deanna@sdf.lonestar.org>
 .\"
 .\"  Permission to use, copy, modify, and distribute this software for any
 .\"  purpose with or without fee is hereby granted, provided that the above

--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -1,5 +1,5 @@
 .\"
-.\"  Copyright © Deanna Phillips <deanna@sdf.lonestar.org>
+.\"  This file Copyright © Deanna Phillips <deanna@sdf.lonestar.org>
 .\"
 .\"  Permission to use, copy, modify, and distribute this software for any
 .\"  purpose with or without fee is hereby granted, provided that the above

--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <assert.h>
 #include <errno.h>

--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <process.h> /* _beginthreadex() */
 

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <errno.h>

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <string>

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Actions.h
+++ b/gtk/Actions.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Actions.h
+++ b/gtk/Actions.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
@@ -1273,7 +1273,7 @@ void Application::Impl::show_about_dialog()
     Gtk::AboutDialog d;
     d.set_authors(authors);
     d.set_comments(_("A fast and easy BitTorrent client"));
-    d.set_copyright(_("Copyright (c) The Transmission Project"));
+    d.set_copyright(_("Copyright © The Transmission Project"));
     d.set_logo_icon_name(AppIconName);
     d.set_name(Glib::get_application_name());
     /* Translators: translate "translator-credits" as your name

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstdlib> // exit()
@@ -72,7 +54,6 @@ char const* const LICENSE =
     "Copyright 2005-2020. All code is copyrighted by the respective authors.\n"
     "\n"
     "Transmission can be redistributed and/or modified under the terms of the "
-    "GNU GPL versions 2 or 3 or by any future license endorsed by Mnemosyne LLC.\n"
     "\n"
     "In addition, linking to and/or using OpenSSL is allowed.\n"
     "\n"

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <memory>

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <memory>

--- a/gtk/FaviconCache.h
+++ b/gtk/FaviconCache.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FaviconCache.h
+++ b/gtk/FaviconCache.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <climits> /* INT_MAX */
 #include <cstddef>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 #include <set>

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FilterBar.h
+++ b/gtk/FilterBar.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FilterBar.h
+++ b/gtk/FilterBar.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 #include <string>

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/FreeSpaceLabel.h
+++ b/gtk/FreeSpaceLabel.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 #include <string>

--- a/gtk/FreeSpaceLabel.h
+++ b/gtk/FreeSpaceLabel.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/HigWorkarea.cc
+++ b/gtk/HigWorkarea.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/tr-macros.h>
 

--- a/gtk/HigWorkarea.cc
+++ b/gtk/HigWorkarea.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/HigWorkarea.h
+++ b/gtk/HigWorkarea.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/HigWorkarea.h
+++ b/gtk/HigWorkarea.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <string>
 

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2022 by its respective authors.
+// This file Copyright © 2005-2022 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 by its respective authors.
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2022 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 #include <string>

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/MakeDialog.h
+++ b/gtk/MakeDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/MakeDialog.h
+++ b/gtk/MakeDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <errno.h>
 #include <stdio.h>

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/MessageLogWindow.h
+++ b/gtk/MessageLogWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/MessageLogWindow.h
+++ b/gtk/MessageLogWindow.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <map>
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Notify.h
+++ b/gtk/Notify.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Notify.h
+++ b/gtk/Notify.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/OptionsDialog.h
+++ b/gtk/OptionsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/OptionsDialog.h
+++ b/gtk/OptionsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file copyright (C) by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <errno.h>
 #include <stdlib.h> /* strtol() */

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -1,4 +1,4 @@
-// This file copyright (C) by its respective authors.
+// This file copyright (C) Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file copyright (C) 2005-2022 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -1,4 +1,4 @@
-// This file copyright (C) 2005-2022 by its respective authors.
+// This file copyright (C) 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <climits> /* USHRT_MAX, INT_MAX */
 #include <sstream>

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/PrefsDialog.h
+++ b/gtk/PrefsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/PrefsDialog.h
+++ b/gtk/PrefsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <memory>

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Transmission authors and contributors
+// Copyright © Transmission authors and contributors
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1,4 +1,4 @@
-// Copyright © Transmission authors and contributors
+// Copyright © Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// Copyright (c) Transmission authors and contributors
+// This file is licensed under the MIT (SPDX: MIT) license,
+// A copy of this license can be found in licenses/ .
 
 #include <algorithm>
 #include <cmath> /* pow() */

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -1,4 +1,4 @@
-// Copyright (c) Transmission authors and contributors
+// Copyright © Transmission authors and contributors
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// Copyright (c) Transmission authors and contributors
+// This file is licensed under the MIT (SPDX: MIT) license,
+// A copy of this license can be found in licenses/ .
 
 #pragma once
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -1,4 +1,4 @@
-// Copyright © Transmission authors and contributors
+// Copyright © Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/StatsDialog.h
+++ b/gtk/StatsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/StatsDialog.h
+++ b/gtk/StatsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 // _AppIndicatorClass::{fallback,unfallback} use deprecated GtkStatusIcon
 #undef GTK_DISABLE_DEPRECATED

--- a/gtk/SystemTrayIcon.h
+++ b/gtk/SystemTrayIcon.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/SystemTrayIcon.h
+++ b/gtk/SystemTrayIcon.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <climits> /* INT_MAX */
 #include <cstring> // strchr()

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <ctype.h> /* isxdigit() */

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 by its respective authors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2021 by its respective authors.
+// This file Copyright © 2005-2021 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (C) 2005-2021 by its respective authors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <cstdio>
 #include <string>

--- a/gtk/transmission-gtk.1
+++ b/gtk/transmission-gtk.1
@@ -1,4 +1,4 @@
-.\" Copyright © 2007 Joshua Elsasser
+.\" This file Copyright © 2007 Joshua Elsasser
 .\"
 .\" Permission is hereby granted, free of charge, to any person obtaining a
 .\" copy of this software and associated documentation files (the "Software"),

--- a/gtk/transmission-gtk.1
+++ b/gtk/transmission-gtk.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2007 Joshua Elsasser
+.\" Copyright © 2007 Joshua Elsasser
 .\"
 .\" Permission is hereby granted, free of charge, to any person obtaining a
 .\" copy of this software and associated documentation files (the "Software"),

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <set>

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <climits> /* USHRT_MAX */
 #include <cstdio> /* fprintf() */

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno> /* errno, EAFNOSUPPORT */
 #include <cstring> /* memset() */

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <vector>

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <vector>

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/block-info.cc
+++ b/libtransmission/block-info.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <event2/util.h>
 

--- a/libtransmission/block-info.cc
+++ b/libtransmission/block-info.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <cstdio>

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstdlib> /* qsort() */
 #include <ctime>

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 /* thanks amc1! */
 

--- a/libtransmission/clients.h
+++ b/libtransmission/clients.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/clients.h
+++ b/libtransmission/clients.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <memory>

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 #include <type_traits>

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <mutex>
 

--- a/libtransmission/crypto-utils-fallback.cc
+++ b/libtransmission/crypto-utils-fallback.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 /* This file is designed specifically to be included by other source files to
    implement missing (or duplicate) functionality without exposing internal

--- a/libtransmission/crypto-utils-fallback.cc
+++ b/libtransmission/crypto-utils-fallback.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #ifdef __APPLE__
 /* OpenSSL "deprecated" as of OS X 10.7, but we still use it */

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <mutex>
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #ifndef TR_CRYPTO_UTILS_H
 #define TR_CRYPTO_UTILS_H

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto.cc
+++ b/libtransmission/crypto.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstring> /* memcpy(), memmove(), memset() */
 

--- a/libtransmission/crypto.cc
+++ b/libtransmission/crypto.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/crypto.h
+++ b/libtransmission/crypto.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 // NB: crypto-test-ref.h needs this, so use it instead of #pragma once
 #ifndef TR_ENCRYPTION_H

--- a/libtransmission/crypto.h
+++ b/libtransmission/crypto.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/error-types.h
+++ b/libtransmission/error-types.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/error-types.h
+++ b/libtransmission/error-types.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <string_view>
 

--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2005-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// This file Copyright © 2005-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/fdlimit.h
+++ b/libtransmission/fdlimit.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// This file Copyright © 2005-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/fdlimit.h
+++ b/libtransmission/fdlimit.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2005-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <vector>

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #undef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <string_view>

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/history.h
+++ b/libtransmission/history.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -1,9 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/jsonsl.c
+++ b/libtransmission/jsonsl.c
@@ -1,6 +1,6 @@
 /* https://github.com/mnunberg/jsonsl */
 
-/* Copyright (C) 2012-2015 Mark Nunberg.
+/* Copyright © 2012-2015 Mark Nunberg.
  *
  * See included LICENSE file for license details.
  */

--- a/libtransmission/jsonsl.h
+++ b/libtransmission/jsonsl.h
@@ -7,7 +7,7 @@
  * - Callback oriented
  * - Lightweight and fast. One source file and one header file
  *
- * Copyright (C) 2012-2015 Mark Nunberg
+ * Copyright © 2012-2015 Mark Nunberg
  * See included LICENSE file for license details.
  */
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <cstdarg>

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstring>

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/mime-types.h
+++ b/libtransmission/mime-types.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/mime-types.h
+++ b/libtransmission/mime-types.h
@@ -1,9 +1,7 @@
-/*
- * This file Copyright (C) 2022 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+// This file Copyright (C) 2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/mime-types.js
+++ b/libtransmission/mime-types.js
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 
 const copyright =
-`/*
- * This file Copyright (C) ${new Date().getFullYear()} Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */`;
+`// This file Copyright (C) ${new Date().getFullYear()} Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 const fs = require('fs');
 const https = require('https');

--- a/libtransmission/mime-types.js
+++ b/libtransmission/mime-types.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 const copyright =
-`// This file Copyright (C) ${new Date().getFullYear()} Mnemosyne LLC.
+`// This file Copyright © 2021-${new Date().getFullYear()} Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
-// License text can be found in the licenses/ folder.
+// License text can be found in the licenses/ folder.`;
 
 const fs = require('fs');
 const https = require('https');

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <ctime>

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -1,4 +1,4 @@
-// Copyright (C) Transmission authors and contributors. This file is
+// Copyright © Transmission authors and contributors. This file is
 // licensed under the MIT (SPDX: MIT) license, A copy is in licenses/
 
 #include <algorithm>

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -1,24 +1,5 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// Copyright (C) Transmission authors and contributors. This file is
+// licensed under the MIT (SPDX: MIT) license, A copy is in licenses/
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -1,5 +1,6 @@
-// Copyright © Transmission authors and contributors. This file is
-// licensed under the MIT (SPDX: MIT) license, A copy is in licenses/
+// This file Copyright © 2010 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// Copyright (C) Transmission authors and contributors.
+// This file is licensed under the MIT (SPDX: MIT) license,
+// A copy of this license can be found in licenses/ .
 
 #pragma once
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -1,4 +1,4 @@
-// Copyright (C) Transmission authors and contributors.
+// Copyright © Transmission authors and contributors.
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>
@@ -570,14 +567,14 @@ static auto utp_function_table = UTPFunctionTable{
 
 static void dummy_read(void* /*closure*/, unsigned char const* /*buf*/, size_t /*buflen*/)
 {
-    /* This cannot happen, as far as I'm aware. */
+    // This cannot happen, as far as I'm aware. */
     tr_logAddNamedError("UTP", "On_read called on closed socket");
 }
 
 static void dummy_write(void* /*closure*/, unsigned char* buf, size_t buflen)
 {
     /* This can very well happen if we've shut down a peer connection that
-       had unflushed buffers.  Complain and send zeroes. */
+       had unflushed buffers.Complain and send zeroes.*/
     tr_logAddNamedDbg("UTP", "On_write called on closed socket");
     memset(buf, 0, buflen);
 }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr-active-requests.cc
+++ b/libtransmission/peer-mgr-active-requests.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <ctime>

--- a/libtransmission/peer-mgr-active-requests.cc
+++ b/libtransmission/peer-mgr-active-requests.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr-active-requests.h
+++ b/libtransmission/peer-mgr-active-requests.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-mgr-active-requests.h
+++ b/libtransmission/peer-mgr-active-requests.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstddef>

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno> /* error codes ERANGE, ... */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <cstring>

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/platform-quota.h
+++ b/libtransmission/platform-quota.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/platform-quota.h
+++ b/libtransmission/platform-quota.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstdarg>

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <sys/types.h>

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/ptrarray.cc
+++ b/libtransmission/ptrarray.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstring> /* memmove */

--- a/libtransmission/ptrarray.h
+++ b/libtransmission/ptrarray.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/ptrarray.h
+++ b/libtransmission/ptrarray.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -1,9 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstring>

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// This file Copyright © 2016-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <ctime>
 #include <string_view>

--- a/libtransmission/session-id.h
+++ b/libtransmission/session-id.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2016-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::partial_sort(), std::min(), std::max()
 #include <cerrno> /* ENOENT */

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <ctime>
 #include <string>

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <csignal>

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -125,7 +125,7 @@ bool tr_spawn_async(
 
     if (!sigchld_handler_set)
     {
-        /* FIXME: "The effects of signal() in a multithreaded process are unspecified." (c) man 2 signal */
+        /* FIXME: "The effects of signal() in a multithreaded process are unspecified." © man 2 signal */
         if (signal(SIGCHLD, &handle_sigchld) == SIG_ERR) // NOLINT(performance-no-int-to-ptr)
         {
             set_system_error(error, errno, "Call to signal()");

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2011-2022 Mnemosyne LLC.
+// This file Copyright © 2011-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
@@ -136,7 +136,7 @@ static wchar_t** to_wide_env(std::map<std::string_view, std::string_view> const&
     wide_env[i] = nullptr;
     TR_ASSERT(i == part_count);
 
-    /* "The sort is case-insensitive, Unicode order, without regard to locale" (c) MSDN */
+    /* "The sort is case-insensitive, Unicode order, without regard to locale" © MSDN */
     qsort(wide_env, part_count, sizeof(wchar_t*), &compare_env_part_names);
 
     return wide_env;

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2011-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2011-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <climits>

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno> // EINVAL
 #include <optional>

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <climits> /* INT_MAX */

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cctype>

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// This file Copyright © 2005-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2005-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2005-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm> /* EINVAL */
 #include <array>

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2021 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstdarg>
 #include <cstdio>

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2010 by Juliusz Chroboczek.
+// This file Copyright © 2009-2010 by Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -1,26 +1,6 @@
-/*
- * Copyright (c) 2009-2010 by Juliusz Chroboczek
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- *
- */
+// This file Copyright (c) 2009-2010 by Juliusz Chroboczek.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2010 by Juliusz Chroboczek.
+// This file Copyright © 2009-2010 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -1,26 +1,6 @@
-/*
- * Copyright (c) 2009-2010 by Juliusz Chroboczek
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- *
- */
+// This file Copyright (c) 2009-2010 by Juliusz Chroboczek.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2010 by Juliusz Chroboczek.
+// This file Copyright © 2009-2010 by Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2010 by Juliusz Chroboczek.
+// This file Copyright © 2009-2010 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstdlib> /* exit() */

--- a/libtransmission/tr-getopt.h
+++ b/libtransmission/tr-getopt.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-getopt.h
+++ b/libtransmission/tr-getopt.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010 by Johannes Lieder
+// This file Copyright © 2010 by Johannes Lieder
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 by Johannes Lieder
+// This file Copyright © 2010 Johannes Lieder.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -1,24 +1,6 @@
-/*
-Copyright (c) 2010 by Johannes Lieder
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+// This file Copyright (c) 2010 by Johannes Lieder
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cerrno>

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -1,24 +1,6 @@
-/*
-Copyright (c) 2010 by Johannes Lieder
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+// This file Copyright (c) 2010 by Johannes Lieder
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010 by Johannes Lieder
+// This file Copyright © 2010 by Johannes Lieder
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 by Johannes Lieder
+// This file Copyright © 2010 Johannes Lieder.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010 by Juliusz Chroboczek
+// This file Copyright © 2010 by Juliusz Chroboczek
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -1,25 +1,6 @@
-/*
-Copyright (c) 2010 by Juliusz Chroboczek
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+// This file Copyright (c) 2010 by Juliusz Chroboczek
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <cstring> /* memcmp(), memcpy(), memset() */
 #include <cstdlib> /* malloc(), free() */

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 by Juliusz Chroboczek
+// This file Copyright © 2010 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-udp.h
+++ b/libtransmission/tr-udp.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010 by Juliusz Chroboczek
+// This file Copyright © 2010 by Juliusz Chroboczek
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-udp.h
+++ b/libtransmission/tr-udp.h
@@ -1,25 +1,6 @@
-/*
-Copyright (c) 2010 by Juliusz Chroboczek
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+// This file Copyright (c) 2010 by Juliusz Chroboczek
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/tr-udp.h
+++ b/libtransmission/tr-udp.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010 by Juliusz Chroboczek
+// This file Copyright © 2010 Juliusz Chroboczek.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -1,25 +1,6 @@
-/*
-Copyright (c) 2010 by Juliusz Chroboczek
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+// Copyright (c) 2010 by Juliusz Chroboczek
+// This file is licensed under the MIT (SPDX: MIT) license,
+// A copy of this license can be found in licenses/ .
 
 #include <event2/event.h>
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010 by Juliusz Chroboczek
+// Copyright © 2010 by Juliusz Chroboczek
 // This file is licensed under the MIT (SPDX: MIT) license,
 // A copy of this license can be found in licenses/ .
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -1,6 +1,6 @@
-// Copyright © 2010 by Juliusz Chroboczek
-// This file is licensed under the MIT (SPDX: MIT) license,
-// A copy of this license can be found in licenses/ .
+// This file Copyright © 2010 Juliusz Chroboczek.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <event2/event.h>
 

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010 by Juliusz Chroboczek. This file is licensed
+/* Copyright © 2010 by Juliusz Chroboczek. This file is licensed
  * under the MIT (SPDX: MIT) license, A copy is in licenses/ */
 
 #pragma once

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -1,25 +1,5 @@
-/*
-Copyright (c) 2010 by Juliusz Chroboczek
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+/* Copyright (c) 2010 by Juliusz Chroboczek. This file is licensed
+ * under the MIT (SPDX: MIT) license, A copy is in licenses/ */
 
 #pragma once
 

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -1,5 +1,6 @@
-/* Copyright © 2010 by Juliusz Chroboczek. This file is licensed
- * under the MIT (SPDX: MIT) license, A copy is in licenses/ */
+// This file Copyright © 2010 Juliusz Chroboczek.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1,5 +1,5 @@
 /*
- * This file Copyright © Transmission authors and contributors
+ * This file Copyright © Transmission authors and contributors.
  *
  * It may be used under the 3-Clause BSD License, the GNU Public License v2,
  * or v3, or any future license endorsed by Mnemosyne LLC.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1,5 +1,5 @@
 /*
- * This file Copyright (C) Transmission authors and contributors
+ * This file Copyright © Transmission authors and contributors
  *
  * It may be used under the 3-Clause BSD License, the GNU Public License v2,
  * or v3, or any future license endorsed by Mnemosyne LLC.

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <cstring>

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/trevent.h
+++ b/libtransmission/trevent.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/trevent.h
+++ b/libtransmission/trevent.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/upnp.h
+++ b/libtransmission/upnp.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/upnp.h
+++ b/libtransmission/upnp.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #ifdef HAVE_MEMMEM
 #ifndef _GNU_SOURCE

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cctype> /* isdigit() */

--- a/libtransmission/variant-common.h
+++ b/libtransmission/variant-common.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/variant-common.h
+++ b/libtransmission/variant-common.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cctype>

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #if defined(HAVE_USELOCALE) && (!defined(_XOPEN_SOURCE) || _XOPEN_SOURCE < 700)
 #undef _XOPEN_SOURCE

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// This file Copyright © 2007-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <ctime>

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2007-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2007-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/watchdir-common.h
+++ b/libtransmission/watchdir-common.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/watchdir-common.h
+++ b/libtransmission/watchdir-common.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <string>

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno>
 #include <climits> /* NAME_MAX */

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cerrno> /* errno */
 #include <string>

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <errno.h>
 #include <stddef.h> /* offsetof */

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstring> /* strcmp() */
 #include <string>

--- a/libtransmission/watchdir.h
+++ b/libtransmission/watchdir.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cstring>

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// This file Copyright © 2021-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <set>

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/webseed.h
+++ b/libtransmission/webseed.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/libtransmission/webseed.h
+++ b/libtransmission/webseed.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/licenses/gpl-2.0.txt
+++ b/licenses/gpl-2.0.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/licenses/gpl-3.0.txt
+++ b/licenses/gpl-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/macosx/AboutWindowController.h
+++ b/macosx/AboutWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AboutWindowController.h
+++ b/macosx/AboutWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AboutWindowController.h
+++ b/macosx/AboutWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/version.h>
 

--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddMagnetWindowController.h
+++ b/macosx/AddMagnetWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddMagnetWindowController.h
+++ b/macosx/AddMagnetWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddMagnetWindowController.h
+++ b/macosx/AddMagnetWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "AddMagnetWindowController.h"
 #import "Controller.h"

--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddWindowController.h
+++ b/macosx/AddWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/AddWindowController.h
+++ b/macosx/AddWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddWindowController.h
+++ b/macosx/AddWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "AddWindowController.h"
 #import "Controller.h"

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BadgeView.h
+++ b/macosx/BadgeView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BadgeView.h
+++ b/macosx/BadgeView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BadgeView.h
+++ b/macosx/BadgeView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "BadgeView.h"
 #import "NSStringAdditions.h"

--- a/macosx/Badger.h
+++ b/macosx/Badger.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Badger.h
+++ b/macosx/Badger.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/Badger.h
+++ b/macosx/Badger.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Badger.mm
+++ b/macosx/Badger.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "Badger.h"
 #import "BadgeView.h"

--- a/macosx/Badger.mm
+++ b/macosx/Badger.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Badger.mm
+++ b/macosx/Badger.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloader.h
+++ b/macosx/BlocklistDownloader.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/BlocklistDownloader.h
+++ b/macosx/BlocklistDownloader.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloader.h
+++ b/macosx/BlocklistDownloader.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "BlocklistDownloader.h"
 #import "BlocklistDownloaderViewController.h"

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloaderViewController.h
+++ b/macosx/BlocklistDownloaderViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/BlocklistDownloaderViewController.h
+++ b/macosx/BlocklistDownloaderViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloaderViewController.h
+++ b/macosx/BlocklistDownloaderViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "BlocklistDownloaderViewController.h"
 #import "BlocklistDownloader.h"

--- a/macosx/BlocklistScheduler.h
+++ b/macosx/BlocklistScheduler.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/BlocklistScheduler.h
+++ b/macosx/BlocklistScheduler.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistScheduler.h
+++ b/macosx/BlocklistScheduler.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "BlocklistScheduler.h"
 #import "BlocklistDownloader.h"

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BonjourController.h
+++ b/macosx/BonjourController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/BonjourController.h
+++ b/macosx/BonjourController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BonjourController.h
+++ b/macosx/BonjourController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BonjourController.mm
+++ b/macosx/BonjourController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "BonjourController.h"
 

--- a/macosx/BonjourController.mm
+++ b/macosx/BonjourController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/BonjourController.mm
+++ b/macosx/BonjourController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ButtonToolbarItem.h
+++ b/macosx/ButtonToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ButtonToolbarItem.h
+++ b/macosx/ButtonToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ButtonToolbarItem.h
+++ b/macosx/ButtonToolbarItem.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/ButtonToolbarItem.mm
+++ b/macosx/ButtonToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ButtonToolbarItem.mm
+++ b/macosx/ButtonToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ButtonToolbarItem.mm
+++ b/macosx/ButtonToolbarItem.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "ButtonToolbarItem.h"
 

--- a/macosx/ColorTextField.h
+++ b/macosx/ColorTextField.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/ColorTextField.h
+++ b/macosx/ColorTextField.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ColorTextField.h
+++ b/macosx/ColorTextField.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ColorTextField.mm
+++ b/macosx/ColorTextField.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "ColorTextField.h"
 

--- a/macosx/ColorTextField.mm
+++ b/macosx/ColorTextField.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ColorTextField.mm
+++ b/macosx/ColorTextField.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 #import <Quartz/Quartz.h>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <IOKit/IOMessage.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/CreatorWindowController.h
+++ b/macosx/CreatorWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/CreatorWindowController.h
+++ b/macosx/CreatorWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/CreatorWindowController.h
+++ b/macosx/CreatorWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>

--- a/macosx/DragOverlayView.h
+++ b/macosx/DragOverlayView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayView.h
+++ b/macosx/DragOverlayView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayView.h
+++ b/macosx/DragOverlayView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/DragOverlayView.mm
+++ b/macosx/DragOverlayView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayView.mm
+++ b/macosx/DragOverlayView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayView.mm
+++ b/macosx/DragOverlayView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "DragOverlayView.h"
 

--- a/macosx/DragOverlayWindow.h
+++ b/macosx/DragOverlayWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayWindow.h
+++ b/macosx/DragOverlayWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayWindow.h
+++ b/macosx/DragOverlayWindow.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "DragOverlayWindow.h"
 #import "DragOverlayView.h"

--- a/macosx/ExpandedPathToIconTransformer.h
+++ b/macosx/ExpandedPathToIconTransformer.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToIconTransformer.h
+++ b/macosx/ExpandedPathToIconTransformer.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
 

--- a/macosx/ExpandedPathToIconTransformer.h
+++ b/macosx/ExpandedPathToIconTransformer.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToIconTransformer.mm
+++ b/macosx/ExpandedPathToIconTransformer.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToIconTransformer.mm
+++ b/macosx/ExpandedPathToIconTransformer.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToIconTransformer.mm
+++ b/macosx/ExpandedPathToIconTransformer.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <AppKit/AppKit.h>
 

--- a/macosx/ExpandedPathToPathTransformer.h
+++ b/macosx/ExpandedPathToPathTransformer.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToPathTransformer.h
+++ b/macosx/ExpandedPathToPathTransformer.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
 

--- a/macosx/ExpandedPathToPathTransformer.h
+++ b/macosx/ExpandedPathToPathTransformer.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToPathTransformer.mm
+++ b/macosx/ExpandedPathToPathTransformer.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToPathTransformer.mm
+++ b/macosx/ExpandedPathToPathTransformer.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ExpandedPathToPathTransformer.mm
+++ b/macosx/ExpandedPathToPathTransformer.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "ExpandedPathToPathTransformer.h"
 

--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "FileListNode.h"
 

--- a/macosx/FileNameCell.h
+++ b/macosx/FileNameCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileNameCell.h
+++ b/macosx/FileNameCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileNameCell.h
+++ b/macosx/FileNameCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>

--- a/macosx/FileOutlineController.h
+++ b/macosx/FileOutlineController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FileOutlineController.h
+++ b/macosx/FileOutlineController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineController.h
+++ b/macosx/FileOutlineController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Quartz/Quartz.h>
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineView.h
+++ b/macosx/FileOutlineView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineView.h
+++ b/macosx/FileOutlineView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineView.h
+++ b/macosx/FileOutlineView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoWindowController.h"
 #import "FileListNode.h"

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilePriorityCell.h
+++ b/macosx/FilePriorityCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilePriorityCell.h
+++ b/macosx/FilePriorityCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilePriorityCell.h
+++ b/macosx/FilePriorityCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "FilePriorityCell.h"
 #import "FileOutlineView.h"

--- a/macosx/FileRenameSheetController.h
+++ b/macosx/FileRenameSheetController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2013-2022 Transmission authors and contributors
+// This file Copyright © 2013-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/20/13.

--- a/macosx/FileRenameSheetController.h
+++ b/macosx/FileRenameSheetController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2013-2022 Transmission authors and contributors
+// This file Copyright © 2013-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/20/13.

--- a/macosx/FileRenameSheetController.h
+++ b/macosx/FileRenameSheetController.h
@@ -1,10 +1,7 @@
-//
-//  FileRenameSheetController.h
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/20/13.
-//  Copyright (c) 2013 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2013-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/20/13.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FileRenameSheetController.mm
+++ b/macosx/FileRenameSheetController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2013-2022 Transmission authors and contributors
+// This file Copyright © 2013-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/20/13.

--- a/macosx/FileRenameSheetController.mm
+++ b/macosx/FileRenameSheetController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2013-2022 Transmission authors and contributors
+// This file Copyright © 2013-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/20/13.

--- a/macosx/FileRenameSheetController.mm
+++ b/macosx/FileRenameSheetController.mm
@@ -1,10 +1,7 @@
-//
-//  FileRenameSheetController.m
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/20/13.
-//  Copyright (c) 2013 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2013-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/20/13.
 
 #import "FileRenameSheetController.h"
 #import "FileListNode.h"

--- a/macosx/FilterBarController.h
+++ b/macosx/FilterBarController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FilterBarController.h
+++ b/macosx/FilterBarController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarController.h
+++ b/macosx/FilterBarController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "FilterBarController.h"
 #import "FilterButton.h"

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarView.h
+++ b/macosx/FilterBarView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FilterBarView.h
+++ b/macosx/FilterBarView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarView.h
+++ b/macosx/FilterBarView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarView.mm
+++ b/macosx/FilterBarView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "FilterBarView.h"
 #import "NSApplicationAdditions.h"

--- a/macosx/FilterBarView.mm
+++ b/macosx/FilterBarView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterBarView.mm
+++ b/macosx/FilterBarView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterButton.h
+++ b/macosx/FilterButton.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterButton.h
+++ b/macosx/FilterButton.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterButton.h
+++ b/macosx/FilterButton.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/FilterButton.mm
+++ b/macosx/FilterButton.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/FilterButton.mm
+++ b/macosx/FilterButton.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "FilterButton.h"
 #import "NSStringAdditions.h"

--- a/macosx/FilterButton.mm
+++ b/macosx/FilterButton.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GlobalOptionsPopoverViewController.h
+++ b/macosx/GlobalOptionsPopoverViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/GlobalOptionsPopoverViewController.h
+++ b/macosx/GlobalOptionsPopoverViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GlobalOptionsPopoverViewController.h
+++ b/macosx/GlobalOptionsPopoverViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GlobalOptionsPopoverViewController.mm
+++ b/macosx/GlobalOptionsPopoverViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GlobalOptionsPopoverViewController.mm
+++ b/macosx/GlobalOptionsPopoverViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "GlobalOptionsPopoverViewController.h"
 

--- a/macosx/GlobalOptionsPopoverViewController.mm
+++ b/macosx/GlobalOptionsPopoverViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupToolbarItem.h
+++ b/macosx/GroupToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupToolbarItem.h
+++ b/macosx/GroupToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupToolbarItem.h
+++ b/macosx/GroupToolbarItem.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/GroupToolbarItem.mm
+++ b/macosx/GroupToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupToolbarItem.mm
+++ b/macosx/GroupToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupToolbarItem.mm
+++ b/macosx/GroupToolbarItem.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "GroupToolbarItem.h"
 

--- a/macosx/GroupsController.h
+++ b/macosx/GroupsController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsController.h
+++ b/macosx/GroupsController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsController.h
+++ b/macosx/GroupsController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "GroupsController.h"
 #import "NSMutableArrayAdditions.h"

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsPrefsController.h
+++ b/macosx/GroupsPrefsController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsPrefsController.h
+++ b/macosx/GroupsPrefsController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsPrefsController.h
+++ b/macosx/GroupsPrefsController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "GroupsPrefsController.h"
 #import "GroupsController.h"

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoActivityViewController.h
+++ b/macosx/InfoActivityViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoActivityViewController.h
+++ b/macosx/InfoActivityViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoActivityViewController.h
+++ b/macosx/InfoActivityViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> //tr_getRatio()

--- a/macosx/InfoFileViewController.h
+++ b/macosx/InfoFileViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoFileViewController.h
+++ b/macosx/InfoFileViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoFileViewController.h
+++ b/macosx/InfoFileViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 #import <Quartz/Quartz.h>

--- a/macosx/InfoFileViewController.mm
+++ b/macosx/InfoFileViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoFileViewController.h"
 #import "FileListNode.h"

--- a/macosx/InfoFileViewController.mm
+++ b/macosx/InfoFileViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoFileViewController.mm
+++ b/macosx/InfoFileViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoGeneralViewController.h
+++ b/macosx/InfoGeneralViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoGeneralViewController.h
+++ b/macosx/InfoGeneralViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoGeneralViewController.h
+++ b/macosx/InfoGeneralViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoGeneralViewController.mm
+++ b/macosx/InfoGeneralViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoGeneralViewController.mm
+++ b/macosx/InfoGeneralViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoGeneralViewController.mm
+++ b/macosx/InfoGeneralViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoGeneralViewController.h"
 #import "NSStringAdditions.h"

--- a/macosx/InfoOptionsViewController.h
+++ b/macosx/InfoOptionsViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoOptionsViewController.h
+++ b/macosx/InfoOptionsViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoOptionsViewController.h
+++ b/macosx/InfoOptionsViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoOptionsViewController.h"
 #import "NSStringAdditions.h"

--- a/macosx/InfoPeersViewController.h
+++ b/macosx/InfoPeersViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoPeersViewController.h
+++ b/macosx/InfoPeersViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoPeersViewController.h
+++ b/macosx/InfoPeersViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTextField.h
+++ b/macosx/InfoTextField.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTextField.h
+++ b/macosx/InfoTextField.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoTextField.h
+++ b/macosx/InfoTextField.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTextField.mm
+++ b/macosx/InfoTextField.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTextField.mm
+++ b/macosx/InfoTextField.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoTextField.h"
 

--- a/macosx/InfoTextField.mm
+++ b/macosx/InfoTextField.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTrackersViewController.h
+++ b/macosx/InfoTrackersViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTrackersViewController.h
+++ b/macosx/InfoTrackersViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTrackersViewController.h
+++ b/macosx/InfoTrackersViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoTrackersViewController.h"
 #import "NSApplicationAdditions.h"

--- a/macosx/InfoViewController.h
+++ b/macosx/InfoViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoViewController.h
+++ b/macosx/InfoViewController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// This file Copyright © 2010-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoViewController.h
+++ b/macosx/InfoViewController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2010-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2010-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/InfoWindowController.h
+++ b/macosx/InfoWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoWindowController.h
+++ b/macosx/InfoWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 #import <Quartz/Quartz.h>

--- a/macosx/InfoWindowController.h
+++ b/macosx/InfoWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "InfoWindowController.h"
 #import "InfoViewController.h"

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/MessageWindowController.h
+++ b/macosx/MessageWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/MessageWindowController.h
+++ b/macosx/MessageWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/MessageWindowController.h
+++ b/macosx/MessageWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/log.h>

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSApplicationAdditions.h
+++ b/macosx/NSApplicationAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSApplicationAdditions.h
+++ b/macosx/NSApplicationAdditions.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <AppKit/AppKit.h>
 

--- a/macosx/NSApplicationAdditions.h
+++ b/macosx/NSApplicationAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSApplicationAdditions.mm
+++ b/macosx/NSApplicationAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSApplicationAdditions.mm
+++ b/macosx/NSApplicationAdditions.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "NSApplicationAdditions.h"
 

--- a/macosx/NSApplicationAdditions.mm
+++ b/macosx/NSApplicationAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSImageAdditions.h
+++ b/macosx/NSImageAdditions.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/NSImageAdditions.h
+++ b/macosx/NSImageAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSImageAdditions.h
+++ b/macosx/NSImageAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSImageAdditions.mm
+++ b/macosx/NSImageAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSImageAdditions.mm
+++ b/macosx/NSImageAdditions.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "NSImageAdditions.h"
 

--- a/macosx/NSImageAdditions.mm
+++ b/macosx/NSImageAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSMutableArrayAdditions.h
+++ b/macosx/NSMutableArrayAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSMutableArrayAdditions.h
+++ b/macosx/NSMutableArrayAdditions.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
 

--- a/macosx/NSMutableArrayAdditions.h
+++ b/macosx/NSMutableArrayAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSMutableArrayAdditions.mm
+++ b/macosx/NSMutableArrayAdditions.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "NSMutableArrayAdditions.h"
 

--- a/macosx/NSMutableArrayAdditions.mm
+++ b/macosx/NSMutableArrayAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSMutableArrayAdditions.mm
+++ b/macosx/NSMutableArrayAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>

--- a/macosx/PeerProgressIndicatorCell.h
+++ b/macosx/PeerProgressIndicatorCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerProgressIndicatorCell.h
+++ b/macosx/PeerProgressIndicatorCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerProgressIndicatorCell.h
+++ b/macosx/PeerProgressIndicatorCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PeerProgressIndicatorCell.mm
+++ b/macosx/PeerProgressIndicatorCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerProgressIndicatorCell.mm
+++ b/macosx/PeerProgressIndicatorCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "PeerProgressIndicatorCell.h"
 #import "NSStringAdditions.h"

--- a/macosx/PeerProgressIndicatorCell.mm
+++ b/macosx/PeerProgressIndicatorCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerTableView.h
+++ b/macosx/PeerTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerTableView.h
+++ b/macosx/PeerTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerTableView.h
+++ b/macosx/PeerTableView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PeerTableView.mm
+++ b/macosx/PeerTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerTableView.mm
+++ b/macosx/PeerTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PeerTableView.mm
+++ b/macosx/PeerTableView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "PeerTableView.h"
 

--- a/macosx/PiecesView.h
+++ b/macosx/PiecesView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PiecesView.h
+++ b/macosx/PiecesView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PiecesView.h
+++ b/macosx/PiecesView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>

--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "PortChecker.h"
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PredicateEditorRowTemplateAny.h
+++ b/macosx/PredicateEditorRowTemplateAny.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PredicateEditorRowTemplateAny.h
+++ b/macosx/PredicateEditorRowTemplateAny.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PredicateEditorRowTemplateAny.h
+++ b/macosx/PredicateEditorRowTemplateAny.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PredicateEditorRowTemplateAny.mm
+++ b/macosx/PredicateEditorRowTemplateAny.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PredicateEditorRowTemplateAny.mm
+++ b/macosx/PredicateEditorRowTemplateAny.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "PredicateEditorRowTemplateAny.h"
 

--- a/macosx/PredicateEditorRowTemplateAny.mm
+++ b/macosx/PredicateEditorRowTemplateAny.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2015-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2015-2022 Transmission authors and contributors
+// This file Copyright © 2015-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2015-2022 Transmission authors and contributors
+// This file Copyright © 2015-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsWindow.h
+++ b/macosx/PrefsWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsWindow.h
+++ b/macosx/PrefsWindow.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/PrefsWindow.h
+++ b/macosx/PrefsWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsWindow.mm
+++ b/macosx/PrefsWindow.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsWindow.mm
+++ b/macosx/PrefsWindow.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PrefsWindow.mm
+++ b/macosx/PrefsWindow.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "PrefsWindow.h"
 

--- a/macosx/ProgressGradients.h
+++ b/macosx/ProgressGradients.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ProgressGradients.h
+++ b/macosx/ProgressGradients.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>

--- a/macosx/ProgressGradients.h
+++ b/macosx/ProgressGradients.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ProgressGradients.mm
+++ b/macosx/ProgressGradients.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ProgressGradients.mm
+++ b/macosx/ProgressGradients.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "ProgressGradients.h"
 #import "NSApplicationAdditions.h"

--- a/macosx/ProgressGradients.mm
+++ b/macosx/ProgressGradients.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ShareToolbarItem.h
+++ b/macosx/ShareToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/8/14.

--- a/macosx/ShareToolbarItem.h
+++ b/macosx/ShareToolbarItem.h
@@ -1,10 +1,7 @@
-//
-//  ShareButtonToolbarItem.h
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/8/14.
-//  Copyright (c) 2014 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/8/14.
 
 #import "ButtonToolbarItem.h"
 

--- a/macosx/ShareToolbarItem.h
+++ b/macosx/ShareToolbarItem.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/8/14.

--- a/macosx/ShareToolbarItem.mm
+++ b/macosx/ShareToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/8/14.

--- a/macosx/ShareToolbarItem.mm
+++ b/macosx/ShareToolbarItem.mm
@@ -1,10 +1,7 @@
-//
-//  ShareToolbarItem.m
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/8/14.
-//  Copyright (c) 2014 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/8/14.
 
 #import "ShareToolbarItem.h"
 #import "ShareTorrentFileHelper.h"

--- a/macosx/ShareToolbarItem.mm
+++ b/macosx/ShareToolbarItem.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/8/14.

--- a/macosx/ShareTorrentFileHelper.h
+++ b/macosx/ShareTorrentFileHelper.h
@@ -1,10 +1,7 @@
-//
-//  ShareTorrentFileHelper.h
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/10/14.
-//  Copyright (c) 2014 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/10/14.
 
 #import <Foundation/Foundation.h>
 

--- a/macosx/ShareTorrentFileHelper.h
+++ b/macosx/ShareTorrentFileHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/10/14.

--- a/macosx/ShareTorrentFileHelper.h
+++ b/macosx/ShareTorrentFileHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/10/14.

--- a/macosx/ShareTorrentFileHelper.mm
+++ b/macosx/ShareTorrentFileHelper.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/10/14.

--- a/macosx/ShareTorrentFileHelper.mm
+++ b/macosx/ShareTorrentFileHelper.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2014-2022 Transmission authors and contributors
+// This file Copyright © 2014-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 // Created by Mitchell Livingston on 1/10/14.

--- a/macosx/ShareTorrentFileHelper.mm
+++ b/macosx/ShareTorrentFileHelper.mm
@@ -1,10 +1,7 @@
-//
-//  ShareTorrentFileHelper.m
-//  Transmission
-//
-//  Created by Mitchell Livingston on 1/10/14.
-//  Copyright (c) 2014 The Transmission Project. All rights reserved.
-//
+// This file Copyright (c) 2014-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+// Created by Mitchell Livingston on 1/10/14.
 
 #import "ShareTorrentFileHelper.h"
 #import "Controller.h"

--- a/macosx/Sparkle.framework/Versions/A/Headers/SUErrors.h
+++ b/macosx/Sparkle.framework/Versions/A/Headers/SUErrors.h
@@ -3,7 +3,7 @@
 //  Sparkle
 //
 //  Created by C.W. Betts on 10/13/14.
-//  Copyright (c) 2014 Sparkle Project. All rights reserved.
+//  Copyright © 2014 Sparkle Project. All rights reserved.
 //
 
 #ifndef SUERRORS_H

--- a/macosx/Sparkle.framework/Versions/A/Headers/SUExport.h
+++ b/macosx/Sparkle.framework/Versions/A/Headers/SUExport.h
@@ -3,7 +3,7 @@
 //  Sparkle
 //
 //  Created by Jake Petroules on 2014-08-23.
-//  Copyright (c) 2014 Sparkle Project. All rights reserved.
+//  Copyright © 2014 Sparkle Project. All rights reserved.
 //
 
 #ifndef SUEXPORT_H

--- a/macosx/StatsWindowController.h
+++ b/macosx/StatsWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatsWindowController.h
+++ b/macosx/StatsWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatsWindowController.h
+++ b/macosx/StatsWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "StatsWindowController.h"
 #import "Controller.h"

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarController.h
+++ b/macosx/StatusBarController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/StatusBarController.h
+++ b/macosx/StatusBarController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarController.h
+++ b/macosx/StatusBarController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarView.h
+++ b/macosx/StatusBarView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarView.h
+++ b/macosx/StatusBarView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarView.h
+++ b/macosx/StatusBarView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>

--- a/macosx/StatusBarView.mm
+++ b/macosx/StatusBarView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarView.mm
+++ b/macosx/StatusBarView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/StatusBarView.mm
+++ b/macosx/StatusBarView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "StatusBarView.h"
 #import "NSApplicationAdditions.h"

--- a/macosx/ToolbarSegmentedCell.h
+++ b/macosx/ToolbarSegmentedCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ToolbarSegmentedCell.h
+++ b/macosx/ToolbarSegmentedCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ToolbarSegmentedCell.h
+++ b/macosx/ToolbarSegmentedCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/ToolbarSegmentedCell.mm
+++ b/macosx/ToolbarSegmentedCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ToolbarSegmentedCell.mm
+++ b/macosx/ToolbarSegmentedCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2007-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2007-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "ToolbarSegmentedCell.h"
 

--- a/macosx/ToolbarSegmentedCell.mm
+++ b/macosx/ToolbarSegmentedCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors
+// This file Copyright © 2007-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 #import <Quartz/Quartz.h>

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <optional>
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <AppKit/AppKit.h>
 

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2006-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2006-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "TorrentCell.h"
 #import "GroupsController.h"

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2022 Transmission authors and contributors
+// This file Copyright © 2006-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_getRatio()

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "TorrentTableView.h"
 #import "Controller.h"

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerCell.h
+++ b/macosx/TrackerCell.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerCell.h
+++ b/macosx/TrackerCell.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/TrackerCell.h
+++ b/macosx/TrackerCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/web-utils.h> //tr_addressIsIP()

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2009-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2009-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "TrackerNode.h"
 #import "NSApplicationAdditions.h"

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2009-2022 Transmission authors and contributors
+// This file Copyright © 2009-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerTableView.h
+++ b/macosx/TrackerTableView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/TrackerTableView.h
+++ b/macosx/TrackerTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerTableView.h
+++ b/macosx/TrackerTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerTableView.mm
+++ b/macosx/TrackerTableView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2008-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "TrackerTableView.h"
 #import "Torrent.h"

--- a/macosx/TrackerTableView.mm
+++ b/macosx/TrackerTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TrackerTableView.mm
+++ b/macosx/TrackerTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2022 Transmission authors and contributors
+// This file Copyright © 2008-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/URLSheetWindowController.h
+++ b/macosx/URLSheetWindowController.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/URLSheetWindowController.h
+++ b/macosx/URLSheetWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/URLSheetWindowController.h
+++ b/macosx/URLSheetWindowController.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2011-2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2011-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "URLSheetWindowController.h"
 #import "Controller.h"

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2011-2022 Transmission authors and contributors
+// This file Copyright © 2011-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/WebSeedTableView.h
+++ b/macosx/WebSeedTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2012-2022 Transmission authors and contributors
+// This file Copyright © 2012-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/WebSeedTableView.h
+++ b/macosx/WebSeedTableView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2012-2022 Transmission authors and contributors
+// This file Copyright © 2012-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/WebSeedTableView.h
+++ b/macosx/WebSeedTableView.h
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2012-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/macosx/WebSeedTableView.mm
+++ b/macosx/WebSeedTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2012-2022 Transmission authors and contributors
+// This file Copyright © 2012-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/WebSeedTableView.mm
+++ b/macosx/WebSeedTableView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2012-2022 Transmission authors and contributors
+// This file Copyright © 2012-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/WebSeedTableView.mm
+++ b/macosx/WebSeedTableView.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2012 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2012-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import "WebSeedTableView.h"
 

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -1,4 +1,4 @@
-// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// This file Copyright © 2005-2022 Transmission authors and contributors
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -1,24 +1,6 @@
-/******************************************************************************
- * Copyright (c) 2005-2019 Transmission authors and contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *****************************************************************************/
+// This file Copyright (c) 2005-2022 Transmission authors and contributors
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
 

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QIcon>

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/AboutDialog.ui
+++ b/qt/AboutDialog.ui
@@ -50,7 +50,7 @@
    <item>
     <widget class="QLabel" name="copyrightsLabel">
      <property name="text">
-      <string>Copyright (c) The Transmission Project</string>
+      <string>Copyright © The Transmission Project</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QDir>
 #include <QFile>

--- a/qt/AddData.h
+++ b/qt/AddData.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/AddData.h
+++ b/qt/AddData.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "Application.h"
 

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/BaseDialog.h
+++ b/qt/BaseDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/BaseDialog.h
+++ b/qt/BaseDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QEvent>
 #include <QGridLayout>

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <windows.h>
 #include <objbase.h>

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/ComInteropHelper.h
+++ b/qt/ComInteropHelper.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/ComInteropHelper.h
+++ b/qt/ComInteropHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/CustomVariantType.h
+++ b/qt/CustomVariantType.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/CustomVariantType.h
+++ b/qt/CustomVariantType.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QDBusConnection>
 #include <QDBusMessage>

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/DBusInteropHelper.h
+++ b/qt/DBusInteropHelper.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/DBusInteropHelper.h
+++ b/qt/DBusInteropHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FaviconCache.h
+++ b/qt/FaviconCache.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QPainter>

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "FilterBar.h"
 

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QStyle>

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QAbstractItemView>
 #include <QComboBox>

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Filters.cc
+++ b/qt/Filters.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "Filters.h"
 

--- a/qt/Filters.cc
+++ b/qt/Filters.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_formatter

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QDir>
 

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// This file Copyright © 2013-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "IconCache.h"
 

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/IconToolButton.cc
+++ b/qt/IconToolButton.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QStyle>
 #include <QStyleOption>

--- a/qt/IconToolButton.cc
+++ b/qt/IconToolButton.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/IconToolButton.h
+++ b/qt/IconToolButton.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/IconToolButton.h
+++ b/qt/IconToolButton.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/InteropHelper.cc
+++ b/qt/InteropHelper.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QVariant>
 

--- a/qt/InteropHelper.cc
+++ b/qt/InteropHelper.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/InteropHelper.h
+++ b/qt/InteropHelper.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/InteropHelper.h
+++ b/qt/InteropHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/InteropObject.cc
+++ b/qt/InteropObject.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/InteropObject.cc
+++ b/qt/InteropObject.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "AddData.h"
 #include "Application.h"

--- a/qt/InteropObject.h
+++ b/qt/InteropObject.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/InteropObject.h
+++ b/qt/InteropObject.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/LicenseDialog.cc
+++ b/qt/LicenseDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "LicenseDialog.h"
 

--- a/qt/LicenseDialog.cc
+++ b/qt/LicenseDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/LicenseDialog.h
+++ b/qt/LicenseDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/LicenseDialog.h
+++ b/qt/LicenseDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/LicenseDialog.ui
+++ b/qt/LicenseDialog.ui
@@ -22,7 +22,6 @@
      <property name="plainText">
       <string notr="true">Copyright 2005-2020. All code is copyrighted by the respective authors.
 
-Transmission can be redistributed and/or modified under the terms of the GNU GPL versions 2 or 3 or by any future license endorsed by Mnemosyne LLC.
 
 In addition, linking to and/or using OpenSSL is allowed.
 

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cassert>

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "MakeDialog.h"
 

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QDir>

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cassert>

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "PrefsDialog.h"
 

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QDir>
 

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <string_view>
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2014-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2014-2022 Mnemosyne LLC.
+// This file Copyright © 2014-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// This file Copyright © 2016-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cassert>
 

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// This file Copyright © 2016-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2016-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "Session.h"
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "Prefs.h"
 #include "Session.h"

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).
+** Copyright © 2009 Nokia Corporation and/or its subsidiary(-ies).
 ** Contact: Qt Software Information (qt-info@nokia.com)
 **
 ** This file is part of the demonstration applications of the Qt Toolkit.

--- a/qt/SqueezeLabel.h
+++ b/qt/SqueezeLabel.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).
+** Copyright © 2009 Nokia Corporation and/or its subsidiary(-ies).
 ** Contact: Qt Software Information (qt-info@nokia.com)
 **
 ** This file is part of the demonstration applications of the Qt Toolkit.

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QTimer>
 

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "StyleHelper.h"
 

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/StyleHelper.h
+++ b/qt/StyleHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// This file Copyright © 2017-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/StyleHelper.h
+++ b/qt/StyleHelper.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QFont>

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <optional>

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <cassert>

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QApplication>
 #include <QStyleOptionHeader>

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// This file Copyright © 2015-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <QAbstractTextDocumentLayout>
 #include <QApplication>

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::sort()
 

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "TrackerModel.h"
 #include "TrackerModelFilter.h"

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// This file Copyright © 2010-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <set>
 #include <unordered_map>

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2020-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "VariantHelpers.h"
 

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2020-2022 Mnemosyne LLC.
+// This file Copyright © 2020-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2020-2022 Mnemosyne LLC.
+// This file Copyright © 2020-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2020-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <memory>
 

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2009-2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2009-2022 Mnemosyne LLC.
+// This file Copyright © 2009-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstdlib>

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/tests/libtransmission/block-info-test.cc
+++ b/tests/libtransmission/block-info-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstdint>
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <cstring> // strlen()
 // #include <unistd.h> // sync()

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <string_view>

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstdint>

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -1,5 +1,5 @@
 /*
- * This file copyright Transmission authors and contributors
+ * This file copyright Transmission authors and contributors.
  *
  * or any future license endorsed by Mnemosyne LLC.
  *

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -1,10 +1,12 @@
 /*
  * This file copyright Transmission authors and contributors
  *
- * It may be used under the GNU GPL versions 2 or 3
  * or any future license endorsed by Mnemosyne LLC.
  *
  */
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #ifndef TR_CRYPTO_TEST_REF_H
 #define TR_CRYPTO_TEST_REF_H

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstring>

--- a/tests/libtransmission/error-test.cc
+++ b/tests/libtransmission/error-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "error.h"

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <numeric>

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "error.h"

--- a/tests/libtransmission/getopt-test.cc
+++ b/tests/libtransmission/getopt-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "tr-getopt.h"

--- a/tests/libtransmission/history-test.cc
+++ b/tests/libtransmission/history-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "history.h"

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2010-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2010-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "magnet-metainfo.h"

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cstdlib> // mktemp()

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <string>
 #include <utility>

--- a/tests/libtransmission/peer-mgr-active-requests-test.cc
+++ b/tests/libtransmission/peer-mgr-active-requests-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #define LIBTRANSMISSION_PEER_MODULE
 

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2021-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <type_traits>

--- a/tests/libtransmission/peer-msgs-test.cc
+++ b/tests/libtransmission/peer-msgs-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "peer-msgs.h"

--- a/tests/libtransmission/quark-test.cc
+++ b/tests/libtransmission/quark-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "quark.h"

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "rpcimpl.h"

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "session.h"

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "file.h"

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2017-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include "transmission.h"
 #include "error.h"

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2017 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cerrno>

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <string_view>
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2015-2016 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2015-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <map>
 #include <memory>

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2013-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2013-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <string_view>
 

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cinttypes>

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <stdio.h> /* fprintf() */

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2008-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <array>
 #include <cassert>

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2008-2022 Mnemosyne LLC.
+// This file Copyright © 2008-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2(SPDX : GPL - 2.0), GPLv3(SPDX : GPL - 3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #include <algorithm>
 #include <array>

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2(SPDX : GPL - 2.0), GPLv3(SPDX : GPL - 3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/utils/units.h
+++ b/utils/units.h
@@ -1,4 +1,4 @@
-// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2022 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/utils/units.h
+++ b/utils/units.h
@@ -1,10 +1,7 @@
-/*
- * This file Copyright (C) 2012-2014 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- *
- */
+// This file Copyright (C) 2012-2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
 
 #pragma once
 

--- a/web/public_html/transmission-app.js.LICENSE.txt
+++ b/web/public_html/transmission-app.js.LICENSE.txt
@@ -1,17 +1,8 @@
-/**
- * @license
- *
- * Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
- *
- * This file is licensed under the GPLv2.
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
+   It may be used under GPLv2 (SPDX: GPL-2.0).
+   License text can be found in the licenses/ folder. */

--- a/web/src/about-dialog.js
+++ b/web/src/about-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { createDialogContainer } from './utils.js';
 

--- a/web/src/action-manager.js
+++ b/web/src/action-manager.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 export class ActionManager extends EventTarget {
   constructor() {

--- a/web/src/alert-dialog.js
+++ b/web/src/alert-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { createDialogContainer } from './utils.js';
 

--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { setEnabled } from './utils.js';
 

--- a/web/src/file-row.js
+++ b/web/src/file-row.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import { makeUUID, setChecked, setEnabled, setTextContent } from './utils.js';

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 const plural_rules = new Intl.PluralRules();
 const current_locale = plural_rules.resolvedOptions().locale;

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { FileRow } from './file-row.js';
 import { Formatter } from './formatter.js';

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { ActionManager } from './action-manager.js';
 import { Notifications } from './notifications.js';

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 let default_path = '';
 

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { setTextContent } from './utils.js';
 

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { AlertDialog } from './alert-dialog.js';
 import { Formatter } from './formatter.js';

--- a/web/src/overflow-menu.js
+++ b/web/src/overflow-menu.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import { Prefs } from './prefs.js';

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import {

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { debounce } from './utils.js';
 

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -1,11 +1,6 @@
-/**
- * @license
- *
- * Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
- *
- * This file is licensed under the GPLv2.
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- */
+/* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
+   It may be used under GPLv2 (SPDX: GPL-2.0).
+   License text can be found in the licenses/ folder. */
 
 import { AlertDialog } from './alert-dialog.js';
 

--- a/web/src/remove-dialog.js
+++ b/web/src/remove-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { createDialogContainer } from './utils.js';
 

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { createDialogContainer } from './utils.js';
 

--- a/web/src/shortcuts-dialog.js
+++ b/web/src/shortcuts-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { createDialogContainer } from './utils.js';
 

--- a/web/src/statistics-dialog.js
+++ b/web/src/statistics-dialog.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import {

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import { Torrent } from './torrent.js';

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
 import { Prefs } from './prefs.js';

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1,11 +1,6 @@
-/**
- * @license
- *
- * Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
- *
- * This file is licensed under the GPLv2.
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- */
+/* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
+   It may be used under GPLv2 (SPDX: GPL-2.0).
+   License text can be found in the licenses/ folder. */
 
 import { AboutDialog } from './about-dialog.js';
 import { ContextMenu } from './context-menu.js';

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,11 +1,7 @@
-/**
- * @license
- *
- * This file Copyright (C) 2020 Mnemosyne LLC
- *
- * It may be used under the GNU GPL versions 2 or 3
- * or any future license endorsed by Mnemosyne LLC.
- */
+/* @license This file Copyright (C) 2020-2022 Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+   or any future license endorsed by Mnemosyne LLC.
+   License text can be found in the licenses/ folder. */
 
 import isEqual from 'lodash.isequal';
 


### PR DESCRIPTION
All changes in this PR are comments-only.

The goal is to have a consistent, concise copyright notice in each source file and to move the full text of the licenses into a licenses/ directory.