### PR TITLE
fixup: unused variable warnings

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -644,8 +644,6 @@ unsigned char const* tr_globalIPv6(tr_session const* session)
     static time_t last_time = 0;
     static bool have_ipv6 = false;
     time_t const now = tr_time();
-    bool is_default;
-    tr_address const* ipv6_bindaddr;
 
     /* Re-check every half hour */
     if (last_time < now - 1800)
@@ -667,7 +665,8 @@ unsigned char const* tr_globalIPv6(tr_session const* session)
     /* We have some sort of address, now make sure that we return
        our bound address if non-default. */
 
-    ipv6_bindaddr = tr_sessionGetPublicAddress(session, TR_AF_INET6, &is_default);
+    bool is_default = false;
+    auto const* ipv6_bindaddr = tr_sessionGetPublicAddress(session, TR_AF_INET6, &is_default);
     if (ipv6_bindaddr != nullptr && !is_default)
         /* Explicitly bound. Return that address. */
         memcpy(ipv6, ipv6_bindaddr->addr.addr6.s6_addr, 16);

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -130,8 +130,6 @@ void tr_udpSetSocketTOS(tr_session* session)
 // TODO: remove goto, it prevents reducing scope of local variables
 static void rebind_ipv6(tr_session* ss, bool force)
 {
-    bool is_default = false;
-    tr_address const* public_addr = nullptr;
     struct sockaddr_in6 sin6;
     unsigned char const* ipv6 = tr_globalIPv6(ss);
     tr_socket_t s = TR_BAD_SOCKET;


### PR DESCRIPTION
fix unused variable warning from the previous commit.