### PR TITLE
test: magnet links with junk values

### DIFF
--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -30,6 +30,27 @@ TEST(MagnetMetainfo, magnetParse)
         "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"
         "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"sv;
 
+    auto constexpr UriHexWithEmptyValue =
+        "magnet:?xt=urn:btih:"
+        "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&empty"
+        "&dn=Display%20Name"
+        "&tr=http%3A%2F%2Ftracker.openbittorrent.com%2Fannounce"
+        "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"
+        "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"sv;
+
+    auto constexpr UriHexWithJunkValues =
+        "magnet:?xt=urn:btih:"
+        "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&empty"
+        "&empty_again"
+        "&dn=Display%20Name"
+        "&tr=http%3A%2F%2Ftracker.openbittorrent.com%2Fannounce"
+        "&empty_again"
+        "&="
+        "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"
+        "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"sv;
+
     auto constexpr UriBase32 =
         "magnet:?xt=urn:btih:"
         "2I2UAEFDZJFN4W3UE65QSOTCUOEZ744B"
@@ -38,7 +59,7 @@ TEST(MagnetMetainfo, magnetParse)
         "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"
         "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"sv;
 
-    for (auto const& uri : { UriHex, UriBase32 })
+    for (auto const& uri : { UriHex, UriHexWithEmptyValue, UriHexWithJunkValues, UriBase32 })
     {
         auto mm = tr_magnet_metainfo{};
 


### PR DESCRIPTION
The bug reported in #1113 was fixed as part of the `tr_info` -> `tr_torrent_metainfo` refactor but did not add any regression tests for the cases described in 1113.

https://github.com/transmission/transmission/pull/1290 _did_ add tests but is out-of-date with the codebase due to the refactor.

This PR updates those tests to the new API and marks 1290 author @clickyotomy as the author of this PR to ensure they get credit.

Fixes #1113.