### PR TITLE
feat: remember tab selection in Details dialog

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -196,6 +196,8 @@ private:
 ****
 ***/
 
+int DetailsDialog::prev_tab_index_ = 0;
+
 DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const& model, QWidget* parent)
     : BaseDialog(parent)
     , session_(session)
@@ -212,6 +214,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
 
     adjustSize();
     ui_.commentBrowser->setMaximumHeight(QWIDGETSIZE_MAX);
+    ui_.tabs->setCurrentIndex(prev_tab_index_);
 
     static std::array<int, 2> constexpr InitKeys = {
         Prefs::SHOW_TRACKER_SCRAPES,
@@ -236,6 +239,11 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     // set up the debounce timer
     connect(&ui_debounce_timer_, &QTimer::timeout, this, &DetailsDialog::refreshUI);
     ui_debounce_timer_.setSingleShot(true);
+}
+
+DetailsDialog::~DetailsDialog()
+{
+    prev_tab_index_ = ui_.tabs->currentIndex();
 }
 
 void DetailsDialog::setIds(torrent_ids_t const& ids)

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -37,6 +37,7 @@ class DetailsDialog : public BaseDialog
 
 public:
     DetailsDialog(Session&, Prefs&, TorrentModel const&, QWidget* parent = nullptr);
+    ~DetailsDialog() override;
 
     void setIds(torrent_ids_t const& ids);
 
@@ -136,4 +137,6 @@ private:
 
     QIcon const icon_encrypted_ = QIcon(QStringLiteral(":/icons/encrypted.png"));
     QIcon const icon_unencrypted_ = {};
+
+    static int prev_tab_index_;
 };


### PR DESCRIPTION
When closing the details dialog, remember the tab selection and auto-select it the next time the details dialog is opened again.

Fixes #2300 for transmission-qt and transmission-gtk.