### PR TITLE
Add more decimals for low ratios

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1135,7 +1135,11 @@ std::string tr_strpercent(double x)
 {
     auto buf = std::array<char, 64>{};
 
-    if (x < 100.0)
+    if (x < 5.0)
+    {
+        tr_strtruncd(std::data(buf), x, 2, std::size(buf));
+    }
+    else if (x < 100.0)
     {
         tr_strtruncd(std::data(buf), x, 1, std::size(buf));
     }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -442,3 +442,25 @@ TEST_F(UtilsTest, saveFile)
     EXPECT_NE(0, error->code);
     tr_error_clear(&error);
 }
+
+TEST_F(UtilsTest, ratioToString)
+{
+    // Testpairs contain ratio as a double and a string
+    std::vector<std::pair<double, std::string>> const tests{
+        { 0.0, "0.00" },        { 0.01, "0.01" },  { 0.1, "0.10" },    { 1.0, "1.00" },        { 1.015, "1.01" },
+        { 4.99, "4.99" },       { 4.996, "4.99" }, { 5.0, "5.0" },     { 5.09999, "5.0" },     { 5.1, "5.1" },
+        { 99.99, "99.9" },      { 100.0, "100" },  { 4000.4, "4000" }, { 600000.0, "600000" }, { 900000000.0, "900000000" },
+        { TR_RATIO_INF, "inf" }
+    };
+    char const nullchar = '\0';
+
+    ASSERT_EQ(tr_strratio(TR_RATIO_NA, "Ratio is NaN"), "None");
+    ASSERT_EQ(tr_strratio(TR_RATIO_INF, "A bit longer text for infinity"), "A bit longer text for infinity");
+    // Inf contains only null character
+    ASSERT_EQ(tr_strratio(TR_RATIO_INF, &nullchar), "");
+
+    for (auto& test : tests)
+    {
+        ASSERT_EQ(tr_strratio(test.first, "inf"), test.second);
+    }
+}


### PR DESCRIPTION
Implements #1053 with tests.
There is no rounding as seen from tests. Some people seed until they reach a certain ratio and rounding might cause confusion as seeding would still continue even with transmission showing that the ratio is reached.