### PR TITLE
test: add tests for parsing http tracker scrape responses

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -233,4 +233,6 @@ void tr_tracker_udp_start_shutdown(tr_session* session);
 
 void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view msg);
 
+void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view msg);
+
 tr_interned_string tr_announcerGetKey(tr_url_parsed_t const& parsed);


### PR DESCRIPTION
Does what it says on the tin: add tests for libtransmission's parsing of http tracker scrape responses. This is prepwork for refactoring how the benc response is parsed to avoid the overhead of tr_variant.

This is part 3 in the series. The previous PR was #2505.