### PR TITLE
test: add tr_torrent_metainfo.infoDictSize() tests

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -24,7 +24,7 @@ size_t tr_announce_list::set(char const* const* announce_urls, tr_tracker_tier_t
 
     for (size_t i = 0; i < n; ++i)
     {
-        add(tiers[i], announce_urls[i]);
+        add(announce_urls[i], tiers[i]);
     }
 
     return size();
@@ -70,10 +70,10 @@ bool tr_announce_list::replace(tr_tracker_id_t id, std::string_view announce_url
 
     auto const tier = it->tier;
     trackers_.erase(it);
-    return add(tier, announce_url_sv);
+    return add(announce_url_sv, tier);
 }
 
-bool tr_announce_list::add(tr_tracker_tier_t tier, std::string_view announce_url_sv)
+bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t tier)
 {
     auto const announce = tr_urlParseTracker(announce_url_sv);
     if (!announce || !canAdd(*announce))

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -92,7 +92,12 @@ public:
     std::set<tr_tracker_tier_t> tiers() const;
     tr_tracker_tier_t nextTier() const;
 
-    bool add(tr_tracker_tier_t tier, std::string_view announce_url_sv);
+    bool add(std::string_view announce_url_sv)
+    {
+        return add(announce_url_sv, this->nextTier());
+    }
+
+    bool add(std::string_view announce_url_sv, tr_tracker_tier_t tier);
     bool remove(std::string_view announce_url);
     bool remove(tr_tracker_id_t id);
     bool replace(tr_tracker_id_t id, std::string_view announce_url_sv);

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -158,7 +158,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** er
         else if (key == "tr"sv || tr_strvStartsWith(key, "tr."sv))
         {
             // "tr." explanation @ https://trac.transmissionbt.com/ticket/3341
-            this->announce_list_.add(this->announce_list_.nextTier(), tr_urlPercentDecode(value));
+            this->announce_list_.add(tr_urlPercentDecode(value));
         }
         else if (key == "ws"sv)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1053,7 +1053,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
             continue;
         }
 
-        tor->announceList().add(tor->announceList().nextTier(), announce);
+        tor->announceList().add(announce);
     }
 
     if (tor->trackerCount() == old_size)

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -380,7 +380,7 @@ std::string_view tr_torrent_metainfo::parseAnnounce(tr_torrent_metainfo& setme, 
                     continue;
                 }
 
-                setme.announce_list_.add(i, url);
+                setme.announce_list_.add(url, i);
             }
         }
     }
@@ -388,7 +388,7 @@ std::string_view tr_torrent_metainfo::parseAnnounce(tr_torrent_metainfo& setme, 
     // single 'announce' url
     if (std::empty(setme.announce_list_) && tr_variantDictFindStrView(meta, TR_KEY_announce, &url))
     {
-        setme.announce_list_.add(0, url);
+        setme.announce_list_.add(url, 0);
     }
 
     return {};

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -142,6 +142,11 @@ public:
         return info_dict_offset_;
     }
 
+    [[nodiscard]] auto piecesOffset() const
+    {
+        return pieces_offset_;
+    }
+
     std::string torrentFile(std::string_view torrent_dir) const
     {
         return makeFilename(torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -28,7 +28,7 @@ TEST_F(AnnounceListTest, canAdd)
     auto constexpr Announce = "https://example.org/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_EQ(1, announce_list.add(Tier, Announce));
+    EXPECT_EQ(1, announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
     EXPECT_EQ(Announce, tracker.announce.full);
     EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape.full);
@@ -46,9 +46,9 @@ TEST_F(AnnounceListTest, groupsSiblingsIntoSameTier)
     auto constexpr Announce3 = "udp://example.org:999/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier1, Announce1));
-    EXPECT_TRUE(announce_list.add(Tier2, Announce2));
-    EXPECT_TRUE(announce_list.add(Tier3, Announce3));
+    EXPECT_TRUE(announce_list.add(Announce1, Tier1));
+    EXPECT_TRUE(announce_list.add(Announce2, Tier2));
+    EXPECT_TRUE(announce_list.add(Announce3, Tier3));
 
     EXPECT_EQ(3, std::size(announce_list));
     EXPECT_EQ(Tier1, announce_list.at(0).tier);
@@ -68,7 +68,7 @@ TEST_F(AnnounceListTest, canAddWithoutScrape)
     auto constexpr Announce = "https://example.org/foo"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce));
+    EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
     EXPECT_EQ(Announce, tracker.announce.full);
     EXPECT_TRUE(std::empty(tracker.scrape_str));
@@ -81,7 +81,7 @@ TEST_F(AnnounceListTest, canAddUdp)
     auto constexpr Announce = "udp://example.org/"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce));
+    EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
     EXPECT_EQ(Announce, tracker.announce.full);
     EXPECT_EQ("udp://example.org/"sv, tracker.scrape.full);
@@ -94,13 +94,13 @@ TEST_F(AnnounceListTest, canNotAddDuplicateAnnounce)
     auto constexpr Announce = "https://example.org/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce));
+    EXPECT_TRUE(announce_list.add(Announce, Tier));
     EXPECT_EQ(1, announce_list.size());
-    EXPECT_FALSE(announce_list.add(Tier, Announce));
+    EXPECT_FALSE(announce_list.add(Announce, Tier));
     EXPECT_EQ(1, announce_list.size());
 
     auto constexpr Announce2 = "https://example.org:443/announce"sv;
-    EXPECT_FALSE(announce_list.add(Tier, Announce2));
+    EXPECT_FALSE(announce_list.add(Announce2, Tier));
     EXPECT_EQ(1, announce_list.size());
 }
 
@@ -110,7 +110,7 @@ TEST_F(AnnounceListTest, canNotAddInvalidUrl)
     auto constexpr Announce = "telnet://example.org/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_FALSE(announce_list.add(Tier, Announce));
+    EXPECT_FALSE(announce_list.add(Announce, Tier));
     EXPECT_EQ(0, announce_list.size());
 }
 
@@ -212,7 +212,7 @@ TEST_F(AnnounceListTest, canRemoveById)
     auto constexpr Tier = tr_tracker_tier_t{ 1 };
 
     auto announce_list = tr_announce_list{};
-    announce_list.add(Tier, Announce);
+    announce_list.add(Announce, Tier);
     EXPECT_EQ(1, std::size(announce_list));
     auto const id = announce_list.at(0).id;
 
@@ -226,7 +226,7 @@ TEST_F(AnnounceListTest, canNotRemoveByInvalidId)
     auto constexpr Tier = tr_tracker_tier_t{ 1 };
 
     auto announce_list = tr_announce_list{};
-    announce_list.add(Tier, Announce);
+    announce_list.add(Announce, Tier);
     EXPECT_EQ(1, std::size(announce_list));
     auto const id = announce_list.at(0).id;
 
@@ -241,7 +241,7 @@ TEST_F(AnnounceListTest, canRemoveByAnnounce)
     auto constexpr Tier = tr_tracker_tier_t{ 1 };
 
     auto announce_list = tr_announce_list{};
-    announce_list.add(Tier, Announce);
+    announce_list.add(Announce, Tier);
     EXPECT_EQ(1, std::size(announce_list));
 
     EXPECT_TRUE(announce_list.remove(Announce));
@@ -254,7 +254,7 @@ TEST_F(AnnounceListTest, canNotRemoveByInvalidAnnounce)
     auto constexpr Tier = tr_tracker_tier_t{ 1 };
 
     auto announce_list = tr_announce_list{};
-    announce_list.add(Tier, Announce);
+    announce_list.add(Announce, Tier);
     EXPECT_EQ(1, std::size(announce_list));
 
     EXPECT_FALSE(announce_list.remove("https://www.not-example.com/announce"sv));
@@ -268,7 +268,7 @@ TEST_F(AnnounceListTest, canReplace)
     auto constexpr Announce2 = "https://www.example.com/2/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce1));
+    EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_TRUE(announce_list.replace(announce_list.at(0).id, Announce2));
     EXPECT_EQ(Announce2, announce_list.at(0).announce.full);
 }
@@ -280,7 +280,7 @@ TEST_F(AnnounceListTest, canNotReplaceInvalidId)
     auto constexpr Announce2 = "https://www.example.com/2/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce1));
+    EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id + 1, Announce2));
     EXPECT_EQ(Announce1, announce_list.at(0).announce.full);
 }
@@ -292,7 +292,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithInvalidAnnounce)
     auto constexpr Announce2 = "telnet://www.example.com/2/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce1));
+    EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce2));
     EXPECT_EQ(Announce1, announce_list.at(0).announce.full);
 }
@@ -303,7 +303,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithDuplicate)
     auto constexpr Announce = "https://www.example.com/announce"sv;
 
     auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Tier, Announce));
+    EXPECT_TRUE(announce_list.add(Announce, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce));
     EXPECT_EQ(Announce, announce_list.at(0).announce.full);
 }
@@ -350,9 +350,9 @@ TEST_F(AnnounceListTest, save)
 
     // make an announce_list for it
     auto announce_list = tr_announce_list();
-    EXPECT_TRUE(announce_list.add(Tiers[0], Urls[0]));
-    EXPECT_TRUE(announce_list.add(Tiers[1], Urls[1]));
-    EXPECT_TRUE(announce_list.add(Tiers[2], Urls[2]));
+    EXPECT_TRUE(announce_list.add(Urls[0], Tiers[0]));
+    EXPECT_TRUE(announce_list.add(Urls[1], Tiers[1]));
+    EXPECT_TRUE(announce_list.add(Urls[2], Tiers[2]));
 
     // try saving to a nonexistent .torrent file
     EXPECT_FALSE(announce_list.save("/this/path/does/not/exist", &error));

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -76,9 +76,11 @@ protected:
         EXPECT_EQ(payloadSize, metainfo.totalSize());
         EXPECT_EQ(makeString(tr_sys_path_basename(input_file.data(), nullptr)), metainfo.name());
         EXPECT_EQ(comment, metainfo.comment());
-        EXPECT_EQ(tr_file_index_t{ 1 }, metainfo.fileCount());
         EXPECT_EQ(isPrivate, metainfo.isPrivate());
         EXPECT_EQ(size_t(trackerCount), std::size(metainfo.announceList()));
+        EXPECT_EQ(tr_file_index_t{ 1 }, metainfo.fileCount());
+        EXPECT_EQ(makeString(tr_sys_path_basename(input_file.data(), nullptr)), metainfo.fileSubpath(0));
+        EXPECT_EQ(payloadSize, metainfo.fileSize(0));
 
         // cleanup
         tr_metaInfoBuilderFree(builder);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -149,6 +149,11 @@ TEST_F(TorrentMetainfoTest, AndroidTorrent)
     tr_error* error = nullptr;
     EXPECT_TRUE(tr_ctorSetMetainfoFromFile(ctor, filename.c_str(), &error));
     EXPECT_EQ(nullptr, error);
+    auto const* const metainfo = tr_ctorGetMetainfo(ctor);
+    EXPECT_NE(nullptr, metainfo);
+    EXPECT_EQ(336, metainfo->infoDictOffset());
+    EXPECT_EQ(26583, metainfo->infoDictSize());
+    EXPECT_EQ(592, metainfo->piecesOffset());
     tr_ctorFree(ctor);
 }
 


### PR DESCRIPTION
improve test coverage for `tr_torrent_metainfo` getters: `infoDictOffset()`, `infoDictSize()`, and `pieceOffset()`

improve makemeta coverage for building single-file torrents.