### PR TITLE
add labels to torrent-add rpc method

### DIFF
--- a/extras/rpc-spec.txt
+++ b/extras/rpc-spec.txt
@@ -424,6 +424,7 @@
    "cookies"            | string      pointer to a string of one or more cookies.
    "download-dir"       | string      path to download the torrent to
    "filename"           | string      filename or URL of the .torrent file
+   "labels"             | array       array of string labels
    "metainfo"           | string      base64-encoded .torrent content
    "paused"             | boolean     if true, don't start the torrent
    "peer-limit"         | number      maximum number of peers
@@ -857,6 +858,7 @@
        |       |      | torrent-get          | new arg "primary-mime-type"
        |       |      | free-space           | new return arg "total-capacity"
        |       |      |                      | undocumented "/upload" endpoint removed
+       |       |      | torrent-add          | new arg "labels"
 
 
 5.1.  Upcoming Breakage

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -41,6 +41,8 @@ struct tr_ctor
 
     tr_priority_t priority = TR_PRI_NORMAL;
 
+    tr_labels_t labels = {};
+
     struct optional_args optional_args[2];
 
     std::string incomplete_dir;
@@ -323,6 +325,31 @@ void tr_ctorSetBandwidthPriority(tr_ctor* ctor, tr_priority_t priority)
 tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
 {
     return ctor->priority;
+}
+
+/***
+****
+***/
+
+void tr_ctorSetLabels(tr_ctor* ctor, char const** labels, size_t len)
+{
+    auto labels_set = tr_labels_t{};
+    for (size_t i = 0; i < len; i++)
+    {
+        labels_set.emplace(labels[i]);
+    }
+
+    tr_ctorSetLabels(ctor, std::move(labels_set));
+}
+
+void tr_ctorSetLabels(tr_ctor* ctor, tr_labels_t&& labels)
+{
+    ctor->labels = std::move(labels);
+}
+
+tr_labels_t tr_ctorGetLabels(tr_ctor const* ctor)
+{
+    return ctor->labels;
 }
 
 /***

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -662,6 +662,8 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->error = TR_STAT_OK;
     tor->finishedSeedingByIdle = false;
 
+    tor->labels = tr_ctorGetLabels(ctor);
+
     tr_peerMgrAddTorrent(session->peerMgr, tor);
 
     TR_ASSERT(tor->downloadedCur == 0);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -39,6 +39,8 @@ struct tr_session;
 struct tr_torrent;
 struct tr_torrent_announcer;
 
+using tr_labels_t = std::unordered_set<std::string>;
+
 /**
 ***  Package-visible ctor API
 **/
@@ -57,11 +59,11 @@ tr_session* tr_ctorGetSession(tr_ctor const* ctor);
 
 bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDir);
 
+tr_labels_t tr_ctorGetLabels(tr_ctor const* ctor);
+
 /**
 ***
 **/
-
-using tr_labels_t = std::unordered_set<std::string>;
 
 void tr_torrentSetLabels(tr_torrent* tor, tr_labels_t&& labels);
 
@@ -781,3 +783,4 @@ void tr_metainfoFree(tr_info* inf);
 tr_torrent_metainfo&& tr_ctorStealMetainfo(tr_ctor* ctor);
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string const& filename, tr_error** error);
+void tr_ctorSetLabels(tr_ctor* ctor, tr_labels_t&& labels);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -889,6 +889,10 @@ void tr_ctorSetFilePriorities(tr_ctor* ctor, tr_file_index_t const* files, tr_fi
 /** @brief Set the download flag for files in a torrent */
 void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* fileIndices, tr_file_index_t fileCount, bool wanted);
 
+/** @brief Set labels for this torrent, the length of the labels array
+    must be the same size as len. */
+void tr_ctorSetLabels(tr_ctor* ctor, char const** labels, size_t len);
+
 /** @brief Get this peer constructor's peer limit */
 bool tr_ctorGetPeerLimit(tr_ctor const* ctor, tr_ctorMode mode, uint16_t* setmeCount);
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -454,7 +454,6 @@ static int getOptMode(int val)
     case 993: /* no-trash-torrent */
         return MODE_SESSION_SET;
 
-    case 'L': /* labels */
     case 712: /* tracker-remove */
     case 950: /* seedratio */
     case 951: /* seedratio-default */
@@ -468,6 +467,7 @@ static int getOptMode(int val)
 
     case 'g': /* get */
     case 'G': /* no-get */
+    case 'L': /* labels */
     case 700: /* torrent priority-high */
     case 701: /* torrent priority-normal */
     case 702: /* torrent priority-low */
@@ -2691,10 +2691,6 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             switch (c)
             {
-            case 'L':
-                addLabels(args, optarg ? optarg : "");
-                break;
-
             case 712:
                 {
                     tr_variant* list;
@@ -2753,6 +2749,10 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             case 'G':
                 addFiles(args, TR_KEY_files_unwanted, optarg);
+                break;
+
+            case 'L':
+                addLabels(args, optarg ? optarg : "");
                 break;
 
             case 900:


### PR DESCRIPTION
See commit for rationale, basically metadata such as labels are likely to be known when adding a torrent, e.g. whether it's a movie, a document, music, ISO, etc. I plan on implementing this in a client after it is merged into transmission.

This still needs to be tested and should not be merged, but I wanted to make this PR for initial feedback about the implementation. I used the `torrent-set` labels call as a guide for how it should be implemented, but I am unsure if putting the declarations like I did in `torrent.h` is correct, for example. 