### PR TITLE
fixup! refactor: base64 utils (#2381)

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2354,7 +2354,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
                     if (!std::empty(tmp))
                     {
-                        tr_variantDictAddStrView(args, TR_KEY_metainfo, tmp);
+                        tr_variantDictAddStr(args, TR_KEY_metainfo, tmp);
                     }
                     else
                     {


### PR DESCRIPTION
fix regression when adding torrent via transmission-remote

Fixes #2541.