### PR TITLE
refactor: replace tr_thread with std::thread

### DIFF
--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -27,7 +27,6 @@
 #include "transmission.h"
 #include "crypto-utils.h"
 #include "log.h"
-#include "platform.h"
 #include "tr-assert.h"
 #include "utils.h"
 

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -25,7 +25,6 @@
 #include "transmission.h"
 #include "crypto-utils.h"
 #include "log.h"
-#include "platform.h"
 #include "tr-assert.h"
 #include "utils.h"
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -55,7 +55,6 @@
 #include "error.h"
 #include "file.h"
 #include "log.h"
-#include "platform.h"
 #include "tr-assert.h"
 #include "utils.h"
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -6,10 +6,11 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstdint>
-#include <cstdlib> /* qsort */
 #include <cstring> /* strcmp, strlen */
 #include <mutex>
+#include <optional>
 #include <string_view>
+#include <thread>
 
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 
@@ -20,7 +21,6 @@
 #include "file.h"
 #include "log.h"
 #include "makemeta.h"
-#include "platform.h" /* threads, locks */
 #include "session.h"
 #include "tr-assert.h"
 #include "utils.h" /* buildpath */
@@ -505,11 +505,11 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
 
 static tr_metainfo_builder* queue = nullptr;
 
-static tr_thread* workerThread = nullptr;
+static std::optional<std::thread::id> worker_thread_id;
 
 static std::recursive_mutex queue_mutex_;
 
-static void makeMetaWorkerFunc(void* /*user_data*/)
+static void makeMetaWorkerFunc()
 {
     for (;;)
     {
@@ -535,7 +535,7 @@ static void makeMetaWorkerFunc(void* /*user_data*/)
         tr_realMakeMetaInfo(builder);
     }
 
-    workerThread = nullptr;
+    worker_thread_id.reset();
 }
 
 void tr_makeMetaInfo(
@@ -591,8 +591,10 @@ void tr_makeMetaInfo(
     builder->nextBuilder = queue;
     queue = builder;
 
-    if (workerThread == nullptr)
+    if (!worker_thread_id)
     {
-        workerThread = tr_threadNew(makeMetaWorkerFunc, nullptr);
+        auto thread = std::thread(makeMetaWorkerFunc);
+        worker_thread_id = thread.get_id();
+        thread.detach();
     }
 }

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -9,6 +9,7 @@
 #include <list>
 #include <string>
 #include <string_view>
+#include <thread>
 
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600 /* needed for recursive locks. */
@@ -88,106 +89,6 @@ static char* tr_buildPath(char const* first_element, ...)
     /* sanity checks & return */
     TR_ASSERT(pch - buf == (ptrdiff_t)bufLen);
     return buf;
-}
-
-/***
-****  THREADS
-***/
-
-#ifdef _WIN32
-using tr_thread_id = DWORD;
-#else
-using tr_thread_id = pthread_t;
-#endif
-
-static tr_thread_id tr_getCurrentThread()
-{
-#ifdef _WIN32
-    return GetCurrentThreadId();
-#else
-    return pthread_self();
-#endif
-}
-
-unsigned long tr_threadCurrentId()
-{
-    return (unsigned long)tr_getCurrentThread();
-}
-
-static bool tr_areThreadsEqual(tr_thread_id a, tr_thread_id b)
-{
-#ifdef _WIN32
-    return a == b;
-#else
-    return pthread_equal(a, b) != 0;
-#endif
-}
-
-/** @brief portability wrapper around OS-dependent threads */
-struct tr_thread
-{
-    void (*func)(void*);
-    void* arg;
-    tr_thread_id thread;
-
-#ifdef _WIN32
-    HANDLE thread_handle;
-#endif
-};
-
-bool tr_amInThread(tr_thread const* t)
-{
-    return tr_areThreadsEqual(tr_getCurrentThread(), t->thread);
-}
-
-#ifdef _WIN32
-#define ThreadFuncReturnType unsigned WINAPI
-#else
-#define ThreadFuncReturnType void*
-#endif
-
-static ThreadFuncReturnType ThreadFunc(void* _t)
-{
-#ifndef _WIN32
-    pthread_detach(pthread_self());
-#endif
-
-    auto* t = static_cast<tr_thread*>(_t);
-
-    t->func(t->arg);
-
-    tr_free(t);
-
-#ifdef _WIN32
-    _endthreadex(0);
-    return 0;
-#else
-    return nullptr;
-#endif
-}
-
-tr_thread* tr_threadNew(void (*func)(void*), void* arg)
-{
-    auto* t = static_cast<tr_thread*>(tr_new0(tr_thread, 1));
-
-    t->func = func;
-    t->arg = arg;
-
-#ifdef _WIN32
-
-    {
-        unsigned int id;
-        t->thread_handle = (HANDLE)_beginthreadex(nullptr, 0, &ThreadFunc, t, 0, &id);
-        t->thread = (DWORD)id;
-    }
-
-#else
-
-    pthread_create(&t->thread, nullptr, (void* (*)(void*))ThreadFunc, t);
-
-#endif
-
-    return t;
 }
 
 /***
@@ -283,11 +184,6 @@ char const* tr_sessionGetConfigDir(tr_session const* session)
 char const* tr_getTorrentDir(tr_session const* session)
 {
     return session->torrent_dir.c_str();
-}
-
-char const* tr_getResumeDir(tr_session const* session)
-{
-    return session->resume_dir.c_str();
 }
 
 char const* tr_getDefaultConfigDir(char const* appname)

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -11,13 +11,6 @@
 #include <string_view>
 #include <thread>
 
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 600 /* needed for recursive locks. */
-#endif
-#ifndef __USE_UNIX98
-#define __USE_UNIX98 /* some older Linuxes need it spelt out for them */
-#endif
-
 #ifdef __HAIKU__
 #include <limits.h> /* PATH_MAX */
 #endif
@@ -28,16 +21,18 @@
 #include <shlobj.h> /* SHGetKnownFolderPath(), FOLDERID_... */
 #else
 #include <unistd.h> /* getuid() */
+#endif
+
 #ifdef BUILD_MAC_CLIENT
 #include <CoreFoundation/CoreFoundation.h>
 #endif
+
 #ifdef __HAIKU__
 #include <FindDirectory.h>
 #endif
-#include <pthread.h>
-#endif
 
 #include "transmission.h"
+
 #include "file.h"
 #include "log.h"
 #include "platform.h"

--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <string_view>
 
+struct tr_session;
+
 /**
  * @addtogroup tr_session Session
  * @{
@@ -25,9 +27,6 @@
  */
 void tr_setConfigDir(tr_session* session, std::string_view config_dir);
 
-/** @brief return the directory where .resume files are stored */
-char const* tr_getResumeDir(tr_session const*);
-
 /** @brief return the directory where .torrent files are stored */
 char const* tr_getTorrentDir(tr_session const*);
 
@@ -38,21 +37,5 @@ char const* tr_getWebClientDir(tr_session const*);
 std::string tr_getSessionIdDir();
 
 /** @} */
-
-/**
- * @addtogroup utils Utilities
- * @{
- */
-
-struct tr_thread;
-
-/** @brief Instantiate a new process thread */
-tr_thread* tr_threadNew(void (*func)(void*), void* arg);
-
-unsigned long tr_threadCurrentId();
-
-/** @brief Return nonzero if this function is being called from `thread'
-    @param thread the thread being tested */
-bool tr_amInThread(tr_thread const* thread);
 
 /* @} */

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -16,7 +16,6 @@
 #include "log.h"
 #include "magnet-metainfo.h"
 #include "peer-mgr.h" /* pex */
-#include "platform.h" /* tr_getResumeDir() */
 #include "resume.h"
 #include "session.h"
 #include "torrent.h"

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -9,7 +9,6 @@
 #include "transmission.h"
 
 #include "log.h"
-#include "platform.h" /* tr_sessionGetConfigDir() */
 #include "session.h"
 #include "stats.h"
 #include "utils.h"

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -43,7 +43,6 @@
 #include "magnet-metainfo.h"
 #include "peer-common.h" /* MAX_BLOCK_SIZE */
 #include "peer-mgr.h"
-#include "platform.h" /* TR_PATH_DELIMITER_STR */
 #include "resume.h"
 #include "session.h"
 #include "subprocess.h"

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -10,6 +10,7 @@
 #include <cstring> /* memcpy(), memset(), memchr(), strlen() */
 #include <ctime>
 #include <string_view>
+#include <thread>
 
 #ifdef _WIN32
 #include <inttypes.h>
@@ -34,7 +35,6 @@
 #include "log.h"
 #include "net.h"
 #include "peer-mgr.h"
-#include "platform.h"
 #include "session.h"
 #include "torrent.h"
 #include "tr-assert.h"
@@ -364,7 +364,7 @@ int tr_dhtInit(tr_session* ss)
     cl->nodes6 = nodes6;
     cl->len = len;
     cl->len6 = len6;
-    tr_threadNew(dht_bootstrap, cl);
+    std::thread(dht_bootstrap, cl).detach();
 
     dht_timer = evtimer_new(session_->event_base, timer_callback, session_);
     tr_timerAdd(dht_timer, 0, tr_rand_int_weak(1000000));

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <thread>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -24,7 +25,6 @@
 #include "log.h"
 #include "net.h" /* tr_address */
 #include "torrent.h"
-#include "platform.h" /* mutex */
 #include "session.h"
 #include "tr-assert.h"
 #include "tr-macros.h"
@@ -342,8 +342,7 @@ static struct tr_web_task* tr_webRunImpl(
     {
         if (session->web == nullptr)
         {
-            tr_threadNew(tr_webThreadFunc, session);
-
+            std::thread(tr_webThreadFunc, session).detach();
             while (session->web == nullptr)
             {
                 tr_wait_msec(20);


### PR DESCRIPTION
Like its sibling #2520, this PR was made to replace handwritten / platform-specific code with `std::` tools:

- `std::` tools make it easier for new contributors to understand libtransmission
- `std::` tools are safer than handwritten since they have an enormous number of users / testers / maintainers
- removing handwritten code simplifies the codebase and makes libtransmission (slightly) smaller

This PR also fixes #1761 