### PR TITLE
refactor: use std::chrono not OS-specific syscalls

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -127,8 +127,7 @@ void tr_logFreeQueue(tr_log_message* list)
 
 char* tr_logGetTimeStr(char* buf, size_t buflen)
 {
-    struct timeval tv;
-    tr_gettimeofday(&tv);
+    auto const tv = tr_gettimeofday();
     time_t const seconds = tv.tv_sec;
     auto const milliseconds = int(tv.tv_usec / 1000);
     char msec_str[8];

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -676,8 +676,7 @@ static void onNowTimer(evutil_socket_t /*fd*/, short /*what*/, void* vsession)
     **/
 
     /* schedule the next timer for right after the next second begins */
-    struct timeval tv;
-    tr_gettimeofday(&tv);
+    auto const tv = tr_gettimeofday();
     int constexpr Min = 100;
     int constexpr Max = 999999;
     int const usec = std::clamp(int(1000000 - tv.tv_usec), Min, Max);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -815,8 +815,8 @@ int dht_sendto(int sockfd, void const* buf, int len, int flags, struct sockaddr 
 extern "C" int dht_gettimeofday(struct timeval* tv, struct timezone* tz)
 {
     TR_ASSERT(tz == nullptr);
-
-    return tr_gettimeofday(tv);
+    *tv = tr_gettimeofday();
+    return 0;
 }
 
 #endif

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -21,9 +21,9 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <shellapi.h> /* CommandLineToArgv() */
-#include <shlwapi.h> /* StrStrIA() */
 #include <windows.h> /* Sleep(), GetEnvironmentVariable() */
+
+#include <shellapi.h> /* CommandLineToArgv() */
 #include <ws2tcpip.h> /* WSAStartup() */
 #endif
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -425,7 +425,7 @@ struct tm* tr_localtime_r(time_t const* _clock, struct tm* _result);
 struct tm* tr_gmtime_r(time_t const* _clock, struct tm* _result);
 
 /** @brief Portability wrapper for gettimeofday(), with tz argument dropped */
-int tr_gettimeofday(struct timeval* tv);
+struct timeval tr_gettimeofday();
 
 /**
  * @brief move a file


### PR DESCRIPTION
implement `tr_gettimeofday()` using std::chrono` instead of OS-specific functions wrapped in #ifdefs.

See also #2548, #2520 for other use-`std::`-instead-of-OS-specific-functions