### PR TITLE
refactor: remove raw ptr variant of tr_peerMgrCompactToPex()

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -7,9 +7,7 @@
 #include <cerrno> /* error codes ERANGE, ... */
 #include <climits> /* INT_MAX */
 #include <cstdlib> /* qsort */
-#include <cstring> /* memcpy, memcmp, strstr */
-#include <ctime>
-#include <iterator>
+#include <ctime> // time_t
 #include <vector>
 
 #include <event2/event.h>
@@ -20,6 +18,7 @@
 #define LIBTRANSMISSION_PEER_MODULE
 
 #include "transmission.h"
+
 #include "announcer.h"
 #include "bandwidth.h"
 #include "blocklist.h"
@@ -31,9 +30,9 @@
 #include "log.h"
 #include "net.h"
 #include "peer-io.h"
-#include "peer-mgr.h"
 #include "peer-mgr-active-requests.h"
 #include "peer-mgr-wishlist.h"
+#include "peer-mgr.h"
 #include "peer-msgs.h"
 #include "ptrarray.h"
 #include "session.h"
@@ -1171,35 +1170,6 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t
     return n_used;
 }
 
-tr_pex* tr_peerMgrCompactToPex(
-    void const* compact,
-    size_t compactLen,
-    uint8_t const* added_f,
-    size_t added_f_len,
-    size_t* pexCount)
-{
-    size_t n = compactLen / 6;
-    auto const* walk = static_cast<uint8_t const*>(compact);
-    auto* const pex = tr_new0(tr_pex, n);
-
-    for (size_t i = 0; i < n; ++i)
-    {
-        pex[i].addr.type = TR_AF_INET;
-        memcpy(&pex[i].addr.addr, walk, 4);
-        walk += 4;
-        memcpy(&pex[i].port, walk, 2);
-        walk += 2;
-
-        if (added_f != nullptr && n == added_f_len)
-        {
-            pex[i].flags = added_f[i];
-        }
-    }
-
-    *pexCount = n;
-    return pex;
-}
-
 std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLen, uint8_t const* added_f, size_t added_f_len)
 {
     size_t n = compactLen / 6;
@@ -1220,35 +1190,6 @@ std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLe
         }
     }
 
-    return pex;
-}
-
-tr_pex* tr_peerMgrCompact6ToPex(
-    void const* compact,
-    size_t compactLen,
-    uint8_t const* added_f,
-    size_t added_f_len,
-    size_t* pexCount)
-{
-    size_t n = compactLen / 18;
-    auto const* walk = static_cast<uint8_t const*>(compact);
-    auto* const pex = tr_new0(tr_pex, n);
-
-    for (size_t i = 0; i < n; ++i)
-    {
-        pex[i].addr.type = TR_AF_INET6;
-        memcpy(&pex[i].addr.addr.addr6.s6_addr, walk, 16);
-        walk += 16;
-        memcpy(&pex[i].port, walk, 2);
-        walk += 2;
-
-        if (added_f != nullptr && n == added_f_len)
-        {
-            pex[i].flags = added_f[i];
-        }
-    }
-
-    *pexCount = n;
     return pex;
 }
 
@@ -1612,7 +1553,7 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
     TR_ASSERT(tab != nullptr);
     TR_ASSERT(tabCount > 0);
 
-    memset(tab, 0, tabCount);
+    std::fill_n(tab, tabCount, int8_t{});
 
     if (tor->hasMetadata())
     {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -8,6 +8,7 @@
 #include <climits> /* INT_MAX */
 #include <cstdlib> /* qsort */
 #include <ctime> // time_t
+#include <iterator> // std::back_inserter
 #include <vector>
 
 #include <event2/event.h>

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -102,20 +102,6 @@ size_t tr_peerMgrCountActiveRequestsToPeer(tr_torrent const* torrent, tr_peer co
 
 void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket);
 
-tr_pex* tr_peerMgrCompactToPex(
-    void const* compact,
-    size_t compactLen,
-    uint8_t const* added_f,
-    size_t added_f_len,
-    size_t* setme_pex_count);
-
-tr_pex* tr_peerMgrCompact6ToPex(
-    void const* compact,
-    size_t compactLen,
-    uint8_t const* added_f,
-    size_t added_f_len,
-    size_t* pexCount);
-
 std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLen, uint8_t const* added_f, size_t added_f_len);
 
 std::vector<tr_pex> tr_peerMgrCompact6ToPex(void const* compact, size_t compactLen, uint8_t const* added_f, size_t added_f_len);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -125,7 +125,7 @@ static auto constexpr RequestBufSecs = int{ 10 };
 namespace
 {
 
-constexpr int MAX_PEX_PEER_COUNT = 50;
+auto constexpr MaxPexPeerCount = size_t{ 50 };
 
 } // unnamed namespace
 
@@ -1323,11 +1323,9 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
                 added_f = nullptr;
             }
 
-            auto n = size_t{};
-            tr_pex* const pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len, &n);
-            n = std::min(n, size_t{ MAX_PEX_PEER_COUNT });
-            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
-            tr_free(pex);
+            auto pex = tr_peerMgrCompactToPex(added, added_len, added_f, added_f_len);
+            pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
+            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
         }
 
         if (tr_variantDictFindRaw(&val, TR_KEY_added6, &added, &added_len))
@@ -1340,11 +1338,9 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
                 added_f = nullptr;
             }
 
-            auto n = size_t{};
-            tr_pex* const pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len, &n);
-            n = std::min(n, size_t{ MAX_PEX_PEER_COUNT });
-            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex, n);
-            tr_free(pex);
+            auto pex = tr_peerMgrCompact6ToPex(added, added_len, added_f, added_f_len);
+            pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
+            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
         }
 
         tr_variantFree(&val);
@@ -2483,8 +2479,8 @@ static void sendPex(tr_peerMsgsImpl* msgs)
         PexDiffs diffs6;
         tr_pex* newPex = nullptr;
         tr_pex* newPex6 = nullptr;
-        int const newCount = tr_peerMgrGetPeers(msgs->torrent, &newPex, TR_AF_INET, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
-        int const newCount6 = tr_peerMgrGetPeers(msgs->torrent, &newPex6, TR_AF_INET6, TR_PEERS_CONNECTED, MAX_PEX_PEER_COUNT);
+        int const newCount = tr_peerMgrGetPeers(msgs->torrent, &newPex, TR_AF_INET, TR_PEERS_CONNECTED, MaxPexPeerCount);
+        int const newCount6 = tr_peerMgrGetPeers(msgs->torrent, &newPex6, TR_AF_INET6, TR_PEERS_CONNECTED, MaxPexPeerCount);
 
         /* build the diffs */
         diffs.added = tr_new(tr_pex, newCount);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -609,14 +609,10 @@ static void callback(void* /*ignore*/, int event, unsigned char const* info_hash
     {
         if (tor != nullptr && tor->allowsDht())
         {
-            size_t n = 0;
-            tr_pex* const pex = event == DHT_EVENT_VALUES ? tr_peerMgrCompactToPex(data, data_len, nullptr, 0, &n) :
-                                                            tr_peerMgrCompact6ToPex(data, data_len, nullptr, 0, &n);
-
-            tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex, n);
-
-            tr_free(pex);
-            tr_logAddTorDbg(tor, "Learned %d %s peers from DHT", (int)n, event == DHT_EVENT_VALUES6 ? "IPv6" : "IPv4");
+            auto const pex = event == DHT_EVENT_VALUES ? tr_peerMgrCompactToPex(data, data_len, nullptr, 0) :
+                                                         tr_peerMgrCompact6ToPex(data, data_len, nullptr, 0);
+            tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, std::data(pex), std::size(pex));
+            tr_logAddTorDbg(tor, "Learned %zu %s peers from DHT", std::size(pex), event == DHT_EVENT_VALUES6 ? "IPv6" : "IPv4");
         }
     }
     else if (event == DHT_EVENT_SEARCH_DONE || event == DHT_EVENT_SEARCH_DONE6)


### PR DESCRIPTION
Another code cleanup PR.

There are two forms of both `tr_peerMgrCompactToPex()` and `tr_peerMgrCompact6ToPex()` -- one form returns a raw unmanaged pointer; the other returns `std::vector<>`.

This PR removes the former raw ptr form.