### PR TITLE
fix: edge case file leak if error while making torrent

### DIFF
--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -318,7 +318,7 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
             b->my_errno = EIO;
             tr_snprintf(b->errfile, sizeof(b->errfile), "error hashing piece %" PRIu32, b->pieceIndex);
             b->result = TR_MAKEMETA_IO_READ;
-            return {};
+            break;
         }
 
         walk = std::copy(std::begin(*digest), std::end(*digest), walk);


### PR DESCRIPTION
Fix a file descriptor leak found by Coverity. It could happen while making a new torrent if scanning and hashing a piece from a file fails. This shouldn't happen in practice but it's theoretically possible, so safeguard against it in the code.