### PR TITLE
daemon: deny memory wx in transmission-daemon.service

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -8,6 +8,7 @@ Type=notify
 ExecStart=/usr/bin/transmission-daemon -f --log-error
 ExecReload=/bin/kill -s HUP $MAINPID
 NoNewPrivileges=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Attempts to create memory mappings that are writable and executable at the same time, or to change existing memory mappings to become executable, or mapping shared memory segments as executable are prohibited.

There's no reason transmission should be doing that. If it does, it's because of malicious code exploiting a vulnerability.

See: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#MemoryDenyWriteExecute=