### PR TITLE
fix cross build

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -268,10 +268,6 @@ if(ICONV_FOUND)
     include_directories(SYSTEM ${ICONV_INCLUDE_DIRS})
 endif()
 
-if(ENABLE_UTP)
-    include_directories(SYSTEM ${TP_TOP}/libutp)
-endif()
-
 add_library(${TR_NAME} STATIC
     ${${PROJECT_NAME}_SOURCES}
     ${${PROJECT_NAME}_PUBLIC_HEADERS}


### PR DESCRIPTION
Remove redundant include, ${UTP_INCLUDE_DIRS} is included already to fix
cross build error with buildroot:

x86_64-linux-g++: ERROR: unsafe header/library path used in cross-compilation: '-isystem' '/libutp'