### PR TITLE
Fix webpack start dev server

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/transmission/transmission",
   "license": "MIT",
   "scripts": {
-    "dev": "WEBPACK_MODE=development webpack-dev-server -d --config webpack.config.js",
+    "dev": "WEBPACK_MODE=development webpack serve --config webpack.config.js",
     "build": "webpack --config webpack.config.js",
     "css": "sass --no-source-map style/",
     "css:map": "sass style/",


### PR DESCRIPTION
`yarn dev` fails to start with:
```
$ yarn dev
yarn run v1.22.10
$ WEBPACK_MODE=development webpack serve -d --config webpack.config.js
[webpack-cli] Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration.devtool should match pattern "^(inline-|hidden-|eval-)?(nosources-)?(cheap-(module-)?)?source-map$".
   BREAKING CHANGE since webpack 5: The devtool option is more strict.
   Please strictly follow the order of the keywords in the pattern.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Fix it by:
- Use webpack instead of webpack-dev-server (which is no longer maintained)
- The webpack -d option requires as string (which is missing) and is specified in the config file, therefore use the devtool option from webpack.config.js