### PR TITLE
refactor: fix a pair of win32 msvc warnings in libtransmission

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -195,7 +195,13 @@ void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt
 ****
 ***/
 
-void tr_logAddMessage(char const* file, int line, tr_log_level level, char const* name, char const* fmt, ...)
+void tr_logAddMessage(
+    [[maybe_unused]] char const* file,
+    [[maybe_unused]] int line,
+    [[maybe_unused]] tr_log_level level,
+    [[maybe_unused]] char const* name,
+    char const* fmt,
+    ...)
 {
     int const err = errno; /* message logging shouldn't affect errno */
     char buf[1024];

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -38,7 +38,7 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
     time_t lastSleptAt = 0;
     uint32_t piecePos = 0;
     tr_file_index_t fileIndex = 0;
-    tr_file_index_t prevFileIndex = ~0;
+    tr_file_index_t prevFileIndex = ~fileIndex;
     tr_piece_index_t piece = 0;
     auto buffer = std::vector<std::byte>(1024 * 256);
     auto sha = tr_sha1_init();


### PR DESCRIPTION
does what it says in the title.

Neither of these warnings caused any production issues; this is just tidying the build