### PR TITLE
refactor: remove callback from tr_torrentVerify() public API

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -320,7 +320,7 @@ int tr_main(int argc, char* argv[])
     if (verify)
     {
         verify = false;
-        tr_torrentVerify(tor, nullptr, nullptr);
+        tr_torrentVerify(tor);
     }
 
     for (;;)

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -166,7 +166,7 @@ void OptionsDialog::Impl::updateTorrent()
         tr_torrentSetDownloadDir(tor_, downloadDir_.c_str());
         file_list_->set_sensitive(tr_torrentHasMetadata(tor_));
         file_list_->set_torrent(tr_torrentId(tor_));
-        tr_torrentVerify(tor_, nullptr, nullptr);
+        tr_torrentVerify(tor_);
     }
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -354,7 +354,7 @@ static char const* torrentVerify(
 {
     for (auto* tor : getTorrents(session, args_in))
     {
-        tr_torrentVerify(tor, nullptr, nullptr);
+        tr_torrentVerify(tor);
         notify(session, TR_RPC_TORRENT_CHANGED, tor);
     }
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1483,24 +1483,9 @@ void tr_torrentAvailability(tr_torrent const* torrent, int8_t* tab, int size);
 void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int size);
 
 /**
- * Callback function invoked when a torrent finishes being verified.
- *
- * @param torrent the torrent that was verified
- * @param aborted true if the verify ended prematurely for some reason,
- *                such as tr_torrentStop() or tr_torrentSetLocation()
- *                being called during verification.
- * @param user_data the user-defined pointer from tr_torrentVerify()
- */
-using tr_verify_done_func = void (*)(tr_torrent* torrent, bool aborted, void* user_data);
-
-/**
  * Queue a torrent for verification.
- *
- * If callback_func is non-nullptr, it will be called from the libtransmission
- * thread after the torrent's completness state is updated after the
- * file verification pass.
  */
-void tr_torrentVerify(tr_torrent* torrent, tr_verify_done_func callback_func_or_nullptr, void* callback_data_or_nullptr);
+void tr_torrentVerify(tr_torrent* torrent);
 
 bool tr_torrentHasMetadata(tr_torrent const* tor);
 

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -9,10 +9,15 @@
 #error only libtransmission should #include this header.
 #endif
 
+struct tr_session;
+struct tr_torrent;
+
 /**
  * @addtogroup file_io File IO
  * @{
  */
+
+using tr_verify_done_func = void (*)(tr_torrent*, bool aborted, void* user_data);
 
 void tr_verifyAdd(tr_torrent* tor, tr_verify_done_func callback_func, void* callback_user_data);
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -415,7 +415,7 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (void)resetCache
 {
-    tr_torrentVerify(fHandle, NULL, NULL);
+    tr_torrentVerify(fHandle);
     [self update];
 }
 

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -435,19 +435,9 @@ protected:
     {
         EXPECT_NE(nullptr, tor->session);
         EXPECT_FALSE(tr_amInEventThread(tor->session));
-
-        auto constexpr onVerifyDone = [](tr_torrent*, bool, void* done) noexcept
-        {
-            *static_cast<bool*>(done) = true;
-        };
-
-        bool done = false;
-        tr_torrentVerify(tor, onVerifyDone, &done);
-        auto test = [&done]()
-        {
-            return done;
-        };
-        EXPECT_TRUE(waitFor(test, 2000));
+        tr_torrentVerify(tor);
+        EXPECT_TRUE(waitFor([tor]() { return tor->verifyState != TR_VERIFY_NONE; }, 2000));
+        EXPECT_TRUE(waitFor([tor]() { return tor->verifyState == TR_VERIFY_NONE; }, 4000));
     }
 
     tr_session* session_ = nullptr;


### PR DESCRIPTION
This doesn't fix #423 but does some prepwork before fixing it. None of the callers of `tr_torrentVerify()` use its callback args, so remove them. This simplifies the `torrent.cc` verify wrapper code a little.