### PR TITLE
Fix Labels section in transmission-remote output.

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -958,13 +958,15 @@ static void printDetails(tr_variant* top)
 
             if (tr_variantDictFindList(t, TR_KEY_labels, &l))
             {
+                printf("  Labels: ");
+
                 size_t child_pos = 0;
                 tr_variant const* child;
                 while ((child = tr_variantListChild(l, child_pos++)))
                 {
                     if (tr_variantGetStrView(child, &sv))
                     {
-                        printf(i == 0 ? "%" TR_PRIsv : ", %" TR_PRIsv, TR_PRIsv_ARG(sv));
+                        printf(child_pos == 1 ? "%" TR_PRIsv : ", %" TR_PRIsv, TR_PRIsv_ARG(sv));
                     }
                 }
 


### PR DESCRIPTION
I noticed that `transmission-remote` output is broken, `Labels` section is not correct.
Current output:
```
$ ./transmission-remote -t 2 -i 
NAME
  Id: 2
  Name: Manson
  Hash: c6cdcb6ce6338e29d99f9f03a938809842b47990
  Magnet: magnet:?xt=urn:btih:c6cdcb6ce6338e29d99f9f03a938809842b47990&dn=Manson&tr=http%3A%2F%2Fbt2.t-ru.org%2Fann%3Fpk%3D1e76b76ff7f5910c77ec5f5a41bd220b&tr=http%3A%2F%2Fretracker.local%2Fannounce
, three, two, one, baz

TRANSFER
...
```
With proposed fix:
```
$ ./transmission-remote -t 2 -i 
NAME
  Id: 2
  Name: Manson
  Hash: c6cdcb6ce6338e29d99f9f03a938809842b47990
  Magnet: magnet:?xt=urn:btih:c6cdcb6ce6338e29d99f9f03a938809842b47990&dn=Manson&tr=http%3A%2F%2Fbt2.t-ru.org%2Fann%3Fpk%3D1e76b76ff7f5910c77ec5f5a41bd220b&tr=http%3A%2F%2Fretracker.local%2Fannounce
  Labels: baz, three, two, one

TRANSFER
...
```

Commit which introduced the bug -- https://github.com/transmission/transmission/commit/677dc73eac3efa769eefb1c7ec4eda232a35977a#diff-f00d4a85f7112ae6a3f8db4ad607edaa264e8485ad5c5a5803f25fa940ef0457L973
