### PR TITLE
Add support for torrent-get calls with the key percentComplete

### DIFF
--- a/extras/rpc-spec.md
+++ b/extras/rpc-spec.md
@@ -248,7 +248,8 @@ The 'source' column here corresponds to the data structure there.
 | `peersFrom` | object (see below)| n/a
 | `peersGettingFromUs` | number| tr_stat
 | `peersSendingToUs` | number| tr_stat
-| `percentDone` | double| tr_stat
+| `percentComplete` | double | tr_stat
+| `percentDone` | double | tr_stat
 | `pieces` | string (see below)| tr_torrent
 | `pieceCount`| number| tr_torrent_view
 | `pieceSize`| number| tr_torrent_view
@@ -938,9 +939,10 @@ Transmission 4.0.0 (`rpc-version-semver` 5.3.0, `rpc-version`: 17)
 | `session-get` | new arg `script-torrent-added-filename`
 | `torrent-add` | new arg `labels`
 | `torrent-get` | new arg `file-count`
+| `torrent-get` | new arg `percentComplete`
+| `torrent-get` | new arg `primary-mime-type`
 | `torrent-get` | new arg `tracker.sitename`
 | `torrent-get` | new arg `trackerStats.sitename`
-| `torrent-get` | new arg `primary-mime-type`
 
 
 ### 5.1. Upcoming Breakage

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr my_static = std::array<std::string_view, 384>{ ""sv,
+auto constexpr my_static = std::array<std::string_view, 385>{ ""sv,
                                                               "activeTorrentCount"sv,
                                                               "activity-date"sv,
                                                               "activityDate"sv,
@@ -230,6 +230,7 @@ auto constexpr my_static = std::array<std::string_view, 384>{ ""sv,
                                                               "peersFrom"sv,
                                                               "peersGettingFromUs"sv,
                                                               "peersSendingToUs"sv,
+                                                              "percentComplete"sv,
                                                               "percentDone"sv,
                                                               "pex-enabled"sv,
                                                               "piece"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -233,6 +233,7 @@ enum
     TR_KEY_peersFrom,
     TR_KEY_peersGettingFromUs,
     TR_KEY_peersSendingToUs,
+    TR_KEY_percentComplete,
     TR_KEY_percentDone,
     TR_KEY_pex_enabled,
     TR_KEY_piece,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -633,6 +633,10 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         tr_variantInitStrView(initme, tr_torrentName(tor));
         break;
 
+    case TR_KEY_percentComplete:
+        tr_variantInitReal(initme, st->percentComplete);
+        break;
+
     case TR_KEY_percentDone:
         tr_variantInitReal(initme, st->percentDone);
         break;


### PR DESCRIPTION
Supersedes https://github.com/transmission/transmission/pull/470, which could not be merged due to merge conflicts. Author is @mhadam.

> `percentDone` is already available as a key when calling `torrent-get` over RPC - it describes the amount of data downloaded as a percent of the files that are wanted in the torrent. I'm interested in getting `percentComplete` - the data downloaded as a percent of the complete torrent size. `percentComplete` is already included in `tr_stat` so it's an easy add.