### PR TITLE
refactor: add fetch options object to tr_webRun()

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -286,7 +286,7 @@ int tr_main(int argc, char* argv[])
     else if (tr_urlIsValid(torrentPath))
     {
         // fetch it
-        tr_webRun(h, torrentPath, onTorrentFileDownloaded, ctor);
+        tr_webRun(h, { torrentPath, onTorrentFileDownloaded, ctor });
         waitingOnWeb = true;
         while (waitingOnWeb)
         {

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -90,7 +90,7 @@ bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
         fav->contents.clear();
         auto* const session = fav->session;
         auto const next_url = get_url(fav->host, fav->type);
-        tr_webRun(session, next_url.c_str(), favicon_web_done_cb, fav.release());
+        tr_webRun(session, { next_url.raw(), favicon_web_done_cb, fav.release() });
     }
 
     // Not released into the next web request, means we're done trying (even if `pixbuf` is still invalid)
@@ -136,7 +136,7 @@ void gtr_get_favicon(
         data->func = pixbuf_ready_func;
         data->host = host;
 
-        tr_webRun(session, get_url(host, 0).c_str(), favicon_web_done_cb, data.release());
+        tr_webRun(session, { get_url(host, 0).raw(), favicon_web_done_cb, data.release() });
     }
 }
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -345,7 +345,7 @@ void tr_tracker_http_announce(
 
     auto const url = announce_url_new(session, request);
     dbgmsg(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
-    tr_webRun(session, url, on_announce_done, d);
+    tr_webRun(session, { url, on_announce_done, d });
 }
 
 /****
@@ -540,5 +540,5 @@ void tr_tracker_http_scrape(
 
     auto const url = scrape_url_new(request);
     dbgmsg(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
-    tr_webRun(session, url, on_scrape_done, d);
+    tr_webRun(session, { url, on_scrape_done, d });
 }

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -6,12 +6,13 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <string_view>
 
 #include "transmission.h"
 
 struct evbuffer;
-struct tr_address;
 struct tr_web_task;
 
 enum tr_web_close_mode
@@ -30,21 +31,25 @@ using tr_web_done_func = void (*)(
     std::string_view response,
     void* user_data);
 
-struct tr_web_task* tr_webRun(tr_session* session, std::string_view url, tr_web_done_func done_func, void* done_func_user_data);
+class tr_web_options
+{
+public:
+    tr_web_options(std::string_view url_in, tr_web_done_func done_func_in, void* done_func_user_data_in)
+        : url{ url_in }
+        , done_func{ done_func_in }
+        , done_func_user_data{ done_func_user_data_in }
+    {
+    }
 
-struct tr_web_task* tr_webRunWithCookies(
-    tr_session* session,
-    std::string_view url,
-    std::string_view cookies,
-    tr_web_done_func done_func,
-    void* done_func_user_data);
+    std::string url;
+    std::optional<int> torrent_id;
+    tr_web_done_func done_func = nullptr;
+    void* done_func_user_data = nullptr;
+    std::string range;
+    std::string cookies;
+    evbuffer* buffer = nullptr;
+};
 
-struct tr_web_task* tr_webRunWebseed(
-    tr_torrent* tor,
-    std::string_view url,
-    std::string_view range,
-    tr_web_done_func done_func,
-    void* done_func_user_data,
-    struct evbuffer* buffer);
+struct tr_web_task* tr_webRun(tr_session* session, tr_web_options&& options);
 
 long tr_webGetTaskResponseCode(struct tr_web_task* task);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -43,7 +43,7 @@ public:
         , session{ tor->session }
         , block{ span.begin }
         , piece_index{ tor->pieceForBlock(this->block) }
-        , piece_offset{ static_cast<uint32_t>(tor->blockSize() * this->block - tor->pieceSize() * this->piece_index) }
+        , piece_offset{ static_cast<uint32_t>(int64_t{tor->blockSize()}* this->block - tor->pieceSize() * this->piece_index) }
         , block_size{ tor->blockSize() }
         , length{ (span.end - 1 - span.begin) * tor->blockSize() + tor->blockSize(span.end - 1) }
     {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -43,7 +43,8 @@ public:
         , session{ tor->session }
         , block{ span.begin }
         , piece_index{ tor->pieceForBlock(this->block) }
-        , piece_offset{ static_cast<uint32_t>(int64_t{tor->blockSize()}* this->block - tor->pieceSize() * this->piece_index) }
+        , piece_offset{ static_cast<uint32_t>(
+              int64_t{ tor->blockSize() } * this->block - tor->pieceSize() * this->piece_index) }
         , block_size{ tor->blockSize() }
         , length{ (span.end - 1 - span.begin) * tor->blockSize() + tor->blockSize(span.end - 1) }
     {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -30,25 +30,44 @@ namespace
 
 struct tr_webseed;
 
-struct tr_webseed_task
+void on_idle(tr_webseed* w);
+
+class tr_webseed_task
 {
-    bool dead;
-    struct evbuffer* content;
-    struct tr_webseed* webseed;
-    tr_session* session;
-    tr_block_index_t block;
-    tr_piece_index_t piece_index;
-    uint32_t piece_offset;
-    uint32_t length;
-    tr_block_index_t blocks_done;
-    uint32_t block_size;
-    struct tr_web_task* web_task;
-    long response_code;
+private:
+    std::shared_ptr<evbuffer> const content_{ evbuffer_new(), evbuffer_free };
+
+public:
+    tr_webseed_task(tr_torrent* tor, tr_webseed* webseed_in, tr_block_span_t span)
+        : webseed{ webseed_in }
+        , session{ tor->session }
+        , block{ span.begin }
+        , piece_index{ tor->pieceForBlock(this->block) }
+        , piece_offset{ static_cast<uint32_t>(tor->blockSize() * this->block - tor->pieceSize() * this->piece_index) }
+        , block_size{ tor->blockSize() }
+        , length{ (span.end - 1 - span.begin) * tor->blockSize() + tor->blockSize(span.end - 1) }
+    {
+    }
+
+    tr_webseed* const webseed;
+
+    [[nodiscard]] auto* content() const
+    {
+        return content_.get();
+    }
+
+    tr_session* const session;
+    tr_block_index_t const block;
+    tr_piece_index_t const piece_index;
+    uint32_t const piece_offset;
+    uint32_t const block_size;
+    uint32_t const length;
+
+    bool dead = false;
+    tr_block_index_t blocks_done = 0;
+    tr_web_task* web_task = nullptr;
+    long response_code = 0;
 };
-
-auto constexpr TR_IDLE_TIMER_MSEC = 2000;
-
-void webseed_timer_func(evutil_socket_t fd, short what, void* vw);
 
 /**
  * Manages how many web tasks should be running at a time.
@@ -141,13 +160,13 @@ public:
         , callback{ callback_in }
         , callback_data{ callback_data_in }
         , bandwidth(tor->bandwidth)
-        , timer(evtimer_new(session->event_base, webseed_timer_func, this))
+        , pulse_timer(evtimer_new(session->event_base, &tr_webseed::onTimer, this), event_free)
     {
         // init parent bits
         have.setHasAll();
         tr_peerUpdateProgress(tor, this);
 
-        tr_timerAddMsec(timer, TR_IDLE_TIMER_MSEC);
+        startTimer();
     }
 
     ~tr_webseed() override
@@ -155,8 +174,6 @@ public:
         // flag all the pending tasks as dead
         std::for_each(std::begin(tasks), std::end(tasks), [](auto* task) { task->dead = true; });
         tasks.clear();
-
-        event_free(timer);
     }
 
     bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
@@ -186,29 +203,29 @@ public:
     Bandwidth bandwidth;
     ConnectionLimiter connection_limiter;
     std::set<tr_webseed_task*> tasks;
-    event* const timer;
-};
 
-} // namespace
-
-tr_webseed_view tr_webseedView(tr_peer const* peer)
-{
-    auto const* w = dynamic_cast<tr_webseed const*>(peer);
-    if (w == nullptr)
+private:
+    void startTimer()
     {
-        return {};
+        tr_timerAddMsec(pulse_timer.get(), IdleTimerMsec);
     }
 
-    auto bytes_per_second = unsigned{ 0 };
-    auto const is_downloading = peer->is_transferring_pieces(tr_time_msec(), TR_DOWN, &bytes_per_second);
-    return { w->base_url.c_str(), is_downloading, bytes_per_second };
-}
+    static void onTimer(evutil_socket_t /*fd*/, short /*what*/, void* vwebseed)
+    {
+        auto* const webseed = static_cast<tr_webseed*>(vwebseed);
+        on_idle(webseed);
+        webseed->startTimer();
+    }
+
+    std::shared_ptr<event> const pulse_timer;
+    static int constexpr IdleTimerMsec = 2000;
+};
 
 /***
 ****
 ***/
 
-static void publish(tr_webseed* w, tr_peer_event* e)
+void publish(tr_webseed* w, tr_peer_event* e)
 {
     if (w->callback != nullptr)
     {
@@ -216,7 +233,7 @@ static void publish(tr_webseed* w, tr_peer_event* e)
     }
 }
 
-static void fire_client_got_rejs(tr_torrent* tor, tr_webseed* w, tr_block_index_t block, tr_block_index_t count)
+void fire_client_got_rejs(tr_torrent* tor, tr_webseed* w, tr_block_index_t block, tr_block_index_t count)
 {
     auto e = tr_peer_event{};
     e.eventType = TR_PEER_CLIENT_GOT_REJ;
@@ -234,7 +251,7 @@ static void fire_client_got_rejs(tr_torrent* tor, tr_webseed* w, tr_block_index_
     }
 }
 
-static void fire_client_got_blocks(tr_torrent* tor, tr_webseed* w, tr_block_index_t block, tr_block_index_t count)
+void fire_client_got_blocks(tr_torrent* tor, tr_webseed* w, tr_block_index_t block, tr_block_index_t count)
 {
     auto e = tr_peer_event{};
     e.eventType = TR_PEER_CLIENT_GOT_BLOCK;
@@ -252,7 +269,7 @@ static void fire_client_got_blocks(tr_torrent* tor, tr_webseed* w, tr_block_inde
     }
 }
 
-static void fire_client_got_piece_data(tr_webseed* w, uint32_t length)
+void fire_client_got_piece_data(tr_webseed* w, uint32_t length)
 {
     auto e = tr_peer_event{};
     e.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
@@ -266,21 +283,37 @@ static void fire_client_got_piece_data(tr_webseed* w, uint32_t length)
 
 struct write_block_data
 {
-    tr_session* session;
-    int torrent_id;
-    struct tr_webseed* webseed;
-    struct evbuffer* content;
+private:
+    std::shared_ptr<evbuffer> const content_{ evbuffer_new(), evbuffer_free };
+
+public:
+    write_block_data(tr_session* session_in, int torrent_id_in, tr_webseed* webseed_in)
+        : session{ session_in }
+        , torrent_id{ torrent_id_in }
+        , webseed{ webseed_in }
+    {
+    }
+
+    [[nodiscard]] auto* content() const
+    {
+        return content_.get();
+    }
+
+    tr_session* const session;
+    int const torrent_id;
+    tr_webseed* const webseed;
+
     tr_piece_index_t piece_index;
     tr_block_index_t block_index;
     tr_block_index_t count;
     uint32_t block_offset;
 };
 
-static void write_block_func(void* vdata)
+void write_block_func(void* vdata)
 {
-    auto* const data = static_cast<struct write_block_data*>(vdata);
+    auto* const data = static_cast<write_block_data*>(vdata);
     struct tr_webseed* const w = data->webseed;
-    struct evbuffer* const buf = data->content;
+    auto* const buf = data->content();
 
     auto* const tor = tr_torrentFindFromId(data->session, data->torrent_id);
     if (tor != nullptr)
@@ -304,19 +337,18 @@ static void write_block_func(void* vdata)
         }
     }
 
-    evbuffer_free(buf);
-    tr_free(data);
+    delete data;
 }
 
 /***
 ****
 ***/
 
-static void on_content_changed(struct evbuffer* buf, struct evbuffer_cb_info const* info, void* vtask)
+void on_content_changed(evbuffer* buf, evbuffer_cb_info const* info, void* vtask)
 {
     size_t const n_added = info->n_added;
-    auto* task = static_cast<struct tr_webseed_task*>(vtask);
-    auto* session = task->session;
+    auto* const task = static_cast<tr_webseed_task*>(vtask);
+    auto* const session = task->session;
     auto const lock = session->unique_lock();
 
     if (!task->dead && n_added > 0)
@@ -331,10 +363,7 @@ static void on_content_changed(struct evbuffer* buf, struct evbuffer_cb_info con
         {
             task->response_code = tr_webGetTaskResponseCode(task->web_task);
 
-            if (task->response_code == 206)
-            {
-                task->webseed->connection_limiter.gotData();
-            }
+            task->webseed->connection_limiter.gotData();
         }
 
         if (task->response_code == 206 && len >= task->block_size)
@@ -344,19 +373,15 @@ static void on_content_changed(struct evbuffer* buf, struct evbuffer_cb_info con
             uint32_t const block_size = task->block_size;
             tr_block_index_t const completed = len / block_size;
 
-            auto* const data = tr_new(struct write_block_data, 1);
-            data->webseed = task->webseed;
+            auto* const data = new write_block_data{ session, w->torrent_id, task->webseed };
             data->piece_index = task->piece_index;
             data->block_index = task->block + task->blocks_done;
             data->count = completed;
             data->block_offset = task->piece_offset + task->blocks_done * block_size;
-            data->content = evbuffer_new();
-            data->torrent_id = w->torrent_id;
-            data->session = w->session;
 
             /* we don't use locking on this evbuffer so we must copy out the data
                that will be needed when writing the block in a different thread */
-            evbuffer_remove_buffer(task->content, data->content, (size_t)block_size * (size_t)completed);
+            evbuffer_remove_buffer(task->content(), data->content(), (size_t)block_size * (size_t)completed);
 
             tr_runInEventThread(w->session, write_block_func, data);
             task->blocks_done += completed;
@@ -364,33 +389,21 @@ static void on_content_changed(struct evbuffer* buf, struct evbuffer_cb_info con
     }
 }
 
-static void task_request_next_chunk(struct tr_webseed_task* task);
+void task_request_next_chunk(tr_webseed_task* task);
 
-static void on_idle(tr_webseed* w)
+void on_idle(tr_webseed* w)
 {
     auto* const tor = tr_torrentFindFromId(w->session, w->torrent_id);
-    if (tor == nullptr || !tor->isRunning || tor->isDone() || w->connection_limiter.slotsAvailable() < 1)
+    if (tor == nullptr || !tor->isRunning || tor->isDone())
     {
         return;
     }
 
-    for (auto const span : tr_peerMgrGetNextRequests(tor, w, 1))
+    for (auto const span : tr_peerMgrGetNextRequests(tor, w, w->connection_limiter.slotsAvailable()))
     {
         w->connection_limiter.taskStarted();
-
-        auto const [begin, end] = span;
-        auto* const task = tr_new0(tr_webseed_task, 1);
-        task->session = tor->session;
-        task->webseed = w;
-        task->block = begin;
-        task->piece_index = tor->pieceForBlock(begin);
-        task->piece_offset = tor->blockSize() * begin - tor->pieceSize() * task->piece_index;
-        task->length = (end - 1 - begin) * tor->blockSize() + tor->blockSize(end - 1);
-        task->blocks_done = 0;
-        task->response_code = 0;
-        task->block_size = tor->blockSize();
-        task->content = evbuffer_new();
-        evbuffer_add_cb(task->content, on_content_changed, task);
+        auto* const task = new tr_webseed_task{ tor, w, span };
+        evbuffer_add_cb(task->content(), on_content_changed, task);
         w->tasks.insert(task);
         task_request_next_chunk(task);
 
@@ -398,7 +411,7 @@ static void on_idle(tr_webseed* w)
     }
 }
 
-static void web_response_func(
+void web_response_func(
     tr_session* session,
     bool /*did_connect*/,
     bool /*did_timeout*/,
@@ -406,7 +419,7 @@ static void web_response_func(
     std::string_view /*response*/,
     void* vtask)
 {
-    auto* t = static_cast<struct tr_webseed_task*>(vtask);
+    auto* const t = static_cast<tr_webseed_task*>(vtask);
     bool const success = response_code == 206;
     tr_webseed* w = t->webseed;
 
@@ -414,8 +427,7 @@ static void web_response_func(
 
     if (t->dead)
     {
-        evbuffer_free(t->content);
-        tr_free(t);
+        delete t;
         return;
     }
 
@@ -433,13 +445,12 @@ static void web_response_func(
             }
 
             w->tasks.erase(t);
-            evbuffer_free(t->content);
-            tr_free(t);
+            delete t;
         }
         else
         {
             uint32_t const bytes_done = t->blocks_done * tor->blockSize();
-            uint32_t const buf_len = evbuffer_get_length(t->content);
+            uint32_t const buf_len = evbuffer_get_length(t->content());
 
             if (bytes_done + buf_len < t->length)
             {
@@ -454,14 +465,19 @@ static void web_response_func(
                 {
                     /* on_content_changed() will not write a block if it is smaller than
                        the torrent's block size, i.e. the torrent's very last block */
-                    tr_cacheWriteBlock(session->cache, tor, t->piece_index, t->piece_offset + bytes_done, buf_len, t->content);
+                    tr_cacheWriteBlock(
+                        session->cache,
+                        tor,
+                        t->piece_index,
+                        t->piece_offset + bytes_done,
+                        buf_len,
+                        t->content());
 
                     fire_client_got_blocks(tor, t->webseed, t->block + t->blocks_done, 1);
                 }
 
                 w->tasks.erase(t);
-                evbuffer_free(t->content);
-                tr_free(t);
+                delete t;
 
                 on_idle(w);
             }
@@ -469,7 +485,7 @@ static void web_response_func(
     }
 }
 
-static std::string make_url(tr_webseed* w, std::string_view name)
+std::string make_url(tr_webseed* w, std::string_view name)
 {
     auto url = w->base_url;
 
@@ -481,49 +497,54 @@ static std::string make_url(tr_webseed* w, std::string_view name)
     return url;
 }
 
-static void task_request_next_chunk(struct tr_webseed_task* t)
+void task_request_next_chunk(tr_webseed_task* t)
 {
     tr_webseed* w = t->webseed;
-    tr_torrent* tor = tr_torrentFindFromId(w->session, w->torrent_id);
 
-    if (tor != nullptr)
+    tr_torrent* const tor = tr_torrentFindFromId(w->session, w->torrent_id);
+    if (tor == nullptr)
     {
-        auto const piece_size = tor->pieceSize();
-        uint64_t const remain = t->length - t->blocks_done * tor->blockSize() - evbuffer_get_length(t->content);
-
-        auto const total_offset = tor->offset(t->piece_index, t->piece_offset, t->length - remain);
-        tr_piece_index_t const step_piece = total_offset / piece_size;
-        uint64_t const step_piece_offset = total_offset - uint64_t(piece_size) * step_piece;
-
-        auto const [file_index, file_offset] = tor->fileOffset(step_piece, step_piece_offset);
-        uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
-
-        auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
-
-        char range[64];
-        tr_snprintf(range, sizeof(range), "%" PRIu64 "-%" PRIu64, file_offset, file_offset + this_pass - 1);
-
-        t->web_task = tr_webRunWebseed(tor, url.c_str(), range, web_response_func, t, t->content);
+        return;
     }
+
+    auto const piece_size = tor->pieceSize();
+    uint64_t const remain = t->length - t->blocks_done * tor->blockSize() - evbuffer_get_length(t->content());
+
+    auto const total_offset = tor->offset(t->piece_index, t->piece_offset, t->length - remain);
+    tr_piece_index_t const step_piece = total_offset / piece_size;
+    uint64_t const step_piece_offset = total_offset - uint64_t(piece_size) * step_piece;
+
+    auto const [file_index, file_offset] = tor->fileOffset(step_piece, step_piece_offset);
+    uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
+
+    auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
+    auto options = tr_web_options{ url, web_response_func, t };
+    options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_pass - 1));
+    options.torrent_id = tor->uniqueId;
+    options.buffer = t->content();
+    t->web_task = tr_webRun(tor->session, std::move(options));
 }
+
+} // namespace
 
 /***
 ****
 ***/
 
-namespace
-{
-
-void webseed_timer_func(evutil_socket_t /*fd*/, short /*what*/, void* vw)
-{
-    auto* w = static_cast<tr_webseed*>(vw);
-    on_idle(w);
-    tr_timerAddMsec(w->timer, TR_IDLE_TIMER_MSEC);
-}
-
-} // unnamed namespace
-
-tr_peer* tr_webseedNew(struct tr_torrent* torrent, std::string_view url, tr_peer_callback callback, void* callback_data)
+tr_peer* tr_webseedNew(tr_torrent* torrent, std::string_view url, tr_peer_callback callback, void* callback_data)
 {
     return new tr_webseed(torrent, url, callback, callback_data);
+}
+
+tr_webseed_view tr_webseedView(tr_peer const* peer)
+{
+    auto const* w = dynamic_cast<tr_webseed const*>(peer);
+    if (w == nullptr)
+    {
+        return {};
+    }
+
+    auto bytes_per_second = unsigned{ 0 };
+    auto const is_downloading = peer->is_transferring_pieces(tr_time_msec(), TR_DOWN, &bytes_per_second);
+    return { w->base_url.c_str(), is_downloading, bytes_per_second };
 }


### PR DESCRIPTION
Part 3 in a series of web + webseed PRs. The previous PR in the series was #2613. The goals are discussed [here](https://github.com/transmission/transmission/pull/2613#discussion_bucket).

---

This PR still has a lot of code smells in web.cc and webseed.cc. Refactoring the entire system is overwhelming, so instead I'm doing it in incremental steps.

- Fold `tr_webRun()`, `tr_webRunWithCookies()`, and `tr_webRunWebseed()` into a single API that takes an options argument that callers can customize to their needs.

- Also does a surface cleanup pass to the tr_webseed and tr_web internal structures, e.g. making fields const where possible, not using raw pointers, and making some fields private.