### PR TITLE
build: define UTF_CPP_CPLUSPLUS before including utf8.h

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -31,7 +31,9 @@
 #include <iconv.h>
 #endif
 
+#define UTF_CPP_CPLUSPLUS 201703L
 #include <utf8.h>
+
 #include <event2/buffer.h>
 #include <event2/event.h>
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -11,8 +11,10 @@
 #include <deque>
 #include <string_view>
 
+#define UTF_CPP_CPLUSPLUS 201703L
 #include <utf8.h>
-#include <event2/buffer.h> /* evbuffer_add() */
+
+#include <event2/buffer.h>
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 


### PR DESCRIPTION
Fixes #2256. This ensures that utfcpp's c++17 code is enabled.