### PR TITLE
feat: newly-added seeds skip the full verify step

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -167,6 +167,16 @@ void tr_completion::setBlocks(tr_bitfield blocks)
     has_valid_.reset();
 }
 
+void tr_completion::setHasAll()
+{
+    auto const total_size = block_info_->totalSize();
+
+    blocks_.setHasAll();
+    size_now_ = total_size;
+    size_when_done_ = total_size;
+    has_valid_ = total_size;
+}
+
 void tr_completion::addPiece(tr_piece_index_t piece)
 {
     auto const [begin, end] = block_info_->blockSpanForPiece(piece);

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -118,6 +118,8 @@ struct tr_completion
         }
     }
 
+    void setHasAll();
+
     void setBlocks(tr_bitfield blocks);
 
     void invalidateSizeWhenDone()

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -638,12 +638,6 @@ static bool isNewTorrentASeed(tr_torrent* tor)
         return false;
     }
 
-    auto const piece_count = tor->pieceCount();
-    if (piece_count == 0)
-    {
-        return false;
-    }
-
     auto filename_buf = std::string{};
     for (tr_file_index_t i = 0, n = tor->fileCount(); i < n; ++i)
     {
@@ -673,16 +667,8 @@ static bool isNewTorrentASeed(tr_torrent* tor)
         }
     }
 
-    // check first and last piece
-    for (auto const piece : { 0UL, piece_count - 1 })
-    {
-        if (!tor->ensurePieceIsChecked(piece))
-        {
-            return false;
-        }
-    }
-
-    return true;
+    // check the first piece
+    return tor->ensurePieceIsChecked(0);
 }
 
 static void refreshCurrentDir(tr_torrent* tor);


### PR DESCRIPTION
Fixes #2261. Testers needed.

This has been a much-requested feature but has also a contentious one. Several years back Transmission briefly had a bug that caused it to seed bad data and I never want that to happen again, so until recently I've argued (loudly) against this feature. So I wanted to give a brief explanation of how seed data is still safe in this PR.

## In this PR: new seeds skip the full verify step

This PR lets newly-added torrents skip the full verify step if the torrent fulfills _all_ these conditions:

- The torrent has metadata (i.e. is not a magnet link)
- All files exist
- All files are not partial (`.part`) files
- All files' sizes match the sizes listed in the .torrent file
- All files' mtimes (timestamp of when they were last modified) are older than when the torrent was added
- The first piece passes the checksum test

When this is true, the initial verify step is bypassed and the torrent is treated like a full seed. Individual pieces are lazy-checked on demand when peers request blocks from them.

## In the nightlies: mtime-based lazy checking

[This code](https://github.com/transmission/transmission/pull/2059) is in the nightlies and will be in Transmission 4.0.0. Transmission's `.resume` file stores two pieces of information about what pieces have been checked:

- `file_mtimes`, an array of `tr_torrent::fileCount()` timestamps of the content files' mtimes (when the file was modified).
- `checked_pieces`, a bitfield of `tr_torrent::pieceCount()` booleans marking true/false whether each piece has been checked.

On startup, Transmission scans the content files' mtimes on the disk and compares them to the ones in `file_mtimes`. If they differ, then pieces that include that piece are set to false in `checked_pieces`. Together, these fields answer the question **"has this piece been checked since the last time its files changed?"**

If the answer is "no" when a peer requests data, then the piece is checked. If the test passes, the request is fulfilled and `checked_pieces` is updated to mark the piece as tested. If the test fails, the torrent is stopped and the "Piece #X is corrupt!" error is set.

The code in this PR to skip the initial verify step does not change any of that. The "does this pass the sniff test as a new seed" code checks the first piece as a sanity check, but all the other pieces have _not_ been tested and so when a peer asks for data from another piece, that piece will be checked before the request is fulfilled.