### PR TITLE
refactor: remove tr_webGetTaskResponseCode()

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -366,11 +366,11 @@ static void task_finish_func(void* vtask)
 
 static void tr_webThreadFunc(void* vsession);
 
-tr_web_task* tr_webRun(tr_session* session, tr_web_options&& options)
+void tr_webRun(tr_session* session, tr_web_options&& options)
 {
     if (session->isClosing())
     {
-        return {};
+        return;
     }
 
     if (session->web == nullptr)
@@ -386,8 +386,6 @@ tr_web_task* tr_webRun(tr_session* session, tr_web_options&& options)
     auto* const task = new tr_web_task{ session, std::move(options) };
     task->next = session->web->tasks;
     session->web->tasks = task;
-
-    return task;
 }
 
 static void tr_webThreadFunc(void* vsession)
@@ -564,11 +562,4 @@ void tr_webClose(tr_session* session, tr_web_close_mode close_mode)
             }
         }
     }
-}
-
-long tr_webGetTaskResponseCode(tr_web_task* task)
-{
-    long code = 0;
-    curl_easy_getinfo(task->curl_easy, CURLINFO_RESPONSE_CODE, &code);
-    return code;
 }

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -13,7 +13,6 @@
 #include "transmission.h"
 
 struct evbuffer;
-struct tr_web_task;
 
 enum tr_web_close_mode
 {
@@ -50,6 +49,4 @@ public:
     evbuffer* buffer = nullptr;
 };
 
-struct tr_web_task* tr_webRun(tr_session* session, tr_web_options&& options);
-
-long tr_webGetTaskResponseCode(struct tr_web_task* task);
+void tr_webRun(tr_session* session, tr_web_options&& options);


### PR DESCRIPTION
Part 4 in a series of web + webseed PRs. The previous PR in the series was #2620. The goals are discussed [here](https://github.com/transmission/transmission/pull/2613#discussion_bucket).

---

Remove `tr_webGetTaskResponseCode()`. It's not really needed anymore, and removing it is aligned with the goal of simplifying the tr_web and tr_webseed codebase.