### PR TITLE
refactor: tr_web

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -125,11 +125,10 @@ static char* tr_strlratio(char* buf, double ratio, size_t buflen)
 static bool waitingOnWeb;
 
 static void onTorrentFileDownloaded(
-    tr_session* /*session*/,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
     long /*response_code*/,
     std::string_view response,
+    bool /*did_connect*/,
+    bool /*did_timeout*/,
     void* vctor)
 {
     auto* ctor = static_cast<tr_ctor*>(vctor);

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -124,15 +124,10 @@ static char* tr_strlratio(char* buf, double ratio, size_t buflen)
 
 static bool waitingOnWeb;
 
-static void onTorrentFileDownloaded(
-    long /*response_code*/,
-    std::string_view response,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
-    void* vctor)
+static void onTorrentFileDownloaded(tr_web::Response&& response)
 {
-    auto* ctor = static_cast<tr_ctor*>(vctor);
-    tr_ctorSetMetainfo(ctor, std::data(response), std::size(response), nullptr);
+    auto* ctor = static_cast<tr_ctor*>(response.user_data);
+    tr_ctorSetMetainfo(ctor, std::data(response.body), std::size(response.body), nullptr);
     waitingOnWeb = false;
 }
 

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -124,7 +124,7 @@ static char* tr_strlratio(char* buf, double ratio, size_t buflen)
 
 static bool waitingOnWeb;
 
-static void onTorrentFileDownloaded(tr_web::Response&& response)
+static void onTorrentFileDownloaded(tr_web::FetchResponse&& response)
 {
     auto* ctor = static_cast<tr_ctor*>(response.user_data);
     tr_ctorSetMetainfo(ctor, std::data(response.body), std::size(response.body), nullptr);

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -19,7 +19,7 @@
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
 #include <libtransmission/web-utils.h>
-#include <libtransmission/web.h> /* tr_webRun */
+#include <libtransmission/web.h> // tr_sessionFetch()
 
 /***
 ****
@@ -286,7 +286,7 @@ int tr_main(int argc, char* argv[])
     else if (tr_urlIsValid(torrentPath))
     {
         // fetch it
-        tr_webRun(h, { torrentPath, onTorrentFileDownloaded, ctor });
+        tr_sessionFetch(h, { torrentPath, onTorrentFileDownloaded, ctor });
         waitingOnWeb = true;
         while (waitingOnWeb)
         {

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -10,7 +10,7 @@
 #include <glib/gstdio.h> /* g_remove() */
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/web.h> /* tr_webRun() */
+#include <libtransmission/web.h> // tr_sessionFetch()
 #include <libtransmission/web-utils.h>
 
 #include "FaviconCache.h"
@@ -90,7 +90,7 @@ bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
         fav->contents.clear();
         auto* const session = fav->session;
         auto const next_url = get_url(fav->host, fav->type);
-        tr_webRun(session, { next_url.raw(), favicon_web_done_cb, fav.release() });
+        tr_sessionFetch(session, { next_url.raw(), favicon_web_done_cb, fav.release() });
     }
 
     // Not released into the next web request, means we're done trying (even if `pixbuf` is still invalid)
@@ -136,7 +136,7 @@ void gtr_get_favicon(
         data->func = pixbuf_ready_func;
         data->host = host;
 
-        tr_webRun(session, { get_url(host, 0).raw(), favicon_web_done_cb, data.release() });
+        tr_sessionFetch(session, { get_url(host, 0).raw(), favicon_web_done_cb, data.release() });
     }
 }
 

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -73,7 +73,7 @@ Glib::RefPtr<Gdk::Pixbuf> favicon_load_from_cache(std::string const& host)
     }
 }
 
-void favicon_web_done_cb(long, std::string_view, bool, bool, gpointer);
+void favicon_web_done_cb(tr_web::Response&& response);
 
 bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
 {
@@ -102,16 +102,10 @@ bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
     return false;
 }
 
-void favicon_web_done_cb(
-    long /*response_code*/,
-    std::string_view data,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
-    gpointer vfav)
+void favicon_web_done_cb(tr_web::Response&& response)
 {
-    auto* fav = static_cast<favicon_data*>(vfav);
-    fav->contents.assign(std::data(data), std::size(data));
-
+    auto* const fav = static_cast<favicon_data*>(response.user_data);
+    fav->contents = response.body;
     Glib::signal_idle().connect([fav]() { return favicon_web_done_idle_cb(std::unique_ptr<favicon_data>(fav)); });
 }
 

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -73,7 +73,7 @@ Glib::RefPtr<Gdk::Pixbuf> favicon_load_from_cache(std::string const& host)
     }
 }
 
-void favicon_web_done_cb(tr_session*, bool, bool, long, std::string_view, gpointer);
+void favicon_web_done_cb(long, std::string_view, bool, bool, gpointer);
 
 bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
 {
@@ -103,11 +103,10 @@ bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
 }
 
 void favicon_web_done_cb(
-    tr_session* /*session*/,
+    long /*response_code*/,
+    std::string_view data,
     bool /*did_connect*/,
     bool /*did_timeout*/,
-    long /*code*/,
-    std::string_view data,
     gpointer vfav)
 {
     auto* fav = static_cast<favicon_data*>(vfav);

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -73,7 +73,7 @@ Glib::RefPtr<Gdk::Pixbuf> favicon_load_from_cache(std::string const& host)
     }
 }
 
-void favicon_web_done_cb(tr_web::Response&& response);
+void favicon_web_done_cb(tr_web::FetchResponse&& response);
 
 bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
 {
@@ -102,7 +102,7 @@ bool favicon_web_done_idle_cb(std::unique_ptr<favicon_data> fav)
     return false;
 }
 
-void favicon_web_done_cb(tr_web::Response&& response)
+void favicon_web_done_cb(tr_web::FetchResponse&& response)
 {
     auto* const fav = static_cast<favicon_data*>(response.user_data);
     fav->contents = response.body;

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -346,11 +346,11 @@ void tr_tracker_http_announce(
     auto const url = announce_url_new(session, request);
     dbgmsg(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
-    auto options = tr_web_options{ url, on_announce_done, d };
+    auto options = tr_web::RunOptions{ url, on_announce_done, d };
     options.timeout_secs = 90L;
     options.sndbuf = 1024;
     options.rcvbuf = 3072;
-    tr_webRun(session, std::move(options));
+    session->web->run(std::move(options));
 }
 
 /****
@@ -546,9 +546,9 @@ void tr_tracker_http_scrape(
     auto const url = scrape_url_new(request);
     dbgmsg(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
-    auto options = tr_web_options{ url, on_scrape_done, d };
+    auto options = tr_web::RunOptions{ url, on_scrape_done, d };
     options.timeout_secs = 30L;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
-    tr_webRun(session, std::move(options));
+    session->web->run(std::move(options));
 }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -281,13 +281,7 @@ struct announce_data
     char log_name[128];
 };
 
-static void on_announce_done(
-    tr_session* /*session*/,
-    bool did_connect,
-    bool did_timeout,
-    long response_code,
-    std::string_view msg,
-    void* vdata)
+static void on_announce_done(long response_code, std::string_view msg, bool did_connect, bool did_timeout, void* vdata)
 {
     auto* data = static_cast<struct announce_data*>(vdata);
 
@@ -450,13 +444,7 @@ struct scrape_data
     char log_name[128];
 };
 
-static void on_scrape_done(
-    tr_session* /*session*/,
-    bool did_connect,
-    bool did_timeout,
-    long response_code,
-    std::string_view msg,
-    void* vdata)
+static void on_scrape_done(long response_code, std::string_view msg, bool did_connect, bool did_timeout, void* vdata)
 {
     auto* data = static_cast<struct scrape_data*>(vdata);
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -345,7 +345,12 @@ void tr_tracker_http_announce(
 
     auto const url = announce_url_new(session, request);
     dbgmsg(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
-    tr_webRun(session, { url, on_announce_done, d });
+
+    auto options = tr_web_options{ url, on_announce_done, d };
+    options.timeout_secs = 90L;
+    options.sndbuf = 1024;
+    options.rcvbuf = 3072;
+    tr_webRun(session, std::move(options));
 }
 
 /****
@@ -540,5 +545,10 @@ void tr_tracker_http_scrape(
 
     auto const url = scrape_url_new(request);
     dbgmsg(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
-    tr_webRun(session, { url, on_scrape_done, d });
+
+    auto options = tr_web_options{ url, on_scrape_done, d };
+    options.timeout_secs = 30L;
+    options.sndbuf = 4096;
+    options.rcvbuf = 4096;
+    tr_webRun(session, std::move(options));
 }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -281,7 +281,7 @@ struct announce_data
     char log_name[128];
 };
 
-static void onAnnounceDone(tr_web::Response&& web_response)
+static void onAnnounceDone(tr_web::FetchResponse&& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, vdata] = web_response;
     auto* data = static_cast<struct announce_data*>(vdata);
@@ -334,11 +334,11 @@ void tr_tracker_http_announce(
     auto const url = announce_url_new(session, request);
     dbgmsg(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
-    auto options = tr_web::RunOptions{ url, onAnnounceDone, d };
+    auto options = tr_web::FetchOptions{ url, onAnnounceDone, d };
     options.timeout_secs = 90L;
     options.sndbuf = 1024;
     options.rcvbuf = 3072;
-    session->web->run(std::move(options));
+    session->web->fetch(std::move(options));
 }
 
 /****
@@ -445,7 +445,7 @@ struct scrape_data
     char log_name[128];
 };
 
-static void onScrapeDone(tr_web::Response&& web_response)
+static void onScrapeDone(tr_web::FetchResponse&& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<struct scrape_data*>(vdata);
@@ -519,9 +519,9 @@ void tr_tracker_http_scrape(
     auto const url = scrape_url_new(request);
     dbgmsg(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
-    auto options = tr_web::RunOptions{ url, onScrapeDone, d };
+    auto options = tr_web::FetchOptions{ url, onScrapeDone, d };
     options.timeout_secs = 30L;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
-    session->web->run(std::move(options));
+    session->web->fetch(std::move(options));
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1378,7 +1378,7 @@ static char const* portTest(
 {
     auto const port = tr_sessionGetPeerPort(session);
     auto const url = tr_strvJoin("https://portcheck.transmissionbt.com/"sv, std::to_string(port));
-    tr_webRun(session, { url, portTested, idle_data });
+    session->web->run({ url, portTested, idle_data });
     return nullptr;
 }
 
@@ -1466,7 +1466,7 @@ static char const* blocklistUpdate(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    tr_webRun(session, { session->blocklistUrl(), gotNewBlocklist, idle_data });
+    session->web->run({ session->blocklistUrl(), gotNewBlocklist, idle_data });
     return nullptr;
 }
 
@@ -1686,9 +1686,9 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         d->data = idle_data;
         d->ctor = ctor;
 
-        auto options = tr_web_options{ filename, gotMetadataFromURL, d };
+        auto options = tr_web::RunOptions{ filename, gotMetadataFromURL, d };
         options.cookies = cookies;
-        tr_webRun(session, std::move(options));
+        session->web->run(std::move(options));
     }
     else
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1341,11 +1341,10 @@ static char const* torrentRenamePath(
 ***/
 
 static void portTested(
-    tr_session* /*session*/,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
     long response_code,
     std::string_view response,
+    bool /*did_connect*/,
+    bool /*did_timeout*/,
     void* user_data)
 {
     char result[1024];
@@ -1387,15 +1386,15 @@ static char const* portTest(
 ***/
 
 static void gotNewBlocklist(
-    tr_session* session,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
     long response_code,
     std::string_view response,
+    bool /*did_connect*/,
+    bool /*did_timeout*/,
     void* user_data)
 {
     char result[1024];
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
+    auto* const session = data->session;
 
     *result = '\0';
 
@@ -1522,11 +1521,10 @@ struct add_torrent_idle_data
 };
 
 static void gotMetadataFromURL(
-    tr_session* /*session*/,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
     long response_code,
     std::string_view response,
+    bool /*did_connect*/,
+    bool /*did_timeout*/,
     void* user_data)
 {
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -163,6 +163,8 @@ void tr_session::WebController::notifyBandwidthConsumed(int torrent_id, size_t b
 
 void tr_session::WebController::run(tr_web::done_func func, tr_web::Response&& response) const
 {
+    // marshall the `func` call into the libtransmission thread
+
     using wrapper_t = std::pair<tr_web::done_func, tr_web::Response>;
 
     auto constexpr callback = [](void* vwrapped)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -161,11 +161,11 @@ void tr_session::WebController::notifyBandwidthConsumed(int torrent_id, size_t b
     }
 }
 
-void tr_session::WebController::run(tr_web::done_func func, tr_web::Response&& response) const
+void tr_session::WebController::run(tr_web::FetchDoneFunc func, tr_web::FetchResponse&& response) const
 {
     // marshall the `func` call into the libtransmission thread
 
-    using wrapper_t = std::pair<tr_web::done_func, tr_web::Response>;
+    using wrapper_t = std::pair<tr_web::FetchDoneFunc, tr_web::FetchResponse>;
 
     auto constexpr callback = [](void* vwrapped)
     {
@@ -177,9 +177,9 @@ void tr_session::WebController::run(tr_web::done_func func, tr_web::Response&& r
     tr_runInEventThread(session_, callback, new wrapper_t{ func, std::move(response) });
 }
 
-void tr_sessionFetch(tr_session* session, tr_web::RunOptions&& options)
+void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 {
-    session->web->run(std::move(options));
+    session->web->fetch(std::move(options));
 }
 
 /***

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -29,6 +29,7 @@
 
 #include "net.h" // tr_socket_t
 #include "quark.h"
+#include "web.h"
 
 enum tr_auto_switch_state_t
 {
@@ -335,6 +336,23 @@ public:
 
     struct tr_cache* cache;
 
+    class WebController final : public tr_web::Controller
+    {
+    public:
+        explicit WebController(tr_session* session)
+            : session_{ session }
+        {
+        }
+        ~WebController() override = default;
+        [[nodiscard]] std::optional<std::string> cookieFile() const override;
+        [[nodiscard]] std::optional<std::string> publicAddress() const override;
+        [[nodiscard]] std::optional<long> desiredSpeedBytesPerSecond(int speed_limit_tag) const override;
+
+    private:
+        tr_session const* const session_;
+    };
+
+    WebController web_controller{ this };
     std::unique_ptr<tr_web> web;
 
     struct tr_session_id* session_id;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -346,10 +346,12 @@ public:
         ~WebController() override = default;
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddress() const override;
+        [[nodiscard]] std::optional<std::string> userAgent() const override;
         [[nodiscard]] std::optional<long> desiredSpeedBytesPerSecond(int speed_limit_tag) const override;
+        void run(tr_web::done_func func, tr_web::Response&& response) const override;
 
     private:
-        tr_session const* const session_;
+        tr_session* const session_;
     };
 
     WebController web_controller{ this };

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -347,7 +347,8 @@ public:
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddress() const override;
         [[nodiscard]] std::optional<std::string> userAgent() const override;
-        [[nodiscard]] std::optional<long> desiredSpeedBytesPerSecond(int speed_limit_tag) const override;
+        [[nodiscard]] unsigned int clamp(int bandwidth_tag, unsigned int byte_count) const override;
+        void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
         void run(tr_web::done_func func, tr_web::Response&& response) const override;
 
     private:

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -344,12 +344,14 @@ public:
         {
         }
         ~WebController() override = default;
+
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddress() const override;
         [[nodiscard]] std::optional<std::string> userAgent() const override;
         [[nodiscard]] unsigned int clamp(int bandwidth_tag, unsigned int byte_count) const override;
         void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
-        void run(tr_web::done_func func, tr_web::Response&& response) const override;
+        // runs the tr_web::fetch response callback in the libtransmission thread
+        void run(tr_web::FetchDoneFunc func, tr_web::FetchResponse&& response) const override;
 
     private:
         tr_session* const session_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -44,6 +44,7 @@ struct evdns_base;
 
 class tr_bitfield;
 class tr_rpc_server;
+class tr_web;
 struct Bandwidth;
 struct tr_address;
 struct tr_announcer;
@@ -334,7 +335,7 @@ public:
 
     struct tr_cache* cache;
 
-    struct tr_web* web;
+    std::unique_ptr<tr_web> web;
 
     struct tr_session_id* session_id;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -131,7 +131,7 @@ public:
 
 #ifdef USE_LIBCURL_SOCKOPT
 
-static int sockoptfunction(void* vtask, curl_socket_t fd, curlsocktype /*purpose*/)
+static int onSocketCreated(void* vtask, curl_socket_t fd, curlsocktype /*purpose*/)
 {
     auto const* const task = static_cast<tr_web_task const*>(vtask);
 
@@ -302,7 +302,7 @@ private:
 
     RunMode run_mode = RunMode::Run;
 
-    static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
+    static size_t onDataReceived(void* ptr, size_t size, size_t nmemb, void* vtask)
     {
         size_t const byteCount = size * nmemb;
         auto* task = static_cast<tr_web_task*>(vtask);
@@ -324,7 +324,7 @@ private:
         curl_easy_setopt(e, CURLOPT_PRIVATE, task);
 
 #ifdef USE_LIBCURL_SOCKOPT
-        curl_easy_setopt(e, CURLOPT_SOCKOPTFUNCTION, sockoptfunction);
+        curl_easy_setopt(e, CURLOPT_SOCKOPTFUNCTION, onSocketCreated);
         curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, task);
 #endif
 
@@ -357,7 +357,7 @@ private:
         curl_easy_setopt(e, CURLOPT_USERAGENT, TR_NAME "/" SHORT_VERSION_STRING);
         curl_easy_setopt(e, CURLOPT_VERBOSE, (long)(impl->curl_verbose ? 1 : 0));
         curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
-        curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);
+        curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, onDataReceived);
 
         if (auto const& tag = task->speedLimitTag(); tag)
         {

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -371,9 +371,9 @@ private:
             (void)curl_easy_setopt(e, CURLOPT_INTERFACE, addrstr->c_str());
         }
 
-        if (auto const& cookies = task->cookies(); !std::empty(cookies))
+        if (auto const& cookies = task->cookies(); cookies)
         {
-            (void)curl_easy_setopt(e, CURLOPT_COOKIE, cookies.c_str());
+            (void)curl_easy_setopt(e, CURLOPT_COOKIE, cookies->c_str());
         }
 
         if (auto const& file = impl->cookie_file; !std::empty(file))
@@ -381,9 +381,9 @@ private:
             (void)curl_easy_setopt(e, CURLOPT_COOKIEFILE, file.c_str());
         }
 
-        if (auto const& range = task->range(); !std::empty(range))
+        if (auto const& range = task->range(); range)
         {
-            curl_easy_setopt(e, CURLOPT_RANGE, range.c_str());
+            curl_easy_setopt(e, CURLOPT_RANGE, range->c_str());
             /* don't bother asking the server to compress webseed fragments */
             curl_easy_setopt(e, CURLOPT_ENCODING, "identity");
         }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -113,7 +113,7 @@ public:
 
         auto const sv = std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(response(), -1)),
                                           evbuffer_get_length(response()) };
-        options.done_func(session, did_connect, did_timeout, response_code, sv, options.done_func_user_data);
+        options.done_func(response_code, sv, did_connect, did_timeout, options.done_func_user_data);
     }
 
     tr_session* const session;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -231,7 +231,7 @@ private:
             }
 
             response.body.assign(reinterpret_cast<char const*>(evbuffer_pullup(body(), -1)), evbuffer_get_length(body()));
-            options.done_func(std::move(this->response));
+            impl.controller.run(options.done_func, std::move(this->response));
         }
 
         tr_web::Impl& impl;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <mutex>
 #include <set>
 #include <string>
 #include <string_view>
@@ -39,8 +40,6 @@ using namespace std::literals;
 #define USE_LIBCURL_SOCKOPT
 #endif
 
-static auto constexpr ThreadfuncMaxSleepMsec = int{ 200 };
-
 #define dbgmsg(...) tr_logAddDeepNamed("web", __VA_ARGS__)
 
 /***
@@ -52,10 +51,10 @@ struct tr_web_task
 private:
     std::shared_ptr<evbuffer> const privbuf{ evbuffer_new(), evbuffer_free };
     std::shared_ptr<CURL> const easy_handle{ curl_easy_init(), curl_easy_cleanup };
-    tr_web_options const options;
+    tr_web::RunOptions const options;
 
 public:
-    tr_web_task(tr_session* session_in, tr_web_options&& options_in)
+    tr_web_task(tr_session* session_in, tr_web::RunOptions&& options_in)
         : options{ std::move(options_in) }
         , session{ session_in }
     {
@@ -130,48 +129,6 @@ public:
 /***
 ****
 ***/
-
-struct tr_web
-{
-    bool const curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
-    bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
-    bool const curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
-
-    std::string curl_ca_bundle;
-    int close_mode = ~0;
-
-    std::recursive_mutex web_tasks_mutex;
-    tr_web_task* tasks = nullptr;
-
-    std::string cookie_filename;
-    std::set<CURL*> paused_easy_handles;
-};
-
-/***
-****
-***/
-
-static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
-{
-    size_t const byteCount = size * nmemb;
-    auto* task = static_cast<tr_web_task*>(vtask);
-
-    /* webseed downloads should be speed limited */
-    if (auto const& torrent_id = task->torrent_id(); torrent_id)
-    {
-        tr_torrent const* const tor = tr_torrentFindFromId(task->session, *torrent_id);
-
-        if (tor != nullptr && tor->bandwidth->clamp(TR_DOWN, nmemb) == 0)
-        {
-            task->session->web->paused_easy_handles.insert(task->easy());
-            return CURL_WRITEFUNC_PAUSE;
-        }
-    }
-
-    evbuffer_add(task->response(), ptr, byteCount);
-    dbgmsg("wrote %zu bytes to task %p's buffer", byteCount, (void*)task);
-    return byteCount;
-}
 
 #ifdef USE_LIBCURL_SOCKOPT
 
@@ -254,294 +211,382 @@ static CURLcode ssl_context_func(CURL* /*curl*/, void* ssl_ctx, void* /*user_dat
     return CURLE_OK;
 }
 
-static void initEasy(tr_session* s, tr_web* web, tr_web_task* task)
+/***
+****
+***/
+
+class tr_web::Impl
 {
-    auto* const e = task->easy();
-
-    curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
-    curl_easy_setopt(e, CURLOPT_ENCODING, "");
-    curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
-    curl_easy_setopt(e, CURLOPT_MAXREDIRS, -1L);
-    curl_easy_setopt(e, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(e, CURLOPT_PRIVATE, task);
-
-#ifdef USE_LIBCURL_SOCKOPT
-    curl_easy_setopt(e, CURLOPT_SOCKOPTFUNCTION, sockoptfunction);
-    curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, task);
-#endif
-
-    if (!web->curl_ssl_verify)
+public:
+    Impl(tr_session* session_in)
+        : session{ session_in }
     {
-        curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
-        curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
-    }
-    else if (!std::empty(web->curl_ca_bundle))
-    {
-        curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle.c_str());
-    }
-    else
-    {
-        curl_easy_setopt(e, CURLOPT_SSL_CTX_FUNCTION, ssl_context_func);
-    }
+        std::call_once(curl_init_flag, curlInit);
 
-    if (!web->curl_proxy_ssl_verify)
-    {
-        curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
-        curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
-    }
-    else if (!std::empty(web->curl_ca_bundle))
-    {
-        curl_easy_setopt(e, CURLOPT_PROXY_CAINFO, web->curl_ca_bundle.c_str());
-    }
-
-    curl_easy_setopt(e, CURLOPT_TIMEOUT, task->timeoutSecs());
-    curl_easy_setopt(e, CURLOPT_URL, task->url().c_str());
-    curl_easy_setopt(e, CURLOPT_USERAGENT, TR_NAME "/" SHORT_VERSION_STRING);
-    curl_easy_setopt(e, CURLOPT_VERBOSE, (long)(web->curl_verbose ? 1 : 0));
-    curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
-    curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);
-
-    auto is_default_value = bool{};
-    tr_address const* addr = tr_sessionGetPublicAddress(s, TR_AF_INET, &is_default_value);
-    if (addr != nullptr && !is_default_value)
-    {
-        (void)curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
-    }
-
-    addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, &is_default_value);
-    if (addr != nullptr && !is_default_value)
-    {
-        (void)curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
-    }
-
-    if (auto const& cookies = task->cookies(); !std::empty(cookies))
-    {
-        (void)curl_easy_setopt(e, CURLOPT_COOKIE, cookies.c_str());
-    }
-
-    if (auto const& filename = web->cookie_filename; !std::empty(filename))
-    {
-        (void)curl_easy_setopt(e, CURLOPT_COOKIEFILE, filename.c_str());
-    }
-
-    if (auto const& range = task->range(); !std::empty(range))
-    {
-        curl_easy_setopt(e, CURLOPT_RANGE, range.c_str());
-        /* don't bother asking the server to compress webseed fragments */
-        curl_easy_setopt(e, CURLOPT_ENCODING, "identity");
-    }
-}
-
-static void task_finish_func(void* vtask)
-{
-    auto* task = static_cast<tr_web_task*>(vtask);
-    task->done();
-    delete task;
-}
-
-/****
-*****
-****/
-
-static void tr_webThreadFunc(void* vsession);
-
-void tr_webRun(tr_session* session, tr_web_options&& options)
-{
-    if (session->isClosing())
-    {
-        return;
-    }
-
-    if (session->web == nullptr)
-    {
-        std::thread(tr_webThreadFunc, session).detach();
-        while (session->web == nullptr)
+        if (auto* bundle = tr_env_get_string("CURL_CA_BUNDLE", nullptr); bundle != nullptr)
         {
-            tr_wait_msec(20);
-        }
-    }
-
-    auto const lock = std::unique_lock(session->web->web_tasks_mutex);
-    auto* const task = new tr_web_task{ session, std::move(options) };
-    task->next = session->web->tasks;
-    session->web->tasks = task;
-}
-
-static void tr_webThreadFunc(void* vsession)
-{
-    auto* session = static_cast<tr_session*>(vsession);
-
-    /* try to enable ssl for https support; but if that fails,
-     * try a plain vanilla init */
-    if (curl_global_init(CURL_GLOBAL_SSL) != CURLE_OK)
-    {
-        curl_global_init(0);
-    }
-
-    auto* const web = new tr_web{};
-
-    if (auto* ca_bundle = tr_env_get_string("CURL_CA_BUNDLE", nullptr); ca_bundle != nullptr)
-    {
-        web->curl_ca_bundle = ca_bundle;
-        tr_free(ca_bundle);
-    }
-
-    if (web->curl_ssl_verify)
-    {
-        tr_logAddNamedInfo(
-            "web",
-            "will verify tracker certs using envvar CURL_CA_BUNDLE: %s",
-            std::empty(web->curl_ca_bundle) ? "none" : web->curl_ca_bundle.c_str());
-        tr_logAddNamedInfo("web", "NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
-        tr_logAddNamedInfo("web", "NB: invalid certs will show up as 'Could not connect to tracker' like many other errors");
-    }
-
-    auto const str = tr_strvPath(session->config_dir, "cookies.txt");
-    if (tr_sys_path_exists(str.c_str(), nullptr))
-    {
-        web->cookie_filename = str;
-    }
-
-    auto const multi = std::shared_ptr<CURLM>(curl_multi_init(), curl_multi_cleanup);
-    session->web = web;
-
-    auto repeats = uint32_t{};
-    for (;;)
-    {
-        if (web->close_mode == TR_WEB_CLOSE_NOW)
-        {
-            break;
+            curl_ca_bundle = bundle;
+            tr_free(bundle);
         }
 
-        if (web->close_mode == TR_WEB_CLOSE_WHEN_IDLE && web->tasks == nullptr)
+        if (curl_ssl_verify)
         {
-            break;
+            auto const* bundle = std::empty(curl_ca_bundle) ? "none" : curl_ca_bundle.c_str();
+            tr_logAddNamedInfo("web", "will verify tracker certs using envvar CURL_CA_BUNDLE: %s", bundle);
+            tr_logAddNamedInfo("web", "NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
+            tr_logAddNamedInfo("web", "NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors");
         }
 
-        /* add tasks from the queue */
+        auto const str = tr_strvPath(session->config_dir, "cookies.txt");
+        if (tr_sys_path_exists(str.c_str(), nullptr))
         {
-            auto const lock = std::unique_lock(web->web_tasks_mutex);
+            cookie_filename = str;
+        }
 
-            while (web->tasks != nullptr)
+        curl_thread = std::make_unique<std::thread>(tr_webThreadFunc, this);
+    }
+
+    ~Impl()
+    {
+        run_mode = RunMode::CloseNow;
+        curl_thread->join();
+    }
+
+    void closeSoon()
+    {
+        run_mode = RunMode::CloseSoon;
+    }
+
+    [[nodiscard]] bool isClosed() const
+    {
+        return is_closed_;
+    }
+
+    void run(RunOptions&& options)
+    {
+        if (run_mode != RunMode::Run)
+        {
+            return;
+        }
+
+        auto const lock = std::unique_lock(web_tasks_mutex);
+        auto* const task = new tr_web_task{ session, std::move(options) };
+        task->next = tasks;
+        tasks = task;
+    }
+
+private:
+    static auto constexpr ThreadfuncMaxSleepMsec = long{ 200 };
+
+    bool const curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
+    bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
+    bool const curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
+
+    tr_session* const session;
+
+    std::string curl_ca_bundle;
+
+    std::recursive_mutex web_tasks_mutex;
+    tr_web_task* tasks = nullptr;
+
+    std::string cookie_filename;
+    std::set<CURL*> paused_easy_handles;
+
+    std::unique_ptr<std::thread> curl_thread;
+
+    enum class RunMode
+    {
+        Run,
+        CloseSoon, // no new tasks; exit when running tasks finish
+        CloseNow // exit now even if tasks are running
+    };
+
+    RunMode run_mode = RunMode::Run;
+
+    static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
+    {
+        size_t const byteCount = size * nmemb;
+        auto* task = static_cast<tr_web_task*>(vtask);
+
+        /* webseed downloads should be speed limited */
+        if (auto const& torrent_id = task->torrent_id(); torrent_id)
+        {
+            tr_torrent const* const tor = tr_torrentFindFromId(task->session, *torrent_id);
+
+            if (tor != nullptr && tor->bandwidth->clamp(TR_DOWN, nmemb) == 0)
             {
-                /* pop the task */
-                auto* const task = web->tasks;
-                web->tasks = task->next;
-                task->next = nullptr;
-
-                dbgmsg("adding task to curl: [%s]", task->url().c_str());
-                initEasy(session, web, task);
-                curl_multi_add_handle(multi.get(), task->easy());
+                task->session->web->impl_->paused_easy_handles.insert(task->easy());
+                return CURL_WRITEFUNC_PAUSE;
             }
         }
 
-        /* resume any paused curl handles.
-           swap paused_easy_handles to prevent oscillation
-           between writeFunc this while loop */
-        auto paused = decltype(web->paused_easy_handles){};
-        std::swap(paused, web->paused_easy_handles);
-        std::for_each(std::begin(paused), std::end(paused), [](auto* curl) { curl_easy_pause(curl, CURLPAUSE_CONT); });
+        evbuffer_add(task->response(), ptr, byteCount);
+        dbgmsg("wrote %zu bytes to task %p's buffer", byteCount, (void*)task);
+        return byteCount;
+    }
 
-        /* maybe wait a little while before calling curl_multi_perform() */
+    static void initEasy(tr_session* s, tr_web::Impl* impl, tr_web_task* task)
+    {
+        auto* const e = task->easy();
+
+        curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
+        curl_easy_setopt(e, CURLOPT_ENCODING, "");
+        curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(e, CURLOPT_MAXREDIRS, -1L);
+        curl_easy_setopt(e, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(e, CURLOPT_PRIVATE, task);
+
+#ifdef USE_LIBCURL_SOCKOPT
+        curl_easy_setopt(e, CURLOPT_SOCKOPTFUNCTION, sockoptfunction);
+        curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, task);
+#endif
+
+        if (!impl->curl_ssl_verify)
+        {
+            curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
+            curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
+        }
+        else if (!std::empty(impl->curl_ca_bundle))
+        {
+            curl_easy_setopt(e, CURLOPT_CAINFO, impl->curl_ca_bundle.c_str());
+        }
+        else
+        {
+            curl_easy_setopt(e, CURLOPT_SSL_CTX_FUNCTION, ssl_context_func);
+        }
+
+        if (!impl->curl_proxy_ssl_verify)
+        {
+            curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
+            curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
+        }
+        else if (!std::empty(impl->curl_ca_bundle))
+        {
+            curl_easy_setopt(e, CURLOPT_PROXY_CAINFO, impl->curl_ca_bundle.c_str());
+        }
+
+        curl_easy_setopt(e, CURLOPT_TIMEOUT, task->timeoutSecs());
+        curl_easy_setopt(e, CURLOPT_URL, task->url().c_str());
+        curl_easy_setopt(e, CURLOPT_USERAGENT, TR_NAME "/" SHORT_VERSION_STRING);
+        curl_easy_setopt(e, CURLOPT_VERBOSE, (long)(impl->curl_verbose ? 1 : 0));
+        curl_easy_setopt(e, CURLOPT_WRITEDATA, task);
+        curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, writeFunc);
+
+        auto is_default_value = bool{};
+        tr_address const* addr = tr_sessionGetPublicAddress(s, TR_AF_INET, &is_default_value);
+        if (addr != nullptr && !is_default_value)
+        {
+            (void)curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
+        }
+
+        addr = tr_sessionGetPublicAddress(s, TR_AF_INET6, &is_default_value);
+        if (addr != nullptr && !is_default_value)
+        {
+            (void)curl_easy_setopt(e, CURLOPT_INTERFACE, tr_address_to_string(addr));
+        }
+
+        if (auto const& cookies = task->cookies(); !std::empty(cookies))
+        {
+            (void)curl_easy_setopt(e, CURLOPT_COOKIE, cookies.c_str());
+        }
+
+        if (auto const& filename = impl->cookie_filename; !std::empty(filename))
+        {
+            (void)curl_easy_setopt(e, CURLOPT_COOKIEFILE, filename.c_str());
+        }
+
+        if (auto const& range = task->range(); !std::empty(range))
+        {
+            curl_easy_setopt(e, CURLOPT_RANGE, range.c_str());
+            /* don't bother asking the server to compress webseed fragments */
+            curl_easy_setopt(e, CURLOPT_ENCODING, "identity");
+        }
+    }
+
+    static void task_finish_func(void* vtask)
+    {
+        auto* task = static_cast<tr_web_task*>(vtask);
+        task->done();
+        delete task;
+    }
+
+    long getWaitMsec(CURLM* const multi) const
+    {
+        // If the msec returned by curl_multi_timeout is 0, proceed immediately
+        // without waiting for anything. If it returns -1, there's no timeout set.
         auto msec = long{};
-        curl_multi_timeout(multi.get(), &msec);
+        curl_multi_timeout(multi, &msec);
         if (msec < 0)
         {
             msec = ThreadfuncMaxSleepMsec;
         }
 
-        if (session->isClosed)
+        if (run_mode != RunMode::Run)
         {
-            msec = 100; /* on shutdown, call perform() more frequently */
+            msec = std::min(msec, 50L); // on shutdown, shorten the wait time
         }
 
-        if (msec > 0)
+        return std::clamp(msec, 0L, ThreadfuncMaxSleepMsec);
+    }
+
+    static void tr_webThreadFunc(void* vimpl)
+    {
+        auto* impl = static_cast<tr_web::Impl*>(vimpl);
+
+        auto const multi = std::shared_ptr<CURLM>(curl_multi_init(), curl_multi_cleanup);
+
+        auto repeats = uint32_t{};
+        for (;;)
         {
-            if (msec > ThreadfuncMaxSleepMsec)
+            if (impl->run_mode == RunMode::CloseNow)
             {
-                msec = ThreadfuncMaxSleepMsec;
+                break;
             }
 
-            auto numfds = int{};
-            curl_multi_wait(multi.get(), nullptr, 0, msec, &numfds);
-            if (numfds == 0)
+            if (impl->run_mode == RunMode::CloseSoon && impl->tasks == nullptr)
             {
-                repeats++;
-                if (repeats > 1)
+                break;
+            }
+
+            /* add tasks from the queue */
+            {
+                auto const lock = std::unique_lock(impl->web_tasks_mutex);
+
+                while (impl->tasks != nullptr)
                 {
-                    /* curl_multi_wait() returns immediately if there are
-                     * no fds to wait for, so we need an explicit wait here
-                     * to emulate select() behavior */
-                    tr_wait_msec(std::min(msec, ThreadfuncMaxSleepMsec / 2L));
+                    /* pop the task */
+                    auto* const task = impl->tasks;
+                    impl->tasks = task->next;
+                    task->next = nullptr;
+
+                    dbgmsg("adding task to curl: [%s]", task->url().c_str());
+                    initEasy(impl->session, impl, task);
+                    curl_multi_add_handle(multi.get(), task->easy());
                 }
             }
-            else
+
+            /* resume any paused curl handles.
+               swap paused_easy_handles to prevent oscillation
+               between writeFunc this while loop */
+            auto paused = decltype(impl->paused_easy_handles){};
+            std::swap(paused, impl->paused_easy_handles);
+            std::for_each(std::begin(paused), std::end(paused), [](auto* curl) { curl_easy_pause(curl, CURLPAUSE_CONT); });
+
+            // Maybe wait a moment before calling multi_perform
+            if (auto const msec = impl->getWaitMsec(multi.get()); msec > 0)
             {
-                repeats = 0;
+                auto numfds = int{};
+                curl_multi_wait(multi.get(), nullptr, 0, msec, &numfds);
+                if (numfds == 0)
+                {
+                    ++repeats;
+                    if (repeats > 1)
+                    {
+                        /* curl_multi_wait() returns immediately if there are
+                         * no fds to wait for, so we need an explicit wait here
+                         * to emulate select() behavior */
+                        tr_wait_msec(std::min(msec, ThreadfuncMaxSleepMsec / 2L));
+                    }
+                }
+                else
+                {
+                    repeats = 0;
+                }
+            }
+
+            /* call curl_multi_perform() */
+            auto mcode = CURLMcode{};
+            auto unused = int{};
+            do
+            {
+                mcode = curl_multi_perform(multi.get(), &unused);
+            } while (mcode == CURLM_CALL_MULTI_PERFORM && impl->run_mode != RunMode::CloseNow);
+
+            /* pump completed tasks from the multi */
+            CURLMsg* msg = nullptr;
+            while ((msg = curl_multi_info_read(multi.get(), &unused)) != nullptr)
+            {
+                if (msg->msg == CURLMSG_DONE && msg->easy_handle != nullptr)
+                {
+                    auto* const e = msg->easy_handle;
+
+                    tr_web_task* task = nullptr;
+                    curl_easy_getinfo(e, CURLINFO_PRIVATE, (void*)&task);
+                    TR_ASSERT(e == task->curl_easy);
+
+                    auto req_bytes_sent = long{};
+                    auto total_time = double{};
+                    curl_easy_getinfo(e, CURLINFO_RESPONSE_CODE, &task->response_code);
+                    curl_easy_getinfo(e, CURLINFO_REQUEST_SIZE, &req_bytes_sent);
+                    curl_easy_getinfo(e, CURLINFO_TOTAL_TIME, &total_time);
+                    task->did_connect = task->response_code > 0 || req_bytes_sent > 0;
+                    task->did_timeout = task->response_code == 0 && total_time >= task->timeoutSecs();
+                    curl_multi_remove_handle(multi.get(), e);
+                    impl->paused_easy_handles.erase(e);
+                    tr_runInEventThread(task->session, task_finish_func, task);
+                }
             }
         }
 
-        /* call curl_multi_perform() */
-        auto mcode = CURLMcode{};
-        auto unused = int{};
-        do
+        /* Discard any remaining tasks.
+         * This is rare, but can happen on shutdown with unresponsive trackers. */
+        while (impl->tasks != nullptr)
         {
-            mcode = curl_multi_perform(multi.get(), &unused);
-        } while (mcode == CURLM_CALL_MULTI_PERFORM);
-
-        /* pump completed tasks from the multi */
-        CURLMsg* msg = nullptr;
-        while ((msg = curl_multi_info_read(multi.get(), &unused)) != nullptr)
-        {
-            if (msg->msg == CURLMSG_DONE && msg->easy_handle != nullptr)
-            {
-                auto* const e = msg->easy_handle;
-
-                tr_web_task* task = nullptr;
-                curl_easy_getinfo(e, CURLINFO_PRIVATE, (void*)&task);
-                TR_ASSERT(e == task->curl_easy);
-
-                auto req_bytes_sent = long{};
-                auto total_time = double{};
-                curl_easy_getinfo(e, CURLINFO_RESPONSE_CODE, &task->response_code);
-                curl_easy_getinfo(e, CURLINFO_REQUEST_SIZE, &req_bytes_sent);
-                curl_easy_getinfo(e, CURLINFO_TOTAL_TIME, &total_time);
-                task->did_connect = task->response_code > 0 || req_bytes_sent > 0;
-                task->did_timeout = task->response_code == 0 && total_time >= task->timeoutSecs();
-                curl_multi_remove_handle(multi.get(), e);
-                web->paused_easy_handles.erase(e);
-                tr_runInEventThread(task->session, task_finish_func, task);
-            }
+            auto* const task = impl->tasks;
+            impl->tasks = task->next;
+            dbgmsg("Discarding task \"%s\"", task->url().c_str());
+            delete task;
         }
+
+        impl->is_closed_ = true;
     }
 
-    /* Discard any remaining tasks.
-     * This is rare, but can happen on shutdown with unresponsive trackers. */
-    while (web->tasks != nullptr)
+private:
+    static std::once_flag curl_init_flag;
+
+    bool is_closed_ = false;
+
+    static void curlInit()
     {
-        auto* const task = web->tasks;
-        web->tasks = task->next;
-        dbgmsg("Discarding task \"%s\"", task->url().c_str());
-        delete task;
+        // try to enable ssl for https support;
+        // but if that fails, try a plain vanilla init
+        if (curl_global_init(CURL_GLOBAL_SSL) != CURLE_OK)
+        {
+            curl_global_init(0);
+        }
     }
+};
 
-    /* cleanup */
-    delete web;
-    session->web = nullptr;
+std::once_flag tr_web::Impl::curl_init_flag;
+
+tr_web::tr_web(tr_session* session)
+    : impl_{ std::make_unique<Impl>(session) }
+{
 }
 
-void tr_webClose(tr_session* session, tr_web_close_mode close_mode)
-{
-    if (session->web != nullptr)
-    {
-        session->web->close_mode = close_mode;
+tr_web::~tr_web() = default;
 
-        if (close_mode == TR_WEB_CLOSE_NOW)
-        {
-            while (session->web != nullptr)
-            {
-                tr_wait_msec(100);
-            }
-        }
-    }
+std::unique_ptr<tr_web> tr_web::create(tr_session* session)
+{
+    return std::unique_ptr<tr_web>(new tr_web(session));
+}
+
+void tr_web::run(RunOptions&& options)
+{
+    impl_->run(std::move(options));
+}
+
+bool tr_web::isClosed() const
+{
+    return impl_->isClosed();
+}
+
+void tr_web::closeSoon()
+{
+    impl_->closeSoon();
+}
+
+void tr_sessionFetch(tr_session* session, tr_web::RunOptions&& options)
+{
+    session->web->run(std::move(options));
 }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -154,7 +154,7 @@ struct tr_web
 static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vtask)
 {
     size_t const byteCount = size * nmemb;
-    auto* task = static_cast<struct tr_web_task*>(vtask);
+    auto* task = static_cast<tr_web_task*>(vtask);
 
     /* webseed downloads should be speed limited */
     if (auto const& torrent_id = task->torrent_id(); torrent_id)
@@ -254,7 +254,7 @@ static CURLcode ssl_context_func(CURL* /*curl*/, void* ssl_ctx, void* /*user_dat
     return CURLE_OK;
 }
 
-static void initEasy(tr_session* s, struct tr_web* web, struct tr_web_task* task)
+static void initEasy(tr_session* s, tr_web* web, tr_web_task* task)
 {
     auto* const e = task->easy();
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -267,34 +267,28 @@ static CURL* createEasy(tr_session* s, struct tr_web* web, struct tr_web_task* t
     curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, task);
 #endif
 
-    if (web->curl_ssl_verify)
-    {
-        if (web->curl_ca_bundle != nullptr)
-        {
-            curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
-        }
-        else
-        {
-            curl_easy_setopt(e, CURLOPT_SSL_CTX_FUNCTION, ssl_context_func);
-        }
-    }
-    else
+    if (!web->curl_ssl_verify)
     {
         curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
         curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
     }
-
-    if (web->curl_proxy_ssl_verify)
+    else if (web->curl_ca_bundle != nullptr)
     {
-        if (web->curl_ca_bundle != nullptr)
-        {
-            curl_easy_setopt(e, CURLOPT_PROXY_CAINFO, web->curl_ca_bundle);
-        }
+        curl_easy_setopt(e, CURLOPT_CAINFO, web->curl_ca_bundle);
     }
     else
     {
+        curl_easy_setopt(e, CURLOPT_SSL_CTX_FUNCTION, ssl_context_func);
+    }
+
+    if (!web->curl_proxy_ssl_verify)
+    {
         curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
         curl_easy_setopt(e, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
+    }
+    else if (web->curl_ca_bundle != nullptr)
+    {
+        curl_easy_setopt(e, CURLOPT_PROXY_CAINFO, web->curl_ca_bundle);
     }
 
     curl_easy_setopt(e, CURLOPT_TIMEOUT, task->timeoutSecs());

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -127,11 +127,11 @@ static int onSocketCreated(void* vtask, curl_socket_t fd, curlsocktype /*purpose
 
     if (auto const& buf = task->sndbuf(); buf)
     {
-        (void)setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &*buf, sizeof(*buf));
+        (void)setsockopt(fd, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<char const*>(&*buf), sizeof(*buf));
     }
     if (auto const& buf = task->rcvbuf(); buf)
     {
-        (void)setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &*buf, sizeof(&*buf));
+        (void)setsockopt(fd, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<char const*>(&*buf), sizeof(*buf));
     }
 
     // return nonzero if this function encountered an error

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -16,7 +16,28 @@ struct tr_session;
 class tr_web
 {
 public:
-    static std::unique_ptr<tr_web> create(tr_session* session);
+    class Controller
+    {
+    public:
+        virtual ~Controller() = default;
+
+        [[nodiscard]] virtual std::optional<std::string> cookieFile() const
+        {
+            return std::nullopt;
+        }
+
+        [[nodiscard]] virtual std::optional<std::string> publicAddress() const
+        {
+            return std::nullopt;
+        }
+
+        [[nodiscard]] virtual std::optional<long> desiredSpeedBytesPerSecond([[maybe_unused]] int speed_limit_tag) const
+        {
+            return std::nullopt;
+        }
+    };
+
+    static std::unique_ptr<tr_web> create(Controller const& controller, tr_session* session);
     ~tr_web();
 
     using tr_web_done_func = void (*)(
@@ -42,7 +63,7 @@ public:
         std::string url;
         std::string range;
         std::string cookies;
-        std::optional<int> torrent_id;
+        std::optional<int> speed_limit_tag;
         std::optional<int> sndbuf;
         std::optional<int> rcvbuf;
         tr_web_done_func done_func = nullptr;
@@ -58,7 +79,7 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> const impl_;
-    explicit tr_web(tr_session* session);
+    explicit tr_web(Controller const& controller, tr_session* session);
 };
 
 void tr_sessionFetch(tr_session* session, tr_web::RunOptions&& options);

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -40,10 +40,10 @@ public:
     static std::unique_ptr<tr_web> create(Controller const& controller, tr_session* session);
     ~tr_web();
 
-    using tr_web_done_func = void (*)(
+    using done_func = void (*)(
         tr_session* session,
-        bool did_connect_flag,
-        bool timeout_flag,
+        bool did_connect,
+        bool did_timeout,
         long response_code,
         std::string_view response,
         void* user_data);
@@ -51,7 +51,7 @@ public:
     class RunOptions
     {
     public:
-        RunOptions(std::string_view url_in, tr_web_done_func done_func_in, void* done_func_user_data_in)
+        RunOptions(std::string_view url_in, done_func done_func_in, void* done_func_user_data_in)
             : url{ url_in }
             , done_func{ done_func_in }
             , done_func_user_data{ done_func_user_data_in }
@@ -66,7 +66,7 @@ public:
         std::optional<int> speed_limit_tag;
         std::optional<int> sndbuf;
         std::optional<int> rcvbuf;
-        tr_web_done_func done_func = nullptr;
+        done_func done_func = nullptr;
         void* done_func_user_data = nullptr;
         evbuffer* buffer = nullptr;
         int timeout_secs = DefaultTimeoutSecs;

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -87,8 +87,8 @@ public:
         static constexpr int DefaultTimeoutSecs = 120;
 
         std::string url;
-        std::string range;
-        std::string cookies;
+        std::optional<std::string> cookies;
+        std::optional<std::string> range;
         std::optional<int> speed_limit_tag;
         std::optional<int> sndbuf;
         std::optional<int> rcvbuf;

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -40,13 +40,8 @@ public:
     static std::unique_ptr<tr_web> create(Controller const& controller, tr_session* session);
     ~tr_web();
 
-    using done_func = void (*)(
-        tr_session* session,
-        bool did_connect,
-        bool did_timeout,
-        long response_code,
-        std::string_view response,
-        void* user_data);
+    using done_func =
+        void (*)(long response_code, std::string_view response, bool did_connect, bool did_timeout, void* user_data);
 
     class RunOptions
     {

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -40,13 +40,18 @@ public:
     {
     }
 
+    static constexpr int DefaultTimeoutSecs = 120;
+
     std::string url;
-    std::optional<int> torrent_id;
-    tr_web_done_func done_func = nullptr;
-    void* done_func_user_data = nullptr;
     std::string range;
     std::string cookies;
+    std::optional<int> torrent_id;
+    std::optional<int> sndbuf;
+    std::optional<int> rcvbuf;
+    tr_web_done_func done_func = nullptr;
+    void* done_func_user_data = nullptr;
     evbuffer* buffer = nullptr;
+    int timeout_secs = DefaultTimeoutSecs;
 };
 
 void tr_webRun(tr_session* session, tr_web_options&& options);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -405,7 +405,7 @@ void on_idle(tr_webseed* w)
     }
 }
 
-void onWebResponse(tr_web::Response&& web_response)
+void onWebResponse(tr_web::FetchResponse&& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, vtask] = web_response;
     bool const success = status == 206;
@@ -508,11 +508,11 @@ void task_request_next_chunk(tr_webseed_task* t)
     uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
 
     auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
-    auto options = tr_web::RunOptions{ url, onWebResponse, t };
+    auto options = tr_web::FetchOptions{ url, onWebResponse, t };
     options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_pass - 1));
     options.speed_limit_tag = tor->uniqueId;
     options.buffer = t->content();
-    tor->session->web->run(std::move(options));
+    tor->session->web->fetch(std::move(options));
 }
 
 } // namespace

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -513,7 +513,7 @@ void task_request_next_chunk(tr_webseed_task* t)
     auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
     auto options = tr_web::RunOptions{ url, web_response_func, t };
     options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_pass - 1));
-    options.torrent_id = tor->uniqueId;
+    options.speed_limit_tag = tor->uniqueId;
     options.buffer = t->content();
     tor->session->web->run(std::move(options));
 }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -406,16 +406,17 @@ void on_idle(tr_webseed* w)
 }
 
 void web_response_func(
-    tr_session* session,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
     long response_code,
     std::string_view /*response*/,
+    bool /*did_connect*/,
+    bool /*did_timeout*/,
     void* vtask)
 {
-    auto* const t = static_cast<tr_webseed_task*>(vtask);
     bool const success = response_code == 206;
-    tr_webseed* w = t->webseed;
+
+    auto* const t = static_cast<tr_webseed_task*>(vtask);
+    auto* const session = t->session;
+    auto* const w = t->webseed;
 
     w->connection_limiter.taskFinished(success);
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -405,14 +405,10 @@ void on_idle(tr_webseed* w)
     }
 }
 
-void web_response_func(
-    long response_code,
-    std::string_view /*response*/,
-    bool /*did_connect*/,
-    bool /*did_timeout*/,
-    void* vtask)
+void onWebResponse(tr_web::Response&& web_response)
 {
-    bool const success = response_code == 206;
+    auto const& [status, body, did_connect, did_timeout, vtask] = web_response;
+    bool const success = status == 206;
 
     auto* const t = static_cast<tr_webseed_task*>(vtask);
     auto* const session = t->session;
@@ -512,7 +508,7 @@ void task_request_next_chunk(tr_webseed_task* t)
     uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
 
     auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
-    auto options = tr_web::RunOptions{ url, web_response_func, t };
+    auto options = tr_web::RunOptions{ url, onWebResponse, t };
     options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_pass - 1));
     options.speed_limit_tag = tor->uniqueId;
     options.buffer = t->content();

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -511,11 +511,11 @@ void task_request_next_chunk(tr_webseed_task* t)
     uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
 
     auto const url = make_url(t->webseed, tor->fileSubpath(file_index));
-    auto options = tr_web_options{ url, web_response_func, t };
+    auto options = tr_web::RunOptions{ url, web_response_func, t };
     options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_pass - 1));
     options.torrent_id = tor->uniqueId;
     options.buffer = t->content();
-    tr_webRun(tor->session, std::move(options));
+    tor->session->web->run(std::move(options));
 }
 
 } // namespace


### PR DESCRIPTION
Part 5 in a series of web + webseed PRs. The previous PR in the series was #2628. The goals are discussed [here](https://github.com/transmission/transmission/pull/2613#discussion_bucket).

---

This PR refactors the `tr_web` module to be a C++ object instead of having global state. It also decouples `tr_web` from `tr_session` so that it can be used even by client code that doesn't have a `tr_session`. It also adds a `CURLSH` shared object and increases the DNS cache timeout to 1 hour. This PR fixes #1829 and fixes (partially) #1815 for http / https announces and scrapes, though more work on UDP announces/scrapes needs to be done for #1815.