### PR TITLE
refactor/remove-unused-utp-includes

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -26,8 +26,6 @@
 
 #include <event2/event.h>
 
-#include <libutp/utp.h>
-
 #include "transmission.h"
 
 #include "announcer.h"

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -14,7 +14,6 @@
 #include <event2/event.h>
 
 #include <cstdint>
-#include <libutp/utp.h>
 
 #include "transmission.h"
 #include "log.h"


### PR DESCRIPTION
very minor cleanup: remove a couple of `#include <libutp/utp.h>` calls that we didn't need