### PR TITLE
refactor: use tr_block_info::Location in cache.cc

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -31,13 +31,10 @@ struct cache_block
 {
     tr_torrent* tor;
 
-    // TODO: use tr_block_info::Location
-    tr_piece_index_t piece;
-    uint32_t offset;
+    tr_block_info::Location loc;
     uint32_t length;
 
     time_t time;
-    tr_block_index_t block;
 
     struct evbuffer* evbuf;
 };
@@ -74,14 +71,14 @@ static int getBlockRun(tr_cache const* cache, int pos, struct run_info* info)
     int const n = tr_ptrArraySize(&cache->blocks);
     auto const* const* blocks = (struct cache_block const* const*)tr_ptrArrayBase(&cache->blocks);
     struct cache_block const* ref = blocks[pos];
-    tr_block_index_t block = ref->block;
+    auto block = ref->loc.block;
     int len = 0;
 
     for (int i = pos; i < n; ++i)
     {
         struct cache_block const* b = blocks[i];
 
-        if (b->block != block)
+        if (b->loc.block != block)
         {
             break;
         }
@@ -99,8 +96,8 @@ static int getBlockRun(tr_cache const* cache, int pos, struct run_info* info)
     {
         struct cache_block const* b = blocks[pos + len - 1];
         info->last_block_time = b->time;
-        info->is_piece_done = b->tor->hasPiece(b->piece);
-        info->is_multi_piece = b->piece != blocks[pos]->piece;
+        info->is_piece_done = b->tor->hasPiece(b->loc.piece);
+        info->is_multi_piece = b->loc.piece != blocks[pos]->loc.piece;
         info->len = len;
         info->pos = pos;
     }
@@ -164,10 +161,10 @@ static int flushContiguous(tr_cache* cache, int pos, int n)
     auto* walk = buf;
     auto** blocks = (struct cache_block**)tr_ptrArrayBase(&cache->blocks);
 
-    struct cache_block* b = blocks[pos];
-    tr_torrent* tor = b->tor;
-    tr_piece_index_t const piece = b->piece;
-    uint32_t const offset = b->offset;
+    auto* b = blocks[pos];
+    auto* const tor = b->tor;
+    auto const piece = b->loc.piece;
+    auto const offset = b->loc.piece_offset;
 
     for (int i = 0; i < n; ++i)
     {
@@ -294,43 +291,40 @@ static int cache_block_compare(void const* va, void const* vb)
     }
 
     /* secondary key: block # */
-    if (a->block != b->block)
+    if (a->loc.block != b->loc.block)
     {
-        return a->block < b->block ? -1 : 1;
+        return a->loc.block < b->loc.block ? -1 : 1;
     }
 
     /* they're equal */
     return 0;
 }
 
-static struct cache_block* findBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t piece, uint32_t offset)
+static struct cache_block* findBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Location loc)
 {
     auto key = cache_block{};
     key.tor = torrent;
-    key.block = torrent->pieceLoc(piece, offset).block;
+    key.loc = loc;
     return static_cast<struct cache_block*>(tr_ptrArrayFindSorted(&cache->blocks, &key, cache_block_compare));
 }
 
 int tr_cacheWriteBlock(
     tr_cache* cache,
     tr_torrent* torrent,
-    tr_piece_index_t piece,
-    uint32_t offset,
+    tr_block_info::Location loc,
     uint32_t length,
     struct evbuffer* writeme)
 {
     TR_ASSERT(tr_amInEventThread(torrent->session));
 
-    struct cache_block* cb = findBlock(cache, torrent, piece, offset);
+    struct cache_block* cb = findBlock(cache, torrent, loc);
 
     if (cb == nullptr)
     {
         cb = tr_new(struct cache_block, 1);
         cb->tor = torrent;
-        cb->piece = piece;
-        cb->offset = offset;
+        cb->loc = loc;
         cb->length = length;
-        cb->block = torrent->pieceLoc(piece, offset).block;
         cb->evbuf = evbuffer_new();
         tr_ptrArrayInsertSorted(&cache->blocks, cb, cache_block_compare);
     }
@@ -348,35 +342,29 @@ int tr_cacheWriteBlock(
     return cacheTrim(cache);
 }
 
-int tr_cacheReadBlock(
-    tr_cache* cache,
-    tr_torrent* torrent,
-    tr_piece_index_t piece,
-    uint32_t offset,
-    uint32_t len,
-    uint8_t* setme)
+int tr_cacheReadBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Location loc, uint32_t len, uint8_t* setme)
 {
     int err = 0;
 
-    if (auto* const cb = findBlock(cache, torrent, piece, offset); cb != nullptr)
+    if (auto* const cb = findBlock(cache, torrent, loc); cb != nullptr)
     {
         evbuffer_copyout(cb->evbuf, setme, len);
     }
     else
     {
-        err = tr_ioRead(torrent, piece, offset, len, setme);
+        err = tr_ioRead(torrent, loc.piece, loc.piece_offset, len, setme);
     }
 
     return err;
 }
 
-int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t piece, uint32_t offset, uint32_t len)
+int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Location loc, uint32_t len)
 {
     int err = 0;
 
-    if (auto const* const cb = findBlock(cache, torrent, piece, offset); cb == nullptr)
+    if (auto const* const cb = findBlock(cache, torrent, loc); cb == nullptr)
     {
-        err = tr_ioPrefetch(torrent, piece, offset, len);
+        err = tr_ioPrefetch(torrent, loc.piece, loc.piece_offset, len);
     }
 
     return err;
@@ -386,11 +374,11 @@ int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t
 ****
 ***/
 
-static int findBlockPos(tr_cache const* cache, tr_torrent* torrent, tr_piece_index_t block)
+static int findBlockPos(tr_cache const* cache, tr_torrent* torrent, tr_block_info::Location loc)
 {
     struct cache_block key;
     key.tor = torrent;
-    key.block = block;
+    key.loc = loc;
     return tr_ptrArrayLowerBound(&cache->blocks, &key, cache_block_compare, nullptr);
 }
 
@@ -420,7 +408,7 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
 {
     auto const [begin, end] = tr_torGetFileBlockSpan(torrent, i);
 
-    int pos = findBlockPos(cache, torrent, begin);
+    int pos = findBlockPos(cache, torrent, torrent->blockLoc(begin));
     dbgmsg("flushing file %d from cache to disk: blocks [%zu...%zu)", (int)i, (size_t)begin, (size_t)end);
 
     /* flush out all the blocks in that file */
@@ -434,7 +422,7 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
             break;
         }
 
-        if (b->block < begin || b->block >= end)
+        if (b->loc.block < begin || b->loc.block >= end)
         {
             break;
         }
@@ -448,7 +436,7 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
 int tr_cacheFlushTorrent(tr_cache* cache, tr_torrent* torrent)
 {
     int err = 0;
-    int const pos = findBlockPos(cache, torrent, 0);
+    int const pos = findBlockPos(cache, torrent, {});
 
     /* flush out all the blocks in that torrent */
     while (err == 0 && pos < tr_ptrArraySize(&cache->blocks))

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -11,6 +11,10 @@
 
 #include <cstdint> // intX_t, uintX_t
 
+#include "transmission.h"
+
+#include "block-info.h"
+
 struct evbuffer;
 struct tr_cache;
 struct tr_torrent;
@@ -34,20 +38,13 @@ int64_t tr_cacheGetLimit(tr_cache const*);
 int tr_cacheWriteBlock(
     tr_cache* cache,
     tr_torrent* torrent,
-    tr_piece_index_t piece,
-    uint32_t offset,
+    tr_block_info::Location loc,
     uint32_t len,
     struct evbuffer* writeme);
 
-int tr_cacheReadBlock(
-    tr_cache* cache,
-    tr_torrent* torrent,
-    tr_piece_index_t piece,
-    uint32_t offset,
-    uint32_t len,
-    uint8_t* setme);
+int tr_cacheReadBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Location loc, uint32_t len, uint8_t* setme);
 
-int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_piece_index_t piece, uint32_t offset, uint32_t len);
+int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Location loc, uint32_t len);
 
 /***
 ****

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -219,7 +219,9 @@ static std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece
     while (bytes_left != 0)
     {
         size_t const len = std::min(bytes_left, std::size(buffer));
-        if (auto const success = tr_cacheReadBlock(tor->session->cache, tor, piece, offset, len, std::data(buffer)) == 0;
+        if (auto const
+                success = tr_cacheReadBlock(tor->session->cache, tor, tor->pieceLoc(piece, offset), len, std::data(buffer)) ==
+                0;
             !success)
         {
             tr_sha1_final(sha);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1462,7 +1462,11 @@ static void prefetchPieces(tr_peerMsgsImpl* msgs)
 
         if (requestIsValid(msgs, req))
         {
-            tr_cachePrefetchBlock(msgs->session->cache, msgs->torrent, req->index, req->offset, req->length);
+            tr_cachePrefetchBlock(
+                msgs->session->cache,
+                msgs->torrent,
+                msgs->torrent->pieceLoc(req->index, req->offset),
+                req->length);
             ++msgs->prefetchCount;
         }
     }
@@ -1916,7 +1920,9 @@ static int clientGotBlock(tr_peerMsgsImpl* msgs, struct evbuffer* data, struct p
     ***  Save the block
     **/
 
-    if (int const err = tr_cacheWriteBlock(msgs->session->cache, tor, req->index, req->offset, req->length, data); err != 0)
+    if (int const
+            err = tr_cacheWriteBlock(msgs->session->cache, tor, tor->pieceLoc(req->index, req->offset), req->length, data);
+        err != 0)
     {
         return err;
     }
@@ -2210,8 +2216,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             bool err = tr_cacheReadBlock(
                            msgs->session->cache,
                            msgs->torrent,
-                           req.index,
-                           req.offset,
+                           msgs->torrent->pieceLoc(req.index, req.offset),
                            req.length,
                            static_cast<uint8_t*>(iovec[0].iov_base)) != 0;
             iovec[0].iov_len = req.length;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -26,7 +26,7 @@
 
 #include <event2/event.h>
 
-#include <libutp/utp.h>
+//#include <libutp/utp.h>
 
 #include "transmission.h"
 

--- a/libtransmission/tr-utp.h
+++ b/libtransmission/tr-utp.h
@@ -10,6 +10,8 @@
 
 #include <cstddef> // size_t
 
+struct tr_session;
+
 bool tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, tr_session* ss);
 
 void tr_utpClose(tr_session*);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -327,7 +327,7 @@ void write_block_func(void* vdata)
             while (len > 0)
             {
                 uint32_t const bytes_this_pass = std::min(len, block_size);
-                tr_cacheWriteBlock(cache, tor, piece, offset_end - len, bytes_this_pass, buf);
+                tr_cacheWriteBlock(cache, tor, tor->pieceLoc(piece, offset_end - len), bytes_this_pass, buf);
                 len -= bytes_this_pass;
             }
 
@@ -457,8 +457,7 @@ void onPartialDataFetched(tr_web::FetchResponse const& web_response)
                     tr_cacheWriteBlock(
                         session->cache,
                         tor,
-                        t->piece_index,
-                        t->piece_offset + bytes_done,
+                        tor->pieceLoc(t->piece_index, t->piece_offset + bytes_done),
                         buf_len,
                         t->content());
 

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -77,7 +77,12 @@ TEST_P(IncompleteDirTest, incompleteDir)
     auto const test_incomplete_dir_threadfunc = [](void* vdata) noexcept
     {
         auto* data = static_cast<TestIncompleteDirData*>(vdata);
-        tr_cacheWriteBlock(data->session->cache, data->tor, 0, data->offset, data->tor->blockSize(), data->buf);
+        tr_cacheWriteBlock(
+            data->session->cache,
+            data->tor,
+            data->tor->pieceLoc(0, data->offset),
+            data->tor->blockSize(),
+            data->buf);
         tr_torrentGotBlock(data->tor, data->block);
         data->done = true;
     };


### PR DESCRIPTION
Part 2 in a series of PRs to simplify piece / block / file offset math. More info [here](https://github.com/transmission/transmission/pull/2649#issue-1143873311). The previous PR in the series was #2649.

This PR updates cache.cc to use the new Location type.