### PR TITLE
refactor: use tr_block_info::Location in inout.cc

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -163,8 +163,7 @@ static int flushContiguous(tr_cache* cache, int pos, int n)
 
     auto* b = blocks[pos];
     auto* const tor = b->tor;
-    auto const piece = b->loc.piece;
-    auto const offset = b->loc.piece_offset;
+    auto const loc = b->loc;
 
     for (int i = 0; i < n; ++i)
     {
@@ -177,7 +176,7 @@ static int flushContiguous(tr_cache* cache, int pos, int n)
 
     tr_ptrArrayErase(&cache->blocks, pos, pos + n);
 
-    err = tr_ioWrite(tor, piece, offset, walk - buf, buf);
+    err = tr_ioWrite(tor, loc, walk - buf, buf);
     tr_free(buf);
 
     ++cache->disk_writes;
@@ -352,7 +351,7 @@ int tr_cacheReadBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::Locat
     }
     else
     {
-        err = tr_ioRead(torrent, loc.piece, loc.piece_offset, len, setme);
+        err = tr_ioRead(torrent, loc, len, setme);
     }
 
     return err;
@@ -364,7 +363,7 @@ int tr_cachePrefetchBlock(tr_cache* cache, tr_torrent* torrent, tr_block_info::L
 
     if (auto const* const cb = findBlock(cache, torrent, loc); cb == nullptr)
     {
-        err = tr_ioPrefetch(torrent, loc.piece, loc.piece_offset, len);
+        err = tr_ioPrefetch(torrent, loc, len);
     }
 
     return err;

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -9,6 +9,10 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include "transmission.h"
+
+#include "block-info.h"
+
 struct tr_torrent;
 
 /**
@@ -20,15 +24,15 @@ struct tr_torrent;
  * Reads the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-int tr_ioRead(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, uint8_t* setme);
+int tr_ioRead(struct tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t* setme);
 
-int tr_ioPrefetch(tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t begin, uint32_t len);
+int tr_ioPrefetch(tr_torrent* tor, tr_block_info::Location loc, uint32_t len);
 
 /**
  * Writes the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-int tr_ioWrite(struct tr_torrent* tor, tr_piece_index_t pieceIndex, uint32_t offset, uint32_t len, uint8_t const* writeme);
+int tr_ioWrite(struct tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t const* writeme);
 
 /**
  * @brief Test to see if the piece matches its metainfo's SHA1 checksum.

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -52,7 +52,7 @@ public:
     {
         return blockInfo().blockLoc(block);
     }
-    [[nodiscard]] auto pieceLoc(tr_piece_index_t piece, uint32_t offset, uint32_t length = 0) const
+    [[nodiscard]] auto pieceLoc(tr_piece_index_t piece, uint32_t offset = 0, uint32_t length = 0) const
     {
         return blockInfo().pieceLoc(piece, offset, length);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -163,7 +163,7 @@ public:
     {
         return metainfo_.blockLoc(block);
     }
-    [[nodiscard]] auto pieceLoc(tr_piece_index_t piece, uint32_t offset, uint32_t length = 0) const
+    [[nodiscard]] auto pieceLoc(tr_piece_index_t piece, uint32_t offset = 0, uint32_t length = 0) const
     {
         return metainfo_.pieceLoc(piece, offset, length);
     }
@@ -282,14 +282,9 @@ public:
         return fpm_.pieceSpan(file);
     }
 
-    [[nodiscard]] auto fileOffset(uint64_t offset) const
+    [[nodiscard]] auto fileOffset(tr_block_info::Location loc) const
     {
-        return fpm_.fileOffset(offset);
-    }
-
-    [[nodiscard]] auto fileOffset(tr_piece_index_t piece, uint32_t piece_offset) const
-    {
-        return fpm_.fileOffset(this->pieceLoc(piece, piece_offset).byte);
+        return fpm_.fileOffset(loc.byte);
     }
 
     /// WANTED

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -502,7 +502,7 @@ void task_request_next_chunk(tr_webseed_task* t)
     tr_piece_index_t const step_piece = total_offset / piece_size;
     uint64_t const step_piece_offset = total_offset - uint64_t(piece_size) * step_piece;
 
-    auto const [file_index, file_offset] = tor->fileOffset(step_piece, step_piece_offset);
+    auto const [file_index, file_offset] = tor->fileOffset(tor->pieceLoc(step_piece, step_piece_offset));
     uint64_t this_pass = std::min(remain, tor->fileSize(file_index) - file_offset);
 
     auto const url = make_url(t->webseed, tor->fileSubpath(file_index));


### PR DESCRIPTION
Part 3 in a series of PRs to simplify piece / block / file offset math. More info [here](https://github.com/transmission/transmission/pull/2649#issue-1143873311). The previous PR in the series was #2652.

This PR updates inout.cc to use the new Location type.