### PR TITLE
refactor: move tr_netClosePeerSocket() impl to net.cc

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -422,6 +422,28 @@ struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address co
     return ret;
 }
 
+void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket)
+{
+    switch (socket.type)
+    {
+    case TR_PEER_SOCKET_TYPE_NONE:
+        break;
+
+    case TR_PEER_SOCKET_TYPE_TCP:
+        tr_netClose(session, socket.handle.tcp);
+        break;
+
+#ifdef WITH_UTP
+    case TR_PEER_SOCKET_TYPE_UTP:
+        UTP_Close(socket.handle.utp);
+        break;
+#endif
+
+    default:
+        TR_ASSERT_MSG(false, "unsupported peer socket type %d", socket.type);
+    }
+}
+
 static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool suppressMsgs, int* errOut)
 {
     TR_ASSERT(tr_address_is_valid(addr));

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -7,6 +7,7 @@
 #include <cerrno> /* error codes ERANGE, ... */
 #include <climits> /* INT_MAX */
 #include <cmath>
+#include <cstdint>
 #include <cstdlib> /* qsort */
 #include <ctime> // time_t
 #include <iterator> // std::back_inserter
@@ -14,11 +15,7 @@
 
 #include <event2/event.h>
 
-#include <cstdint>
-#include <libutp/utp.h>
-
 #define LIBTRANSMISSION_PEER_MODULE
-
 #include "transmission.h"
 
 #include "announcer.h"
@@ -1084,30 +1081,6 @@ static bool on_handshake_done(tr_handshake_result const& result)
     return success;
 }
 
-static void close_peer_socket(struct tr_peer_socket const socket, tr_session* session)
-{
-    switch (socket.type)
-    {
-    case TR_PEER_SOCKET_TYPE_NONE:
-        break;
-
-    case TR_PEER_SOCKET_TYPE_TCP:
-        tr_netClose(session, socket.handle.tcp);
-        break;
-
-#ifdef WITH_UTP
-
-    case TR_PEER_SOCKET_TYPE_UTP:
-        UTP_Close(socket.handle.utp);
-        break;
-
-#endif
-
-    default:
-        TR_ASSERT_MSG(false, "unsupported peer socket type %d", socket.type);
-    }
-}
-
 void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket)
 {
     TR_ASSERT(tr_isSession(manager->session));
@@ -1118,11 +1091,11 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     if (tr_sessionIsAddressBlocked(session, addr))
     {
         tr_logAddDebug("Banned IP address \"%s\" tried to connect to us", tr_address_to_string(addr));
-        close_peer_socket(socket, session);
+        tr_netClosePeerSocket(session, socket);
     }
     else if (getExistingHandshake(&manager->incomingHandshakes, addr) != nullptr)
     {
-        close_peer_socket(socket, session);
+        tr_netClosePeerSocket(session, socket);
     }
     else /* we don't have a connection to them yet... */
     {

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -40,3 +40,5 @@ struct tr_address;
 struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
 
 struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
+
+void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -43,6 +43,7 @@
 #include "error.h"
 #include "log.h"
 #include "mime-types.h"
+#include "net.h" // ntohl()
 #include "platform-quota.h" /* tr_device_info_create(), tr_device_info_get_disk_space(), tr_device_info_free() */
 #include "tr-assert.h"
 #include "utils.h"

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -41,10 +41,8 @@
 
 #include "error-types.h"
 #include "error.h"
-#include "file.h"
 #include "log.h"
 #include "mime-types.h"
-#include "net.h"
 #include "platform-quota.h" /* tr_device_info_create(), tr_device_info_get_disk_space(), tr_device_info_free() */
 #include "tr-assert.h"
 #include "utils.h"


### PR DESCRIPTION
Minor refactor to reduce the amount of libtransmission code that needs to work directly with libutp.

(libutp is great; just trying to improve separation of concerns slightly in libtransmission)