### PR TITLE
fix for magnet links not being reloaded after restart on macOS

### DIFF
--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -293,7 +293,7 @@ static void onHaveAllMetainfo(tr_torrent* tor, tr_incomplete_metadata* m)
         tor->incompleteMetadata = nullptr;
         tor->isStopping = true;
         tor->magnetVerify = true;
-        tor->startAfterVerify = !tor->prefetchMagnetMetadata;
+        tor->startAfterVerify = !tr_sessionGetPaused(tor->session);
         tor->markEdited();
     }
     else /* drat. */

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 
 @property(nonatomic, getter=isMagnet, readonly) BOOL magnet;
 @property(nonatomic, readonly) NSString* magnetLink;
-@property(nonatomic, readonly) NSString* magnetLocation;
+@property(nonatomic, readonly) id magnetLocation;
 
 @property(nonatomic, readonly) CGFloat ratio;
 @property(nonatomic) tr_ratiolimit ratioSetting;

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 
 @property(nonatomic, getter=isMagnet, readonly) BOOL magnet;
 @property(nonatomic, readonly) NSString* magnetLink;
-@property(nonatomic, readonly) id magnetLocation;
+@property(nonatomic, readonly) NSString* magnetLocation;
 
 @property(nonatomic, readonly) CGFloat ratio;
 @property(nonatomic) tr_ratiolimit ratioSetting;

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 
 @property(nonatomic, getter=isMagnet, readonly) BOOL magnet;
 @property(nonatomic, readonly) NSString* magnetLink;
+@property(nonatomic, readonly) NSString* magnetLocation;
 
 @property(nonatomic, readonly) CGFloat ratio;
 @property(nonatomic) tr_ratiolimit ratioSetting;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -254,17 +254,23 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (NSDictionary*)history
 {
-    return @{
+    NSMutableDictionary *history = [NSMutableDictionary dictionaryWithDictionary:@{
         @"InternalTorrentPath" : self.torrentLocation,
         @"TorrentHash" : self.hashString,
         @"Active" : @(self.active),
         @"WaitToStart" : @(self.waitingToStart),
         @"GroupValue" : @(fGroupValue),
         @"RemoveWhenFinishSeeding" : @(_removeWhenFinishSeeding),
-        @"IsMagnet" : @(self.isMagnet),
-        @"MagnetLink" : self.magnetLink,
-        @"MagnetLocation" : self.magnetLocation
-    };
+        @"IsMagnet" : @(self.isMagnet)
+    }];
+
+    if (self.isMagnet)
+    {
+        [history setValue:self.magnetLink forKey:@"MagnetLink"];
+        [history setValue:self.magnetLocation forKey:@"MagnetLocation"];
+    }
+    
+    return history;
 }
 
 - (void)dealloc
@@ -449,7 +455,7 @@ bool trashDataFile(char const* filename, tr_error** error)
             return @(tr_torrentGetDownloadDir(fHandle));
         }
     }
-    return @"";
+    return nil;
 }
 
 - (CGFloat)ratio

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -198,7 +198,13 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (instancetype)initWithHistory:(NSDictionary*)history lib:(tr_session*)lib forcePause:(BOOL)pause
 {
-    if ([history[@"IsMagnet"] boolValue] == true)
+    bool isMagnet = false;
+    if (history[@"IsMagnet"] != nil)
+    {
+        isMagnet = [history[@"IsMagnet"] boolValue];
+    }
+    
+    if (isMagnet == true)
     {
         self = [self initWithMagnetAddress:history[@"MagnetLink"] location:history[@"MagnetLocation"] lib:lib];
     }

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -198,13 +198,7 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (instancetype)initWithHistory:(NSDictionary*)history lib:(tr_session*)lib forcePause:(BOOL)pause
 {
-    BOOL isMagnet = NO;
-    if (history[@"IsMagnet"] != nil)
-    {
-        isMagnet = [history[@"IsMagnet"] boolValue];
-    }
-    
-    if (isMagnet)
+    if ([history[@"IsMagnet"] boolValue])
     {
         self = [self initWithMagnetAddress:history[@"MagnetLink"] location:history[@"MagnetLocation"] lib:lib];
     }

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -269,7 +269,7 @@ bool trashDataFile(char const* filename, tr_error** error)
         @"RemoveWhenFinishSeeding" : @(_removeWhenFinishSeeding),
         @"IsMagnet" : @(self.isMagnet),
         @"MagnetLink" : self.magnetLink,
-        @"MagnetLocation" : (NSString *)self.magnetLocation
+        @"MagnetLocation" : self.magnetLocation
     };
 }
 
@@ -446,7 +446,7 @@ bool trashDataFile(char const* filename, tr_error** error)
     return @(tr_torrentGetMagnetLink(fHandle));
 }
 
-- (id)magnetLocation
+- (NSString*)magnetLocation
 {
     if (self.isMagnet)
     {
@@ -455,7 +455,7 @@ bool trashDataFile(char const* filename, tr_error** error)
             return @(tr_torrentGetDownloadDir(fHandle));
         }
     }
-    return [NSNull null];
+    return @"";
 }
 
 - (CGFloat)ratio

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -198,13 +198,13 @@ bool trashDataFile(char const* filename, tr_error** error)
 
 - (instancetype)initWithHistory:(NSDictionary*)history lib:(tr_session*)lib forcePause:(BOOL)pause
 {
-    bool isMagnet = false;
+    BOOL isMagnet = NO;
     if (history[@"IsMagnet"] != nil)
     {
         isMagnet = [history[@"IsMagnet"] boolValue];
     }
     
-    if (isMagnet == true)
+    if (isMagnet)
     {
         self = [self initWithMagnetAddress:history[@"MagnetLink"] location:history[@"MagnetLocation"] lib:lib];
     }

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -269,7 +269,7 @@ bool trashDataFile(char const* filename, tr_error** error)
         @"RemoveWhenFinishSeeding" : @(_removeWhenFinishSeeding),
         @"IsMagnet" : @(self.isMagnet),
         @"MagnetLink" : self.magnetLink,
-        @"MagnetLocation" : self.magnetLocation
+        @"MagnetLocation" : (NSString *)self.magnetLocation
     };
 }
 
@@ -446,7 +446,7 @@ bool trashDataFile(char const* filename, tr_error** error)
     return @(tr_torrentGetMagnetLink(fHandle));
 }
 
-- (NSString*)magnetLocation
+- (id)magnetLocation
 {
     if (self.isMagnet)
     {
@@ -455,7 +455,7 @@ bool trashDataFile(char const* filename, tr_error** error)
             return @(tr_torrentGetDownloadDir(fHandle));
         }
     }
-    return @"";
+    return [NSNull null];
 }
 
 - (CGFloat)ratio


### PR DESCRIPTION
this fixes an issue with magnet links not being reloaded if the metadata has not completed downloading before a restart.

https://github.com/transmission/transmission/issues/1102
