### PR TITLE
fix: recent memory leak regressions

### DIFF
--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -240,6 +240,7 @@ void tr_metaInfoBuilderFree(tr_metainfo_builder* builder)
         }
 
         tr_free(builder->trackers);
+        tr_free(builder->webseeds);
         tr_free(builder->outputFile);
         tr_free(builder);
     }

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -218,6 +218,7 @@ static void libeventThreadFunc(tr_event_handle* events)
     {
         evdns_base_free(dns_base, 0);
     }
+    event_free(events->work_queue_event);
     event_base_free(base);
     events->session->event_base = nullptr;
     events->session->evdns_base = nullptr;


### PR DESCRIPTION
While running valgrind on the unit tests, I found new recent leaks. This PR fixes them.