### PR TITLE
Clarify torrent-add result on duplicate torrents

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -467,7 +467,7 @@ Response arguments:
 
 * On success, a `torrent-added` object in the form of one of 3.3's torrent objects with the fields for `id`, `name`, and `hashString`.
 
-* On failure due to a duplicate torrent existing, a `torrent-duplicate` object in the same form.
+* When attempting to add a duplicate torrent, a `torrent-duplicate` object in the same form is returned, but the response's `result` value is still `success`.
 
 ### 3.5. Removing a Torrent
 


### PR DESCRIPTION
Rewrote a sentence to ensure it's clear that a duplicate torrent error still returns a "success" result over RPC.