### PR TITLE
feat: better dialog when adding duplicate magnet

### DIFF
--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -29,6 +29,23 @@ QString getNameFromMetainfo(QByteArray const& benc)
     return QString::fromStdString(metainfo.name());
 }
 
+QString getNameFromMagnet(QString const& magnet)
+{
+    auto tmp = tr_magnet_metainfo{};
+
+    if (!tmp.parseMagnet(magnet.toStdString()))
+    {
+        return magnet;
+    }
+
+    if (!std::empty(tmp.name()))
+    {
+        return QString::fromStdString(tmp.name());
+    }
+
+    return QString::fromStdString(tmp.infoHashString());
+}
+
 } // namespace
 
 int AddData::set(QString const& key)
@@ -79,7 +96,7 @@ QString AddData::readableName() const
         return filename;
 
     case MAGNET:
-        return magnet;
+        return getNameFromMagnet(magnet);
 
     case URL:
         return url.toString();


### PR DESCRIPTION
Instead of giving the entire magnet link, which can be too long to be readable, give the magnet's display name (if available) or the info hash as a fallback.

Fixes #1217.