### PR TITLE
refactor: remove utils dependency from peer-io

### DIFF
--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -27,7 +27,6 @@
 #include "net.h" /* tr_address */
 #include "peer-socket.h"
 #include "tr-assert.h"
-#include "utils.h" // tr_time()
 
 class tr_peerIo;
 struct Bandwidth;
@@ -70,14 +69,16 @@ public:
         bool is_incoming,
         tr_address const& addr_in,
         tr_port port_in,
-        bool is_seed_in)
+        bool is_seed_in,
+        time_t current_time)
         : crypto{ torrent_hash, is_incoming }
         , addr{ addr_in }
         , session{ session_in }
+        , time_created{ current_time }
         , inbuf{ evbuffer_new() }
         , outbuf{ evbuffer_new() }
         , port{ port_in }
-        , isSeed{ is_seed_in }
+        , is_seed{ is_seed_in }
     {
     }
 
@@ -99,9 +100,9 @@ public:
 
     struct tr_peer_socket socket = {};
 
-    time_t const timeCreated = tr_time();
-
     tr_session* const session;
+
+    time_t const time_created;
 
     tr_can_read_cb canRead = nullptr;
     tr_did_write_cb didWrite = nullptr;
@@ -131,7 +132,7 @@ public:
 
     tr_priority_t priority = TR_PRI_NORMAL;
 
-    bool const isSeed;
+    bool const is_seed;
     bool dhtSupported = false;
     bool extendedProtocolSupported = false;
     bool fastExtensionSupported = false;
@@ -142,13 +143,15 @@ public:
 ***
 **/
 
+// TODO: 8 constructor args is too many; maybe a builder object?
 tr_peerIo* tr_peerIoNewOutgoing(
     tr_session* session,
     Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
+    time_t current_time,
     tr_sha1_digest_t const& torrent_hash,
-    bool isSeed,
+    bool is_seed,
     bool utp);
 
 tr_peerIo* tr_peerIoNewIncoming(
@@ -156,6 +159,7 @@ tr_peerIo* tr_peerIoNewIncoming(
     Bandwidth* parent,
     struct tr_address const* addr,
     tr_port port,
+    time_t current_time,
     struct tr_peer_socket const socket);
 
 void tr_peerIoRefImpl(char const* file, int line, tr_peerIo* io);
@@ -235,12 +239,6 @@ int tr_peerIoReconnect(tr_peerIo* io);
 constexpr bool tr_peerIoIsIncoming(tr_peerIo const* io)
 {
     return io->crypto.is_incoming;
-}
-
-// TODO: remove this func; let caller get the current time instead
-static inline int tr_peerIoGetAge(tr_peerIo const* io)
-{
-    return tr_time() - io->timeCreated;
 }
 
 /**

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -357,9 +357,9 @@ public:
         set_active(direction, calculate_active(direction));
     }
 
-    [[nodiscard]] time_t get_connection_age() const override
+    [[nodiscard]] bool is_connection_older_than(time_t timestamp) const override
     {
-        return tr_peerIoGetAge(io);
+        return io->time_created < timestamp;
     }
 
     void cancel_block_request(tr_block_index_t block) override

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -47,7 +47,7 @@ public:
     virtual bool is_active(tr_direction direction) const = 0;
     virtual void update_active(tr_direction direction) = 0;
 
-    virtual time_t get_connection_age() const = 0;
+    virtual bool is_connection_older_than(time_t time) const = 0;
 
     virtual void cancel_block_request(tr_block_index_t block) = 0;
 

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "tr-macros.h" // tr_sha1_digest_t
 

--- a/tests/libtransmission/benc-test.cc
+++ b/tests/libtransmission/benc-test.cc
@@ -25,7 +25,11 @@ TEST_F(BencTest, MalformedBenc)
     auto handler = TestHandler{};
     tr_error* error = nullptr;
     EXPECT_FALSE(transmission::benc::parse(Benc, stack, handler, nullptr, &error));
-    EXPECT_NE(nullptr, error->message);
+    EXPECT_NE(nullptr, error);
+    if (error != nullptr)
+    {
+        EXPECT_NE(nullptr, error->message);
+    }
     tr_error_clear(&error);
 }
 


### PR DESCRIPTION
Just removing a minor wart. The `tr_time()` call in peer-io.h both added a header dependency to utils.h and also made it harder to write future tests because of the extra complication of how to get the current time's time_t. This PR passes the timestamp in when the peer-io is created.

This still isn't a complete fix -- that timestamp is still gotten from `tr_time()` in peer-msgs when creating the peer-io -- but at least it moves the dependency one step further outward, making future cleanup easier.