### PR TITLE
Delay start of daemon systemd service until network is configured

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Transmission BitTorrent Daemon
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=transmission


### PR DESCRIPTION
Currently, systemd may start the daemon before the network configuration is completed, which may result in errors for configurations that rely on e.g. binding to specific addresses, such as in #2720.