### PR TITLE
refactor: remove redundant MAX_BLOCK_SIZE constant

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -12,7 +12,6 @@
 #include "cache.h"
 #include "inout.h"
 #include "log.h"
-#include "peer-common.h" /* MAX_BLOCK_SIZE */
 #include "ptrarray.h"
 #include "torrent.h"
 #include "tr-assert.h"
@@ -157,7 +156,7 @@ static int calcRuns(tr_cache const* cache, struct run_info* runs)
 static int flushContiguous(tr_cache* cache, int pos, int n)
 {
     int err = 0;
-    auto* const buf = tr_new(uint8_t, n * MAX_BLOCK_SIZE);
+    auto* const buf = tr_new(uint8_t, n * tr_block_info::BlockSize);
     auto* walk = buf;
     auto** blocks = (struct cache_block**)tr_ptrArrayBase(&cache->blocks);
 
@@ -237,7 +236,7 @@ static int cacheTrim(tr_cache* cache)
 
 static int getMaxBlocks(int64_t max_bytes)
 {
-    return max_bytes / (double)MAX_BLOCK_SIZE;
+    return max_bytes / static_cast<double>(tr_block_info::BlockSize);
 }
 
 int tr_cacheSetLimit(tr_cache* cache, int64_t max_bytes)

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -24,11 +24,6 @@ class tr_peer;
 class tr_swarm;
 struct peer_atom;
 
-/* This is the maximum size of a block request.
-   most bittorrent clients will reject requests
-   larger than this size. */
-auto inline constexpr MAX_BLOCK_SIZE = 1024 * 16;
-
 /**
 ***  Peer Publish / Subscribe
 **/

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -20,7 +20,6 @@
 #include "bandwidth.h"
 #include "log.h"
 #include "net.h"
-#include "peer-common.h" /* MAX_BLOCK_SIZE */
 #include "peer-io.h"
 #include "tr-assert.h"
 #include "tr-utp.h"
@@ -1007,7 +1006,7 @@ static unsigned int getDesiredOutputBufferSize(tr_peerIo const* io, uint64_t now
     unsigned int const currentSpeed_Bps = io->bandwidth->getPieceSpeedBytesPerSecond(now, TR_UP);
     unsigned int const period = 15U; /* arbitrary */
     /* the 3 is arbitrary; the .5 is to leave room for messages */
-    static auto const ceiling = (unsigned int)(MAX_BLOCK_SIZE * 3.5);
+    static auto const ceiling = (unsigned int)(tr_block_info::BlockSize * 3.5);
     return std::max(ceiling, currentSpeed_Bps * period);
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -41,7 +41,6 @@
 #include "inout.h" /* tr_ioTestPiece() */
 #include "log.h"
 #include "magnet-metainfo.h"
-#include "peer-common.h" /* MAX_BLOCK_SIZE */
 #include "peer-mgr.h"
 #include "resume.h"
 #include "session.h"
@@ -1959,7 +1958,7 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
     {
         err = 3;
     }
-    else if (length > MAX_BLOCK_SIZE)
+    else if (length > tr_block_info::BlockSize)
     {
         err = 4;
     }


### PR DESCRIPTION
A followup to 13ad2b58dc. Now that we have `tr_block_info::BlockSize`, the `MAX_BLOCK_SIZE` const isn't needed anymore.