### PR TITLE
refactor: remove deep logging

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -272,7 +272,7 @@ static char const* levelName(tr_log_level level)
     case TR_LOG_CRITICAL:
         return "CRIT ";
     case TR_LOG_ERROR:
-        return "ERROR";
+        return "ERR  ";
     case TR_LOG_WARN:
         return "WARN ";
     case TR_LOG_DEBUG:

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -71,7 +71,7 @@ private:
     Glib::RefPtr<Gtk::ListStore> store_;
     Glib::RefPtr<Gtk::TreeModelFilter> filter_;
     Glib::RefPtr<Gtk::TreeModelSort> sort_;
-    tr_log_level maxLevel_ = TR_LOG_SILENT;
+    tr_log_level maxLevel_ = TR_LOG_OFF;
     bool isPaused_ = false;
     sigc::connection refresh_tag_;
 };

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -236,8 +236,8 @@ void tr_tracker_udp_announce(
 
 void tr_tracker_udp_start_shutdown(tr_session* session);
 
-void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view msg);
+void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view msg, char const* log_name);
 
-void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view msg);
+void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view msg, char const* log_name);
 
 tr_interned_string tr_announcerGetKey(tr_url_parsed_t const& parsed);

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -31,7 +31,7 @@
 #include "web-utils.h"
 #include "web.h"
 
-#define dbgmsg(name, ...) tr_logAddDeepNamed(name, __VA_ARGS__)
+#define logtrace(name, ...) tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, name, __VA_ARGS__)
 
 using namespace std::literals;
 
@@ -292,7 +292,7 @@ static void onAnnounceDone(tr_web::FetchResponse const& web_response)
     tr_announce_response* const response = &data->response;
     response->did_connect = did_connect;
     response->did_timeout = did_timeout;
-    dbgmsg(data->log_name, "Got announce response");
+    logtrace(data->log_name, "Got announce response");
 
     if (status != HTTP_OK)
     {
@@ -306,12 +306,12 @@ static void onAnnounceDone(tr_web::FetchResponse const& web_response)
 
     if (!std::empty(response->pex6))
     {
-        dbgmsg(data->log_name, "got a peers6 length of %zu", std::size(response->pex6));
+        logtrace(data->log_name, "got a peers6 length of %zu", std::size(response->pex6));
     }
 
     if (!std::empty(response->pex))
     {
-        dbgmsg(data->log_name, "got a peers length of %zu", std::size(response->pex));
+        logtrace(data->log_name, "got a peers length of %zu", std::size(response->pex));
     }
 
     if (data->response_func != nullptr)
@@ -335,7 +335,7 @@ void tr_tracker_http_announce(
     tr_strlcpy(d->log_name, request->log_name, sizeof(d->log_name));
 
     auto const url = announce_url_new(session, request);
-    dbgmsg(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
+    logtrace(request->log_name, "Sending announce to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
     auto options = tr_web::FetchOptions{ url, onAnnounceDone, d };
     options.timeout_secs = 90L;
@@ -466,7 +466,7 @@ static void onScrapeDone(tr_web::FetchResponse const& web_response)
     response.did_timeout = did_timeout;
 
     auto const scrape_url_sv = response.scrape_url.sv();
-    dbgmsg(data->log_name, "Got scrape response for \"%" TR_PRIsv "\"", TR_PRIsv_ARG(scrape_url_sv));
+    logtrace(data->log_name, "Got scrape response for \"%" TR_PRIsv "\"", TR_PRIsv_ARG(scrape_url_sv));
 
     if (status != HTTP_OK)
     {
@@ -528,7 +528,7 @@ void tr_tracker_http_scrape(
     tr_strlcpy(d->log_name, request->log_name, sizeof(d->log_name));
 
     auto const url = scrape_url_new(request);
-    dbgmsg(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
+    logtrace(request->log_name, "Sending scrape to libcurl: \"%" TR_PRIsv "\"", TR_PRIsv_ARG(url));
 
     auto options = tr_web::FetchOptions{ url, onScrapeDone, d };
     options.timeout_secs = 30L;

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -148,7 +148,7 @@ static void verboseLog(std::string_view description, tr_direction direction, std
 
 static auto constexpr MaxBencDepth = 8;
 
-void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view benc)
+void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view benc, char const* log_name)
 {
     verboseLog("Announce response:", TR_DOWN, benc);
 
@@ -271,7 +271,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
     transmission::benc::parse(benc, stack, handler, nullptr, &error);
     if (error != nullptr)
     {
-        tr_logAddError("%s", error->message);
+        tr_logAddMessage(__FILE__, __LINE__, TR_LOG_WARN, log_name, "%s (%d)", error->message, error->code);
         tr_error_clear(&error);
     }
 }
@@ -301,7 +301,7 @@ static void onAnnounceDone(tr_web::FetchResponse const& web_response)
     }
     else
     {
-        tr_announcerParseHttpAnnounceResponse(*response, body);
+        tr_announcerParseHttpAnnounceResponse(*response, body, data->log_name);
     }
 
     if (!std::empty(response->pex6))
@@ -350,7 +350,7 @@ void tr_tracker_http_announce(
 *****
 ****/
 
-void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view benc)
+void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view benc, char const* log_name)
 {
     verboseLog("Scrape response:", TR_DOWN, benc);
 
@@ -443,7 +443,7 @@ void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::stri
     transmission::benc::parse(benc, stack, handler, nullptr, &error);
     if (error != nullptr)
     {
-        tr_logAddError("%s", error->message);
+        tr_logAddMessage(__FILE__, __LINE__, TR_LOG_WARN, log_name, "%s (%d)", error->message, error->code);
         tr_error_clear(&error);
     }
 }
@@ -475,7 +475,7 @@ static void onScrapeDone(tr_web::FetchResponse const& web_response)
     }
     else
     {
-        tr_announcerParseHttpScrapeResponse(response, body);
+        tr_announcerParseHttpScrapeResponse(response, body, data->log_name);
     }
 
     if (data->response_func != nullptr)

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -43,7 +43,7 @@ using namespace std::literals;
     { \
         if (tr_logLevelIsActive(level)) \
         { \
-            auto name = std::array<char, TR_ADDRSTRLEN>{}; \
+            auto name = std::array<char, 512>{}; \
             tier->buildLogName(std::data(name), std::size(name)); \
             tr_logAddMessage(__FILE__, __LINE__, level, std::data(name), __VA_ARGS__); \
         } \
@@ -732,7 +732,7 @@ static void logtrace_tier_announce_queue(tr_tier const* tier)
         return;
     }
 
-    auto name = std::array<char, 128>{};
+    auto name = std::array<char, 512>{};
     tier->buildLogName(std::data(name), std::size(name));
 
     auto* const buf = evbuffer_new();

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -38,16 +38,21 @@
 
 using namespace std::literals;
 
-#define dbgmsg(tier, ...) \
+#define logimpl(tier, level, ...) \
     do \
     { \
-        if (tr_logGetDeepEnabled()) \
+        if (tr_logLevelIsActive(level)) \
         { \
-            auto name = std::array<char, 128>{}; \
+            auto name = std::array<char, TR_ADDRSTRLEN>{}; \
             tier->buildLogName(std::data(name), std::size(name)); \
-            tr_logAddDeep(__FILE__, __LINE__, std::data(name), __VA_ARGS__); \
+            tr_logAddMessage(__FILE__, __LINE__, level, std::data(name), __VA_ARGS__); \
         } \
     } while (0)
+
+#define logerr(io, ...) logimpl(io, TR_LOG_ERROR, __VA_ARGS__)
+#define logwarn(io, ...) logimpl(io, TR_LOG_WARN, __VA_ARGS__)
+#define logdbg(io, ...) logimpl(io, TR_LOG_DEBUG, __VA_ARGS__)
+#define logtrace(io, ...) logimpl(io, TR_LOG_TRACE, __VA_ARGS__)
 
 /* unless the tracker says otherwise, rescrape this frequently */
 static auto constexpr DefaultScrapeIntervalSec = int{ 60 * 30 };
@@ -653,7 +658,7 @@ static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
         e.messageType = TR_TRACKER_COUNTS;
         e.seeders = seeders;
         e.leechers = leechers;
-        dbgmsg(tier, "peer counts: %d seeders, %d leechers.", seeders, leechers);
+        logdbg(tier, "peer counts: %d seeders, %d leechers.", seeders, leechers);
 
         (*tier->tor->torrent_announcer->callback)(tier->tor, &e, nullptr);
     }
@@ -668,7 +673,7 @@ static void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vecto
         e.seeders = seeders;
         e.leechers = leechers;
         e.pex = pex;
-        dbgmsg(
+        logdbg(
             tier,
             "tracker knows of %d seeders and %d leechers and gave a list of %zu peers.",
             seeders,
@@ -720,24 +725,26 @@ time_t tr_announcerNextManualAnnounce(tr_torrent const* tor)
     return ret;
 }
 
-static void dbgmsg_tier_announce_queue(tr_tier const* tier)
+static void logtrace_tier_announce_queue(tr_tier const* tier)
 {
-    if (tr_logGetDeepEnabled())
+    if (!tr_logLevelIsActive(TR_LOG_TRACE))
     {
-        auto name = std::array<char, 128>{};
-        tier->buildLogName(std::data(name), std::size(name));
-
-        auto* const buf = evbuffer_new();
-        for (size_t i = 0, n = std::size(tier->announce_events); i < n; ++i)
-        {
-            tr_announce_event const e = tier->announce_events[i];
-            char const* str = tr_announce_event_get_string(e);
-            evbuffer_add_printf(buf, "[%zu:%s]", i, str);
-        }
-
-        auto const message = evbuffer_free_to_str(buf);
-        tr_logAddDeep(__FILE__, __LINE__, std::data(name), "announce queue is %" TR_PRIsv, TR_PRIsv_ARG(message));
+        return;
     }
+
+    auto name = std::array<char, 128>{};
+    tier->buildLogName(std::data(name), std::size(name));
+
+    auto* const buf = evbuffer_new();
+    for (size_t i = 0, n = std::size(tier->announce_events); i < n; ++i)
+    {
+        tr_announce_event const e = tier->announce_events[i];
+        char const* str = tr_announce_event_get_string(e);
+        evbuffer_add_printf(buf, "[%zu:%s]", i, str);
+    }
+
+    auto const message = evbuffer_free_to_str(buf);
+    tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, std::data(name), "%s", message.c_str());
 }
 
 // higher priorities go to the front of the announce queue
@@ -767,8 +774,8 @@ static void tier_announce_event_push(tr_tier* tier, tr_announce_event e, time_t 
 {
     TR_ASSERT(tier != nullptr);
 
-    dbgmsg_tier_announce_queue(tier);
-    dbgmsg(tier, "queued \"%s\"", tr_announce_event_get_string(e));
+    logtrace_tier_announce_queue(tier);
+    logtrace(tier, "queued \"%s\"", tr_announce_event_get_string(e));
 
     auto& events = tier->announce_events;
     if (!std::empty(events))
@@ -797,8 +804,8 @@ static void tier_announce_event_push(tr_tier* tier, tr_announce_event e, time_t 
     tier->announceAt = announceAt;
     tier_update_announce_priority(tier);
 
-    dbgmsg_tier_announce_queue(tier);
-    dbgmsg(tier, "announcing in %d seconds", (int)difftime(announceAt, tr_time()));
+    logtrace_tier_announce_queue(tier);
+    logtrace(tier, "announcing in %d seconds", (int)difftime(announceAt, tr_time()));
 }
 
 static auto tier_announce_event_pull(tr_tier* tier)
@@ -957,14 +964,14 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
     auto const* const host_cstr = current_tracker->host.c_str();
     if (isUnregistered(err))
     {
-        dbgmsg(tier, "Tracker '%s' announce error: %s", host_cstr, err);
+        logerr(tier, "Tracker '%s' announce error: %s", host_cstr, err);
         tr_logAddTorInfo(tier->tor, "Tracker '%s' announce error: %s", host_cstr, err);
     }
     else
     {
         /* schedule a reannounce */
         int const interval = current_tracker->getRetryInterval();
-        dbgmsg(tier, "Tracker '%s' announce error: %s (Retrying in %d seconds)", host_cstr, err, interval);
+        logwarn(tier, "Tracker '%s' announce error: %s (Retrying in %d seconds)", host_cstr, err, interval);
         tr_logAddTorInfo(tier->tor, "Tracker '%s' announce error: %s (Retrying in %d seconds)", host_cstr, err, interval);
         tier_announce_event_push(tier, e, tr_time() + interval);
     }
@@ -981,7 +988,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
 
     if (tier != nullptr)
     {
-        dbgmsg(
+        logtrace(
             tier,
             "Got announce response: "
             "connected:%d "
@@ -1082,7 +1089,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
             if (auto const& warning = response->warning; !std::empty(warning))
             {
                 tier->last_announce_str = warning;
-                dbgmsg(tier, "tracker gave \"%s\"", warning.c_str());
+                logtrace(tier, "tracker gave \"%s\"", warning.c_str());
                 publishWarning(tier, warning);
             }
             else
@@ -1149,7 +1156,7 @@ static void on_announce_done(tr_announce_response const* response, void* vdata)
             {
                 /* the queue is empty, so enqueue a perodic update */
                 int const i = tier->announceIntervalSec;
-                dbgmsg(tier, "Sending periodic reannounce in %d seconds", i);
+                logtrace(tier, "Sending periodic reannounce in %d seconds", i);
                 tier_announce_event_push(tier, TR_ANNOUNCE_EVENT_NONE, now + i);
             }
         }
@@ -1254,7 +1261,7 @@ static void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char c
     // schedule a rescrape
     auto const interval = current_tracker->getRetryInterval();
     auto const* const host_cstr = current_tracker->host.c_str();
-    dbgmsg(tier, "Tracker '%s' scrape error: %s (Retrying in %zu seconds)", host_cstr, errmsg, (size_t)interval);
+    logtrace(tier, "Tracker '%s' scrape error: %s (Retrying in %zu seconds)", host_cstr, errmsg, (size_t)interval);
     tr_logAddTorInfo(tier->tor, "Tracker '%s' error: %s (Retrying in %zu seconds)", host_cstr, errmsg, (size_t)interval);
     tier->lastScrapeSucceeded = false;
     tier->scheduleNextScrape(interval);
@@ -1318,7 +1325,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
 
             auto const scrape_url_sv = response->scrape_url.sv();
 
-            dbgmsg(
+            logtrace(
                 tier,
                 "scraped url:%" TR_PRIsv
                 " -- "

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -14,7 +14,7 @@
 #include "tr-assert.h"
 #include "utils.h"
 
-#define dbgmsg(...) tr_logAddDeepNamed(nullptr, __VA_ARGS__)
+#define logtrace(...) tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, nullptr, __VA_ARGS__)
 
 /***
 ****
@@ -166,7 +166,7 @@ void Bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
      * peers from starving the others. Loop through the peers, giving each a
      * small chunk of bandwidth. Keep looping until we run out of bandwidth
      * and/or peers that can use it */
-    dbgmsg("%lu peers to go round-robin for %s", peerArray.size(), dir == TR_UP ? "upload" : "download");
+    logtrace("%lu peers to go round-robin for %s", peerArray.size(), dir == TR_UP ? "upload" : "download");
 
     size_t n = peerArray.size();
     while (n > 0)
@@ -180,7 +180,7 @@ void Bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
 
         int const bytes_used = tr_peerIoFlush(peerArray[i], dir, increment);
 
-        dbgmsg("peer #%d of %zu used %d bytes in this pass", i, n, bytes_used);
+        logtrace("peer #%d of %zu used %d bytes in this pass", i, n, bytes_used);
 
         if (bytes_used != int(increment))
         {

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -20,7 +20,7 @@
 
 static char constexpr MyName[] = "Cache";
 
-#define dbgmsg(...) tr_logAddDeepNamed(MyName, __VA_ARGS__)
+#define logtrace(...) tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, nullptr, __VA_ARGS__)
 
 /****
 *****
@@ -409,7 +409,7 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
     auto const [begin, end] = tr_torGetFileBlockSpan(torrent, i);
 
     int pos = findBlockPos(cache, torrent, torrent->blockLoc(begin));
-    dbgmsg("flushing file %d from cache to disk: blocks [%zu...%zu)", (int)i, (size_t)begin, (size_t)end);
+    logtrace("flushing file %d from cache to disk: blocks [%zu...%zu)", (int)i, (size_t)begin, (size_t)end);
 
     /* flush out all the blocks in that file */
     int err = 0;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <string_view>
@@ -130,14 +131,14 @@ struct tr_handshake
 ***
 **/
 
-#define dbgmsg(handshake, ...) \
+#define logtrace(handshake, ...) \
     do \
     { \
-        if (tr_logGetDeepEnabled()) \
+        if (tr_logLevelIsActive(TR_LOG_TRACE)) \
         { \
-            char addrstr[TR_ADDRSTRLEN]; \
-            tr_peerIoGetAddrStr(handshake->io, addrstr, sizeof(addrstr)); \
-            tr_logAddDeep(__FILE__, __LINE__, addrstr, __VA_ARGS__); \
+            auto addrstr = std::array<char, TR_ADDRSTRLEN>{}; \
+            tr_peerIoGetAddrStr(handshake->io, std::data(addrstr), std::size(addrstr)); \
+            tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, std::data(addrstr), __VA_ARGS__); \
         } \
     } while (0)
 
@@ -163,7 +164,7 @@ static char const* getStateName(handshake_state_t const state)
 
 static void setState(tr_handshake* handshake, handshake_state_t state)
 {
-    dbgmsg(handshake, "setting to state [%s]", getStateName(state));
+    logtrace(handshake, "setting to state [%s]", getStateName(state));
     handshake->state = state;
 }
 
@@ -222,7 +223,7 @@ static handshake_parse_err_t parseHandshake(tr_handshake* handshake, struct evbu
     uint8_t name[HANDSHAKE_NAME_LEN];
     uint8_t reserved[HANDSHAKE_FLAGS_LEN];
 
-    dbgmsg(handshake, "payload: need %d, got %zu", HANDSHAKE_SIZE, evbuffer_get_length(inbuf));
+    logtrace(handshake, "payload: need %d, got %zu", HANDSHAKE_SIZE, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < HANDSHAKE_SIZE)
     {
@@ -245,7 +246,7 @@ static handshake_parse_err_t parseHandshake(tr_handshake* handshake, struct evbu
     tr_peerIoReadBytes(handshake->io, inbuf, std::data(hash), std::size(hash));
     if (auto const torrent_hash = tr_peerIoGetTorrentHash(handshake->io); !torrent_hash || *torrent_hash != hash)
     {
-        dbgmsg(handshake, "peer returned the wrong hash. wtf?");
+        logtrace(handshake, "peer returned the wrong hash. wtf?");
         return HANDSHAKE_BAD_TORRENT;
     }
 
@@ -255,11 +256,11 @@ static handshake_parse_err_t parseHandshake(tr_handshake* handshake, struct evbu
     handshake->peer_id = peer_id;
 
     /* peer id */
-    dbgmsg(handshake, "peer-id is [%" TR_PRIsv "]", TR_PRIsv_ARG(peer_id));
+    logtrace(handshake, "peer-id is [%" TR_PRIsv "]", TR_PRIsv_ARG(peer_id));
 
     if (auto* const tor = handshake->session->torrents().get(hash); peer_id == tr_torrentGetPeerId(tor))
     {
-        dbgmsg(handshake, "streuth!  we've connected to ourselves.");
+        logtrace(handshake, "streuth!  we've connected to ourselves.");
         return HANDSHAKE_PEER_IS_SELF;
     }
 
@@ -383,7 +384,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
         }
     }
 
-    dbgmsg(handshake, "got an %s handshake", (isEncrypted ? "encrypted" : "plain"));
+    logtrace(handshake, "got an %s handshake", (isEncrypted ? "encrypted" : "plain"));
 
     tr_peerIoSetEncryption(handshake->io, isEncrypted ? PEER_ENCRYPTION_RC4 : PEER_ENCRYPTION_NONE);
 
@@ -412,7 +413,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
         auto const req1 = computeRequestHash(handshake, "req1"sv);
         if (!req1)
         {
-            dbgmsg(handshake, "error while computing req1 hash after Yb");
+            logtrace(handshake, "error while computing req1 hash after Yb");
             return tr_handshakeDone(handshake, false);
         }
         evbuffer_add(outbuf, std::data(*req1), std::size(*req1));
@@ -424,7 +425,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
         auto const req3 = computeRequestHash(handshake, "req3"sv);
         if (!req2 || !req3)
         {
-            dbgmsg(handshake, "error while computing req2/req3 hash after Yb");
+            logtrace(handshake, "error while computing req2/req3 hash after Yb");
             return tr_handshakeDone(handshake, false);
         }
 
@@ -490,7 +491,7 @@ static ReadState readVC(tr_handshake* handshake, struct evbuffer* inbuf)
     {
         if (evbuffer_get_length(inbuf) < VC_LENGTH)
         {
-            dbgmsg(handshake, "not enough bytes... returning read_more");
+            logtrace(handshake, "not enough bytes... returning read_more");
             return READ_LATER;
         }
 
@@ -506,7 +507,7 @@ static ReadState readVC(tr_handshake* handshake, struct evbuffer* inbuf)
         evbuffer_drain(inbuf, 1);
     }
 
-    dbgmsg(handshake, "got it!");
+    logtrace(handshake, "got it!");
     evbuffer_drain(inbuf, key_len);
     setState(handshake, AWAITING_CRYPTO_SELECT);
     return READ_NOW;
@@ -524,21 +525,21 @@ static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbu
     uint32_t crypto_select = 0;
     tr_peerIoReadUint32(handshake->io, inbuf, &crypto_select);
     handshake->crypto_select = crypto_select;
-    dbgmsg(handshake, "crypto select is %d", (int)crypto_select);
+    logtrace(handshake, "crypto select is %d", (int)crypto_select);
 
     if ((crypto_select & getCryptoProvide(handshake)) == 0)
     {
-        dbgmsg(handshake, "peer selected an encryption option we didn't offer");
+        logtrace(handshake, "peer selected an encryption option we didn't offer");
         return tr_handshakeDone(handshake, false);
     }
 
     uint16_t pad_d_len = 0;
     tr_peerIoReadUint16(handshake->io, inbuf, &pad_d_len);
-    dbgmsg(handshake, "pad_d_len is %d", (int)pad_d_len);
+    logtrace(handshake, "pad_d_len is %d", (int)pad_d_len);
 
     if (pad_d_len > 512)
     {
-        dbgmsg(handshake, "encryption handshake: pad_d_len is too long");
+        logtrace(handshake, "encryption handshake: pad_d_len is too long");
         return tr_handshakeDone(handshake, false);
     }
 
@@ -552,7 +553,7 @@ static ReadState readPadD(tr_handshake* handshake, struct evbuffer* inbuf)
 {
     size_t const needlen = handshake->pad_d_len;
 
-    dbgmsg(handshake, "pad d: need %zu, got %zu", needlen, evbuffer_get_length(inbuf));
+    logtrace(handshake, "pad d: need %zu, got %zu", needlen, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < needlen)
     {
@@ -575,7 +576,7 @@ static ReadState readPadD(tr_handshake* handshake, struct evbuffer* inbuf)
 
 static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    dbgmsg(handshake, "payload: need %d, got %zu", INCOMING_HANDSHAKE_LEN, evbuffer_get_length(inbuf));
+    logtrace(handshake, "payload: need %d, got %zu", INCOMING_HANDSHAKE_LEN, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < INCOMING_HANDSHAKE_LEN)
     {
@@ -592,7 +593,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
         if (handshake->encryptionMode == TR_ENCRYPTION_REQUIRED)
         {
-            dbgmsg(handshake, "peer is unencrypted, and we're disallowing that");
+            logtrace(handshake, "peer is unencrypted, and we're disallowing that");
             return tr_handshakeDone(handshake, false);
         }
     }
@@ -602,7 +603,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
         if (tr_peerIoIsIncoming(handshake->io))
         {
-            dbgmsg(handshake, "I think peer is sending us an encrypted handshake...");
+            logtrace(handshake, "I think peer is sending us an encrypted handshake...");
             setState(handshake, AWAITING_YA);
             return READ_NOW;
         }
@@ -611,7 +612,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
         if (pstrlen != 19)
         {
-            dbgmsg(handshake, "I think peer has sent us a corrupt handshake...");
+            logtrace(handshake, "I think peer has sent us a corrupt handshake...");
             return tr_handshakeDone(handshake, false);
         }
     }
@@ -649,7 +650,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
     {
         if (!handshake->session->torrents().contains(hash))
         {
-            dbgmsg(handshake, "peer is trying to connect to us for a torrent we don't have.");
+            logtrace(handshake, "peer is trying to connect to us for a torrent we don't have.");
             return tr_handshakeDone(handshake, false);
         }
 
@@ -660,7 +661,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
         auto const torrent_hash = tr_peerIoGetTorrentHash(handshake->io);
         if (!torrent_hash || *torrent_hash != hash)
         {
-            dbgmsg(handshake, "peer returned the wrong hash. wtf?");
+            logtrace(handshake, "peer returned the wrong hash. wtf?");
             return tr_handshakeDone(handshake, false);
         }
     }
@@ -699,7 +700,7 @@ static ReadState readPeerId(tr_handshake* handshake, struct evbuffer* inbuf)
 
     char client[128] = {};
     tr_clientForId(client, sizeof(client), peer_id);
-    dbgmsg(handshake, "peer-id is [%s] ... isIncoming is %d", client, tr_peerIoIsIncoming(handshake->io));
+    logtrace(handshake, "peer-id is [%s] ... isIncoming is %d", client, tr_peerIoIsIncoming(handshake->io));
 
     // if we've somehow connected to ourselves, don't keep the connection
     auto const hash = tr_peerIoGetTorrentHash(handshake->io);
@@ -711,7 +712,7 @@ static ReadState readPeerId(tr_handshake* handshake, struct evbuffer* inbuf)
 
 static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    dbgmsg(handshake, "in readYa... need %d, have %zu", KEY_LEN, evbuffer_get_length(inbuf));
+    logtrace(handshake, "in readYa... need %d, have %zu", KEY_LEN, evbuffer_get_length(inbuf));
 
     if (evbuffer_get_length(inbuf) < KEY_LEN)
     {
@@ -730,13 +731,13 @@ static ReadState readYa(tr_handshake* handshake, struct evbuffer* inbuf)
     auto req1 = computeRequestHash(handshake, "req1"sv);
     if (!req1)
     {
-        dbgmsg(handshake, "error while computing req1 hash after Ya");
+        logtrace(handshake, "error while computing req1 hash after Ya");
         return tr_handshakeDone(handshake, false);
     }
     handshake->myReq1 = *req1;
 
     /* send our public key to the peer */
-    dbgmsg(handshake, "sending B->A: Diffie Hellman Yb, PadB");
+    logtrace(handshake, "sending B->A: Diffie Hellman Yb, PadB");
     uint8_t outbuf[KEY_LEN + PadB_MAXLEN];
     uint8_t* walk = outbuf;
     int len = 0;
@@ -763,7 +764,7 @@ static ReadState readPadA(tr_handshake* handshake, struct evbuffer* inbuf)
     if (ptr.pos != -1) /* match */
     {
         evbuffer_drain(inbuf, ptr.pos);
-        dbgmsg(handshake, "found it... looking setting to awaiting_crypto_provide");
+        logtrace(handshake, "found it... looking setting to awaiting_crypto_provide");
         setState(handshake, AWAITING_CRYPTO_PROVIDE);
         return READ_NOW;
     }
@@ -798,14 +799,14 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     /* This next piece is HASH('req2', SKEY) xor HASH('req3', S) ...
      * we can get the first half of that (the obufscatedTorrentHash)
      * by building the latter and xor'ing it with what the peer sent us */
-    dbgmsg(handshake, "reading obfuscated torrent hash...");
+    logtrace(handshake, "reading obfuscated torrent hash...");
     auto req2 = tr_sha1_digest_t{};
     evbuffer_remove(inbuf, std::data(req2), std::size(req2));
 
     auto const req3 = computeRequestHash(handshake, "req3"sv);
     if (!req3)
     {
-        dbgmsg(handshake, "error while computing req3 hash after req2");
+        logtrace(handshake, "error while computing req3 hash after req2");
         return tr_handshakeDone(handshake, false);
     }
 
@@ -819,18 +820,18 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     {
         bool const clientIsSeed = tor->isDone();
         bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, tr_peerIoGetAddress(handshake->io, nullptr));
-        dbgmsg(handshake, "got INCOMING connection's encrypted handshake for torrent [%s]", tr_torrentName(tor));
+        logtrace(handshake, "got INCOMING connection's encrypted handshake for torrent [%s]", tr_torrentName(tor));
         tr_peerIoSetTorrentHash(handshake->io, tor->infoHash());
 
         if (clientIsSeed && peerIsSeed)
         {
-            dbgmsg(handshake, "another seed tried to reconnect to us!");
+            logtrace(handshake, "another seed tried to reconnect to us!");
             return tr_handshakeDone(handshake, false);
         }
     }
     else
     {
-        dbgmsg(handshake, "can't find that torrent...");
+        logtrace(handshake, "can't find that torrent...");
         return tr_handshakeDone(handshake, false);
     }
 
@@ -842,10 +843,10 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
 
     tr_peerIoReadUint32(handshake->io, inbuf, &crypto_provide);
     handshake->crypto_provide = crypto_provide;
-    dbgmsg(handshake, "crypto_provide is %d", (int)crypto_provide);
+    logtrace(handshake, "crypto_provide is %d", (int)crypto_provide);
 
     tr_peerIoReadUint16(handshake->io, inbuf, &padc_len);
-    dbgmsg(handshake, "padc is %d", (int)padc_len);
+    logtrace(handshake, "padc is %d", (int)padc_len);
     handshake->pad_c_len = padc_len;
     setState(handshake, AWAITING_PAD_C);
     return READ_NOW;
@@ -867,7 +868,7 @@ static ReadState readPadC(tr_handshake* handshake, struct evbuffer* inbuf)
 
     /* read ia_len */
     tr_peerIoReadUint16(handshake->io, inbuf, &ia_len);
-    dbgmsg(handshake, "ia_len is %d", (int)ia_len);
+    logtrace(handshake, "ia_len is %d", (int)ia_len);
     handshake->ia_len = ia_len;
     setState(handshake, AWAITING_IA);
     return READ_NOW;
@@ -877,7 +878,7 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
 {
     size_t const needlen = handshake->ia_len;
 
-    dbgmsg(handshake, "reading IA... have %zu, need %zu", evbuffer_get_length(inbuf), needlen);
+    logtrace(handshake, "reading IA... have %zu, need %zu", evbuffer_get_length(inbuf), needlen);
 
     if (evbuffer_get_length(inbuf) < needlen)
     {
@@ -896,7 +897,7 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
         uint8_t vc[VC_LENGTH];
         memset(vc, 0, VC_LENGTH);
         evbuffer_add(outbuf, vc, VC_LENGTH);
-        dbgmsg(handshake, "sending vc");
+        logtrace(handshake, "sending vc");
     }
 
     /* send crypto_select */
@@ -904,17 +905,17 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
 
     if (crypto_select != 0)
     {
-        dbgmsg(handshake, "selecting crypto mode '%d'", (int)crypto_select);
+        logtrace(handshake, "selecting crypto mode '%d'", (int)crypto_select);
         evbuffer_add_uint32(outbuf, crypto_select);
     }
     else
     {
-        dbgmsg(handshake, "peer didn't offer an encryption mode we like.");
+        logtrace(handshake, "peer didn't offer an encryption mode we like.");
         evbuffer_free(outbuf);
         return tr_handshakeDone(handshake, false);
     }
 
-    dbgmsg(handshake, "sending pad d");
+    logtrace(handshake, "sending pad d");
 
     /* ENCRYPT(VC, crypto_provide, len(PadD), PadD
      * PadD is reserved for future extensions to the handshake...
@@ -931,7 +932,7 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
         tr_peerIoSetEncryption(handshake->io, PEER_ENCRYPTION_NONE);
     }
 
-    dbgmsg(handshake, "sending handshake");
+    logtrace(handshake, "sending handshake");
 
     /* send our handshake */
     {
@@ -959,7 +960,7 @@ static ReadState readPayloadStream(tr_handshake* handshake, struct evbuffer* inb
 {
     size_t const needlen = HANDSHAKE_SIZE;
 
-    dbgmsg(handshake, "reading payload stream... have %zu, need %zu", evbuffer_get_length(inbuf), needlen);
+    logtrace(handshake, "reading payload stream... have %zu, need %zu", evbuffer_get_length(inbuf), needlen);
 
     if (evbuffer_get_length(inbuf) < needlen)
     {
@@ -968,7 +969,7 @@ static ReadState readPayloadStream(tr_handshake* handshake, struct evbuffer* inb
 
     /* parse the handshake ... */
     handshake_parse_err_t const i = parseHandshake(handshake, inbuf);
-    dbgmsg(handshake, "parseHandshake returned %d", i);
+    logtrace(handshake, "parseHandshake returned %d", i);
 
     if (i != HANDSHAKE_OK)
     {
@@ -997,7 +998,7 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
     /* no piece data in handshake */
     *piece = 0;
 
-    dbgmsg(handshake, "handling canRead; state is [%s]", getStateName(handshake->state));
+    logtrace(handshake, "handling canRead; state is [%s]", getStateName(handshake->state));
 
     ReadState ret = READ_NOW;
     while (readyForMore)
@@ -1108,7 +1109,7 @@ static void tr_handshakeFree(tr_handshake* handshake)
 
 static ReadState tr_handshakeDone(tr_handshake* handshake, bool isOK)
 {
-    dbgmsg(handshake, "handshakeDone: %s", isOK ? "connected" : "aborting");
+    logtrace(handshake, "handshakeDone: %s", isOK ? "connected" : "aborting");
     tr_peerIoSetIOFuncs(handshake->io, nullptr, nullptr, nullptr, nullptr);
 
     bool const success = fireDoneFunc(handshake, isOK);
@@ -1160,7 +1161,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
     {
         uint8_t msg[HANDSHAKE_SIZE];
 
-        dbgmsg(handshake, "handshake failed, trying plaintext...");
+        logtrace(handshake, "handshake failed, trying plaintext...");
         buildHandshakeMessage(handshake, msg);
         handshake->haveSentBitTorrentHandshake = true;
         setReadState(handshake, AWAITING_HANDSHAKE);
@@ -1168,7 +1169,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
     }
     else
     {
-        dbgmsg(handshake, "libevent got an error what==%d, errno=%d (%s)", (int)what, errcode, tr_strerror(errcode));
+        logtrace(handshake, "libevent got an error what==%d, errno=%d (%s)", (int)what, errcode, tr_strerror(errcode));
         tr_handshakeDone(handshake, false);
     }
 }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -28,16 +28,6 @@ static tr_log_message* myQueue = nullptr;
 static tr_log_message** myQueueTail = &myQueue;
 static int myQueueLength = 0;
 
-#ifndef _WIN32
-
-/* make null versions of these win32 functions */
-static inline bool IsDebuggerPresent()
-{
-    return false;
-}
-
-#endif
-
 /***
 ****
 ***/
@@ -139,56 +129,6 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
 
     tr_snprintf(buf, buflen, "%s.%s", date_str, msec_str);
     return buf;
-}
-
-bool tr_logGetDeepEnabled()
-{
-    static int8_t deepLoggingIsActive = -1;
-
-    if (deepLoggingIsActive < 0)
-    {
-        deepLoggingIsActive = (int8_t)(IsDebuggerPresent() || tr_logGetFile() != TR_BAD_SYS_FILE);
-    }
-
-    return deepLoggingIsActive != 0;
-}
-
-void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt, ...)
-{
-    tr_sys_file_t const fp = tr_logGetFile();
-
-    if (fp != TR_BAD_SYS_FILE || IsDebuggerPresent())
-    {
-        struct evbuffer* buf = evbuffer_new();
-        char* base = tr_sys_path_basename(file, nullptr);
-
-        char timestr[64];
-        evbuffer_add_printf(buf, "[%s] ", tr_logGetTimeStr(timestr, sizeof(timestr)));
-
-        if (name != nullptr)
-        {
-            evbuffer_add_printf(buf, "%s ", name);
-        }
-
-        va_list args;
-        va_start(args, fmt);
-        evbuffer_add_vprintf(buf, fmt, args);
-        va_end(args);
-        evbuffer_add_printf(buf, " (%s:%d)" TR_NATIVE_EOL_STR, base, line);
-
-        auto const message = evbuffer_free_to_str(buf);
-
-#ifdef _WIN32
-        OutputDebugStringA(message.c_str());
-#endif
-
-        if (fp != TR_BAD_SYS_FILE)
-        {
-            tr_sys_file_write(fp, std::data(message), std::size(message), nullptr, nullptr);
-        }
-
-        tr_free(base);
-    }
 }
 
 /***

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -138,11 +138,16 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
 void tr_logAddMessage(
     [[maybe_unused]] char const* file,
     [[maybe_unused]] int line,
-    [[maybe_unused]] tr_log_level level,
+    tr_log_level level,
     [[maybe_unused]] char const* name,
     char const* fmt,
     ...)
 {
+    if (!tr_logLevelIsActive(level))
+    {
+        return;
+    }
+
     int const err = errno; /* message logging shouldn't affect errno */
     char buf[1024];
     va_list ap;

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -8,7 +8,7 @@
 #include <stddef.h> /* size_t */
 
 #include "file.h" /* tr_sys_file_t */
-#include "tr-macros.h"
+#include "transmission.h"
 
 #define TR_LOG_MAX_QUEUE_LENGTH 10000
 
@@ -48,21 +48,6 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, char const
 #define tr_logAddDebug(...) tr_logAdd(TR_LOG_DEBUG, __VA_ARGS__)
 
 tr_sys_file_t tr_logGetFile(void);
-
-/** @brief return true if deep logging has been enabled by the user, false otherwise */
-bool tr_logGetDeepEnabled(void);
-
-void tr_logAddDeep(char const* file, int line, char const* name, char const* fmt, ...) TR_GNUC_PRINTF(4, 5)
-    TR_GNUC_NONNULL(1, 4);
-
-#define tr_logAddDeepNamed(name, ...) \
-    do \
-    { \
-        if (tr_logGetDeepEnabled()) \
-        { \
-            tr_logAddDeep(__FILE__, __LINE__, name, __VA_ARGS__); \
-        } \
-    } while (0)
 
 /** @brief set the buffer with the current time formatted for deep logging. */
 char* tr_logGetTimeStr(char* buf, size_t buflen) TR_GNUC_NONNULL(1);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -44,6 +44,11 @@ tr_address const tr_in6addr_any = { TR_AF_INET6, { IN6ADDR_ANY_INIT } };
 
 tr_address const tr_inaddr_any = { TR_AF_INET, { { { { INADDR_ANY } } } } };
 
+#define logerr(...) tr_logAddNamed(TR_LOG_ERROR, "net", __VA_ARGS__)
+#define logwarn(...) tr_logAddNamed(TR_LOG_WARN, "net", __VA_ARGS__)
+#define logdbg(...) tr_logAddNamed(TR_LOG_DEBUG, "net", __VA_ARGS__)
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "net", __VA_ARGS__)
+
 std::string tr_net_strerror(int err)
 {
 #ifdef _WIN32
@@ -235,7 +240,7 @@ void tr_netSetTOS([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_a
 
         if (setsockopt(s, IPPROTO_IP, IP_TOS, (void const*)&tos, sizeof(tos)) == -1)
         {
-            tr_logAddNamedInfo("Net", "Can't set TOS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
+            logwarn("Can't set TOS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
         }
 #endif
     }
@@ -244,14 +249,14 @@ void tr_netSetTOS([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_a
 #if defined(IPV6_TCLASS) && !defined(_WIN32)
         if (setsockopt(s, IPPROTO_IPV6, IPV6_TCLASS, (void const*)&tos, sizeof(tos)) == -1)
         {
-            tr_logAddNamedInfo("Net", "Can't set IPv6 QoS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
+            logwarn("Can't set IPv6 QoS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
         }
 #endif
     }
     else
     {
         /* program should never reach here! */
-        tr_logAddNamedInfo("Net", "Something goes wrong while setting TOS/Traffic-Class");
+        logdbg("Something goes wrong while setting TOS/Traffic-Class");
     }
 }
 
@@ -261,11 +266,7 @@ void tr_netSetCongestionControl([[maybe_unused]] tr_socket_t s, [[maybe_unused]]
 
     if (setsockopt(s, IPPROTO_TCP, TCP_CONGESTION, (void const*)algorithm, strlen(algorithm) + 1) == -1)
     {
-        tr_logAddNamedInfo(
-            "Net",
-            "Can't set congestion control algorithm '%s': %s",
-            algorithm,
-            tr_net_strerror(sockerrno).c_str());
+        logwarn("Can't set congestion control algorithm '%s': %s", algorithm, tr_net_strerror(sockerrno).c_str());
     }
 
 #endif
@@ -345,10 +346,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
         if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<char const*>(&n), sizeof(n)) == -1)
         {
-            tr_logAddInfo(
-                "Unable to set SO_RCVBUF on socket %" PRIdMAX ": %s",
-                (intmax_t)s,
-                tr_net_strerror(sockerrno).c_str());
+            logwarn("Unable to set SO_RCVBUF on socket %" PRIdMAX ": %s", (intmax_t)s, tr_net_strerror(sockerrno).c_str());
         }
     }
 
@@ -367,7 +365,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
     {
-        tr_logAddError(
+        logwarn(
             _("Couldn't set source address %s on %" PRIdMAX ": %s"),
             tr_address_to_string(source_addr),
             (intmax_t)s,
@@ -386,7 +384,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
         if ((tmperrno != ENETUNREACH && tmperrno != EHOSTUNREACH) || addr->type == TR_AF_INET)
         {
-            tr_logAddError(
+            logwarn(
                 _("Couldn't connect socket %" PRIdMAX " to %s, port %d (errno %d - %s)"),
                 (intmax_t)s,
                 tr_address_to_string(addr),
@@ -402,12 +400,9 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
         ret = tr_peer_socket_tcp_create(s);
     }
 
-    if (tr_logGetDeepEnabled())
-    {
-        char addrstr[TR_ADDRSTRLEN];
-        tr_address_and_port_to_string(addrstr, sizeof(addrstr), addr, port);
-        tr_logAddDeep(__FILE__, __LINE__, nullptr, "New OUTGOING connection %" PRIdMAX " (%s)", (intmax_t)s, addrstr);
-    }
+    char addrstr[TR_ADDRSTRLEN];
+    tr_address_and_port_to_string(addrstr, sizeof(addrstr), addr, port);
+    logtrace("New OUTGOING connection %" PRIdMAX " (%s)", (intmax_t)s, addrstr);
 
     return ret;
 }
@@ -504,7 +499,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
             char const* const fmt = hint == nullptr ? _("Couldn't bind port %d on %s: %s") :
                                                       _("Couldn't bind port %d on %s: %s (%s)");
 
-            tr_logAddError(fmt, port, tr_address_to_string(addr), tr_net_strerror(err).c_str(), hint);
+            logerr(fmt, port, tr_address_to_string(addr), tr_net_strerror(err).c_str(), hint);
         }
 
         tr_netCloseSocket(fd);
@@ -514,7 +509,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
     if (!suppressMsgs)
     {
-        tr_logAddDebug("Bound socket %" PRIdMAX " to port %d on %s", (intmax_t)fd, port, tr_address_to_string(addr));
+        logdbg("Bound socket %" PRIdMAX " to port %d on %s", (intmax_t)fd, port, tr_address_to_string(addr));
     }
 
 #ifdef TCP_FASTOPEN

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -68,16 +68,21 @@ static size_t guessPacketOverhead(size_t d)
 ***
 **/
 
-#define dbgmsg(io, ...) \
+#define logimpl(io, level, ...) \
     do \
     { \
-        if (tr_logGetDeepEnabled()) \
+        if (tr_logLevelIsActive(level)) \
         { \
-            char addrstr[TR_ADDRSTRLEN]; \
-            tr_peerIoGetAddrStr(io, addrstr, sizeof(addrstr)); \
-            tr_logAddDeep(__FILE__, __LINE__, addrstr, __VA_ARGS__); \
+            auto name = std::array<char, TR_ADDRSTRLEN>{}; \
+            tr_peerIoGetAddrStr(io, std::data(name), std::size(name)); \
+            tr_logAddMessage(__FILE__, __LINE__, level, std::data(name), __VA_ARGS__); \
         } \
     } while (0)
+
+#define logerr(io, ...) logimpl(io, TR_LOG_ERROR, __VA_ARGS__)
+#define logwarn(io, ...) logimpl(io, TR_LOG_WARN, __VA_ARGS__)
+#define logdbg(io, ...) logimpl(io, TR_LOG_DEBUG, __VA_ARGS__)
+#define logtrace(io, ...) logimpl(io, TR_LOG_TRACE, __VA_ARGS__)
 
 /**
 ***
@@ -188,7 +193,7 @@ static void didWriteWrapper(tr_peerIo* io, unsigned int bytes_transferred)
 
 static void canReadWrapper(tr_peerIo* io)
 {
-    dbgmsg(io, "canRead");
+    logtrace(io, "canRead");
 
     tr_peerIoRef(io);
 
@@ -273,7 +278,7 @@ static void event_read_cb(evutil_socket_t fd, short /*event*/, void* vio)
     unsigned int howmuch = curlen >= max ? 0 : max - curlen;
     howmuch = io->bandwidth->clamp(TR_DOWN, howmuch);
 
-    dbgmsg(io, "libevent says this peer is ready to read");
+    logtrace(io, "libevent says this peer is ready to read");
 
     /* if we don't have any bandwidth left, stop reading */
     if (howmuch < 1)
@@ -312,7 +317,7 @@ static void event_read_cb(evutil_socket_t fd, short /*event*/, void* vio)
             what |= BEV_EVENT_ERROR;
         }
 
-        dbgmsg(io, "event_read_cb err: res:%d, what:%hd, errno:%d (%s)", res, what, e, tr_net_strerror(e).c_str());
+        logdbg(io, "event_read_cb err: res:%d, what:%hd, errno:%d (%s)", res, what, e, tr_net_strerror(e).c_str());
 
         if (io->gotError != nullptr)
         {
@@ -326,7 +331,7 @@ static int tr_evbuffer_write(tr_peerIo* io, int fd, size_t howmuch)
     EVUTIL_SET_SOCKET_ERROR(0);
     int const n = evbuffer_write_atmost(io->outbuf, fd, howmuch);
     int const e = EVUTIL_SOCKET_ERROR();
-    dbgmsg(io, "wrote %d to peer (%s)", n, (n == -1 ? tr_net_strerror(e).c_str() : ""));
+    logtrace(io, "wrote %d to peer (%s)", n, (n == -1 ? tr_net_strerror(e).c_str() : ""));
 
     return n;
 }
@@ -344,7 +349,7 @@ static void event_write_cb(evutil_socket_t fd, short /*event*/, void* vio)
 
     io->pendingEvents &= ~EV_WRITE;
 
-    dbgmsg(io, "libevent says this peer is ready to write");
+    logtrace(io, "libevent says this peer is ready to write");
 
     /* Write as much as possible, since the socket is non-blocking, write() will
      * return if it can't write any more data without blocking */
@@ -400,7 +405,7 @@ RESCHEDULE:
 
 FAIL:
     auto const errmsg = tr_net_strerror(e);
-    dbgmsg(io, "event_write_cb got an err. res:%d, what:%hd, errno:%d (%s)", res, what, e, errmsg.c_str());
+    logdbg(io, "event_write_cb got an err. res:%d, what:%hd, errno:%d (%s)", res, what, e, errmsg.c_str());
 
     if (io->gotError != nullptr)
     {
@@ -430,7 +435,7 @@ static void utp_on_read(void* vio, unsigned char const* buf, size_t buflen)
     TR_ASSERT(tr_isPeerIo(io));
 
     int rc = evbuffer_add(io->inbuf, buf, buflen);
-    dbgmsg(io, "utp_on_read got %zu bytes", buflen);
+    logtrace(io, "utp_on_read got %zu bytes", buflen);
 
     if (rc < 0)
     {
@@ -449,12 +454,12 @@ static void utp_on_write(void* vio, unsigned char* buf, size_t buflen)
     TR_ASSERT(tr_isPeerIo(io));
 
     int rc = evbuffer_remove(io->outbuf, buf, buflen);
-    dbgmsg(io, "utp_on_write sending %zu bytes... evbuffer_remove returned %d", buflen, rc);
+    logtrace(io, "utp_on_write sending %zu bytes... evbuffer_remove returned %d", buflen, rc);
     TR_ASSERT(rc == (int)buflen); /* if this fails, we've corrupted our bookkeeping somewhere */
 
     if (rc < (long)buflen)
     {
-        tr_logAddNamedError("UTP", "Short write: %d < %ld", rc, (long)buflen);
+        logwarn(io, "Short write: %d < %ld", rc, (long)buflen);
     }
 
     didWriteWrapper(io, buflen);
@@ -468,7 +473,7 @@ static size_t utp_get_rb_size(void* vio)
 
     size_t bytes = io->bandwidth->clamp(TR_DOWN, UTP_READ_BUFFER_SIZE);
 
-    dbgmsg(io, "utp_get_rb_size is saying it's ready to read %zu bytes", bytes);
+    logtrace(io, "utp_get_rb_size is saying it's ready to read %zu bytes", bytes);
     return UTP_READ_BUFFER_SIZE - bytes;
 }
 
@@ -476,7 +481,7 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch);
 
 static void utp_on_writable(tr_peerIo* io)
 {
-    dbgmsg(io, "libutp says this peer is ready to write");
+    logtrace(io, "libutp says this peer is ready to write");
 
     int const n = tr_peerIoTryWrite(io, SIZE_MAX);
     tr_peerIoSetEnabled(io, TR_UP, n != 0 && evbuffer_get_length(io->outbuf) != 0);
@@ -490,12 +495,12 @@ static void utp_on_state_change(void* vio, int state)
 
     if (state == UTP_STATE_CONNECT)
     {
-        dbgmsg(io, "utp_on_state_change -- changed to connected");
+        logdbg(io, "utp_on_state_change -- changed to connected");
         io->utpSupported = true;
     }
     else if (state == UTP_STATE_WRITABLE)
     {
-        dbgmsg(io, "utp_on_state_change -- changed to writable");
+        logdbg(io, "utp_on_state_change -- changed to writable");
 
         if ((io->pendingEvents & EV_WRITE) != 0)
         {
@@ -511,12 +516,12 @@ static void utp_on_state_change(void* vio, int state)
     }
     else if (state == UTP_STATE_DESTROYING)
     {
-        tr_logAddNamedError("UTP", "Impossible state UTP_STATE_DESTROYING");
+        logerr(io, "Impossible state UTP_STATE_DESTROYING");
         return;
     }
     else
     {
-        tr_logAddNamedError("UTP", "Unknown state %d", state);
+        logerr(io, "Unknown state %d", state);
     }
 }
 
@@ -526,7 +531,7 @@ static void utp_on_error(void* vio, int errcode)
 
     TR_ASSERT(tr_isPeerIo(io));
 
-    dbgmsg(io, "utp_on_error -- errcode is %d", errcode);
+    logdbg(io, "utp_on_error -- errcode is %d", errcode);
 
     if (io->gotError != nullptr)
     {
@@ -541,7 +546,7 @@ static void utp_on_overhead(void* vio, bool send, size_t count, int /*type*/)
 
     TR_ASSERT(tr_isPeerIo(io));
 
-    dbgmsg(io, "utp_on_overhead -- count is %zu", count);
+    logtrace(io, "utp_on_overhead -- count is %zu", count);
 
     io->bandwidth->notifyBandwidthConsumed(send ? TR_UP : TR_DOWN, count, false, tr_time_msec());
 }
@@ -622,12 +627,12 @@ static tr_peerIo* tr_peerIoNew(
     io->socket = socket;
     io->bandwidth = new Bandwidth(parent);
     io->bandwidth->setPeer(io);
-    dbgmsg(io, "bandwidth is %p; its parent is %p", (void*)&io->bandwidth, (void*)parent);
+    logtrace(io, "bandwidth is %p; its parent is %p", (void*)&io->bandwidth, (void*)parent);
 
     switch (socket.type)
     {
     case TR_PEER_SOCKET_TYPE_TCP:
-        dbgmsg(io, "socket (tcp) is %" PRIdMAX, (intmax_t)socket.handle.tcp);
+        logtrace(io, "socket (tcp) is %" PRIdMAX, (intmax_t)socket.handle.tcp);
         io->event_read = event_new(session->event_base, socket.handle.tcp, EV_READ, event_read_cb, io);
         io->event_write = event_new(session->event_base, socket.handle.tcp, EV_WRITE, event_write_cb, io);
         break;
@@ -635,14 +640,14 @@ static tr_peerIo* tr_peerIoNew(
 #ifdef WITH_UTP
 
     case TR_PEER_SOCKET_TYPE_UTP:
-        dbgmsg(io, "socket (utp) is %p", (void*)socket.handle.utp);
+        logtrace(io, "socket (utp) is %p", (void*)socket.handle.utp);
         UTP_SetSockopt(socket.handle.utp, SO_RCVBUF, UTP_READ_BUFFER_SIZE);
-        dbgmsg(io, "%s", "calling UTP_SetCallbacks &utp_function_table");
+        logtrace(io, "%s", "calling UTP_SetCallbacks &utp_function_table");
         UTP_SetCallbacks(socket.handle.utp, &utp_function_table, io);
 
         if (!is_incoming)
         {
-            dbgmsg(io, "%s", "calling UTP_Connect");
+            logtrace(io, "%s", "calling UTP_Connect");
             UTP_Connect(socket.handle.utp);
         }
 
@@ -694,7 +699,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
     if (socket.type == TR_PEER_SOCKET_TYPE_NONE)
     {
         socket = tr_netOpenPeerSocket(session, addr, port, is_seed);
-        dbgmsg(
+        logdbg(
             nullptr,
             "tr_netOpenPeerSocket returned fd %" PRIdMAX,
             (intmax_t)(socket.type != TR_PEER_SOCKET_TYPE_NONE ? socket.handle.tcp : TR_BAD_SOCKET));
@@ -728,7 +733,7 @@ static void event_enable(tr_peerIo* io, short event)
 
     if ((event & EV_READ) != 0 && (io->pendingEvents & EV_READ) == 0)
     {
-        dbgmsg(io, "enabling ready-to-read polling");
+        logtrace(io, "enabling ready-to-read polling");
 
         if (need_events)
         {
@@ -740,7 +745,7 @@ static void event_enable(tr_peerIo* io, short event)
 
     if ((event & EV_WRITE) != 0 && (io->pendingEvents & EV_WRITE) == 0)
     {
-        dbgmsg(io, "enabling ready-to-write polling");
+        logtrace(io, "enabling ready-to-write polling");
 
         if (need_events)
         {
@@ -767,7 +772,7 @@ static void event_disable(tr_peerIo* io, short event)
 
     if ((event & EV_READ) != 0 && (io->pendingEvents & EV_READ) != 0)
     {
-        dbgmsg(io, "disabling ready-to-read polling");
+        logtrace(io, "disabling ready-to-read polling");
 
         if (need_events)
         {
@@ -779,7 +784,7 @@ static void event_disable(tr_peerIo* io, short event)
 
     if ((event & EV_WRITE) != 0 && (io->pendingEvents & EV_WRITE) != 0)
     {
-        dbgmsg(io, "disabling ready-to-write polling");
+        logtrace(io, "disabling ready-to-write polling");
 
         if (need_events)
         {
@@ -834,7 +839,7 @@ static void io_close_socket(tr_peerIo* io)
 #endif
 
     default:
-        dbgmsg(io, "unsupported peer socket type %d", io->socket.type);
+        logdbg(io, "unsupported peer socket type %d", io->socket.type);
     }
 
     io->socket = {};
@@ -858,7 +863,7 @@ static void io_dtor(tr_peerIo* const io)
     TR_ASSERT(tr_amInEventThread(io->session));
     TR_ASSERT(io->session->events != nullptr);
 
-    dbgmsg(io, "in tr_peerIo destructor");
+    logdbg(io, "in tr_peerIo destructor");
     event_disable(io, EV_READ | EV_WRITE);
     delete io->bandwidth;
     io_close_socket(io);
@@ -876,7 +881,7 @@ static void tr_peerIoFree(tr_peerIo* io)
 {
     if (io != nullptr)
     {
-        dbgmsg(io, "in tr_peerIoFree");
+        logdbg(io, "in tr_peerIoFree");
         io->canRead = nullptr;
         io->didWrite = nullptr;
         io->gotError = nullptr;
@@ -888,7 +893,7 @@ void tr_peerIoRefImpl(char const* file, int line, tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
-    dbgmsg(io, "%s:%d is incrementing the IO's refcount from %d to %d", file, line, io->refCount, io->refCount + 1);
+    logtrace(io, "%s:%d is incrementing the IO's refcount from %d to %d", file, line, io->refCount, io->refCount + 1);
 
     ++io->refCount;
 }
@@ -897,7 +902,7 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
 
-    dbgmsg(io, "%s:%d is decrementing the IO's refcount from %d to %d", file, line, io->refCount, io->refCount - 1);
+    logtrace(io, "%s:%d is decrementing the IO's refcount from %d to %d", file, line, io->refCount, io->refCount - 1);
 
     if (--io->refCount == 0)
     {
@@ -1248,7 +1253,7 @@ static int tr_peerIoTryRead(tr_peerIo* io, size_t howmuch)
             res = evbuffer_read(io->inbuf, io->socket.handle.tcp, (int)howmuch);
             int const e = EVUTIL_SOCKET_ERROR();
 
-            dbgmsg(io, "read %d from peer (%s)", res, res == -1 ? tr_net_strerror(e).c_str() : "");
+            logtrace(io, "read %d from peer (%s)", res, res == -1 ? tr_net_strerror(e).c_str() : "");
 
             if (evbuffer_get_length(io->inbuf) != 0)
             {
@@ -1264,7 +1269,7 @@ static int tr_peerIoTryRead(tr_peerIo* io, size_t howmuch)
                     what |= BEV_EVENT_EOF;
                 }
 
-                dbgmsg(io, "tr_peerIoTryRead err: res:%d what:%hd, errno:%d (%s)", res, what, e, tr_net_strerror(e).c_str());
+                logtrace(io, "tr_peerIoTryRead err: res:%d what:%hd, errno:%d (%s)", res, what, e, tr_net_strerror(e).c_str());
 
                 io->gotError(io, what, io->userData);
             }
@@ -1273,7 +1278,7 @@ static int tr_peerIoTryRead(tr_peerIo* io, size_t howmuch)
         }
 
     default:
-        dbgmsg(io, "unsupported peer socket type %d", io->socket.type);
+        logdbg(io, "unsupported peer socket type %d", io->socket.type);
     }
 
     return res;
@@ -1283,7 +1288,7 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch)
 {
     auto const old_len = size_t{ evbuffer_get_length(io->outbuf) };
 
-    dbgmsg(io, "in tr_peerIoTryWrite %zu", howmuch);
+    logtrace(io, "in tr_peerIoTryWrite %zu", howmuch);
     howmuch = std::min(howmuch, old_len);
     howmuch = io->bandwidth->clamp(TR_UP, howmuch);
     if (howmuch == 0)
@@ -1314,7 +1319,7 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch)
             {
                 short const what = BEV_EVENT_WRITING | BEV_EVENT_ERROR;
 
-                dbgmsg(io, "tr_peerIoTryWrite err: res:%d, what:%hd, errno:%d (%s)", n, what, e, tr_net_strerror(e).c_str());
+                logtrace(io, "tr_peerIoTryWrite err: res:%d, what:%hd, errno:%d (%s)", n, what, e, tr_net_strerror(e).c_str());
                 io->gotError(io, what, io->userData);
             }
 
@@ -1322,7 +1327,7 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch)
         }
 
     default:
-        dbgmsg(io, "unsupported peer socket type %d", io->socket.type);
+        logdbg(io, "unsupported peer socket type %d", io->socket.type);
     }
 
     return n;
@@ -1334,7 +1339,7 @@ int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t limit)
     TR_ASSERT(tr_isDirection(dir));
 
     int const bytes_used = dir == TR_DOWN ? tr_peerIoTryRead(io, limit) : tr_peerIoTryWrite(io, limit);
-    dbgmsg(io, "flushing peer-io, direction:%d, limit:%zu, byte_used:%d", (int)dir, limit, bytes_used);
+    logtrace(io, "flushing peer-io, direction:%d, limit:%zu, byte_used:%d", (int)dir, limit, bytes_used);
     return bytes_used;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -46,11 +46,7 @@ static auto constexpr RecentlyActiveSeconds = time_t{ 60 };
 
 using namespace std::literals;
 
-#if 0
-#define dbgmsg(fmt, ...) fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, __VA_ARGS__)
-#else
-#define dbgmsg(...) tr_logAddDeepNamed("RPC", __VA_ARGS__)
-#endif
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "rpc", __VA_ARGS__)
 
 enum class TrFormat
 {
@@ -1518,7 +1514,7 @@ static void onMetadataFetched(tr_web::FetchResponse const& web_response)
     auto const& [status, body, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
-    dbgmsg(
+    logtrace(
         "torrentAdd: HTTP response code was %ld (%s); response length was %zu bytes",
         status,
         tr_webGetResponseStr(status),
@@ -1660,7 +1656,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         tr_ctorSetLabels(ctor, std::move(labels));
     }
 
-    dbgmsg("torrentAdd: filename is \"%" TR_PRIsv "\"", TR_PRIsv_ARG(filename));
+    logtrace("torrentAdd: filename is \"%" TR_PRIsv "\"", TR_PRIsv_ARG(filename));
 
     if (isCurlURL(filename))
     {

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -93,13 +93,7 @@ static void saveCumulativeStats(tr_session const* session, tr_session_stats cons
     tr_variantDictAddInt(&top, TR_KEY_session_count, s->sessionCount);
     tr_variantDictAddInt(&top, TR_KEY_uploaded_bytes, s->uploadedBytes);
 
-    auto const filename = getFilename(session);
-    if (tr_logGetDeepEnabled())
-    {
-        tr_logAddDeep(__FILE__, __LINE__, nullptr, "Saving stats to \"%s\"", filename.c_str());
-    }
-
-    tr_variantToFile(&top, TR_VARIANT_FMT_JSON, filename);
+    tr_variantToFile(&top, TR_VARIANT_FMT_JSON, getFilename(session));
 
     tr_variantFree(&top);
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -29,7 +29,7 @@
 
 using namespace std::literals;
 
-#define dbgmsg(tor, ...) tr_logAddDeepNamed(tr_torrentName(tor), __VA_ARGS__)
+#define logdbg(tor, ...) tr_logAddNamed(TR_LOG_DEBUG, tr_torrentName(tor), __VA_ARGS__)
 
 /***
 ****
@@ -76,7 +76,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
 
     int const n = (size <= 0 || size > INT_MAX) ? -1 : size / METADATA_PIECE_SIZE + (size % METADATA_PIECE_SIZE != 0 ? 1 : 0);
 
-    dbgmsg(tor, "metadata is %" PRId64 " bytes in %d pieces", size, n);
+    logdbg(tor, "metadata is %" PRId64 " bytes in %d pieces", size, n);
 
     if (n <= 0)
     {
@@ -311,7 +311,7 @@ static void onHaveAllMetainfo(tr_torrent* tor, tr_incomplete_metadata* m)
 
         m->piecesNeededCount = n;
         char const* const msg = error != nullptr && error->message != nullptr ? error->message : "unknown error";
-        dbgmsg(tor, "metadata error: %s. (trying again; %d pieces left)", msg, n);
+        logdbg(tor, "metadata error: %s. (trying again; %d pieces left)", msg, n);
         tr_error_clear(&error);
     }
 }
@@ -322,7 +322,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
     TR_ASSERT(data != nullptr);
     TR_ASSERT(len >= 0);
 
-    dbgmsg(tor, "got metadata piece %d of %d bytes", piece, len);
+    logdbg(tor, "got metadata piece %d of %d bytes", piece, len);
 
     // are we set up to download metadata?
     tr_incomplete_metadata* const m = tor->incompleteMetadata;
@@ -356,12 +356,12 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, in
     tr_removeElementFromArray(m->piecesNeeded, idx, sizeof(struct metadata_node), m->piecesNeededCount);
     --m->piecesNeededCount;
 
-    dbgmsg(tor, "saving metainfo piece %d... %d remain", piece, m->piecesNeededCount);
+    logdbg(tor, "saving metainfo piece %d... %d remain", piece, m->piecesNeededCount);
 
     /* are we done? */
     if (m->piecesNeededCount == 0)
     {
-        dbgmsg(tor, "metainfo piece %d was the last one", piece);
+        logdbg(tor, "metainfo piece %d was the last one", piece);
         onHaveAllMetainfo(tor, m);
     }
 }
@@ -382,7 +382,7 @@ bool tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now, int* setme_pi
         m->piecesNeeded[i].piece = piece;
         m->piecesNeeded[i].requestedAt = now;
 
-        dbgmsg(tor, "next piece to request: %d", piece);
+        logdbg(tor, "next piece to request: %d", piece);
         *setme_piece = piece;
         have_request = true;
     }

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -17,28 +17,24 @@
 #include "tr-utp.h"
 #include "utils.h"
 
+#define logwarn(...) tr_logAddNamed(TR_LOG_WARN, "utp", __VA_ARGS__)
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "utp", __VA_ARGS__)
+
 #ifndef WITH_UTP
-
-static char constexpr MyName[] = "UTP";
-
-#define dbgmsg(...) tr_logAddDeepNamed(MyName, __VA_ARGS__)
 
 void UTP_Close(struct UTPSocket* socket)
 {
-    tr_logAddNamedError(MyName, "UTP_Close(%p) was called.", socket);
-    dbgmsg("UTP_Close(%p) was called.", socket);
+    logtrace("UTP_Close(%p) was called.", socket);
 }
 
 void UTP_RBDrained(struct UTPSocket* socket)
 {
-    tr_logAddNamedError(MyName, "UTP_RBDrained(%p) was called.", socket);
-    dbgmsg("UTP_RBDrained(%p) was called.", socket);
+    logtrace("UTP_RBDrained(%p) was called.", socket);
 }
 
 bool UTP_Write(struct UTPSocket* socket, size_t count)
 {
-    tr_logAddNamedError(MyName, "UTP_RBDrained(%p, %zu) was called.", socket, count);
-    dbgmsg("UTP_RBDrained(%p, %zu) was called.", socket, count);
+    logtrace("UTP_RBDrained(%p, %zu) was called.", socket, count);
     return false;
 }
 
@@ -99,7 +95,7 @@ static void incoming(void* vsession, struct UTPSocket* s)
 
     if (!tr_address_from_sockaddr_storage(&addr, &port, &from_storage))
     {
-        tr_logAddNamedError("UTP", "Unknown socket family");
+        logwarn("Unknown socket family");
         UTP_Close(s);
         return;
     }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -744,11 +744,29 @@ bool tr_sessionIsScriptEnabled(tr_session const*, TrScript);
 
 enum tr_log_level
 {
-    TR_LOG_SILENT = 0,
-    TR_LOG_ERROR = 1,
-    TR_LOG_INFO = 2,
-    TR_LOG_DEBUG = 3,
-    TR_LOG_FIREHOSE = 4
+    // No logging at all
+    TR_LOG_OFF,
+
+    // Errors that prevent Transmission from running
+    TR_LOG_CRITICAL,
+
+    // Errors that could prevent a single torrent from running, e.g. missing
+    // files or a private torrent's tracker responding "unregistered torrent"
+    TR_LOG_ERROR,
+
+    // Smaller errors that don't stop the overall system,
+    // e.g. unable to preallocate a file, or unable to connect to a tracker
+    // when other trackers are available
+    TR_LOG_WARN,
+
+    // User-visible info, e.g. "torrent completed" or "running script"
+    TR_LOG_INFO,
+
+    // Debug messages
+    TR_LOG_DEBUG,
+
+    // High-volume debug messages, e.g. tracing peer protocol messages
+    TR_LOG_TRACE
 };
 
 void tr_logSetLevel(tr_log_level);

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -29,6 +29,8 @@
 #include "trevent.h"
 #include "utils.h"
 
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "trevent", __VA_ARGS__)
+
 /***
 ****
 ***/
@@ -211,7 +213,7 @@ static void libeventThreadFunc(tr_event_handle* events)
     events->session->evdns_base = nullptr;
     events->session->events = nullptr;
     delete events;
-    tr_logAddDebug("Closing libevent thread");
+    logtrace("Closing libevent thread");
 }
 
 void tr_eventInit(tr_session* session)
@@ -241,10 +243,7 @@ void tr_eventClose(tr_session* session)
 
     event_base_loopexit(events->base, nullptr);
 
-    if (tr_logGetDeepEnabled())
-    {
-        tr_logAddDeep(__FILE__, __LINE__, nullptr, "closing trevent pipe");
-    }
+    logtrace("closing trevent pipe");
 }
 
 /**

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -51,6 +51,8 @@
 
 using namespace std::literals;
 
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, nullptr, __VA_ARGS__)
+
 time_t __tr_current_time = 0;
 
 /***
@@ -362,7 +364,7 @@ bool tr_saveFile(std::string const& filename, std::string_view contents, tr_erro
         return false;
     }
 
-    tr_logAddInfo(_("Saved \"%s\""), filename.c_str());
+    logtrace("Saved \"%s\"", filename.c_str());
     return true;
 }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -34,7 +34,8 @@ using namespace std::literals;
 #define USE_LIBCURL_SOCKOPT
 #endif
 
-#define dbgmsg(...) tr_logAddDeepNamed("web", __VA_ARGS__)
+#define loginfo(...) tr_logAddNamed(TR_LOG_INFO, "web", __VA_ARGS__)
+#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "web", __VA_ARGS__)
 
 /***
 ****
@@ -118,9 +119,9 @@ public:
         if (curl_ssl_verify)
         {
             auto const* bundle = std::empty(curl_ca_bundle) ? "none" : curl_ca_bundle.c_str();
-            tr_logAddNamedInfo("web", "will verify tracker certs using envvar CURL_CA_BUNDLE: %s", bundle);
-            tr_logAddNamedInfo("web", "NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
-            tr_logAddNamedInfo("web", "NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors");
+            loginfo("will verify tracker certs using envvar CURL_CA_BUNDLE: %s", bundle);
+            loginfo("NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
+            loginfo("NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors");
         }
 
         if (auto const& file = mediator.cookieFile(); file)
@@ -290,7 +291,7 @@ private:
         }
 
         evbuffer_add(task->body(), data, bytes_used);
-        dbgmsg("wrote %zu bytes to task %p's buffer", bytes_used, (void*)task);
+        logtrace("wrote %zu bytes to task %p's buffer", bytes_used, (void*)task);
         return bytes_used;
     }
 
@@ -456,7 +457,7 @@ private:
                 // add queued tasks
                 for (auto* task : impl->queued_tasks)
                 {
-                    dbgmsg("adding task to curl: [%s]", task->url().c_str());
+                    logtrace("adding task to curl: [%s]", task->url().c_str());
                     initEasy(impl, task);
                     curl_multi_add_handle(multi.get(), task->easy());
                 }

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -21,6 +21,8 @@ using AnnouncerTest = ::testing::Test;
 
 using namespace std::literals;
 
+static char const* const LogName = "LogName";
+
 TEST_F(AnnouncerTest, parseHttpAnnounceResponseNoPeers)
 {
     // clang-format off
@@ -37,7 +39,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponseNoPeers)
     // clang-format on
 
     auto response = tr_announce_response{};
-    tr_announcerParseHttpAnnounceResponse(response, NoPeers);
+    tr_announcerParseHttpAnnounceResponse(response, NoPeers, LogName);
     EXPECT_EQ(1803, response.interval);
     EXPECT_EQ(1800, response.min_interval);
     EXPECT_EQ(3, response.seeders);
@@ -66,7 +68,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexCompact)
     // clang-format on
 
     auto response = tr_announce_response{};
-    tr_announcerParseHttpAnnounceResponse(response, IPv4Peers);
+    tr_announcerParseHttpAnnounceResponse(response, IPv4Peers, LogName);
     EXPECT_EQ(1803, response.interval);
     EXPECT_EQ(1800, response.min_interval);
     EXPECT_EQ(3, response.seeders);
@@ -105,7 +107,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexList)
     // clang-format on
 
     auto response = tr_announce_response{};
-    tr_announcerParseHttpAnnounceResponse(response, IPv4Peers);
+    tr_announcerParseHttpAnnounceResponse(response, IPv4Peers, LogName);
     EXPECT_EQ(1803, response.interval);
     EXPECT_EQ(1800, response.min_interval);
     EXPECT_EQ(3, response.seeders);
@@ -138,7 +140,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponseFailureReason)
     // clang-format on
 
     auto response = tr_announce_response{};
-    tr_announcerParseHttpAnnounceResponse(response, NoPeers);
+    tr_announcerParseHttpAnnounceResponse(response, NoPeers, LogName);
     EXPECT_EQ(1803, response.interval);
     EXPECT_EQ(1800, response.min_interval);
     EXPECT_EQ(3, response.seeders);
@@ -186,7 +188,7 @@ TEST_F(AnnouncerTest, parseHttpScrapeResponseMulti)
     std::fill_n(std::data(response.rows[1].info_hash), std::size(response.rows[1].info_hash), std::byte{ 'b' });
     std::fill_n(std::data(response.rows[2].info_hash), std::size(response.rows[2].info_hash), std::byte{ 'c' });
     response.row_count = 3;
-    tr_announcerParseHttpScrapeResponse(response, ResponseBenc);
+    tr_announcerParseHttpScrapeResponse(response, ResponseBenc, LogName);
 
     EXPECT_EQ(1, response.rows[0].seeders);
     EXPECT_EQ(2, response.rows[0].leechers);
@@ -244,7 +246,7 @@ TEST_F(AnnouncerTest, parseHttpScrapeResponseMultiWithUnexpected)
     std::fill_n(std::data(response.rows[1].info_hash), std::size(response.rows[1].info_hash), std::byte{ 'b' });
     std::fill_n(std::data(response.rows[2].info_hash), std::size(response.rows[2].info_hash), std::byte{ 'c' });
     response.row_count = 3;
-    tr_announcerParseHttpScrapeResponse(response, ResponseBenc);
+    tr_announcerParseHttpScrapeResponse(response, ResponseBenc, LogName);
 
     EXPECT_EQ(1, response.rows[0].seeders);
     EXPECT_EQ(2, response.rows[0].leechers);
@@ -288,7 +290,7 @@ TEST_F(AnnouncerTest, parseHttpScrapeResponseMultiWithMissing)
     std::fill_n(std::data(response.rows[1].info_hash), std::size(response.rows[1].info_hash), std::byte{ 'b' });
     std::fill_n(std::data(response.rows[2].info_hash), std::size(response.rows[2].info_hash), std::byte{ 'c' });
     response.row_count = 3;
-    tr_announcerParseHttpScrapeResponse(response, ResponseBenc);
+    tr_announcerParseHttpScrapeResponse(response, ResponseBenc, LogName);
 
     EXPECT_EQ(1, response.rows[0].seeders);
     EXPECT_EQ(2, response.rows[0].leechers);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -75,7 +75,7 @@ TEST_F(TorrentMetainfoTest, bucket)
         { "", false },
     } };
 
-    tr_logSetLevel(TR_LOG_SILENT);
+    tr_logSetLevel(TR_LOG_OFF);
 
     for (auto const& test : tests)
     {


### PR DESCRIPTION
Part 1 of a series to update Transmission's logging mechanism. There is also an [active PR](https://github.com/transmission/transmission/pull/2744) to move to the [fmt library](https://fmt.dev) but it is so sprawling that I'd like to break the pieces out into standalone PRs like this.

Goals of the series:
- [x] Simplify the code (e.g. unify the logging and "deep logging" mechanisms) (this PR)
- [ ] Reduce the volume of logging output, e.g. by demoting recoverable errors down to warnings, or demoting high-volume debug messages down to trace messages.
- [ ] Introduce a cutoff mechanism for repetitive warnings. For example if IPv6 is disabled on your system and the first 20 error messages of "couldn't create IPv6 socket" didn't help, the remaining aren't going to help either.
- [x] Don't log messages that are beneath the current logging threshold. The current behavior is to record them but not show them, in case a user changes the log level in the GUI so that they can be shown. This edge case is not worth the high overhead. If you need verbose logging of startup, just change your settings and then restart the app. (this PR)
- [ ] Ensure that all warning, error, and info messages are flagged for i18n.
- [ ] Consider using [fmt](https://fmt.dev/) for type-safe string building (probably)
- [ ] Consider using [spdlog](https://github.com/gabime/spdlog) for logging (maybe)

---

This PR tackles the first item in the list by using `TR_LOG_TRACE` (formerly `TR_LOG_FIREHOSE`) for high-frequency log messages, using the same mechanism for these messages as all the others, and removes the "Deep Logging" mechanism.

Then it skips ahead in the list to the fourth item, not logging messages that are beneath the current log level. This needs to be in the same PR in order to prevent unifying logging + deep logging from causing all those high-frequency messages from eating up memory in the logging queue.

As a side-effect of removing deep logging, some parts of the codebase have been cleaned up for step two as well (e.g. demoting some failures from errors down to warnings and some debug messages down to trace messages). However that's not the main focus of this PR and there's still work to be done, so stays unchecked on the TODO.