### PR TITLE
fix: memory corruption in RPC when fetching torrent piece info

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -676,7 +676,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         {
             auto const bytes = tor->createPieceBitfield();
             auto const enc = tr_base64_encode({ reinterpret_cast<char const*>(std::data(bytes)), std::size(bytes) });
-            tr_variantInitStrView(initme, enc);
+            tr_variantInitStr(initme, enc);
         }
         else
         {


### PR DESCRIPTION
Thanks to MatanZ for finding and tracking down this problem

Fixes #2757.