### PR TITLE
refactor: fmt part 2

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -346,7 +346,12 @@ void register_magnet_link_handler()
     }
     catch (Gio::Error const& e)
     {
-        g_warning(_("Error registering Transmission as a %s handler: %s"), content_type.c_str(), e.what().c_str());
+        auto const msg = fmt::format(
+            _("Couldn't register Transmission as a {content_type} handler: {errmsg} ({errcode})"),
+            fmt::arg("content_type", content_type),
+            fmt::arg("errmsg", e.what().raw()),
+            fmt::arg("errcode", e.code()));
+        g_warning("%s", msg.c_str());
     }
 }
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -14,6 +14,8 @@
 #include <locale.h>
 #include <signal.h>
 
+#include <fmt/core.h>
+
 #include <giomm.h>
 #include <glib/gmessages.h>
 #include <glibmm/i18n.h>
@@ -889,7 +891,7 @@ void Application::Impl::on_app_exit()
     p->attach(*icon, 0, 0, 1, 2);
 
     auto* top_label = Gtk::make_managed<Gtk::Label>();
-    top_label->set_markup(_("<b>Closing Connections</b>"));
+    top_label->set_markup(fmt::format("<b>{}</b>", _("Closing Connections…")));
     top_label->set_halign(Gtk::ALIGN_START);
     top_label->set_valign(Gtk::ALIGN_CENTER);
     p->attach(*top_label, 1, 0, 1, 1);

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -11,6 +11,8 @@
 #include <glibmm.h>
 #include <glibmm/i18n.h>
 
+#include <fmt/core.h>
+
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 
@@ -741,7 +743,12 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
     {
         Gtk::MessageDialog w(
             *static_cast<Gtk::Window*>(widget_.get_toplevel()),
-            gtr_sprintf(_("Unable to rename file as \"%s\": %s"), newname, tr_strerror(error)),
+            fmt::format(
+                _("Couldn't rename '{oldpath}' as '{path}': {errmsg} ({errcode})"),
+                fmt::arg("oldpath", path_string.raw()),
+                fmt::arg("path", newname.raw()),
+                fmt::arg("errmsg", tr_strerror(error)),
+                fmt::arg("errcode", error)),
             false,
             Gtk::MESSAGE_ERROR,
             Gtk::BUTTONS_CLOSE,

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -478,7 +478,7 @@ MakeDialog::Impl::Impl(MakeDialog& dialog, Glib::RefPtr<Session> const& core)
     t->add_row_w(row, *file_radio_, *file_chooser_);
 
     pieces_lb_ = Gtk::make_managed<Gtk::Label>();
-    pieces_lb_->set_markup(_("<i>No source selected</i>"));
+    pieces_lb_->set_markup(fmt::format("<i>{}</i>", _("No source selected")));
     t->add_row(row, {}, *pieces_lb_);
 
     t->add_section_divider(row);

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -7,7 +7,9 @@
 #include <string>
 
 #include <glibmm.h>
-#include <glibmm/i18n.h>
+#include <glibmm/i18n.h>a
+
+#include <fmt/base.h>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/makemeta.h>
@@ -121,7 +123,7 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     }
     else if (builder_.result == TrMakemetaResult::ERR_URL)
     {
-        str = gtr_sprintf(_("Error: invalid announce URL \"%s\""), builder_.errfile);
+        str = fmt::format(_("Unsupported URL: {url}"), fmt::arg("url", builder_.errfile));
     }
     else if (builder_.result == TrMakemetaResult::ERR_IO_READ)
     {

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -156,7 +156,9 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     else
     {
         /* how much data we've scanned through to generate checksums */
-        str = gtr_sprintf(_("Scanned %s"), tr_strlsize((uint64_t)builder_.pieceIndex * (uint64_t)builder_.pieceSize));
+        str = fmt::format(
+            _("Scanned {file_size}"),
+            fmt::arg("file_size", tr_strlsize((uint64_t)builder_.pieceIndex * (uint64_t)builder_.pieceSize)));
     }
 
     progress_bar_->set_fraction(fraction);

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -158,7 +158,7 @@ bool MakeProgressDialog::onProgressDialogRefresh()
         /* how much data we've scanned through to generate checksums */
         str = fmt::format(
             _("Scanned {file_size}"),
-            fmt::arg("file_size", tr_strlsize((uint64_t)builder_.pieceIndex * (uint64_t)builder_.pieceSize)));
+            fmt::arg("file_size", tr_strlsize((uint64_t)builder_.pieceIndex * (uint64_t)builder_.pieceSize).raw()));
     }
 
     progress_bar_->set_fraction(fraction);

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -7,9 +7,9 @@
 #include <string>
 
 #include <glibmm.h>
-#include <glibmm/i18n.h>a
+#include <glibmm/i18n.h>
 
-#include <fmt/base.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/makemeta.h>

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -127,11 +127,19 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     }
     else if (builder_.result == TrMakemetaResult::ERR_IO_READ)
     {
-        str = gtr_sprintf(_("Error reading \"%s\": %s"), builder_.errfile, Glib::strerror(builder_.my_errno));
+        str = fmt::format(
+            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            fmt::arg("path", builder_.errfile),
+            fmt::arg("errmsg", Glib::strerror(builder_.my_errno).raw()),
+            fmt::arg("errcode", builder_.my_errno));
     }
     else if (builder_.result == TrMakemetaResult::ERR_IO_WRITE)
     {
-        str = gtr_sprintf(_("Error writing \"%s\": %s"), builder_.errfile, Glib::strerror(builder_.my_errno));
+        str = fmt::format(
+            _("Couldn't save '{path}': {errmsg} ({errcode})"),
+            fmt::arg("path", builder_.errfile),
+            fmt::arg("errmsg", Glib::strerror(builder_.my_errno).raw()),
+            fmt::arg("errcode", builder_.my_errno));
     }
     else
     {

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -841,19 +841,30 @@ Gtk::ComboBox* new_time_combo(Glib::RefPtr<Session> const& core, tr_quark const 
     return w;
 }
 
+static auto get_weekday_string(Glib::Date::Weekday weekday)
+{
+    auto date = Glib::Date{};
+    date.set_time_current();
+    while (date.get_weekday() != weekday)
+    {
+        date.add_days(1);
+    }
+    return date.format_string("%A");
+}
+
 Gtk::ComboBox* new_week_combo(Glib::RefPtr<Session> const& core, tr_quark const key)
 {
     auto* w = gtr_combo_box_new_enum({
         { _("Every Day"), TR_SCHED_ALL },
         { _("Weekdays"), TR_SCHED_WEEKDAY },
         { _("Weekends"), TR_SCHED_WEEKEND },
-        { _("Sunday"), TR_SCHED_SUN },
-        { _("Monday"), TR_SCHED_MON },
-        { _("Tuesday"), TR_SCHED_TUES },
-        { _("Wednesday"), TR_SCHED_WED },
-        { _("Thursday"), TR_SCHED_THURS },
-        { _("Friday"), TR_SCHED_FRI },
-        { _("Saturday"), TR_SCHED_SAT },
+        { get_weekday_string(Glib::Date::MONDAY), TR_SCHED_MON },
+        { get_weekday_string(Glib::Date::TUESDAY), TR_SCHED_TUES },
+        { get_weekday_string(Glib::Date::WEDNESDAY), TR_SCHED_WED },
+        { get_weekday_string(Glib::Date::THURSDAY), TR_SCHED_THURS },
+        { get_weekday_string(Glib::Date::FRIDAY), TR_SCHED_FRI },
+        { get_weekday_string(Glib::Date::SATURDAY), TR_SCHED_SAT },
+        { get_weekday_string(Glib::Date::SUNDAY), TR_SCHED_SUN },
     });
     gtr_combo_box_set_active_enum(*w, gtr_pref_int_get(key));
     w->signal_changed().connect([w, key, core]() { onIntComboChanged(w, key, core); });

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -444,7 +444,9 @@ void onBlocklistUpdated(Glib::RefPtr<Session> const& core, int n, blocklist_data
         ngettext("Blocklist has {count} entry", "Blocklist has {count} entries", count),
         fmt::arg("count", count));
     data->updateBlocklistButton->set_sensitive(true);
-    data->updateBlocklistDialog->set_message(success ? _("<b>Update succeeded!</b>") : _("<b>Unable to update.</b>"), true);
+    data->updateBlocklistDialog->set_message(
+        fmt::format("<b>{}</b>", success ? _("Blocklist updated!") : _("Couldn't update blocklist")),
+        true);
     data->updateBlocklistDialog->set_secondary_text(msg);
     updateBlocklistText(data->label, core);
 }
@@ -1016,7 +1018,7 @@ void onPortTest(std::shared_ptr<network_page_data> const& data)
 {
     data->portButton->set_sensitive(false);
     data->portSpin->set_sensitive(false);
-    data->portLabel->set_markup(_("<i>Testing TCP port…</i>"));
+    data->portLabel->set_markup(fmt::format("<i>{}</i>", _("Testing TCP port…")));
 
     if (!data->portTag.connected())
     {

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -10,6 +10,8 @@
 #include <glibmm.h>
 #include <glibmm/i18n.h>
 
+#include <fmt/core.h>
+
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
@@ -410,8 +412,10 @@ struct blocklist_data
 void updateBlocklistText(Gtk::Label* w, Glib::RefPtr<Session> const& core)
 {
     int const n = tr_blocklistGetRuleCount(core->get_session());
-    w->set_markup(
-        gtr_sprintf("<i>%s</i>", gtr_sprintf(ngettext("Blocklist contains %'d rule", "Blocklist contains %'d rules", n), n)));
+    auto const msg = fmt::format(
+        ngettext("Blocklist has {count} entry", "Blocklist has {count} entries", n),
+        fmt::arg("count", n));
+    w->set_markup(gtr_sprintf("<i>%s</i>", msg.c_str()));
 }
 
 /* prefs dialog is being destroyed, so stop listening to blocklist updates */
@@ -436,10 +440,12 @@ void onBlocklistUpdated(Glib::RefPtr<Session> const& core, int n, blocklist_data
 {
     bool const success = n >= 0;
     int const count = n >= 0 ? n : tr_blocklistGetRuleCount(core->get_session());
+    auto const msg = fmt::format(
+        ngettext("Blocklist has {count} entry", "Blocklist has {count} entries", count),
+        fmt::arg("count", count));
     data->updateBlocklistButton->set_sensitive(true);
     data->updateBlocklistDialog->set_message(success ? _("<b>Update succeeded!</b>") : _("<b>Unable to update.</b>"), true);
-    data->updateBlocklistDialog->set_secondary_text(
-        gtr_sprintf(ngettext("Blocklist has %'d rule.", "Blocklist has %'d rules.", count), count));
+    data->updateBlocklistDialog->set_secondary_text(msg);
     updateBlocklistText(data->label, core);
 }
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -615,7 +615,13 @@ void rename_torrent(Glib::RefPtr<Gio::File> const& file)
         }
         catch (Glib::Error const& e)
         {
-            g_message("Unable to rename \"%s\" as \"%s\": %s", old_name.c_str(), new_name.c_str(), e.what().c_str());
+            auto const errmsg = fmt::format(
+                _("Couldn't rename '{oldpath}' as '{path}': {errmsg} ({errcode})"),
+                fmt::arg("oldpath", old_name.raw()),
+                fmt::arg("path", new_name.raw()),
+                fmt::arg("errmsg", e.what().raw()),
+                fmt::arg("errcode", e.code()));
+            g_message("%s", errmsg.c_str());
         }
     }
 }

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -12,7 +12,7 @@
 #include <giomm.h> /* g_file_trash() */
 #include <glibmm/i18n.h>
 
-#include <fmt/base.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h> /* TR_RATIO_NA, TR_RATIO_INF */
 

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -166,7 +166,7 @@ void gtr_add_torrent_error_dialog(Gtk::Widget& child, tr_torrent* duplicate_torr
 
     auto w = std::make_shared<Gtk::MessageDialog>(
         *win,
-        _("Error opening torrent"),
+        _("Couldn't open torrent"),
         false,
         Gtk::MESSAGE_ERROR,
         Gtk::BUTTONS_CLOSE);

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -12,6 +12,8 @@
 #include <giomm.h> /* g_file_trash() */
 #include <glibmm/i18n.h>
 
+#include <fmt/base.h>
+
 #include <libtransmission/transmission.h> /* TR_RATIO_NA, TR_RATIO_INF */
 
 #include <libtransmission/error.h>
@@ -450,7 +452,7 @@ void gtr_unrecognized_url_dialog(Gtk::Widget& parent, Glib::ustring const& url)
 
     auto w = std::make_shared<Gtk::MessageDialog>(
         *window,
-        _("Unrecognized URL"),
+        fmt::format(_("Unsupported URL: {url}"), fmt::arg("url", url.raw())),
         false /*use markup*/,
         Gtk::MESSAGE_ERROR,
         Gtk::BUTTONS_CLOSE,

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -14,6 +14,8 @@
 #include <event2/dns.h>
 #include <event2/util.h>
 
+#include <fmt/core.h>
+
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
 #include "transmission.h"
@@ -462,8 +464,11 @@ static void tau_tracker_on_dns(int errcode, struct evutil_addrinfo* addr, void* 
 
     if (errcode != 0)
     {
-        auto const errmsg = tr_strvJoin("DNS Lookup failed: "sv, evutil_gai_strerror(errcode));
-        logwarn(tracker->key, "%s", errmsg.c_str());
+        auto const errmsg = fmt::format(
+            _("DNS lookup failed: {errmsg} ({errcode})"),
+            fmt::arg("errmsg", evutil_gai_strerror(errcode)),
+            fmt::arg("errcode", errcode));
+        logwarn(tracker->key, errmsg);
         tracker->failAll(false, false, errmsg.c_str());
     }
     else

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -465,7 +465,8 @@ static void tau_tracker_on_dns(int errcode, struct evutil_addrinfo* addr, void* 
     if (errcode != 0)
     {
         auto const errmsg = fmt::format(
-            _("DNS lookup failed: {errmsg} ({errcode})"),
+            _("Couldn't find address of tracker '{host}': {errmsg} ({errcode})"),
+            fmt::arg("host", tracker->host.sv()),
             fmt::arg("errmsg", evutil_gai_strerror(errcode)),
             fmt::arg("errcode", errcode));
         logwarn(tracker->key, errmsg);

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -968,7 +968,7 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
         tr_logAddWarnTier(
             tier,
             fmt::format(
-                ngettext_(
+                ngettext(
                     "Announce error: {errmsg} (Retrying in {count} second)",
                     "Announce error: {errmsg} (Retrying in {count} seconds)",
                     interval),

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1301,7 +1301,7 @@ static void checkMultiscrapeMax(tr_announcer* announcer, tr_scrape_response cons
         auto const parsed = *tr_urlParse(url.sv());
         auto clean_url = std::string{};
         tr_buildBuf(clean_url, parsed.scheme, "://"sv, parsed.host, ":"sv, parsed.portstr);
-        tr_logAddNamedInfo(clean_url.c_str(), fmt::format(_("Reducing multiscrape max to {}"), n));
+        tr_logAddNamedDebug(clean_url.c_str(), fmt::format("Reducing multiscrape max to {}", n));
         multiscrape_max = n;
     }
 }

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -6,15 +6,16 @@
 #include <algorithm>
 #include <vector>
 
+#include <fmt/core.h>
+
 #include "transmission.h"
+
 #include "bandwidth.h"
 #include "crypto-utils.h" /* tr_rand_int_weak() */
 #include "log.h"
 #include "peer-io.h"
 #include "tr-assert.h"
 #include "utils.h"
-
-#define logtrace(...) tr_logAddMessage(__FILE__, __LINE__, TR_LOG_TRACE, "", __VA_ARGS__)
 
 /***
 ****
@@ -166,7 +167,7 @@ void Bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
      * peers from starving the others. Loop through the peers, giving each a
      * small chunk of bandwidth. Keep looping until we run out of bandwidth
      * and/or peers that can use it */
-    logtrace("%lu peers to go round-robin for %s", peerArray.size(), dir == TR_UP ? "upload" : "download");
+    tr_logAddTrace(fmt::format("{} peers to go round-robin for {}", peerArray.size(), dir == TR_UP ? "upload" : "download"));
 
     size_t n = peerArray.size();
     while (n > 0)
@@ -180,7 +181,7 @@ void Bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
 
         int const bytes_used = tr_peerIoFlush(peerArray[i], dir, increment);
 
-        logtrace("peer #%d of %zu used %d bytes in this pass", i, n, bytes_used);
+        tr_logAddTrace(fmt::format("peer #{} of {} used {} bytes in this pass", i, n, bytes_used));
 
         if (bytes_used != int(increment))
         {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -101,7 +101,7 @@ static void blocklistLoad(tr_blocklistFile* b)
 
     char* const base = tr_sys_path_basename(b->filename, nullptr);
     tr_logAddInfo(fmt::format(
-        ngettext_("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", b->ruleCount),
+        ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", b->ruleCount),
         fmt::arg("path", base),
         fmt::arg("count", b->ruleCount)));
     tr_free(base);
@@ -483,12 +483,9 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     {
         char* base = tr_sys_path_basename(b->filename, nullptr);
         tr_logAddInfo(fmt::format(
-            ngettext_(
-                "Blocklist '{path}' updated with {count} entry",
-                "Blocklist '{path}' updated with {count} entries",
-                ranges_count),
+            ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", b->ruleCount),
             fmt::arg("path", base),
-            fmt::arg("count", ranges_count)));
+            fmt::arg("count", b->ruleCount)));
         tr_free(base);
     }
 

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -8,6 +8,8 @@
 
 #include <event2/buffer.h>
 
+#include <fmt/base.h>
+
 #include "transmission.h"
 #include "cache.h"
 #include "inout.h"
@@ -18,7 +20,7 @@
 #include "trevent.h"
 #include "utils.h"
 
-auto constexpr CodeName = std::string_view{ "cache" };
+auto constexpr LogName = std::string_view{ "cache" };
 
 /****
 *****
@@ -243,10 +245,8 @@ int tr_cacheSetLimit(tr_cache* cache, int64_t max_bytes)
     cache->max_blocks = getMaxBlocks(max_bytes);
 
     tr_logAddNamedDebug(
-        CodeName,
-        "Maximum cache size set to %s (%d blocks)",
-        tr_formatter_mem_B(cache->max_bytes).c_str(),
-        cache->max_blocks);
+        LogName,
+        fmt::format("Maximum cache size set to {} ({} blocks)", tr_formatter_mem_B(cache->max_bytes), cache->max_blocks));
 
     return cacheTrim(cache);
 }
@@ -406,13 +406,9 @@ int tr_cacheFlushFile(tr_cache* cache, tr_torrent* torrent, tr_file_index_t i)
 {
     auto const [begin, end] = tr_torGetFileBlockSpan(torrent, i);
 
-    int pos = findBlockPos(cache, torrent, torrent->blockLoc(begin));
-    tr_logAddNamedTrace(
-        CodeName,
-        "flushing file %d from cache to disk: blocks [%zu...%zu)",
-        (int)i,
-        (size_t)begin,
-        (size_t)end);
+    int const pos = findBlockPos(cache, torrent, torrent->blockLoc(begin));
+
+    tr_logAddNamedTrace(LogName, fmt::format("flushing file {} from cache to disk: blocks [{}...{})", i, begin, end));
 
     /* flush out all the blocks in that file */
     int err = 0;

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -8,7 +8,7 @@
 
 #include <event2/buffer.h>
 
-#include <fmt/base.h>
+#include <fmt/core.h>
 
 #include "transmission.h"
 #include "cache.h"

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -219,12 +219,12 @@ static int cached_file_open(
         if (allocation == TR_PREALLOCATE_FULL)
         {
             success = preallocate_file_full(fd, file_size, &error);
-            type = _("full");
+            type = "full";
         }
         else if (allocation == TR_PREALLOCATE_SPARSE)
         {
             success = preallocate_file_sparse(fd, file_size, &error);
-            type = _("sparse");
+            type = "sparse";
         }
 
         TR_ASSERT(type != nullptr);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -21,6 +21,8 @@
 
 #include <event2/util.h>
 
+#include <fmt/core.h>
+
 #include <cstdint>
 #include <libutp/utp.h>
 
@@ -34,20 +36,30 @@
 #include "tr-assert.h"
 #include "tr-macros.h"
 #include "tr-utp.h" /* tr_utpSendTo() */
-#include "utils.h" /* tr_time(), tr_logAddDebug() */
+#include "utils.h" /* tr_time() */
 
 #ifndef IN_MULTICAST
 #define IN_MULTICAST(a) (((a)&0xf0000000) == 0xe0000000)
 #endif
 
+#undef tr_logAddCritical
+#undef tr_logAddError
+#undef tr_logAddWarn
+#undef tr_logAddInfo
+#undef tr_logAddDebug
+#undef tr_logAddTrace
+
+auto constexpr LogName = std::string_view{ "net" };
+#define tr_logAddCritical(...) tr_logAddNamed(TR_LOG_CRITICAL, LogName, __VA_ARGS__)
+#define tr_logAddError(...) tr_logAddNamed(TR_LOG_ERROR, LogName, __VA_ARGS__)
+#define tr_logAddWarn(...) tr_logAddNamed(TR_LOG_WARN, LogName, __VA_ARGS__)
+#define tr_logAddInfo(...) tr_logAddNamed(TR_LOG_INFO, LogName, __VA_ARGS__)
+#define tr_logAddDebug(...) tr_logAddNamed(TR_LOG_DEBUG, LogName, __VA_ARGS__)
+#define tr_logAddTrace(...) tr_logAddNamed(TR_LOG_TRACE, LogName, __VA_ARGS__)
+
 tr_address const tr_in6addr_any = { TR_AF_INET6, { IN6ADDR_ANY_INIT } };
 
 tr_address const tr_inaddr_any = { TR_AF_INET, { { { { INADDR_ANY } } } } };
-
-#define logerr(...) tr_logAddNamed(TR_LOG_ERROR, "net", __VA_ARGS__)
-#define logwarn(...) tr_logAddNamed(TR_LOG_WARN, "net", __VA_ARGS__)
-#define logdbg(...) tr_logAddNamed(TR_LOG_DEBUG, "net", __VA_ARGS__)
-#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "net", __VA_ARGS__)
 
 std::string tr_net_strerror(int err)
 {
@@ -257,7 +269,7 @@ void tr_netSetTOS([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_a
 
         if (setsockopt(s, IPPROTO_IP, IP_TOS, (void const*)&tos, sizeof(tos)) == -1)
         {
-            logwarn("Can't set TOS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
+            tr_logAddDebug(fmt::format("Can't set TOS '{}': {}", tos, tr_net_strerror(sockerrno)));
         }
 #endif
     }
@@ -266,14 +278,14 @@ void tr_netSetTOS([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_a
 #if defined(IPV6_TCLASS) && !defined(_WIN32)
         if (setsockopt(s, IPPROTO_IPV6, IPV6_TCLASS, (void const*)&tos, sizeof(tos)) == -1)
         {
-            logwarn("Can't set IPv6 QoS '%d': %s", tos, tr_net_strerror(sockerrno).c_str());
+            tr_logAddDebug(fmt::format("Can't set IPv6 QoS '{}': {}", tos, tr_net_strerror(sockerrno)));
         }
 #endif
     }
     else
     {
         /* program should never reach here! */
-        logdbg("Something goes wrong while setting TOS/Traffic-Class");
+        tr_logAddDebug("Something goes wrong while setting TOS/Traffic-Class");
     }
 }
 
@@ -283,7 +295,7 @@ void tr_netSetCongestionControl([[maybe_unused]] tr_socket_t s, [[maybe_unused]]
 
     if (setsockopt(s, IPPROTO_TCP, TCP_CONGESTION, (void const*)algorithm, strlen(algorithm) + 1) == -1)
     {
-        logwarn("Can't set congestion control algorithm '%s': %s", algorithm, tr_net_strerror(sockerrno).c_str());
+        tr_logAddDebug(fmt::format("Can't set congestion control algorithm '{}': {}", algorithm, tr_net_strerror(sockerrno)));
     }
 
 #endif
@@ -363,7 +375,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
         if (setsockopt(s, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<char const*>(&n), sizeof(n)) == -1)
         {
-            logwarn("Unable to set SO_RCVBUF on socket %" PRIdMAX ": %s", (intmax_t)s, tr_net_strerror(sockerrno).c_str());
+            tr_logAddDebug(fmt::format("Unable to set SO_RCVBUF on socket {}: {}", s, tr_net_strerror(sockerrno)));
         }
     }
 
@@ -382,11 +394,12 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
     {
-        logwarn(
-            _("Couldn't set source address %s on %" PRIdMAX ": %s"),
-            tr_address_to_string(source_addr),
-            (intmax_t)s,
-            tr_net_strerror(sockerrno).c_str());
+        tr_logAddWarn(fmt::format(
+            _("Couldn't set source address {address} on {socket}: {errmsg} ({errcode})"),
+            fmt::arg("address", source_addr->to_string()),
+            fmt::arg("socket", s),
+            fmt::arg("errmsg", tr_net_strerror(sockerrno)),
+            fmt::arg("errcode", sockerrno)));
         tr_netClose(session, s);
         return ret;
     }
@@ -401,13 +414,13 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
         if ((tmperrno != ENETUNREACH && tmperrno != EHOSTUNREACH) || addr->type == TR_AF_INET)
         {
-            logwarn(
-                _("Couldn't connect socket %" PRIdMAX " to %s, port %d (errno %d - %s)"),
-                (intmax_t)s,
-                tr_address_to_string(addr),
-                (int)ntohs(port),
-                tmperrno,
-                tr_net_strerror(tmperrno).c_str());
+            tr_logAddWarn(fmt::format(
+                _("Couldn't connect socket {socket} to {address}:{port}: {errmsg} ({errcode})"),
+                fmt::arg("socket", s),
+                fmt::arg("address", addr->to_string()),
+                fmt::arg("port", ntohs(port)),
+                fmt::arg("errmsg", tr_net_strerror(tmperrno)),
+                fmt::arg("errcode", tmperrno)));
         }
 
         tr_netClose(session, s);
@@ -419,7 +432,7 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 
     char addrstr[TR_ADDRSTRLEN];
     tr_address_and_port_to_string(addrstr, sizeof(addrstr), addr, port);
-    logtrace("New OUTGOING connection %" PRIdMAX " (%s)", (intmax_t)s, addrstr);
+    tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, addrstr));
 
     return ret;
 }
@@ -511,12 +524,14 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
         if (!suppressMsgs)
         {
-            char const* const hint = err == EADDRINUSE ? _("Is another copy of Transmission already running?") : nullptr;
-
-            char const* const fmt = hint == nullptr ? _("Couldn't bind port %d on %s: %s") :
-                                                      _("Couldn't bind port %d on %s: %s (%s)");
-
-            logerr(fmt, port, tr_address_to_string(addr), tr_net_strerror(err).c_str(), hint);
+            tr_logAddError(fmt::format(
+                err == EADDRINUSE ?
+                    _("Couldn't bind port {port} on {address}: {errmsg} ({errcode}) -- Is another copy of Transmission already running?") :
+                    _("Couldn't bind port {port} on {address}: {errmsg} ({errcode})"),
+                fmt::arg("address", addr->to_string()),
+                fmt::arg("port", port),
+                fmt::arg("errmsg", tr_net_strerror(err)),
+                fmt::arg("errcode", err)));
         }
 
         tr_netCloseSocket(fd);
@@ -526,7 +541,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
     if (!suppressMsgs)
     {
-        logdbg("Bound socket %" PRIdMAX " to port %d on %s", (intmax_t)fd, port, tr_address_to_string(addr));
+        tr_logAddDebug(fmt::format("Bound socket {} to port {} on {}", fd, port, addr->to_string()));
     }
 
 #ifdef TCP_FASTOPEN

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -160,10 +160,7 @@ std::string tr_address::to_string(tr_port port) const
 {
     auto addrbuf = std::array<char, TR_ADDRSTRLEN>{};
     tr_address_to_string_with_buf(this, std::data(addrbuf), std::size(addrbuf));
-
-    auto buf = std::array<char, TR_ADDRSTRLEN>{};
-    tr_snprintf(std::data(buf), std::size(buf), "[%s]:%u", std::data(addrbuf), ntohs(port));
-    return std::data(buf);
+    return fmt::format("[{}]:{}", std::data(addrbuf), ntohs(port));
 }
 
 tr_address tr_address::from_4byte_ipv4(std::string_view in)

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -8,6 +8,8 @@
 
 #include <event2/event.h>
 
+#include <fmt/core.h>
+
 #include "transmission.h"
 #include "natpmp_local.h"
 #include "log.h"
@@ -104,7 +106,10 @@ static void natPulse(tr_shared* s, bool do_check)
 
     if (new_status != old_status)
     {
-        loginfo(_("State changed from \"%1$s\" to \"%2$s\""), getNatStateStr(old_status), getNatStateStr(new_status));
+        loginfo(fmt::format(
+            _("State changed from '{old_state}' to '{state}"),
+            fmt::arg("old_state", getNatStateStr(old_status)),
+            fmt::arg("state", getNatStateStr(new_status))));
     }
 }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -781,12 +781,12 @@ static void startServer(tr_rpc_server* server)
         {
             int const retry_delay = rpc_server_start_retry(server);
 
-            tr_logAddDebug(fmt::format("Unable to bind to {}, retrying in {} seconds", addr_port_str, retry_delay));
+            tr_logAddDebug(fmt::format("Couldn't bind to {}, retrying in {} seconds", addr_port_str, retry_delay));
             return;
         }
 
         tr_logAddError(fmt::format(
-            _("Unable to bind to {address} after {count} attempts, giving up"),
+            _("Couldn't bind to {address} after {count} attempts, giving up"),
             fmt::arg("address", addr_port_str),
             fmt::arg("count", ServerStartRetryCount)));
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2052,7 +2052,7 @@ static void sessionLoadTorrents(struct sessionLoadTorrentsData* const data)
 
     if (n != 0)
     {
-        tr_logAddInfo(fmt::format(ngettext_("Loaded {count} torrent", "Loaded {count} torrents", n), fmt::arg("count", n)));
+        tr_logAddInfo(fmt::format(ngettext("Loaded {count} torrent", "Loaded {count} torrents", n), fmt::arg("count", n)));
     }
 
     if (data->setmeCount != nullptr)

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -11,6 +11,8 @@
 
 #include <event2/buffer.h>
 
+#include <fmt/core.h>
+
 #include "transmission.h"
 
 #include "crypto-utils.h" /* tr_sha1() */
@@ -311,7 +313,7 @@ static void onHaveAllMetainfo(tr_torrent* tor, tr_incomplete_metadata* m)
 
         m->piecesNeededCount = n;
         char const* const msg = error != nullptr && error->message != nullptr ? error->message : "unknown error";
-        logdbg(tor, "metadata error: %s. (trying again; %d pieces left)", msg, n);
+        logdbg(tor, fmt::format("metadata error: {}. (trying again; {} pieces left)", msg, n));
         tr_error_clear(&error);
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2576,7 +2576,7 @@ void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block)
             else
             {
                 uint32_t const n = tor->pieceSize(piece);
-                logdbg(tor, _("Piece %" PRIu32 ", which was just downloaded, failed its checksum test"), piece);
+                logdbg(tor, fmt::format("Piece {}, which was just downloaded, failed its checksum test", piece));
                 tor->corruptCur += n;
                 tor->downloadedCur -= std::min(tor->downloadedCur, uint64_t{ n });
                 tr_peerMgrGotBadPiece(tor, piece);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -28,7 +28,7 @@
 
 #include <event2/util.h> /* evutil_vsnprintf() */
 
-#include <fmt/base.h>
+#include <fmt/core.h>
 
 #include "transmission.h"
 
@@ -1807,9 +1807,10 @@ void tr_torrent::recheckCompleteness()
         {
             logtrace(
                 this,
-                fmt::format("State changed from {} to {}"),
-                getCompletionString(this->completeness),
-                getCompletionString(completeness));
+                fmt::format(
+                    "State changed from {} to {}",
+                    getCompletionString(this->completeness),
+                    getCompletionString(completeness)));
         }
 
         this->completeness = new_completeness;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -28,6 +28,8 @@
 
 #include <event2/util.h> /* evutil_vsnprintf() */
 
+#include <fmt/base.h>
+
 #include "transmission.h"
 
 #include "announcer.h"
@@ -1650,13 +1652,13 @@ static char const* getCompletionString(int type)
            "Complete" means we've downloaded every file in the torrent.
            "Done" means we're done downloading the files we wanted, but NOT all
            that exist */
-        return _("Done");
+        return "Done";
 
     case TR_SEED:
-        return _("Complete");
+        return "Complete";
 
     default:
-        return _("Incomplete");
+        return "Incomplete";
     }
 }
 
@@ -1805,7 +1807,7 @@ void tr_torrent::recheckCompleteness()
         {
             logtrace(
                 this,
-                _("State changed from \"%1$s\" to \"%2$s\""),
+                fmt::format("State changed from {} to {}"),
                 getCompletionString(this->completeness),
                 getCompletionString(completeness));
         }

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -6,6 +6,7 @@
 #include <cerrno>
 #include <future>
 #include <mutex>
+#include <string_view>
 #include <thread>
 
 #include <fmt/core.h>
@@ -29,19 +30,18 @@
 namespace
 {
 
-char constexpr Key[] = "Port Forwarding (UPnP)";
-
 #undef tr_logAddError
 #undef tr_logAddWarn
 #undef tr_logAddInfo
 #undef tr_logAddDebug
 #undef tr_logAddTrace
 
-#define tr_logAddError(...) tr_logAddNamedError(Key, __VA_ARGS__)
-#define tr_logAddWarn(...) tr_logAddNamedWarn(Key, __VA_ARGS__)
-#define tr_logAddInfo(...) tr_logAddNamedInfo(Key, __VA_ARGS__)
-#define tr_logAddDebug(...) tr_logAddNamedDebug(Key, __VA_ARGS__)
-#define tr_logAddTrace(...) tr_logAddNamedTrace(Key, __VA_ARGS__)
+auto constexpr LogName = std::string_view{ "Port Forwarding (UPnP)" };
+#define tr_logAddError(...) tr_logAddNamedError(LogName, __VA_ARGS__)
+#define tr_logAddWarn(...) tr_logAddNamedWarn(LogName, __VA_ARGS__)
+#define tr_logAddInfo(...) tr_logAddNamedInfo(LogName, __VA_ARGS__)
+#define tr_logAddDebug(...) tr_logAddNamedDebug(LogName, __VA_ARGS__)
+#define tr_logAddTrace(...) tr_logAddNamedTrace(LogName, __VA_ARGS__)
 
 enum class UpnpState
 {

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -44,13 +44,9 @@ char const* tr_strip_positional_args(char const* fmt);
 #endif
 #endif
 
-#if !defined(ngettext)
-#if defined(HAVE_NGETTEXT) && !defined(__APPLE__)
+#if !defined(HAVE_NGETTEXT) && !defined(__APPLE__)
 #include <libintl.h>
-#define ngettext(singular, plural, count) ngettext(singular, plural, count)
-#else
 #define ngettext(singular, plural, count) ((count) == 1 ? (singular) : (plural))
-#endif
 #endif
 
 /* #define DISABLE_GETTEXT */

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -44,12 +44,12 @@ char const* tr_strip_positional_args(char const* fmt);
 #endif
 #endif
 
-#if !defined(ngettext_)
+#if !defined(ngettext)
 #if defined(HAVE_NGETTEXT) && !defined(__APPLE__)
 #include <libintl.h>
-#define ngettext_(singular, plural, count) ngettext(singular, plural, count)
+#define ngettext(singular, plural, count) ngettext(singular, plural, count)
 #else
-#define ngettext_(singular, plural, count) ((count) == 1 ? (singular) : (plural))
+#define ngettext(singular, plural, count) ((count) == 1 ? (singular) : (plural))
 #endif
 #endif
 
@@ -61,9 +61,9 @@ char const* tr_strip_positional_args(char const* fmt);
 #endif
 #ifdef DISABLE_GETTEXT
 #undef _
-#undef ngettext_
+#undef ngettext
 #define _(a) tr_strip_positional_args(a)
-#define ngettext_(singular, plural, count) tr_strip_positional_args((count) == 1 ? (singular) : (plural))
+#define ngettext(singular, plural, count) tr_strip_positional_args((count) == 1 ? (singular) : (plural))
 #endif
 
 /****

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -22,6 +22,9 @@
 
 #include <event2/buffer.h>
 
+#include <fmt/core.h>
+#include <fmt/format.h>
+
 #include "crypto-utils.h"
 #include "log.h"
 #include "tr-assert.h"
@@ -119,9 +122,10 @@ public:
         if (curl_ssl_verify)
         {
             auto const* bundle = std::empty(curl_ca_bundle) ? "none" : curl_ca_bundle.c_str();
-            loginfo("will verify tracker certs using envvar CURL_CA_BUNDLE: %s", bundle);
-            loginfo("NB: this only works if you built against libcurl with openssl or gnutls, NOT nss");
-            loginfo("NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors");
+            loginfo(
+                fmt::format(_("Will verify tracker certs using envvar CURL_CA_BUNDLE: {bundle}"), fmt::arg("bundle", bundle)));
+            loginfo(_("NB: this only works if you built against libcurl with openssl or gnutls, NOT nss"));
+            loginfo(_("NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors"));
         }
 
         if (auto const& file = mediator.cookieFile(); file)
@@ -291,7 +295,7 @@ private:
         }
 
         evbuffer_add(task->body(), data, bytes_used);
-        logtrace("wrote %zu bytes to task %p's buffer", bytes_used, (void*)task);
+        logtrace(fmt::format("wrote {} bytes to task {}'s buffer", bytes_used, fmt::ptr(task)));
         return bytes_used;
     }
 
@@ -457,7 +461,7 @@ private:
                 // add queued tasks
                 for (auto* task : impl->queued_tasks)
                 {
-                    logtrace("adding task to curl: [%s]", task->url().c_str());
+                    logtrace(fmt::format("adding task to curl: '{}'", task->url()));
                     initEasy(impl, task);
                     curl_multi_add_handle(multi.get(), task->easy());
                 }


### PR DESCRIPTION
Part 5 of a series to update Transmission's logging mechanism. #2758 is the previous in the series. The goals are described [here](https://github.com/transmission/transmission/pull/2749#pullrequest-875916992).

---

This PR uses [fmt](https://fmt.dev) for strings marked for i18n.  Is a partial-but-not-complete fix for #1353. There are a _lot_ of strings so this is a high-volume task being split into a few PRs in this series.