### PR TITLE
refactor: fmt part 3

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -273,10 +273,10 @@ static auto onFileAdded(tr_watchdir_t dir, char const* name, void* vsession)
             if (!tr_sys_path_remove(filename.c_str(), &error))
             {
                 tr_logAddError(fmt::format(
-                    _("Couldn't remove '{path}': {errmsg} ({errcode})"),
+                    _("Couldn't remove '{path}': {error} ({error_code})"),
                     fmt::arg("path", name),
-                    fmt::arg("errmsg", error->message),
-                    fmt::arg("errcode", error->code)));
+                    fmt::arg("error", error->message),
+                    fmt::arg("error_code", error->code)));
                 tr_error_free(error);
             }
         }
@@ -730,10 +730,10 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
         else
         {
             tr_logAddError(fmt::format(
-                _("Couldn't save '{path}': {errmsg} ({errcode})"),
+                _("Couldn't save '{path}': {error} ({error_code})"),
                 fmt::arg("path", sz_pid_filename),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
             tr_error_free(error);
         }
     }
@@ -802,21 +802,21 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
 
         if (status_ev == nullptr)
         {
-            auto const errcode = errno;
+            auto const error_code = errno;
             tr_logAddError(fmt::format(
-                _("Couldn't create status event: {errmsg} ({errcode})"),
-                fmt::arg("errmsg", tr_strerror(errcode)),
-                fmt::arg("errcode", errcode)));
+                _("Couldn't create status event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
             goto CLEANUP;
         }
 
         if (event_add(status_ev, &one_sec) == -1)
         {
-            auto const errcode = errno;
+            auto const error_code = errno;
             tr_logAddError(fmt::format(
-                _("Couldn't add status event: {errmsg} ({errcode})"),
-                fmt::arg("errmsg", tr_strerror(errcode)),
-                fmt::arg("errcode", errcode)));
+                _("Couldn't add status event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
             goto CLEANUP;
         }
     }
@@ -826,11 +826,11 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
     /* Run daemon event loop */
     if (event_base_dispatch(ev_base) == -1)
     {
-        auto const errcode = errno;
+        auto const error_code = errno;
         tr_logAddError(fmt::format(
-            _("Couldn't launch daemon event loop: {errmsg} ({errcode})"),
-            fmt::arg("errmsg", tr_strerror(errcode)),
-            fmt::arg("errcode", errcode)));
+            _("Couldn't launch daemon event loop: {error} ({error_code})"),
+            fmt::arg("error", tr_strerror(error_code)),
+            fmt::arg("error_code", error_code)));
         goto CLEANUP;
     }
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -347,10 +347,10 @@ void register_magnet_link_handler()
     catch (Gio::Error const& e)
     {
         auto const msg = fmt::format(
-            _("Couldn't register Transmission as a {content_type} handler: {errmsg} ({errcode})"),
+            _("Couldn't register Transmission as a {content_type} handler: {error} ({error_code})"),
             fmt::arg("content_type", content_type),
-            fmt::arg("errmsg", e.what().raw()),
-            fmt::arg("errcode", e.code()));
+            fmt::arg("error", e.what().raw()),
+            fmt::arg("error_code", e.code()));
         g_warning("%s", msg.c_str());
     }
 }

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -744,11 +744,11 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
         Gtk::MessageDialog w(
             *static_cast<Gtk::Window*>(widget_.get_toplevel()),
             fmt::format(
-                _("Couldn't rename '{oldpath}' as '{path}': {errmsg} ({errcode})"),
-                fmt::arg("oldpath", path_string.raw()),
+                _("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})"),
+                fmt::arg("old_path", path_string.raw()),
                 fmt::arg("path", newname.raw()),
-                fmt::arg("errmsg", tr_strerror(error)),
-                fmt::arg("errcode", error)),
+                fmt::arg("error", tr_strerror(error)),
+                fmt::arg("error_code", error)),
             false,
             Gtk::MESSAGE_ERROR,
             Gtk::BUTTONS_CLOSE,

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -128,18 +128,18 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     else if (builder_.result == TrMakemetaResult::ERR_IO_READ)
     {
         str = fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", builder_.errfile),
-            fmt::arg("errmsg", Glib::strerror(builder_.my_errno).raw()),
-            fmt::arg("errcode", builder_.my_errno));
+            fmt::arg("error", Glib::strerror(builder_.my_errno).raw()),
+            fmt::arg("error_code", builder_.my_errno));
     }
     else if (builder_.result == TrMakemetaResult::ERR_IO_WRITE)
     {
         str = fmt::format(
-            _("Couldn't save '{path}': {errmsg} ({errcode})"),
+            _("Couldn't save '{path}': {error} ({error_code})"),
             fmt::arg("path", builder_.errfile),
-            fmt::arg("errmsg", Glib::strerror(builder_.my_errno).raw()),
-            fmt::arg("errcode", builder_.my_errno));
+            fmt::arg("error", Glib::strerror(builder_.my_errno).raw()),
+            fmt::arg("error_code", builder_.my_errno));
     }
     else
     {

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -417,11 +417,6 @@ bool MessageLogWindow::Impl::onRefresh()
     return true;
 }
 
-namespace
-{
-
-} // namespace
-
 /**
 ***  Public Functions
 **/

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -183,14 +183,14 @@ void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& fi
 
     if (fp == nullptr)
     {
-        auto const errcode = errno;
+        auto const error_code = errno;
         auto w = std::make_shared<Gtk::MessageDialog>(
             parent,
             fmt::format(
-                _("Couldn't save '{path}': {errmsg} ({errcode})"),
+                _("Couldn't save '{path}': {error} ({error_code})"),
                 fmt::arg("path", filename.raw()),
-                fmt::arg("errmsg", g_strerror(errcode)),
-                fmt::arg("errcode", errcode)),
+                fmt::arg("error", g_strerror(error_code)),
+                fmt::arg("error_code", error_code)),
             false,
             Gtk::MESSAGE_ERROR,
             Gtk::BUTTONS_CLOSE);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1133,7 +1133,7 @@ void Session::Impl::add_file_async_callback(
             _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", file->get_parse_name().raw()),
             fmt::arg("error", e.what().raw()),
-            fmt::arg("error", e.code()));
+            fmt::arg("error_code", e.code()));
         g_message("%s", errmsg.c_str());
     }
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -616,11 +616,11 @@ void rename_torrent(Glib::RefPtr<Gio::File> const& file)
         catch (Glib::Error const& e)
         {
             auto const errmsg = fmt::format(
-                _("Couldn't rename '{oldpath}' as '{path}': {errmsg} ({errcode})"),
-                fmt::arg("oldpath", old_name.raw()),
+                _("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})"),
+                fmt::arg("old_path", old_name.raw()),
                 fmt::arg("path", new_name.raw()),
-                fmt::arg("errmsg", e.what().raw()),
-                fmt::arg("errcode", e.code()));
+                fmt::arg("error", e.what().raw()),
+                fmt::arg("error_code", e.code()));
             g_message("%s", errmsg.c_str());
         }
     }
@@ -1130,10 +1130,10 @@ void Session::Impl::add_file_async_callback(
     catch (Glib::Error const& e)
     {
         auto const errmsg = fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", file->get_parse_name().raw()),
-            fmt::arg("errmsg", e.what().raw()),
-            fmt::arg("errmsg", e.code()));
+            fmt::arg("error", e.what().raw()),
+            fmt::arg("error", e.code()));
         g_message("%s", errmsg.c_str());
     }
 
@@ -1457,7 +1457,7 @@ bool gtr_inhibit_hibernation(guint32& cookie)
     }
     catch (Glib::Error const& e)
     {
-        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {errmsg}"), fmt::arg("errmsg", e.what().raw())));
+        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {error}"), fmt::arg("error", e.what().raw())));
     }
 
     return success;
@@ -1482,7 +1482,7 @@ void gtr_uninhibit_hibernation(guint inhibit_cookie)
     }
     catch (Glib::Error const& e)
     {
-        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {errmsg}"), fmt::arg("errmsg", e.what().raw())));
+        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {error}"), fmt::arg("error", e.what().raw())));
     }
 }
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -272,9 +272,9 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
     if (error != nullptr)
     {
         auto const errmsg = fmt::format(
-            _("Couldn't parse announce response: {errmsg} ({errcode})"),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code));
+            _("Couldn't parse announce response: {error} ({error_code})"),
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code));
         tr_logAddNamedWarn(log_name, errmsg);
         tr_error_clear(&error);
     }
@@ -450,9 +450,9 @@ void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::stri
         tr_logAddNamedWarn(
             log_name,
             fmt::format(
-                _("Couldn't parse scrape response: {errmsg} ({errcode})"),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                _("Couldn't parse scrape response: {error} ({error_code})"),
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
         tr_error_clear(&error);
     }
 }

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -465,10 +465,10 @@ static void tau_tracker_on_dns(int errcode, struct evutil_addrinfo* addr, void* 
     if (errcode != 0)
     {
         auto const errmsg = fmt::format(
-            _("Couldn't find address of tracker '{host}': {errmsg} ({errcode})"),
+            _("Couldn't find address of tracker '{host}': {error} ({error_code})"),
             fmt::arg("host", tracker->host.sv()),
-            fmt::arg("errmsg", evutil_gai_strerror(errcode)),
-            fmt::arg("errcode", errcode));
+            fmt::arg("error", evutil_gai_strerror(errcode)),
+            fmt::arg("error_code", errcode));
         logwarn(tracker->key, errmsg);
         tracker->failAll(false, false, errmsg.c_str());
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -959,7 +959,7 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
 
     if (isUnregistered(err))
     {
-        tr_logAddErrorTier(tier, fmt::format(_("Announce error: {errmsg}"), fmt::arg("errmsg", err)));
+        tr_logAddErrorTier(tier, fmt::format(_("Announce error: {error}"), fmt::arg("error", err)));
     }
     else
     {
@@ -969,10 +969,10 @@ static void on_announce_error(tr_tier* tier, char const* err, tr_announce_event 
             tier,
             fmt::format(
                 ngettext(
-                    "Announce error: {errmsg} (Retrying in {count} second)",
-                    "Announce error: {errmsg} (Retrying in {count} seconds)",
+                    "Announce error: {error} (Retrying in {count} second)",
+                    "Announce error: {error} (Retrying in {count} seconds)",
                     interval),
-                fmt::arg("errmsg", err),
+                fmt::arg("error", err),
                 fmt::arg("count", interval)));
         tier_announce_event_push(tier, e, tr_time() + interval);
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1196,7 +1196,7 @@ static void announce_request_delegate(
     }
     else
     {
-        tr_logAddWarn(fmt::format("Unsupported url: {}", announce_sv));
+        tr_logAddWarn(fmt::format(_("Unsupported URL: '{url}'"), fmt::arg("url", announce_sv)));
         delete callback_data;
     }
 

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -74,10 +74,10 @@ static void blocklistLoad(tr_blocklistFile* b)
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", b->filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
         return;
     }
@@ -86,10 +86,10 @@ static void blocklistLoad(tr_blocklistFile* b)
     if (b->rules == nullptr)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", b->filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_sys_file_close(fd, nullptr);
         tr_error_free(error);
         return;
@@ -382,10 +382,10 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     if (in == TR_BAD_SYS_FILE)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
         return 0;
     }
@@ -396,10 +396,10 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     if (out == TR_BAD_SYS_FILE)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", b->filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
         tr_sys_file_close(in, nullptr);
         return 0;
@@ -473,10 +473,10 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     if (!tr_sys_file_write(out, ranges, sizeof(struct tr_ipv4_range) * ranges_count, nullptr, &error))
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't save '{path}': {errmsg} ({errcode})"),
+            _("Couldn't save '{path}': {error} ({error_code})"),
             fmt::arg("path", b->filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
     }
     else

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -97,10 +97,10 @@ void log_ccrypto_error(CCCryptorStatus error_code, char const* file, int line)
     if (tr_logLevelIsActive(TR_LOG_ERROR))
     {
         auto const errmsg = fmt::format(
-            _("{crypto_library} error: {errmsg} ({errcode})"),
+            _("{crypto_library} error: {error} ({error_code})"),
             fmt::arg("crypto_library", "CCrypto"),
-            fmt::arg("errmsg", ccrypto_error_to_str(error_code)),
-            fmt::arg("errcode", error_code));
+            fmt::arg("error", ccrypto_error_to_str(error_code)),
+            fmt::arg("error_code", error_code));
         tr_logAddMessage(file, line, TR_LOG_ERROR, MyName, errmsg);
     }
 }

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -64,10 +64,10 @@ static void log_cyassl_error(int error_code, char const* file, int line)
 #endif
 
         auto const errmsg = fmt::format(
-            _("{crypto_library} error: {errmsg} ({errcode})"),
+            _("{crypto_library} error: {error} ({error_code})"),
             fmt::arg("crypto_library", "CyaSSL"),
-            fmt::arg("errmsg", error_message),
-            fmt::arg("errcode", error_code));
+            fmt::arg("error", error_message),
+            fmt::arg("error_code", error_code));
         tr_logAddMessage(file, line, TR_LOG_ERROR, MyName, errmsg);
     }
 }

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -62,10 +62,10 @@ static void log_openssl_error(char const* file, int line)
 
         ERR_error_string_n(error_code, buf, sizeof(buf));
         auto const errmsg = fmt::format(
-            _("{crypto_library} error: {errmsg} ({errcode})"),
+            _("{crypto_library} error: {error} ({error_code})"),
             fmt::arg("crypto_library", "OpenSSL"),
-            fmt::arg("errmsg", buf),
-            fmt::arg("errcode", error_code));
+            fmt::arg("error", buf),
+            fmt::arg("error_code", error_code));
         tr_logAddMessage(file, line, TR_LOG_ERROR, MyName, errmsg);
     }
 }

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -59,10 +59,10 @@ static void log_polarssl_error(int error_code, char const* file, int line)
 #endif
 
         auto const errmsg = fmt::format(
-            _("{crypto_library} error: {errmsg} ({errcode})"),
+            _("{crypto_library} error: {error} ({error_code})"),
             fmt::arg("crypto_library", "PolarSSL"),
-            fmt::arg("errmsg", error_message),
-            fmt::arg("errcode", error_code));
+            fmt::arg("error", error_message),
+            fmt::arg("error_code", error_code));
         tr_logAddMessage(file, line, TR_LOG_ERROR, MyName, errmsg);
     }
 }

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -169,20 +169,20 @@ static int cached_file_open(
         if (dir == nullptr)
         {
             tr_logAddError(fmt::format(
-                _("Couldn't create '{path}': {errmsg} ({errcode})"),
+                _("Couldn't create '{path}': {error} ({error_code})"),
                 fmt::arg("path", filename),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
             goto FAIL;
         }
 
         if (!tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
         {
             tr_logAddError(fmt::format(
-                _("Couldn't create '{path}': {errmsg} ({errcode})"),
+                _("Couldn't create '{path}': {error} ({error_code})"),
                 fmt::arg("path", dir),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
             tr_free(dir);
             goto FAIL;
         }
@@ -204,10 +204,10 @@ static int cached_file_open(
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddError(fmt::format(
-            _("Couldn't open '{path}': {errmsg} ({errcode})"),
+            _("Couldn't open '{path}': {error} ({error_code})"),
             fmt::arg("path", filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         goto FAIL;
     }
 
@@ -232,10 +232,10 @@ static int cached_file_open(
         if (!success)
         {
             tr_logAddError(fmt::format(
-                _("Couldn't preallocate '{path}': {errmsg} ({errcode})"),
+                _("Couldn't preallocate '{path}': {error} ({error_code})"),
                 fmt::arg("path", filename),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
             goto FAIL;
         }
 
@@ -251,10 +251,10 @@ static int cached_file_open(
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't truncate '{path}': {errmsg} ({errcode})"),
+            _("Couldn't truncate '{path}': {error} ({error_code})"),
             fmt::arg("path", filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         goto FAIL;
     }
 
@@ -527,9 +527,9 @@ tr_socket_t tr_fdSocketCreate(tr_session* session, int domain, int type)
         if ((s == TR_BAD_SOCKET) && (sockerrno != EAFNOSUPPORT))
         {
             tr_logAddWarn(fmt::format(
-                _("Couldn't create socket: {errmsg} ({errcode})"),
-                fmt::arg("errmsg", tr_net_strerror(sockerrno)),
-                fmt::arg("errcode", sockerrno)));
+                _("Couldn't create socket: {error} ({error_code})"),
+                fmt::arg("error", tr_net_strerror(sockerrno)),
+                fmt::arg("error_code", sockerrno)));
         }
     }
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -268,10 +268,10 @@ FAILURE:
     TR_ASSERT(my_error != nullptr);
 
     tr_logAddError(fmt::format(
-        _("Couldn't create '{path}': {errmsg} ({errcode})"),
+        _("Couldn't create '{path}': {error} ({error_code})"),
         fmt::arg("path", path),
-        fmt::arg("errmsg", my_error->message),
-        fmt::arg("errcode", my_error->code)));
+        fmt::arg("error", my_error->message),
+        fmt::arg("error_code", my_error->code)));
     tr_error_propagate(error, &my_error);
 
 CLEANUP:

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -136,10 +136,10 @@ int readOrWriteBytes(
                 tr_logAddErrorTor(
                     tor,
                     fmt::format(
-                        _("Couldn't get '{path}': {errmsg} ({errcode})"),
+                        _("Couldn't get '{path}': {error} ({error_code})"),
                         fmt::arg("path", filename),
-                        fmt::arg("errmsg", tr_strerror(err)),
-                        fmt::arg("errcode", err)));
+                        fmt::arg("error", tr_strerror(err)),
+                        fmt::arg("error_code", err)));
             }
             else if (doWrite)
             {
@@ -171,10 +171,10 @@ int readOrWriteBytes(
             tr_logAddErrorTor(
                 tor,
                 fmt::format(
-                    _("Couldn't read '{path}': {errmsg} ({errcode})"),
+                    _("Couldn't read '{path}': {error} ({error_code})"),
                     fmt::arg("path", tor->fileSubpath(file_index)),
-                    fmt::arg("errmsg", error->message),
-                    fmt::arg("errcode", error->code)));
+                    fmt::arg("error", error->message),
+                    fmt::arg("error_code", error->code)));
             tr_error_free(error);
         }
         break;
@@ -186,10 +186,10 @@ int readOrWriteBytes(
             tr_logAddErrorTor(
                 tor,
                 fmt::format(
-                    _("Couldn't save '{path}': {errmsg} ({errcode})"),
+                    _("Couldn't save '{path}': {error} ({error_code})"),
                     fmt::arg("path", tor->fileSubpath(file_index)),
-                    fmt::arg("errmsg", error->message),
-                    fmt::arg("errcode", error->code)));
+                    fmt::arg("error", error->message),
+                    fmt::arg("error_code", error->code)));
             tr_error_free(error);
         }
         break;

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -58,10 +58,10 @@ static struct FileList* getFiles(char const* dir, char const* base, struct FileL
     if (tr_error* error = nullptr; !tr_sys_path_get_info(buf.c_str(), 0, &info, &error))
     {
         tr_logAddWarn(fmt::format(
-            _("Skipping '{path}': {errmsg} ({errcode})"),
+            _("Skipping '{path}': {error} ({error_code})"),
             fmt::arg("path", buf),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
         return list;
     }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -207,9 +207,9 @@ bool tr_metaInfoBuilderSetPieceSize(tr_metainfo_builder* b, uint32_t bytes)
     if (!isValidPieceSize(bytes))
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't use invalid piece size {size_requested}; using {size_used} instead"),
-            fmt::arg("size_requested", tr_formatter_mem_B(bytes)),
-            fmt::arg("size_used", tr_formatter_mem_B(b->pieceSize))));
+            _("Couldn't use invalid piece size {expected_size}; using {actual_size} instead"),
+            fmt::arg("expected_size", tr_formatter_mem_B(bytes)),
+            fmt::arg("actual_size", tr_formatter_mem_B(b->pieceSize))));
         return false;
     }
 

--- a/libtransmission/natpmp.cc
+++ b/libtransmission/natpmp.cc
@@ -25,7 +25,7 @@
 static auto constexpr LifetimeSecs = uint32_t{ 3600 };
 static auto constexpr CommandWaitSecs = time_t{ 8 };
 
-static auto constexpr CodeName = std::string_view{ "nat-pmp" };
+static auto constexpr LogName = std::string_view{ "nat-pmp" };
 
 /**
 ***
@@ -40,12 +40,12 @@ static void logVal(char const* func, int ret)
 
     if (ret >= 0)
     {
-        tr_logAddNamedDebug(CodeName, fmt::format("{} succeeded ({})", func, ret));
+        tr_logAddNamedDebug(LogName, fmt::format("{} succeeded ({})", func, ret));
     }
     else
     {
         tr_logAddNamedDebug(
-            CodeName,
+            LogName,
             fmt::format(
                 "{} failed. Natpmp returned {} ({}); errno is {} ({})",
                 func,
@@ -113,7 +113,7 @@ tr_port_forwarding tr_natpmpPulse(
         {
             char str[128];
             evutil_inet_ntop(AF_INET, &response.pnu.publicaddress.addr, str, sizeof(str));
-            tr_logAddNamedInfo(CodeName, fmt::format(_("Found public address '{address}'"), fmt::arg("address", str)));
+            tr_logAddNamedInfo(LogName, fmt::format(_("Found public address '{address}'"), fmt::arg("address", str)));
             nat->state = TR_NATPMP_IDLE;
         }
         else if (val != NATPMP_TRYAGAIN)
@@ -146,7 +146,7 @@ tr_port_forwarding tr_natpmpPulse(
         {
             int const unmapped_port = resp.pnu.newportmapping.privateport;
 
-            tr_logAddNamedInfo(CodeName, fmt::format(_("Port {port} is no longer forwarded"), fmt::arg("port", unmapped_port)));
+            tr_logAddNamedInfo(LogName, fmt::format(_("Port {port} is no longer forwarded"), fmt::arg("port", unmapped_port)));
 
             if (nat->private_port == unmapped_port)
             {
@@ -196,7 +196,7 @@ tr_port_forwarding tr_natpmpPulse(
             nat->private_port = resp.pnu.newportmapping.privateport;
             nat->public_port = resp.pnu.newportmapping.mappedpublicport;
             tr_logAddNamedInfo(
-                CodeName,
+                LogName,
                 fmt::format(_("Port {port} forwarded successfully"), fmt::arg("port", nat->private_port)));
         }
         else if (val != NATPMP_TRYAGAIN)

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -390,11 +390,11 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't set source address {address} on {socket}: {errmsg} ({errcode})"),
+            _("Couldn't set source address {address} on {socket}: {error} ({error_code})"),
             fmt::arg("address", source_addr->to_string()),
             fmt::arg("socket", s),
-            fmt::arg("errmsg", tr_net_strerror(sockerrno)),
-            fmt::arg("errcode", sockerrno)));
+            fmt::arg("error", tr_net_strerror(sockerrno)),
+            fmt::arg("error_code", sockerrno)));
         tr_netClose(session, s);
         return ret;
     }
@@ -410,12 +410,12 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
         if ((tmperrno != ENETUNREACH && tmperrno != EHOSTUNREACH) || addr->type == TR_AF_INET)
         {
             tr_logAddWarn(fmt::format(
-                _("Couldn't connect socket {socket} to {address}:{port}: {errmsg} ({errcode})"),
+                _("Couldn't connect socket {socket} to {address}:{port}: {error} ({error_code})"),
                 fmt::arg("socket", s),
                 fmt::arg("address", addr->to_string()),
                 fmt::arg("port", ntohs(port)),
-                fmt::arg("errmsg", tr_net_strerror(tmperrno)),
-                fmt::arg("errcode", tmperrno)));
+                fmt::arg("error", tr_net_strerror(tmperrno)),
+                fmt::arg("error_code", tmperrno)));
         }
 
         tr_netClose(session, s);
@@ -521,12 +521,12 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
         {
             tr_logAddError(fmt::format(
                 err == EADDRINUSE ?
-                    _("Couldn't bind port {port} on {address}: {errmsg} ({errcode}) -- Is another copy of Transmission already running?") :
-                    _("Couldn't bind port {port} on {address}: {errmsg} ({errcode})"),
+                    _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
+                    _("Couldn't bind port {port} on {address}: {error} ({error_code})"),
                 fmt::arg("address", addr->to_string()),
                 fmt::arg("port", port),
-                fmt::arg("errmsg", tr_net_strerror(err)),
-                fmt::arg("errcode", err)));
+                fmt::arg("error", tr_net_strerror(err)),
+                fmt::arg("error_code", err)));
         }
 
         tr_netCloseSocket(fd);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -42,7 +42,6 @@
 #define IN_MULTICAST(a) (((a)&0xf0000000) == 0xe0000000)
 #endif
 
-#undef tr_logAddCritical
 #undef tr_logAddError
 #undef tr_logAddWarn
 #undef tr_logAddInfo
@@ -50,7 +49,6 @@
 #undef tr_logAddTrace
 
 auto constexpr LogName = std::string_view{ "net" };
-#define tr_logAddCritical(...) tr_logAddNamed(TR_LOG_CRITICAL, LogName, __VA_ARGS__)
 #define tr_logAddError(...) tr_logAddNamed(TR_LOG_ERROR, LogName, __VA_ARGS__)
 #define tr_logAddWarn(...) tr_logAddNamed(TR_LOG_WARN, LogName, __VA_ARGS__)
 #define tr_logAddInfo(...) tr_logAddNamed(TR_LOG_INFO, LogName, __VA_ARGS__)

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -68,8 +68,7 @@ struct tr_pex
 
     [[nodiscard]] std::string to_string() const
     {
-        auto buf = std::array<char, 64>{};
-        return std::string{ to_string(std::data(buf), std::size(buf)) };
+        return addr.to_string(port);
     }
 };
 

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -115,8 +115,8 @@ static void natPulse(tr_shared* s, bool do_check)
         tr_logAddNamedInfo(
             CodeName,
             fmt::format(
-                _("State changed from '{oldstate}' to '{state}"),
-                fmt::arg("oldstate", getNatStateStr(old_status)),
+                _("State changed from '{old_state}' to '{state}"),
+                fmt::arg("old_state", getNatStateStr(old_status)),
                 fmt::arg("state", getNatStateStr(new_status))));
     }
 }

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -24,7 +24,7 @@
 #include "upnp.h"
 #include "utils.h"
 
-static auto constexpr CodeName = std::string_view{ "port-fwd" };
+static auto constexpr LogName = std::string_view{ "port-fwd" };
 
 struct tr_shared
 {
@@ -94,7 +94,7 @@ static void natPulse(tr_shared* s, bool do_check)
         session->public_peer_port = public_peer_port;
         session->private_peer_port = received_private_port;
         tr_logAddNamedInfo(
-            CodeName,
+            LogName,
             fmt::format(
                 _("Mapped private port '{private_port}' to public port '{public_port}'"),
                 fmt::arg("public_port", session->public_peer_port),
@@ -113,7 +113,7 @@ static void natPulse(tr_shared* s, bool do_check)
     if (new_status != old_status)
     {
         tr_logAddNamedInfo(
-            CodeName,
+            LogName,
             fmt::format(
                 _("State changed from '{old_state}' to '{state}"),
                 fmt::arg("old_state", getNatStateStr(old_status)),
@@ -206,7 +206,7 @@ static void stop_timer(tr_shared* s)
 
 static void stop_forwarding(tr_shared* s)
 {
-    tr_logAddNamedTrace(CodeName, "stopped");
+    tr_logAddNamedTrace(LogName, "stopped");
     natPulse(s, false);
 
     tr_natpmpClose(s->natpmp);

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -4,6 +4,8 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <string_view>
+
 #include <sys/types.h>
 
 #include <event2/event.h>
@@ -22,8 +24,7 @@
 #include "upnp.h"
 #include "utils.h"
 
-#define loginfo(...) tr_logAddNamed(TR_LOG_INFO, "port-forwarding", __VA_ARGS__)
-#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "port-forwarding", __VA_ARGS__)
+static auto constexpr CodeName = std::string_view{ "port-fwd" };
 
 struct tr_shared
 {
@@ -92,7 +93,12 @@ static void natPulse(tr_shared* s, bool do_check)
     {
         session->public_peer_port = public_peer_port;
         session->private_peer_port = received_private_port;
-        loginfo("public peer port %d (private %d) ", session->public_peer_port, session->private_peer_port);
+        tr_logAddNamedInfo(
+            CodeName,
+            fmt::format(
+                _("Mapped private port '{private_port}' to public port '{public_port}'"),
+                fmt::arg("public_port", session->public_peer_port),
+                fmt::arg("private_port", session->private_peer_port)));
     }
 
     s->upnpStatus = tr_upnpPulse(
@@ -106,10 +112,12 @@ static void natPulse(tr_shared* s, bool do_check)
 
     if (new_status != old_status)
     {
-        loginfo(fmt::format(
-            _("State changed from '{oldstate}' to '{state}"),
-            fmt::arg("oldstate", getNatStateStr(old_status)),
-            fmt::arg("state", getNatStateStr(new_status))));
+        tr_logAddNamedInfo(
+            CodeName,
+            fmt::format(
+                _("State changed from '{oldstate}' to '{state}"),
+                fmt::arg("oldstate", getNatStateStr(old_status)),
+                fmt::arg("state", getNatStateStr(new_status))));
     }
 }
 
@@ -198,7 +206,7 @@ static void stop_timer(tr_shared* s)
 
 static void stop_forwarding(tr_shared* s)
 {
-    logtrace("stopped");
+    tr_logAddNamedTrace(CodeName, "stopped");
     natPulse(s, false);
 
     tr_natpmpClose(s->natpmp);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -567,7 +567,12 @@ static auto loadProgress(tr_variant* dict, tr_torrent* tor)
 
         if (std::size(mtimes) != n_files)
         {
-            tr_logAddWarnTor(tor, fmt::format("got {} mtimes; expected {}", std::size(mtimes), n_files));
+            tr_logAddWarnTor(
+                tor,
+                fmt::format(
+                    _("Couldn't load mtime data: expected {expected_size} mtimes; got {actual_size}"),
+                    fmt::arg("expected_size", std::size(mtimes)),
+                    fmt::arg("actual_size", n_files)));
             // if resizing grows the vector, we'll get 0 mtimes for the
             // new items which is exactly what we want since the pieces
             // in an unknown state should be treated as untested

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -567,12 +567,7 @@ static auto loadProgress(tr_variant* dict, tr_torrent* tor)
 
         if (std::size(mtimes) != n_files)
         {
-            tr_logAddWarnTor(
-                tor,
-                fmt::format(
-                    _("Couldn't load mtime data: expected {expected_size} mtimes; got {actual_size}"),
-                    fmt::arg("expected_size", std::size(mtimes)),
-                    fmt::arg("actual_size", n_files)));
+            tr_logAddDebugTor(tor, fmt::format("Couldn't load mtimes: expected {} got {}", std::size(mtimes), n_files));
             // if resizing grows the vector, we'll get 0 mtimes for the
             // new items which is exactly what we want since the pieces
             // in an unknown state should be treated as untested

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -908,7 +908,7 @@ static auto parseWhitelist(std::string_view whitelist)
         if (token.find_first_of("+-"sv) != std::string_view::npos)
         {
             tr_logAddWarn(fmt::format(
-                _("Added '{entry}' to host whitelist and it has a '+' or '-'!  Are you using an old ACL by mistake?)"),
+                _("Added '{entry}' to host whitelist and it has a '+' or '-'! Are you using an old ACL by mistake?"),
                 fmt::arg("entry", token)));
         }
         else

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -708,7 +708,7 @@ static bool bindUnixSocket(
     if (chmod(addr.sun_path, (mode_t)socket_mode) != 0)
     {
         tr_logAddWarn(
-            fmt::format(_("Could not set RPC socket mode to {mode:o}, defaulting to 0755"), fmt::arg("mode", socket_mode)));
+            fmt::format(_("Could not set RPC socket mode to {mode:#o}, defaulting to 0755"), fmt::arg("mode", socket_mode)));
     }
 
     return evhttp_bind_listener(httpd, lev) != nullptr;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1209,9 +1209,9 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     else if (!tr_rpc_address_from_string(*bindAddress, sv))
     {
         tr_logAddWarn(fmt::format(
-            _("The '{key}' setting is '{address}' but must be an IPv4 or IPv6 address or a Unix socket path. Using default value '0.0.0.0'"),
+            _("The '{key}' setting is '{value}' but must be an IPv4 or IPv6 address or a Unix socket path. Using default value '0.0.0.0'"),
             fmt::format("key", tr_quark_get_string(key)),
-            fmt::format("address", sv)));
+            fmt::format("value", sv)));
         bindAddress->set_inaddr_any();
     }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -826,7 +826,7 @@ static void stopServer(tr_rpc_server* server)
     }
 
     tr_logAddInfo(fmt::format(
-        _("Listening for RPC and Web requests on '{address}'"),
+        _("Stopped listening for RPC and Web requests on '{address}'"),
         fmt::arg("address", tr_rpc_address_with_port(server))));
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -13,6 +13,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/core.h>
+
 #include <libdeflate.h>
 
 #include "transmission.h"
@@ -38,15 +40,13 @@
 #include "web-utils.h"
 #include "web.h"
 
-static auto constexpr RpcVersion = int64_t{ 17 };
-static auto constexpr RpcVersionMin = int64_t{ 14 };
-static char constexpr RpcVersionSemver[] = "5.3.0";
-
-static auto constexpr RecentlyActiveSeconds = time_t{ 60 };
-
 using namespace std::literals;
 
-#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "rpc", __VA_ARGS__)
+static auto constexpr CodeName = "rpc"sv;
+static auto constexpr RecentlyActiveSeconds = time_t{ 60 };
+static auto constexpr RpcVersion = int64_t{ 17 };
+static auto constexpr RpcVersionMin = int64_t{ 14 };
+static auto constexpr RpcVersionSemver = "5.3.0"sv;
 
 enum class TrFormat
 {
@@ -1514,11 +1514,13 @@ static void onMetadataFetched(tr_web::FetchResponse const& web_response)
     auto const& [status, body, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
-    logtrace(
-        "torrentAdd: HTTP response code was %ld (%s); response length was %zu bytes",
-        status,
-        tr_webGetResponseStr(status),
-        std::size(body));
+    tr_logAddNamedTrace(
+        CodeName,
+        fmt::format(
+            "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",
+            status,
+            tr_webGetResponseStr(status),
+            std::size(body)));
 
     if (status == 200 || status == 221) /* http or ftp success.. */
     {
@@ -1656,7 +1658,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         tr_ctorSetLabels(ctor, std::move(labels));
     }
 
-    logtrace("torrentAdd: filename is \"%" TR_PRIsv "\"", TR_PRIsv_ARG(filename));
+    tr_logAddNamedTrace(CodeName, fmt::format("torrentAdd: filename is '{}'", filename));
 
     if (isCurlURL(filename))
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -42,7 +42,7 @@
 
 using namespace std::literals;
 
-static auto constexpr CodeName = "rpc"sv;
+static auto constexpr LogName = "rpc"sv;
 static auto constexpr RecentlyActiveSeconds = time_t{ 60 };
 static auto constexpr RpcVersion = int64_t{ 17 };
 static auto constexpr RpcVersionMin = int64_t{ 14 };
@@ -1515,7 +1515,7 @@ static void onMetadataFetched(tr_web::FetchResponse const& web_response)
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
     tr_logAddNamedTrace(
-        CodeName,
+        LogName,
         fmt::format(
             "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",
             status,
@@ -1658,7 +1658,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         tr_ctorSetLabels(ctor, std::move(labels));
     }
 
-    tr_logAddNamedTrace(CodeName, fmt::format("torrentAdd: filename is '{}'", filename));
+    tr_logAddNamedTrace(LogName, fmt::format("torrentAdd: filename is '{}'", filename));
 
     if (isCurlURL(filename))
     {

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -94,10 +94,10 @@ static tr_sys_file_t create_session_id_lock_file(char const* session_id)
     if (error != nullptr)
     {
         tr_logAddWarn(fmt::format(
-            _("Couldn't create '{path}': {errmsg} ({errcode})"),
+            _("Couldn't create '{path}': {error} ({error_code})"),
             fmt::arg("path", lock_file_path),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         tr_error_free(error);
     }
 
@@ -201,10 +201,10 @@ bool tr_session_id_is_local(char const* session_id)
         if (error != nullptr)
         {
             tr_logAddWarn(fmt::format(
-                _("Couldn't open session lock file '{path}': {errmsg} ({errcode})"),
+                _("Couldn't open session lock file '{path}': {error} ({error_code})"),
                 fmt::arg("path", lock_file_path),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
             tr_error_free(error);
         }
     }

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -542,8 +542,8 @@ bool tr_torrent_metainfo::migrateFile(
         tr_logAddNamedError(
             name,
             fmt::format(
-                _("Migrated torrent file from '{oldpath}' to '{path}'"),
-                fmt::arg("oldpath", old_filename),
+                _("Migrated torrent file from '{old_path}' to '{path}'"),
+                fmt::arg("old_path", old_filename),
                 fmt::arg("path", new_filename)));
         return true;
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1789,10 +1789,10 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
         logwarn(
             tor,
             fmt::format(
-                _("Couldn't call script '{path}': {errmsg} ({errcode})"),
+                _("Couldn't call script '{path}': {error} ({error_code})"),
                 fmt::arg("path", script),
-                fmt::arg("errmsg", error->message),
-                fmt::arg("errcode", error->code)));
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
         tr_error_free(error);
     }
 }
@@ -2396,11 +2396,11 @@ static void setLocationImpl(struct LocationData* const data)
                         logerr(
                             tor,
                             fmt::format(
-                                _("Couldn't move '{oldpath}' to '{path}': {errmsg} ({errcode})"),
-                                fmt::arg("oldpath", oldpath),
+                                _("Couldn't move '{old_path}' to '{path}': {error} ({error_code})"),
+                                fmt::arg("old_path", oldpath),
                                 fmt::arg("path", newpath),
-                                fmt::arg("errmsg", error->message),
-                                fmt::arg("errcode", error->code)));
+                                fmt::arg("error", error->message),
+                                fmt::arg("error_code", error->code)));
                         tr_error_free(error);
                     }
                 }
@@ -2542,11 +2542,11 @@ static void tr_torrentFileCompleted(tr_torrent* tor, tr_file_index_t i)
                 logerr(
                     tor,
                     fmt::format(
-                        _("Couldn't move '{oldpath}' to '{path}': {errmsg} ({errcode})"),
-                        fmt::arg("oldpath", oldpath),
+                        _("Couldn't move '{old_path}' to '{path}': {error} ({error_code})"),
+                        fmt::arg("old_path", oldpath),
                         fmt::arg("path", newpath),
-                        fmt::arg("errmsg", error->message),
-                        fmt::arg("errcode", error->code)));
+                        fmt::arg("error", error->message),
+                        fmt::arg("error_code", error->code)));
                 tr_error_free(error);
             }
         }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -673,15 +673,15 @@ static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
     int const rc = dht_search(dht_hash, announce ? tr_sessionGetPeerPort(session_) : 0, af, callback, nullptr);
     if (rc < 0)
     {
-        auto const errcode = errno;
+        auto const error_code = errno;
         tr_logAddWarnTor(
             tor,
             fmt::format(
-                _("Unable to announce torrent in DHT with {type}: {errmsg} ({errcode}); status is {status}"),
+                _("Unable to announce torrent in DHT with {type}: {error} ({error_code}); state is {state}"),
                 fmt::arg("type", af == AF_INET6 ? "IPv6" : "IPv4"),
-                fmt::arg("status", tr_dhtPrintableStatus(status)),
-                fmt::arg("errcode", errcode),
-                fmt::arg("errmsg", tr_strerror(errcode))));
+                fmt::arg("state", tr_dhtPrintableStatus(status)),
+                fmt::arg("error_code", error_code),
+                fmt::arg("error", tr_strerror(error_code))));
         return AnnounceResult::FAILED;
     }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -389,9 +389,9 @@ fail:
         tr_logAddNamedWarn(
             CodeName,
             fmt::format(
-                _("Couldn't initialize LPD: {errmsg} ({errcode})"),
-                fmt::arg("errmsg", tr_strerror(save)),
-                fmt::arg("errcode", save)));
+                _("Couldn't initialize LPD: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(save)),
+                fmt::arg("error_code", save)));
         errno = save;
     }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -37,7 +37,7 @@ using in_port_t = uint16_t; /* all missing */
 #include "tr-lpd.h"
 #include "utils.h"
 
-static auto constexpr CodeName = std::string_view{ "lpd" };
+static auto constexpr LogName = std::string_view{ "lpd" };
 
 static auto constexpr SIZEOF_HASH_STRING = TR_SHA1_DIGEST_STRLEN;
 
@@ -282,7 +282,7 @@ int tr_lpdInit(tr_session* ss, tr_address* /*tr_addr*/)
         return -1;
     }
 
-    tr_logAddNamedDebug(CodeName, "Initialising Local Peer Discovery");
+    tr_logAddNamedDebug(LogName, "Initialising Local Peer Discovery");
 
     /* setup datagram socket (receive) */
     {
@@ -375,7 +375,7 @@ int tr_lpdInit(tr_session* ss, tr_address* /*tr_addr*/)
     upkeep_timer = evtimer_new(ss->event_base, on_upkeep_timer, ss);
     tr_timerAdd(upkeep_timer, UpkeepIntervalSecs, 0);
 
-    tr_logAddNamedDebug(CodeName, "Local Peer Discovery initialised");
+    tr_logAddNamedDebug(LogName, "Local Peer Discovery initialised");
 
     return 1;
 
@@ -387,7 +387,7 @@ fail:
         lpd_socket = lpd_socket2 = TR_BAD_SOCKET;
         session = nullptr;
         tr_logAddNamedWarn(
-            CodeName,
+            LogName,
             fmt::format(
                 _("Couldn't initialize LPD: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(save)),
@@ -405,7 +405,7 @@ void tr_lpdUninit(tr_session* ss)
         return;
     }
 
-    tr_logAddNamedTrace(CodeName, "Uninitialising Local Peer Discovery");
+    tr_logAddNamedTrace(LogName, "Uninitialising Local Peer Discovery");
 
     event_free(lpd_event);
     lpd_event = nullptr;
@@ -416,7 +416,7 @@ void tr_lpdUninit(tr_session* ss)
     /* just shut down, we won't remember any former nodes */
     evutil_closesocket(lpd_socket);
     evutil_closesocket(lpd_socket2);
-    tr_logAddNamedTrace(CodeName, "Done uninitialising Local Peer Discovery");
+    tr_logAddNamedTrace(LogName, "Done uninitialising Local Peer Discovery");
 
     session = nullptr;
 }
@@ -555,7 +555,7 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
             return 1;
         }
 
-        tr_logAddNamedDebug(CodeName, fmt::format("Cannot serve torrent #{}", hashString));
+        tr_logAddNamedDebug(LogName, fmt::format("Cannot serve torrent #{}", hashString));
     }
 
     return res;
@@ -630,7 +630,7 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
         if (lpd_unsolicitedMsgCounter < 0)
         {
             tr_logAddNamedTrace(
-                CodeName,
+                LogName,
                 fmt::format(
                     "Dropped {} announces in the last interval (max. {} allowed)",
                     -lpd_unsolicitedMsgCounter,
@@ -700,6 +700,6 @@ static void event_callback(evutil_socket_t /*s*/, short type, void* /*user_data*
             }
         }
 
-        tr_logAddNamedTrace(CodeName, "Discarded invalid multicast message");
+        tr_logAddNamedTrace(LogName, "Discarded invalid multicast message");
     }
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -234,10 +234,10 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     if (!tr_sys_path_get_info(path, 0, &info, &my_error))
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
         return nullptr;
     }
@@ -260,10 +260,10 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
         return nullptr;
     }
@@ -272,10 +272,10 @@ uint8_t* tr_loadFile(char const* path, size_t* size, tr_error** error)
     if (!tr_sys_file_read(fd, buf, info.size, nullptr, &my_error))
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_sys_file_close(fd, nullptr);
         tr_free(buf);
         tr_error_propagate(error, &my_error);
@@ -298,10 +298,10 @@ bool tr_loadFile(std::vector<char>& setme, std::string const& path, tr_error** e
     if (!tr_sys_path_get_info(path_sz, 0, &info, &my_error))
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
         return false;
     }
@@ -318,10 +318,10 @@ bool tr_loadFile(std::vector<char>& setme, std::string const& path, tr_error** e
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
         return false;
     }
@@ -330,10 +330,10 @@ bool tr_loadFile(std::vector<char>& setme, std::string const& path, tr_error** e
     if (!tr_sys_file_read(fd, std::data(setme), info.size, nullptr, &my_error))
     {
         tr_logAddError(fmt::format(
-            _("Couldn't read '{path}': {errmsg} ({errcode})"),
+            _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", path),
-            fmt::arg("errmsg", my_error->message),
-            fmt::arg("errcode", my_error->code)));
+            fmt::arg("error", my_error->message),
+            fmt::arg("error_code", my_error->code)));
         tr_sys_file_close(fd, nullptr);
         tr_error_propagate(error, &my_error);
         return false;
@@ -1161,10 +1161,10 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
         if (!tr_sys_path_remove(oldpath, &my_error))
         {
             tr_logAddError(fmt::format(
-                _("Couldn't remove '{path}': {errmsg} ({errcode})"),
+                _("Couldn't remove '{path}': {error} ({error_code})"),
                 fmt::arg("path", oldpath),
-                fmt::arg("errmsg", my_error->message),
-                fmt::arg("errcode", my_error->code)));
+                fmt::arg("error", my_error->message),
+                fmt::arg("error_code", my_error->code)));
             tr_error_free(my_error);
         }
     }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -82,11 +82,11 @@ static void error_handler(jsonsl_t jsn, jsonsl_error_t error, jsonsl_state_st* /
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
     tr_logAddError(fmt::format(
-        _("JSON parse failed at pos {pos} '{text:16s}': {errmsg} ({errcode})"),
+        _("JSON parse failed at pos {pos} '{text:16s}': {error} ({error_code})"),
         fmt::arg("pos", jsn->pos),
         fmt::arg("text", buf),
-        fmt::arg("errmsg", jsonsl_strerror(error)),
-        fmt::arg("errcode", error)));
+        fmt::arg("error", jsonsl_strerror(error)),
+        fmt::arg("error_code", error)));
 
     data->error = EILSEQ;
 }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1216,10 +1216,10 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string const&
     if (error != nullptr)
     {
         tr_logAddError(fmt::format(
-            _("Couldn't save '{path}': {errmsg} ({errcode})"),
+            _("Couldn't save '{path}': {error} ({error_code})"),
             fmt::arg("path", filename),
-            fmt::arg("errmsg", error->message),
-            fmt::arg("errcode", error->code)));
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
         error_code = error->code;
         tr_error_clear(&error);
     }


### PR DESCRIPTION
Part 6 of a series to update Transmission's logging mechanism. #2771 is the previous in the series. The goals are described [here](https://github.com/transmission/transmission/pull/2749#pullrequest-875916992).

---

This PR continues the previous two that (a) use fmt instead of vararg to improve typesafe logging and (b) ensure that all log messages of severity "Info" or higher are flagged for translation. There are a _lot_ of strings so this is a high-volume task being split up into four PRs, of which this is the third.