### PR TITLE
refactor: fmt pt 4

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -804,7 +804,7 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
         {
             auto const error_code = errno;
             tr_logAddError(fmt::format(
-                _("Couldn't create status event: {error} ({error_code})"),
+                _("Couldn't create event: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
             goto CLEANUP;
@@ -814,7 +814,7 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
         {
             auto const error_code = errno;
             tr_logAddError(fmt::format(
-                _("Couldn't add status event: {error} ({error_code})"),
+                _("Couldn't add event: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
             goto CLEANUP;

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -60,7 +60,7 @@ using namespace std::literals;
 ****
 ***/
 
-static auto constexpr CodeName = "daemon"sv;
+static auto constexpr LogName = "daemon"sv;
 
 #undef tr_logAddError
 #undef tr_logAddWarn
@@ -68,11 +68,11 @@ static auto constexpr CodeName = "daemon"sv;
 #undef tr_logAddDebug
 #undef tr_logAddTrace
 
-#define tr_logAddError(...) tr_logAddNamedError(CodeName, __VA_ARGS__)
-#define tr_logAddWarn(...) tr_logAddNamedWarn(CodeName, __VA_ARGS__)
-#define tr_logAddInfo(...) tr_logAddNamedInfo(CodeName, __VA_ARGS__)
-#define tr_logAddDebug(...) tr_logAddNamedDebug(CodeName, __VA_ARGS__)
-#define tr_logAddTrace(...) tr_logAddNamedTrace(CodeName, __VA_ARGS__)
+#define tr_logAddError(...) tr_logAddNamedError(LogName, __VA_ARGS__)
+#define tr_logAddWarn(...) tr_logAddNamedWarn(LogName, __VA_ARGS__)
+#define tr_logAddInfo(...) tr_logAddNamedInfo(LogName, __VA_ARGS__)
+#define tr_logAddDebug(...) tr_logAddNamedDebug(LogName, __VA_ARGS__)
+#define tr_logAddTrace(...) tr_logAddNamedTrace(LogName, __VA_ARGS__)
 
 /***
 ****

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1457,7 +1457,10 @@ bool gtr_inhibit_hibernation(guint32& cookie)
     }
     catch (Glib::Error const& e)
     {
-        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {error}"), fmt::arg("error", e.what().raw())));
+        tr_logAddError(fmt::format(
+            _("Couldn't inhibit desktop hibernation: {error} ({error_code})"),
+            fmt::arg("error", e.what().raw()),
+            fmt::arg("error_code", e.code())));
     }
 
     return success;
@@ -1482,7 +1485,10 @@ void gtr_uninhibit_hibernation(guint inhibit_cookie)
     }
     catch (Glib::Error const& e)
     {
-        tr_logAddError(fmt::format(_("Couldn't inhibit desktop hibernation: {error}"), fmt::arg("error", e.what().raw())));
+        tr_logAddError(fmt::format(
+            _("Couldn't inhibit desktop hibernation: {error} ({error_code})"),
+            fmt::arg("error", e.what().raw()),
+            fmt::arg("error_code", e.code())));
     }
 }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -708,7 +708,7 @@ static bool bindUnixSocket(
     if (chmod(addr.sun_path, (mode_t)socket_mode) != 0)
     {
         tr_logAddWarn(
-            fmt::format(_("Could not set RPC socket mode to {mode:#o}, defaulting to 0755"), fmt::arg("mode", socket_mode)));
+            fmt::format(_("Couldn't set RPC socket mode to {mode:#o}, defaulting to 0755"), fmt::arg("mode", socket_mode)));
     }
 
     return evhttp_bind_listener(httpd, lev) != nullptr;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2366,7 +2366,7 @@ static void setLocationImpl(struct LocationData* const data)
                 auto const oldpath = tr_strvPath(oldbase, sub);
                 auto const newpath = tr_strvPath(location, sub);
 
-                tr_logAddTraceTor(tor, fmt::format("Found file #{}: {}", i, oldpath));
+                tr_logAddTraceTor(tor, fmt::format("Found file #{}: '{}'", i, oldpath));
 
                 if (do_move && !tr_sys_path_is_same(oldpath.c_str(), newpath.c_str(), nullptr))
                 {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -528,7 +528,7 @@ static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, vo
         break;
 
     case TR_TRACKER_WARNING:
-        tr_logAddWarnTor(tor, fmt::format(_("Tracker warning: '{error}'"), fmt::arg("error", event->text)));
+        tr_logAddWarnTor(tor, fmt::format(_("Tracker warning: '{warning}'"), fmt::arg("warning", event->text)));
         tor->error = TR_STAT_TRACKER_WARNING;
         tor->error_announce_url = event->announce_url;
         tor->error_string = event->text;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1770,7 +1770,7 @@ static void torrentCallScript(tr_torrent const* tor, char const* script)
         { "TR_TORRENT_TRACKERS"sv, trackers_str },
     };
 
-    tr_logAddInfoTor(tor, fmt::format(_("Calling script '{path}'"), script));
+    tr_logAddInfoTor(tor, fmt::format(_("Calling script '{path}'"), fmt::arg("path", script)));
 
     tr_error* error = nullptr;
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -50,7 +50,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
 
     if (rc < 0)
     {
-        logdbg(fmt::format("Failed to set receive buffer: {}", tr_net_strerror(sockerrno)));
+        logdbg(fmt::format("Couldn't set receive buffer: {}", tr_net_strerror(sockerrno)));
     }
 
     size = large ? SEND_BUFFER_SIZE : SMALL_BUFFER_SIZE;
@@ -58,7 +58,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
 
     if (rc < 0)
     {
-        logdbg(fmt::format("Failed to set send buffer: {}", tr_net_strerror(sockerrno)));
+        logdbg(fmt::format("Couldn't set send buffer: {}", tr_net_strerror(sockerrno)));
     }
 
     if (large)
@@ -79,7 +79,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
 
         if (rbuf < RECV_BUFFER_SIZE)
         {
-            logdbg(fmt::format("Failed to set receive buffer: requested {}, got {}", RECV_BUFFER_SIZE, rbuf));
+            logdbg(fmt::format("Couldn't set receive buffer: requested {}, got {}", RECV_BUFFER_SIZE, rbuf));
 #ifdef __linux__
             logdbg(fmt::format("Please add the line 'net.core.rmem_max = {}' to /etc/sysctl.conf", RECV_BUFFER_SIZE));
 #endif
@@ -87,7 +87,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
 
         if (sbuf < SEND_BUFFER_SIZE)
         {
-            logdbg(fmt::format("Failed to set send buffer: requested {}, got {}", SEND_BUFFER_SIZE, sbuf));
+            logdbg(fmt::format("Couldn't set send buffer: requested {}, got {}", SEND_BUFFER_SIZE, sbuf));
 #ifdef __linux__
             logdbg(fmt::format("Please add the line 'net.core.wmem_max = {}' to /etc/sysctl.conf", SEND_BUFFER_SIZE));
 #endif

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -2,39 +2,44 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#include <cstdint>
+#include <string_view>
+
 #include <event2/event.h>
 
-#include <cstdint>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
 #include <libutp/utp.h>
 
 #include "transmission.h"
+
+#include "crypto-utils.h" /* tr_rand_int_weak() */
 #include "log.h"
 #include "net.h"
-#include "session.h"
-#include "crypto-utils.h" /* tr_rand_int_weak() */
 #include "peer-mgr.h"
 #include "peer-socket.h"
+#include "session.h"
 #include "tr-utp.h"
 #include "utils.h"
 
-#define logwarn(...) tr_logAddNamed(TR_LOG_WARN, "utp", __VA_ARGS__)
-#define logtrace(...) tr_logAddNamed(TR_LOG_TRACE, "utp", __VA_ARGS__)
+static auto constexpr CodeName = std::string_view{ "utp" };
 
 #ifndef WITH_UTP
 
 void UTP_Close(struct UTPSocket* socket)
 {
-    logtrace("UTP_Close(%p) was called.", socket);
+    tr_logAddNamedTrace(CodeName, fmt::format("UTP_Close({}) was called.", fmt::ptr(socket)));
 }
 
 void UTP_RBDrained(struct UTPSocket* socket)
 {
-    logtrace("UTP_RBDrained(%p) was called.", socket);
+    tr_logAddNamedTrace(CodeName, fmt::format("UTP_RBDrained({}) was called.", fmt::ptr(socket)));
 }
 
 bool UTP_Write(struct UTPSocket* socket, size_t count)
 {
-    logtrace("UTP_RBDrained(%p, %zu) was called.", socket, count);
+    tr_logAddNamedTrace(CodeName, fmt::format("UTP_Write({}, {}) was called.", fmt::ptr(socket), count));
     return false;
 }
 
@@ -95,7 +100,7 @@ static void incoming(void* vsession, struct UTPSocket* s)
 
     if (!tr_address_from_sockaddr_storage(&addr, &port, &from_storage))
     {
-        logwarn("Unknown socket family");
+        tr_logAddNamedWarn(CodeName, _("Unknown socket family"));
         UTP_Close(s);
         return;
     }

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -23,23 +23,23 @@
 #include "tr-utp.h"
 #include "utils.h"
 
-static auto constexpr CodeName = std::string_view{ "utp" };
+static auto constexpr LogName = std::string_view{ "utp" };
 
 #ifndef WITH_UTP
 
 void UTP_Close(struct UTPSocket* socket)
 {
-    tr_logAddNamedTrace(CodeName, fmt::format("UTP_Close({}) was called.", fmt::ptr(socket)));
+    tr_logAddNamedTrace(LogName, fmt::format("UTP_Close({}) was called.", fmt::ptr(socket)));
 }
 
 void UTP_RBDrained(struct UTPSocket* socket)
 {
-    tr_logAddNamedTrace(CodeName, fmt::format("UTP_RBDrained({}) was called.", fmt::ptr(socket)));
+    tr_logAddNamedTrace(LogName, fmt::format("UTP_RBDrained({}) was called.", fmt::ptr(socket)));
 }
 
 bool UTP_Write(struct UTPSocket* socket, size_t count)
 {
-    tr_logAddNamedTrace(CodeName, fmt::format("UTP_Write({}, {}) was called.", fmt::ptr(socket), count));
+    tr_logAddNamedTrace(LogName, fmt::format("UTP_Write({}, {}) was called.", fmt::ptr(socket), count));
     return false;
 }
 
@@ -100,7 +100,7 @@ static void incoming(void* vsession, struct UTPSocket* s)
 
     if (!tr_address_from_sockaddr_storage(&addr, &port, &from_storage))
     {
-        tr_logAddNamedWarn(CodeName, _("Unknown socket family"));
+        tr_logAddNamedWarn(LogName, _("Unknown socket family"));
         UTP_Close(s);
         return;
     }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -82,8 +82,8 @@ static void error_handler(jsonsl_t jsn, jsonsl_error_t error, jsonsl_state_st* /
     auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
 
     tr_logAddError(fmt::format(
-        _("JSON parse failed at pos {pos} '{text:16s}': {error} ({error_code})"),
-        fmt::arg("pos", jsn->pos),
+        _("Couldn't parse JSON at position {position} '{text:16s}': {error} ({error_code})"),
+        fmt::arg("position", jsn->pos),
         fmt::arg("text", buf),
         fmt::arg("error", jsonsl_strerror(error)),
         fmt::arg("error_code", error)));

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -85,7 +85,7 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Failed to create event: {error} ({error_code})"),
+                _("Couldn't create event: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
         goto FAIL;
@@ -97,7 +97,7 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Failed to add event: {error} ({error_code})"),
+                _("Couldn't add event: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
         goto FAIL;

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -5,9 +5,12 @@
 
 #include <cerrno>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include <event2/event.h>
+
+#include <fmt/core.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 
@@ -18,13 +21,7 @@
 #include "watchdir.h"
 #include "watchdir-common.h"
 
-/***
-****
-***/
-
-#define log_error(...) \
-    (!tr_logLevelIsActive(TR_LOG_ERROR) ? (void)0 : \
-                                          tr_logAddMessage(__FILE__, __LINE__, TR_LOG_ERROR, "watchdir:generic", __VA_ARGS__))
+static auto constexpr LogName = std::string_view{ "watchdir:generic" };
 
 /***
 ****
@@ -84,13 +81,25 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
              ->event = event_new(tr_watchdir_get_event_base(handle), -1, EV_PERSIST, &tr_watchdir_generic_on_event, handle)) ==
         nullptr)
     {
-        log_error("Failed to create event: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Failed to create event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto FAIL;
     }
 
     if (event_add(backend->event, &tr_watchdir_generic_interval) == -1)
     {
-        log_error("Failed to add event: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Failed to add event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto FAIL;
     }
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -5,6 +5,7 @@
 
 #include <cerrno>
 #include <climits> /* NAME_MAX */
+#include <string_view>
 
 #include <unistd.h> /* close() */
 
@@ -12,6 +13,8 @@
 
 #include <event2/bufferevent.h>
 #include <event2/event.h>
+
+#include <fmt/core.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 
@@ -22,13 +25,7 @@
 #include "watchdir.h"
 #include "watchdir-common.h"
 
-/***
-****
-***/
-
-#define log_error(...) \
-    (!tr_logLevelIsActive(TR_LOG_ERROR) ? (void)0 : \
-                                          tr_logAddMessage(__FILE__, __LINE__, TR_LOG_ERROR, "watchdir:inotify", __VA_ARGS__))
+static auto constexpr LogName = std::string_view{ "watchdir:inotify" };
 
 /***
 ****
@@ -77,13 +74,24 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
     {
         if (nread == (size_t)-1)
         {
-            log_error("Failed to read inotify event: %s", tr_strerror(errno));
+            auto const error_code = errno;
+            tr_logAddNamedError(
+                LogName,
+                fmt::format(
+                    _("Failed to read inotify event: {error} ({error_code})"),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             break;
         }
 
         if (nread != sizeof(ev))
         {
-            log_error("Failed to read inotify event: expected %zu, got %zu bytes.", sizeof(ev), nread);
+            tr_logAddNamedError(
+                LogName,
+                fmt::format(
+                    _("Failed to read inotify event: expected {expected_size}, got {actual_size}"),
+                    fmt::arg("expected_size", sizeof(ev)),
+                    fmt::arg("actual_size", nread)));
             break;
         }
 
@@ -100,13 +108,24 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
         /* Consume entire name into buffer */
         if ((nread = bufferevent_read(event, name, ev.len)) == (size_t)-1)
         {
-            log_error("Failed to read inotify name: %s", tr_strerror(errno));
+            auto const error_code = errno;
+            tr_logAddNamedError(
+                LogName,
+                fmt::format(
+                    _("Failed to read filename from inotify: {error} ({error_code})"),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             break;
         }
 
         if (nread != ev.len)
         {
-            log_error("Failed to read inotify name: expected %" PRIu32 ", got %zu bytes.", ev.len, nread);
+            tr_logAddNamedError(
+                LogName,
+                fmt::format(
+                    _("Failed to read filename from inotify: expected {expected_size}, got {actual_size}"),
+                    fmt::arg("expected_size", sizeof(ev)),
+                    fmt::arg("actual_size", nread)));
             break;
         }
 
@@ -152,24 +171,46 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
 
     auto* const backend = tr_new0(tr_watchdir_inotify, 1);
     backend->base.free_func = &tr_watchdir_inotify_free;
-    backend->infd = -1;
-    backend->inwd = -1;
 
-    if ((backend->infd = inotify_init()) == -1)
+    backend->infd = inotify_init();
+    if (backend->infd == -1)
     {
-        log_error("Unable to inotify_init: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto FAIL;
     }
 
-    if ((backend->inwd = inotify_add_watch(backend->infd, path, INOTIFY_WATCH_MASK | IN_ONLYDIR)) == -1)
+    backend->inwd = inotify_add_watch(backend->infd, path, INOTIFY_WATCH_MASK | IN_ONLYDIR);
+    if (backend->inwd == -1)
     {
-        log_error("Failed to setup watchdir \"%s\": %s (%d)", path, tr_strerror(errno), errno);
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto FAIL;
     }
 
-    if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->infd, 0)) == nullptr)
+    backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->infd, 0);
+    if (backend->event == nullptr)
     {
-        log_error("Failed to create event buffer: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto FAIL;
     }
 
@@ -188,7 +229,14 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
             handle,
             nullptr) == -1)
     {
-        log_error("Failed to perform initial scan: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedWarn(
+            LogName,
+            fmt::format(
+                _("Couldn't scan '{path} for new .torrent files': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
     }
 
     return BACKEND_DOWNCAST(backend);

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -78,7 +78,7 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
             tr_logAddNamedError(
                 LogName,
                 fmt::format(
-                    _("Failed to read inotify event: {error} ({error_code})"),
+                    _("Couldn't read event: {error} ({error_code})"),
                     fmt::arg("error", tr_strerror(error_code)),
                     fmt::arg("error_code", error_code)));
             break;
@@ -89,7 +89,7 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
             tr_logAddNamedError(
                 LogName,
                 fmt::format(
-                    _("Failed to read inotify event: expected {expected_size}, got {actual_size}"),
+                    _("Couldn't read event: expected {expected_size}, got {actual_size}"),
                     fmt::arg("expected_size", sizeof(ev)),
                     fmt::arg("actual_size", nread)));
             break;
@@ -112,7 +112,7 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
             tr_logAddNamedError(
                 LogName,
                 fmt::format(
-                    _("Failed to read filename from inotify: {error} ({error_code})"),
+                    _("Couldn't read filename: {error} ({error_code})"),
                     fmt::arg("error", tr_strerror(error_code)),
                     fmt::arg("error_code", error_code)));
             break;
@@ -123,7 +123,7 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
             tr_logAddNamedError(
                 LogName,
                 fmt::format(
-                    _("Failed to read filename from inotify: expected {expected_size}, got {actual_size}"),
+                    _("Couldn't read filename: expected {expected_size}, got {actual_size}"),
                     fmt::arg("expected_size", sizeof(ev)),
                     fmt::arg("actual_size", nread)));
             break;
@@ -179,7 +179,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                _("Couldn't watch '{path}': {error} ({error_code})"),
                 fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
@@ -193,7 +193,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                _("Couldn't watch '{path}': {error} ({error_code})"),
                 fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
@@ -207,7 +207,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Couldn't watch '{path} for new .torrent files': {error} ({error_code})"),
+                _("Couldn't watch '{path}': {error} ({error_code})"),
                 fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
@@ -233,7 +233,7 @@ tr_watchdir_backend* tr_watchdir_inotify_new(tr_watchdir_t handle)
         tr_logAddNamedWarn(
             LogName,
             fmt::format(
-                _("Couldn't scan '{path} for new .torrent files': {error} ({error_code})"),
+                _("Couldn't scan '{path}': {error} ({error_code})"),
                 fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -60,7 +60,7 @@ static void tr_watchdir_kqueue_on_event(evutil_socket_t /*fd*/, short /*type*/, 
     auto const handle = static_cast<tr_watchdir_t>(context);
     auto* const backend = BACKEND_UPCAST(tr_watchdir_get_backend(handle));
 
-    auto ke = kevent{};
+    struct kevent ke;
     auto ts = timespec{};
     if (kevent(backend->kq, nullptr, 0, &ke, 1, &ts) == -1)
     {
@@ -181,6 +181,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
 
     if (event_add(backend->event, nullptr) == -1)
     {
+        auto const error_code = errno;
         tr_logAddNamedError(
             LogName,
             fmt::format(

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -125,6 +125,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
             LogName,
             fmt::format(
                 _("Couldn't watch '{path}': {error} ({error_code})"),
+                fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
         goto fail;

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -5,6 +5,7 @@
 
 #include <cerrno> /* errno */
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include <fcntl.h> /* open() */
@@ -19,22 +20,18 @@
 
 #include <event2/event.h>
 
-#define LIBTRANSMISSION_WATCHDIR_MODULE
+#include <fmt/core.h>
 
+#define LIBTRANSMISSION_WATCHDIR_MODULE
 #include "transmission.h"
+
 #include "log.h"
 #include "tr-assert.h"
 #include "utils.h"
-#include "watchdir.h"
 #include "watchdir-common.h"
+#include "watchdir.h"
 
-/***
-****
-***/
-
-#define log_error(...) \
-    (!tr_logLevelIsActive(TR_LOG_ERROR) ? (void)0 : \
-                                          tr_logAddMessage(__FILE__, __LINE__, TR_LOG_ERROR, "watchdir:kqueue", __VA_ARGS__))
+static auto constexpr LogName = std::string_view{ "watchdir:kqueue" };
 
 /***
 ****
@@ -67,7 +64,13 @@ static void tr_watchdir_kqueue_on_event(evutil_socket_t /*fd*/, short /*type*/, 
 
     if (kevent(backend->kq, nullptr, 0, &ke, 1, &ts) == -1)
     {
-        log_error("Failed to fetch kevent: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Failed to fetch kevent: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         return;
     }
 
@@ -112,19 +115,33 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
 
     auto* backend = new tr_watchdir_kqueue{};
     backend->base.free_func = &tr_watchdir_kqueue_free;
-    backend->kq = -1;
     backend->dirfd = -1;
 
-    if ((backend->kq = kqueue()) == -1)
+    backend->kq = kqueue();
+    if (backend->kq == -1)
     {
-        log_error("Failed to start kqueue");
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't start kqueue: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto fail;
     }
 
     /* Open fd for watching */
-    if ((backend->dirfd = open(path, O_RDONLY | O_EVTONLY)) == -1)
+    backend->dirfd = open(path, O_RDONLY | O_EVTONLY);
+    if (backend->dirfd == -1)
     {
-        log_error("Failed to passively watch directory \"%s\": %s", path, tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't watch '{path}': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto fail;
     }
 
@@ -133,7 +150,14 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
 
     if (kevent(backend->kq, &ke, 1, nullptr, 0, nullptr) == -1)
     {
-        log_error("Failed to set directory event filter with fd %d: %s", backend->kq, tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't set directory event filter for '{path}': {error} ({error_code})"),
+                fmt::arg("path", path),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto fail;
     }
 
@@ -145,13 +169,24 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
              &tr_watchdir_kqueue_on_event,
              handle)) == nullptr)
     {
-        log_error("Failed to create event: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't create event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto fail;
     }
 
     if (event_add(backend->event, nullptr) == -1)
     {
-        log_error("Failed to add event: %s", tr_strerror(errno));
+        tr_logAddNamedError(
+            LogName,
+            fmt::format(
+                _("Couldn't add event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto fail;
     }
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -28,8 +28,8 @@
 #include "log.h"
 #include "tr-assert.h"
 #include "utils.h"
-#include "watchdir-common.h"
 #include "watchdir.h"
+#include "watchdir-common.h"
 
 static auto constexpr LogName = std::string_view{ "watchdir:kqueue" };
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -58,17 +58,17 @@ struct tr_watchdir_kqueue
 static void tr_watchdir_kqueue_on_event(evutil_socket_t /*fd*/, short /*type*/, void* context)
 {
     auto const handle = static_cast<tr_watchdir_t>(context);
-    tr_watchdir_kqueue* const backend = BACKEND_UPCAST(tr_watchdir_get_backend(handle));
-    struct kevent ke;
-    auto ts = timespec{};
+    auto* const backend = BACKEND_UPCAST(tr_watchdir_get_backend(handle));
 
+    auto ke = kevent{};
+    auto ts = timespec{};
     if (kevent(backend->kq, nullptr, 0, &ke, 1, &ts) == -1)
     {
         auto const error_code = errno;
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Failed to fetch kevent: {error} ({error_code})"),
+                _("Couldn't read event: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
         return;
@@ -124,7 +124,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Couldn't start kqueue: {error} ({error_code})"),
+                _("Couldn't watch '{path}': {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
         goto fail;
@@ -154,7 +154,7 @@ tr_watchdir_backend* tr_watchdir_kqueue_new(tr_watchdir_t handle)
         tr_logAddNamedError(
             LogName,
             fmt::format(
-                _("Couldn't set directory event filter for '{path}': {error} ({error_code})"),
+                _("Couldn't watch '{path}': {error} ({error_code})"),
                 fmt::arg("path", path),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -198,11 +198,11 @@ static void tr_watchdir_win32_on_event(struct bufferevent* event, void* context)
         /* Consume entire name into buffer */
         if ((nread = bufferevent_read(event, buffer + header_size, nleft)) == (size_t)-1)
         {
-            auto const error_code = erro;
+            auto const error_code = errno;
             log_error(fmt::format(
                 _("Couldn't read filename: {error} ({error_code})"),
                 fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error)));
+                fmt::arg("error_code", error_code)));
             break;
         }
 

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -284,7 +284,7 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
     backend->fd = INVALID_HANDLE_VALUE;
     backend->notify_pipe[0] = backend->notify_pipe[1] = TR_BAD_SOCKET;
 
-    wchar_t* const wide_path = tr_win32_utf8_to_native(path, -1);
+    wchar_t* wide_path = tr_win32_utf8_to_native(path, -1);
     if (wide_path == nullptr)
     {
         log_error(fmt::format(_("Couldn't convert '{path}' to native path"), fmt::arg("path", path)));

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -3,9 +3,10 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstddef> /* offsetof */
+#include <cstdlib> /* realloc() */
 #include <errno.h>
-#include <stddef.h> /* offsetof */
-#include <stdlib.h> /* realloc() */
+#include <string_view>
 
 #include <process.h> /* _beginthreadex() */
 
@@ -14,6 +15,8 @@
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 #include <event2/util.h>
+
+#include <fmt/core.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 
@@ -29,9 +32,9 @@
 ****
 ***/
 
-#define log_error(...) \
-    (!tr_logLevelIsActive(TR_LOG_ERROR) ? (void)0 : \
-                                          tr_logAddMessage(__FILE__, __LINE__, TR_LOG_ERROR, "watchdir:win32", __VA_ARGS__))
+static auto constexpr LogName = std::string_view{ "watchdir:win32" };
+
+#define log_error(...) tr_logAddNamedError(LogName, __VA_ARGS__)
 
 /***
 ****
@@ -127,14 +130,14 @@ static unsigned int __stdcall tr_watchdir_win32_thread(void* context)
                 &backend->overlapped,
                 nullptr))
         {
-            log_error("Failed to read directory changes");
+            log_error(_("Couldn't read directory changes"));
             return 0;
         }
     }
 
     if (GetLastError() != ERROR_OPERATION_ABORTED)
     {
-        log_error("Failed to wait for directory changes");
+        log_error(_("Couldn't wait for directory changes"));
     }
 
     return 0;
@@ -162,13 +165,20 @@ static void tr_watchdir_win32_on_event(struct bufferevent* event, void* context)
     {
         if (nread == (size_t)-1)
         {
-            log_error("Failed to read event: %s", tr_strerror(errno));
+            auto const error_code = errno;
+            log_error(fmt::format(
+                _("Couldn't read event: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
             break;
         }
 
         if (nread != header_size)
         {
-            log_error("Failed to read event: expected %zu, got %zu bytes.", header_size, nread);
+            log_error(fmt::format(
+                _("Couldn't read event: expected {expected_size}, got {actual_size}"),
+                fmt::arg("expected_size", header_size),
+                fmt::arg("actual_size", nread)));
             break;
         }
 
@@ -188,13 +198,20 @@ static void tr_watchdir_win32_on_event(struct bufferevent* event, void* context)
         /* Consume entire name into buffer */
         if ((nread = bufferevent_read(event, buffer + header_size, nleft)) == (size_t)-1)
         {
-            log_error("Failed to read name: %s", tr_strerror(errno));
+            auto const error_code = erro;
+            log_error(fmt::format(
+                _("Couldn't read filename: {error} ({error_code})"),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error)));
             break;
         }
 
         if (nread != nleft)
         {
-            log_error("Failed to read name: expected %zu, got %zu bytes.", nleft, nread);
+            log_error(fmt::format(
+                _("Couldn't read filename: expected {expected_size}, got {actual_size}"),
+                fmt::arg("expected_size", nleft),
+                fmt::arg("actual_size", nread)));
             break;
         }
 
@@ -261,17 +278,16 @@ static void tr_watchdir_win32_free(tr_watchdir_backend* backend_base)
 tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
 {
     char const* const path = tr_watchdir_get_path(handle);
-    wchar_t* wide_path;
-    tr_watchdir_win32* backend;
 
-    backend = tr_new0(tr_watchdir_win32, 1);
+    auto* const backend = tr_new0(tr_watchdir_win32, 1);
     backend->base.free_func = &tr_watchdir_win32_free;
     backend->fd = INVALID_HANDLE_VALUE;
     backend->notify_pipe[0] = backend->notify_pipe[1] = TR_BAD_SOCKET;
 
-    if ((wide_path = tr_win32_utf8_to_native(path, -1)) == nullptr)
+    wchar_t* const wide_path = tr_win32_utf8_to_native(path, -1);
+    if (wide_path == nullptr)
     {
-        log_error("Failed to convert \"%s\" to native path", path);
+        log_error(fmt::format(_("Couldn't convert '{path}' to native path"), fmt::arg("path", path)));
         goto fail;
     }
 
@@ -284,7 +300,7 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
              FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
              nullptr)) == INVALID_HANDLE_VALUE)
     {
-        log_error("Failed to open directory \"%s\"", path);
+        log_error(fmt::format(_("Couldn't read '{path}'"), fmt::arg("path", path)));
         goto fail;
     }
 
@@ -303,19 +319,27 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
             &backend->overlapped,
             nullptr))
     {
-        log_error("Failed to read directory changes");
+        log_error(fmt::format(_("Couldn't read '{path}'"), fmt::arg("path", path)));
         goto fail;
     }
 
     if (evutil_socketpair(AF_INET, SOCK_STREAM, 0, backend->notify_pipe) == -1)
     {
-        log_error("Failed to create notify pipe: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        log_error(fmt::format(
+            _("Couldn't create pipe: {error} ({error_code})"),
+            fmt::arg("error", tr_strerror(error_code)),
+            fmt::arg("error_code", error_code)));
         goto fail;
     }
 
     if ((backend->event = bufferevent_socket_new(tr_watchdir_get_event_base(handle), backend->notify_pipe[0], 0)) == nullptr)
     {
-        log_error("Failed to create event buffer: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        log_error(fmt::format(
+            _("Couldn't create event: {error} ({error_code})"),
+            fmt::arg("error", tr_strerror(error_code)),
+            fmt::arg("error_code", error_code)));
         goto fail;
     }
 
@@ -325,7 +349,7 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
 
     if ((backend->thread = (HANDLE)_beginthreadex(nullptr, 0, &tr_watchdir_win32_thread, handle, 0, nullptr)) == nullptr)
     {
-        log_error("Failed to create thread");
+        log_error(_("Couldn't create thread"));
         goto fail;
     }
 
@@ -338,7 +362,12 @@ tr_watchdir_backend* tr_watchdir_win32_new(tr_watchdir_t handle)
             handle,
             nullptr) == -1)
     {
-        log_error("Failed to perform initial scan: %s", tr_strerror(errno));
+        auto const error_code = errno;
+        log_error(fmt::format(
+            _("Couldn't scan '{path}': {error} ({error_code})"),
+            fmt::arg("path", path),
+            fmt::arg("error", tr_strerror(error_code)),
+            fmt::arg("error_code", error_code)));
     }
 
     return BACKEND_DOWNCAST(backend);

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -331,7 +331,7 @@ void tr_watchdir_scan(tr_watchdir_t handle, std::unordered_set<std::string>* dir
         tr_logAddNamedWarn(
             LogName,
             fmt::format(
-                _("Couldn't read '{path}': {error} ({error_code})"),
+                _("Couldn't open '{path}': {error} ({error_code})"),
                 fmt::arg("path", handle->path),
                 fmt::arg("error", error->message),
                 fmt::arg("error_code", error->code)));

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -61,7 +61,7 @@ static bool is_regular_file(char const* dir, char const* name)
             tr_logAddNamedWarn(
                 LogName,
                 fmt::format(
-                    _("Skipping '{path}': {error} ({error_code})"),
+                    _("Couldn't read '{path}': {error} ({error_code})"),
                     fmt::arg("path", path),
                     fmt::arg("error", error->message),
                     fmt::arg("error_code", error->code)));

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -11,6 +11,8 @@
 #include <atomic> /* atomic, atomic_fetch_add_explicit, memory_order_relaxed */
 
 #include <libtransmission/transmission.h>
+
+#include <libtransmission/log.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/variant.h>


### PR DESCRIPTION
Part 7 of a series to update Transmission's logging mechanism. #2773 is the previous in the series. The goals are described [here](https://github.com/transmission/transmission/pull/2749#pullrequest-875916992).

---

This PR continues the previous three that (a) use fmt instead of vararg to improve typesafe logging and (b) ensure that all log messages of severity "Info" or higher are flagged for translation. There are a _lot_ of strings so this is a high-volume task being split up into four PRs.

There will be (at least) one more PR in the logging series, but this PR should finish off the task of updating translatable log strings in `libtransmission/`.