### PR TITLE
Fix translations

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -814,7 +814,7 @@ msgstr "Af: %1$s, Op: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "grootte|Af: %1$s, Op: %2$s"
+msgstr "Af: %1$s, Op: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -807,7 +807,7 @@ msgstr "Baxada: %1$s, Xuba: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "tamañu|Baxada: %1$s, Xuba: %2$s"
+msgstr "Baxada: %1$s, Xuba: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/be.po
+++ b/po/be.po
@@ -843,7 +843,7 @@ msgstr "Спампоўванне: %1$s, Раздача: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "size|Спампоўванне: %1$s, Раздача: %2$s"
+msgstr "Спампоўванне: %1$s, Раздача: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -811,7 +811,7 @@ msgstr "নিচে: %1$s, উপরে: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "আকার|নিচে: %1$s, উপরে: %2$s"
+msgstr "নিচে: %1$s, উপরে: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -831,7 +831,7 @@ msgstr "Ned: %1$s, Op: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "størrelse|Ned: %1$s, Op: %2$s"
+msgstr "Ned: %1$s, Op: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -841,7 +841,7 @@ msgstr "Κατέβασμα: %1$s, Ανέβασμα: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "μέγεθος|Λήψη:%1$s, Αποστολή: %2$s"
+msgstr "Λήψη:%1$s, Αποστολή: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -808,7 +808,7 @@ msgstr "Down: %1$s, Up: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "size|Down: %1$s, Up: %2$s"
+msgstr "Down: %1$s, Up: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -889,7 +889,7 @@ msgstr "Bajado: %1$s, Subido: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "Tamaño|Descarga: %1$s, Subida: %2$s"
+msgstr "Descarga: %1$s, Subida: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -819,7 +819,7 @@ msgstr "Deskarga: %1$s, Karga: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "tamaina|Behera: %1$s, Gora: %2$s"
+msgstr "Behera: %1$s, Gora: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/fo.po
+++ b/po/fo.po
@@ -807,7 +807,7 @@ msgstr ""
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "stødd|Niður: %1$s, Upp: %2$s"
+msgstr "Niður: %1$s, Upp: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -813,7 +813,7 @@ msgstr "Aval : %1$s, amont : %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "taille|Aval : %1$s, amont : %2$s"
+msgstr "Aval : %1$s, amont : %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -803,7 +803,7 @@ msgstr "Aval : %1$s, amont : %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "taille|aval : %1$s, amont : %2$s"
+msgstr "aval : %1$s, amont : %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -814,7 +814,7 @@ msgstr "Descargado: %1$s, Enviado: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "tamaño|descargado: %1$s, enviado: %2$s"
+msgstr "descargado: %1$s, enviado: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/hi.po
+++ b/po/hi.po
@@ -813,7 +813,7 @@ msgstr "डाउनलोड: %1$s, अपलोड: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "आकार|डाउनलोड: %1$s, अपलोड: %2$s"
+msgstr "डाउनलोड: %1$s, अपलोड: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -826,7 +826,7 @@ msgstr "Preuzimanje: %1$s, Slanje: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "veličina|Preuzimanje: %1$s, Slanje: %2$s"
+msgstr "Preuzimanje: %1$s, Slanje: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/id.po
+++ b/po/id.po
@@ -811,7 +811,7 @@ msgstr "Unduh: %1$s, Unggah: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "size|Unduh: %1$s, Unggah: %2$s"
+msgstr "Unduh: %1$s, Unggah: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/is.po
+++ b/po/is.po
@@ -811,7 +811,7 @@ msgstr "Inn: %1$s, út: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "stærð|Inn: %1$s, út: %2$s"
+msgstr "Inn: %1$s, út: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -826,7 +826,7 @@ msgstr "下り: %1$s, 上り: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "サイズ|下り: %1$s, 上り: %2$s"
+msgstr "下り: %1$s, 上り: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/ko.po
+++ b/po/ko.po
@@ -815,7 +815,7 @@ msgstr "다운로드: %1$s, 업로드: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "크기|다운로드: %1$s, 업로드: %2$s"
+msgstr "다운로드: %1$s, 업로드: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/ms.po
+++ b/po/ms.po
@@ -794,7 +794,7 @@ msgstr "Muat Turun: %1$s, Naik: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "saiz|Muat Turun: %1$s, Muat Naik: %2$s"
+msgstr "Muat Turun: %1$s, Muat Naik: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -840,7 +840,7 @@ msgstr "Download: %1$s, Upload: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "grootte|Download: %1$s, Upload: %2$s"
+msgstr "Download: %1$s, Upload: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -841,7 +841,7 @@ msgstr "Prejemanje: %1$s, Pošiljanje: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "size|Prejemanje: %1$s, Pošiljanje: %2$s"
+msgstr "Prejemanje: %1$s, Pošiljanje: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -805,7 +805,7 @@ msgstr "Shkarkim: %1$s, Ngarkim: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "masa|Shkarkimi: %1$s, Ngarkimi: %2$s"
+msgstr "Shkarkimi: %1$s, Ngarkimi: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/te.po
+++ b/po/te.po
@@ -807,7 +807,7 @@ msgstr "క్రిందికి: %1$s, పైకి: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "పరిమాణం|కిందికి: %1$s, పైకి: %2$s"
+msgstr "కిందికి: %1$s, పైకి: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/th.po
+++ b/po/th.po
@@ -802,7 +802,7 @@ msgstr ""
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "size|ดาวน์: %1$s, อัพ: %2$s"
+msgstr "ดาวน์: %1$s, อัพ: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/uz.po
+++ b/po/uz.po
@@ -799,7 +799,7 @@ msgstr "Pastga: %1$s, Yuqoriga: %2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "hajmi|Past: %1$s, Yuqori: %2$s"
+msgstr "Past: %1$s, Yuqori: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -802,7 +802,7 @@ msgstr ""
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "cỡ|Xuống: %1$s, Lên: %2$s"
+msgstr "Xuống: %1$s, Lên: %2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -838,7 +838,7 @@ msgstr "下载：%1$s，上传：%2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "量|下载：%s，上传：%s"
+msgstr "下载：%s，上传：%s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -798,7 +798,7 @@ msgstr "下載：%1$s，上傳：%2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "大小|下載：%1$s，上傳：%2$s"
+msgstr "下載：%1$s，上傳：%2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -817,7 +817,7 @@ msgstr "下載：%1$s，上傳：%2$s"
 #: ../gtk/MainWindow.cc:611
 #, c-format
 msgid "size|Down: %1$s, Up: %2$s"
-msgstr "大小|下載：%1$s，上傳：%2$s"
+msgstr "下載：%1$s，上傳：%2$s"
 
 #: ../gtk/MakeDialog.cc:112
 #, c-format


### PR DESCRIPTION
Transmission 3.00 has some weird French translation when displaying the
total transfer.  It looks like this comment a few lines above the
translation in the po file was not respected:

> #. Translators: "size|" is here for disambiguation. Please remove it from your translation.

"size" was not removed but was translated to "taille", the French
translation of the word "size".

A quick `grep --files-with-match -r '^msgstr .*|' po` made it obvious
that the problem exist in other languages, so I adjusted the po files to
fix them likewise.

However I felt not confident enough to fix the 2 following RTL
languages that are also affected:
po/fa.po
po/ug.po
