### PR TITLE
fixup! fix: ensure all bytes read / written to file (#2682)

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -786,7 +786,7 @@ bool tr_sys_file_read_at(
 
     static_assert(sizeof(*bytes_read) >= sizeof(my_bytes_read));
 
-    if (my_bytes_read != -1)
+    if (my_bytes_read > 0)
     {
         if (bytes_read != nullptr)
         {


### PR DESCRIPTION
fix: infinite loop when pread returns 0 at EOF on POSIX. This issue was introduced on Feb 22 by #2682 / e6e1e1d2208cb2e6792b35ddbf3cd700458bb1a0.

With this PR, reading starting at EOF will return an error, both on file-win32 (existing behavior) and file-posix (new to this PR).