### PR TITLE
refactor: aggregate bandwidth objects

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -86,11 +86,9 @@ void Bandwidth::notifyBandwidthConsumedBytes(uint64_t const now, RateControl* r,
 ****
 ***/
 
-Bandwidth::Bandwidth(Bandwidth* new_parent)
+Bandwidth::Bandwidth(Bandwidth* parent)
 {
-    this->band_[TR_UP].honor_parent_limits_ = true;
-    this->band_[TR_DOWN].honor_parent_limits_ = true;
-    this->setParent(new_parent);
+    this->setParent(parent);
 }
 
 /***

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -27,10 +27,10 @@ class tr_peerIo;
 
 struct tr_bandwidth_limits
 {
-    bool up_limited;
-    unsigned int up_limit_KBps;
-    bool down_limited;
-    unsigned int down_limit_KBps;
+    unsigned int up_limit_KBps = 0;
+    unsigned int down_limit_KBps = 0;
+    bool up_limited = false;
+    bool down_limited = false;
 };
 
 /**
@@ -233,8 +233,8 @@ public:
         RateControl piece_;
         unsigned int bytes_left_;
         unsigned int desired_speed_bps_;
-        bool is_limited_;
-        bool honor_parent_limits_;
+        bool is_limited_ = false;
+        bool honor_parent_limits_ = true;
     };
 
     tr_bandwidth_limits getLimits() const;

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -7,8 +7,6 @@
 
 #include <string_view>
 
-#include "transmission.h"
-
 #include "quark.h"
 
 /**

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1071,7 +1071,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
 
                 /* this steals its refcount too, which is balanced by our unref in peerDelete() */
                 tr_peerIo* stolen = tr_handshakeStealIO(result.handshake);
-                tr_peerIoSetParent(stolen, s->tor->bandwidth);
+                tr_peerIoSetParent(stolen, &s->tor->bandwidth_);
                 createBitTorrentPeer(s->tor, stolen, atom, client);
 
                 success = true;
@@ -1100,7 +1100,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     }
     else /* we don't have a connection to them yet... */
     {
-        tr_peerIo* const io = tr_peerIoNewIncoming(session, session->bandwidth, addr, port, tr_time(), socket);
+        tr_peerIo* const io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket);
         tr_handshake* const handshake = tr_handshakeNew(io, session->encryptionMode, on_handshake_done, manager);
 
         tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
@@ -2091,15 +2091,15 @@ static int getRate(tr_torrent const* tor, struct peer_atom const* atom, uint64_t
     return Bps;
 }
 
-static inline bool isBandwidthMaxedOut(Bandwidth const* b, uint64_t const now_msec, tr_direction dir)
+static inline bool isBandwidthMaxedOut(Bandwidth const& b, uint64_t const now_msec, tr_direction dir)
 {
-    if (!b->isLimited(dir))
+    if (!b.isLimited(dir))
     {
         return false;
     }
 
-    unsigned int const got = b->getPieceSpeedBytesPerSecond(now_msec, dir);
-    unsigned int const want = b->getDesiredSpeedBytesPerSecond(dir);
+    unsigned int const got = b.getPieceSpeedBytesPerSecond(now_msec, dir);
+    unsigned int const want = b.getDesiredSpeedBytesPerSecond(dir);
     return got >= want;
 }
 
@@ -2112,7 +2112,7 @@ static void rechokeUploads(tr_swarm* s, uint64_t const now)
     auto* const choke = tr_new0(struct ChokeData, peerCount);
     tr_session const* session = s->manager->session;
     bool const chokeAll = !s->tor->clientCanUpload();
-    bool const isMaxedOut = isBandwidthMaxedOut(s->tor->bandwidth, now, TR_UP);
+    bool const isMaxedOut = isBandwidthMaxedOut(s->tor->bandwidth_, now, TR_UP);
 
     /* an optimistic unchoke peer's "optimistic"
      * state lasts for N calls to rechokeUploads(). */
@@ -2604,8 +2604,8 @@ static void bandwidthPulse(evutil_socket_t /*fd*/, short /*what*/, void* vmgr)
     pumpAllPeers(mgr);
 
     /* allocate bandwidth to the peers */
-    session->bandwidth->allocate(TR_UP, BandwidthPeriodMsec);
-    session->bandwidth->allocate(TR_DOWN, BandwidthPeriodMsec);
+    session->top_bandwidth_.allocate(TR_UP, BandwidthPeriodMsec);
+    session->top_bandwidth_.allocate(TR_DOWN, BandwidthPeriodMsec);
 
     /* torrent upkeep */
     for (auto* const tor : session->torrents())
@@ -2973,7 +2973,7 @@ static std::vector<peer_candidate> getPeerCandidates(tr_session* session, size_t
         }
 
         /* if we've already got enough speed in this torrent... */
-        if (seeding && isBandwidthMaxedOut(tor->bandwidth, now_msec, TR_UP))
+        if (seeding && isBandwidthMaxedOut(tor->bandwidth_, now_msec, TR_UP))
         {
             continue;
         }
@@ -3026,7 +3026,7 @@ static void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, struct peer_atom* a
 
     tr_peerIo* const io = tr_peerIoNewOutgoing(
         mgr->session,
-        mgr->session->bandwidth,
+        &mgr->session->top_bandwidth_,
         &atom->addr,
         atom->port,
         tr_time(),

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1725,14 +1725,14 @@ static char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args
         }
     }
 
-    tr_variant* list = tr_variantDictAddList(args_out, TR_KEY_group, 1);
+    auto* const list = tr_variantDictAddList(args_out, TR_KEY_group, 1);
     for (auto const& [name, group] : s->bandwidth_groups_)
     {
-        if (names.empty() || names.count(name) > 0)
+        if (names.empty() || names.count(name.sv()) > 0)
         {
             tr_variant* dict = tr_variantListAddDict(list, 5);
             auto limits = group->getLimits();
-            tr_variantDictAddStrView(dict, TR_KEY_name, name);
+            tr_variantDictAddStrView(dict, TR_KEY_name, name.sv());
             tr_variantDictAddBool(dict, TR_KEY_uploadLimited, limits.up_limited);
             tr_variantDictAddInt(dict, TR_KEY_uploadLimit, limits.up_limit_KBps);
             tr_variantDictAddBool(dict, TR_KEY_downloadLimited, limits.down_limited);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -78,8 +78,9 @@ static auto constexpr DefaultPrefetchEnabled = bool{ true };
 #endif
 static auto constexpr SaveIntervalSecs = int{ 360 };
 
-static void bandwidthGroupRead(tr_session* session, char const* configDir);
-static int bandwidthGroupWrite(tr_session* session, char const* configDir);
+static void bandwidthGroupRead(tr_session* session, std::string_view config_dir);
+static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir);
+static auto constexpr BandwidthGroupsFilename = "bandwidth-groups.json"sv;
 
 static tr_port getRandomPort(tr_session const* s)
 {
@@ -149,17 +150,18 @@ std::optional<std::string> tr_session::WebMediator::publicAddress() const
 unsigned int tr_session::WebMediator::clamp(int torrent_id, unsigned int byte_count) const
 {
     auto const lock = session_->unique_lock();
+
     auto const* const tor = session_->torrents().get(torrent_id);
-    return tor == nullptr ? 0U : tor->bandwidth->clamp(TR_DOWN, byte_count);
+    return tor == nullptr ? 0U : tor->bandwidth_.clamp(TR_DOWN, byte_count);
 }
 
 void tr_session::WebMediator::notifyBandwidthConsumed(int torrent_id, size_t byte_count)
 {
     auto const lock = session_->unique_lock();
-    auto const* const tor = session_->torrents().get(torrent_id);
-    if (tor != nullptr)
+
+    if (auto* const tor = session_->torrents().get(torrent_id); tor != nullptr)
     {
-        tor->bandwidth->notifyBandwidthConsumed(TR_DOWN, byte_count, true, tr_time_msec());
+        tor->bandwidth_.notifyBandwidthConsumed(TR_DOWN, byte_count, true, tr_time_msec());
     }
 }
 
@@ -600,7 +602,6 @@ tr_session* tr_sessionInit(char const* config_dir, bool messageQueuingEnabled, t
     session->cache = tr_cacheNew(1024 * 1024 * 2);
     session->magicNumber = SESSION_MAGIC_NUMBER;
     session->session_id = tr_session_id_new();
-    session->bandwidth = new Bandwidth(nullptr);
     session->removed_torrents.clear();
     bandwidthGroupRead(session, config_dir);
 
@@ -702,7 +703,7 @@ static void tr_sessionInitImpl(init_data* data)
     TR_ASSERT(tr_variantIsDict(clientSettings));
 
     tr_logAddTrace(
-        fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&session->bandwidth)));
+        fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&session->top_bandwidth_)));
 
     tr_variant settings;
 
@@ -1392,9 +1393,8 @@ static void updateBandwidth(tr_session* session, tr_direction dir)
     bool const isLimited = tr_sessionGetActiveSpeedLimit_Bps(session, dir, &limit_Bps);
     bool const zeroCase = isLimited && limit_Bps == 0;
 
-    session->bandwidth->setLimited(dir, isLimited && !zeroCase);
-
-    session->bandwidth->setDesiredSpeedBytesPerSecond(dir, limit_Bps);
+    session->top_bandwidth_.setLimited(dir, isLimited && !zeroCase);
+    session->top_bandwidth_.setDesiredSpeedBytesPerSecond(dir, limit_Bps);
 }
 
 static auto constexpr MinutesPerHour = int{ 60 };
@@ -1780,12 +1780,12 @@ bool tr_sessionGetDeleteSource(tr_session const* session)
 
 unsigned int tr_sessionGetPieceSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->bandwidth->getPieceSpeedBytesPerSecond(0, dir) : 0;
+    return tr_isSession(session) ? session->top_bandwidth_.getPieceSpeedBytesPerSecond(0, dir) : 0;
 }
 
 static unsigned int tr_sessionGetRawSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->bandwidth->getRawSpeedBytesPerSecond(0, dir) : 0;
+    return tr_isSession(session) ? session->top_bandwidth_.getRawSpeedBytesPerSecond(0, dir) : 0;
 }
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
@@ -1990,7 +1990,6 @@ void tr_sessionClose(tr_session* session)
     }
 
     /* free the session memory */
-    delete session->bandwidth;
     delete session->turtle.minutes;
     tr_session_id_free(session->session_id);
 
@@ -2274,20 +2273,10 @@ void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers)
 ****
 ***/
 
-Bandwidth* tr_session::bandwidthGroupFind(std::string_view name)
+Bandwidth& tr_session::getBandwidthGroup(std::string_view name)
 {
-    std::string str_name{ name };
-    if (name.empty())
-    {
-        return nullptr;
-    }
-
-    if (bandwidth_groups[str_name] == nullptr)
-    {
-        Bandwidth* bw = new Bandwidth(bandwidth);
-        bandwidth_groups[str_name] = bw;
-    }
-    return bandwidth_groups[str_name];
+    auto const [it, is_new] = bandwidth_groups_.try_emplace(std::string{ name }, &top_bandwidth_);
+    return *it->second;
 }
 
 /***
@@ -2873,66 +2862,63 @@ int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)
     return max - active_count;
 }
 
-static void bandwidthGroupRead(tr_session* session, char const* configDir)
+static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 {
-    tr_variant group_list;
-    auto const filename = tr_strvPath(configDir, "bandwidthGroups");
-    if (!tr_variantFromFile(&group_list, TR_VARIANT_PARSE_JSON, filename, nullptr) || !tr_variantIsList(&group_list))
+    auto group_list = tr_variant{};
+
+    if (auto const path = tr_strvPath(config_dir, BandwidthGroupsFilename);
+        !tr_variantFromFile(&group_list, TR_VARIANT_PARSE_JSON, path, nullptr) || !tr_variantIsList(&group_list))
     {
         return;
     }
-    int n = tr_variantListSize(&group_list);
 
-    for (int i = 0; i < n; i++)
+    for (size_t i = 0, n = tr_variantListSize(&group_list); i < n; ++i)
     {
-        tr_variant* dict = tr_variantListChild(&group_list, i);
+        auto* const dict = tr_variantListChild(&group_list, i);
+
         std::string_view name;
         if (!tr_variantDictFindStrView(dict, TR_KEY_name, &name) || name.empty())
         {
             continue;
         }
 
-        Bandwidth* group = session->bandwidthGroupFind(name);
-        if (group == nullptr)
-        {
-            continue;
-        }
+        auto& group = session->getBandwidthGroup(name);
 
-        int64_t val = 0;
-        tr_bandwidth_limits limits;
+        auto limits = tr_bandwidth_limits{};
         tr_variantDictFindBool(dict, TR_KEY_uploadLimited, &limits.up_limited);
-        if (tr_variantDictFindInt(dict, TR_KEY_uploadLimit, &val))
-        {
-            limits.up_limit_KBps = val;
-        }
-
         tr_variantDictFindBool(dict, TR_KEY_downloadLimited, &limits.down_limited);
-        if (tr_variantDictFindInt(dict, TR_KEY_downloadLimit, &val))
+
+        if (auto limit = int64_t{}; tr_variantDictFindInt(dict, TR_KEY_uploadLimit, &limit))
         {
-            limits.down_limit_KBps = val;
+            limits.up_limit_KBps = limit;
         }
 
-        group->setLimits(&limits);
-
-        bool honors = false;
-        if (tr_variantDictFindBool(dict, TR_KEY_honorsSessionLimits, &honors))
+        if (auto limit = int64_t{}; tr_variantDictFindInt(dict, TR_KEY_downloadLimit, &limit))
         {
-            group->honorParentLimits(TR_UP, honors);
-            group->honorParentLimits(TR_DOWN, honors);
+            limits.down_limit_KBps = limit;
+        }
+
+        group.setLimits(&limits);
+
+        if (auto honors = bool{}; tr_variantDictFindBool(dict, TR_KEY_honorsSessionLimits, &honors))
+        {
+            group.honorParentLimits(TR_UP, honors);
+            group.honorParentLimits(TR_DOWN, honors);
         }
     }
     tr_variantFree(&group_list);
 }
 
-static int bandwidthGroupWrite(tr_session* session, char const* configDir)
+static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
 {
-    tr_variant group_list;
-    int n = session->bandwidth_groups.size();
-    tr_variantInitList(&group_list, n);
-    for (auto const& [name, group] : session->bandwidth_groups)
+    auto group_list = tr_variant{};
+
+    auto const& groups = session->bandwidth_groups_;
+    tr_variantInitList(&group_list, std::size(groups));
+    for (auto const& [name, group] : groups)
     {
-        tr_variant* dict = tr_variantListAddDict(&group_list, 5);
-        auto limits = group->getLimits();
+        auto* const dict = tr_variantListAddDict(&group_list, 5);
+        auto const limits = group->getLimits();
 
         tr_variantDictAddStr(dict, TR_KEY_name, name);
         tr_variantDictAddBool(dict, TR_KEY_uploadLimited, limits.up_limited);
@@ -2942,7 +2928,7 @@ static int bandwidthGroupWrite(tr_session* session, char const* configDir)
         tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->areParentLimitsHonored(TR_UP));
     }
 
-    auto const filename = tr_strvPath(configDir, "bandwidthGroups");
+    auto const filename = tr_strvPath(config_dir, BandwidthGroupsFilename);
     auto const ret = tr_variantToFile(&group_list, TR_VARIANT_FMT_JSON, filename);
     tr_variantFree(&group_list);
     return ret;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -16,6 +16,7 @@
 #include <cstdint> // uintX_t
 #include <ctime>
 #include <list>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -27,6 +28,7 @@
 
 #include "announce-list.h"
 #include "bandwidth.h"
+#include "interned-string.h"
 #include "net.h" // tr_socket_t
 #include "quark.h"
 #include "torrents.h"
@@ -391,7 +393,7 @@ public:
     // monitors the "global pool" speeds
     Bandwidth top_bandwidth_;
 
-    std::map<std::string, std::unique_ptr<Bandwidth>> bandwidth_groups_;
+    std::map<tr_interned_string, std::unique_ptr<Bandwidth>> bandwidth_groups_;
 
     float desiredRatio;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -255,6 +255,10 @@ public:
         tr_netSetTOS(sock, peer_socket_tos_, type);
     }
 
+    // bandwidth
+
+    Bandwidth& getBandwidthGroup(std::string_view name);
+
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
@@ -384,10 +388,10 @@ public:
     struct event* nowTimer;
     struct event* saveTimer;
 
-    /* monitors the "global pool" speeds */
-    // Changed to non-owning pointer temporarily till tr_session becomes C++-constructible and destructible
-    // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    Bandwidth* bandwidth;
+    // monitors the "global pool" speeds
+    Bandwidth top_bandwidth_;
+
+    std::map<std::string, std::unique_ptr<Bandwidth>> bandwidth_groups_;
 
     float desiredRatio;
 
@@ -404,9 +408,6 @@ public:
     // See tr_netTos*() in libtransmission/net.h for more info
     // Only session.cc should use this.
     int peer_socket_tos_ = *tr_netTosFromName(TR_DEFAULT_PEER_SOCKET_TOS_STR);
-
-    Bandwidth* bandwidthGroupFind(std::string_view name);
-    std::map<std::string, Bandwidth*> bandwidth_groups;
 
 private:
     static std::recursive_mutex session_mutex_;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -587,9 +587,7 @@ public:
 
     tr_torrent_announcer* torrent_announcer = nullptr;
 
-    // Changed to non-owning pointer temporarily till tr_torrent becomes C++-constructible and destructible
-    // TODO: change tr_bandwidth* to owning pointer to the bandwidth, or remove * and own the value
-    Bandwidth* bandwidth = nullptr;
+    Bandwidth bandwidth_;
 
     tr_swarm* swarm = nullptr;
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -154,7 +154,7 @@ public:
         , base_url{ url }
         , callback{ callback_in }
         , callback_data{ callback_data_in }
-        , bandwidth(tor->bandwidth)
+        , bandwidth(&tor->bandwidth_)
         , pulse_timer(evtimer_new(session->event_base, &tr_webseed::onTimer, this), event_free)
     {
         // init parent bits


### PR DESCRIPTION
#2761 got me looking at the bandwidth code again and realizing that after a4d7e11a14f16b4bac69b99d4c0da055847b9625 it's possible to aggregate the bandwidth objects in tr_session and tr_torrent directly, rather than via new and delete.

Also implements a couple of code comments from #2761, e.g. not leaking bandwidth groups from the tr_session on shutdown. Bandwidth is designed to not be copyable, so this is done by making a map of Bandwidth unique_ptrs in tr_session.