### PR TITLE
feat: handle new log levels in transmission-daemon's cli invocation

### DIFF
--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -6,7 +6,10 @@
 #pragma once
 
 #include <ctime>
+#include <optional>
 #include <string_view>
+
+///
 
 enum tr_log_level
 {
@@ -34,6 +37,12 @@ enum tr_log_level
     // High-volume debug messages, e.g. tracing peer protocol messages
     TR_LOG_TRACE
 };
+
+std::optional<tr_log_level> tr_logGetLevelFromKey(std::string_view key);
+
+std::string_view tr_logLevelToKey(tr_log_level);
+
+///
 
 struct tr_log_message
 {


### PR DESCRIPTION
Followup PR to af339a15edba96b33c51f05e4607b88f6d533436 from the logging refactor series described in #2749. The previous PR in this series was #2776.

This is a minor update that lets users choose the new log levels from the command line when starting `transmission-daemon`.