### PR TITLE
fixes "no data found..." error on restart for paused torrents

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -774,9 +774,9 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         // if tr_resume::load() loaded progress info, then initCheckedPieces()
         // has already looked for local data on the filesystem
         has_local_data = std::any_of(
-        std::begin(tor->file_mtimes_),
-        std::end(tor->file_mtimes_),
-        [](auto mtime) { return mtime > 0; });
+            std::begin(tor->file_mtimes_),
+            std::end(tor->file_mtimes_),
+            [](auto mtime) { return mtime > 0; });
     }
 
     // if we don't have a local .torrent or .magnet file already, assume the torrent is new

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -622,7 +622,7 @@ static bool setLocalErrorIfFilesDisappeared(tr_torrent* tor, std::optional<bool>
         has_local_data = hasAnyLocalData(tor);
     }
 
-    bool const files_disappeared = tor->hasTotal() > 0 && !*has_local_data;
+    bool const files_disappeared = tor->hasTotal() > 0 && !has_local_data;
     if (files_disappeared)
     {
         tr_logAddTraceTor(tor, "[LAZY] uh oh, the files disappeared");


### PR DESCRIPTION
paused torrents incorrectly fail `setLocalErrorIfFilesDisappeared` upon restarting Transmission as it incorrectly checks the pointer`*has_local_data` rather than `has_local_data`

Fixes: #2796