### PR TITLE
Fix RPC API / return correct bitfield when fully downloaded

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -176,7 +176,7 @@ std::vector<uint8_t> tr_bitfield::raw() const
 
     if (hasAll())
     {
-        setAllTrue(std::data(raw), std::size(raw));
+        setAllTrue(std::data(raw), bit_count_);
     }
 
     return raw;


### PR DESCRIPTION
`setAllTrue(arr, n)` takes the number of bits, not bytes of the array
Fixes the problem mentioned here: https://github.com/transmission/transmission/issues/2768#issuecomment-1066165254