### PR TITLE
test: fix file-info test edge case

### DIFF
--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -243,7 +243,7 @@ TEST_F(FileTest, getInfo)
     EXPECT_EQ(nullptr, err) << *err;
     EXPECT_EQ(TR_SYS_PATH_IS_FILE, info.type);
     EXPECT_EQ(4, info.size);
-    EXPECT_GT(info.last_modified_at, t - 1);
+    EXPECT_GE(info.last_modified_at, t - 1);
     EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
 
     // Good file info (by handle)
@@ -253,7 +253,7 @@ TEST_F(FileTest, getInfo)
     EXPECT_EQ(nullptr, err) << *err;
     EXPECT_EQ(TR_SYS_PATH_IS_FILE, info.type);
     EXPECT_EQ(4, info.size);
-    EXPECT_GT(info.last_modified_at, t - 1);
+    EXPECT_GE(info.last_modified_at, t - 1);
     EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
     tr_sys_file_close(fd, nullptr);
 


### PR DESCRIPTION
Fix an edge case that causes the file-info test to fail once in awhile.