### PR TITLE
Update MessageWindowController.mm

### DIFF
--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -268,15 +268,19 @@
         {
         case TR_LOG_CRITICAL:
         case TR_LOG_ERROR:
-        case TR_LOG_WARN:
             return [NSImage imageNamed:@"RedDotFlat"];
 
+        case TR_LOG_WARN:
+            return [NSImage imageNamed:@"OrangeDotFlat"];
+
         case TR_LOG_INFO:
-            return [NSImage imageNamed:@"YellowDotFlat"];
+            return [NSImage imageNamed:@"GreenDotFlat"];
 
         case TR_LOG_DEBUG:
-        case TR_LOG_TRACE:
             return [NSImage imageNamed:@"PurpleDotFlat"];
+            
+        case TR_LOG_TRACE:
+            return [NSImage imageNamed:@"BlueDotFlat"];
 
         default:
             NSAssert1(NO, @"Unknown message log level: %ld", level);


### PR DESCRIPTION
An adjunct for #2779 that places the correct colours within the log windows.

A side note, within MessageWindowController.mm is mention of: case TR_LOG_CRITICAL.

Is this something being recorded as a separate log? Should it be revealed as an option for users to see to help with reporting bugs or proposed fixes?