### PR TITLE
feat: strbuf features

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2935,8 +2935,8 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
         tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->areParentLimitsHonored(TR_UP));
     }
 
-    auto const filename = tr_strvPath(config_dir, BandwidthGroupsFilename);
-    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
+    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
+    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename.sv());
     tr_variantFree(&groups_dict);
     return ret;
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2935,8 +2935,8 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
         tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->areParentLimitsHonored(TR_UP));
     }
 
-    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
-    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename.sv());
+    auto const filename = tr_strvPath(config_dir, BandwidthGroupsFilename);
+    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
     tr_variantFree(&groups_dict);
     return ret;
 }

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -81,24 +81,43 @@ public:
         return size() == 0;
     }
 
-    [[nodiscard]] auto* data()
+    [[nodiscard]] constexpr auto* data()
     {
         return buffer_.data();
     }
 
-    [[nodiscard]] auto const* data() const
+    [[nodiscard]] constexpr auto const* data() const
     {
         return buffer_.data();
     }
 
-    [[nodiscard]] auto const* c_str() const
+    [[nodiscard]] constexpr auto const* c_str() const
     {
         return data();
     }
 
     [[nodiscard]] constexpr auto sv() const
     {
-        return std::string_view{ data(), size() };
+        return std::basic_string_view<T>{ data(), size() };
+    }
+
+    [[nodiscard]] constexpr bool ends_with(T const& x) const
+    {
+        auto const n = size();
+        return n != 0 && data()[n - 1] == x;
+    }
+
+    template<typename ContiguousRange>
+    [[nodiscard]] bool ends_with(ContiguousRange const& x) const
+    {
+        auto const x_len = std::size(x);
+        auto const len = size();
+        return len >= x_len && this->sv().substr(len - x_len) == x;
+    }
+
+    [[nodiscard]] bool ends_with(T const* x) const
+    {
+        return x != nullptr && ends_with(std::basic_string_view<T>(x));
     }
 
     ///

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -121,41 +121,52 @@ public:
         ensure_sz();
     }
 
-    template<typename... ContiguousRange>
-    void append(ContiguousRange const&... args)
+    template<typename ContiguousRange>
+    void append(ContiguousRange const& args)
     {
-        buffer_.reserve((std::size(args) + ...));
-        (buffer_.append(std::data(args), std::data(args) + std::size(args)), ...);
+        buffer_.append(std::data(args), std::data(args) + std::size(args));
         ensure_sz();
     }
 
-    template<typename... ContiguousRange>
-    void assign(ContiguousRange const&... args)
+    void append(T const* sz_value)
+    {
+        if (sz_value != nullptr)
+        {
+            append(std::basic_string_view<T>{ sz_value });
+        }
+    }
+
+    template<typename... Args>
+    void append(Args const&... args)
+    {
+        (append(args), ...);
+    }
+
+    template<typename Arg>
+    auto& operator+=(Arg const& arg)
+    {
+        append(arg);
+        return *this;
+    }
+
+    template<typename... Args>
+    void assign(Args const&... args)
     {
         clear();
         append(args...);
     }
 
-    template<typename ContiguousRange>
-    auto& operator+=(ContiguousRange const& range)
+    template<typename Arg>
+    auto& operator=(Arg const& arg)
     {
-        append(range);
+        assign(arg);
         return *this;
     }
 
-    template<typename ContiguousRange>
-    auto& operator=(ContiguousRange const& range)
+    template<typename... Args>
+    void buildPath(Args const&... args)
     {
         clear();
-        append(range);
-        return *this;
-    }
-
-    template<typename... ContiguousRange>
-    void buildPath(ContiguousRange const&... args)
-    {
-        clear();
-        buffer_.reserve(sizeof...(args) + (std::size(args) + ...));
         ((append(args), push_back('/')), ...);
         resize(size() - 1);
     }

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -121,18 +121,19 @@ public:
         ensure_sz();
     }
 
-    template<typename ContiguousRange>
-    void append(ContiguousRange const& range)
-    {
-        buffer_.append(std::data(range), std::data(range) + std::size(range));
-        ensure_sz();
-    }
-
     template<typename... ContiguousRange>
     void append(ContiguousRange const&... args)
     {
         buffer_.reserve((std::size(args) + ...));
-        (append(args), ...);
+        (buffer_.append(std::data(args), std::data(args) + std::size(args)), ...);
+        ensure_sz();
+    }
+
+    template<typename... ContiguousRange>
+    void assign(ContiguousRange const&... args)
+    {
+        clear();
+        append(args...);
     }
 
     template<typename ContiguousRange>
@@ -153,6 +154,7 @@ public:
     template<typename... ContiguousRange>
     void buildPath(ContiguousRange const&... args)
     {
+        clear();
         buffer_.reserve(sizeof...(args) + (std::size(args) + ...));
         ((append(args), push_back('/')), ...);
         resize(size() - 1);

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -61,7 +61,7 @@ public:
         return buffer_.end();
     }
 
-    [[nodiscard]] auto& operator[](size_t pos)
+    [[nodiscard]] constexpr auto& operator[](size_t pos)
     {
         return buffer_[pos];
     }
@@ -71,12 +71,12 @@ public:
         return buffer_[pos];
     }
 
-    [[nodiscard]] auto size() const
+    [[nodiscard]] constexpr auto size() const
     {
         return buffer_.size();
     }
 
-    [[nodiscard]] bool empty() const
+    [[nodiscard]] constexpr bool empty() const
     {
         return size() == 0;
     }
@@ -101,6 +101,8 @@ public:
         return std::basic_string_view<T>{ data(), size() };
     }
 
+    ///
+
     [[nodiscard]] constexpr bool ends_with(T const& x) const
     {
         auto const n = size();
@@ -108,16 +110,35 @@ public:
     }
 
     template<typename ContiguousRange>
-    [[nodiscard]] bool ends_with(ContiguousRange const& x) const
+    [[nodiscard]] constexpr bool ends_with(ContiguousRange const& x) const
     {
         auto const x_len = std::size(x);
         auto const len = size();
         return len >= x_len && this->sv().substr(len - x_len) == x;
     }
 
-    [[nodiscard]] bool ends_with(T const* x) const
+    [[nodiscard]] constexpr bool ends_with(T const* x) const
     {
         return x != nullptr && ends_with(std::basic_string_view<T>(x));
+    }
+
+    ///
+
+    [[nodiscard]] constexpr bool starts_with(T const& x) const
+    {
+        return !empty() && *data() == x;
+    }
+
+    template<typename ContiguousRange>
+    [[nodiscard]] constexpr bool starts_with(ContiguousRange const& x) const
+    {
+        auto const x_len = std::size(x);
+        return size() >= x_len && this->sv().substr(0, x_len) == x;
+    }
+
+    [[nodiscard]] constexpr bool starts_with(T const* x) const
+    {
+        return x != nullptr && starts_with(std::basic_string_view<T>(x));
     }
 
     ///

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -14,7 +14,7 @@
  * but falls back to heap allocation when necessary.
  * Useful for building temp strings without heap allocation.
  *
- * `fmt::basic_memory_buffer` is final, so aggregate intead
+ * `fmt::basic_memory_buffer` is final, so aggregate instead
  * of subclassing ¯\_(ツ)_/¯
  */
 template<typename T, size_t N>
@@ -155,7 +155,9 @@ public:
         ensure_sz();
     }
 
-    void push_back(T const& value)
+    ///
+
+    void append(T const& value)
     {
         buffer_.push_back(value);
         ensure_sz();
@@ -189,6 +191,8 @@ public:
         return *this;
     }
 
+    ///
+
     template<typename... Args>
     void assign(Args const&... args)
     {
@@ -203,12 +207,26 @@ public:
         return *this;
     }
 
+    ///
+
     template<typename... Args>
-    void buildPath(Args const&... args)
+    void join(T delim, Args const&... args)
     {
-        clear();
-        ((append(args), push_back('/')), ...);
+        ((append(args), append(delim)), ...);
         resize(size() - 1);
+    }
+
+    template<typename ContiguousRange, typename... Args>
+    void join(ContiguousRange const& delim, Args const&... args)
+    {
+        ((append(args), append(delim)), ...);
+        resize(size() - std::size(delim));
+    }
+
+    template<typename... Args>
+    void join(T const* sz_delim, Args const&... args)
+    {
+        join(std::basic_string_view<T>{ sz_delim }, args...);
     }
 
 private:

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -35,8 +35,8 @@ public:
         return *this;
     }
 
-    template<typename... ContiguousRange>
-    tr_strbuf(ContiguousRange const&... args)
+    template<typename... Args>
+    tr_strbuf(Args const&... args)
     {
         append(args...);
     }

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -36,13 +36,6 @@ TEST_F(StrbufTest, assign)
     EXPECT_EQ(Value, buf.sv());
 }
 
-TEST_F(StrbufTest, buildPath)
-{
-    auto buf = tr_pathbuf{};
-    buf.buildPath("foo"sv, "bar"sv, "baz"sv);
-    EXPECT_EQ("foo/bar/baz", buf.sv());
-}
-
 TEST_F(StrbufTest, cStr)
 {
     static char const* const Value = "Hello, World!";
@@ -141,6 +134,23 @@ TEST_F(StrbufTest, iterators)
         EXPECT_EQ(Value.front(), *begin);
         EXPECT_EQ(std::size(Value), std::distance(begin, end));
     }
+}
+
+TEST_F(StrbufTest, join)
+{
+    auto buf = tr_pathbuf{};
+
+    buf.clear();
+    buf.join(' ', 'A', "short", "phrase"sv);
+    EXPECT_EQ("A short phrase"sv, buf.sv());
+
+    buf.clear();
+    buf.join("  ", 'A', "short", "phrase"sv);
+    EXPECT_EQ("A  short  phrase"sv, buf.sv());
+
+    buf.clear();
+    buf.join("--"sv, 'A', "short", "phrase"sv);
+    EXPECT_EQ("A--short--phrase"sv, buf.sv());
 }
 
 TEST_F(StrbufTest, startsWith)

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -142,3 +142,21 @@ TEST_F(StrbufTest, sz)
     EXPECT_STREQ(Value, buf.c_str());
     EXPECT_EQ(strlen(Value), std::size(buf));
 }
+
+TEST_F(StrbufTest, endsWith)
+{
+    auto const buf = tr_pathbuf{ "/hello/world" };
+    EXPECT_TRUE(buf.ends_with('d'));
+    EXPECT_TRUE(buf.ends_with("world"));
+    EXPECT_TRUE(buf.ends_with("world"sv));
+    EXPECT_TRUE(buf.ends_with("/hello/world"));
+    EXPECT_TRUE(buf.ends_with("/hello/world"sv));
+
+    EXPECT_FALSE(buf.ends_with('g'));
+    EXPECT_FALSE(buf.ends_with("gorld"));
+    EXPECT_FALSE(buf.ends_with("gorld"sv));
+    EXPECT_FALSE(buf.ends_with("worlg"));
+    EXPECT_FALSE(buf.ends_with("worlg"sv));
+    EXPECT_FALSE(buf.ends_with("/hellg/world"));
+    EXPECT_FALSE(buf.ends_with("/hellg/world"sv));
+}

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -67,6 +67,12 @@ TEST_F(StrbufTest, constructorAssign)
 
     auto buf = tr_pathbuf{ Value };
     EXPECT_EQ(Value, buf.sv());
+
+    buf = tr_pathbuf{ Value.substr(7, 5), Value.substr(5, 2), Value.substr(0, 5), Value.substr(12, 1) };
+    EXPECT_EQ("World, Hello!"sv, buf.sv());
+
+    buf = tr_pathbuf{ "Hello, ", "World!" };
+    EXPECT_EQ(Value, buf.sv());
 }
 
 TEST_F(StrbufTest, heap)
@@ -127,7 +133,12 @@ TEST_F(StrbufTest, iterators)
 TEST_F(StrbufTest, sz)
 {
     static char const* const Value = "Hello, World!";
-    auto buf = tr_pathbuf{ std::string_view{ Value } };
+
+    auto buf = tr_pathbuf{ Value };
+    EXPECT_STREQ(Value, buf.c_str());
+    EXPECT_EQ(strlen(Value), std::size(buf));
+
+    buf = tr_pathbuf{ "H", Value + 1 };
     EXPECT_STREQ(Value, buf.c_str());
     EXPECT_EQ(strlen(Value), std::size(buf));
 }

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -43,6 +43,19 @@ TEST_F(StrbufTest, buildPath)
     EXPECT_EQ("foo/bar/baz", buf.sv());
 }
 
+TEST_F(StrbufTest, cStr)
+{
+    static char const* const Value = "Hello, World!";
+
+    auto buf = tr_pathbuf{ Value };
+    EXPECT_STREQ(Value, buf.c_str());
+    EXPECT_EQ(strlen(Value), std::size(buf));
+
+    buf = tr_pathbuf{ "H", Value + 1 };
+    EXPECT_STREQ(Value, buf.c_str());
+    EXPECT_EQ(strlen(Value), std::size(buf));
+}
+
 TEST_F(StrbufTest, clear)
 {
     static auto constexpr Value = "Hello, World!"sv;
@@ -128,19 +141,6 @@ TEST_F(StrbufTest, iterators)
         EXPECT_EQ(Value.front(), *begin);
         EXPECT_EQ(std::size(Value), std::distance(begin, end));
     }
-}
-
-TEST_F(StrbufTest, sz)
-{
-    static char const* const Value = "Hello, World!";
-
-    auto buf = tr_pathbuf{ Value };
-    EXPECT_STREQ(Value, buf.c_str());
-    EXPECT_EQ(strlen(Value), std::size(buf));
-
-    buf = tr_pathbuf{ "H", Value + 1 };
-    EXPECT_STREQ(Value, buf.c_str());
-    EXPECT_EQ(strlen(Value), std::size(buf));
 }
 
 TEST_F(StrbufTest, startsWith)

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -143,16 +143,42 @@ TEST_F(StrbufTest, sz)
     EXPECT_EQ(strlen(Value), std::size(buf));
 }
 
+TEST_F(StrbufTest, startsWith)
+{
+    auto const buf = tr_pathbuf{ "/hello/world" };
+    EXPECT_TRUE(buf.starts_with('/'));
+    EXPECT_TRUE(buf.starts_with("/"));
+    EXPECT_TRUE(buf.starts_with("/"sv));
+    EXPECT_TRUE(buf.starts_with("/hello"));
+    EXPECT_TRUE(buf.starts_with("/hello"sv));
+    EXPECT_TRUE(buf.starts_with("/hello/world"));
+    EXPECT_TRUE(buf.starts_with("/hello/world"sv));
+
+    EXPECT_FALSE(buf.starts_with('g'));
+    EXPECT_FALSE(buf.starts_with("g"));
+    EXPECT_FALSE(buf.starts_with("g"sv));
+    EXPECT_FALSE(buf.starts_with("ghello"));
+    EXPECT_FALSE(buf.starts_with("ghello"sv));
+    EXPECT_FALSE(buf.starts_with("/hellg"));
+    EXPECT_FALSE(buf.starts_with("/hellg"sv));
+    EXPECT_FALSE(buf.starts_with("/hellg/world"));
+    EXPECT_FALSE(buf.starts_with("/hellg/world"sv));
+}
+
 TEST_F(StrbufTest, endsWith)
 {
     auto const buf = tr_pathbuf{ "/hello/world" };
     EXPECT_TRUE(buf.ends_with('d'));
+    EXPECT_TRUE(buf.ends_with("d"));
+    EXPECT_TRUE(buf.ends_with("d"sv));
     EXPECT_TRUE(buf.ends_with("world"));
     EXPECT_TRUE(buf.ends_with("world"sv));
     EXPECT_TRUE(buf.ends_with("/hello/world"));
     EXPECT_TRUE(buf.ends_with("/hello/world"sv));
 
     EXPECT_FALSE(buf.ends_with('g'));
+    EXPECT_FALSE(buf.ends_with("g"));
+    EXPECT_FALSE(buf.ends_with("g"sv));
     EXPECT_FALSE(buf.ends_with("gorld"));
     EXPECT_FALSE(buf.ends_with("gorld"sv));
     EXPECT_FALSE(buf.ends_with("worlg"));


### PR DESCRIPTION
- add `.starts_with()`
- add `.ends_with()`
- handle zero-terminated string inputs
- `.append()` and the constructor now take arbitrary number of arguments
- strbuf is always zero-terminated, so `c_str()` is now a const method
- made methods `constexpr` / `[[nodiscard]]` where applicable