### PR TITLE
refactor: tr_variantToFile() takes a string_view filename

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -227,7 +227,7 @@ bool tr_announce_list::save(std::string const& torrent_file, tr_error** error) c
 {
     // load the torrent file
     auto metainfo = tr_variant{};
-    if (!tr_variantFromFile(&metainfo, TR_VARIANT_PARSE_BENC, std::string{ torrent_file }, error))
+    if (!tr_variantFromFile(&metainfo, TR_VARIANT_PARSE_BENC, torrent_file, error))
     {
         return false;
     }

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -131,9 +131,9 @@ struct tr_block_info
     }
 
     // Location of the torrent's nth byte
-    [[nodiscard]] Location constexpr byteLoc(uint64_t byte) const
+    [[nodiscard]] Location constexpr byteLoc(uint64_t byte_idx) const
     {
-        TR_ASSERT(byte <= total_size);
+        TR_ASSERT(byte_idx <= total_size);
 
         if (!isInitialized())
         {
@@ -142,17 +142,17 @@ struct tr_block_info
 
         auto loc = Location{};
 
-        loc.byte = byte;
+        loc.byte = byte_idx;
 
-        if (byte == totalSize()) // handle 0-byte files at the end of a torrent
+        if (byte_idx == totalSize()) // handle 0-byte files at the end of a torrent
         {
             loc.block = blockCount() - 1;
             loc.piece = pieceCount() - 1;
         }
         else
         {
-            loc.block = byte / BlockSize;
-            loc.piece = byte / pieceSize();
+            loc.block = byte_idx / BlockSize;
+            loc.piece = byte_idx / pieceSize();
         }
 
         loc.block_offset = static_cast<uint32_t>(loc.byte - (uint64_t{ loc.block } * BlockSize));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -487,9 +487,9 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
 
     /* file settings override the defaults */
     auto fileSettings = tr_variant{};
-    auto const filename = tr_strvPath(config_dir, "settings.json"sv);
+    auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
     auto success = bool{};
-    if (tr_error* error = nullptr; tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename, &error))
+    if (tr_error* error = nullptr; tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename.sv(), &error))
     {
         tr_variantMergeDicts(dict, &fileSettings);
         tr_variantFree(&fileSettings);
@@ -510,7 +510,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     TR_ASSERT(tr_variantIsDict(clientSettings));
 
     tr_variant settings;
-    auto const filename = tr_strvPath(config_dir, "settings.json"sv);
+    auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
 
     tr_variantInitDict(&settings, 0);
 
@@ -518,7 +518,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     {
         tr_variant fileSettings;
 
-        if (tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename, nullptr))
+        if (tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename.sv(), nullptr))
         {
             tr_variantMergeDicts(&settings, &fileSettings);
             tr_variantFree(&fileSettings);
@@ -538,7 +538,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     }
 
     /* save the result */
-    tr_variantToFile(&settings, TR_VARIANT_FMT_JSON, filename);
+    tr_variantToFile(&settings, TR_VARIANT_FMT_JSON, filename.sv());
 
     /* cleanup */
     tr_variantFree(&settings);
@@ -2874,10 +2874,9 @@ int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)
 
 static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 {
+    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
     auto groups_dict = tr_variant{};
-
-    if (auto const path = tr_strvPath(config_dir, BandwidthGroupsFilename);
-        !tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, path, nullptr) || !tr_variantIsList(&groups_dict))
+    if (!tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename.sv(), nullptr) || !tr_variantIsList(&groups_dict))
     {
         return;
     }
@@ -2935,8 +2934,8 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
         tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->areParentLimitsHonored(TR_UP));
     }
 
-    auto const filename = tr_strvPath(config_dir, BandwidthGroupsFilename);
-    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
+    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
+    auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename.sv());
     tr_variantFree(&groups_dict);
     return ret;
 }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -45,6 +45,7 @@
 #include "torrent.h"
 #include "tr-assert.h"
 #include "tr-dht.h"
+#include "tr-strbuf.h"
 #include "trevent.h"
 #include "utils.h"
 #include "variant.h"
@@ -299,9 +300,9 @@ int tr_dhtInit(tr_session* ss)
         dht_debug = stderr;
     }
 
-    auto const dat_file = tr_strvPath(ss->config_dir, "dht.dat"sv);
     auto benc = tr_variant{};
-    auto const ok = tr_variantFromFile(&benc, TR_VARIANT_PARSE_BENC, dat_file);
+    auto const dat_file = tr_pathbuf{ ss->config_dir, "/dht.dat"sv };
+    auto const ok = tr_variantFromFile(&benc, TR_VARIANT_PARSE_BENC, dat_file.sv());
 
     bool have_id = false;
     uint8_t* nodes = nullptr;
@@ -451,8 +452,8 @@ void tr_dhtUninit(tr_session* ss)
             tr_variantDictAddRaw(&benc, TR_KEY_nodes6, compact6, out6 - compact6);
         }
 
-        auto const dat_file = tr_strvPath(ss->config_dir, "dht.dat");
-        tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file);
+        auto const dat_file = tr_pathbuf{ ss->config_dir, "/dht.dat" };
+        tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file.sv());
         tr_variantFree(&benc);
     }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1206,7 +1206,7 @@ std::string tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt)
     return evbuffer_free_to_str(tr_variantToBuf(v, fmt));
 }
 
-int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string const& filename)
+int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view filename)
 {
     auto error_code = int{ 0 };
     auto const contents = tr_variantToStr(v, fmt);
@@ -1262,7 +1262,7 @@ bool tr_variantFromBuf(tr_variant* setme, int opts, std::string_view buf, char c
     return success;
 }
 
-bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, std::string const& filename, tr_error** error)
+bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, std::string_view filename, tr_error** error)
 {
     // can't do inplace when this function is allocating & freeing the memory...
     TR_ASSERT((opts & TR_VARIANT_PARSE_INPLACE) == 0);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -104,7 +104,7 @@ enum tr_variant_fmt
     TR_VARIANT_FMT_JSON_LEAN /* saves bandwidth by omitting all whitespace. */
 };
 
-int tr_variantToFile(tr_variant const* variant, tr_variant_fmt fmt, std::string const& filename);
+int tr_variantToFile(tr_variant const* variant, tr_variant_fmt fmt, std::string_view filename);
 
 std::string tr_variantToStr(tr_variant const* variant, tr_variant_fmt fmt);
 
@@ -120,7 +120,7 @@ enum tr_variant_parse_opts
 bool tr_variantFromFile(
     tr_variant* setme,
     tr_variant_parse_opts opts,
-    std::string const& filename,
+    std::string_view filename,
     struct tr_error** error = nullptr);
 
 bool tr_variantFromBuf(

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -427,13 +427,13 @@ Prefs::~Prefs()
     tr_variant file_settings;
     QFile const file(QDir(config_dir_).absoluteFilePath(QStringLiteral("settings.json")));
 
-    if (!tr_variantFromFile(&file_settings, TR_VARIANT_PARSE_JSON, file.fileName().toUtf8().constData(), nullptr))
+    if (!tr_variantFromFile(&file_settings, TR_VARIANT_PARSE_JSON, file.fileName().toStdString(), nullptr))
     {
         tr_variantInitDict(&file_settings, PREFS_COUNT);
     }
 
     tr_variantMergeDicts(&file_settings, &current_settings);
-    tr_variantToFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toUtf8().constData());
+    tr_variantToFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toStdString());
     tr_variantFree(&file_settings);
 
     // cleanup

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -26,7 +26,7 @@ static char constexpr Usage[] = "Usage: transmission-edit [options] torrent-file
 
 struct app_options
 {
-    std::vector<char const*> files;
+    std::vector<std::string_view> files;
     char const* add = nullptr;
     char const* deleteme = nullptr;
     std::array<char const*, 2> replace;
@@ -338,7 +338,7 @@ int tr_main(int argc, char* argv[])
         bool changed = false;
         tr_error* error = nullptr;
 
-        printf("%s\n", filename);
+        printf("%" TR_PRIsv "\n", TR_PRIsv_ARG(filename));
 
         if (!tr_variantFromFile(&top, TR_VARIANT_PARSE_BENC, filename, &error))
         {


### PR DESCRIPTION
Fourth in the `tr_strbuf` series. The previous PR was #2822 and the series goals are described [here](https://github.com/transmission/transmission/pull/2810#issue-1180004274).

---

This PR builds on the previous one: now that `tr_saveFile()` and `tr_loadFile()` no longer require a `std::string const& filename` argument, some of the caller functions don't need to take them either. `tr_variantToFile()` and `tr_variantFromFile()` are two such methods.

As with previous PRs, this also means that we can avoid heap allocations by using `tr_pathbuf` instead of `std::string` for these short-term filename strings.