### PR TITLE
refactor: make err arg optional in tr_sys_* funcs

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -255,7 +255,7 @@ int tr_main(int argc, char* argv[])
         // tr_sys_path_exists and tr_sys_dir_create need zero-terminated strs
         auto const sz_download_dir = std::string{ sv };
 
-        if (!tr_sys_path_exists(sz_download_dir.c_str(), nullptr))
+        if (!tr_sys_path_exists(sz_download_dir.c_str()))
         {
             tr_error* error = nullptr;
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -192,7 +192,7 @@ static bool reopen_log_file(char const* filename)
 
     if (old_log_file != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(old_log_file, nullptr);
+        tr_sys_file_close(old_log_file);
     }
 
     return true;
@@ -269,7 +269,7 @@ static auto onFileAdded(tr_watchdir_t dir, char const* name, void* vsession)
         else
         {
             auto const new_filename = filename + ".added";
-            tr_sys_path_rename(filename.c_str(), new_filename.c_str(), nullptr);
+            tr_sys_path_rename(filename.c_str(), new_filename.c_str());
         }
     }
 
@@ -311,7 +311,7 @@ static void printMessage(
     {
         auto timestr = std::array<char, 64>{};
         tr_logGetTimeStr(std::data(timestr), std::size(timestr));
-        tr_sys_file_write_line(file, tr_strvJoin("["sv, std::data(timestr), "] "sv, levelName(level), " "sv, out), nullptr);
+        tr_sys_file_write_line(file, tr_strvJoin("["sv, std::data(timestr), "] "sv, levelName(level), " "sv, out));
     }
 
 #ifdef HAVE_SYSLOG
@@ -362,7 +362,7 @@ static void pumpLogMessages(tr_sys_file_t file)
 
     if (file != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_flush(file, nullptr);
+        tr_sys_file_flush(file);
     }
 
     tr_logFreeQueue(list);
@@ -722,8 +722,8 @@ static int daemon_start(void* varg, [[maybe_unused]] bool foreground)
         if (fp != TR_BAD_SYS_FILE)
         {
             auto const out = std::to_string(getpid());
-            tr_sys_file_write(fp, std::data(out), std::size(out), nullptr, nullptr);
-            tr_sys_file_close(fp, nullptr);
+            tr_sys_file_write(fp, std::data(out), std::size(out), nullptr);
+            tr_sys_file_close(fp);
             tr_logAddInfo(fmt::format(_("Saved pidfile '{path}'"), fmt::arg("path", sz_pid_filename)));
             pidfile_created = true;
         }
@@ -867,7 +867,7 @@ CLEANUP:
     /* cleanup */
     if (pidfile_created)
     {
-        tr_sys_path_remove(sz_pid_filename.c_str(), nullptr);
+        tr_sys_path_remove(sz_pid_filename.c_str());
     }
 
     sd_notify(0, "STATUS=\n");
@@ -896,7 +896,7 @@ static bool init_daemon_data(int argc, char* argv[], struct daemon_data* data, b
 
     if (*foreground && logfile == TR_BAD_SYS_FILE)
     {
-        logfile = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, nullptr);
+        logfile = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
     }
 
     if (!loaded)

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -186,7 +186,7 @@ void OptionsDialog::Impl::sourceChanged(Gtk::FileChooserButton* b)
     {
         bool new_file = false;
 
-        if (!filename.empty() && (filename_.empty() || !tr_sys_path_is_same(filename.c_str(), filename_.c_str(), nullptr)))
+        if (!filename.empty() && (filename_.empty() || !tr_sys_path_is_same(filename.c_str(), filename_.c_str())))
         {
             filename_ = filename;
             tr_ctorSetMetainfoFromFile(ctor_.get(), filename_.c_str(), nullptr);
@@ -216,7 +216,7 @@ void OptionsDialog::Impl::downloadDirChanged(Gtk::FileChooserButton* b)
 {
     auto const fname = b->get_filename();
 
-    if (!fname.empty() && (downloadDir_.empty() || !tr_sys_path_is_same(fname.c_str(), downloadDir_.c_str(), nullptr)))
+    if (!fname.empty() && (downloadDir_.empty() || !tr_sys_path_is_same(fname.c_str(), downloadDir_.c_str())))
     {
         downloadDir_ = fname;
         updateTorrent();

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -44,8 +44,8 @@ static void blocklistClose(tr_blocklistFile* b)
 {
     if (b->rules != nullptr)
     {
-        tr_sys_file_unmap(b->rules, b->byteCount, nullptr);
-        tr_sys_file_close(b->fd, nullptr);
+        tr_sys_file_unmap(b->rules, b->byteCount);
+        tr_sys_file_close(b->fd);
         b->rules = nullptr;
         b->ruleCount = 0;
         b->byteCount = 0;
@@ -58,7 +58,7 @@ static void blocklistLoad(tr_blocklistFile* b)
     blocklistClose(b);
 
     auto info = tr_sys_path_info{};
-    if (!tr_sys_path_get_info(b->filename, 0, &info, nullptr))
+    if (!tr_sys_path_get_info(b->filename, 0, &info))
     {
         return;
     }
@@ -90,7 +90,7 @@ static void blocklistLoad(tr_blocklistFile* b)
             fmt::arg("path", b->filename),
             fmt::arg("error", error->message),
             fmt::arg("error_code", error->code)));
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
         tr_error_free(error);
         return;
     }
@@ -134,7 +134,7 @@ static int compareAddressToRange(void const* va, void const* vb)
 static void blocklistDelete(tr_blocklistFile* b)
 {
     blocklistClose(b);
-    tr_sys_path_remove(b->filename, nullptr);
+    tr_sys_path_remove(b->filename);
 }
 
 /***
@@ -165,7 +165,7 @@ void tr_blocklistFileFree(tr_blocklistFile* b)
 
 bool tr_blocklistFileExists(tr_blocklistFile const* b)
 {
-    return tr_sys_path_exists(b->filename, nullptr);
+    return tr_sys_path_exists(b->filename);
 }
 
 int tr_blocklistFileGetRuleCount(tr_blocklistFile const* b)
@@ -399,12 +399,12 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
             fmt::arg("error", error->message),
             fmt::arg("error_code", error->code)));
         tr_error_free(error);
-        tr_sys_file_close(in, nullptr);
+        tr_sys_file_close(in);
         return 0;
     }
 
     /* load the rules into memory */
-    while (tr_sys_file_read_line(in, line, sizeof(line), nullptr))
+    while (tr_sys_file_read_line(in, line, sizeof(line)))
     {
         struct tr_ipv4_range range;
 
@@ -486,8 +486,8 @@ int tr_blocklistFileSetContent(tr_blocklistFile* b, char const* filename)
     }
 
     tr_free(ranges);
-    tr_sys_file_close(out, nullptr);
-    tr_sys_file_close(in, nullptr);
+    tr_sys_file_close(out);
+    tr_sys_file_close(in);
 
     blocklistLoad(b);
 

--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -136,7 +136,7 @@ static void cached_file_close(struct tr_cached_file* o)
 
     if (o != nullptr)
     {
-        tr_sys_file_close(o->fd, nullptr);
+        tr_sys_file_close(o->fd);
         o->fd = TR_BAD_SYS_FILE;
     }
 }
@@ -187,7 +187,7 @@ static int cached_file_open(
         }
     }
 
-    already_existed = tr_sys_path_get_info(filename, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_FILE;
+    already_existed = tr_sys_path_get_info(filename, 0, &info) && info.type == TR_SYS_PATH_IS_FILE;
 
     /* we can't resize the file w/o write permissions */
     resize_needed = already_existed && (file_size < info.size);
@@ -264,7 +264,7 @@ FAIL:
 
     if (fd != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
     }
 
     return err;
@@ -434,7 +434,7 @@ void tr_fdFileClose(tr_session* s, tr_torrent const* tor, tr_file_index_t i)
          * up-to-date when this function returns to the caller... */
         if (o->is_writable)
         {
-            tr_sys_file_flush(o->fd, nullptr);
+            tr_sys_file_flush(o->fd);
         }
 
         cached_file_close(o);

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -456,7 +456,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
     if (!tr_sys_file_get_info(in, &info, error))
     {
         tr_error_prefix(error, "Unable to get information on source file: ");
-        tr_sys_file_close(in, nullptr);
+        tr_sys_file_close(in);
         return false;
     }
 
@@ -464,7 +464,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
     if (out == TR_BAD_SYS_FILE)
     {
         tr_error_prefix(error, "Unable to open destination file: ");
-        tr_sys_file_close(in, nullptr);
+        tr_sys_file_close(in);
         return false;
     }
 
@@ -530,8 +530,8 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 #endif /* USE_COPY_FILE_RANGE || USE_SENDFILE64 */
 
     /* cleanup */
-    tr_sys_file_close(out, nullptr);
-    tr_sys_file_close(in, nullptr);
+    tr_sys_file_close(out);
+    tr_sys_file_close(in);
 
     if (file_size != 0)
     {

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -144,7 +144,7 @@ struct tr_sys_path_info
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_path_copy(char const* src_path, char const* dst_path, struct tr_error** error);
+bool tr_sys_path_copy(char const* src_path, char const* dst_path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `stat()`.
@@ -157,7 +157,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, struct tr_erro
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, struct tr_error** error);
+bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `access()`.
@@ -170,7 +170,7 @@ bool tr_sys_path_get_info(char const* path, int flags, tr_sys_path_info* info, s
  *         be returned in case of error; if you need to distinguish the two,
  *         check if `error` is `nullptr` afterwards.
  */
-bool tr_sys_path_exists(char const* path, struct tr_error** error);
+bool tr_sys_path_exists(char const* path, struct tr_error** error = nullptr);
 
 /**
  * @brief Check whether path is relative.
@@ -196,7 +196,7 @@ bool tr_sys_path_is_relative(std::string_view path);
  *         if you need to distinguish the two, check if `error` is `nullptr`
  *         afterwards.
  */
-bool tr_sys_path_is_same(char const* path1, char const* path2, struct tr_error** error);
+bool tr_sys_path_is_same(char const* path1, char const* path2, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `realpath()`.
@@ -252,7 +252,7 @@ std::string tr_sys_path_dirname(std::string_view path, struct tr_error** error =
  *         Rename will generally only succeed if both source and destination are
  *         on the same partition.
  */
-bool tr_sys_path_rename(char const* src_path, char const* dst_path, struct tr_error** error);
+bool tr_sys_path_rename(char const* src_path, char const* dst_path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `remove()`.
@@ -265,7 +265,7 @@ bool tr_sys_path_rename(char const* src_path, char const* dst_path, struct tr_er
  *         Directory removal will only succeed if it is empty (contains no other
  *         files and directories).
  */
-bool tr_sys_path_remove(char const* path, struct tr_error** error);
+bool tr_sys_path_remove(char const* path, struct tr_error** error = nullptr);
 
 /**
  * @brief Transform path separators to native ones, in-place.
@@ -289,7 +289,7 @@ char* tr_sys_path_native_separators(char* path);
  *         `error` set accordingly). DO NOT pass this descriptor to
  *         @ref tr_sys_file_close (unless you know what you are doing).
  */
-tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, struct tr_error** error);
+tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `open()`.
@@ -304,7 +304,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, struct tr_error** 
  * @return Opened file descriptor on success, `TR_BAD_SYS_FILE` otherwise (with
  *         `error` set accordingly).
  */
-tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, struct tr_error** error);
+tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `mkstemp()`.
@@ -320,7 +320,7 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, str
  * @return Opened file descriptor on success, `TR_BAD_SYS_FILE` otherwise (with
  *         `error` set accordingly).
  */
-tr_sys_file_t tr_sys_file_open_temp(char* path_template, struct tr_error** error);
+tr_sys_file_t tr_sys_file_open_temp(char* path_template, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `close()`.
@@ -331,7 +331,7 @@ tr_sys_file_t tr_sys_file_open_temp(char* path_template, struct tr_error** error
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_close(tr_sys_file_t handle, struct tr_error** error);
+bool tr_sys_file_close(tr_sys_file_t handle, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `fstat()`.
@@ -343,7 +343,7 @@ bool tr_sys_file_close(tr_sys_file_t handle, struct tr_error** error);
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_get_info(tr_sys_file_t handle, tr_sys_path_info* info, struct tr_error** error);
+bool tr_sys_file_get_info(tr_sys_file_t handle, tr_sys_path_info* info, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `lseek()`.
@@ -363,7 +363,7 @@ bool tr_sys_file_seek(
     int64_t offset,
     tr_seek_origin_t origin,
     uint64_t* new_offset,
-    struct tr_error** error);
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `read()`.
@@ -378,7 +378,12 @@ bool tr_sys_file_seek(
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_t* bytes_read, struct tr_error** error);
+bool tr_sys_file_read(
+    tr_sys_file_t handle,
+    void* buffer,
+    uint64_t size,
+    uint64_t* bytes_read,
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Like `pread()`, except that the position is undefined afterwards.
@@ -401,7 +406,7 @@ bool tr_sys_file_read_at(
     uint64_t size,
     uint64_t offset,
     uint64_t* bytes_read,
-    struct tr_error** error);
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `write()`.
@@ -421,7 +426,7 @@ bool tr_sys_file_write(
     void const* buffer,
     uint64_t size,
     uint64_t* bytes_written,
-    struct tr_error** error);
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Like `pwrite()`, except that the position is undefined afterwards.
@@ -444,7 +449,7 @@ bool tr_sys_file_write_at(
     uint64_t size,
     uint64_t offset,
     uint64_t* bytes_written,
-    struct tr_error** error);
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `fsync()`.
@@ -455,7 +460,7 @@ bool tr_sys_file_write_at(
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_flush(tr_sys_file_t handle, struct tr_error** error);
+bool tr_sys_file_flush(tr_sys_file_t handle, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `ftruncate()`.
@@ -467,7 +472,7 @@ bool tr_sys_file_flush(tr_sys_file_t handle, struct tr_error** error);
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, struct tr_error** error);
+bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, struct tr_error** error = nullptr);
 
 /**
  * @brief Tell system to prefetch or discard some part of file which is [not] to be read soon.
@@ -485,7 +490,7 @@ bool tr_sys_file_advise(
     uint64_t offset,
     uint64_t size,
     tr_sys_file_advice_t advice,
-    struct tr_error** error);
+    struct tr_error** error = nullptr);
 
 /**
  * @brief Preallocate file to specified size in full or sparse mode.
@@ -498,7 +503,7 @@ bool tr_sys_file_advise(
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, struct tr_error** error);
+bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `mmap()` for files.
@@ -512,7 +517,7 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, str
  * @return Pointer to mapped file data on success, `nullptr` otherwise (with
  *         `error` set accordingly).
  */
-void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_t size, struct tr_error** error);
+void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_t size, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `munmap()` for files.
@@ -524,7 +529,7 @@ void* tr_sys_file_map_for_reading(tr_sys_file_t handle, uint64_t offset, uint64_
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_unmap(void const* address, uint64_t size, struct tr_error** error);
+bool tr_sys_file_unmap(void const* address, uint64_t size, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `flock()`.
@@ -539,7 +544,7 @@ bool tr_sys_file_unmap(void const* address, uint64_t size, struct tr_error** err
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_lock(tr_sys_file_t handle, int operation, struct tr_error** error);
+bool tr_sys_file_lock(tr_sys_file_t handle, int operation, struct tr_error** error = nullptr);
 
 /* File-related wrappers (utility) */
 
@@ -564,7 +569,7 @@ bool tr_sys_file_lock(tr_sys_file_t handle, int operation, struct tr_error** err
  *         you need to distinguish the two, check if `error` is `nullptr`
  *         afterwards.
  */
-bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_size, struct tr_error** error);
+bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_size, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `fputs()`, appending EOL internally.
@@ -582,7 +587,7 @@ bool tr_sys_file_read_line(tr_sys_file_t handle, char* buffer, size_t buffer_siz
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, struct tr_error** error);
+bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, struct tr_error** error = nullptr);
 
 /* Directory-related wrappers */
 
@@ -596,7 +601,7 @@ bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, struc
  *         directory (use @ref tr_free to free it when no longer needed) on
  *         success, `nullptr` otherwise (with `error` set accordingly).
  */
-char* tr_sys_dir_get_current(struct tr_error** error);
+char* tr_sys_dir_get_current(struct tr_error** error = nullptr);
 
 /**
  * @brief Like `mkdir()`, but makes parent directories if needed.
@@ -610,7 +615,7 @@ char* tr_sys_dir_get_current(struct tr_error** error);
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_dir_create(char const* path, int flags, int permissions, struct tr_error** error);
+bool tr_sys_dir_create(char const* path, int flags, int permissions, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `mkdtemp()`.
@@ -625,7 +630,7 @@ bool tr_sys_dir_create(char const* path, int flags, int permissions, struct tr_e
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_dir_create_temp(char* path_template, struct tr_error** error);
+bool tr_sys_dir_create_temp(char* path_template, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `opendir()`.
@@ -637,7 +642,7 @@ bool tr_sys_dir_create_temp(char* path_template, struct tr_error** error);
  * @return Opened directory descriptor on success, `TR_BAD_SYS_DIR` otherwise
  *         (with `error` set accordingly).
  */
-tr_sys_dir_t tr_sys_dir_open(char const* path, struct tr_error** error);
+tr_sys_dir_t tr_sys_dir_open(char const* path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `readdir()`.
@@ -652,7 +657,7 @@ tr_sys_dir_t tr_sys_dir_open(char const* path, struct tr_error** error);
  *         of directory; if you need to distinguish the two, check if `error`
  *         is `nullptr` afterwards.
  */
-char const* tr_sys_dir_read_name(tr_sys_dir_t handle, struct tr_error** error);
+char const* tr_sys_dir_read_name(tr_sys_dir_t handle, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `closedir()`.
@@ -663,7 +668,7 @@ char const* tr_sys_dir_read_name(tr_sys_dir_t handle, struct tr_error** error);
  *
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
-bool tr_sys_dir_close(tr_sys_dir_t handle, struct tr_error** error);
+bool tr_sys_dir_close(tr_sys_dir_t handle, struct tr_error** error = nullptr);
 
 /** @} */
 /** @} */

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -195,7 +195,7 @@ int readOrWriteBytes(
         break;
 
     case IoMode::Prefetch:
-        tr_sys_file_advise(fd, file_offset, buflen, TR_SYS_FILE_ADVICE_WILL_NEED, nullptr);
+        tr_sys_file_advise(fd, file_offset, buflen, TR_SYS_FILE_ADVICE_WILL_NEED);
         break;
     }
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -69,11 +69,11 @@ tr_sys_file_t tr_logGetFile()
         switch (tr_env_get_int("TR_DEBUG_FD", 0))
         {
         case 1:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_OUT, nullptr);
+            file = tr_sys_file_get_std(TR_STD_SYS_FILE_OUT);
             break;
 
         case 2:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, nullptr);
+            file = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
             break;
 
         default:
@@ -169,15 +169,15 @@ void logAddImpl(
 
         if (fp == TR_BAD_SYS_FILE)
         {
-            fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR, nullptr);
+            fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
         }
 
         tr_logGetTimeStr(timestr, sizeof(timestr));
 
         auto const out = !std::empty(name) ? tr_strvJoin("["sv, timestr, "] "sv, name, ": "sv, msg) :
                                              tr_strvJoin("["sv, timestr, "] "sv, msg);
-        tr_sys_file_write_line(fp, out, nullptr);
-        tr_sys_file_flush(fp, nullptr);
+        tr_sys_file_write_line(fp, out);
+        tr_sys_file_flush(fp);
     }
 #endif
 }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -66,11 +66,11 @@ static struct FileList* getFiles(std::string_view dir, std::string_view base, st
         return list;
     }
 
-    if (tr_sys_dir_t odir = info.type == TR_SYS_PATH_IS_DIRECTORY ? tr_sys_dir_open(buf.c_str(), nullptr) : TR_BAD_SYS_DIR;
+    if (tr_sys_dir_t odir = info.type == TR_SYS_PATH_IS_DIRECTORY ? tr_sys_dir_open(buf.c_str()) : TR_BAD_SYS_DIR;
         odir != TR_BAD_SYS_DIR)
     {
         char const* name = nullptr;
-        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
+        while ((name = tr_sys_dir_read_name(odir)) != nullptr)
         {
             if (name[0] != '.') /* skip dotfiles */
             {
@@ -78,7 +78,7 @@ static struct FileList* getFiles(std::string_view dir, std::string_view base, st
             }
         }
 
-        tr_sys_dir_close(odir, nullptr);
+        tr_sys_dir_close(odir);
     }
     else if (info.type == TR_SYS_PATH_IS_FILE)
     {
@@ -133,7 +133,7 @@ static uint32_t bestPieceSize(uint64_t totalSize)
 
 tr_metainfo_builder* tr_metaInfoBuilderCreate(char const* topFileArg)
 {
-    char* const real_top = tr_sys_path_resolve(topFileArg, nullptr);
+    char* const real_top = tr_sys_path_resolve(topFileArg);
 
     if (real_top == nullptr)
     {
@@ -147,7 +147,7 @@ tr_metainfo_builder* tr_metaInfoBuilderCreate(char const* topFileArg)
 
     {
         tr_sys_path_info info;
-        ret->isFolder = tr_sys_path_get_info(ret->top, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_DIRECTORY;
+        ret->isFolder = tr_sys_path_get_info(ret->top, 0, &info) && info.type == TR_SYS_PATH_IS_DIRECTORY;
     }
 
     /* build a list of files containing top file and,
@@ -292,7 +292,7 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
         {
             uint64_t const n_this_pass = std::min(b->files[fileIndex].size - off, leftInPiece);
             uint64_t n_read = 0;
-            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, nullptr);
+            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read);
             bufptr += n_read;
             off += n_read;
             leftInPiece -= n_read;
@@ -300,7 +300,7 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
             if (off == b->files[fileIndex].size)
             {
                 off = 0;
-                tr_sys_file_close(fd, nullptr);
+                tr_sys_file_close(fd);
                 fd = TR_BAD_SYS_FILE;
 
                 if (++fileIndex < b->fileCount)
@@ -347,7 +347,7 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
 
     if (fd != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
     }
 
     return ret;

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -171,8 +171,8 @@ void tr_setConfigDir(tr_session* session, std::string_view config_dir)
     session->config_dir = config_dir;
     session->resume_dir = tr_strvPath(config_dir, ResumeSubdir);
     session->torrent_dir = tr_strvPath(config_dir, TorrentSubdir);
-    tr_sys_dir_create(session->resume_dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
-    tr_sys_dir_create(session->torrent_dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
+    tr_sys_dir_create(session->resume_dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777);
+    tr_sys_dir_create(session->torrent_dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777);
 }
 
 char const* tr_sessionGetConfigDir(tr_session const* session)
@@ -318,7 +318,7 @@ char const* tr_getDefaultDownloadDir()
 static bool isWebClientDir(std::string_view path)
 {
     auto tmp = tr_strvPath(path, "index.html");
-    bool const ret = tr_sys_path_exists(tmp.c_str(), nullptr);
+    bool const ret = tr_sys_path_exists(tmp.c_str());
     tr_logAddTrace(fmt::format("Searching for web interface file '{}'", tmp));
     return ret;
 }
@@ -483,7 +483,7 @@ std::string tr_getSessionIdDir()
     char* program_data_dir = win32_get_known_folder_ex(FOLDERID_ProgramData, KF_FLAG_CREATE);
     auto const result = tr_strvPath(program_data_dir, "Transmission");
     tr_free(program_data_dir);
-    tr_sys_dir_create(result.c_str(), 0, 0, nullptr);
+    tr_sys_dir_create(result.c_str(), 0, 0);
     return result;
 
 #endif

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1459,7 +1459,7 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     // feed it to the session and give the client a response
     int const rule_count = tr_blocklistSetContent(session, filename.c_str());
     tr_variantDictAddInt(data->args_out, TR_KEY_blocklist_size, rule_count);
-    tr_sys_path_remove(filename.c_str(), nullptr);
+    tr_sys_path_remove(filename.c_str());
     tr_idle_function_done(data, "success");
 }
 

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -86,7 +86,7 @@ static tr_sys_file_t create_session_id_lock_file(char const* session_id)
         }
         else
         {
-            tr_sys_file_close(lock_file, nullptr);
+            tr_sys_file_close(lock_file);
             lock_file = TR_BAD_SYS_FILE;
         }
     }
@@ -108,13 +108,13 @@ static void destroy_session_id_lock_file(tr_sys_file_t lock_file, char const* se
 {
     if (lock_file != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(lock_file, nullptr);
+        tr_sys_file_close(lock_file);
     }
 
     if (session_id != nullptr)
     {
         auto const lock_file_path = get_session_id_lock_file_path(session_id);
-        tr_sys_path_remove(lock_file_path.c_str(), nullptr);
+        tr_sys_path_remove(lock_file_path.c_str());
     }
 }
 
@@ -195,7 +195,7 @@ bool tr_session_id_is_local(char const* session_id)
                 tr_error_clear(&error);
             }
 
-            tr_sys_file_close(lock_file, nullptr);
+            tr_sys_file_close(lock_file);
         }
 
         if (error != nullptr)

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -123,7 +123,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
         return nullptr;
     }
 
-    auto const fd = tr_sys_file_open(tor->torrentFile().c_str(), TR_SYS_FILE_READ, 0, nullptr);
+    auto const fd = tr_sys_file_open(tor->torrentFile().c_str(), TR_SYS_FILE_READ, 0);
     if (fd == TR_BAD_SYS_FILE)
     {
         return nullptr;
@@ -133,7 +133,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
     TR_ASSERT(info_dict_size > 0);
 
     char* ret = nullptr;
-    if (size_t o = piece * METADATA_PIECE_SIZE; tr_sys_file_seek(fd, tor->infoDictOffset() + o, TR_SEEK_SET, nullptr, nullptr))
+    if (size_t o = piece * METADATA_PIECE_SIZE; tr_sys_file_seek(fd, tor->infoDictOffset() + o, TR_SEEK_SET, nullptr))
     {
         size_t const l = o + METADATA_PIECE_SIZE <= info_dict_size ? METADATA_PIECE_SIZE : info_dict_size - o;
 
@@ -141,7 +141,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
         {
             auto* buf = tr_new(char, l);
 
-            if (auto n = uint64_t{}; tr_sys_file_read(fd, buf, l, &n, nullptr) && n == l)
+            if (auto n = uint64_t{}; tr_sys_file_read(fd, buf, l, &n) && n == l)
             {
                 *len = l;
                 ret = buf;
@@ -152,7 +152,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
         }
     }
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
     TR_ASSERT(ret == nullptr || *len > 0);
     return ret;
@@ -279,7 +279,7 @@ static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_
     }
 
     // remove .magnet file
-    tr_sys_path_remove(tor->magnetFile().c_str(), nullptr);
+    tr_sys_path_remove(tor->magnetFile().c_str());
 
     // tor should keep this metainfo
     tor->setMetainfo(metainfo);

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -521,13 +521,13 @@ bool tr_torrent_metainfo::migrateFile(
     std::string_view suffix)
 {
     auto const old_filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
-    auto const old_filename_exists = tr_sys_path_exists(old_filename.c_str(), nullptr);
+    auto const old_filename_exists = tr_sys_path_exists(old_filename.c_str());
     auto const new_filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
-    auto const new_filename_exists = tr_sys_path_exists(new_filename.c_str(), nullptr);
+    auto const new_filename_exists = tr_sys_path_exists(new_filename.c_str());
 
     if (old_filename_exists && new_filename_exists)
     {
-        tr_sys_path_remove(old_filename.c_str(), nullptr);
+        tr_sys_path_remove(old_filename.c_str());
         return false;
     }
 
@@ -536,7 +536,7 @@ bool tr_torrent_metainfo::migrateFile(
         return false;
     }
 
-    if (old_filename_exists && tr_sys_path_rename(old_filename.c_str(), new_filename.c_str(), nullptr))
+    if (old_filename_exists && tr_sys_path_rename(old_filename.c_str(), new_filename.c_str()))
     {
         tr_logAddError(
             fmt::format(
@@ -557,10 +557,10 @@ void tr_torrent_metainfo::removeFile(
     std::string_view suffix)
 {
     auto filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
-    tr_sys_path_remove(filename.c_str(), nullptr);
+    tr_sys_path_remove(filename.c_str());
 
     filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
-    tr_sys_path_remove(filename.c_str(), nullptr);
+    tr_sys_path_remove(filename.c_str());
 }
 
 std::string const& tr_torrent_metainfo::fileSubpath(tr_file_index_t i) const

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -782,7 +782,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     // if we don't have a local .torrent or .magnet file already, assume the torrent is new
     auto const filename = tor->hasMetadata() ? tor->torrentFile() : tor->magnetFile();
 
-    bool const is_new_torrent = !tr_sys_path_exists(filename.c_str(), nullptr);
+    bool const is_new_torrent = !tr_sys_path_exists(filename.c_str());
     if (is_new_torrent)
     {
         tr_error* error = nullptr;
@@ -2162,7 +2162,7 @@ uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor)
             bytesLeft += length;
 
             tr_sys_path_info info;
-            if (path != nullptr && tr_sys_path_get_info(path, 0, &info, nullptr) && info.type == TR_SYS_PATH_IS_FILE &&
+            if (path != nullptr && tr_sys_path_get_info(path, 0, &info) && info.type == TR_SYS_PATH_IS_FILE &&
                 info.size <= length)
             {
                 bytesLeft -= info.size;
@@ -2200,34 +2200,33 @@ static bool isJunkFile(std::string_view base)
 
 static void removeEmptyFoldersAndJunkFiles(char const* folder)
 {
-    auto const odir = tr_sys_dir_open(folder, nullptr);
+    auto const odir = tr_sys_dir_open(folder);
     if (odir == TR_BAD_SYS_DIR)
     {
         return;
     }
 
     char const* name = nullptr;
-    while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
+    while ((name = tr_sys_dir_read_name(odir)) != nullptr)
     {
         if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
         {
             auto const filename = tr_strvPath(folder, name);
 
             auto info = tr_sys_path_info{};
-            if (tr_sys_path_get_info(filename.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr) &&
-                info.type == TR_SYS_PATH_IS_DIRECTORY)
+            if (tr_sys_path_get_info(filename.c_str(), TR_SYS_PATH_NO_FOLLOW, &info) && info.type == TR_SYS_PATH_IS_DIRECTORY)
             {
                 removeEmptyFoldersAndJunkFiles(filename.c_str());
             }
             else if (isJunkFile(name))
             {
-                tr_sys_path_remove(filename.c_str(), nullptr);
+                tr_sys_path_remove(filename.c_str());
             }
         }
     }
 
-    tr_sys_path_remove(folder, nullptr);
-    tr_sys_dir_close(odir, nullptr);
+    tr_sys_path_remove(folder);
+    tr_sys_dir_close(odir);
 }
 
 /**
@@ -2246,7 +2245,7 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
     auto const top = std::string{ tor->currentDir().sv() };
 
     /* don't try to delete local data if the directory's gone missing */
-    if (!tr_sys_path_exists(top.c_str(), nullptr))
+    if (!tr_sys_path_exists(top.c_str()))
     {
         return;
     }
@@ -2262,18 +2261,18 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
     ***/
 
     auto tmpdir = tr_strvPath(top, tr_torrentName(tor) + "__XXXXXX"s);
-    tr_sys_dir_create_temp(std::data(tmpdir), nullptr);
+    tr_sys_dir_create_temp(std::data(tmpdir));
 
     for (tr_file_index_t f = 0, n = tor->fileCount(); f < n; ++f)
     {
         /* try to find the file, looking in the partial and download dirs */
         auto filename = tr_strvPath(top, tor->fileSubpath(f));
 
-        if (!tr_sys_path_exists(filename.c_str(), nullptr))
+        if (!tr_sys_path_exists(filename.c_str()))
         {
             filename += ".part"sv;
 
-            if (!tr_sys_path_exists(filename.c_str(), nullptr))
+            if (!tr_sys_path_exists(filename.c_str()))
             {
                 filename.clear();
             }
@@ -2298,10 +2297,10 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
     ***/
 
     /* try deleting the local data's top-level files & folders */
-    if (auto const odir = tr_sys_dir_open(tmpdir.c_str(), nullptr); odir != TR_BAD_SYS_DIR)
+    if (auto const odir = tr_sys_dir_open(tmpdir.c_str()); odir != TR_BAD_SYS_DIR)
     {
         char const* name = nullptr;
-        while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
+        while ((name = tr_sys_dir_read_name(odir)) != nullptr)
         {
             if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
             {
@@ -2310,7 +2309,7 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
             }
         }
 
-        tr_sys_dir_close(odir, nullptr);
+        tr_sys_dir_close(odir);
     }
 
     /* go from the bottom up */
@@ -2318,7 +2317,7 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
     {
         auto walk = file;
 
-        while (tr_sys_path_exists(walk.c_str(), nullptr) && !tr_sys_path_is_same(tmpdir.c_str(), walk.c_str(), nullptr))
+        while (tr_sys_path_exists(walk.c_str()) && !tr_sys_path_is_same(tmpdir.c_str(), walk.c_str()))
         {
             (*func)(walk.c_str(), nullptr);
 
@@ -2344,13 +2343,13 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
         }
 
         /* walk up the directory tree until we reach 'top' */
-        if (!tr_sys_path_is_same(top.c_str(), dir.c_str(), nullptr) && dir == top)
+        if (!tr_sys_path_is_same(top.c_str(), dir.c_str()) && dir == top)
         {
             for (;;)
             {
                 auto const parent = tr_sys_path_dirname(dir);
 
-                if (tr_sys_path_is_same(top.c_str(), parent.c_str(), nullptr) || parent == top)
+                if (tr_sys_path_is_same(top.c_str(), parent.c_str()) || parent == top)
                 {
                     folders.emplace(dir);
                     break;
@@ -2368,7 +2367,7 @@ static void deleteLocalData(tr_torrent const* tor, tr_fileFunc func)
     }
 
     /* cleanup */
-    tr_sys_path_remove(tmpdir.c_str(), nullptr);
+    tr_sys_path_remove(tmpdir.c_str());
 }
 
 static void tr_torrentDeleteLocalData(tr_torrent* tor, tr_fileFunc func)
@@ -2417,9 +2416,9 @@ static void setLocationImpl(struct LocationData* const data)
         tor,
         fmt::format("Moving '{}' location from currentDir '{}' to '{}'", tor->name(), tor->currentDir().sv(), location));
 
-    tr_sys_dir_create(location.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
+    tr_sys_dir_create(location.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777);
 
-    if (!tr_sys_path_is_same(location.c_str(), tor->currentDir().c_str(), nullptr))
+    if (!tr_sys_path_is_same(location.c_str(), tor->currentDir().c_str()))
     {
         /* bad idea to move files while they're being verified... */
         tr_verifyRemove(tor);
@@ -2440,7 +2439,7 @@ static void setLocationImpl(struct LocationData* const data)
 
                 tr_logAddTraceTor(tor, fmt::format("Found file #{}: '{}'", i, oldpath));
 
-                if (do_move && !tr_sys_path_is_same(oldpath.c_str(), newpath.c_str(), nullptr))
+                if (do_move && !tr_sys_path_is_same(oldpath.c_str(), newpath.c_str()))
                 {
                     tr_error* error = nullptr;
 
@@ -2678,13 +2677,13 @@ std::optional<tr_torrent::tr_found_file_t> tr_torrent::findFile(std::string& fil
         auto const base = this->downloadDir().sv();
 
         tr_buildBuf(filename, base, "/"sv, subpath);
-        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info, nullptr))
+        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info))
         {
             return tr_found_file_t{ file_info, filename, base };
         }
 
         tr_buildBuf(filename, base, "/"sv, subpath, ".part"sv);
-        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info, nullptr))
+        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info))
         {
             return tr_found_file_t{ file_info, filename, base };
         }
@@ -2695,13 +2694,13 @@ std::optional<tr_torrent::tr_found_file_t> tr_torrent::findFile(std::string& fil
         auto const base = this->incompleteDir().sv();
 
         tr_buildBuf(filename, base, "/"sv, subpath);
-        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info, nullptr))
+        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info))
         {
             return tr_found_file_t{ file_info, filename, base };
         }
 
         tr_buildBuf(filename, base, "/"sv, subpath, ".part"sv);
-        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info, nullptr))
+        if (tr_sys_path_get_info(filename.c_str(), 0, &file_info))
         {
             return tr_found_file_t{ file_info, filename, base };
         }
@@ -2965,19 +2964,19 @@ static int renamePath(tr_torrent* tor, char const* oldpath, char const* newname)
 
     auto src = tr_strvPath(base, oldpath);
 
-    if (!tr_sys_path_exists(src.c_str(), nullptr)) /* check for it as a partial */
+    if (!tr_sys_path_exists(src.c_str())) /* check for it as a partial */
     {
         src += ".part"sv;
     }
 
-    if (tr_sys_path_exists(src.c_str(), nullptr))
+    if (tr_sys_path_exists(src.c_str()))
     {
         auto const parent = tr_sys_path_dirname(src);
         auto const tgt = tr_strvEndsWith(src, ".part"sv) ? tr_strvJoin(parent, TR_PATH_DELIMITER_STR, newname, ".part"sv) :
                                                            tr_strvPath(parent, newname);
 
         auto tmp = errno;
-        bool const tgt_exists = tr_sys_path_exists(tgt.c_str(), nullptr);
+        bool const tgt_exists = tr_sys_path_exists(tgt.c_str());
         errno = tmp;
 
         if (!tgt_exists)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -279,13 +279,13 @@ uint8_t* tr_loadFile(std::string_view path_in, size_t* size, tr_error** error)
             fmt::arg("path", path.sv()),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
         tr_free(buf);
         tr_error_propagate(error, &my_error);
         return nullptr;
     }
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
     buf[info.size] = '\0';
     *size = info.size;
     return buf;
@@ -337,12 +337,12 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
             fmt::arg("path", path.sv()),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
         tr_error_propagate(error, &my_error);
         return false;
     }
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
     return true;
 }
 
@@ -1146,7 +1146,7 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
     }
 
     /* they might be on the same filesystem... */
-    if (tr_sys_path_rename(oldpath, newpath, nullptr))
+    if (tr_sys_path_rename(oldpath, newpath))
     {
         return true;
     }

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -63,7 +63,7 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
         {
             char* const filename = tr_torrentFindFile(tor, fileIndex);
             fd = filename == nullptr ? TR_BAD_SYS_FILE :
-                                       tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
+                                       tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
             tr_free(filename);
             prevFileIndex = fileIndex;
         }
@@ -78,11 +78,11 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
         if (fd != TR_BAD_SYS_FILE)
         {
             auto numRead = uint64_t{};
-            if (tr_sys_file_read_at(fd, std::data(buffer), bytesThisPass, filePos, &numRead, nullptr) && numRead > 0)
+            if (tr_sys_file_read_at(fd, std::data(buffer), bytesThisPass, filePos, &numRead) && numRead > 0)
             {
                 bytesThisPass = numRead;
                 tr_sha1_update(sha, std::data(buffer), bytesThisPass);
-                tr_sys_file_advise(fd, filePos, bytesThisPass, TR_SYS_FILE_ADVICE_DONT_NEED, nullptr);
+                tr_sys_file_advise(fd, filePos, bytesThisPass, TR_SYS_FILE_ADVICE_DONT_NEED);
             }
         }
 
@@ -126,7 +126,7 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
         {
             if (fd != TR_BAD_SYS_FILE)
             {
-                tr_sys_file_close(fd, nullptr);
+                tr_sys_file_close(fd);
                 fd = TR_BAD_SYS_FILE;
             }
 
@@ -138,7 +138,7 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
     /* cleanup */
     if (fd != TR_BAD_SYS_FILE)
     {
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
     }
 
     tor->verify_progress.reset();

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -365,7 +365,7 @@ void tr_watchdir_scan(tr_watchdir_t handle, std::unordered_set<std::string>* dir
         tr_error_free(error);
     }
 
-    tr_sys_dir_close(dir, nullptr);
+    tr_sys_dir_close(dir);
 
     if (dir_entries != nullptr)
     {

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -44,11 +44,11 @@ protected:
     void createFileWithContents(char const* path, char const* contents)
     {
         auto const dir = tr_sys_path_dirname(path);
-        tr_sys_dir_create(dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700, nullptr);
+        tr_sys_dir_create(dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700);
 
-        auto const fd = tr_sys_file_open(path, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0600, nullptr);
+        auto const fd = tr_sys_file_open(path, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0600);
         blockingFileWrite(fd, contents, strlen(contents));
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
 
         sync();
     }

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -46,8 +46,8 @@ protected:
         EXPECT_TRUE(filesAreIdentical(path1.c_str(), path2.c_str()));
 
         /* Dispose of those files that we created. */
-        tr_sys_path_remove(path1.c_str(), nullptr);
-        tr_sys_path_remove(path2.c_str(), nullptr);
+        tr_sys_path_remove(path1.c_str());
+        tr_sys_path_remove(path2.c_str());
     }
 
 private:
@@ -61,7 +61,7 @@ private:
             uint64_t const chunk_size = std::min(uint64_t{ buf_len - buf_pos }, bytes_remaining);
             uint64_t bytes_read = 0;
 
-            tr_sys_file_read(fd, buf + buf_pos, chunk_size, &bytes_read, nullptr);
+            tr_sys_file_read(fd, buf + buf_pos, chunk_size, &bytes_read);
 
             EXPECT_LE(buf_pos + bytes_read, buf_len);
             EXPECT_LE(bytes_read, bytes_remaining);
@@ -76,15 +76,15 @@ private:
     {
         bool identical = true;
 
-        tr_sys_file_t fd1 = tr_sys_file_open(fn1, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
-        tr_sys_file_t fd2 = tr_sys_file_open(fn2, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, nullptr);
+        tr_sys_file_t fd1 = tr_sys_file_open(fn1, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
+        tr_sys_file_t fd2 = tr_sys_file_open(fn2, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
         EXPECT_NE(fd1, TR_BAD_SYS_FILE);
         EXPECT_NE(fd2, TR_BAD_SYS_FILE);
 
         tr_sys_path_info info1;
         tr_sys_path_info info2;
-        tr_sys_file_get_info(fd1, &info1, nullptr);
-        tr_sys_file_get_info(fd2, &info2, nullptr);
+        tr_sys_file_get_info(fd1, &info1);
+        tr_sys_file_get_info(fd2, &info2);
         EXPECT_EQ(info1.size, info2.size);
 
         uint64_t bytes_left1 = info1.size;
@@ -114,8 +114,8 @@ private:
 
         tr_free(readbuf1);
         tr_free(readbuf2);
-        tr_sys_file_close(fd1, nullptr);
-        tr_sys_file_close(fd2, nullptr);
+        tr_sys_file_close(fd1);
+        tr_sys_file_close(fd2);
 
         return identical;
     }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -48,7 +48,7 @@ protected:
     auto createTestDir(std::string const& child_name)
     {
         auto test_dir = tr_strvPath(tr_sessionGetConfigDir(session_), child_name);
-        tr_sys_dir_create(std::data(test_dir), 0, 0777, nullptr);
+        tr_sys_dir_create(std::data(test_dir), 0, 0777);
         return test_dir;
     }
 
@@ -125,7 +125,7 @@ protected:
 
             auto const path_part = std::string{ path, size_t(slash_pos - path + 1) };
 
-            if (!tr_sys_path_get_info(path_part.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr) ||
+            if (!tr_sys_path_get_info(path_part.c_str(), TR_SYS_PATH_NO_FOLLOW, &info) ||
                 (info.type != TR_SYS_PATH_IS_FILE && info.type != TR_SYS_PATH_IS_DIRECTORY))
             {
                 return false;
@@ -247,7 +247,7 @@ TEST_F(FileTest, getInfo)
     EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
 
     // Good file info (by handle)
-    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0, nullptr);
+    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0);
     clearPathInfo(&info);
     EXPECT_TRUE(tr_sys_file_get_info(fd, &info, &err));
     EXPECT_EQ(nullptr, err) << *err;
@@ -255,13 +255,13 @@ TEST_F(FileTest, getInfo)
     EXPECT_EQ(4, info.size);
     EXPECT_GE(info.last_modified_at, t - 1);
     EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     // Good directory info
     t = time(nullptr);
-    tr_sys_dir_create(path1.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path1.c_str(), 0, 0777);
     clearPathInfo(&info);
     EXPECT_TRUE(tr_sys_path_get_info(path1.c_str(), 0, &info, &err));
     EXPECT_EQ(nullptr, err) << *err;
@@ -269,7 +269,7 @@ TEST_F(FileTest, getInfo)
     EXPECT_NE(uint64_t(-1), info.size);
     EXPECT_GE(info.last_modified_at, t - 1);
     EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     if (createSymlink(path1.c_str(), path2.c_str(), false))
     {
@@ -291,7 +291,7 @@ TEST_F(FileTest, getInfo)
         EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
 
         // Good file info (by handle)
-        fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0, nullptr);
+        fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0);
         clearPathInfo(&info);
         EXPECT_TRUE(tr_sys_file_get_info(fd, &info, &err));
         EXPECT_EQ(nullptr, err) << *err;
@@ -299,14 +299,14 @@ TEST_F(FileTest, getInfo)
         EXPECT_EQ(4, info.size);
         EXPECT_GE(info.last_modified_at, t - 1);
         EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
 
         // Good directory info
         t = time(nullptr);
-        tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+        tr_sys_dir_create(path2.c_str(), 0, 0777);
         EXPECT_TRUE(createSymlink(path1.c_str(), path2.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         clearPathInfo(&info);
         EXPECT_TRUE(tr_sys_path_get_info(path1.c_str(), 0, &info, &err));
@@ -316,8 +316,8 @@ TEST_F(FileTest, getInfo)
         EXPECT_GE(info.last_modified_at, t - 1);
         EXPECT_LE(info.last_modified_at, time(nullptr) + 1);
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
     }
     else
     {
@@ -342,14 +342,14 @@ TEST_F(FileTest, pathExists)
     EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     // Create directory and see that it exists
-    tr_sys_dir_create(path1.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path1.c_str(), 0, 0777);
     EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     if (createSymlink(path1.c_str(), path2.c_str(), false))
     {
@@ -362,17 +362,17 @@ TEST_F(FileTest, pathExists)
         EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
 
         /* Create directory and see that it exists (via symlink) */
-        tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+        tr_sys_dir_create(path2.c_str(), 0, 0777);
         EXPECT_TRUE(createSymlink(path1.c_str(), path2.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
     }
     else
     {
@@ -457,10 +457,10 @@ TEST_F(FileTest, pathIsSame)
     EXPECT_FALSE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     /* Two same directories are the same */
-    tr_sys_dir_create(path1.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path1.c_str(), 0, 0777);
     EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
@@ -470,15 +470,15 @@ TEST_F(FileTest, pathIsSame)
     EXPECT_FALSE(tr_sys_path_is_same(path2.c_str(), path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path2.c_str(), nullptr);
+    tr_sys_path_remove(path2.c_str());
 
     /* Two separate directories are not the same */
-    tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path2.c_str(), 0, 0777);
     EXPECT_FALSE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
-    tr_sys_path_remove(path2.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
+    tr_sys_path_remove(path2.c_str());
 
     if (createSymlink(path1.c_str(), ".", true))
     {
@@ -501,17 +501,17 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_FALSE(tr_sys_path_is_same(path2.c_str(), path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
 
         /* Symlinks pointing to same directory are the same */
         createSymlink(path2.c_str(), ".", true);
         EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
 
         /* Directory and symlink pointing to another directory are not the same */
-        tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+        tr_sys_dir_create(path2.c_str(), 0, 0777);
         EXPECT_FALSE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
         EXPECT_FALSE(tr_sys_path_is_same(path2.c_str(), path1.c_str(), &err));
@@ -522,7 +522,7 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path1.c_str());
 
         /* File and symlink pointing to directory are not the same */
         createFileWithContents(path1, "test");
@@ -531,7 +531,7 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_FALSE(tr_sys_path_is_same(path3.c_str(), path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
 
         /* File and symlink pointing to same file are the same */
         createSymlink(path3.c_str(), path1.c_str(), false);
@@ -541,16 +541,16 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_EQ(nullptr, err) << *err;
 
         /* Symlinks pointing to non-existent files are not the same */
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path1.c_str());
         createSymlink(path1.c_str(), "missing", false);
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
         createSymlink(path3.c_str(), "missing", false);
         EXPECT_FALSE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
         EXPECT_FALSE(tr_sys_path_is_same(path3.c_str(), path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
 
         /* Symlinks pointing to same non-existent file are not the same */
         createSymlink(path3.c_str(), ".." NATIVE_PATH_SEP "missing", false);
@@ -560,14 +560,14 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_EQ(nullptr, err) << *err;
 
         /* Non-existent file and symlink pointing to non-existent file are not the same */
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
         EXPECT_FALSE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
         EXPECT_FALSE(tr_sys_path_is_same(path3.c_str(), path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
     }
     else
     {
@@ -591,12 +591,12 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
 
         EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
 
         /* File and hardlink to another file are not the same */
         createFileWithContents(path3, "test");
@@ -606,8 +606,8 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_FALSE(tr_sys_path_is_same(path2.c_str(), path1.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
-        tr_sys_path_remove(path2.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
+        tr_sys_path_remove(path2.c_str());
     }
     else
     {
@@ -624,9 +624,9 @@ TEST_F(FileTest, pathIsSame)
         fprintf(stderr, "WARNING: [%s] unable to run combined symlink and hardlink tests\n", __FUNCTION__);
     }
 
-    tr_sys_path_remove(path3.c_str(), nullptr);
-    tr_sys_path_remove(path2.c_str(), nullptr);
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path3.c_str());
+    tr_sys_path_remove(path2.c_str());
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, pathResolve)
@@ -645,10 +645,10 @@ TEST_F(FileTest, pathResolve)
         EXPECT_EQ(nullptr, err) << *err;
         EXPECT_TRUE(pathContainsNoSymlinks(tmp.c_str()));
 
-        tr_sys_path_remove(path2.c_str(), nullptr);
-        tr_sys_path_remove(path1.c_str(), nullptr);
+        tr_sys_path_remove(path2.c_str());
+        tr_sys_path_remove(path1.c_str());
 
-        tr_sys_dir_create(path1.c_str(), 0, 0755, nullptr);
+        tr_sys_dir_create(path1.c_str(), 0, 0755);
         EXPECT_TRUE(createSymlink(path2.c_str(), path1.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         tmp = makeString(tr_sys_path_resolve(path2.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
@@ -659,8 +659,8 @@ TEST_F(FileTest, pathResolve)
         fprintf(stderr, "WARNING: [%s] unable to run symlink tests\n", __FUNCTION__);
     }
 
-    tr_sys_path_remove(path2.c_str(), nullptr);
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path2.c_str());
+    tr_sys_path_remove(path1.c_str());
 
 #ifdef _WIN32
 
@@ -795,20 +795,20 @@ TEST_F(FileTest, pathRename)
     createFileWithContents(path1, "test");
 
     /* Preconditions */
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
-    EXPECT_FALSE(tr_sys_path_exists(path2.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
+    EXPECT_FALSE(tr_sys_path_exists(path2.c_str()));
 
     /* Forward rename works */
     tr_error* err = nullptr;
     EXPECT_TRUE(tr_sys_path_rename(path1.c_str(), path2.c_str(), &err));
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
-    EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
+    EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
     EXPECT_EQ(nullptr, err) << *err;
 
     /* Backward rename works */
     EXPECT_TRUE(tr_sys_path_rename(path2.c_str(), path1.c_str(), &err));
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
-    EXPECT_FALSE(tr_sys_path_exists(path2.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
+    EXPECT_FALSE(tr_sys_path_exists(path2.c_str()));
     EXPECT_EQ(nullptr, err) << *err;
 
     /* Another backward rename [of non-existent file] does not work */
@@ -832,7 +832,7 @@ TEST_F(FileTest, pathRename)
     EXPECT_TRUE(tr_sys_path_rename(path2.c_str(), path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path2.c_str(), 0, 0777);
 
     /* Renaming file does not overwrite existing directory, and vice versa */
     EXPECT_FALSE(tr_sys_path_rename(path1.c_str(), path2.c_str(), &err));
@@ -842,25 +842,25 @@ TEST_F(FileTest, pathRename)
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 
-    tr_sys_path_remove(path2.c_str(), nullptr);
+    tr_sys_path_remove(path2.c_str());
 
     path3 = tr_strvPath(test_dir, "c"sv);
 
     if (createSymlink(path2.c_str(), path1.c_str(), false))
     {
         /* Preconditions */
-        EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
-        EXPECT_FALSE(tr_sys_path_exists(path3.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), nullptr));
+        EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
+        EXPECT_FALSE(tr_sys_path_exists(path3.c_str()));
+        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path2.c_str()));
 
         /* Rename of symlink works, files stay the same */
         EXPECT_TRUE(tr_sys_path_rename(path2.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
-        EXPECT_FALSE(tr_sys_path_exists(path2.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_exists(path3.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), nullptr));
+        EXPECT_FALSE(tr_sys_path_exists(path2.c_str()));
+        EXPECT_TRUE(tr_sys_path_exists(path3.c_str()));
+        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str()));
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
     }
     else
     {
@@ -870,25 +870,25 @@ TEST_F(FileTest, pathRename)
     if (createHardlink(path2.c_str(), path1.c_str()))
     {
         /* Preconditions */
-        EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
-        EXPECT_FALSE(tr_sys_path_exists(path3.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path2.c_str(), nullptr));
+        EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
+        EXPECT_FALSE(tr_sys_path_exists(path3.c_str()));
+        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path2.c_str()));
 
         /* Rename of hardlink works, files stay the same */
         EXPECT_TRUE(tr_sys_path_rename(path2.c_str(), path3.c_str(), &err));
         EXPECT_EQ(nullptr, err) << *err;
-        EXPECT_FALSE(tr_sys_path_exists(path2.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_exists(path3.c_str(), nullptr));
-        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str(), nullptr));
+        EXPECT_FALSE(tr_sys_path_exists(path2.c_str()));
+        EXPECT_TRUE(tr_sys_path_exists(path3.c_str()));
+        EXPECT_TRUE(tr_sys_path_is_same(path1.c_str(), path3.c_str()));
 
-        tr_sys_path_remove(path3.c_str(), nullptr);
+        tr_sys_path_remove(path3.c_str());
     }
     else
     {
         fprintf(stderr, "WARNING: [%s] unable to run hardlink tests\n", __FUNCTION__);
     }
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, pathRemove)
@@ -900,40 +900,40 @@ TEST_F(FileTest, pathRemove)
     auto const path3 = tr_strvPath(path2.c_str(), "c"sv);
 
     /* Can't remove non-existent file/directory */
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
     tr_error* err = nullptr;
     EXPECT_FALSE(tr_sys_path_remove(path1.c_str(), &err));
     EXPECT_NE(nullptr, err);
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
     tr_error_clear(&err);
 
     /* Removing file works */
     createFileWithContents(path1, "test");
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
     EXPECT_TRUE(tr_sys_path_remove(path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
 
     /* Removing empty directory works */
-    tr_sys_dir_create(path1.c_str(), 0, 0777, nullptr);
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
+    tr_sys_dir_create(path1.c_str(), 0, 0777);
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
     EXPECT_TRUE(tr_sys_path_remove(path1.c_str(), &err));
     EXPECT_EQ(nullptr, err) << *err;
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
 
     /* Removing non-empty directory fails */
-    tr_sys_dir_create(path2.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path2.c_str(), 0, 0777);
     createFileWithContents(path3, "test");
-    EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
-    EXPECT_TRUE(tr_sys_path_exists(path3.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
+    EXPECT_TRUE(tr_sys_path_exists(path3.c_str()));
     EXPECT_FALSE(tr_sys_path_remove(path2.c_str(), &err));
     EXPECT_NE(nullptr, err);
-    EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
-    EXPECT_TRUE(tr_sys_path_exists(path3.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
+    EXPECT_TRUE(tr_sys_path_exists(path3.c_str()));
     tr_error_clear(&err);
 
-    tr_sys_path_remove(path3.c_str(), nullptr);
-    tr_sys_path_remove(path2.c_str(), nullptr);
+    tr_sys_path_remove(path3.c_str());
+    tr_sys_path_remove(path2.c_str());
 }
 
 TEST_F(FileTest, pathNativeSeparators)
@@ -969,19 +969,19 @@ TEST_F(FileTest, fileOpen)
 
     // can't open non-existent file
     auto const path1 = tr_strvPath(test_dir, "a"sv);
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
     tr_error* err = nullptr;
     EXPECT_EQ(TR_BAD_SYS_FILE, tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0600, &err));
     EXPECT_NE(nullptr, err);
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
     tr_error_clear(&err);
     EXPECT_EQ(TR_BAD_SYS_FILE, tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE, 0600, &err));
     EXPECT_NE(nullptr, err);
-    EXPECT_FALSE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path1.c_str()));
     tr_error_clear(&err);
 
     // can't open directory
-    tr_sys_dir_create(path1.c_str(), 0, 0777, nullptr);
+    tr_sys_dir_create(path1.c_str(), 0, 0777);
 #ifdef _WIN32
     // this works on *NIX
     EXPECT_EQ(TR_BAD_SYS_FILE, tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0600, &err));
@@ -992,28 +992,28 @@ TEST_F(FileTest, fileOpen)
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     // can create non-existent file
     auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0640, &err);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_close(fd, nullptr);
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
+    tr_sys_file_close(fd);
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
     EXPECT_TRUE(validatePermissions(path1.c_str(), 0640));
 
     // can open existing file
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
     fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0600, &err);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
     fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE, 0600, &err);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
     createFileWithContents(path1, "test");
 
     /* Can't create new file if it already exists */
@@ -1022,36 +1022,36 @@ TEST_F(FileTest, fileOpen)
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
     tr_sys_path_info info;
-    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr);
+    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info);
     EXPECT_EQ(4, info.size);
 
     /* Pointer is at the end of file */
-    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr);
+    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info);
     EXPECT_EQ(4, info.size);
     fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_APPEND, 0600, &err);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_write(fd, "s", 1, nullptr, nullptr); /* On *NIX, pointer is positioned on each write but not initially */
+    tr_sys_file_write(fd, "s", 1, nullptr); /* On *NIX, pointer is positioned on each write but not initially */
     auto n = uint64_t{};
-    tr_sys_file_seek(fd, 0, TR_SEEK_CUR, &n, nullptr);
+    tr_sys_file_seek(fd, 0, TR_SEEK_CUR, &n);
     EXPECT_EQ(5, n);
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
     /* File gets truncated */
-    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr);
+    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info);
     EXPECT_EQ(5, info.size);
     fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_TRUNCATE, 0600, &err);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_get_info(fd, &info, nullptr);
+    tr_sys_file_get_info(fd, &info);
     EXPECT_EQ(0, info.size);
-    tr_sys_file_close(fd, nullptr);
-    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info, nullptr);
+    tr_sys_file_close(fd);
+    tr_sys_path_get_info(path1.c_str(), TR_SYS_PATH_NO_FOLLOW, &info);
     EXPECT_EQ(0, info.size);
 
     /* TODO: symlink and hardlink tests */
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, fileReadWriteSeek)
@@ -1059,7 +1059,7 @@ TEST_F(FileTest, fileReadWriteSeek)
     auto const test_dir = createTestDir(currentTestName());
 
     auto const path1 = tr_strvPath(test_dir, "a"sv);
-    auto const fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, nullptr);
+    auto const fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
 
     uint64_t n;
     tr_error* err = nullptr;
@@ -1132,9 +1132,9 @@ TEST_F(FileTest, fileReadWriteSeek)
 
     EXPECT_EQ(0, memcmp("st-ok", buf.data(), 5));
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, fileTruncate)
@@ -1142,44 +1142,44 @@ TEST_F(FileTest, fileTruncate)
     auto const test_dir = createTestDir(currentTestName());
 
     auto const path1 = tr_strvPath(test_dir, "a"sv);
-    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, nullptr);
+    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
 
     tr_error* err = nullptr;
     EXPECT_TRUE(tr_sys_file_truncate(fd, 10, &err));
     EXPECT_EQ(nullptr, err) << *err;
     tr_sys_path_info info;
-    tr_sys_file_get_info(fd, &info, nullptr);
+    tr_sys_file_get_info(fd, &info);
     EXPECT_EQ(10, info.size);
 
     EXPECT_TRUE(tr_sys_file_truncate(fd, 20, &err));
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_get_info(fd, &info, nullptr);
+    tr_sys_file_get_info(fd, &info);
     EXPECT_EQ(20, info.size);
 
     EXPECT_TRUE(tr_sys_file_truncate(fd, 0, &err));
     EXPECT_EQ(nullptr, err) << *err;
-    tr_sys_file_get_info(fd, &info, nullptr);
+    tr_sys_file_get_info(fd, &info);
     EXPECT_EQ(0, info.size);
 
     EXPECT_TRUE(tr_sys_file_truncate(fd, 50, &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_get_info(path1.c_str(), 0, &info, nullptr);
+    tr_sys_path_get_info(path1.c_str(), 0, &info);
     EXPECT_EQ(50, info.size);
 
-    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, nullptr);
+    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
 
     EXPECT_TRUE(tr_sys_file_truncate(fd, 25, &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_get_info(path1.c_str(), 0, &info, nullptr);
+    tr_sys_path_get_info(path1.c_str(), 0, &info);
     EXPECT_EQ(25, info.size);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, filePreallocate)
@@ -1187,7 +1187,7 @@ TEST_F(FileTest, filePreallocate)
     auto const test_dir = createTestDir(currentTestName());
 
     auto const path1 = tr_strvPath(test_dir, "a"sv);
-    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, nullptr);
+    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
 
     tr_error* err = nullptr;
     auto prealloc_size = size_t{ 50 };
@@ -1195,7 +1195,7 @@ TEST_F(FileTest, filePreallocate)
     {
         EXPECT_EQ(nullptr, err) << *err;
         tr_sys_path_info info;
-        tr_sys_file_get_info(fd, &info, nullptr);
+        tr_sys_file_get_info(fd, &info);
         EXPECT_EQ(prealloc_size, info.size);
     }
     else
@@ -1205,18 +1205,18 @@ TEST_F(FileTest, filePreallocate)
         tr_error_clear(&err);
     }
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
-    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600, nullptr);
+    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
 
     prealloc_size = 500 * 1024 * 1024;
     if (tr_sys_file_preallocate(fd, prealloc_size, TR_SYS_FILE_PREALLOC_SPARSE, &err))
     {
         EXPECT_EQ(nullptr, err) << *err;
         tr_sys_path_info info;
-        tr_sys_file_get_info(fd, &info, nullptr);
+        tr_sys_file_get_info(fd, &info);
         EXPECT_EQ(prealloc_size, info.size);
     }
     else
@@ -1226,9 +1226,9 @@ TEST_F(FileTest, filePreallocate)
         tr_error_clear(&err);
     }
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, map)
@@ -1239,7 +1239,7 @@ TEST_F(FileTest, map)
     auto const contents = std::string{ "test" };
     createFileWithContents(path1, contents.data());
 
-    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, 0600, nullptr);
+    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, 0600);
 
     tr_error* err = nullptr;
     auto map_len = contents.size();
@@ -1263,9 +1263,9 @@ TEST_F(FileTest, map)
     EXPECT_TRUE(tr_sys_file_unmap(view, map_len, &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, fileUtilities)
@@ -1276,7 +1276,7 @@ TEST_F(FileTest, fileUtilities)
     auto const contents = std::string{ "a\nbc\r\ndef\nghij\r\n\n\nklmno\r" };
     createFileWithContents(path1, contents.data());
 
-    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0, nullptr);
+    auto fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ, 0);
 
     tr_error* err = nullptr;
     auto buffer = std::array<char, 16>{};
@@ -1308,9 +1308,9 @@ TEST_F(FileTest, fileUtilities)
     EXPECT_EQ(nullptr, err) << *err;
     EXPECT_STREQ("o", buffer.data()); // on EOF, buffer stays unchanged
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_TRUNCATE, 0, nullptr);
+    fd = tr_sys_file_open(path1.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_TRUNCATE, 0);
 
     EXPECT_TRUE(tr_sys_file_write_line(fd, "p", &err));
     EXPECT_EQ(nullptr, err) << *err;
@@ -1327,7 +1327,7 @@ TEST_F(FileTest, fileUtilities)
     EXPECT_TRUE(tr_sys_file_write_line(fd, "vwxy2", &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_file_seek(fd, 0, TR_SEEK_SET, nullptr, nullptr);
+    tr_sys_file_seek(fd, 0, TR_SEEK_SET, nullptr);
 
     EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), &err));
     EXPECT_EQ(nullptr, err) << *err;
@@ -1354,9 +1354,9 @@ TEST_F(FileTest, fileUtilities)
     EXPECT_EQ(nullptr, err) << *err;
     EXPECT_STREQ("vwxy2", buffer.data()); // on EOF, buffer stays unchanged
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, dirCreate)
@@ -1370,10 +1370,10 @@ TEST_F(FileTest, dirCreate)
     tr_error* err = nullptr;
     EXPECT_TRUE(tr_sys_dir_create(path1.c_str(), 0, 0700, &err));
     EXPECT_EQ(nullptr, err) << *err;
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
     EXPECT_TRUE(validatePermissions(path1.c_str(), 0700));
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
     createFileWithContents(path1, "test");
 
     // Can't create directory where file already exists
@@ -1384,19 +1384,19 @@ TEST_F(FileTest, dirCreate)
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
 
     // Can't create directory which has no parent
     EXPECT_FALSE(tr_sys_dir_create(path2.c_str(), 0, 0700, &err));
     EXPECT_NE(nullptr, err);
-    EXPECT_FALSE(tr_sys_path_exists(path2.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(path2.c_str()));
     tr_error_clear(&err);
 
     // Can create directory with parent directories
     EXPECT_TRUE(tr_sys_dir_create(path2.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0751, &err));
     EXPECT_EQ(nullptr, err) << *err;
-    EXPECT_TRUE(tr_sys_path_exists(path1.c_str(), nullptr));
-    EXPECT_TRUE(tr_sys_path_exists(path2.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(path1.c_str()));
+    EXPECT_TRUE(tr_sys_path_exists(path2.c_str()));
     EXPECT_TRUE(validatePermissions(path1.c_str(), 0751));
     EXPECT_TRUE(validatePermissions(path2.c_str(), 0751));
 
@@ -1406,8 +1406,8 @@ TEST_F(FileTest, dirCreate)
     EXPECT_TRUE(tr_sys_dir_create(path1.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0700, &err));
     EXPECT_EQ(nullptr, err) << *err;
 
-    tr_sys_path_remove(path2.c_str(), nullptr);
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path2.c_str());
+    tr_sys_path_remove(path1.c_str());
 }
 
 TEST_F(FileTest, dirRead)
@@ -1433,7 +1433,7 @@ TEST_F(FileTest, dirRead)
     EXPECT_TRUE(have1);
     EXPECT_TRUE(have2);
 
-    tr_sys_path_remove(path1.c_str(), nullptr);
+    tr_sys_path_remove(path1.c_str());
     testDirReadImpl(test_dir, &have1, &have2);
     EXPECT_FALSE(have1);
     EXPECT_TRUE(have2);

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -113,7 +113,7 @@ protected:
         // create the top temp directory
         auto top = tr_strvPath(sandboxDir(), "folder.XXXXXX");
         tr_sys_path_native_separators(std::data(top));
-        tr_sys_dir_create_temp(std::data(top), nullptr);
+        tr_sys_dir_create_temp(std::data(top));
 
         // build the payload files that go into the top temp directory
         auto files = std::vector<std::string>{};

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -93,7 +93,7 @@ protected:
         auto* path = tr_torrentFindFile(tor, file_index);
         if (path != nullptr)
         {
-            EXPECT_TRUE(tr_sys_path_exists(path, nullptr));
+            EXPECT_TRUE(tr_sys_path_exists(path));
 
             size_t contents_len;
             uint8_t* contents = tr_loadFile(path, &contents_len, nullptr);
@@ -192,17 +192,17 @@ TEST_F(RenameTest, singleFilenameTorrent)
     ***/
 
     auto tmpstr = tr_strvPath(tor->currentDir().sv(), "hello-world.txt");
-    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str()));
     EXPECT_STREQ("hello-world.txt", tr_torrentName(tor));
     EXPECT_EQ(0, torrentRenameAndWait(tor, tr_torrentName(tor), "foobar"));
-    EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the old filename can't be found
+    EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str())); // confirm the old filename can't be found
     EXPECT_STREQ("foobar", tr_torrentName(tor)); // confirm the torrent's name is now 'foobar'
     EXPECT_STREQ("foobar", tr_torrentFile(tor, 0).name); // confirm the file's name is now 'foobar'
     char* const torrent_filename = tr_torrentFilename(tor);
     EXPECT_STREQ(nullptr, strstr(torrent_filename, "foobar")); // confirm torrent file hasn't changed
     tr_free(torrent_filename);
     tmpstr = tr_strvPath(tor->currentDir().sv(), "foobar");
-    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr)); // confirm the file's name is now 'foobar' on the disk
+    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str())); // confirm the file's name is now 'foobar' on the disk
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 0, "hello, world!\n")); // confirm the contents are right
 
     // (while it's renamed: confirm that the .resume file remembers the changes)
@@ -217,9 +217,9 @@ TEST_F(RenameTest, singleFilenameTorrent)
     ***/
 
     tmpstr = tr_strvPath(tor->currentDir().sv(), "foobar");
-    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
+    EXPECT_TRUE(tr_sys_path_exists(tmpstr.c_str()));
     EXPECT_EQ(0, torrentRenameAndWait(tor, "foobar", "hello-world.txt"));
-    EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str(), nullptr));
+    EXPECT_FALSE(tr_sys_path_exists(tmpstr.c_str()));
     EXPECT_STREQ("hello-world.txt", tr_torrentName(tor));
     EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 0, "hello, world!\n"));
@@ -343,12 +343,12 @@ TEST_F(RenameTest, multifileTorrent)
     // remove the directory Felidae/Felinae/Felis/catus
     str = tr_torrentFindFile(tor, 1);
     EXPECT_NE(nullptr, str);
-    tr_sys_path_remove(str, nullptr);
+    tr_sys_path_remove(str);
     tr_free(str);
     str = tr_torrentFindFile(tor, 2);
     EXPECT_NE(nullptr, str);
-    tr_sys_path_remove(str, nullptr);
-    tr_sys_path_remove(tr_sys_path_dirname(str).c_str(), nullptr);
+    tr_sys_path_remove(str);
+    tr_sys_path_remove(tr_sys_path_dirname(str).c_str());
     tr_free(str);
     sync();
     blockingTorrentVerify(tor);

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
     {
         for (int i = 3; i < argc; ++i)
         {
-            tr_sys_file_write_line(fd, argv[i], nullptr);
+            tr_sys_file_write_line(fd, argv[i]);
         }
     }
     else if (test_action == "--dump-env")
@@ -44,24 +44,24 @@ int main(int argc, char** argv)
         for (int i = 3; i < argc; ++i)
         {
             char* const value = tr_env_get_string(argv[i], "<null>");
-            tr_sys_file_write_line(fd, value, nullptr);
+            tr_sys_file_write_line(fd, value);
             tr_free(value);
         }
     }
     else if (test_action == "--dump-cwd")
     {
         char* const value = tr_sys_dir_get_current(nullptr);
-        tr_sys_file_write_line(fd, value != nullptr ? value : "<null>", nullptr);
+        tr_sys_file_write_line(fd, value != nullptr ? value : "<null>");
         tr_free(value);
     }
     else
     {
-        tr_sys_file_close(fd, nullptr);
-        tr_sys_path_remove(tmp_result_path.data(), nullptr);
+        tr_sys_file_close(fd);
+        tr_sys_path_remove(tmp_result_path.data());
         return 1;
     }
 
-    tr_sys_file_close(fd, nullptr);
-    tr_sys_path_rename(tmp_result_path.data(), result_path.data(), nullptr);
+    tr_sys_file_close(fd);
+    tr_sys_path_rename(tmp_result_path.data(), result_path.data());
     return 0;
 }

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -31,7 +31,7 @@ namespace test
 
 std::string getTestProgramPath(std::string const& filename)
 {
-    auto const exe_path = makeString(tr_sys_path_resolve(testing::internal::GetArgvs().front().data(), nullptr));
+    auto const exe_path = makeString(tr_sys_path_resolve(testing::internal::GetArgvs().front().data()));
     auto const exe_dir = tr_sys_path_dirname(exe_path);
     return exe_dir + TR_PATH_DELIMITER + filename;
 }
@@ -69,7 +69,7 @@ protected:
     {
         auto const test = [path]()
         {
-            return tr_sys_path_exists(path.data(), nullptr);
+            return tr_sys_path_exists(path.data());
         };
         EXPECT_TRUE(waitFor(test, 30000));
     }
@@ -122,38 +122,38 @@ TEST_P(SubprocessTest, SpawnAsyncArgs)
 
     waitForFileToExist(result_path);
 
-    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0, nullptr); // NOLINT
+    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0); // NOLINT
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
 
     auto buffer = std::array<char, 1024>{};
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     buffer.back() = '\0';
     EXPECT_EQ(test_arg1, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     buffer.back() = '\0';
     EXPECT_EQ(test_arg2, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     buffer.back() = '\0';
     EXPECT_EQ(test_arg3, buffer.data());
 
     if (allow_batch_metachars)
     {
         buffer[0] = '\0';
-        EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+        EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
         buffer.back() = '\0';
         EXPECT_EQ(test_arg4, buffer.data());
     }
 
-    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     buffer.back() = '\0';
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 }
 
 TEST_P(SubprocessTest, SpawnAsyncEnv)
@@ -203,38 +203,38 @@ TEST_P(SubprocessTest, SpawnAsyncEnv)
 
     waitForFileToExist(result_path);
 
-    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0, nullptr); // NOLINT
+    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0); // NOLINT
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
 
     auto buffer = std::array<char, 1024>{};
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(test_env_value1, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(test_env_value2, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(test_env_value3, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(test_env_value4, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(test_env_value5, buffer.data());
 
     buffer[0] = '\0';
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_STREQ("<null>", buffer.data());
 
-    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 }
 
 TEST_P(SubprocessTest, SpawnAsyncCwdExplicit)
@@ -251,18 +251,18 @@ TEST_P(SubprocessTest, SpawnAsyncCwdExplicit)
 
     waitForFileToExist(result_path);
 
-    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0, nullptr); // NOLINT
+    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0); // NOLINT
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
 
     auto buffer = std::array<char, 1024>{};
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(
         makeString(tr_sys_path_native_separators(tr_strdup(test_dir.c_str()))),
         tr_sys_path_native_separators(&buffer.front()));
 
-    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 }
 
 TEST_P(SubprocessTest, SpawnAsyncCwdInherit)
@@ -278,15 +278,15 @@ TEST_P(SubprocessTest, SpawnAsyncCwdInherit)
     EXPECT_EQ(nullptr, error) << *error;
 
     waitForFileToExist(result_path);
-    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0, nullptr); // NOLINT
+    auto fd = tr_sys_file_open(result_path.data(), TR_SYS_FILE_READ, 0); // NOLINT
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
 
     auto buffer = std::array<char, 1024>{};
-    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_TRUE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
     EXPECT_EQ(expected_cwd, tr_sys_path_native_separators(&buffer.front()));
-    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size(), nullptr));
+    EXPECT_FALSE(tr_sys_file_read_line(fd, buffer.data(), buffer.size()));
 
-    tr_sys_file_close(fd, nullptr);
+    tr_sys_file_close(fd);
 }
 
 TEST_P(SubprocessTest, SpawnAsyncCwdMissing)

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -111,7 +111,7 @@ protected:
     static std::string create_sandbox(std::string const& parent_dir, std::string const& tmpl)
     {
         auto path = tr_strvPath(parent_dir, tmpl);
-        tr_sys_dir_create_temp(std::data(path), nullptr);
+        tr_sys_dir_create_temp(std::data(path));
         tr_sys_path_native_separators(std::data(path));
         return path;
     }
@@ -121,13 +121,13 @@ protected:
         std::vector<std::string> ret;
 
         tr_sys_path_info info;
-        if (tr_sys_path_get_info(path.data(), 0, &info, nullptr) && (info.type == TR_SYS_PATH_IS_DIRECTORY))
+        if (tr_sys_path_get_info(path.data(), 0, &info) && (info.type == TR_SYS_PATH_IS_DIRECTORY))
         {
-            auto const odir = tr_sys_dir_open(path.data(), nullptr);
+            auto const odir = tr_sys_dir_open(path.data());
             if (odir != TR_BAD_SYS_DIR)
             {
                 char const* name;
-                while ((name = tr_sys_dir_read_name(odir, nullptr)) != nullptr)
+                while ((name = tr_sys_dir_read_name(odir)) != nullptr)
                 {
                     if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
                     {
@@ -135,7 +135,7 @@ protected:
                     }
                 }
 
-                tr_sys_dir_close(odir, nullptr);
+                tr_sys_dir_close(odir);
             }
         }
 
@@ -154,7 +154,7 @@ protected:
             std::cerr << "cleanup: removing '" << path << "'" << std::endl;
         }
 
-        tr_sys_path_remove(path.data(), nullptr);
+        tr_sys_path_remove(path.data());
     }
 
 private:
@@ -219,9 +219,9 @@ protected:
         buildParentDir(tmpl);
 
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.InnerPointer)
-        auto const fd = tr_sys_file_open_temp(&tmpl.front(), nullptr);
+        auto const fd = tr_sys_file_open_temp(&tmpl.front());
         blockingFileWrite(fd, payload, n);
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
         sync();
 
         errno = tmperr;
@@ -239,7 +239,7 @@ protected:
             0600,
             nullptr);
         blockingFileWrite(fd, payload, n);
-        tr_sys_file_close(fd, nullptr);
+        tr_sys_file_close(fd);
         sync();
 
         errno = tmperr;
@@ -309,7 +309,7 @@ private:
         auto q = TR_KEY_download_dir;
         auto const download_dir = tr_variantDictFindStrView(settings, q, &sv) ? tr_strvPath(sandboxDir(), sv) :
                                                                                 tr_strvPath(sandboxDir(), "Downloads");
-        tr_sys_dir_create(download_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700, nullptr);
+        tr_sys_dir_create(download_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700);
         tr_variantDictAddStr(settings, q, download_dir.data());
 
         // incomplete dir
@@ -320,7 +320,7 @@ private:
 
         // blocklists
         auto const blocklist_dir = tr_strvPath(sandboxDir(), "blocklists");
-        tr_sys_dir_create(blocklist_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700, nullptr);
+        tr_sys_dir_create(blocklist_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0700);
 
         // fill in any missing settings
 
@@ -405,7 +405,7 @@ protected:
                                                 tr_strvJoin(tor->currentDir().sv(), TR_PATH_DELIMITER_STR, file.name);
 
             auto const dirname = tr_sys_path_dirname(path);
-            tr_sys_dir_create(dirname.data(), TR_SYS_DIR_CREATE_PARENTS, 0700, nullptr);
+            tr_sys_dir_create(dirname.data(), TR_SYS_DIR_CREATE_PARENTS, 0700);
             auto fd = tr_sys_file_open(
                 path.c_str(),
                 TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
@@ -414,14 +414,14 @@ protected:
 
             for (uint64_t j = 0; j < file.length; ++j)
             {
-                tr_sys_file_write(fd, (!complete && i == 0 && j < tor->pieceSize()) ? "\1" : "\0", 1, nullptr, nullptr);
+                tr_sys_file_write(fd, (!complete && i == 0 && j < tor->pieceSize()) ? "\1" : "\0", 1, nullptr);
             }
 
-            tr_sys_file_close(fd, nullptr);
+            tr_sys_file_close(fd);
 
             path = makeString(tr_torrentFindFile(tor, i));
             auto const err = errno;
-            EXPECT_TRUE(tr_sys_path_exists(path.c_str(), nullptr));
+            EXPECT_TRUE(tr_sys_path_exists(path.c_str()));
             errno = err;
         }
 

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -95,7 +95,7 @@ protected:
         path += TR_PATH_DELIMITER;
         path += name;
 
-        tr_sys_dir_create(path.c_str(), 0, 0700, nullptr);
+        tr_sys_dir_create(path.c_str(), 0, 0700);
 
         return path;
     }
@@ -139,7 +139,7 @@ TEST_P(WatchDirTest, construct)
 
     auto wd = createWatchDir(path, &callback, nullptr);
     EXPECT_NE(nullptr, wd);
-    EXPECT_TRUE(tr_sys_path_is_same(path.c_str(), tr_watchdir_get_path(wd), nullptr));
+    EXPECT_TRUE(tr_sys_path_is_same(path.c_str(), tr_watchdir_get_path(wd)));
 
     processEvents();
 


### PR DESCRIPTION
minor refactor: in the `tr_sys_file_*()` and `tr_sys_path_*()` functions that take a `tr_error*` as the final argument, make the error optional.

There were 100+ places that were just passing in `nullptr`, so this PR makes `nullptr` the default value.