### PR TITLE
refactor: add fmt::formatters

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		62F644738FE3D8788EBF73A9 /* block-info.cc in Sources */ = {isa = PBXBuildFile; fileRef = A54D44C6A7AAF131D9AE29F5 /* block-info.cc */; };
 		66F977825E65AD498C028BB0 /* announce-list.cc in Sources */ = {isa = PBXBuildFile; fileRef = 66F977825E65AD498C028BB1 /* announce-list.cc */; };
 		66F977825E65AD498C028BB2 /* announce-list.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F977825E65AD498C028BB3 /* announce-list.h */; };
+		888A256631B3DE536FEB8B00 /* tr-strbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = 888A256631B3DE536FEB8B01 /* tr-strbuf.h */; };
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.mm */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
@@ -344,7 +345,6 @@
 		C1305EBE186A13B100F03351 /* file.cc in Sources */ = {isa = PBXBuildFile; fileRef = C1305EB8186A134000F03351 /* file.cc */; };
 		C1425B361EE9C605001DB85F /* tr-assert.h in Headers */ = {isa = PBXBuildFile; fileRef = C1425B331EE9C5EA001DB85F /* tr-assert.h */; };
 		C1425B371EE9C705001DB85F /* tr-macros.h in Headers */ = {isa = PBXBuildFile; fileRef = C1425B341EE9C5EA001DB85F /* tr-macros.h */; };
-		888A256631B3DE536FEB8B00 /* tr-strbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = 888A256631B3DE536FEB8B01 /* tr-strbuf.h */; };
 		C1425B381EE9C805001DB85F /* peer-socket.h in Headers */ = {isa = PBXBuildFile; fileRef = C1425B351EE9C5EA001DB85F /* peer-socket.h */; };
 		C1639A741A55F4E000E42033 /* libb64.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1639A6F1A55F4D600E42033 /* libb64.a */; };
 		C1639A781A55F56600E42033 /* cdecode.c in Sources */ = {isa = PBXBuildFile; fileRef = C1639A761A55F56600E42033 /* cdecode.c */; };
@@ -617,6 +617,7 @@
 		66F977825E65AD498C028BB1 /* announce-list.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "announce-list.cc"; sourceTree = "<group>"; };
 		66F977825E65AD498C028BB3 /* announce-list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "announce-list.h"; sourceTree = "<group>"; };
 		6A044CBD8C049AFCBD4DB411 /* block-info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "block-info.h"; sourceTree = SOURCE_ROOT; };
+		888A256631B3DE536FEB8B01 /* tr-strbuf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tr-strbuf.h"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A200B8390A2263BA007BBB1E /* InfoWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoWindowController.h; sourceTree = "<group>"; };
@@ -1071,7 +1072,6 @@
 		C1425B321EE9C5EA001DB85F /* tr-assert.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-assert.cc"; sourceTree = "<group>"; };
 		C1425B331EE9C5EA001DB85F /* tr-assert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tr-assert.h"; sourceTree = "<group>"; };
 		C1425B341EE9C5EA001DB85F /* tr-macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tr-macros.h"; sourceTree = "<group>"; };
-		888A256631B3DE536FEB8B01 /* tr-strbuf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tr-macros.h"; sourceTree = "<group>"; };
 		C1425B351EE9C5EA001DB85F /* peer-socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "peer-socket.h"; sourceTree = "<group>"; };
 		C1639A6F1A55F4D600E42033 /* libb64.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libb64.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1639A761A55F56600E42033 /* cdecode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = cdecode.c; path = src/cdecode.c; sourceTree = "<group>"; };
@@ -2553,16 +2553,6 @@
 				};
 			};
 			buildConfigurationList = 4DF0C59A089918A300DD8943 /* Build configuration list for PBXProject "Transmission" */;
-			buildSettings = {
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"third-party/fmt/include",
-				);
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
-				);
-			};
 			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
@@ -3437,9 +3427,14 @@
 				GCC_PREFIX_HEADER = macosx/Transmission_Prefix.pch;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"third-party/fmt/include",
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFMT_HEADER_ONLY",
+				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				WRAPPER_EXTENSION = app;
@@ -3454,8 +3449,8 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					.,
 					"third-party/libevent/include",
+					.,
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
@@ -3470,8 +3465,8 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					.,
 					"third-party/libevent/include",
+					.,
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3648,8 +3643,13 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
+					"third-party/fmt/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFMT_HEADER_ONLY",
+				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				WRAPPER_EXTENSION = app;
@@ -3813,8 +3813,13 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
+					"third-party/fmt/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFMT_HEADER_ONLY",
+				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				WRAPPER_EXTENSION = app;

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -2383,16 +2383,6 @@
 			dependencies = (
 				A2F35BD615C5A1A100EBF632 /* PBXTargetDependency */,
 			);
-			buildSettings = {
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"third-party/fmt/include",
-				);
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
-				);
-			};
 			name = QuickLookPlugin;
 			productName = QuickLookPlugin;
 			productReference = A2F35BB915C5A0A100EBF632 /* QuickLookPlugin.qlgenerator */;
@@ -2563,6 +2553,16 @@
 				};
 			};
 			buildConfigurationList = 4DF0C59A089918A300DD8943 /* Build configuration list for PBXProject "Transmission" */;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+				);
+			};
 			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
@@ -3406,14 +3406,12 @@
 					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
-					"third-party/fmt/include",
 					"third-party/libdeflate",
 					"third-party/libpsl/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DWITH_UTP",
-					"-DFMT_HEADER_ONLY",
 					"-D__TRANSMISSION__",
 					"-DHAVE_FLOCK",
 					"-DHAVE_STRLCPY",
@@ -3474,11 +3472,9 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
 					"-DHAVE_DAEMON",
 				);
 				OTHER_LDFLAGS = "-lc++";
@@ -3496,11 +3492,6 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
-				);
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
@@ -3609,14 +3600,12 @@
 					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
-					"third-party/fmt/include",
 					"third-party/libdeflate",
 					"third-party/libpsl/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DWITH_UTP",
-					"-DFMT_HEADER_ONLY",
 					"-D__TRANSMISSION__",
 					"-DHAVE_FLOCK",
 					"-DHAVE_STRLCPY",
@@ -3862,14 +3851,12 @@
 					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
-					"third-party/fmt/include",
 					"third-party/libdeflate",
 					"third-party/libpsl/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DWITH_UTP",
-					"-DFMT_HEADER_ONLY",
 					"-D__TRANSMISSION__",
 					"-DHAVE_FLOCK",
 					"-DHAVE_STRLCPY",
@@ -3893,12 +3880,10 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DHAVE_DAEMON",
-					"-DFMT_HEADER_ONLY",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
@@ -3915,13 +3900,8 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
-				);
 				PRODUCT_NAME = "transmission-remote";
 			};
 			name = "Release - Debug";
@@ -4067,11 +4047,9 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
 					"-DHAVE_DAEMON",
 				);
 				OTHER_LDFLAGS = "-lc++";
@@ -4089,13 +4067,8 @@
 					"$(inherited)",
 					.,
 					"third-party/libevent/include",
-					"third-party/fmt/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
-				);
 				PRODUCT_NAME = "transmission-remote";
 			};
 			name = Release;

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1781,16 +1781,6 @@
 			name = QuickLookPlugin;
 			path = macosx/QuickLookPlugin;
 			sourceTree = "<group>";
-			buildSettings = {
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"third-party/fmt/include",
-				);
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DFMT_HEADER_ONLY",
-				);
-			};
 		};
 		A2F35BC415C5A0A100EBF632 /* Supporting Files */ = {
 			isa = PBXGroup;
@@ -2393,6 +2383,16 @@
 			dependencies = (
 				A2F35BD615C5A1A100EBF632 /* PBXTargetDependency */,
 			);
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+				);
+			};
 			name = QuickLookPlugin;
 			productName = QuickLookPlugin;
 			productReference = A2F35BB915C5A0A100EBF632 /* QuickLookPlugin.qlgenerator */;

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3409,6 +3409,7 @@
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
@@ -3430,10 +3431,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-DFMT_HEADER_ONLY",
-				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -3451,6 +3450,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3471,6 +3472,7 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3487,6 +3489,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3549,6 +3553,11 @@
 				INFOPLIST_PREPROCESS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
@@ -3608,6 +3617,7 @@
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
@@ -3624,6 +3634,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3645,10 +3657,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-DFMT_HEADER_ONLY",
-				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -3710,7 +3720,12 @@
 				INFOPLIST_PREFIX_HEADER = libtransmission/version.h;
 				INFOPLIST_PREPROCESS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "-DNDEBUG";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+					"-DNDEBUG",
+				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -3719,6 +3734,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = NO;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = Debug;
@@ -3727,6 +3744,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = NO;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = "Release - Debug";
@@ -3735,6 +3754,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = NO;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = Release;
@@ -3795,6 +3816,11 @@
 				INFOPLIST_PREPROCESS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
@@ -3815,10 +3841,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-DFMT_HEADER_ONLY",
-				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -3836,6 +3860,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3869,6 +3895,7 @@
 					"-DHAVE_ZLIB",
 					"-DHAVE_ICONV",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
@@ -3889,6 +3916,7 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3905,6 +3933,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -3964,6 +3994,8 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -3984,6 +4016,8 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -4004,6 +4038,8 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
@@ -4059,6 +4095,7 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
@@ -4075,6 +4112,8 @@
 					"$(inherited)",
 					.,
 				);
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
 				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1781,6 +1781,16 @@
 			name = QuickLookPlugin;
 			path = macosx/QuickLookPlugin;
 			sourceTree = "<group>";
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFMT_HEADER_ONLY",
+				);
+			};
 		};
 		A2F35BC415C5A0A100EBF632 /* Supporting Files */ = {
 			isa = PBXGroup;

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3393,7 +3393,6 @@
 					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
-					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
 					"third-party/libdeflate",
@@ -3411,6 +3410,7 @@
 					"-DHAVE_ICONV",
 				);
 				PRODUCT_NAME = transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
 			};
 			name = Debug;
@@ -3427,7 +3427,6 @@
 				GCC_PREFIX_HEADER = macosx/Transmission_Prefix.pch;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"third-party/fmt/include",
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
@@ -3437,6 +3436,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -3449,11 +3449,11 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"third-party/libevent/include",
 					.,
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Debug;
 		};
@@ -3465,7 +3465,6 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"third-party/libevent/include",
 					.,
 				);
 				OTHER_CFLAGS = (
@@ -3474,6 +3473,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Debug;
 		};
@@ -3486,10 +3486,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Debug;
 		};
@@ -3592,7 +3592,6 @@
 					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
-					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
 					"third-party/libdeflate",
@@ -3610,6 +3609,7 @@
 					"-DHAVE_ICONV",
 				);
 				PRODUCT_NAME = transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
 			};
 			name = Release;
@@ -3623,10 +3623,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Release;
 		};
@@ -3643,7 +3643,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/fmt/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				OTHER_CPLUSPLUSFLAGS = (
@@ -3652,6 +3651,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -3813,7 +3813,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/fmt/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				OTHER_CPLUSPLUSFLAGS = (
@@ -3822,6 +3821,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Release - Debug";
@@ -3835,10 +3835,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = "Release - Debug";
 		};
@@ -3853,7 +3853,6 @@
 					"third-party/arc4/src",
 					"third-party/dht",
 					"third-party/libb64/include",
-					"third-party/libevent/include",
 					"third-party/libutp",
 					"third-party/utfcpp/source",
 					"third-party/libdeflate",
@@ -3871,6 +3870,7 @@
 					"-DHAVE_ICONV",
 				);
 				PRODUCT_NAME = transmission;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
 			};
 			name = "Release - Debug";
@@ -3884,7 +3884,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3892,6 +3891,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = "Release - Debug";
 		};
@@ -3904,10 +3904,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = "Release - Debug";
 		};
@@ -3966,6 +3966,7 @@
 				INSTALL_PATH = /Library/QuickLook;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Debug;
@@ -3985,6 +3986,7 @@
 				INSTALL_PATH = /Library/QuickLook;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = "Release - Debug";
@@ -4004,6 +4006,7 @@
 				INSTALL_PATH = /Library/QuickLook;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Release;
@@ -4051,7 +4054,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -4059,6 +4061,7 @@
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Release;
 		};
@@ -4071,10 +4074,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
-					"third-party/libevent/include",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-remote";
+				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
 			};
 			name = Release;
 		};

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -468,7 +468,7 @@ static void tau_tracker_on_dns(int errcode, struct evutil_addrinfo* addr, void* 
     {
         auto const errmsg = fmt::format(
             _("Couldn't find address of tracker '{host}': {error} ({error_code})"),
-            fmt::arg("host", tracker->host.sv()),
+            fmt::arg("host", tracker->host),
             fmt::arg("error", evutil_gai_strerror(errcode)),
             fmt::arg("error_code", errcode));
         logwarn(tracker->key, errmsg);
@@ -729,8 +729,7 @@ static struct tr_announcer_udp* announcer_udp_get(tr_session* session)
 static tau_tracker* tau_session_get_tracker(tr_announcer_udp* tau, tr_interned_string announce_url)
 {
     // build a lookup key for this tracker
-    auto const announce_sv = announce_url.sv();
-    auto parsed = tr_urlParseTracker(announce_sv);
+    auto const parsed = tr_urlParseTracker(announce_url);
     TR_ASSERT(parsed);
     if (!parsed)
     {

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -7,6 +7,8 @@
 
 #include <string_view>
 
+#include <fmt/format.h>
+
 #include "quark.h"
 
 /**
@@ -44,7 +46,7 @@ public:
         return *this = std::string_view{ c_str != nullptr ? c_str : "" };
     }
 
-    [[nodiscard]] tr_quark quark() const
+    [[nodiscard]] constexpr tr_quark quark() const noexcept
     {
         return quark_;
     }
@@ -61,7 +63,7 @@ public:
     {
         return std::data(this->sv());
     }
-    [[nodiscard]] auto empty() const
+    [[nodiscard]] constexpr auto empty() const noexcept
     {
         return quark_ == TR_KEY_NONE;
     }
@@ -92,7 +94,7 @@ public:
         return std::rend(this->sv());
     }
 
-    [[nodiscard]] auto compare(tr_interned_string const& that) const // <=>
+    [[nodiscard]] constexpr auto compare(tr_interned_string const& that) const noexcept // <=>
     {
         if (this->quark() < that.quark())
         {
@@ -107,21 +109,21 @@ public:
         return 0;
     }
 
-    [[nodiscard]] bool operator<(tr_interned_string const& that) const
+    [[nodiscard]] constexpr bool operator<(tr_interned_string const& that) const noexcept
     {
         return this->compare(that) < 0;
     }
 
-    [[nodiscard]] bool operator>(tr_interned_string const& that) const
+    [[nodiscard]] constexpr bool operator>(tr_interned_string const& that) const noexcept
     {
         return this->compare(that) > 0;
     }
 
-    [[nodiscard]] bool operator==(tr_interned_string const& that) const
+    [[nodiscard]] constexpr bool operator==(tr_interned_string const& that) const noexcept
     {
         return this->compare(that) == 0;
     }
-    [[nodiscard]] bool operator!=(tr_interned_string const& that) const
+    [[nodiscard]] constexpr bool operator!=(tr_interned_string const& that) const noexcept
     {
         return this->compare(that) != 0;
     }
@@ -143,6 +145,21 @@ public:
         return *this != std::string_view{ that != nullptr ? that : "" };
     }
 
+    operator std::string_view() const
+    {
+        return sv();
+    }
+
 private:
     tr_quark quark_ = TR_KEY_NONE;
+};
+
+template<>
+struct fmt::formatter<tr_interned_string> : formatter<std::string_view>
+{
+    template<typename FormatContext>
+    constexpr auto format(tr_interned_string const& str, FormatContext& ctx) const
+    {
+        return formatter<std::string_view>::format(str.sv(), ctx);
+    }
 };

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1442,13 +1442,13 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     // so save content into a tmpfile
     auto const filename = tr_pathbuf{ session->config_dir, "/blocklist.tmp"sv };
     tr_error* error = nullptr;
-    if (!tr_saveFile(filename.sv(), content, &error))
+    if (!tr_saveFile(filename, content, &error))
     {
         fmt::format_to_n(
             result,
             sizeof(result),
             _("Couldn't save '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename.sv()),
+            fmt::arg("path", filename),
             fmt::arg("error", error->message),
             fmt::arg("error_code", error->code));
         tr_error_clear(&error);
@@ -1740,7 +1740,7 @@ static char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args
         {
             tr_variant* dict = tr_variantListAddDict(list, 5);
             auto limits = group->getLimits();
-            tr_variantDictAddStrView(dict, TR_KEY_name, name.sv());
+            tr_variantDictAddStr(dict, TR_KEY_name, name);
             tr_variantDictAddBool(dict, TR_KEY_uploadLimited, limits.up_limited);
             tr_variantDictAddInt(dict, TR_KEY_uploadLimit, limits.up_limit_KBps);
             tr_variantDictAddBool(dict, TR_KEY_downloadLimited, limits.down_limited);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1863,7 +1863,7 @@ void tr_torrent::recheckCompleteness()
 
             if (this->currentDir() == this->incompleteDir())
             {
-                this->setLocation(this->downloadDir().sv(), true, nullptr, nullptr);
+                this->setLocation(this->downloadDir(), true, nullptr, nullptr);
             }
         }
 
@@ -2414,7 +2414,7 @@ static void setLocationImpl(struct LocationData* const data)
 
     tr_logAddTraceTor(
         tor,
-        fmt::format("Moving '{}' location from currentDir '{}' to '{}'", tor->name(), tor->currentDir().sv(), location));
+        fmt::format("Moving '{}' location from currentDir '{}' to '{}'", tor->name(), tor->currentDir(), location));
 
     tr_sys_dir_create(location.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777);
 

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -245,7 +245,7 @@ public:
         return sv();
     }
 
-    [[nodiscard]] constexpr operator Char const*() const noexcept
+    [[nodiscard]] constexpr operator auto() const noexcept
     {
         return c_str();
     }

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -67,12 +67,12 @@ public:
         return buffer_.end();
     }
 
-    [[nodiscard]] constexpr auto& operator[](size_t pos) noexcept
+    constexpr Char& operator[](size_t pos) noexcept
     {
         return buffer_[pos];
     }
 
-    [[nodiscard]] constexpr auto const& operator[](size_t pos) const noexcept
+    [[nodiscard]] constexpr Char operator[](size_t pos) const noexcept
     {
         return buffer_[pos];
     }

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -67,12 +67,12 @@ public:
         return buffer_.end();
     }
 
-    constexpr Char& operator[](size_t pos) noexcept
+    [[nodiscard]] constexpr Char& at(size_t pos) noexcept
     {
         return buffer_[pos];
     }
 
-    [[nodiscard]] constexpr Char operator[](size_t pos) const noexcept
+    [[nodiscard]] constexpr Char at(size_t pos) const noexcept
     {
         return buffer_[pos];
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -238,7 +238,7 @@ uint8_t* tr_loadFile(std::string_view path_in, size_t* size, tr_error** error)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
@@ -247,7 +247,7 @@ uint8_t* tr_loadFile(std::string_view path_in, size_t* size, tr_error** error)
 
     if (info.type != TR_SYS_PATH_IS_FILE)
     {
-        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", path.sv())));
+        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", path)));
         tr_error_set(error, TR_ERROR_EISDIR, "Not a regular file"sv);
         return nullptr;
     }
@@ -264,7 +264,7 @@ uint8_t* tr_loadFile(std::string_view path_in, size_t* size, tr_error** error)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
@@ -276,7 +276,7 @@ uint8_t* tr_loadFile(std::string_view path_in, size_t* size, tr_error** error)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_sys_file_close(fd);
@@ -302,7 +302,7 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
@@ -311,7 +311,7 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
 
     if (info.type != TR_SYS_PATH_IS_FILE)
     {
-        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", path.sv())));
+        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", path)));
         tr_error_set(error, TR_ERROR_EISDIR, "Not a regular file"sv);
         return false;
     }
@@ -322,7 +322,7 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
@@ -334,7 +334,7 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path.sv()),
+            fmt::arg("path", path),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_sys_file_close(fd);
@@ -391,7 +391,7 @@ bool tr_saveFile(std::string_view filename_in, std::string_view contents, tr_err
         return false;
     }
 
-    tr_logAddTrace(fmt::format("Saved '{}'", filename.sv()));
+    tr_logAddTrace(fmt::format("Saved '{}'", filename));
     return true;
 }
 

--- a/tests/libtransmission/peer-mgr-active-requests-test.cc
+++ b/tests/libtransmission/peer-mgr-active-requests-test.cc
@@ -43,17 +43,17 @@ TEST_F(PeerMgrActiveRequestsTest, requestsMadeAreCounted)
 
     auto const block = tr_block_index_t{ 100 };
     auto const peer = static_cast<tr_peer*>(nullptr);
-    auto const when = time_t(0);
+    auto const when = time_t{};
 
-    EXPECT_EQ(0, requests.count(block));
-    EXPECT_EQ(0, requests.count(peer));
-    EXPECT_EQ(0, requests.size());
+    EXPECT_EQ(0U, requests.count(block));
+    EXPECT_EQ(0U, requests.count(peer));
+    EXPECT_EQ(0U, requests.size());
 
     EXPECT_TRUE(requests.add(block, peer, when));
 
-    EXPECT_EQ(1, requests.count(block));
-    EXPECT_EQ(1, requests.count(peer));
-    EXPECT_EQ(1, requests.size());
+    EXPECT_EQ(1U, requests.count(block));
+    EXPECT_EQ(1U, requests.count(peer));
+    EXPECT_EQ(1U, requests.size());
 }
 
 TEST_F(PeerMgrActiveRequestsTest, requestsAreRemoved)

--- a/tests/libtransmission/quark-test.cc
+++ b/tests/libtransmission/quark-test.cc
@@ -27,7 +27,7 @@ protected:
 
 TEST_F(QuarkTest, allPredefinedKeysCanBeLookedUp)
 {
-    for (int i = 0; i < TR_N_KEYS; i++)
+    for (size_t i = 0; i < TR_N_KEYS; ++i)
     {
         auto const str = quarkGetString(i);
         auto const q = tr_quark_lookup(str);

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -102,14 +102,14 @@ TEST_F(StrbufTest, indexOperator)
     // mutable
     {
         auto buf = tr_pathbuf{ Value1 };
-        buf[0] = 'W';
+        buf.at(0) = 'W';
         EXPECT_EQ(Value2, buf.sv());
     }
 
     // const
     {
         auto const buf = tr_pathbuf{ Value1 };
-        EXPECT_EQ(Value1.front(), buf[0]);
+        EXPECT_EQ(Value1.front(), buf.at(0));
     }
 }
 


### PR DESCRIPTION
Fifth in the `tr_strbuf` series. The previous PR was #2824 and the series goals are described [here](https://github.com/transmission/transmission/pull/2810#issue-1180004274).

---

This is a small PR that adds `fmt::formatter`s for `tr_strbuf` and also `tr_interned_string` so that objects of those two types don't have to be manually converted into `std::string_view`s when being formatted with `fmt::format`.

Also adds `noexcept` to methods in those two classes that shouldn't ever be able to throw.