### PR TITLE
refactor: strbuf for metainfo files

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -223,7 +223,7 @@ bool tr_announce_list::canAdd(tr_url_parsed_t const& announce)
     return std::none_of(std::begin(trackers_), std::end(trackers_), is_same);
 }
 
-bool tr_announce_list::save(std::string const& torrent_file, tr_error** error) const
+bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) const
 {
     // load the torrent file
     auto metainfo = tr_variant{};

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -126,7 +126,7 @@ public:
     bool parse(std::string_view text);
     [[nodiscard]] std::string toString() const;
 
-    bool save(std::string const& torrent_file, tr_error** error = nullptr) const;
+    bool save(std::string_view torrent_file, tr_error** error = nullptr) const;
 
     static std::optional<std::string> announceToScrape(std::string_view announce);
     static tr_quark announceToScrape(tr_quark announce);

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -67,8 +67,8 @@ static void makeAnnounceUrl(tr_session const* session, tr_announce_request const
         "&key={key}"
         "&compact=1"
         "&supportcrypto=1",
-        fmt::arg("url", req->announce_url.sv()),
-        fmt::arg("sep", req->announce_url.sv().find('?') == std::string_view::npos ? '?' : '&'),
+        fmt::arg("url", req->announce_url),
+        fmt::arg("sep", tr_strvContains(req->announce_url.sv(), '?') ? '&' : '?'),
         fmt::arg("info_hash", std::data(escaped_info_hash)),
         fmt::arg("peer_id", std::data(req->peer_id)),
         fmt::arg("port", req->port),
@@ -338,7 +338,7 @@ void tr_tracker_http_announce(
 
     auto url = tr_urlbuf{};
     makeAnnounceUrl(session, request, std::back_inserter(url));
-    tr_logAddTrace(fmt::format("Sending announce to libcurl: '{}'", url.sv()), request->log_name);
+    tr_logAddTrace(fmt::format("Sending announce to libcurl: '{}'", url), request->log_name);
 
     auto options = tr_web::FetchOptions{ url.sv(), onAnnounceDone, d };
     options.timeout_secs = 90L;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <ctime>
 #include <deque>
-#include <iterator>
 #include <map>
 #include <set>
 #include <string>

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1296,7 +1296,7 @@ static void checkMultiscrapeMax(tr_announcer* announcer, tr_scrape_response cons
     {
         // don't log the full URL, since that might have a personal announce id
         // (note: we know 'parsed' will be successful since this url has a scrape_info)
-        auto const parsed = *tr_urlParse(url.sv());
+        auto const parsed = *tr_urlParse(url);
         auto clean_url = std::string{};
         tr_buildBuf(clean_url, parsed.scheme, "://"sv, parsed.host, ":"sv, parsed.portstr);
         tr_logAddDebug(fmt::format("Reducing multiscrape max to {}", n), clean_url);
@@ -1324,8 +1324,6 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                 continue;
             }
 
-            auto const scrape_url_sv = response->scrape_url.sv();
-
             tr_logAddTraceTier(
                 tier,
                 fmt::format(
@@ -1339,7 +1337,7 @@ static void on_scrape_done(tr_scrape_response const* response, void* vsession)
                     "downloaders:{} "
                     "min_request_interval:{} "
                     "err:{} ",
-                    scrape_url_sv,
+                    response->scrape_url.sv(),
                     response->did_connect,
                     response->did_timeout,
                     row.seeders,

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -5,7 +5,7 @@
 
 #include <array>
 #include <cstring>
-#include <cctype> // isxdigit()
+#include <iterator> // back_inserter
 #include <string>
 #include <string_view>
 
@@ -149,6 +149,31 @@ std::optional<tr_sha1_digest_t> parseHash(std::string_view sv)
 /***
 ****
 ***/
+
+tr_urlbuf tr_magnet_metainfo::magnet() const
+{
+    auto s = tr_urlbuf{ "magnet:?xt=urn:btih:"sv, infoHashString() };
+
+    if (!std::empty(name_))
+    {
+        s += "&dn="sv;
+        tr_http_escape(std::back_inserter(s), name_, true);
+    }
+
+    for (auto const& tracker : this->announceList())
+    {
+        s += "&tr="sv;
+        tr_http_escape(std::back_inserter(s), tracker.announce.full, true);
+    }
+
+    for (auto const& webseed : webseed_urls_)
+    {
+        s += "&ws="sv;
+        tr_http_escape(std::back_inserter(s), webseed, true);
+    }
+
+    return s;
+}
 
 bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** error)
 {

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -150,34 +150,6 @@ std::optional<tr_sha1_digest_t> parseHash(std::string_view sv)
 ****
 ***/
 
-std::string tr_magnet_metainfo::magnet() const
-{
-    auto s = std::string{};
-
-    s += "magnet:?xt=urn:btih:"sv;
-    s += infoHashString();
-
-    if (!std::empty(name_))
-    {
-        s += "&dn="sv;
-        tr_http_escape(s, name_, true);
-    }
-
-    for (auto const& tracker : this->announceList())
-    {
-        s += "&tr="sv;
-        tr_http_escape(s, tracker.announce.full, true);
-    }
-
-    for (auto const& webseed : webseed_urls_)
-    {
-        s += "&ws="sv;
-        tr_http_escape(s, webseed, true);
-    }
-
-    return s;
-}
-
 bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** error)
 {
     magnet_link = tr_strvStrip(magnet_link);

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -92,6 +93,13 @@ public:
             out = append(out, "&ws="sv);
             tr_http_escape(out, webseed, true);
         }
+    }
+
+    [[nodiscard]] tr_urlbuf magnet() const
+    {
+        auto url = tr_urlbuf{};
+        this->magnet(std::back_inserter(url));
+        return url;
     }
 
 protected:

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -12,6 +12,8 @@
 #include "transmission.h"
 
 #include "announce-list.h"
+#include "tr-strbuf.h"
+#include "web-utils.h"
 
 struct tr_error;
 struct tr_variant;
@@ -20,8 +22,6 @@ class tr_magnet_metainfo
 {
 public:
     bool parseMagnet(std::string_view magnet_link, tr_error** error = nullptr);
-
-    std::string magnet() const;
 
     auto const& infoHash() const
     {
@@ -61,6 +61,37 @@ public:
     void setName(std::string_view name)
     {
         name_ = name;
+    }
+
+    template<typename OutputIt>
+    void magnet(OutputIt out) const
+    {
+        using namespace std::literals;
+        auto constexpr append = [](OutputIt out, auto x)
+        {
+            return std::copy(std::begin(x), std::end(x), out);
+        };
+
+        out = append(out, "magnet:?xt=urn:btih:"sv);
+        out = append(out, infoHashString());
+
+        if (!std::empty(name_))
+        {
+            out = append(out, "&dn="sv);
+            tr_http_escape(out, name_, true);
+        }
+
+        for (auto const& tracker : this->announceList())
+        {
+            out = append(out, "&tr="sv);
+            tr_http_escape(out, tracker.announce.full, true);
+        }
+
+        for (auto const& webseed : webseed_urls_)
+        {
+            out = append(out, "&ws="sv);
+            tr_http_escape(out, webseed, true);
+        }
     }
 
 protected:

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -672,8 +672,7 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
         *did_migrate_filename = migrated;
     }
 
-    auto filename = tr_pathbuf{};
-    tor->resumeFile(std::back_inserter(filename));
+    auto const filename = tor->resumeFile();
     auto buf = std::vector<char>{};
     tr_error* error = nullptr;
     auto top = tr_variant{};
@@ -960,8 +959,7 @@ void save(tr_torrent* tor)
     saveLabels(&top, tor);
     saveGroup(&top, tor);
 
-    auto resume_file = tr_pathbuf{};
-    tor->resumeFile(std::back_inserter(resume_file));
+    auto const resume_file = tor->resumeFile();
     if (auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, resume_file); err != 0)
     {
         tor->setLocalError(tr_strvJoin("Unable to save resume file: ", tr_strerror(err)));

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstring>
 #include <ctime>
+#include <iterator>
 #include <string_view>
 #include <vector>
 
@@ -671,7 +672,8 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
         *did_migrate_filename = migrated;
     }
 
-    auto const filename = tor->resumeFile();
+    auto filename = tr_pathbuf{};
+    tor->resumeFile(std::back_inserter(filename));
     auto buf = std::vector<char>{};
     tr_error* error = nullptr;
     auto top = tr_variant{};
@@ -958,7 +960,9 @@ void save(tr_torrent* tor)
     saveLabels(&top, tor);
     saveGroup(&top, tor);
 
-    if (auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, tor->resumeFile()); err != 0)
+    auto resume_file = tr_pathbuf{};
+    tor->resumeFile(std::back_inserter(resume_file));
+    if (auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, resume_file); err != 0)
     {
         tor->setLocalError(tr_strvJoin("Unable to save resume file: ", tr_strerror(err)));
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cstring>
 #include <ctime>
-#include <iterator>
 #include <string_view>
 #include <vector>
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -794,11 +794,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         }
 
     case TR_KEY_torrentFile:
-        {
-            auto filename = tr_pathbuf{};
-            tor->torrentFile(std::back_inserter(filename));
-            tr_variantInitStr(initme, filename);
-        }
+        tr_variantInitStr(initme, tor->torrentFile());
         break;
 
     case TR_KEY_totalSize:
@@ -1087,9 +1083,7 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    auto filename = tr_pathbuf{};
-    tor->torrentFile(std::back_inserter(filename));
-    tor->announceList().save(filename.sv());
+    tor->announceList().save(tor->torrentFile());
 
     return nullptr;
 }
@@ -1115,9 +1109,7 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    auto filename = tr_pathbuf{};
-    tor->torrentFile(std::back_inserter(filename));
-    tor->announceList().save(filename.sv());
+    tor->announceList().save(tor->torrentFile());
 
     return nullptr;
 }
@@ -1143,9 +1135,7 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         return "error setting announce list";
     }
 
-    auto filename = tr_pathbuf{};
-    tor->torrentFile(std::back_inserter(filename));
-    tor->announceList().save(filename.sv());
+    tor->announceList().save(tor->torrentFile());
 
     return nullptr;
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -794,7 +794,11 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         }
 
     case TR_KEY_torrentFile:
-        tr_variantInitStrView(initme, tor->torrentFile());
+        {
+            auto filename = tr_pathbuf{};
+            tor->torrentFile(std::back_inserter(filename));
+            tr_variantInitStr(initme, filename);
+        }
         break;
 
     case TR_KEY_totalSize:
@@ -1083,7 +1087,10 @@ static char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->torrentFile());
+    auto filename = tr_pathbuf{};
+    tor->torrentFile(std::back_inserter(filename));
+    tor->announceList().save(filename.sv());
+
     return nullptr;
 }
 
@@ -1108,7 +1115,10 @@ static char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->torrentFile());
+    auto filename = tr_pathbuf{};
+    tor->torrentFile(std::back_inserter(filename));
+    tor->announceList().save(filename.sv());
+
     return nullptr;
 }
 
@@ -1133,7 +1143,10 @@ static char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         return "error setting announce list";
     }
 
-    tor->announceList().save(tor->torrentFile());
+    auto filename = tr_pathbuf{};
+    tor->torrentFile(std::back_inserter(filename));
+    tor->announceList().save(filename.sv());
+
     return nullptr;
 }
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -113,7 +113,7 @@ char const* tr_ctorGetSourceFile(tr_ctor const* ctor)
     return ctor->torrent_filename.c_str();
 }
 
-bool tr_ctorSaveContents(tr_ctor const* ctor, std::string const& filename, tr_error** error)
+bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_error** error)
 {
     TR_ASSERT(ctor != nullptr);
     TR_ASSERT(!std::empty(filename));

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -127,20 +127,6 @@ bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_erro
     return tr_saveFile(filename, ctor->contents, error);
 }
 
-bool tr_ctorSaveMagnetContents(tr_torrent* tor, std::string const& filename, tr_error** error)
-{
-    TR_ASSERT(tor != nullptr);
-    TR_ASSERT(!std::empty(filename));
-
-    auto const magnet = tor->magnet();
-    if (std::empty(magnet))
-    {
-        tr_error_set(error, EINVAL, "torrent has no magnetlink to save"sv);
-        return false;
-    }
-    return tr_saveFile(filename, magnet, error);
-}
-
 /***
 ****
 ***/

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <climits> /* INT_MAX */
 #include <ctime>
+#include <iterator>
 #include <string>
 #include <string_view>
 
@@ -411,5 +412,7 @@ double tr_torrentGetMetadataPercent(tr_torrent const* tor)
 
 char* tr_torrentGetMagnetLink(tr_torrent const* tor)
 {
-    return tr_strvDup(tor->metainfo_.magnet());
+    auto urlbuf = tr_urlbuf{};
+    tor->metainfo_.magnet(std::back_inserter(urlbuf));
+    return tr_strvDup(urlbuf.sv());
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -124,9 +124,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
         return nullptr;
     }
 
-    auto filename = tr_pathbuf{};
-    tor->torrentFile(std::back_inserter(filename));
-    auto const fd = tr_sys_file_open(filename, TR_SYS_FILE_READ, 0);
+    auto const fd = tr_sys_file_open(tor->torrentFile(), TR_SYS_FILE_READ, 0);
     if (fd == TR_BAD_SYS_FILE)
     {
         return nullptr;
@@ -276,17 +274,13 @@ static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_
     }
 
     // save it
-    auto filename = tr_pathbuf{};
-    tor->torrentFile(std::back_inserter(filename));
-    if (!tr_saveFile(filename, benc, error))
+    if (!tr_saveFile(tor->torrentFile(), benc, error))
     {
         return false;
     }
 
     // remove .magnet file
-    auto magnet_filename = tr_pathbuf{};
-    tor->magnetFile(std::back_inserter(magnet_filename));
-    tr_sys_path_remove(magnet_filename.c_str());
+    tr_sys_path_remove(tor->magnetFile());
 
     // tor should keep this metainfo
     tor->setMetainfo(metainfo);
@@ -418,7 +412,5 @@ double tr_torrentGetMetadataPercent(tr_torrent const* tor)
 
 char* tr_torrentGetMagnetLink(tr_torrent const* tor)
 {
-    auto urlbuf = tr_urlbuf{};
-    tor->metainfo_.magnet(std::back_inserter(urlbuf));
-    return tr_strvDup(urlbuf.sv());
+    return tr_strvDup(tor->metainfo_.magnet());
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <climits> /* INT_MAX */
 #include <ctime>
-#include <iterator>
 #include <string>
 #include <string_view>
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <iterator>
 #include <numeric>
 #include <string>
 #include <string_view>

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -500,18 +500,28 @@ tr_sha1_digest_t const& tr_torrent_metainfo::pieceHash(tr_piece_index_t piece) c
     return this->pieces_[piece];
 }
 
+tr_pathbuf tr_torrent_metainfo::makeFilename(
+    std::string_view dirname,
+    std::string_view name,
+    std::string_view info_hash_string,
+    BasenameFormat format,
+    std::string_view suffix)
+{
+    // `${dirname}/${name}.${info_hash}${suffix}`
+    // `${dirname}/${info_hash}${suffix}`
+    return format == BasenameFormat::Hash ? tr_pathbuf{ dirname, "/"sv, info_hash_string, suffix } :
+                                            tr_pathbuf{ dirname, "/"sv, name, "."sv, info_hash_string.substr(0, 16), suffix };
+}
+
 bool tr_torrent_metainfo::migrateFile(
     std::string_view dirname,
     std::string_view name,
     std::string_view info_hash_string,
     std::string_view suffix)
 {
-    auto old_filename = tr_pathbuf{};
-    makeFilename(std::back_inserter(old_filename), dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
+    auto const old_filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
     auto const old_filename_exists = tr_sys_path_exists(old_filename.c_str());
-
-    auto new_filename = tr_pathbuf{};
-    makeFilename(std::back_inserter(new_filename), dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
+    auto const new_filename = makeFilename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
     auto const new_filename_exists = tr_sys_path_exists(new_filename.c_str());
 
     if (old_filename_exists && new_filename_exists)
@@ -545,13 +555,8 @@ void tr_torrent_metainfo::removeFile(
     std::string_view info_hash_string,
     std::string_view suffix)
 {
-    auto filename = tr_pathbuf{};
-    makeFilename(std::back_inserter(filename), dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix);
-    tr_sys_path_remove(filename.c_str());
-
-    filename.clear();
-    makeFilename(std::back_inserter(filename), dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
-    tr_sys_path_remove(filename.c_str());
+    tr_sys_path_remove(makeFilename(dirname, name, info_hash_string, BasenameFormat::NameAndPartialHash, suffix));
+    tr_sys_path_remove(makeFilename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix));
 }
 
 std::string const& tr_torrent_metainfo::fileSubpath(tr_file_index_t i) const

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -6,17 +6,15 @@
 #pragma once
 
 #include <ctime>
-#include <iterator>
 #include <string>
 #include <string_view>
 #include <vector>
-
-#include <fmt/core.h>
 
 #include "transmission.h"
 
 #include "block-info.h"
 #include "magnet-metainfo.h"
+#include "tr-strbuf.h"
 
 struct tr_error;
 
@@ -139,23 +137,17 @@ public:
 
     [[nodiscard]] auto torrentFile(std::string_view torrent_dir) const
     {
-        auto filename = tr_pathbuf{};
-        makeFilename(std::back_inserter(filename), torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");
-        return filename;
+        return makeFilename(torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");
     }
 
     [[nodiscard]] auto magnetFile(std::string_view torrent_dir) const
     {
-        auto filename = tr_pathbuf{};
-        makeFilename(std::back_inserter(filename), torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".magnet");
-        return filename;
+        return makeFilename(torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".magnet");
     }
 
     [[nodiscard]] auto resumeFile(std::string_view resume_dir) const
     {
-        auto filename = tr_pathbuf{};
-        makeFilename(std::back_inserter(filename), resume_dir, name(), infoHashString(), BasenameFormat::Hash, ".resume");
-        return filename;
+        return makeFilename(resume_dir, name(), infoHashString(), BasenameFormat::Hash, ".resume");
     }
 
     static bool migrateFile(
@@ -184,31 +176,16 @@ private:
         NameAndPartialHash
     };
 
-    template<typename OutputIt>
-    static void makeFilename(
-        OutputIt out,
+    [[nodiscard]] static tr_pathbuf makeFilename(
         std::string_view dirname,
         std::string_view name,
         std::string_view info_hash_string,
         BasenameFormat format,
-        std::string_view suffix)
-    {
-        // `${dirname}/${name}.${info_hash}${suffix}`
-        // `${dirname}/${info_hash}${suffix}`
-        if (format == BasenameFormat::Hash)
-        {
-            fmt::format_to(out, "{}/{}{}", dirname, info_hash_string, suffix);
-        }
-        else
-        {
-            fmt::format_to(out, "{}/{}.{}{}", dirname, name, info_hash_string.substr(0, 16), suffix);
-        }
-    }
+        std::string_view suffix);
 
-    template<typename OutputIt>
-    void makeFilename(OutputIt out, std::string_view dirname, BasenameFormat format, std::string_view suffix) const
+    auto makeFilename(std::string_view dirname, BasenameFormat format, std::string_view suffix) const
     {
-        makeFilename(out, dirname, name(), infoHashString(), format, suffix);
+        return makeFilename(dirname, name(), infoHashString(), format, suffix);
     }
 
     struct file_t

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <ctime>
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -136,22 +137,25 @@ public:
         return pieces_offset_;
     }
 
-    template<typename OutputIt>
-    void torrentFile(OutputIt out, std::string_view torrent_dir) const
+    [[nodiscard]] auto torrentFile(std::string_view torrent_dir) const
     {
-        return makeFilename(out, torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");
+        auto filename = tr_pathbuf{};
+        makeFilename(std::back_inserter(filename), torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".torrent");
+        return filename;
     }
 
-    template<typename OutputIt>
-    void magnetFile(OutputIt out, std::string_view torrent_dir) const
+    [[nodiscard]] auto magnetFile(std::string_view torrent_dir) const
     {
-        return makeFilename(out, torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".magnet");
+        auto filename = tr_pathbuf{};
+        makeFilename(std::back_inserter(filename), torrent_dir, name(), infoHashString(), BasenameFormat::Hash, ".magnet");
+        return filename;
     }
 
-    template<typename OutputIt>
-    void resumeFile(OutputIt out, std::string_view resume_dir) const
+    [[nodiscard]] auto resumeFile(std::string_view resume_dir) const
     {
-        return makeFilename(out, resume_dir, name(), infoHashString(), BasenameFormat::Hash, ".resume");
+        auto filename = tr_pathbuf{};
+        makeFilename(std::back_inserter(filename), resume_dir, name(), infoHashString(), BasenameFormat::Hash, ".resume");
+        return filename;
     }
 
     static bool migrateFile(

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -3,14 +3,14 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm> /* EINVAL */
+#include <algorithm>
 #include <array>
-#include <cerrno> /* EINVAL */
+#include <cerrno> // EINVAL
 #include <climits> /* INT_MAX */
 #include <cmath>
 #include <csignal> /* signal() */
-#include <cstring> /* memcmp */
 #include <ctime>
+#include <iterator>
 #include <map>
 #include <set>
 #include <sstream>
@@ -793,7 +793,9 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         }
         else // magnet link
         {
-            tr_saveFile(filename, tor->magnet(), &error);
+            auto magnet_link = tr_urlbuf{};
+            tor->magnet(std::back_inserter(magnet_link));
+            tr_saveFile(filename, magnet_link.sv(), &error);
         }
 
         if (error != nullptr)
@@ -2099,7 +2101,10 @@ bool tr_torrent::setTrackerList(std::string_view text)
     if (!has_metadata)
     {
         tr_error* save_error = nullptr;
-        if (!tr_saveFile(this->magnetFile(), this->magnet(), &save_error))
+        auto magnet_link = tr_urlbuf{};
+        this->magnet(std::back_inserter(magnet_link));
+
+        if (!tr_saveFile(this->magnetFile(), magnet_link.sv(), &save_error))
         {
             this->setLocalError(fmt::format(
                 _("Couldn't save '{path}': {error} ({error_code})"),

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <csignal> /* signal() */
 #include <ctime>
-#include <iterator>
 #include <map>
 #include <set>
 #include <sstream>

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -54,8 +54,6 @@ void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 
 bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_error** error);
 
-bool tr_ctorSaveMagnetContents(tr_torrent* tor, std::string const& filename, tr_error** error);
-
 std::string_view tr_ctorGetContents(tr_ctor const* ctor);
 
 tr_session* tr_ctorGetSession(tr_ctor const* ctor);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -465,28 +465,24 @@ public:
         return metainfo_.dateCreated();
     }
 
-    template<typename OutputIt>
-    void torrentFile(OutputIt out) const
+    [[nodiscard]] auto torrentFile() const
     {
-        metainfo_.torrentFile(out, this->session->torrent_dir);
+        return metainfo_.torrentFile(this->session->torrent_dir);
     }
 
-    template<typename OutputIt>
-    void magnetFile(OutputIt out) const
+    [[nodiscard]] auto magnetFile() const
     {
-        metainfo_.magnetFile(out, this->session->torrent_dir);
+        return metainfo_.magnetFile(this->session->torrent_dir);
     }
 
-    template<typename OutputIt>
-    void resumeFile(OutputIt out) const
+    [[nodiscard]] auto resumeFile() const
     {
-        metainfo_.resumeFile(out, this->session->resume_dir);
+        return metainfo_.resumeFile(this->session->resume_dir);
     }
 
-    template<typename OutputIt>
-    void magnet(OutputIt out) const
+    [[nodiscard]] auto magnet() const
     {
-        metainfo_.magnet(out);
+        return metainfo_.magnet();
     }
 
     [[nodiscard]] auto const& comment() const

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -31,6 +31,7 @@
 #include "session.h"
 #include "torrent-metainfo.h"
 #include "tr-macros.h"
+#include "tr-strbuf.h"
 
 class tr_swarm;
 struct tr_error;
@@ -479,9 +480,10 @@ public:
         return metainfo_.resumeFile(this->session->resume_dir);
     }
 
-    [[nodiscard]] auto magnet() const
+    template<typename OutputIt>
+    void magnet(OutputIt out) const
     {
-        return metainfo_.magnet();
+        metainfo_.magnet(out);
     }
 
     [[nodiscard]] auto const& comment() const

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -52,7 +52,7 @@ void tr_ctorInitTorrentPriorities(tr_ctor const* ctor, tr_torrent* tor);
 
 void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor);
 
-bool tr_ctorSaveContents(tr_ctor const* ctor, std::string const& filename, tr_error** error);
+bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_error** error);
 
 bool tr_ctorSaveMagnetContents(tr_torrent* tor, std::string const& filename, tr_error** error);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -465,19 +465,22 @@ public:
         return metainfo_.dateCreated();
     }
 
-    [[nodiscard]] auto torrentFile() const
+    template<typename OutputIt>
+    void torrentFile(OutputIt out) const
     {
-        return metainfo_.torrentFile(this->session->torrent_dir);
+        metainfo_.torrentFile(out, this->session->torrent_dir);
     }
 
-    [[nodiscard]] auto magnetFile() const
+    template<typename OutputIt>
+    void magnetFile(OutputIt out) const
     {
-        return metainfo_.magnetFile(this->session->torrent_dir);
+        metainfo_.magnetFile(out, this->session->torrent_dir);
     }
 
-    [[nodiscard]] auto resumeFile() const
+    template<typename OutputIt>
+    void resumeFile(OutputIt out) const
     {
-        return metainfo_.resumeFile(this->session->resume_dir);
+        metainfo_.resumeFile(out, this->session->resume_dir);
     }
 
     template<typename OutputIt>

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -14,7 +14,6 @@
 #include <cstdlib> // getenv()
 #include <cstring> /* strerror() */
 #include <ctime> // nanosleep()
-#include <iterator> // std::back_inserter
 #include <set>
 #include <string>
 #include <string_view>

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -14,12 +14,8 @@
 #include <string>
 #include <string_view>
 
-#include <event2/buffer.h>
-
 #define PSL_STATIC
 #include <libpsl.h>
-
-#include <fmt/core.h>
 
 #include "transmission.h"
 
@@ -171,64 +167,6 @@ char const* tr_webGetResponseStr(long code)
 
     default:
         return "Unknown Error";
-    }
-}
-
-#if 0
-void tr_http_escape(tr_urlbuf& append_me, std::string_view str, bool escape_reserved)
-{
-    auto constexpr ReservedChars = std::string_view{ "!*'();:@&=+$,/?%#[]" };
-    auto constexpr UnescapedChars = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~" };
-
-    for (auto const& ch : str)
-    {
-        if (tr_strvContains(UnescapedChars, ch) || (tr_strvContains(ReservedChars, ch) && !escape_reserved))
-        {
-            append_me.append(ch);
-        }
-        else
-        {
-            fmt::format_to(std::back_inserter(append_me), "%{:02X}", unsigned(ch & 0xFF));
-        }
-    }
-}
-#endif
-
-void tr_http_escape(struct evbuffer* out, std::string_view str, bool escape_reserved)
-{
-    auto constexpr ReservedChars = std::string_view{ "!*'();:@&=+$,/?%#[]" };
-    auto constexpr UnescapedChars = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~" };
-
-    for (auto const& ch : str)
-    {
-        if (tr_strvContains(UnescapedChars, ch) || (tr_strvContains(ReservedChars, ch) && !escape_reserved))
-        {
-            evbuffer_add_printf(out, "%c", ch);
-        }
-        else
-        {
-            evbuffer_add_printf(out, "%%%02X", (unsigned)(ch & 0xFF));
-        }
-    }
-}
-
-void tr_http_escape(std::string& appendme, std::string_view str, bool escape_reserved)
-{
-    auto constexpr ReservedChars = std::string_view{ "!*'();:@&=+$,/?%#[]" };
-    auto constexpr UnescapedChars = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~" };
-
-    for (auto const& ch : str)
-    {
-        if (tr_strvContains(UnescapedChars, ch) || (!escape_reserved && tr_strvContains(ReservedChars, ch)))
-        {
-            appendme += ch;
-        }
-        else
-        {
-            char buf[16];
-            tr_snprintf(buf, sizeof(buf), "%%%02X", (unsigned)(ch & 0xFF));
-            appendme += buf;
-        }
     }
 }
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdlib>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <string>
@@ -17,6 +18,8 @@
 
 #define PSL_STATIC
 #include <libpsl.h>
+
+#include <fmt/core.h>
 
 #include "transmission.h"
 
@@ -170,6 +173,26 @@ char const* tr_webGetResponseStr(long code)
         return "Unknown Error";
     }
 }
+
+#if 0
+void tr_http_escape(tr_urlbuf& append_me, std::string_view str, bool escape_reserved)
+{
+    auto constexpr ReservedChars = std::string_view{ "!*'();:@&=+$,/?%#[]" };
+    auto constexpr UnescapedChars = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~" };
+
+    for (auto const& ch : str)
+    {
+        if (tr_strvContains(UnescapedChars, ch) || (tr_strvContains(ReservedChars, ch) && !escape_reserved))
+        {
+            append_me.append(ch);
+        }
+        else
+        {
+            fmt::format_to(std::back_inserter(append_me), "%{:02X}", unsigned(ch & 0xFF));
+        }
+    }
+}
+#endif
 
 void tr_http_escape(struct evbuffer* out, std::string_view str, bool escape_reserved)
 {

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -8,7 +8,6 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdlib>
-#include <iterator>
 #include <limits>
 #include <optional>
 #include <string>

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -112,10 +112,6 @@ void tr_http_escape(OutputIt out, std::string_view str, bool escape_reserved)
     }
 }
 
-[[deprecated]] void tr_http_escape(std::string& appendme, std::string_view str, bool escape_reserved);
-
-[[deprecated]] void tr_http_escape(struct evbuffer* out, std::string_view str, bool escape_reserved);
-
 void tr_http_escape_sha1(char* out, uint8_t const* sha1_digest);
 
 void tr_http_escape_sha1(char* out, tr_sha1_digest_t const& digest);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -43,10 +43,7 @@ TEST_F(TorrentMetainfoTest, magnetLink)
     EXPECT_TRUE(metainfo.parseMagnet(MagnetLink));
     EXPECT_EQ(0, metainfo.fileCount()); // because it's a magnet link
     EXPECT_EQ(2, std::size(metainfo.announceList()));
-
-    auto magnet_link = tr_urlbuf{};
-    metainfo.magnet(std::back_inserter(magnet_link));
-    EXPECT_EQ(MagnetLink, magnet_link.sv());
+    EXPECT_EQ(MagnetLink, metainfo.magnet().sv());
 }
 
 #define BEFORE_PATH \

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -166,7 +166,7 @@ TEST_F(TorrentMetainfoTest, ctorSaveContents)
     // try saving without passing any metainfo.
     auto* ctor = tr_ctorNew(session_);
     tr_error* error = nullptr;
-    EXPECT_FALSE(tr_ctorSaveContents(ctor, tgt_filename.c_str(), &error));
+    EXPECT_FALSE(tr_ctorSaveContents(ctor, tgt_filename.sv(), &error));
     EXPECT_NE(nullptr, error);
     if (error != nullptr)
     {
@@ -177,7 +177,7 @@ TEST_F(TorrentMetainfoTest, ctorSaveContents)
     // now try saving _with_ metainfo
     EXPECT_TRUE(tr_ctorSetMetainfoFromFile(ctor, src_filename.c_str(), &error));
     EXPECT_EQ(nullptr, error) << *error;
-    EXPECT_TRUE(tr_ctorSaveContents(ctor, tgt_filename.c_str(), &error));
+    EXPECT_TRUE(tr_ctorSaveContents(ctor, tgt_filename.sv(), &error));
     EXPECT_EQ(nullptr, error) << *error;
 
     // the saved contents should match the source file's contents

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <cerrno>
 #include <cstring>
+#include <iterator>
 #include <string_view>
 
 #include "transmission.h"
@@ -42,7 +43,10 @@ TEST_F(TorrentMetainfoTest, magnetLink)
     EXPECT_TRUE(metainfo.parseMagnet(MagnetLink));
     EXPECT_EQ(0, metainfo.fileCount()); // because it's a magnet link
     EXPECT_EQ(2, std::size(metainfo.announceList()));
-    EXPECT_EQ(MagnetLink, metainfo.magnet());
+
+    auto magnet_link = tr_urlbuf{};
+    metainfo.magnet(std::back_inserter(magnet_link));
+    EXPECT_EQ(MagnetLink, magnet_link.sv());
 }
 
 #define BEFORE_PATH \

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -6,7 +6,6 @@
 #include <array>
 #include <cerrno>
 #include <cstring>
-#include <iterator>
 #include <string_view>
 
 #include "transmission.h"

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <cstring>
-#include <iterator>
 #include <set>
 
 #include "transmission.h"

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -41,9 +41,7 @@ TEST_F(TorrentsTest, simpleTests)
 
     EXPECT_EQ(tor, torrents.get(id));
     EXPECT_EQ(tor, torrents.get(tor->infoHash()));
-    auto magnet_link = tr_urlbuf{};
-    tor->magnet(std::back_inserter(magnet_link));
-    EXPECT_EQ(tor, torrents.get(magnet_link.sv()));
+    EXPECT_EQ(tor, torrents.get(tor->magnet()));
 
     tm = tr_torrent_metainfo{};
     EXPECT_TRUE(tm.parseTorrentFile(TorrentFile));

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -3,6 +3,10 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstring>
+#include <iterator>
+#include <set>
+
 #include "transmission.h"
 
 #include "torrent.h"
@@ -10,9 +14,6 @@
 #include "utils.h"
 
 #include "gtest/gtest.h"
-
-#include <cstring>
-#include <set>
 
 using namespace std::literals;
 
@@ -40,7 +41,9 @@ TEST_F(TorrentsTest, simpleTests)
 
     EXPECT_EQ(tor, torrents.get(id));
     EXPECT_EQ(tor, torrents.get(tor->infoHash()));
-    EXPECT_EQ(tor, torrents.get(tor->magnet()));
+    auto magnet_link = tr_urlbuf{};
+    tor->magnet(std::back_inserter(magnet_link));
+    EXPECT_EQ(tor, torrents.get(magnet_link.sv()));
 
     tm = tr_torrent_metainfo{};
     EXPECT_TRUE(tm.parseTorrentFile(TorrentFile));

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -356,9 +356,7 @@ int tr_main(int argc, char* argv[])
 
     if (opts.show_magnet)
     {
-        auto magnet_link = tr_urlbuf{};
-        metainfo.magnet(std::back_inserter(magnet_link));
-        printf("%s", magnet_link.c_str());
+        printf("%s", metainfo.magnet().c_str());
     }
     else
     {

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdio>
 #include <ctime>
+#include <iterator>
 #include <string>
 #include <string_view>
 
@@ -355,7 +356,9 @@ int tr_main(int argc, char* argv[])
 
     if (opts.show_magnet)
     {
-        printf("%s", metainfo.magnet().c_str());
+        auto magnet_link = tr_urlbuf{};
+        metainfo.magnet(std::back_inserter(magnet_link));
+        printf("%s", magnet_link.c_str());
     }
     else
     {


### PR DESCRIPTION
Sixth in the `tr_strbuf` series. The previous PR was #2829 and the series goals are described [here](https://github.com/transmission/transmission/pull/2810#issue-1180004274).

---

Migrate some of the code that uses temporary strings from using `std::string` to `tr_pathbuf` and `tr_urlbuf`:

- `announce_url_new` now returns a `tr_urlbuf` instead of a `std::string`
- `scrape_url_new` now returns a `tr_urlbuf` instead of a `std::string`
- `tr_magnet_metainfo.magnet()` now returns a `tr_urlbuf` instead of a `std::string`
- `tr_torrent_metainfo.torrentFile()` now returns a `tr_pathbuf` instead of a `std::string`
- `tr_torrent_metainfo.resumeFile()` now returns a `tr_pathbuf` instead of a `std::string`
- `tr_torrent_metainfo.magnetFile()` now returns a `tr_pathbuf` instead of a `std::string`
- `tr_announce_list.save()` now takes a `std::string_view` instead of a `std::string`
- `tr_http_escape()` now takes a `std::back_inserter` instead of a `std::string&`
- `tr_ctorSaveContents` now takes a `std::string_view` instead of a `std::string const&`