### PR TITLE
test: fix race condition in move-test

### DIFF
--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -106,7 +106,7 @@ public:
 
     [[nodiscard]] uint64_t fileSize(tr_file_index_t i) const;
 
-    [[nodiscard]] auto const& isPrivate() const
+    [[nodiscard]] auto const& isPrivate() const noexcept
     {
         return is_private_;
     }
@@ -191,7 +191,7 @@ private:
     struct file_t
     {
     public:
-        [[nodiscard]] std::string const& path() const
+        [[nodiscard]] std::string const& path() const noexcept
         {
             return path_;
         }
@@ -201,7 +201,7 @@ private:
             path_ = subpath;
         }
 
-        [[nodiscard]] uint64_t size() const
+        [[nodiscard]] uint64_t size() const noexcept
         {
             return size_;
         }

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -52,8 +52,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
 
     // init an incomplete torrent.
     // the test zero_torrent will be missing its first piece.
-    auto* tor = zeroTorrentInit();
-    zeroTorrentPopulate(tor, false);
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
     EXPECT_EQ(tr_strvJoin(incomplete_dir, "/", tr_torrentFile(tor, 0).name, ".part"), makeString(tr_torrentFindFile(tor, 0)));
     EXPECT_EQ(tr_strvPath(incomplete_dir, tr_torrentFile(tor, 1).name), makeString(tr_torrentFindFile(tor, 1)));
     EXPECT_EQ(tor->pieceSize(), tr_torrentStat(tor)->leftUntilDone);
@@ -165,8 +164,7 @@ TEST_F(MoveTest, setLocation)
     tr_sys_dir_create(target_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
 
     // init a torrent.
-    auto* tor = zeroTorrentInit();
-    zeroTorrentPopulate(tor, true);
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
     blockingTorrentVerify(tor);
     EXPECT_EQ(0, tr_torrentStat(tor)->leftUntilDone);
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -458,15 +458,14 @@ TEST_F(RenameTest, partialFile)
     ****  create our test torrent with an incomplete .part file
     ***/
 
-    auto* tor = zeroTorrentInit();
+    auto* tor = zeroTorrentInit(ZeroTorrentState::Partial);
     EXPECT_EQ(TotalSize, tor->totalSize());
     EXPECT_EQ(PieceSize, tor->pieceSize());
     EXPECT_EQ(PieceCount, tor->pieceCount());
     EXPECT_EQ("files-filled-with-zeroes/1048576"sv, tor->fileSubpath(0));
     EXPECT_EQ("files-filled-with-zeroes/4096"sv, tor->fileSubpath(1));
     EXPECT_EQ("files-filled-with-zeroes/512"sv, tor->fileSubpath(2));
-
-    zeroTorrentPopulate(tor, false);
+    EXPECT_NE(0, tr_torrentFile(tor, 0).have);
     EXPECT_EQ(Length[0], tr_torrentFile(tor, 0).have + PieceSize);
     EXPECT_EQ(Length[1], tr_torrentFile(tor, 1).have);
     EXPECT_EQ(Length[2], tr_torrentFile(tor, 2).have);

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -79,7 +79,7 @@ TEST_F(RpcTest, sessionGet)
         tr_variantInitBool(response, false);
     };
 
-    auto* tor = zeroTorrentInit();
+    auto* tor = zeroTorrentInit(ZeroTorrentState::NoFiles);
     EXPECT_NE(nullptr, tor);
 
     tr_variant request;


### PR DESCRIPTION
When creating a test torrent, populate its files _before_ instantiating the torrent rather than after.

This should solve a should-have-been-obvious-from-the-beginning race condition of the torrent verifying its files in the background vs. the torrent's files being populated. 