### PR TITLE
fix: tr_strbuf move op loses zero-termination

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -26,19 +26,25 @@ public:
     using value_type = Char;
     using const_reference = const Char&;
 
-    tr_strbuf() = default;
+    tr_strbuf()
+    {
+        ensure_sz();
+    }
+
     ~tr_strbuf() = default;
     tr_strbuf(tr_strbuf const& other) = delete;
     tr_strbuf& operator=(tr_strbuf const& other) = delete;
 
-    tr_strbuf(tr_strbuf&& other) noexcept
+    tr_strbuf(tr_strbuf&& other)
+        : buffer_{ std::move(other.buffer_) }
     {
-        buffer_ = std::move(other.buffer_);
+        ensure_sz();
     }
 
-    tr_strbuf& operator=(tr_strbuf&& other) noexcept
+    tr_strbuf& operator=(tr_strbuf&& other)
     {
         buffer_ = std::move(other.buffer_);
+        ensure_sz();
         return *this;
     }
 

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -153,6 +153,19 @@ TEST_F(StrbufTest, join)
     EXPECT_EQ("A--short--phrase"sv, buf.sv());
 }
 
+TEST_F(StrbufTest, move)
+{
+    static auto constexpr Value = "/hello/world"sv;
+
+    auto generator = []()
+    {
+        return tr_pathbuf{ Value };
+    };
+    auto const path = generator();
+    EXPECT_EQ(Value, path.sv());
+    EXPECT_EQ(Value, path.c_str());
+}
+
 TEST_F(StrbufTest, startsWith)
 {
     auto const buf = tr_pathbuf{ "/hello/world" };


### PR DESCRIPTION
`tr_strbuf`'s move constructor and move assignment operator incorrectly assumed that the aggregate object `buffer_`'s full contents, including the implicit zero termination at `buffer[buffer.size()]`, would be moved. The full buffer is not guaranteed, so the recipient object needs to re-ensure zero termination.