### PR TITLE
refactor: prefer FMT_STRING

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -898,7 +898,7 @@ void Application::Impl::on_app_exit()
     p->attach(*icon, 0, 0, 1, 2);
 
     auto* top_label = Gtk::make_managed<Gtk::Label>();
-    top_label->set_markup(fmt::format("<b>{}</b>", _("Closing Connections…")));
+    top_label->set_markup(fmt::format(FMT_STRING("<b>{:s}</b>"), _("Closing Connections…")));
     top_label->set_halign(Gtk::ALIGN_START);
     top_label->set_valign(Gtk::ALIGN_CENTER);
     p->attach(*top_label, 1, 0, 1, 1);

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -608,7 +608,7 @@ std::string get_date_string(time_t t)
 
     struct tm tm;
     tr_localtime_r(&t, &tm);
-    return fmt::format("{:%x}", tm);
+    return fmt::format(FMT_STRING("{:%x}"), tm);
 }
 
 } // namespace
@@ -1382,7 +1382,7 @@ void DetailsDialog::Impl::refreshPeerList(std::vector<tr_torrent*> const& torren
 
     auto make_key = [](tr_torrent const* tor, tr_peer_stat const* ps)
     {
-        return fmt::format("{}.{}", tr_torrentId(tor), ps->addr);
+        return fmt::format(FMT_STRING("{:d}.{:s}"), tr_torrentId(tor), ps->addr);
     };
 
     /* step 3: add any new peers */
@@ -1450,7 +1450,7 @@ void DetailsDialog::Impl::refreshWebseedList(std::vector<tr_torrent*> const& tor
 
     auto make_key = [](tr_torrent const* tor, char const* url)
     {
-        return fmt::format("{}.{}", tr_torrentId(tor), url);
+        return fmt::format(FMT_STRING("{:d}.{:s}"), tr_torrentId(tor), url);
     };
 
     /* step 1: mark all webseeds as not-updated */
@@ -2050,7 +2050,7 @@ void buildTrackerSummary(
     // hostname
     gstr << text_dir_mark[direction];
     gstr << (tracker.isBackup ? "<i>" : "<b>");
-    gstr << Glib::Markup::escape_text(!key.empty() ? fmt::format("{} - {}", tracker.host, key) : tracker.host);
+    gstr << Glib::Markup::escape_text(!key.empty() ? fmt::format(FMT_STRING("{:s} - {:s}"), tracker.host, key) : tracker.host);
     gstr << (tracker.isBackup ? "</i>" : "</b>");
 
     if (!tracker.isBackup)

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -180,7 +180,7 @@ bool refreshFilesForeach(
             (*iter)[file_cols.enabled] = enabled;
             (*iter)[file_cols.have] = have;
             (*iter)[file_cols.prog] = prog;
-            (*iter)[file_cols.prog_str] = fmt::format("{}%", prog);
+            (*iter)[file_cols.prog_str] = fmt::format(FMT_STRING("{:d}%"), prog);
         }
     }
     else
@@ -236,7 +236,7 @@ bool refreshFilesForeach(
             (*iter)[file_cols.priority] = priority;
             (*iter)[file_cols.enabled] = enabled;
             (*iter)[file_cols.prog] = prog;
-            (*iter)[file_cols.prog_str] = fmt::format("{}%", prog);
+            (*iter)[file_cols.prog_str] = fmt::format(FMT_STRING("{:d}%"), prog);
         }
     }
 

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -50,7 +50,7 @@ bool FreeSpaceLabel::Impl::on_freespace_timer()
 
     auto const bytes = tr_dirSpace(dir_).free;
     auto const text = bytes < 0 ? _("Error") : fmt::format(_("{disk_space} free"), fmt::arg("disk_space", tr_strlsize(bytes)));
-    label_.set_markup(fmt::format("<i>{}</i>", text));
+    label_.set_markup(fmt::format(FMT_STRING("<i>{:s}</i>"), text));
 
     return true;
 }

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -480,7 +480,7 @@ MakeDialog::Impl::Impl(MakeDialog& dialog, Glib::RefPtr<Session> const& core)
     t->add_row_w(row, *file_radio_, *file_chooser_);
 
     pieces_lb_ = Gtk::make_managed<Gtk::Label>();
-    pieces_lb_->set_markup(fmt::format("<i>{}</i>", _("No source selected")));
+    pieces_lb_->set_markup(fmt::format(FMT_STRING("<i>{:s}</i>"), _("No source selected")));
     t->add_row(row, {}, *pieces_lb_);
 
     t->add_section_divider(row);

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -415,7 +415,7 @@ void updateBlocklistText(Gtk::Label* w, Glib::RefPtr<Session> const& core)
     auto const msg = fmt::format(
         ngettext("Blocklist has {count} entry", "Blocklist has {count} entries", n),
         fmt::arg("count", n));
-    w->set_markup(fmt::format("<i>{}</i>", msg));
+    w->set_markup(fmt::format(FMT_STRING("<i>{:s}</i>"), msg));
 }
 
 /* prefs dialog is being destroyed, so stop listening to blocklist updates */
@@ -445,7 +445,7 @@ void onBlocklistUpdated(Glib::RefPtr<Session> const& core, int n, blocklist_data
         fmt::arg("count", count));
     data->updateBlocklistButton->set_sensitive(true);
     data->updateBlocklistDialog->set_message(
-        fmt::format("<b>{}</b>", success ? _("Blocklist updated!") : _("Couldn't update blocklist")),
+        fmt::format(FMT_STRING("<b>{:s}</b>"), success ? _("Blocklist updated!") : _("Couldn't update blocklist")),
         true);
     data->updateBlocklistDialog->set_secondary_text(msg);
     updateBlocklistText(data->label, core);
@@ -914,7 +914,7 @@ Gtk::Widget* PrefsDialog::Impl::speedPage()
 
     {
         auto* h = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL, GUI_PAD);
-        auto* w = Gtk::make_managed<Gtk::Label>(fmt::format("<b>{}</b>", _("Alternative Speed Limits")));
+        auto* w = Gtk::make_managed<Gtk::Label>(fmt::format(FMT_STRING("<b>{:s}</b>"), _("Alternative Speed Limits")));
         w->set_halign(Gtk::ALIGN_START);
         w->set_valign(Gtk::ALIGN_CENTER);
         w->set_use_markup(true);
@@ -925,7 +925,7 @@ Gtk::Widget* PrefsDialog::Impl::speedPage()
 
     {
         auto* w = Gtk::make_managed<Gtk::Label>(
-            fmt::format("<small>{}</small>", _("Override normal speed limits manually or at scheduled times")));
+            fmt::format(FMT_STRING("<small>{:s}</small>"), _("Override normal speed limits manually or at scheduled times")));
         w->set_use_markup(true);
         w->set_halign(Gtk::ALIGN_START);
         w->set_valign(Gtk::ALIGN_CENTER);
@@ -1029,7 +1029,7 @@ void onPortTest(std::shared_ptr<network_page_data> const& data)
 {
     data->portButton->set_sensitive(false);
     data->portSpin->set_sensitive(false);
-    data->portLabel->set_markup(fmt::format("<i>{}</i>", _("Testing TCP port…")));
+    data->portLabel->set_markup(fmt::format(FMT_STRING("<i>{:s}</i>"), _("Testing TCP port…")));
 
     if (!data->portTag.connected())
     {

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -171,7 +171,7 @@ std::string getShortStatusString(
     case TR_STATUS_DOWNLOAD:
     case TR_STATUS_SEED:
         return fmt::format(
-            "{} {}",
+            FMT_STRING("{:s} {:s}"),
             getShortTransferString(tor, st, uploadSpeed_KBps, downloadSpeed_KBps),
             fmt::format(_("Ratio: {ratio}"), fmt::arg("ratio", tr_strlratio(st->ratio))));
 
@@ -282,7 +282,7 @@ std::string getStatusString(
     {
         if (auto const buf = getShortTransferString(tor, st, uploadSpeed_KBps, downloadSpeed_KBps); !std::empty(buf))
         {
-            status_str += fmt::format(" - {}", buf);
+            status_str += fmt::format(FMT_STRING(" - {:s}"), buf);
         }
     }
 

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -105,21 +105,21 @@ Glib::ustring tr_strltime(time_t seconds)
     auto const h = fmt::format(ngettext("{hours} hour", "{hours} hours", hours), fmt::arg("hours", hours));
     if (days != 0)
     {
-        return (days >= 4 || hours == 0) ? d : fmt::format("{}, {}", d, h);
+        return (days >= 4 || hours == 0) ? d : fmt::format(FMT_STRING("{:s}, {:s}"), d, h);
     }
 
     int const minutes = (seconds % 3600) / 60;
     auto const m = fmt::format(ngettext("{minutes} minute", "{minutes} minutes", minutes), fmt::arg("minutes", minutes));
     if (hours != 0)
     {
-        return (hours >= 4 || minutes == 0) ? h : fmt::format("{}, {}", h, m);
+        return (hours >= 4 || minutes == 0) ? h : fmt::format(FMT_STRING("{:s}, {:s}"), h, m);
     }
 
     seconds = (seconds % 3600) % 60;
     auto const s = fmt::format(ngettext("{seconds} second", "{seconds} seconds", seconds), fmt::arg("seconds", seconds));
     if (minutes != 0)
     {
-        return (minutes >= 4 || seconds == 0) ? m : fmt::format("{}, {}", m, s);
+        return (minutes >= 4 || seconds == 0) ? m : fmt::format(FMT_STRING("{:s}, {:s}"), m, s);
     }
 
     return s;

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -15,7 +15,6 @@
 #include <event2/http.h> /* for HTTP_OK */
 
 #include <fmt/core.h>
-#include <fmt/compile.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
@@ -302,7 +301,7 @@ static void onAnnounceDone(tr_web::FetchResponse const& web_response)
     if (status != HTTP_OK)
     {
         auto const* const response_str = tr_webGetResponseStr(status);
-        response->errmsg = fmt::format(FMT_COMPILE("Tracker HTTP response {:d} ({:s}"), status, response_str);
+        response->errmsg = fmt::format(FMT_STRING("Tracker HTTP response {:d} ({:s}"), status, response_str);
     }
     else
     {
@@ -482,7 +481,7 @@ static void onScrapeDone(tr_web::FetchResponse const& web_response)
     if (status != HTTP_OK)
     {
         auto const* const response_str = tr_webGetResponseStr(status);
-        response.errmsg = fmt::format(FMT_COMPILE("Tracker HTTP response {:d} ({:s})"), status, response_str);
+        response.errmsg = fmt::format(FMT_STRING("Tracker HTTP response {:d} ({:s})"), status, response_str);
     }
     else if (!std::empty(body))
     {

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -15,6 +15,7 @@
 #include <event2/http.h> /* for HTTP_OK */
 
 #include <fmt/core.h>
+#include <fmt/compile.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
@@ -301,7 +302,7 @@ static void onAnnounceDone(tr_web::FetchResponse const& web_response)
     if (status != HTTP_OK)
     {
         auto const* const response_str = tr_webGetResponseStr(status);
-        response->errmsg = tr_strvJoin("Tracker HTTP response "sv, std::to_string(status), " ("sv, response_str, ")"sv);
+        response->errmsg = fmt::format(FMT_COMPILE("Tracker HTTP response {:d} ({:s}"), status, response_str);
     }
     else
     {
@@ -481,7 +482,7 @@ static void onScrapeDone(tr_web::FetchResponse const& web_response)
     if (status != HTTP_OK)
     {
         auto const* const response_str = tr_webGetResponseStr(status);
-        response.errmsg = tr_strvJoin("Tracker HTTP response "sv, std::to_string(status), " ("sv, response_str, ")"sv);
+        response.errmsg = fmt::format(FMT_COMPILE("Tracker HTTP response {:d} ({:s})"), status, response_str);
     }
     else if (!std::empty(body))
     {

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -5,6 +5,8 @@
 
 #include <string_view>
 
+#include <fmt/compile.h>
+
 #include "transmission.h"
 
 #include "error.h"
@@ -79,7 +81,7 @@ void tr_error_prefix(tr_error** error, char const* prefix)
     }
 
     auto* err = *error;
-    auto* const new_message = tr_strvDup(tr_strvJoin(prefix, err->message));
+    auto* const new_message = tr_strvDup(fmt::format(FMT_COMPILE("{:s}{:s}"), prefix, err->message));
     tr_free(err->message);
     err->message = new_message;
 }

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -5,7 +5,7 @@
 
 #include <string_view>
 
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -81,7 +81,7 @@ void tr_error_prefix(tr_error** error, char const* prefix)
     }
 
     auto* err = *error;
-    auto* const new_message = tr_strvDup(fmt::format(FMT_COMPILE("{:s}{:s}"), prefix, err->message));
+    auto* const new_message = tr_strvDup(fmt::format(FMT_STRING("{:s}{:s}"), prefix, err->message));
     tr_free(err->message);
     err->message = new_message;
 }

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -51,6 +51,7 @@
 #define USE_COPY_FILE_RANGE
 #endif /* __linux__ */
 
+#include <fmt/compile.h>
 #include <fmt/core.h>
 
 #include "transmission.h"
@@ -177,7 +178,7 @@ static bool create_path_require_dir(char const* path, tr_error** error)
 
     if ((sb.st_mode & S_IFMT) != S_IFDIR)
     {
-        tr_error_set(error, ENOTDIR, tr_strvJoin("File is in the way: "sv, path));
+        tr_error_set(error, ENOTDIR, fmt::format(FMT_COMPILE("File is in the way: {:s}"), path));
         return false;
     }
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -51,8 +51,7 @@
 #define USE_COPY_FILE_RANGE
 #endif /* __linux__ */
 
-#include <fmt/compile.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 #include "error.h"
@@ -178,7 +177,7 @@ static bool create_path_require_dir(char const* path, tr_error** error)
 
     if ((sb.st_mode & S_IFMT) != S_IFDIR)
     {
-        tr_error_set(error, ENOTDIR, fmt::format(FMT_COMPILE("File is in the way: {:s}"), path));
+        tr_error_set(error, ENOTDIR, fmt::format(FMT_STRING("File is in the way: {:s}"), path));
         return false;
     }
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <fmt/core.h>
+#include <fmt/compile.h>
 
 #include "transmission.h"
 
@@ -220,7 +221,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         if (err != 0 && io_mode == IoMode::Write && tor->error != TR_STAT_LOCAL_ERROR)
         {
             auto const path = tr_strvPath(tor->downloadDir().sv(), tor->fileSubpath(file_index));
-            tor->setLocalError(tr_strvJoin(tr_strerror(err), " ("sv, path, ")"sv));
+            tor->setLocalError(fmt::format(FMT_COMPILE("{:s} ({:s})"), tr_strerror(err), path));
         }
 
         ++file_index;

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <fmt/core.h>
-#include <fmt/compile.h>
 
 #include "transmission.h"
 
@@ -221,7 +220,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         if (err != 0 && io_mode == IoMode::Write && tor->error != TR_STAT_LOCAL_ERROR)
         {
             auto const path = tr_strvPath(tor->downloadDir().sv(), tor->fileSubpath(file_index));
-            tor->setLocalError(fmt::format(FMT_COMPILE("{:s} ({:s})"), tr_strerror(err), path));
+            tor->setLocalError(fmt::format(FMT_STRING("{:s} ({:s})"), tr_strerror(err), path));
         }
 
         ++file_index;

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -101,7 +101,7 @@ void logAddImpl(
     auto const lock = log_state.unique_lock();
 #ifdef _WIN32
 
-    OutputDebugStringA(tr_strvJoin(msg, "\r\n").c_str());
+    OutputDebugStringA(fmt::format(FMT_COMPILE("{:s}\r\n"), msg).c_str());
 
 #elif defined(__ANDROID__)
 
@@ -173,9 +173,10 @@ void logAddImpl(
 
         tr_logGetTimeStr(timestr, sizeof(timestr));
 
-        auto const out = !std::empty(name) ? tr_strvJoin("["sv, timestr, "] "sv, name, ": "sv, msg) :
-                                             tr_strvJoin("["sv, timestr, "] "sv, msg);
-        tr_sys_file_write_line(fp, out);
+        tr_sys_file_write_line(
+            fp,
+            !std::empty(name) ? fmt::format(FMT_COMPILE("[{:s}] {:s}: {:s}"), timestr, name, msg) :
+                                fmt::format(FMT_COMPILE("[{:s}] {:s}"), timestr, msg));
         tr_sys_file_flush(fp);
     }
 #endif

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -14,7 +14,6 @@
 #include <event2/buffer.h>
 
 #include <fmt/core.h>
-#include <fmt/compile.h>
 #include <fmt/format.h>
 
 #include "transmission.h"
@@ -101,7 +100,7 @@ void logAddImpl(
     auto const lock = log_state.unique_lock();
 #ifdef _WIN32
 
-    OutputDebugStringA(fmt::format(FMT_COMPILE("{:s}\r\n"), msg).c_str());
+    OutputDebugStringA(fmt::format(FMT_STRING("{:s}\r\n"), msg).c_str());
 
 #elif defined(__ANDROID__)
 
@@ -175,8 +174,8 @@ void logAddImpl(
 
         tr_sys_file_write_line(
             fp,
-            !std::empty(name) ? fmt::format(FMT_COMPILE("[{:s}] {:s}: {:s}"), timestr, name, msg) :
-                                fmt::format(FMT_COMPILE("[{:s}] {:s}"), timestr, msg));
+            !std::empty(name) ? fmt::format(FMT_STRING("[{:s}] {:s}: {:s}"), timestr, name, msg) :
+                                fmt::format(FMT_STRING("[{:s}] {:s}"), timestr, msg));
         tr_sys_file_flush(fp);
     }
 #endif
@@ -262,7 +261,7 @@ void tr_logAddMessage(char const* file, int line, tr_log_level level, std::strin
     if (std::empty(name))
     {
         auto const base = tr_sys_path_basename(file);
-        name_fallback = fmt::format(FMT_COMPILE("{}:{}"), !std::empty(base) ? base : "?", line);
+        name_fallback = fmt::format(FMT_STRING("{}:{}"), !std::empty(base) ? base : "?", line);
         name = name_fallback;
     }
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -15,6 +15,7 @@
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 
 #include <fmt/core.h>
+#include <fmt/compile.h>
 
 #include "transmission.h"
 
@@ -615,14 +616,8 @@ void tr_makeMetaInfo(
     builder->isPrivate = isPrivate;
     builder->source = tr_strdup(source);
 
-    if (!tr_str_is_empty(outputFile))
-    {
-        builder->outputFile = tr_strdup(outputFile);
-    }
-    else
-    {
-        builder->outputFile = tr_strvDup(tr_strvJoin(builder->top, ".torrent"sv));
-    }
+    builder->outputFile = !tr_str_is_empty(outputFile) ? tr_strdup(outputFile) :
+                                                         tr_strvDup(fmt::format(FMT_COMPILE("{:s}.torrent"), builder->top));
 
     /* enqueue the builder */
     auto const lock = std::lock_guard(queue_mutex_);

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -15,7 +15,7 @@
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 
 #include <fmt/core.h>
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -617,7 +617,7 @@ void tr_makeMetaInfo(
     builder->source = tr_strdup(source);
 
     builder->outputFile = !tr_str_is_empty(outputFile) ? tr_strdup(outputFile) :
-                                                         tr_strvDup(fmt::format(FMT_COMPILE("{:s}.torrent"), builder->top));
+                                                         tr_strvDup(fmt::format(FMT_STRING("{:s}.torrent"), builder->top));
 
     /* enqueue the builder */
     auto const lock = std::lock_guard(queue_mutex_);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -15,6 +15,8 @@
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
+#include <fmt/compile.h>
+
 #include "transmission.h"
 
 #include "cache.h"
@@ -2207,11 +2209,8 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
                 err = !msgs->torrent->ensurePieceIsChecked(req.index);
                 if (err)
                 {
-                    auto const errmsg = tr_strvJoin(
-                        "Please Verify Local Data! Piece #",
-                        std::to_string(req.index),
-                        " is corrupt.");
-                    msgs->torrent->setLocalError(errmsg);
+                    msgs->torrent->setLocalError(
+                        fmt::format(FMT_COMPILE("Please Verify Local Data! Piece #{:d} is corrupt."), req.index));
                 }
             }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -15,8 +15,6 @@
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
-#include <fmt/compile.h>
-
 #include "transmission.h"
 
 #include "cache.h"
@@ -2210,7 +2208,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
                 if (err)
                 {
                     msgs->torrent->setLocalError(
-                        fmt::format(FMT_COMPILE("Please Verify Local Data! Piece #{:d} is corrupt."), req.index));
+                        fmt::format(FMT_STRING("Please Verify Local Data! Piece #{:d} is corrupt."), req.index));
                 }
             }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include <fmt/compile.h>
 #include <fmt/core.h>
 #include <fmt/format.h> // fmt::ptr
 
@@ -960,7 +961,7 @@ void save(tr_torrent* tor)
     auto const resume_file = tor->resumeFile();
     if (auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, resume_file); err != 0)
     {
-        tor->setLocalError(tr_strvJoin("Unable to save resume file: ", tr_strerror(err)));
+        tor->setLocalError(fmt::format(FMT_COMPILE("Unable to save resume file: {:s}"), tr_strerror(err)));
     }
 
     tr_variantFree(&top);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/compile.h>
 #include <fmt/core.h>
 #include <fmt/format.h> // fmt::ptr
 
@@ -961,7 +960,7 @@ void save(tr_torrent* tor)
     auto const resume_file = tor->resumeFile();
     if (auto const err = tr_variantToFile(&top, TR_VARIANT_FMT_BENC, resume_file); err != 0)
     {
-        tor->setLocalError(fmt::format(FMT_COMPILE("Unable to save resume file: {:s}"), tr_strerror(err)));
+        tor->setLocalError(fmt::format(FMT_STRING("Unable to save resume file: {:s}"), tr_strerror(err)));
     }
 
     tr_variantFree(&top);

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -13,6 +13,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <fmt/compile.h>
+
 #include "transmission.h"
 #include "error.h"
 #include "subprocess.h"
@@ -42,7 +44,7 @@ static void set_system_error(tr_error** error, int code, std::string_view what)
         return;
     }
 
-    tr_error_set(error, code, tr_strvJoin(what, " failed "sv, tr_strerror(code)));
+    tr_error_set(error, code, fmt::format(FMT_COMPILE("{:s} failed: {:s} ({:d})"), what, tr_strerror(code), code));
 }
 
 static bool tr_spawn_async_in_child(

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -13,7 +13,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 #include "error.h"
@@ -44,7 +44,7 @@ static void set_system_error(tr_error** error, int code, std::string_view what)
         return;
     }
 
-    tr_error_set(error, code, fmt::format(FMT_COMPILE("{:s} failed: {:s} ({:d})"), what, tr_strerror(code), code));
+    tr_error_set(error, code, fmt::format(FMT_STRING("{:s} failed: {:s} ({:d})"), what, tr_strerror(code), code));
 }
 
 static bool tr_spawn_async_in_child(

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <fmt/core.h>
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -477,7 +477,7 @@ bool tr_torrent_metainfo::parseBenc(std::string_view benc, tr_error** error)
     tr_variantFree(&top);
     if (!std::empty(errmsg))
     {
-        tr_error_set(error, TR_ERROR_EINVAL, fmt::format(FMT_COMPILE("Error parsing metainfo: {:s}"), errmsg));
+        tr_error_set(error, TR_ERROR_EINVAL, fmt::format(FMT_STRING("Error parsing metainfo: {:s}"), errmsg));
         return false;
     }
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <fmt/core.h>
+#include <fmt/compile.h>
 
 #include "transmission.h"
 
@@ -476,7 +477,7 @@ bool tr_torrent_metainfo::parseBenc(std::string_view benc, tr_error** error)
     tr_variantFree(&top);
     if (!std::empty(errmsg))
     {
-        tr_error_set(error, TR_ERROR_EINVAL, tr_strvJoin("Error parsing metainfo: ", errmsg));
+        tr_error_set(error, TR_ERROR_EINVAL, fmt::format(FMT_COMPILE("Error parsing metainfo: {:s}"), errmsg));
         return false;
     }
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -12,7 +12,7 @@
 #include <event2/buffer.h>
 #include <event2/event.h>
 
-#include <fmt/compile.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -492,7 +492,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     auto url = tr_urlbuf{};
     makeUrl(webseed, tor->fileSubpath(file_index), std::back_inserter(url));
     auto options = tr_web::FetchOptions{ url.sv(), onPartialDataFetched, task };
-    options.range = fmt::format(FMT_COMPILE("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
+    options.range = fmt::format(FMT_STRING("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->uniqueId;
     options.buffer = task->content();
     tor->session->web->fetch(std::move(options));

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -12,6 +12,8 @@
 #include <event2/buffer.h>
 #include <event2/event.h>
 
+#include <fmt/compile.h>
+
 #include "transmission.h"
 
 #include "bandwidth.h"
@@ -490,7 +492,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     auto url = tr_urlbuf{};
     makeUrl(webseed, tor->fileSubpath(file_index), std::back_inserter(url));
     auto options = tr_web::FetchOptions{ url.sv(), onPartialDataFetched, task };
-    options.range = tr_strvJoin(std::to_string(file_offset), "-"sv, std::to_string(file_offset + this_chunk - 1));
+    options.range = fmt::format(FMT_COMPILE("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->uniqueId;
     options.buffer = task->content();
     tor->session->web->fetch(std::move(options));


### PR DESCRIPTION
When calling `fmt::format()` with a fmt string that's fixed at compile time (that is, strings that we're not passing through `gettext()` first), use the `FMT_STRING()` macro to pick up compile-time safety checks.