### PR TITLE
Avoid crash in tr_file_piece_map::fileOffset(0)

### DIFF
--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -201,7 +201,7 @@ public:
 
     [[nodiscard]] auto hasMetainfo() const noexcept
     {
-        return completion.hasMetainfo() > 0;
+        return fileCount() > 0 && completion.hasMetainfo();
     }
 
     [[nodiscard]] auto hasAll() const


### PR DESCRIPTION
This is a partial rollback of #2836 in order to fix the crash on launch referenced by #2842.
This fixes #2842.