### PR TITLE
refactor: tr_sys_path_dirname() returns tr_pathbuf

### DIFF
--- a/libtransmission/fdlimit.cc
+++ b/libtransmission/fdlimit.cc
@@ -176,7 +176,7 @@ static int cached_file_open(
             goto FAIL;
         }
 
-        if (!tr_sys_dir_create(dir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
+        if (!tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
         {
             tr_logAddError(fmt::format(
                 _("Couldn't create '{path}': {error} ({error_code})"),

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -384,26 +384,26 @@ char* tr_sys_path_resolve(char const* path, tr_error** error)
     return ret;
 }
 
-std::string tr_sys_path_basename(std::string_view path, tr_error** error)
+tr_pathbuf tr_sys_path_basename(std::string_view in, tr_error** error)
 {
-    auto tmp = std::string{ path };
+    auto buf = tr_pathbuf{ in };
 
-    if (char const* ret = basename(std::data(tmp)); ret != nullptr)
+    if (char const* ret = basename(std::data(buf)); ret != nullptr)
     {
-        return ret;
+        return tr_pathbuf{ ret };
     }
 
     set_system_error(error, errno);
     return {};
 }
 
-std::string tr_sys_path_dirname(std::string_view path, tr_error** error)
+tr_pathbuf tr_sys_path_dirname(std::string_view in, tr_error** error)
 {
-    auto tmp = std::string{ path };
+    auto buf = tr_pathbuf{ in };
 
-    if (char const* ret = dirname(std::data(tmp)); ret != nullptr)
+    if (char const* ret = dirname(std::data(buf)); ret != nullptr)
     {
-        return ret;
+        return tr_pathbuf{ ret };
     }
 
     set_system_error(error, errno);

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -648,7 +648,7 @@ cleanup:
     return ret;
 }
 
-std::string tr_sys_path_basename(std::string_view path, tr_error** error)
+tr_pathbuf tr_sys_path_basename(std::string_view path, tr_error** error)
 {
     if (std::empty(path))
     {
@@ -686,10 +686,10 @@ std::string tr_sys_path_basename(std::string_view path, tr_error** error)
         return "/";
     }
 
-    return { name, size_t(end - name) };
+    return std::string_view{ name, size_t(end - name) };
 }
 
-std::string tr_sys_path_dirname(std::string_view path, tr_error** error)
+tr_pathbuf tr_sys_path_dirname(std::string_view path, tr_error** error)
 {
     if (std::empty(path))
     {
@@ -706,7 +706,7 @@ std::string tr_sys_path_dirname(std::string_view path, tr_error** error)
 
     if (is_unc && path[2] == '\0')
     {
-        return std::string{ path };
+        return tr_pathbuf{ path };
     }
 
     char const* const begin = std::data(path);
@@ -741,7 +741,7 @@ std::string tr_sys_path_dirname(std::string_view path, tr_error** error)
 
     if (name > begin && *(name - 1) == ':' && *name != '\0' && !is_slash(*name))
     {
-        return fmt::format("{}:.", begin[0]);
+        return tr_pathbuf{ begin[0], ":."sv };
     }
 
     return { begin, size_t(name - begin) };

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -16,6 +16,7 @@
 #endif
 
 #include "tr-macros.h"
+#include "tr-strbuf.h"
 
 struct tr_error;
 
@@ -224,7 +225,7 @@ char* tr_sys_path_resolve(char const* path, struct tr_error** error = nullptr);
  *         it when no longer needed), `nullptr` otherwise (with `error` set
  *         accordingly).
  */
-std::string tr_sys_path_basename(std::string_view path, struct tr_error** error = nullptr);
+tr_pathbuf tr_sys_path_basename(std::string_view path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `dirname()`.
@@ -238,7 +239,7 @@ std::string tr_sys_path_basename(std::string_view path, struct tr_error** error 
  *         when no longer needed), `nullptr` otherwise (with `error` set
  *         accordingly).
  */
-std::string tr_sys_path_dirname(std::string_view path, struct tr_error** error = nullptr);
+tr_pathbuf tr_sys_path_dirname(std::string_view path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `rename()`.

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -117,7 +117,7 @@ int readOrWriteBytes(
             // Let's figure out where it goes so that we can create it.
             auto const base = tor->currentDir();
             auto const suffix = tor->session->isIncompleteFileNamingEnabled ? tr_torrent::PartialFileSuffix : ""sv;
-            found = { {}, tr_pathbuf{ base, "/"sv, tor->fileSubpath(file_index), suffix }, std::size(base) };
+            found = { {}, tr_pathbuf{ base, '/', tor->fileSubpath(file_index), suffix }, std::size(base) };
         }
 
         if (err == 0)

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -317,10 +317,9 @@ char const* tr_getDefaultDownloadDir()
 
 static bool isWebClientDir(std::string_view path)
 {
-    auto tmp = tr_strvPath(path, "index.html");
-    bool const ret = tr_sys_path_exists(tmp.c_str());
+    auto const tmp = tr_pathbuf{ path, '/', "index.html"sv };
     tr_logAddTrace(fmt::format("Searching for web interface file '{}'", tmp));
-    return ret;
+    return tr_sys_path_exists(tmp);
 }
 
 char const* tr_getWebClientDir([[maybe_unused]] tr_session const* session)
@@ -402,12 +401,12 @@ char const* tr_getWebClientDir([[maybe_unused]] tr_session const* session)
                 wchar_t wide_module_path[MAX_PATH];
                 GetModuleFileNameW(nullptr, wide_module_path, TR_N_ELEMENTS(wide_module_path));
                 char* module_path = tr_win32_native_to_utf8(wide_module_path, -1);
-                auto const dir = tr_sys_path_dirname(module_path);
+                auto dir = tr_sys_path_dirname(module_path);
                 tr_free(module_path);
 
                 if (!std::empty(dir))
                 {
-                    char* path = tr_buildPath(dir.c_str(), "Web", nullptr);
+                    dir.append('/', "Web"sv);
 
                     if (isWebClientDir(path))
                     {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -291,7 +291,7 @@ static void handle_web_client(struct evhttp_request* req, tr_rpc_server* server)
         }
         else
         {
-            auto const filename = tr_pathbuf{ webClientDir, "/"sv, tr_str_is_empty(subpath) ? "index.html" : subpath };
+            auto const filename = tr_pathbuf{ webClientDir, '/', tr_str_is_empty(subpath) ? "index.html" : subpath };
             serve_file(req, server, filename.sv());
         }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2036,7 +2036,7 @@ static void sessionLoadTorrents(struct sessionLoadTorrentsData* const data)
                 continue;
             }
 
-            auto const path = tr_pathbuf{ dirname_sv, "/"sv, name };
+            auto const path = tr_pathbuf{ dirname_sv, '/', name };
 
             // is a magnet link?
             if (!tr_ctorSetMetainfoFromFile(data->ctor, std::string{ path }, nullptr))
@@ -2880,7 +2880,7 @@ int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction dir)
 
 static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 {
-    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
+    auto const filename = tr_pathbuf{ config_dir, '/', BandwidthGroupsFilename };
     auto groups_dict = tr_variant{};
     if (!tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename, nullptr) || !tr_variantIsList(&groups_dict))
     {
@@ -2942,7 +2942,7 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
         tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->areParentLimitsHonored(TR_UP));
     }
 
-    auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
+    auto const filename = tr_pathbuf{ config_dir, '/', BandwidthGroupsFilename };
     auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
     tr_variantFree(&groups_dict);
     return ret;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -510,8 +510,8 @@ tr_pathbuf tr_torrent_metainfo::makeFilename(
 {
     // `${dirname}/${name}.${info_hash}${suffix}`
     // `${dirname}/${info_hash}${suffix}`
-    return format == BasenameFormat::Hash ? tr_pathbuf{ dirname, "/"sv, info_hash_string, suffix } :
-                                            tr_pathbuf{ dirname, "/"sv, name, "."sv, info_hash_string.substr(0, 16), suffix };
+    return format == BasenameFormat::Hash ? tr_pathbuf{ dirname, '/', info_hash_string, suffix } :
+                                            tr_pathbuf{ dirname, '/', name, '.', info_hash_string.substr(0, 16), suffix };
 }
 
 bool tr_torrent_metainfo::migrateFile(

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -373,15 +373,23 @@ public:
     struct tr_found_file_t : public tr_sys_path_info
     {
         tr_pathbuf filename; // /home/foo/Downloads/torrent/01-file-one.txt
-        std::string_view base; // /home/foo/Downloads
-        std::string_view subpath; // /torrent/01-file-one.txt
+        size_t base_len;
 
-        tr_found_file_t(tr_sys_path_info info, tr_pathbuf&& filename_in, size_t base_len)
+        tr_found_file_t(tr_sys_path_info info, tr_pathbuf&& filename_in, size_t base_len_in)
             : tr_sys_path_info{ info }
             , filename{ std::move(filename_in) }
-            , base{ filename.sv().substr(0, base_len) }
-            , subpath{ filename.sv().substr(base_len + 1) }
+            , base_len{ base_len_in }
         {
+        }
+
+        auto base() const // /home/foo/Downloads
+        {
+            return filename.sv().substr(0, base_len);
+        }
+
+        auto subpath() const // /torrent/01-file-one.txt
+        {
+            return filename.sv().substr(base_len + 1);
         }
     };
 

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -54,6 +54,12 @@ public:
         append(args...);
     }
 
+    template<typename ContiguousRange>
+    [[nodiscard]] bool operator==(ContiguousRange const& x) const noexcept
+    {
+        return size() == x.size() && std::equal(begin(), end(), x.begin());
+    }
+
     [[nodiscard]] constexpr auto begin() noexcept
     {
         return buffer_.begin();

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1136,7 +1136,7 @@ bool tr_moveFile(char const* oldpath, char const* newpath, tr_error** error)
     // ensure the target directory exists
     {
         auto const newdir = tr_sys_path_dirname(newpath, error);
-        bool const i = !std::empty(newdir) && tr_sys_dir_create(newdir.c_str(), TR_SYS_DIR_CREATE_PARENTS, 0777, error);
+        bool const i = !std::empty(newdir) && tr_sys_dir_create(newdir, TR_SYS_DIR_CREATE_PARENTS, 0777, error);
         if (!i)
         {
             tr_error_prefix(error, "Unable to create directory for new file: ");

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -466,7 +466,7 @@ void makeUrl(tr_webseed* w, std::string_view name, OutputIt out)
 
     out = std::copy(std::begin(url), std::end(url), out);
 
-    if (tr_strvEndsWith(url, "/"sv) && !std::empty(name))
+    if (tr_strvEndsWith(url, '/') && !std::empty(name))
     {
         tr_http_escape(out, name, false);
     }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -158,7 +158,7 @@ protected:
         char const* output;
     };
 
-    static void testPathXname(XnameTestData const* data, size_t data_size, std::string (*func)(std::string_view, tr_error**))
+    static void testPathXname(XnameTestData const* data, size_t data_size, tr_pathbuf (*func)(std::string_view, tr_error**))
     {
         for (size_t i = 0; i < data_size; ++i)
         {
@@ -169,11 +169,11 @@ protected:
             {
                 EXPECT_NE(""sv, name);
                 EXPECT_EQ(nullptr, err) << *err;
-                EXPECT_EQ(data[i].output, name);
+                EXPECT_EQ(data[i].output, name.sv());
             }
             else
             {
-                EXPECT_EQ(""sv, name);
+                EXPECT_EQ(""sv, name.sv());
                 EXPECT_NE(nullptr, err);
                 tr_error_clear(&err);
             }

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -29,11 +29,11 @@ namespace libtransmission
 namespace test
 {
 
-std::string getTestProgramPath(std::string const& filename)
+auto getTestProgramPath(std::string const& filename)
 {
     auto const exe_path = makeString(tr_sys_path_resolve(testing::internal::GetArgvs().front().data()));
     auto const exe_dir = tr_sys_path_dirname(exe_path);
-    return exe_dir + TR_PATH_DELIMITER + filename;
+    return tr_pathbuf{ exe_dir, '/', filename };
 }
 
 class SubprocessTest

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -63,7 +63,7 @@ TEST_F(TorrentsTest, rangedLoop)
 
     for (auto const& name : Filenames)
     {
-        auto const path = tr_strvJoin(LIBTRANSMISSION_TEST_ASSETS_DIR, "/"sv, name);
+        auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', name };
         auto tm = tr_torrent_metainfo{};
         EXPECT_TRUE(tm.parseTorrentFile(path));
         auto* const tor = new tr_torrent(std::move(tm));

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -171,17 +171,17 @@ int tr_main(int argc, char* argv[])
     if (std::empty(options.outfile))
     {
         tr_error* error = nullptr;
-        auto const base = tr_sys_path_basename(options.infile, &error);
+        auto basename = tr_sys_path_basename(options.infile, &error);
 
-        if (std::empty(base))
+        if (std::empty(basename))
         {
             fprintf(stderr, "ERROR: Cannot deduce output path from input path: %s\n", error->message);
             return EXIT_FAILURE;
         }
 
-        auto const end = tr_strvJoin(base, ".torrent"sv);
+        basename.append(".torrent"sv);
         char* cwd = tr_getcwd();
-        options.outfile = tr_strvDup(tr_strvPath(cwd, end.c_str()));
+        options.outfile = tr_strvDup(fmt::format("{}/{}", cwd, basename.sv()));
         tr_free(cwd);
     }
 


### PR DESCRIPTION
refactor `tr_sys_path_dirname()` and `tr_sys_path_basename()` to return a `tr_pathbuf()`.

This is currently a proof-of-concept; I'm not sure how I feel about dirname() and basename() returning custom types.