### PR TITLE
Bandwidth group are written to a dict, not to a list.

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2882,7 +2882,7 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 {
     auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
     auto groups_dict = tr_variant{};
-    if (!tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename, nullptr) || !tr_variantIsList(&groups_dict))
+    if (!tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename, nullptr) || !tr_variantIsDict(&groups_dict))
     {
         return;
     }


### PR DESCRIPTION
Without this the bandwidth groups file is written correctly, but it is not read at session start.