### PR TITLE
refactor: remove tr_strdup_printf()

### DIFF
--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -7,7 +7,7 @@
 
 #include <windows.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/error.h>
@@ -45,9 +45,7 @@ static HANDLE service_stop_thread = nullptr;
 static void set_system_error(tr_error** error, DWORD code, char const* message)
 {
     auto* const system_message = tr_win32_format_message(code);
-    auto* const buf = tr_strdup_printf("%s (0x%08lx): %s", message, code, system_message);
-    tr_error_set(error, code, buf);
-    tr_free(buf);
+    tr_error_set(error, code, fmt::format(FMT_STRING("{:s} ({:#08x}): {:s})"), message, code, system_message));
     tr_free(system_message);
 }
 

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -36,16 +36,15 @@ static void set_system_error(tr_error** error, DWORD code, std::string_view what
         return;
     }
 
-    char* message = tr_win32_format_message(code);
-
-    if (message == nullptr)
+    if (char* message = tr_win32_format_message(code); message != nullptr)
     {
-        message = fmt::format(FMT_STRING("Unknown error: {:#08x}"), code);
+        tr_error_set(error, code, fmt::format(FMT_STRING("{:s} failed: {:s}"), what, message);
+        tr_free(message);
     }
-
-    tr_error_set(error, code, tr_strvJoin(what, " failed: "sv, message));
-
-    tr_free(message);
+    else
+    {
+        tr_error_set(error, code, fmt::format(FMT_STRING("{:s} failed: Unknown error: {:#08x}"), what, code));
+    }
 }
 
 static void append_to_env_block(wchar_t** env_block, size_t* env_block_len, wchar_t const* part, size_t part_len)

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -38,7 +38,7 @@ static void set_system_error(tr_error** error, DWORD code, std::string_view what
 
     if (char* message = tr_win32_format_message(code); message != nullptr)
     {
-        tr_error_set(error, code, fmt::format(FMT_STRING("{:s} failed: {:s}"), what, message);
+        tr_error_set(error, code, fmt::format(FMT_STRING("{:s} failed: {:s}"), what, message));
         tr_free(message);
     }
     else

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -38,7 +38,7 @@ static void set_system_error(tr_error** error, DWORD code, std::string_view what
 
     if (message == nullptr)
     {
-        message = tr_strdup_printf("Unknown error: 0x%08lx", code);
+        message = fmt::format(FMT_STRING("Unknown error: {:#08x}"), code);
     }
 
     tr_error_set(error, code, tr_strvJoin(what, " failed: "sv, message));

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -11,6 +11,8 @@
 #include <map>
 #include <string_view>
 
+#include <fmt/format.h>
+
 #include <windows.h>
 
 #include "transmission.h"

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -871,7 +871,7 @@ char* tr_win32_format_message(uint32_t code)
 
     if (wide_size == 0)
     {
-        return tr_strvDup(fmt::format(FMT_STRING("Unknown error ({:#08x})"), code);
+        return tr_strvDup(fmt::format(FMT_STRING("Unknown error ({:#08x})"), code));
     }
 
     if (wide_size != 0 && wide_text != nullptr)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -36,7 +36,7 @@
 #include <event2/buffer.h>
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -466,18 +466,6 @@ bool tr_wildmat(char const* text, char const* p)
     return (p[0] == '*' && p[1] == '\0') || (DoMatch(text, p) != 0);
 }
 
-char* tr_strdup_printf(char const* fmt, ...)
-{
-    evbuffer* const buf = evbuffer_new();
-
-    va_list ap;
-    va_start(ap, fmt);
-    evbuffer_add_vprintf(buf, fmt, ap);
-    va_end(ap);
-
-    return evbuffer_free_to_str(buf, nullptr);
-}
-
 char const* tr_strerror(int i)
 {
     char const* ret = strerror(i);
@@ -899,7 +887,7 @@ char* tr_win32_format_message(uint32_t code)
 
     if (wide_size == 0)
     {
-        return tr_strdup_printf("Unknown error (0x%08x)", code);
+        return tr_strvDup(fmt::format(FMT_STRING("Unknown error ({:#08x})"), code);
     }
 
     if (wide_size != 0 && wide_text != nullptr)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -419,22 +419,6 @@ std::string evbuffer_free_to_str(evbuffer* buf)
     return ret;
 }
 
-static char* evbuffer_free_to_str(struct evbuffer* buf, size_t* result_len)
-{
-    size_t const n = evbuffer_get_length(buf);
-    auto* const ret = tr_new(char, n + 1);
-    evbuffer_copyout(buf, ret, n);
-    evbuffer_free(buf);
-    ret[n] = '\0';
-
-    if (result_len != nullptr)
-    {
-        *result_len = n;
-    }
-
-    return ret;
-}
-
 char* tr_strvDup(std::string_view in)
 {
     auto const n = std::size(in);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -269,12 +269,6 @@ constexpr bool tr_str_is_empty(char const* value)
 
 std::string evbuffer_free_to_str(evbuffer* buf);
 
-/**
- * @brief sprintf() a string into a newly-allocated buffer large enough to hold it
- * @return a newly-allocated string that can be freed with tr_free()
- */
-char* tr_strdup_printf(char const* fmt, ...) TR_GNUC_MALLOC TR_GNUC_PRINTF(1, 2);
-
 /** @brief Portability wrapper for strlcpy() that uses the system implementation if available */
 size_t tr_strlcpy(void* dst, void const* src, size_t siz);
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -331,41 +331,6 @@ TEST_F(UtilsTest, truncd)
 #endif
 }
 
-TEST_F(UtilsTest, trStrdupPrintfFmtS)
-{
-    auto s = makeString(tr_strdup_printf("%s", "test"));
-    EXPECT_EQ("test", s);
-}
-
-TEST_F(UtilsTest, trStrdupPrintf)
-{
-    auto s = makeString(tr_strdup_printf("%d %s %c %u", -1, "0", '1', 2));
-    EXPECT_EQ("-1 0 1 2", s);
-
-    auto* s3 = reinterpret_cast<char*>(tr_malloc0(4098));
-    memset(s3, '-', 4097);
-    s3[2047] = 't';
-    s3[2048] = 'e';
-    s3[2049] = 's';
-    s3[2050] = 't';
-
-    auto* s2 = reinterpret_cast<char*>(tr_malloc0(4096));
-    memset(s2, '-', 4095);
-    s2[2047] = '%';
-    s2[2048] = 's';
-
-    // NOLINTNEXTLINE(clang-diagnostic-format-nonliteral)
-    s = makeString(tr_strdup_printf(s2, "test"));
-    EXPECT_EQ(s3, s);
-
-    tr_free(s2);
-
-    s = makeString(tr_strdup_printf("%s", s3));
-    EXPECT_EQ(s3, s);
-
-    tr_free(s3);
-}
-
 TEST_F(UtilsTest, trStrlcpy)
 {
     // destination will be initialized with this char


### PR DESCRIPTION
remove one of the C-era utilities; use `fmt::format()` instead.