### PR TITLE
fixup! refactor: use fmt to build the GTK client's user-visible strings

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -890,8 +890,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
             double const d = sizeWhenDone != 0 ? (100.0 * available) / sizeWhenDone : 0;
             double const ratio = 100.0 * (sizeWhenDone != 0 ? (haveValid + haveUnchecked) / (double)sizeWhenDone : 1);
 
-            auto const avail = tr_strlpercent(d);
-            auto const buf2 = tr_strlpercent(ratio);
+            auto const avail = tr_strpercent(d);
+            auto const buf2 = tr_strpercent(ratio);
             auto const total = tr_strlsize(haveUnchecked + haveValid);
             auto const unver = tr_strlsize(haveUnchecked);
 

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -634,10 +634,10 @@ void MainWindow::Impl::updateSpeeds()
             up_speed += row.get_value(torrent_cols.speed_up);
         }
 
-        dl_lb_->set_text(fmt::format(_("{download_speed} ▼"), fmt::arg("download_speed", dn_speed)));
+        dl_lb_->set_text(fmt::format(_("{download_speed} ▼"), fmt::arg("download_speed", tr_formatter_speed_KBps(dn_speed))));
         dl_lb_->set_visible(dn_count > 0);
 
-        ul_lb_->set_text(fmt::format(_("{upload_speed} ▲"), fmt::arg("upload_speed", up_speed)));
+        ul_lb_->set_text(fmt::format(_("{upload_speed} ▲"), fmt::arg("upload_speed", tr_formatter_speed_KBps(up_speed))));
         ul_lb_->set_visible(dn_count > 0 || up_count > 0);
     }
 }

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -53,7 +53,7 @@ auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const
             _("{current_size} of {complete_size} ({percent_done}%)"),
             fmt::arg("current_size", tr_strlsize(haveTotal)),
             fmt::arg("complete_size", tr_strlsize(st->sizeWhenDone)),
-            fmt::arg("percent_done", tr_strlpercent(st->percentDone * 100.0)));
+            fmt::arg("percent_done", tr_strpercent(st->percentDone * 100.0)));
     }
     else if (!isSeed && hasSeedRatio) // partial seed, seed ratio
     {
@@ -62,7 +62,7 @@ auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const
             _("{current_size} of {complete_size} ({percent_complete}%), uploaded {uploaded_size} (Ratio: {ratio}, Goal: {seed_ratio})"),
             fmt::arg("current_size", tr_strlsize(haveTotal)),
             fmt::arg("complete_size", tr_strlsize(total_size)),
-            fmt::arg("percent_done", tr_strlpercent(st->percentComplete * 100.0)),
+            fmt::arg("percent_complete", tr_strpercent(st->percentComplete * 100.0)),
             fmt::arg("uploaded_size", tr_strlsize(st->uploadedEver)),
             fmt::arg("ratio", tr_strlratio(st->ratio)),
             fmt::arg("seed_ratio", tr_strlratio(seedRatio)));
@@ -73,7 +73,7 @@ auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const
             _("{current_size} of {complete_size} ({percent_complete}%), uploaded {uploaded_size} (Ratio: {ratio})"),
             fmt::arg("current_size", tr_strlsize(haveTotal)),
             fmt::arg("complete_size", tr_strlsize(total_size)),
-            fmt::arg("percent_complete", tr_strlpercent(st->percentComplete * 100.0)),
+            fmt::arg("percent_complete", tr_strpercent(st->percentComplete * 100.0)),
             fmt::arg("uploaded_size", tr_strlsize(st->uploadedEver)),
             fmt::arg("ratio", tr_strlratio(st->ratio)));
     }
@@ -165,7 +165,7 @@ std::string getShortStatusString(
 
     case TR_STATUS_CHECK:
         return fmt::format(
-            _("Verifying local data ({percent_done:.1}% tested)"),
+            _("Verifying local data ({percent_done}% tested)"),
             fmt::arg("percent_done", tr_truncd(st->recheckProgress * 100.0, 1)));
 
     case TR_STATUS_DOWNLOAD:
@@ -222,7 +222,7 @@ auto getActivityString(
                     "Downloading metadata from {active_count} connected peers ({percent_done:d}% done)",
                     st->peersConnected),
                 fmt::arg("active_count", st->peersConnected),
-                fmt::arg("percent_done", 100.0 * st->metadataPercentComplete));
+                fmt::arg("percent_done", tr_strpercent(st->metadataPercentComplete * 100.0)));
         }
 
         if (st->peersSendingToUs != 0 && st->webseedsSendingToUs != 0)
@@ -611,8 +611,9 @@ void TorrentCellRenderer::Impl::render_compact(
     icon_renderer_->property_sensitive() = sensitive;
     icon_renderer_->render(cr, widget, icon_area, icon_area, flags);
 
-    progress_renderer_->property_value() = (int)(percentDone * 100.0);
-    progress_renderer_->property_text() = Glib::ustring();
+    auto const percent_done = static_cast<int>(percentDone * 100.0);
+    progress_renderer_->property_value() = percent_done;
+    progress_renderer_->property_text() = fmt::format(FMT_STRING("{:d}%"), percent_done);
     progress_renderer_->property_sensitive() = sensitive;
     progress_renderer_->render(cr, widget, prog_area, prog_area, flags);
 
@@ -748,7 +749,7 @@ void TorrentCellRenderer::Impl::render_full(
     text_renderer_->property_weight() = Pango::WEIGHT_NORMAL;
     text_renderer_->render(cr, widget, prog_area, prog_area, flags);
 
-    progress_renderer_->property_value() = (int)(percentDone * 100.0);
+    progress_renderer_->property_value() = static_cast<int>(percentDone * 100.0);
     progress_renderer_->property_text() = Glib::ustring();
     progress_renderer_->property_sensitive() = sensitive;
     progress_renderer_->render(cr, widget, prct_area, prct_area, flags);

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -82,11 +82,6 @@ Glib::ustring tr_strlratio(double ratio)
     return tr_strratio(ratio, gtr_get_unicode_string(GtrUnicode::Inf).c_str());
 }
 
-Glib::ustring tr_strlpercent(double x)
-{
-    return tr_strpercent(x);
-}
-
 Glib::ustring tr_strlsize(guint64 bytes)
 {
     return bytes == 0 ? Q_("None") : tr_formatter_size_B(bytes);

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -48,9 +48,6 @@ enum class GtrUnicode
 
 Glib::ustring gtr_get_unicode_string(GtrUnicode);
 
-/* return a percent formatted string of either x.xx, xx.x or xxx */
-Glib::ustring tr_strlpercent(double x);
-
 /* return a human-readable string for the size given in bytes. */
 Glib::ustring tr_strlsize(guint64 size);
 


### PR DESCRIPTION
fix: formattted speeds and percentages.

Discussed by @catadropa at https://github.com/transmission/transmission/issues/2817#issuecomment-1079652989.

Fixes #2817 