### PR TITLE
refactor: remove varargs from TR_ASSERT_MSG()

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -218,12 +218,7 @@ void tr_bitfield::freeArray()
 
 void tr_bitfield::setTrueCount(size_t n)
 {
-    TR_ASSERT_MSG(
-        bit_count_ == 0 || n <= bit_count_,
-        "bit_count_:%zu, n:%zu, std::size(flags_):%zu",
-        bit_count_,
-        n,
-        size_t(std::size(flags_)));
+    TR_ASSERT(bit_count_ == 0 || n <= bit_count_);
 
     true_count_ = n;
     have_all_hint_ = n == bit_count_;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -582,7 +582,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
         break;
 
     default:
-        TR_ASSERT_MSG(false, "unknown standard file %d", (int)std_file);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), static_cast<int>(std_file)));
         set_system_error(error, EINVAL);
     }
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -582,7 +582,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
         break;
 
     default:
-        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), static_cast<int>(std_file)));
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), std_file));
         set_system_error(error, EINVAL);
     }
 

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -12,7 +12,7 @@
 #include <shlobj.h> /* SHCreateDirectoryEx() */
 #include <winioctl.h> /* FSCTL_SET_SPARSE */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 #include "crypto-utils.h" /* tr_rand_int() */
@@ -894,7 +894,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
         break;
 
     default:
-        TR_ASSERT_MSG(false, "unknown standard file %d", (int)std_file);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), std_file));
         set_system_error(error, ERROR_INVALID_PARAMETER);
         return TR_BAD_SYS_FILE;
     }

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1055,7 +1055,7 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
 
         default:
 #ifdef TR_ENABLE_ASSERTS
-            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled handshake state {:d}"), int(handshake->state)));
+            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled handshake state {:d}"), handshake->state));
 #else
             ret = READ_ERR;
             break;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -12,7 +12,7 @@
 #include <event2/buffer.h>
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 #include "clients.h"
@@ -1055,7 +1055,7 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
 
         default:
 #ifdef TR_ENABLE_ASSERTS
-            TR_ASSERT_MSG(false, "unhandled handshake state %d", (int)handshake->state);
+            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled handshake state {:d}"), int(handshake->state)));
 #else
             ret = READ_ERR;
             break;

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -456,7 +456,7 @@ void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket)
 #endif
 
     default:
-        TR_ASSERT_MSG(false, "unsupported peer socket type %d", socket.type);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unsupported peer socket type {:d}"), socket.type));
     }
 }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1189,7 +1189,7 @@ void tr_peerIoReadBytes(tr_peerIo* io, struct evbuffer* inbuf, void* bytes, size
         break;
 
     default:
-        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled encryption type {:d}"), static_cast<int>(io->encryption_type)));
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled encryption type {:d}"), io->encryption_type));
     }
 }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -15,8 +15,7 @@
 
 #include <libutp/utp.h>
 
-#include <fmt/core.h>
-#include <fmt/format.h> // fmt::ptr
+#include <fmt/format.h>
 
 #include "transmission.h"
 #include "session.h"
@@ -648,7 +647,7 @@ static tr_peerIo* tr_peerIoNew(
 #endif
 
     default:
-        TR_ASSERT_MSG(false, "unsupported peer socket type %d", socket.type);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unsupported peer socket type {:d}"), socket.type));
     }
 
     return io;
@@ -1190,7 +1189,7 @@ void tr_peerIoReadBytes(tr_peerIo* io, struct evbuffer* inbuf, void* bytes, size
         break;
 
     default:
-        TR_ASSERT_MSG(false, "unhandled encryption type %d", (int)io->encryption_type);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled encryption type {:d}"), static_cast<int>(io->encryption_type)));
     }
 }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -16,7 +16,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_PEER_MODULE
 #include "transmission.h"
@@ -863,7 +863,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
         break;
 
     default:
-        TR_ASSERT_MSG(false, "%s", fmt::format("unhandled peer event type {}", e->eventType).c_str());
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled peer event type {:d}"), e->eventType));
     }
 }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -15,6 +15,8 @@
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
+#include <fmt/format.h>
+
 #include "transmission.h"
 
 #include "cache.h"
@@ -1961,7 +1963,7 @@ static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
 
         default:
 #ifdef TR_ENABLE_ASSERTS
-            TR_ASSERT_MSG(false, "unhandled peer messages state %d", int(msgs->state));
+            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled peer messages state {:d}"), int(msgs->state)));
 #else
             ret = READ_ERR;
             break;

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -343,7 +343,7 @@ static void append_app_launcher_arguments(enum tr_app_type app_type, char** args
         break;
 
     default:
-        TR_ASSERT_MSG(false, "unsupported application type %d", (int)app_type);
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unsupported application type {:d}"), app_type));
         break;
     }
 }

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -6,22 +6,15 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #include "tr-assert.h"
 
 #if !defined(NDEBUG) || defined(TR_FORCE_ASSERTIONS)
 
-[[noreturn]] bool tr_assert_report(char const* file, int line, char const* message_fmt, ...)
+[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
 {
-    va_list args;
-    va_start(args, message_fmt);
-
-    fprintf(stderr, "assertion failed: ");
-    vfprintf(stderr, message_fmt, args);
-    fprintf(stderr, " (%s:%d)\n", file, line);
-
-    va_end(args);
-
+    std::cerr << "assertion failed: " << message << " (" << file << ':' << line << ')' << std::endl;
     abort();
 }
 

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -3,7 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -7,14 +7,14 @@
 
 #if !defined(NDEBUG) || defined(TR_FORCE_ASSERTIONS)
 
-#include <stdbool.h>
+#include <string_view>
 
 #include "tr-macros.h"
 
-[[noreturn]] bool tr_assert_report(char const* file, int line, char const* message_fmt, ...) TR_GNUC_PRINTF(3, 4);
+[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message);
 
-#define TR_ASSERT(x) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, "%s", #x)))
-#define TR_ASSERT_MSG(x, ...) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, __VA_ARGS__)))
+#define TR_ASSERT(x) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, #x)))
+#define TR_ASSERT_MSG(x, message) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, message)))
 #define TR_UNREACHABLE() tr_assert_report(__FILE__, __LINE__, "Unreachable code")
 
 #define TR_ENABLE_ASSERTS

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -16,8 +16,8 @@
 
 [[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
 {
-    auto const message = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), buffer, file, line);
-    [NSException raise:NSInternalInconsistencyException format:@"%s", message.c_str()];
+    auto const full_text = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), buffer, file, line);
+    [NSException raise:NSInternalInconsistencyException format:@"%s", full_text.c_str()];
 
     // We should not reach this anyway, but it helps mark the function as propertly noreturn
     // (the Objective-C NSException method does not).

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -16,7 +16,7 @@
 
 [[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
 {
-    auto const full_text = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), buffer, file, line);
+    auto const full_text = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), message, file, line);
     [NSException raise:NSInternalInconsistencyException format:@"%s", full_text.c_str()];
 
     // We should not reach this anyway, but it helps mark the function as propertly noreturn

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -5,9 +5,7 @@
 
 #import <Foundation/Foundation.h>
 
-#include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
+#include <fmt/format.h>
 
 #include "tr-assert.h"
 
@@ -16,16 +14,10 @@
 // macOS implementation of tr_assert_report() that provides the message in the crash report
 // This replaces the generic implementation of the function in tr-assert.cc
 
-[[noreturn]] bool tr_assert_report(char const* file, int line, char const* message_fmt, ...)
+[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
 {
-    char buffer[1024];
-    va_list args;
-
-    va_start(args, message_fmt);
-    vsnprintf(buffer, sizeof(buffer), message_fmt, args);
-    va_end(args);
-
-    [NSException raise:NSInternalInconsistencyException format:@"assertion failed: %s (%s:%d)", buffer, file, line];
+    auto const message = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), buffer, file, line);
+    [NSException raise:NSInternalInconsistencyException format:@"%s", message.c_str()];
 
     // We should not reach this anyway, but it helps mark the function as propertly noreturn
     // (the Objective-C NSException method does not).


### PR DESCRIPTION
Another step towards removing `-cert-dcl50-cpp` (do not define C-style variadic functions) from `libtransmission/.clang-tidy`.