### PR TITLE
refactor: annotate nodiscard, constexpr, noexcept methods

### DIFF
--- a/libtransmission/benc.h
+++ b/libtransmission/benc.h
@@ -131,13 +131,13 @@ struct BasicHandler : public Handler
     }
 
 private:
-    void push()
+    constexpr void push() noexcept
     {
         ++depth_;
         keys_[depth_] = {};
     }
 
-    void pop()
+    constexpr void pop() noexcept
     {
         --depth_;
     }
@@ -162,26 +162,27 @@ struct ParserStack
     std::array<Node, MaxDepth> stack;
     std::size_t depth = 0;
 
-    void clear()
+    constexpr void clear() noexcept
     {
         depth = 0;
     }
 
-    void tokenWalked()
+    constexpr void tokenWalked()
     {
         ++stack[depth].n_children_walked;
     }
 
-    Node& current()
-    {
-        return stack[depth];
-    }
-    Node& current() const
+    [[nodiscard]] constexpr Node& current()
     {
         return stack[depth];
     }
 
-    [[nodiscard]] bool expectingDictKey() const
+    [[nodiscard]] constexpr Node& current() const
+    {
+        return stack[depth];
+    }
+
+    [[nodiscard]] constexpr bool expectingDictKey() const
     {
         return depth > 0 && stack[depth].parent_type == ParentType::Dict && (stack[depth].n_children_walked % 2) == 0;
     }

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <array>
 #include <vector>
 
 #include "transmission.h"
@@ -19,7 +20,7 @@
 namespace
 {
 
-constexpr size_t getBytesNeeded(size_t bit_count)
+[[nodiscard]] constexpr size_t getBytesNeeded(size_t bit_count) noexcept
 {
     return (bit_count >> 3) + ((bit_count & 7) != 0 ? 1 : 0);
 }
@@ -36,7 +37,7 @@ void setAllTrue(uint8_t* array, size_t bit_count)
     }
 }
 
-constexpr int8_t const trueBitCount[256] = {
+auto constexpr TrueBitCount = std::array<size_t, 256>{
     0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2,
     3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3,
     3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5,
@@ -46,25 +47,30 @@ constexpr int8_t const trueBitCount[256] = {
     6, 7, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8
 };
 
+[[nodiscard]] constexpr size_t rawCountFlags(uint8_t const* flags, size_t n) noexcept
+{
+    auto ret = size_t{};
+
+    for (auto const* const end = flags + n; flags != end; ++flags)
+    {
+        ret += TrueBitCount[*flags];
+    }
+
+    return ret;
+}
+
 } // namespace
 
 /****
 *****
 ****/
 
-size_t tr_bitfield::countFlags() const
+size_t tr_bitfield::countFlags() const noexcept
 {
-    size_t ret = 0;
-
-    for (auto ch : flags_)
-    {
-        ret += trueBitCount[ch];
-    }
-
-    return ret;
+    return rawCountFlags(std::data(flags_), std::size(flags_));
 }
 
-size_t tr_bitfield::countFlags(size_t begin, size_t end) const
+size_t tr_bitfield::countFlags(size_t begin, size_t end) const noexcept
 {
     size_t ret = 0;
     size_t const first_byte = begin >> 3U;
@@ -94,7 +100,7 @@ size_t tr_bitfield::countFlags(size_t begin, size_t end) const
         val >>= i;
         val <<= i;
 
-        ret += trueBitCount[val];
+        ret += TrueBitCount[val];
     }
     else
     {
@@ -105,12 +111,12 @@ size_t tr_bitfield::countFlags(size_t begin, size_t end) const
         uint8_t val = flags_[first_byte];
         val <<= first_shift;
         val >>= first_shift;
-        ret += trueBitCount[val];
+        ret += TrueBitCount[val];
 
         /* middle bytes */
         for (size_t i = first_byte + 1; i < walk_end; ++i)
         {
-            ret += trueBitCount[flags_[i]];
+            ret += TrueBitCount[flags_[i]];
         }
 
         /* last byte */
@@ -120,7 +126,7 @@ size_t tr_bitfield::countFlags(size_t begin, size_t end) const
             val = flags_[last_byte];
             val >>= last_shift;
             val <<= last_shift;
-            ret += trueBitCount[val];
+            ret += TrueBitCount[val];
         }
     }
 
@@ -141,17 +147,6 @@ size_t tr_bitfield::count(size_t begin, size_t end) const
     }
 
     return countFlags(begin, end);
-}
-
-bool tr_bitfield::testFlag(size_t n) const
-{
-    if (n >> 3U >= std::size(flags_))
-    {
-        return false;
-    }
-
-    bool ret = (flags_[n >> 3U] << (n & 7U) & 0x80) != 0;
-    return ret;
 }
 
 /***
@@ -211,12 +206,12 @@ bool tr_bitfield::ensureNthBitAlloced(size_t nth)
     return true;
 }
 
-void tr_bitfield::freeArray()
+void tr_bitfield::freeArray() noexcept
 {
     flags_ = std::vector<uint8_t>{};
 }
 
-void tr_bitfield::setTrueCount(size_t n)
+void tr_bitfield::setTrueCount(size_t n) noexcept
 {
     TR_ASSERT(bit_count_ == 0 || n <= bit_count_);
 
@@ -232,12 +227,12 @@ void tr_bitfield::setTrueCount(size_t n)
     TR_ASSERT(isValid());
 }
 
-void tr_bitfield::rebuildTrueCount()
+void tr_bitfield::rebuildTrueCount() noexcept
 {
     setTrueCount(countFlags());
 }
 
-void tr_bitfield::incrementTrueCount(size_t inc)
+void tr_bitfield::incrementTrueCount(size_t inc) noexcept
 {
     TR_ASSERT(bit_count_ == 0 || inc <= bit_count_);
     TR_ASSERT(bit_count_ == 0 || true_count_ <= bit_count_ - inc);
@@ -245,7 +240,7 @@ void tr_bitfield::incrementTrueCount(size_t inc)
     setTrueCount(true_count_ + inc);
 }
 
-void tr_bitfield::decrementTrueCount(size_t dec)
+void tr_bitfield::decrementTrueCount(size_t dec) noexcept
 {
     TR_ASSERT(bit_count_ == 0 || dec <= bit_count_);
     TR_ASSERT(bit_count_ == 0 || true_count_ >= dec);
@@ -263,7 +258,7 @@ tr_bitfield::tr_bitfield(size_t bit_count)
     TR_ASSERT(isValid());
 }
 
-void tr_bitfield::setHasNone()
+void tr_bitfield::setHasNone() noexcept
 {
     freeArray();
     true_count_ = 0;
@@ -273,7 +268,7 @@ void tr_bitfield::setHasNone()
     TR_ASSERT(isValid());
 }
 
-void tr_bitfield::setHasAll()
+void tr_bitfield::setHasAll() noexcept
 {
     freeArray();
     true_count_ = bit_count_;

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -39,8 +39,8 @@ class tr_bitfield
 public:
     explicit tr_bitfield(size_t bit_count);
 
-    void setHasAll();
-    void setHasNone();
+    void setHasAll() noexcept;
+    void setHasNone() noexcept;
 
     // set one or more bits
     void set(size_t bit, bool value = true);
@@ -59,56 +59,66 @@ public:
     // corresponds to indices 0 - 7 from high bit to low bit, respectively.
     // The next one 8-15, etc. Spare bits at the end are set to zero.
     void setRaw(uint8_t const* bits, size_t byte_count);
-    std::vector<uint8_t> raw() const;
+    [[nodiscard]] std::vector<uint8_t> raw() const;
 
-    [[nodiscard]] constexpr bool hasAll() const
+    [[nodiscard]] constexpr bool hasAll() const noexcept
     {
         return have_all_hint_ || (bit_count_ > 0 && bit_count_ == true_count_);
     }
 
-    [[nodiscard]] constexpr bool hasNone() const
+    [[nodiscard]] constexpr bool hasNone() const noexcept
     {
         return have_none_hint_ || (bit_count_ > 0 && true_count_ == 0);
     }
 
-    [[nodiscard]] bool test(size_t bit) const
+    [[nodiscard]] constexpr bool test(size_t bit) const
     {
         return hasAll() || (!hasNone() && testFlag(bit));
     }
 
-    [[nodiscard]] constexpr size_t count() const
+    [[nodiscard]] constexpr size_t count() const noexcept
     {
         return true_count_;
     }
 
     [[nodiscard]] size_t count(size_t begin, size_t end) const;
 
-    [[nodiscard]] constexpr size_t size() const
+    [[nodiscard]] constexpr size_t size() const noexcept
     {
         return bit_count_;
     }
 
-    [[nodiscard]] constexpr size_t empty() const
+    [[nodiscard]] constexpr size_t empty() const noexcept
     {
         return size() == 0;
     }
 
-    bool isValid() const;
+    [[nodiscard]] bool isValid() const;
 
 private:
     std::vector<uint8_t> flags_;
-    [[nodiscard]] size_t countFlags() const;
-    [[nodiscard]] size_t countFlags(size_t begin, size_t end) const;
-    [[nodiscard]] bool testFlag(size_t bit) const;
+    [[nodiscard]] size_t countFlags() const noexcept;
+    [[nodiscard]] size_t countFlags(size_t begin, size_t end) const noexcept;
+
+    [[nodiscard]] constexpr bool testFlag(size_t n) const
+    {
+        if (n >> 3U >= std::size(flags_))
+        {
+            return false;
+        }
+
+        bool ret = (flags_[n >> 3U] << (n & 7U) & 0x80) != 0;
+        return ret;
+    }
 
     void ensureBitsAlloced(size_t n);
     [[nodiscard]] bool ensureNthBitAlloced(size_t nth);
-    void freeArray();
+    void freeArray() noexcept;
 
-    void setTrueCount(size_t n);
-    void rebuildTrueCount();
-    void incrementTrueCount(size_t inc);
-    void decrementTrueCount(size_t dec);
+    void setTrueCount(size_t n) noexcept;
+    void rebuildTrueCount() noexcept;
+    void incrementTrueCount(size_t inc) noexcept;
+    void decrementTrueCount(size_t dec) noexcept;
 
     size_t bit_count_ = 0;
     size_t true_count_ = 0;

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -100,7 +100,7 @@ private:
     [[nodiscard]] size_t countFlags() const noexcept;
     [[nodiscard]] size_t countFlags(size_t begin, size_t end) const noexcept;
 
-    [[nodiscard]] constexpr bool testFlag(size_t n) const
+    [[nodiscard]] bool testFlag(size_t n) const
     {
         if (n >> 3U >= std::size(flags_))
         {

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -29,7 +29,7 @@ struct tr_block_info
 
     void initSizes(uint64_t total_size_in, uint64_t piece_size_in);
 
-    [[nodiscard]] constexpr auto blockCount() const
+    [[nodiscard]] constexpr auto blockCount() const noexcept
     {
         return n_blocks;
     }
@@ -40,18 +40,18 @@ struct tr_block_info
         return block + 1 == n_blocks ? final_block_size : BlockSize;
     }
 
-    [[nodiscard]] constexpr auto pieceCount() const
+    [[nodiscard]] constexpr auto pieceCount() const noexcept
     {
         return n_pieces;
     }
 
-    [[nodiscard]] constexpr auto pieceSize() const
+    [[nodiscard]] constexpr auto pieceSize() const noexcept
     {
         return piece_size;
     }
 
     // return the number of bytes in `piece`
-    [[nodiscard]] constexpr auto pieceSize(tr_piece_index_t piece) const
+    [[nodiscard]] constexpr auto pieceSize(tr_piece_index_t piece) const noexcept
     {
         return piece + 1 == n_pieces ? final_piece_size : pieceSize();
     }
@@ -66,7 +66,7 @@ struct tr_block_info
         return { pieceLoc(piece).block, pieceLastLoc(piece).block + 1 };
     }
 
-    [[nodiscard]] constexpr auto totalSize() const
+    [[nodiscard]] constexpr auto totalSize() const noexcept
     {
         return total_size;
     }
@@ -164,7 +164,7 @@ struct tr_block_info
     [[nodiscard]] static uint32_t bestBlockSize(uint64_t piece_size);
 
 private:
-    [[nodiscard]] bool constexpr isInitialized() const
+    [[nodiscard]] bool constexpr isInitialized() const noexcept
     {
         return piece_size != 0;
     }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -40,7 +40,7 @@ struct tr_completion
         blocks_.setHasNone();
     }
 
-    [[nodiscard]] constexpr tr_bitfield const& blocks() const
+    [[nodiscard]] constexpr tr_bitfield const& blocks() const noexcept
     {
         return blocks_;
     }
@@ -70,7 +70,7 @@ struct tr_completion
         return block_info_->piece_size != 0 && countMissingBlocksInPiece(piece) == 0;
     }
 
-    [[nodiscard]] constexpr uint64_t hasTotal() const
+    [[nodiscard]] constexpr uint64_t hasTotal() const noexcept
     {
         return size_now_;
     }

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -24,37 +24,37 @@ public:
 
     [[nodiscard]] tr_urlbuf magnet() const;
 
-    auto const& infoHash() const
+    [[nodiscard]] constexpr auto const& infoHash() const noexcept
     {
         return info_hash_;
     }
 
-    auto const& name() const
+    [[nodiscard]] constexpr auto const& name() const noexcept
     {
         return name_;
     }
 
-    auto webseedCount() const
+    [[nodiscard]] constexpr auto webseedCount() const noexcept
     {
         return std::size(webseed_urls_);
     }
 
-    auto const& webseed(size_t i) const
+    [[nodiscard]] auto const& webseed(size_t i) const
     {
         return webseed_urls_[i];
     }
 
-    auto& announceList()
+    [[nodiscard]] constexpr auto& announceList() noexcept
     {
         return announce_list_;
     }
 
-    auto const& announceList() const
+    [[nodiscard]] constexpr auto const& announceList() const noexcept
     {
         return announce_list_;
     }
 
-    std::string const& infoHashString() const
+    [[nodiscard]] constexpr std::string const& infoHashString() const noexcept
     {
         return info_hash_str_;
     }

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -165,7 +165,7 @@ tr_address tr_address::from_4byte_ipv4(std::string_view in)
  * >0 if a > b
  * 0  if a == b
  */
-int tr_address_compare(tr_address const* a, tr_address const* b)
+int tr_address_compare(tr_address const* a, tr_address const* b) noexcept
 {
     // IPv6 addresses are always "greater than" IPv4
     if (a->type != b->type)

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -70,7 +70,7 @@ enum tr_address_type
 
 struct tr_address;
 
-int tr_address_compare(tr_address const* a, tr_address const* b);
+[[nodiscard]] int tr_address_compare(tr_address const* a, tr_address const* b) noexcept;
 
 struct tr_address
 {
@@ -88,22 +88,22 @@ struct tr_address
         struct in_addr addr4;
     } addr;
 
-    [[nodiscard]] int compare(tr_address const& that) const
+    [[nodiscard]] int compare(tr_address const& that) const noexcept
     {
         return tr_address_compare(this, &that);
     }
 
-    [[nodiscard]] bool operator==(tr_address const& that) const
+    [[nodiscard]] bool operator==(tr_address const& that) const noexcept
     {
         return compare(that) == 0;
     }
 
-    [[nodiscard]] bool operator<(tr_address const& that) const
+    [[nodiscard]] bool operator<(tr_address const& that) const noexcept
     {
         return compare(that) < 0;
     }
 
-    [[nodiscard]] bool operator>(tr_address const& that) const
+    [[nodiscard]] bool operator>(tr_address const& that) const noexcept
     {
         return compare(that) > 0;
     }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -110,12 +110,12 @@ struct tr_turtle_info
 struct tr_session
 {
 public:
-    [[nodiscard]] auto const& torrents() const
+    [[nodiscard]] constexpr auto& torrents()
     {
         return torrents_;
     }
 
-    [[nodiscard]] auto& torrents()
+    [[nodiscard]] constexpr auto const& torrents() const
     {
         return torrents_;
     }
@@ -125,14 +125,14 @@ public:
         return std::unique_lock(session_mutex_);
     }
 
-    [[nodiscard]] bool isClosing() const
+    [[nodiscard]] constexpr auto isClosing() const noexcept
     {
         return is_closing_;
     }
 
     // download dir
 
-    std::string const& downloadDir() const
+    [[nodiscard]] constexpr auto const& downloadDir() const noexcept
     {
         return download_dir_;
     }
@@ -145,12 +145,12 @@ public:
     // default trackers
     // (trackers to apply automatically to public torrents)
 
-    auto const& defaultTrackersStr() const
+    [[nodiscard]] constexpr auto const& defaultTrackersStr() const noexcept
     {
         return default_trackers_str_;
     }
 
-    auto const& defaultTrackers() const
+    [[nodiscard]] constexpr auto const& defaultTrackers() const noexcept
     {
         return default_trackers_;
     }
@@ -159,7 +159,7 @@ public:
 
     // incomplete dir
 
-    std::string const& incompleteDir() const
+    [[nodiscard]] constexpr auto const& incompleteDir() const noexcept
     {
         return incomplete_dir_;
     }
@@ -169,24 +169,24 @@ public:
         incomplete_dir_ = dir;
     }
 
-    bool useIncompleteDir() const
+    [[nodiscard]] constexpr auto useIncompleteDir() const noexcept
     {
         return incomplete_dir_enabled_;
     }
 
-    void useIncompleteDir(bool enabled)
+    constexpr void useIncompleteDir(bool enabled) noexcept
     {
         incomplete_dir_enabled_ = enabled;
     }
 
     // scripts
 
-    void useScript(TrScript i, bool enabled)
+    constexpr void useScript(TrScript i, bool enabled)
     {
         scripts_enabled_[i] = enabled;
     }
 
-    bool useScript(TrScript i) const
+    [[nodiscard]] auto useScript(TrScript i) const
     {
         return scripts_enabled_[i];
     }
@@ -196,21 +196,21 @@ public:
         scripts_[i] = path;
     }
 
-    std::string const& script(TrScript i) const
+    [[nodiscard]] constexpr auto const& script(TrScript i) const
     {
         return scripts_[i];
     }
 
     // blocklist
 
-    bool useBlocklist() const
+    [[nodiscard]] constexpr auto useBlocklist() const noexcept
     {
         return blocklist_enabled_;
     }
 
     void useBlocklist(bool enabled);
 
-    std::string const& blocklistUrl() const
+    [[nodiscard]] constexpr auto const& blocklistUrl() const noexcept
     {
         return blocklist_url_;
     }
@@ -228,9 +228,9 @@ public:
 
     void useRpcWhitelist(bool enabled) const;
 
-    bool useRpcWhitelist() const;
+    [[nodiscard]] bool useRpcWhitelist() const;
 
-    auto externalIP() const
+    [[nodiscard]] auto externalIP() const noexcept
     {
         return external_ip_;
     }
@@ -242,7 +242,7 @@ public:
 
     // peer networking
 
-    std::string const& peerCongestionAlgorithm() const
+    [[nodiscard]] constexpr auto const& peerCongestionAlgorithm() const noexcept
     {
         return peer_congestion_algorithm_;
     }
@@ -259,7 +259,7 @@ public:
 
     // bandwidth
 
-    Bandwidth& getBandwidthGroup(std::string_view name);
+    [[nodiscard]] Bandwidth& getBandwidthGroup(std::string_view name);
 
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -21,7 +21,7 @@ struct tr_error;
 struct tr_torrent_metainfo : public tr_magnet_metainfo
 {
 public:
-    [[nodiscard]] auto empty() const
+    [[nodiscard]] constexpr auto empty() const noexcept
     {
         return std::empty(files_);
     }
@@ -36,12 +36,12 @@ public:
 
     /// BLOCK INFO
 
-    [[nodiscard]] constexpr auto const& blockInfo() const
+    [[nodiscard]] constexpr auto const& blockInfo() const noexcept
     {
         return block_info_;
     }
 
-    [[nodiscard]] constexpr auto blockCount() const
+    [[nodiscard]] constexpr auto blockCount() const noexcept
     {
         return blockInfo().blockCount();
     }
@@ -65,11 +65,11 @@ public:
     {
         return blockInfo().blockSpanForPiece(piece);
     }
-    [[nodiscard]] constexpr auto pieceCount() const
+    [[nodiscard]] constexpr auto pieceCount() const noexcept
     {
         return blockInfo().pieceCount();
     }
-    [[nodiscard]] constexpr auto pieceSize() const
+    [[nodiscard]] constexpr auto pieceSize() const noexcept
     {
         return blockInfo().pieceSize();
     }
@@ -77,25 +77,25 @@ public:
     {
         return blockInfo().pieceSize(piece);
     }
-    [[nodiscard]] constexpr auto totalSize() const
+    [[nodiscard]] constexpr auto totalSize() const noexcept
     {
         return blockInfo().totalSize();
     }
 
-    [[nodiscard]] auto const& comment() const
+    [[nodiscard]] auto const& comment() const noexcept
     {
         return comment_;
     }
-    [[nodiscard]] auto const& creator() const
+    [[nodiscard]] auto const& creator() const noexcept
     {
         return creator_;
     }
-    [[nodiscard]] auto const& source() const
+    [[nodiscard]] auto const& source() const noexcept
     {
         return source_;
     }
 
-    [[nodiscard]] auto fileCount() const
+    [[nodiscard]] auto fileCount() const noexcept
     {
         return std::size(files_);
     }
@@ -113,24 +113,24 @@ public:
 
     [[nodiscard]] tr_sha1_digest_t const& pieceHash(tr_piece_index_t piece) const;
 
-    [[nodiscard]] auto const& dateCreated() const
+    [[nodiscard]] auto const& dateCreated() const noexcept
     {
         return date_created_;
     }
 
     [[nodiscard]] std::string benc() const;
 
-    [[nodiscard]] auto infoDictSize() const
+    [[nodiscard]] auto infoDictSize() const noexcept
     {
         return info_dict_size_;
     }
 
-    [[nodiscard]] auto infoDictOffset() const
+    [[nodiscard]] auto infoDictOffset() const noexcept
     {
         return info_dict_offset_;
     }
 
-    [[nodiscard]] auto piecesOffset() const
+    [[nodiscard]] auto piecesOffset() const noexcept
     {
         return pieces_offset_;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -244,17 +244,17 @@ public:
         return completion.createPieceBitfield();
     }
 
-    [[nodiscard]] constexpr bool isDone() const
+    [[nodiscard]] constexpr bool isDone() const noexcept
     {
         return completeness != TR_LEECH;
     }
 
-    [[nodiscard]] constexpr bool isSeed() const
+    [[nodiscard]] constexpr bool isSeed() const noexcept
     {
         return completeness == TR_SEED;
     }
 
-    [[nodiscard]] constexpr bool isPartialSeed() const
+    [[nodiscard]] constexpr bool isPartialSeed() const noexcept
     {
         return completeness == TR_PARTIAL_SEED;
     }
@@ -333,17 +333,17 @@ public:
 
     /// LOCATION
 
-    [[nodiscard]] tr_interned_string currentDir() const
+    [[nodiscard]] constexpr tr_interned_string currentDir() const noexcept
     {
         return this->current_dir;
     }
 
-    [[nodiscard]] tr_interned_string downloadDir() const
+    [[nodiscard]] constexpr tr_interned_string downloadDir() const noexcept
     {
         return this->download_dir;
     }
 
-    [[nodiscard]] tr_interned_string incompleteDir() const
+    [[nodiscard]] constexpr tr_interned_string incompleteDir() const noexcept
     {
         return this->incomplete_dir;
     }
@@ -530,7 +530,7 @@ public:
 
     ///
 
-    [[nodiscard]] auto isQueued() const
+    [[nodiscard]] constexpr auto isQueued() const noexcept
     {
         return this->is_queued;
     }

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -63,40 +63,40 @@ public:
 
     [[nodiscard]] std::set<int> removedSince(time_t) const;
 
-    [[nodiscard]] auto cbegin() const
+    [[nodiscard]] constexpr auto cbegin() const noexcept
     {
         return std::cbegin(by_hash_);
     }
-    [[nodiscard]] auto begin() const
+    [[nodiscard]] constexpr auto begin() const noexcept
     {
         return cbegin();
     }
-    [[nodiscard]] auto begin()
+    [[nodiscard]] constexpr auto begin() noexcept
     {
         return std::begin(by_hash_);
     }
 
-    [[nodiscard]] auto cend() const
+    [[nodiscard]] constexpr auto cend() const noexcept
     {
         return std::cend(by_hash_);
     }
 
-    [[nodiscard]] auto end() const
+    [[nodiscard]] constexpr auto end() const noexcept
     {
         return cend();
     }
 
-    [[nodiscard]] auto end()
+    [[nodiscard]] constexpr auto end() noexcept
     {
         return std::end(by_hash_);
     }
 
-    [[nodiscard]] auto size() const
+    [[nodiscard]] constexpr auto size() const noexcept
     {
         return std::size(by_hash_);
     }
 
-    [[nodiscard]] auto empty() const
+    [[nodiscard]] constexpr auto empty() const noexcept
     {
         return std::empty(by_hash_);
     }

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -63,30 +63,30 @@ public:
 
     [[nodiscard]] std::set<int> removedSince(time_t) const;
 
-    [[nodiscard]] constexpr auto cbegin() const noexcept
+    [[nodiscard]] auto cbegin() const noexcept
     {
         return std::cbegin(by_hash_);
     }
-    [[nodiscard]] constexpr auto begin() const noexcept
+    [[nodiscard]] auto begin() const noexcept
     {
         return cbegin();
     }
-    [[nodiscard]] constexpr auto begin() noexcept
+    [[nodiscard]] auto begin() noexcept
     {
         return std::begin(by_hash_);
     }
 
-    [[nodiscard]] constexpr auto cend() const noexcept
+    [[nodiscard]] auto cend() const noexcept
     {
         return std::cend(by_hash_);
     }
 
-    [[nodiscard]] constexpr auto end() const noexcept
+    [[nodiscard]] auto end() const noexcept
     {
         return cend();
     }
 
-    [[nodiscard]] constexpr auto end() noexcept
+    [[nodiscard]] auto end() noexcept
     {
         return std::end(by_hash_);
     }


### PR DESCRIPTION
No functional changes. Just adding annotation to help the compiler to flag warnings and / or to better optimize the build.