### PR TITLE
refactor: remove tr_snprintf() pt 2

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -403,7 +403,7 @@ struct tr_tier
         auto const* const torrent_name = tr_torrentName(tor);
         auto const* const current_tracker = currentTracker();
         auto const host_sv = current_tracker == nullptr ? "?"sv : current_tracker->host.sv();
-        *fmt::format_to_n(buf, buflen, FMT_STRING("{:s} at {:s}"), torrent_name, host_sv).out = '\0';
+        *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:s} at {:s}"), torrent_name, host_sv).out = '\0';
     }
 
     [[nodiscard]] bool canManualAnnounce() const

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -403,7 +403,7 @@ struct tr_tier
         auto const* const torrent_name = tr_torrentName(tor);
         auto const* const current_tracker = currentTracker();
         auto const host_sv = current_tracker == nullptr ? "?"sv : current_tracker->host.sv();
-        tr_snprintf(buf, buflen, "%s at %" TR_PRIsv, torrent_name, TR_PRIsv_ARG(host_sv));
+        *fmt::format_to_n(buf, buflen, FMT_STRING("{:s} at {:s}"), torrent_name, host_sv).out = '\0';
     }
 
     [[nodiscard]] bool canManualAnnounce() const

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -14,7 +14,6 @@
 
 #include <event2/util.h> /* evutil_ascii_strcasecmp() */
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include "transmission.h"
@@ -326,7 +325,12 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
         if (!digest)
         {
             b->my_errno = EIO;
-            tr_snprintf(b->errfile, sizeof(b->errfile), "error hashing piece %" PRIu32, b->pieceIndex);
+            auto const [out, len] = fmt::format_to_n(
+                b->errfile,
+                sizeof(b->errfile) - 1,
+                FMT_STRING("error hashing piece {:d}"),
+                b->pieceIndex);
+            *out = '\0';
             b->result = TrMakemetaResult::ERR_IO_READ;
             break;
         }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -325,12 +325,7 @@ static std::vector<std::byte> getHashInfo(tr_metainfo_builder* b)
         if (!digest)
         {
             b->my_errno = EIO;
-            auto const [out, len] = fmt::format_to_n(
-                b->errfile,
-                sizeof(b->errfile) - 1,
-                FMT_STRING("error hashing piece {:d}"),
-                b->pieceIndex);
-            *out = '\0';
+            *fmt::format_to_n(b->errfile, sizeof(b->errfile) - 1, "error hashing piece {:d}", b->pieceIndex).out = '\0';
             b->result = TrMakemetaResult::ERR_IO_READ;
             break;
         }

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -65,7 +65,7 @@ char const* tr_address_and_port_to_string(char* buf, size_t buflen, tr_address c
 {
     char addr_buf[INET6_ADDRSTRLEN];
     tr_address_to_string_with_buf(addr, addr_buf, sizeof(addr_buf));
-    tr_snprintf(buf, buflen, "[%s]:%u", addr_buf, ntohs(port));
+    *fmt::format_to_n(buf, buflen - 1, FMT_STRING("[{:s}]:{:d}"), addr_buf, ntohs(port)).out = '\0';
     return buf;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1323,8 +1323,7 @@ static void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char con
     tr_variantDictAddStr(data->args_out, TR_KEY_path, oldpath);
     tr_variantDictAddStr(data->args_out, TR_KEY_name, newname);
 
-    auto const result = error == 0 ? SuccessResult : tr_strerror(error);
-    tr_idle_function_done(data, result);
+    tr_idle_function_done(data, error != 0 ? tr_strerror(error) : SuccessResult);
 }
 
 static char const* torrentRenamePath(

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1405,7 +1405,9 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
         // we failed to download the blocklist...
         tr_idle_function_done(
             data,
-            fmt::format(FMT_STRING("blocklist http error: {:s} ({:d})"), tr_webGetResponseStr(status), status));
+            fmt::format(_("Couldn't fetch blocklist: {error} ({error_code})"),
+                fmt::arg("error", tr_webGetResponseStr(status)),
+                fmt::arg("error_code", status)));
         return;
     }
 
@@ -1537,7 +1539,7 @@ static void onMetadataFetched(tr_web::FetchResponse const& web_response)
         tr_idle_function_done(
             data->data,
             fmt::format(
-                _("Couldn't fetch page: {error} ({error_code})"),
+                _("Couldn't fetch torrent: {error} ({error_code})"),
                 fmt::arg("error", tr_webGetResponseStr(status)),
                 fmt::arg("error_code", status)));
     }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -86,13 +86,10 @@ struct tr_rpc_idle_data
     void* callback_user_data;
 };
 
-static void tr_idle_function_done(struct tr_rpc_idle_data* data, char const* result)
-{
-    if (result == nullptr)
-    {
-        result = "success";
-    }
+static auto constexpr SuccessResult = "success"sv;
 
+static void tr_idle_function_done(struct tr_rpc_idle_data* data, std::string_view result)
+{
     tr_variantDictAddStr(data->response, TR_KEY_result, result);
 
     (*data->callback)(data->session, data->response, data->callback_user_data);
@@ -1326,7 +1323,7 @@ static void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char con
     tr_variantDictAddStr(data->args_out, TR_KEY_path, oldpath);
     tr_variantDictAddStr(data->args_out, TR_KEY_name, newname);
 
-    char const* const result = error == 0 ? nullptr : tr_strerror(error);
+    auto const result = error == 0 ? SuccessResult : tr_strerror(error);
     tr_idle_function_done(data, result);
 }
 
@@ -1363,21 +1360,23 @@ static char const* torrentRenamePath(
 static void onPortTested(tr_web::FetchResponse const& web_response)
 {
     auto const& [status, body, did_connect, did_tmieout, user_data] = web_response;
-    char result[1024];
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
 
     if (status != 200)
     {
-        tr_snprintf(result, sizeof(result), "portTested: http error %ld: %s", status, tr_webGetResponseStr(status));
+        tr_idle_function_done(
+            data,
+            fmt::format(
+                _("Couldn't test port: {error} ({error_code})"),
+                fmt::arg("error", tr_webGetResponseStr(status)),
+                fmt::arg("error_code", status)));
     }
     else /* success */
     {
         bool const isOpen = tr_strvStartsWith(body, '1');
         tr_variantDictAddBool(data->args_out, TR_KEY_port_is_open, isOpen);
-        tr_snprintf(result, sizeof(result), "success");
+        tr_idle_function_done(data, SuccessResult);
     }
-
-    tr_idle_function_done(data, result);
 }
 
 static char const* portTest(
@@ -1402,13 +1401,12 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
     auto* const session = data->session;
 
-    char result[1024] = {};
-
     if (status != 200)
     {
         // we failed to download the blocklist...
-        tr_snprintf(result, sizeof(result), "gotNewBlocklist: http error %ld: %s", status, tr_webGetResponseStr(status));
-        tr_idle_function_done(data, result);
+        tr_idle_function_done(
+            data,
+            fmt::format(FMT_STRING("blocklist http error: {:s} ({:d})"), tr_webGetResponseStr(status), status));
         return;
     }
 
@@ -1446,15 +1444,14 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     auto const filename = tr_pathbuf{ session->config_dir, "/blocklist.tmp"sv };
     if (tr_error* error = nullptr; !tr_saveFile(filename, content, &error))
     {
-        fmt::format_to_n(
-            result,
-            sizeof(result),
-            _("Couldn't save '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename),
-            fmt::arg("error", error->message),
-            fmt::arg("error_code", error->code));
+        tr_idle_function_done(
+            data,
+            fmt::format(
+                _("Couldn't save '{path}': {error} ({error_code})"),
+                fmt::arg("path", filename),
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
         tr_error_clear(&error);
-        tr_idle_function_done(data, result);
         return;
     }
 
@@ -1462,7 +1459,7 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     int const rule_count = tr_blocklistSetContent(session, filename);
     tr_variantDictAddInt(data->args_out, TR_KEY_blocklist_size, rule_count);
     tr_sys_path_remove(filename);
-    tr_idle_function_done(data, "success");
+    tr_idle_function_done(data, SuccessResult);
 }
 
 static char const* blocklistUpdate(
@@ -1485,39 +1482,33 @@ static void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
     tr_torrent* tor = tr_torrentNew(ctor, &duplicate_of);
     tr_ctorFree(ctor);
 
-    auto key = tr_quark{};
-    char const* result = "invalid or corrupt torrent file";
-    if (tor != nullptr)
+    if (tor == nullptr && duplicate_of == nullptr)
     {
-        key = TR_KEY_torrent_added;
-        result = nullptr;
-    }
-    else if (duplicate_of != nullptr)
-    {
-        tor = duplicate_of;
-        key = TR_KEY_torrent_duplicate;
-        result = "duplicate torrent";
+        tr_idle_function_done(data, "invalid or corrupt torrent file"sv);
+        return;
     }
 
-    if (tor != nullptr && key != 0)
+    static auto constexpr Fields = std::array<tr_quark, 3>{ TR_KEY_id, TR_KEY_name, TR_KEY_hashString };
+    if (duplicate_of != nullptr)
     {
-        tr_quark const fields[] = {
-            TR_KEY_id,
-            TR_KEY_name,
-            TR_KEY_hashString,
-        };
-
-        addTorrentInfo(tor, TrFormat::Object, tr_variantDictAdd(data->args_out, key), fields, TR_N_ELEMENTS(fields));
-
-        if (result == nullptr)
-        {
-            notify(data->session, TR_RPC_TORRENT_ADDED, tor);
-        }
-
-        result = nullptr;
+        addTorrentInfo(
+            duplicate_of,
+            TrFormat::Object,
+            tr_variantDictAdd(data->args_out, TR_KEY_torrent_duplicate),
+            std::data(Fields),
+            std::size(Fields));
+        tr_idle_function_done(data, "duplicate torrent"sv);
+        return;
     }
 
-    tr_idle_function_done(data, result);
+    notify(data->session, TR_RPC_TORRENT_ADDED, tor);
+    addTorrentInfo(
+        tor,
+        TrFormat::Object,
+        tr_variantDictAdd(data->args_out, TR_KEY_torrent_added),
+        std::data(Fields),
+        std::size(Fields));
+    tr_idle_function_done(data, SuccessResult);
 }
 
 struct add_torrent_idle_data
@@ -1544,9 +1535,12 @@ static void onMetadataFetched(tr_web::FetchResponse const& web_response)
     }
     else
     {
-        char result[1024];
-        tr_snprintf(result, sizeof(result), "onMetadataFetched: http error %ld: %s", status, tr_webGetResponseStr(status));
-        tr_idle_function_done(data->data, result);
+        tr_idle_function_done(
+            data->data,
+            fmt::format(
+                _("Couldn't fetch page: {error} ({error_code})"),
+                fmt::arg("error", tr_webGetResponseStr(status)),
+                fmt::arg("error_code", status)));
     }
 
     tr_free(data);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1405,7 +1405,8 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
         // we failed to download the blocklist...
         tr_idle_function_done(
             data,
-            fmt::format(_("Couldn't fetch blocklist: {error} ({error_code})"),
+            fmt::format(
+                _("Couldn't fetch blocklist: {error} ({error_code})"),
                 fmt::arg("error", tr_webGetResponseStr(status)),
                 fmt::arg("error_code", status)));
         return;

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -32,7 +32,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -106,12 +106,11 @@ static void bootstrap_from_name(char const* name, tr_port port, int af)
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_family = af;
 
-    /* No, just passing p + 1 to gai won't work. */
-    char pp[10];
-    tr_snprintf(pp, sizeof(pp), "%d", (int)port);
+    auto port_str = std::array<char, 16>{};
+    *fmt::format_to(std::data(port_str), FMT_STRING("{:d}"), port) = '\0';
 
     addrinfo* info = nullptr;
-    if (int const rc = getaddrinfo(name, pp, &hints, &info); rc != 0)
+    if (int const rc = getaddrinfo(name, std::data(port_str), &hints, &info); rc != 0)
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't look up '{addresss}:{port}': {error} ({error_code})"),

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -114,6 +114,12 @@ public:
         return std::basic_string_view<Char>{ data(), size() };
     }
 
+    template<typename ContiguousRange>
+    [[nodiscard]] constexpr auto operator== (ContiguousRange const& x) const noexcept
+    {
+        return sv() == x;
+    }
+
     ///
 
     [[nodiscard]] constexpr bool ends_with(Char const& x) const noexcept

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -115,7 +115,7 @@ public:
     }
 
     template<typename ContiguousRange>
-    [[nodiscard]] constexpr auto operator== (ContiguousRange const& x) const noexcept
+    [[nodiscard]] constexpr auto operator==(ContiguousRange const& x) const noexcept
     {
         return sv() == x;
     }

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -140,18 +140,17 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
 {
     char intClient[16];
     char intPort[16];
-    char portStr[16];
 
     *intClient = '\0';
     *intPort = '\0';
 
-    tr_snprintf(portStr, sizeof(portStr), "%d", handle->port);
+    auto const port_str = fmt::format(FMT_STRING("{:d}"), handle->port);
 
 #if (MINIUPNPC_API_VERSION >= 10) /* adds remoteHost arg */
     int const err = UPNP_GetSpecificPortMappingEntry(
         handle->urls.controlURL,
         handle->data.first.servicetype,
-        portStr,
+        port_str.c_str(),
         proto,
         nullptr /*remoteHost*/,
         intClient,
@@ -163,7 +162,7 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
     int const err = UPNP_GetSpecificPortMappingEntry(
         handle->urls.controlURL,
         handle->data.first.servicetype,
-        portStr,
+        port_str.c_str(),
         proto,
         intClient,
         intPort,
@@ -174,7 +173,7 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
     int const err = UPNP_GetSpecificPortMappingEntry(
         handle->urls.controlURL,
         handle->data.first.servicetype,
-        portStr,
+        port_str.c_str(),
         proto,
         intClient,
         intPort);
@@ -186,17 +185,16 @@ static int tr_upnpGetSpecificPortMappingEntry(tr_upnp* handle, char const* proto
 static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_port port, char const* desc)
 {
     int const old_errno = errno;
-    char portStr[16];
     errno = 0;
 
-    tr_snprintf(portStr, sizeof(portStr), "%d", (int)port);
+    auto const port_str = fmt::format(FMT_STRING("{:d}"), port);
 
 #if (MINIUPNPC_API_VERSION >= 8)
     int err = UPNP_AddPortMapping(
         handle->urls.controlURL,
         handle->data.first.servicetype,
-        portStr,
-        portStr,
+        port_str.c_str(),
+        port_str.c_str(),
         handle->lanaddr,
         desc,
         proto,
@@ -206,8 +204,8 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
     int err = UPNP_AddPortMapping(
         handle->urls.controlURL,
         handle->data.first.servicetype,
-        portStr,
-        portStr,
+        port_str.c_str(),
+        port_str.c_str(),
         handle->lanaddr,
         desc,
         proto,
@@ -225,11 +223,9 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
 
 static void tr_upnpDeletePortMapping(tr_upnp const* handle, char const* proto, tr_port port)
 {
-    char portStr[16];
+    auto const port_str = fmt::format(FMT_STRING("{:d}"), port);
 
-    tr_snprintf(portStr, sizeof(portStr), "%d", (int)port);
-
-    UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, portStr, proto, nullptr);
+    UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, port_str.c_str(), proto, nullptr);
 }
 
 /**
@@ -338,11 +334,9 @@ tr_port_forwarding tr_upnpPulse(tr_upnp* handle, tr_port port, bool isEnabled, b
         }
         else
         {
-            char desc[64];
-            tr_snprintf(desc, sizeof(desc), "%s at %d", TR_NAME, port);
-
-            int const err_tcp = tr_upnpAddPortMapping(handle, "TCP", port, desc);
-            int const err_udp = tr_upnpAddPortMapping(handle, "UDP", port, desc);
+            auto const desc = fmt::format(FMT_STRING("{:s} at {:d}"), TR_NAME, port);
+            int const err_tcp = tr_upnpAddPortMapping(handle, "TCP", port, desc.c_str());
+            int const err_udp = tr_upnpAddPortMapping(handle, "UDP", port, desc.c_str());
 
             handle->isMapped = err_tcp == 0 || err_udp == 0;
         }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -428,12 +428,6 @@ char* tr_strvDup(std::string_view in)
     return ret;
 }
 
-char* tr_strndup(void const* vin, size_t len)
-{
-    auto const* const in = static_cast<char const*>(vin);
-    return in == nullptr ? nullptr : tr_strvDup({ in, len });
-}
-
 char* tr_strdup(void const* in)
 {
     return in == nullptr ? nullptr : tr_strvDup(static_cast<char const*>(in));
@@ -722,7 +716,7 @@ static char* to_utf8(std::string_view sv)
         iconv_close(cd);
         if (rv != size_t(-1))
         {
-            char* const ret = tr_strndup(out, buflen - outbytesleft);
+            char* const ret = tr_strvDup({ out, buflen - outbytesleft });
             tr_free(out);
             return ret;
         }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -243,14 +243,6 @@ void* tr_memdup(void const* src, size_t byteCount);
     (static_cast<struct_type*>(tr_realloc((mem), sizeof(struct_type) * (size_t)(n_structs))))
 
 /**
- * @brief make a newly-allocated copy of a substring
- * @param in is a void* so that callers can pass in both signed & unsigned without a cast
- * @param len length of the substring to copy. if a length less than zero is passed in, strlen(len) is used
- * @return a newly-allocated copy of `in' that can be freed with tr_free()
- */
-char* tr_strndup(void const* in, size_t len) TR_GNUC_MALLOC;
-
-/**
  * @brief make a newly-allocated copy of a string
  * @param in is a void* so that callers can pass in both signed & unsigned without a cast
  * @return a newly-allocated copy of `in' that can be freed with tr_free()

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -297,8 +297,7 @@ static void saveRealFunc(tr_variant const* val, void* vevbuf)
     // the benc spec doesn't handle floats; save it as a string.
 
     auto buf = std::array<char, 64>{};
-    auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, FMT_STRING("{:f}"), val->val.d);
-
+    auto out = fmt::format_to(std::data(buf), FMT_STRING("{:f}"), val->val.d);
     auto* const evbuf = static_cast<evbuffer*>(vevbuf);
     saveStringImpl(evbuf, { std::data(buf), static_cast<size_t>(out - std::data(buf)) });
 }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -16,7 +16,7 @@
 
 #include <event2/buffer.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 
@@ -587,7 +587,7 @@ static void jsonStringFunc(tr_variant const* val, void* vdata)
                     auto const* const end8 = begin8 + std::size(sv);
                     auto const* walk8 = begin8;
                     auto const uch32 = utf8::next(walk8, end8);
-                    outwalk += tr_snprintf(outwalk, outend - outwalk, "\\u%04x", uch32);
+                    outwalk = fmt::format_to_n(outwalk, outend - outwalk - 1, FMT_STRING("\\u{:04x}"), uch32).out;
                     sv.remove_prefix(walk8 - begin8 - 1);
                 }
                 catch (utf8::exception const&)

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -9,6 +9,8 @@
 #include <string>
 #include <string_view>
 
+#include <fmt/format.h>
+
 #include "transmission.h"
 
 #include "crypto-utils.h"
@@ -44,10 +46,10 @@ protected:
     {
 
         // create a single input file
-        auto input_file = tr_strvPath(sandboxDir().data(), "test.XXXXXX");
-        createTmpfileWithContents(input_file, payload, payloadSize);
+        auto input_file = tr_pathbuf{ sandboxDir(), '/', "test.XXXXXX" };
+        createTmpfileWithContents(std::data(input_file), payload, payloadSize);
         tr_sys_path_native_separators(std::data(input_file));
-        auto* builder = tr_metaInfoBuilderCreate(input_file.c_str());
+        auto* builder = tr_metaInfoBuilderCreate(input_file);
         EXPECT_EQ(tr_file_index_t{ 1 }, builder->fileCount);
         EXPECT_EQ(input_file, builder->top);
         EXPECT_EQ(input_file, builder->files[0].filename);
@@ -57,10 +59,10 @@ protected:
         EXPECT_FALSE(builder->abortFlag);
 
         // have tr_makeMetaInfo() build the torrent file
-        auto const torrent_file = tr_strvJoin(input_file, ".torrent"sv);
+        auto const torrent_file = tr_pathbuf{ input_file, ".torrent"sv };
         tr_makeMetaInfo(
             builder,
-            torrent_file.c_str(),
+            torrent_file,
             trackers,
             trackerCount,
             webseeds,
@@ -111,7 +113,7 @@ protected:
         char const* source)
     {
         // create the top temp directory
-        auto top = tr_strvPath(sandboxDir(), "folder.XXXXXX");
+        auto top = tr_pathbuf{ sandboxDir(), '/', "folder.XXXXXX"sv };
         tr_sys_path_native_separators(std::data(top));
         tr_sys_dir_create_temp(std::data(top));
 
@@ -122,10 +124,8 @@ protected:
 
         for (size_t i = 0; i < payload_count; i++)
         {
-            auto tmpl = std::array<char, 16>{};
-            tr_snprintf(tmpl.data(), tmpl.size(), "file.%04zu%s", i, "XXXXXX");
-            auto path = tr_strvPath(top, std::data(tmpl));
-            createTmpfileWithContents(path, payloads[i], payload_sizes[i]);
+            auto path = fmt::format(FMT_STRING("{:s}/file.{:04}XXXXXX"), top.sv(), i);
+            createTmpfileWithContents(std::data(path), payloads[i], payload_sizes[i]);
             tr_sys_path_native_separators(std::data(path));
             files.push_back(path);
             total_size += payload_sizes[i];
@@ -134,7 +134,7 @@ protected:
         sync();
 
         // init the builder
-        auto* builder = tr_metaInfoBuilderCreate(top.c_str());
+        auto* builder = tr_metaInfoBuilderCreate(top);
         EXPECT_FALSE(builder->abortFlag);
         EXPECT_EQ(top, builder->top);
         EXPECT_EQ(payload_count, builder->fileCount);
@@ -148,7 +148,7 @@ protected:
         }
 
         // build the torrent file
-        auto torrent_file = tr_strvJoin(top, ".torrent"sv);
+        auto const torrent_file = tr_pathbuf{ top, ".torrent"sv };
         tr_makeMetaInfo(
             builder,
             torrent_file.c_str(),

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -178,7 +178,7 @@ protected:
         return child;
     }
 
-    void buildParentDir(std::string const& path) const
+    void buildParentDir(std::string_view path) const
     {
         auto const tmperr = errno;
 
@@ -211,14 +211,14 @@ protected:
         }
     }
 
-    void createTmpfileWithContents(std::string& tmpl, void const* payload, size_t n) const
+    void createTmpfileWithContents(char* tmpl, void const* payload, size_t n) const
     {
         auto const tmperr = errno;
 
         buildParentDir(tmpl);
 
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.InnerPointer)
-        auto const fd = tr_sys_file_open_temp(&tmpl.front());
+        auto const fd = tr_sys_file_open_temp(tmpl);
         blockingFileWrite(fd, payload, n);
         tr_sys_file_close(fd);
         sync();

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -3,7 +3,13 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
 #include <array>
+#include <cmath> // sqrt()
+#include <cstdlib> // setenv(), unsetenv()
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -22,14 +28,6 @@
 #include "utils.h"
 
 #include "test-fixtures.h"
-
-#include <algorithm>
-#include <array>
-#include <cmath> // sqrt()
-#include <cstdlib> // setenv(), unsetenv()
-#include <iostream>
-#include <sstream>
-#include <string>
 
 using ::libtransmission::test::makeString;
 using UtilsTest = ::testing::Test;


### PR DESCRIPTION
part 1 [here](https://github.com/transmission/transmission/pull/2867).

Not much to say about this; it's part of the C++ification to phase out use of manually-allocated / manually-freed C strings.