### PR TITLE
Fix typographical errors in the man pages.

### DIFF
--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -53,7 +53,7 @@ the daemon will load them into Transmission.
 .It Fl C
 Do not watch for new .torrent files.
 .It Fl B Fl -no-blocklist
-Disble blocklists.
+Disable blocklists.
 .It Fl d
 Dump transmission-daemon's settings to stderr.
 .It Fl f Fl -foreground
@@ -99,7 +99,7 @@ Disable portmapping
 .It Fl o Fl -dht
 Enable distributed hash table (DHT).
 .It Fl O Fl -no-dht
-Disable distribued hash table (DHT).
+Disable distributed hash table (DHT).
 .It Fl p Fl -port Ar port
 Port to open and listen for RPC requests on. Default: 9091
 .It Fl P Fl -peerport Ar port

--- a/utils/transmission-remote.1
+++ b/utils/transmission-remote.1
@@ -202,7 +202,7 @@ See netrc(5) for more information.
 .It Fl o Fl -dht
 Enable distributed hash table (DHT).
 .It Fl O Fl -no-dht
-Disable distribued hash table (DHT).
+Disable distributed hash table (DHT).
 .It Fl p Fl -port Ar port
 Set the
 .Ar port


### PR DESCRIPTION
While reading the man page for `transmission-daemon` I stumbled upon a typo and fixed it.
Additionally I decided to check all the man pages for similar errors and found another one.