### PR TITLE
Fix typographical errors in the documentation.

### DIFF
--- a/docs/Bug-Submission.md
+++ b/docs/Bug-Submission.md
@@ -16,15 +16,15 @@ If you're having trouble with Transmission then the things you should do in orde
 
 ## Information Required in a Bug Report ##
 
- * State the version of Transmission you're using (eg Linux/GTK+ 1.80).
+ * State the version of Transmission you're using (e.g. Linux/GTK+ 1.80).
    If you're using a GUI version of Transmission, you can find its version in the `About` dialog in the Help menu.
    **Don't** say _the latest version_ it's ambiguous.
- * State what operating system and version (eg Mac OS X 10.5.8, Ubuntu 8.04, ...)
+ * State what operating system and version (e.g. Mac OS X 10.5.8, Ubuntu 8.04, ...)
  * Describe the symptoms in a short precise manner.
  * If the problem is reproducible and you explain how to reproduce it, then it stands a high chance of being addressed.
    If the problem is intermittent then we still want to know, but if you can't tell us how to reproduce it we can't easily work on it.
  * See if the problem only occurs under certain conditions.
-   Eg: If you're seeing the bug with 50 torrents running and speed limits turned on, see if it persists with speed limits turned off.
+   E.g.: If you're seeing the bug with 50 torrents running and speed limits turned on, see if it persists with speed limits turned off.
    See if it persists with 1 torrent running. See if it persists after pausing and restarting the torrent. etc.
 
 **The more work you do to narrow down the bug, the more chance we have of finding and fixing it.**
@@ -50,7 +50,7 @@ If you're experiencing slow speeds and you've been through the wiki, then please
 ### Crash on the Mac ###
 
 If you have problems on the Mac version then please do these extra steps:
-  * Make sure your system is updated to the latest version of your operating sytem. Note As of 1.60 Transmission requires Mac OS X 10.5 or later.
+  * Make sure your system is updated to the latest version of your operating system. Note As of 1.60 Transmission requires Mac OS X 10.5 or later.
   * If you're running a nightly build, set the language to English. The localizations will sometimes crash the nightly builds until they are updated right before an official release.
   * OS X collects two pieces of crash information that can help us fix the crash:
      1. In Console.app, look under LOG FILES > ~/Library/Logs/ > CrashReporter > for Transmission. If you find one, include it in your forum post.

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -192,7 +192,7 @@ The procedure is documented at [Building Transmission Qt on Windows](https://tra
 
 ## Switches ##
 
-The transmission `./configure` (or `./autogen.sh`) script allows you to switch on/off certain parts. To use these, you'll either use `--enable-*` or `--disable-*`. eg. To disable the GTK client: `--disable-gtk`.
+The transmission `./configure` (or `./autogen.sh`) script allows you to switch on/off certain parts. To use these, you'll either use `--enable-*` or `--disable-*`. e.g. To disable the GTK client: `--disable-gtk`.
 
 The switches that are available are:
  * **gtk** = enables GTK+ client (default)
@@ -204,4 +204,4 @@ The switches that are available are:
  * **wx** = enables wxWidgets client (unsupported)
  * **beos** = enables beos client (unsupported)
 
-Note: _`--disable-nls` removes the dependancy on gettext and intltool. It's designed for, and should only be used on, [HeadlessUsage embedded devices]. If you do have GTK+ installed on your box, you must also specify `--disable-gtk`._
+Note: _`--disable-nls` removes the dependency on gettext and intltool. It's designed for, and should only be used on, [HeadlessUsage embedded devices]. If you do have GTK+ installed on your box, you must also specify `--disable-gtk`._

--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -2,7 +2,7 @@ It's not always possible to set all configurations from the GUI, especially on t
 
 Note: The client _should_ be closed before making changes, otherwise settings will be reverted to it's previous state.
 
-Some of Transmission's behavior can also be customized via EnvironmentVariables.
+Some of Transmission's behavior can also be customized via environment variables.
 
 # GTK / Daemon / CLI
 

--- a/docs/Environment-Variables.md
+++ b/docs/Environment-Variables.md
@@ -11,7 +11,7 @@ Users can set environmental variables to override Transmission's default behavio
    $ export TR_DEBUG_FD=2
    $ transmission 2>runlog
    ```
- * If `TR_DHT_VERBOSE` is set, then Transmission will log all of the DHT's activities in excrutiating detail to standard error.
+ * If `TR_DHT_VERBOSE` is set, then Transmission will log all of the DHT's activities in excruciating detail to standard error.
 
 ## Standard Variables Used By Transmission
 

--- a/docs/Peer-ID-and-User-Agent.md
+++ b/docs/Peer-ID-and-User-Agent.md
@@ -5,7 +5,7 @@ From version 0.80 onward, Transmission's peer-id is formatted Azureus style with
   * `-TR133Z-` &mdash; Nightly build between 1.33 and 1.34
   * `-TR133X-` &mdash; Beta release of 1.34
 
-Rationale: This differentiates between official and unofficial releases in a way easy for trackers to detect with simple string comparison. An official release (`-TR1330-`) is lexigraphically smaller than its post-release unsupported versions (`-TR133Z-` and `-TR133X-`), which in turn are lexigraphically smaller than the next official release (`-TR1340-`).
+Rationale: This differentiates between official and unofficial releases in a way easy for trackers to detect with simple string comparison. An official release (`-TR1330-`) is lexicographically smaller than its post-release unsupported versions (`-TR133Z-` and `-TR133X-`), which in turn are lexicographically smaller than the next official release (`-TR1340-`).
 
 Before 0.80, versions of Transmission used two digits for the major version and two for the minor. For example, `-TR0072-` was Transmission 0.72.
 

--- a/docs/Port-Forwarding-Guide.md
+++ b/docs/Port-Forwarding-Guide.md
@@ -1,6 +1,6 @@
 # Port Forwarding Guide
 
-[BitTorrent](http://en.wikipedia.org/wiki/BitTorrent_protocol) is a peer-to-peer protocol which allows users to send and recieve bits of files without the need of it being hosted on a centralized server.
+[BitTorrent](http://en.wikipedia.org/wiki/BitTorrent_protocol) is a peer-to-peer protocol which allows users to send and receive bits of files without the need of it being hosted on a centralized server.
 
 For this to be possible, it is required to be accessible from the internet. However, this isn't always as straight forward as it may seem. Because of the nature of the internet and security reasons, routers create a local network that makes your computer invisible to the internet. This technology is called [NAT](http://en.wikipedia.org/wiki/Network_address_translation).
 
@@ -28,7 +28,7 @@ If this doesn't happen, you can add Transmission to Leopard's firewall manually:
 
 ### On Unix
 
- * For instructions on how to use it, open a Terminal open the man page of your Firewall. (eg. 'man ufw, man firewalld')
+ * For instructions on how to use it, open a Terminal open the man page of your Firewall. (e.g. 'man ufw, man firewalld')
  * You need to ensure that Transmission's port (displayed in Preferences) is opened in the firewall.
 
 ### Windows
@@ -45,7 +45,7 @@ If this doesn't happen, you can add Transmission to Leopard's firewall manually:
  1. The last thing is to give the rule a name. It can be whatever just make sure it's something you can read and remember exactly what it's for.
 
   * Note this only opens the port in Windows and has no effect on the router
-	
+
 ## Open ports & forwarding
 
 To allow other peers to connect to you, you'll need to forward a port from the router to your computer.
@@ -63,7 +63,7 @@ Most routers manufactured since 2001 have either the UPnP or NAT-PMP feature.
 ### Forward manually through a Router
 
  1. Find out what your IP address is.
-  * *On Mac OS X*- Go to System Preferencess >> Network, double-clicking on your connection (for instance, Built-in Ethernet), and clicking the TCP/IP tab. The address is probably something like 192.168.1.100, or 10.0.1.2. The IP of your router is here too.
+  * *On Mac OS X*- Go to System Preferences >> Network, double-clicking on your connection (for instance, Built-in Ethernet), and clicking the TCP/IP tab. The address is probably something like 192.168.1.100, or 10.0.1.2. The IP of your router is here too.
   * *On Unix*- In Ubuntu, right click the Network Manager applet in the menu bar, and select 'Connection Information'. The address is probably something like 192.168.1.2, or 10.0.1.2.
    * If you don't have Network Manager, open a Terminal and type 'ifconfig'. It will list information for each of your network devices. Find the one you are using, and use the number after 'inet addr:'.
    * Using the command "ip a" will achieve the same results in a different format.
@@ -71,9 +71,9 @@ Most routers manufactured since 2001 have either the UPnP or NAT-PMP feature.
  3. Go into your router configuration screen. Normally this is done via your web browser using the address 192.168.0.1 etc.
  4. Find the port forwarding (sometimes called port mapping) screen. While the page will be different for each router generally you will enter something similar to the following:
  5. For 'Application' type 'Trans'.
- 6. For 'Start Port' and 'End port' type in the port you chose in Step 2. (eg. 51413).
+ 6. For 'Start Port' and 'End port' type in the port you chose in Step 2. (e.g. 51413).
  7. For Protocol, choose Both.
- 8. For IP address, type in your IP address you found in Step 1. (eg. 192.168.1.2).
+ 8. For IP address, type in your IP address you found in Step 1. (e.g. 192.168.1.2).
  9. Check Enable.
  10. Click save settings.
 

--- a/docs/Release-Notes.md
+++ b/docs/Release-Notes.md
@@ -182,7 +182,7 @@
 [http://trac.transmissionbt.com/query?milestone#2.80&group#component&order#severity All tickets closed by this release]
 #### All Platforms ####
   * Support renaming a transfer's files and folders
-  * Remove the most frequent thread locks in libtransmission (ie, fewer beachballs)
+  * Remove the most frequent thread locks in libtransmission (i.e., fewer beachballs)
   * Show the free disk space available when adding torrent
   * Faster reading and parsing of local data files
   * Better use of the OS's filesystem cache
@@ -1332,7 +1332,7 @@ This is a huge listen-to-the-users release -- it uses 103 ideas from users, incl
   * Fix 1.40 "lazy bitfield" error
   * Fix 1.40 "jumpy upload speed" bug
   * Fix handshake peer_id error
-  * Corrrectly handle Windows-style newlines in Bluetack blocklists
+  * Correctly handle Windows-style newlines in Bluetack blocklists
   * More accurate bandwidth measurement
   * File selection & priority was reset when editing a torrent's tracker list
   * Fix autoconf/automake build warnings
@@ -1524,7 +1524,7 @@ This is a huge listen-to-the-users release -- it uses 103 ideas from users, incl
   * Various backend bug fixes & improvements
 #### Mac ####
   * Window when adding torrents to select files and other settings
-  * Leopard: Collapsable group dividers
+  * Leopard: Collapsible group dividers
   * Use the file icon as the per-torrent action button
   * Tracker tab in the inspector
   * Message log specifies the torrent/activity the message relates to

--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-Thanks to the powerful [RPC](./rpc-spec.md), `transmission-remote` can talk to any client that has the RPC enabled. This means that a script written using `transmission-remote` or [RPC](./rpc-spec.md) can, without rewrite, comunicate with all the Transmission clients: Mac, Linux, Windows, and headless.
+Thanks to the powerful [RPC](./rpc-spec.md), `transmission-remote` can talk to any client that has the RPC enabled. This means that a script written using `transmission-remote` or [RPC](./rpc-spec.md) can, without rewrite, communicate with all the Transmission clients: Mac, Linux, Windows, and headless.
 
-Mac OS users may wonder wether there will be Applescript scripts, the answer is ''no''. Although Applescript is a nice technology, it's a pain to implement. However, Mac OS X is a Unix after all, so any script you find here will also work on the Mac. Even from within Applescript, you can run these scripts by typing: `do shell script "path/to/script"`.
+Mac OS users may wonder whether there will be Applescript scripts, the answer is ''no''. Although Applescript is a nice technology, it's a pain to implement. However, Mac OS X is a Unix after all, so any script you find here will also work on the Mac. Even from within Applescript, you can run these scripts by typing: `do shell script "path/to/script"`.
 
 ## How-To
 
@@ -21,7 +21,7 @@ For those who need more information how to use the scripts, have a look at the f
 ## Scripts
 
 ### Start/Stop
- * [wiki:Scripts/initd init.d script] (Debian, Ubuntu and BSD deratives)
+ * [wiki:Scripts/initd init.d script] (Debian, Ubuntu and BSD derivatives)
  * [wiki:Scripts/runscript runscript] (Gentoo and other `runscript`-compatible systems)
 
 
@@ -32,7 +32,7 @@ Transmission can be set to invoke a script when downloads complete. The environm
  * `TR_APP_VERSION` - Transmission's short version string, e.g. `4.0.0`
  * `TR_TIME_LOCALTIME`
  * `TR_TORRENT_BYTES_DOWNLOADED` - Number of bytes that were downloaded for this torrent
- * `TR_TORRENT_DIR` - Loation of the downloaded data
+ * `TR_TORRENT_DIR` - Location of the downloaded data
  * `TR_TORRENT_HASH` - The torrent's info hash
  * `TR_TORRENT_ID`
  * `TR_TORRENT_LABELS` - A comma-delimited list of the torrent's labels
@@ -52,7 +52,7 @@ Functionality of these scripts has been implemented in libtransmission and is th
 
 ## contrib/scripts
 
-Tomas Carnecky (aka wereHamster) is maintaining a set of scripts in his [http://github.com/wereHamster/transmission/tree/master/contrib/scripts/ github repository].
+Tomas Carnecky (aka wereHamster) is maintaining a set of scripts in his [http://github.com/wereHamster/transmission/tree/master/contrib/scripts/ GitHub repository].
 
 Falk Husemann (aka hxgn) is maintaining scripts in his [http://falkhusemann.de/blog/category/tcp_ip/transmission-tcp_ip/ blog].
 

--- a/docs/Why-Are-My-Speeds-So-Slow.md
+++ b/docs/Why-Are-My-Speeds-So-Slow.md
@@ -24,7 +24,7 @@ If you're downloading, things are a little better because you can download from 
 
 ## 4. Is it your speed limits?
 
-This falls into the are-you-sure-it-is-plugged-in category, but don't be embarassed: lots of people have been bitten by this. Note: remember that there are both per-torrent and overall speed limits. :)
+This falls into the are-you-sure-it-is-plugged-in category, but don't be embarrassed: lots of people have been bitten by this. Note: remember that there are both per-torrent and overall speed limits. :)
 
 ## 5. Is it a small swarm?
 

--- a/docs/Why-is-my-port-closed.md
+++ b/docs/Why-is-my-port-closed.md
@@ -1,4 +1,4 @@
-Transmission needs an open port to communicate. You can open one manually or let transmission try to aquire one using NAT PMP or UPnP. If both automatic port mapping and manual forwarding failed
+Transmission needs an open port to communicate. You can open one manually or let transmission try to acquire one using NAT PMP or UPnP. If both automatic port mapping and manual forwarding failed
 
 ## Open ports & forwarding
 
@@ -10,7 +10,7 @@ If you get the Message 'Port is closed'/'Port is Stealth' in the 'Ports' section
 
 ### Port check website is down
 
-Transmission needs an external site to check wether the port is open. However, if that site is down, Transmission has no way to check wether the port is open or not. If you suspect this is the case, go to [CanYouSeeMe.org](http://www.canyouseeme.org/).
+Transmission needs an external site to check whether the port is open. However, if that site is down, Transmission has no way to check whether the port is open or not. If you suspect this is the case, go to [CanYouSeeMe.org](http://www.canyouseeme.org/).
 
 ### UPnP / NAT-PMP
 
@@ -19,7 +19,7 @@ For UPnP/NAT-PMP compatible routers, make sure:
   * DMZ mode is disabled.
   * The port has not already been forwarded manually.
   * The port is not taken by another application
-  * The port has been released properly by Transmission. In some rare situations Transmission won't be able to release the port so it can't be aquired by Transmission afterwards.
+  * The port has been released properly by Transmission. In some rare situations Transmission won't be able to release the port so it can't be acquired by Transmission afterwards.
 
 Note: NAT-PMP is only for Apple Airport routers.
 
@@ -41,8 +41,8 @@ Though initially this was done to "combat viruses and spam", it is sometimes use
 
 ### LAN ISP
 
-eg. Universities, Wifi hotspots, RV parks and some 'true' ISPs (common in Rome, Italy).
+e.g. Universities, Wifi hotspots, RV parks and some 'true' ISPs (common in Rome, Italy).
 
-Though these ISPs are often very interesting, offering high speeds, unlimited bandwidth (sometimes) and low prizes. This because they don't buy IP adresses for their clients and provide the (local) network themselves.
+Though these ISPs are often very interesting, offering high speeds, unlimited bandwidth (sometimes) and low prizes. This because they don't buy IP addresses for their clients and provide the (local) network themselves.
 
 Basically the only thing you can do, is to ''politely'' ask for them to open (forward) a port for you.

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -9,7 +9,7 @@ RPC requests and responses are formatted in JSON.
 
 ### 1.2 Tools
 
-If `transmission-remote` is called with a `--debug` argument, its RPC traffic to the Transmission server will be dumped to the terinal. This can be useful when you want to compare requests in your application to another for reference.
+If `transmission-remote` is called with a `--debug` argument, its RPC traffic to the Transmission server will be dumped to the terminal. This can be useful when you want to compare requests in your application to another for reference.
 
 If `transmission-qt` is run with an environment variable `TR_RPC_VERBOSE` set, it too will dump the RPC requests and responses to the terminal for inspection.
 


### PR DESCRIPTION
The same deal as with pull request #2875.

This time I was reading the specification of the RPC interface, saw "terinal" instead of "terminal" and then spell checked all the other documentation files.

The capitalisation of many words is also questionable, but I decided not to change it.
Additionally the file Port-Forwarding-Guide.md uses DOS line endings, but I decided to keep it that way because changing it would introduce a ton of diff noise.
