### PR TITLE
refactor: convert watchdir to C++

### DIFF
--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -17,6 +17,7 @@
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 
 #include "transmission.h"
+
 #include "error.h"
 #include "error-types.h"
 #include "file.h"
@@ -41,6 +42,9 @@ auto tr_watchdir_retry_max_interval = timeval{ 10, 0 };
 class tr_watchdir_retry
 {
 public:
+    tr_watchdir_retry(tr_watchdir_retry const&) = delete;
+    tr_watchdir_retry& operator=(tr_watchdir_retry const&) = delete;
+
     tr_watchdir_retry(tr_watchdir_t handle_in, struct event_base* base, std::string_view name_in)
         : handle_{ handle_in }
         , name_{ name_in }
@@ -84,9 +88,6 @@ public:
         evtimer_add(timer_, &interval_);
         return true;
     }
-
-    tr_watchdir_retry(tr_watchdir_retry const&) = delete;
-    tr_watchdir_retry& operator=(tr_watchdir_retry const&) = delete;
 
     [[nodiscard]] auto const& name() const noexcept
     {
@@ -133,8 +134,6 @@ public:
         {
             backend_ = tr_watchdir_generic_new(this);
         }
-
-        TR_ASSERT(backend_->free_func != nullptr);
     }
 
     ~tr_watchdir()

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -167,7 +167,7 @@ static void tr_watchdir_on_retry_timer(evutil_socket_t /*fd*/, short /*type*/, v
 
 static tr_watchdir_retry* tr_watchdir_retry_new(tr_watchdir_t handle, char const* name)
 {
-    auto* const retry = tr_new0(tr_watchdir_retry, 1);
+    auto* const retry = new tr_watchdir_retry{};
     retry->handle = handle;
     retry->name = tr_strdup(name);
     retry->timer = evtimer_new(handle->event_base, &tr_watchdir_on_retry_timer, retry);
@@ -192,7 +192,7 @@ static void tr_watchdir_retry_free(tr_watchdir_retry* retry)
     }
 
     tr_free(retry->name);
-    tr_free(retry);
+    delete retry;
 }
 
 static void tr_watchdir_retry_restart(tr_watchdir_retry* retry)
@@ -218,7 +218,7 @@ tr_watchdir_t tr_watchdir_new(
     struct event_base* event_base,
     bool force_generic)
 {
-    auto* handle = tr_new0(struct tr_watchdir, 1);
+    auto* handle = new tr_watchdir{};
     handle->path = tr_strvDup(path);
     handle->callback = callback;
     handle->callback_user_data = callback_user_data;
@@ -269,7 +269,7 @@ void tr_watchdir_free(tr_watchdir_t handle)
     }
 
     tr_free(handle->path);
-    tr_free(handle);
+    delete handle;
 }
 
 char const* tr_watchdir_get_path(tr_watchdir_t handle)

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -104,6 +104,8 @@ private:
     struct timeval interval_ = tr_watchdir_retry_start_interval;
 };
 
+// TODO: notify / kqueue / win32 / generic should subclass from tr_watchdir
+
 struct tr_watchdir
 {
 public:


### PR DESCRIPTION
A partial refactor of `tr_watchdir`.

This is a partial refactor that addresses manually-managed pointers in `tr_watchdir` and `tr_watchdir_retry`.  There is still further work to be done to modernize the inotify / kqueue / win32 / generic backends.