### PR TITLE
meta info piece_size should be maximum UINT32_MAX

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1141,6 +1141,9 @@
 		C3D9062127B7E3C900EF2386 /* libpsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libpsl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C88771A92803EE42005C7523 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		C88771AB2803EE53005C7523 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
+		C887BEC02807FCE900867D3C /* create.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = create.cc; sourceTree = "<group>"; };
+		C887BEC22807FCE900867D3C /* edit.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = edit.cc; sourceTree = "<group>"; };
+		C887BEC32807FCE900867D3C /* show.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = show.cc; sourceTree = "<group>"; };
 		CAB35C62252F6F5E00552A55 /* mime-types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "mime-types.h"; sourceTree = "<group>"; };
 		E138A9750C04D88F00C5426C /* ProgressGradients.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProgressGradients.h; sourceTree = "<group>"; };
 		E138A9760C04D88F00C5426C /* ProgressGradients.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProgressGradients.mm; sourceTree = "<group>"; };
@@ -1879,7 +1882,10 @@
 		C15E58AC219A37C600AB292F /* utils */ = {
 			isa = PBXGroup;
 			children = (
+				C887BEC02807FCE900867D3C /* create.cc */,
+				C887BEC22807FCE900867D3C /* edit.cc */,
 				BEFC1C140C07756200B0BB3C /* remote.cc */,
+				C887BEC32807FCE900867D3C /* show.cc */,
 			);
 			path = utils;
 			sourceTree = "<group>";

--- a/libtransmission/block-info.cc
+++ b/libtransmission/block-info.cc
@@ -8,7 +8,7 @@
 #include "block-info.h"
 #include "tr-assert.h"
 
-void tr_block_info::initSizes(uint64_t total_size_in, uint64_t piece_size_in) noexcept
+void tr_block_info::initSizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept
 {
     TR_ASSERT(piece_size_in == 0 || piece_size_in >= BlockSize);
     if (piece_size_in == 0)
@@ -22,7 +22,7 @@ void tr_block_info::initSizes(uint64_t total_size_in, uint64_t piece_size_in) no
     n_pieces_ = (total_size_ + piece_size_ - 1) / piece_size_;
     n_blocks_ = (total_size_ + BlockSize - 1) / BlockSize;
 
-    auto remainder = total_size_ % piece_size_;
+    uint32_t remainder = total_size_ % piece_size_;
     final_piece_size_ = remainder != 0U ? remainder : piece_size_;
 
     remainder = total_size_ % BlockSize;

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -13,11 +13,13 @@ struct tr_block_info
 {
 private:
     uint64_t total_size_ = 0;
-    uint64_t piece_size_ = 0;
-    uint64_t n_pieces_ = 0;
+    uint32_t piece_size_ = 0;
+    tr_piece_index_t n_pieces_ = 0;
 
     tr_block_index_t n_blocks_ = 0;
+    // should be same type as BlockSize
     uint32_t final_block_size_ = 0;
+    // should be same type as piece_size
     uint32_t final_piece_size_ = 0;
 
 public:
@@ -25,12 +27,12 @@ public:
 
     tr_block_info() noexcept = default;
 
-    tr_block_info(uint64_t total_size_in, uint64_t piece_size_in) noexcept
+    tr_block_info(uint64_t total_size_in, uint32_t piece_size_in) noexcept
     {
         initSizes(total_size_in, piece_size_in);
     }
 
-    void initSizes(uint64_t total_size_in, uint64_t piece_size_in) noexcept;
+    void initSizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept;
 
     [[nodiscard]] constexpr auto blockCount() const noexcept
     {

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -425,11 +425,11 @@ std::string_view tr_torrent_metainfo::parseImpl(tr_torrent_metainfo& setme, tr_v
     }
 
     // piece length
-    if (!tr_variantDictFindInt(info_dict, TR_KEY_piece_length, &i) && (i <= 0))
+    if (!tr_variantDictFindInt(info_dict, TR_KEY_piece_length, &i) || (i <= 0) || (i > UINT32_MAX))
     {
         return "'info' dict 'piece length' is missing or has an invalid value";
     }
-    auto const piece_size = i;
+    auto const piece_size = (uint32_t)i;
 
     // pieces
     if (!tr_variantDictFindStrView(info_dict, TR_KEY_pieces, &sv) || (std::size(sv) % sizeof(tr_sha1_digest_t) != 0))

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -29,8 +29,8 @@
 
 using tr_file_index_t = uint32_t;
 using tr_piece_index_t = uint32_t;
-/* assuming a 16 KiB block, a 32-bit block index gives us a maximum torrent size of 63 TiB.
- * if we ever need to grow past that, change this to uint64_t ;) */
+/* Assuming a 16 KiB block (tr_block_info::BlockSize), a 32-bit block index gives us a maximum torrent size of 64 TiB.
+ * When we ever need to grow past that, change tr_block_index_t and  tr_piece_index_t to uint64_t. */
 using tr_block_index_t = uint32_t;
 using tr_port = uint16_t;
 using tr_tracker_tier_t = uint32_t;

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -211,7 +211,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
             printf("  Source: %s\n", metainfo.source().c_str());
         }
 
-        printf("  Piece Count: %" PRIu64 "\n", metainfo.pieceCount());
+        printf("  Piece Count: %" PRIu32 "\n", metainfo.pieceCount());
         printf("  Piece Size: %s\n", tr_formatter_mem_B(metainfo.pieceSize()).c_str());
         printf("  Total Size: %s\n", tr_formatter_size_B(metainfo.totalSize()).c_str());
         printf("  Privacy: %s\n", metainfo.isPrivate() ? "Private torrent" : "Public torrent");


### PR DESCRIPTION
This strengthens the expected behaviour for piece_size, avoiding meta_info giving a value greater than `UINT32_MAX`. Also addressing a couple of conversion warnings.

Alternative considered: changing `final_block_size_` and `final_piece_size_` to `uint64_t`, but that would be an untested scenario (potentially broken) and reasonably unneeded for some years.