### PR TITLE
refactor: add tr_torrent_files::move() and remove()

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		1BB44E07B1B52E28291B4E32 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */; };
 		1BB44E07B1B52E28291B4E33 /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E31 /* file-piece-map.h */; };
 		2856E0656A49F2665D69E760 /* benc.h in Headers */ = {isa = PBXBuildFile; fileRef = 2856E0656A49F2665D69E761 /* benc.h */; };
-		A47A7C87B8B57BE50DF0D410 /* files.cc in Sources */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D411 /* files.cc */; };
-		A47A7C87B8B57BE50DF0D412 /* files.h in Headers */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D413 /* files.h */; };
+		A47A7C87B8B57BE50DF0D410 /* torrent-files.cc in Sources */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D411 /* torrent-files.cc */; };
+		A47A7C87B8B57BE50DF0D412 /* torrent-files.h in Headers */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D413 /* torrent-files.h */; };
 		2B9BA6C508B488FE586A0AB0 /* torrents.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2B9BA6C508B488FE586A0AB1 /* torrents.cc */; };
 		2B9BA6C508B488FE586A0AB2 /* torrents.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B9BA6C508B488FE586A0AB3 /* torrents.h */; };
 		35F373030C2DA89000DAA8F2 /* FilePriorityCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */; };
@@ -571,8 +571,8 @@
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		2B9BA6C508B488FE586A0AB1 /* torrents.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = torrents.cc; sourceTree = "<group>"; };
 		2B9BA6C508B488FE586A0AB3 /* torrents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = torrents.h; sourceTree = "<group>"; };
-		A47A7C87B8B57BE50DF0D411 /* files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = files.cc; sourceTree = "<group>"; };
-		A47A7C87B8B57BE50DF0D413 /* files.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = files.h; sourceTree = "<group>"; };
+		A47A7C87B8B57BE50DF0D411 /* torrent-files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = torrent-files.cc; sourceTree = "<group>"; };
+		A47A7C87B8B57BE50DF0D413 /* torrent-files.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = torrent-files.h; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* Transmission_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Transmission_Prefix.pch; sourceTree = "<group>"; };
 		35F373000C2DA88F00DAA8F2 /* FilePriorityCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilePriorityCell.h; sourceTree = "<group>"; };
 		35F373010C2DA88F00DAA8F2 /* FilePriorityCell.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FilePriorityCell.mm; sourceTree = "<group>"; };
@@ -1567,7 +1567,7 @@
 				A29DF8B70DB2544C00D04E5A /* resume.h */,
 				A29DF8B80DB2544C00D04E5A /* torrent.h */,
 				2B9BA6C508B488FE586A0AB3 /* torrents.h */,
-				A47A7C87B8B57BE50DF0D413 /* files.h */,
+				A47A7C87B8B57BE50DF0D413 /* torrent-files.h */,
 				C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */,
 				C1033E041A3279B800EF44D8 /* crypto-utils-ccrypto.cc */,
 				C1033E051A3279B800EF44D8 /* crypto-utils.cc */,
@@ -1615,7 +1615,7 @@
 				A2AA9BE0132CAC8D00FA131E /* announcer-udp.cc */,
 				BEFC1DF90C07861A00B0BB3C /* torrent.cc */,
 				2B9BA6C508B488FE586A0AB1 /* torrents.cc */,
-				A47A7C87B8B57BE50DF0D411 /* files.cc */,
+				A47A7C87B8B57BE50DF0D411 /* torrent-files.cc */,
 				BEFC1DFC0C07861A00B0BB3C /* port-forwarding.h */,
 				BEFC1DFD0C07861A00B0BB3C /* port-forwarding.cc */,
 				A21FBBA90EDA78C300BC3C51 /* bandwidth.h */,
@@ -2109,7 +2109,7 @@
 				A29DF8BA0DB2544C00D04E5A /* resume.h in Headers */,
 				A29DF8BB0DB2544C00D04E5A /* torrent.h in Headers */,
 				2B9BA6C508B488FE586A0AB2 /* torrents.h in Headers */,
-				A47A7C87B8B57BE50DF0D412 /* files.h in Headers */,
+				A47A7C87B8B57BE50DF0D412 /* torrent-files.h in Headers */,
 				A29DF8BE0DB2545F00D04E5A /* verify.h in Headers */,
 				C1FEE57B1C3223CC00D62832 /* watchdir.h in Headers */,
 				A2AAB6650DE0D08B00E04DDA /* blocklist.h in Headers */,
@@ -2786,7 +2786,7 @@
 				BEFC1E2F0C07861A00B0BB3C /* session.cc in Sources */,
 				BEFC1E320C07861A00B0BB3C /* torrent.cc in Sources */,
 				2B9BA6C508B488FE586A0AB0 /* torrents.cc in Sources */,
-				A47A7C87B8B57BE50DF0D410 /* files.cc */,
+				A47A7C87B8B57BE50DF0D410 /* torrent-files.cc */,
 				BEFC1E360C07861A00B0BB3C /* port-forwarding.cc in Sources */,
 				BEFC1E3C0C07861A00B0BB3C /* platform.cc in Sources */,
 				BEFC1E460C07861A00B0BB3C /* net.cc in Sources */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -31,7 +31,6 @@ set(PROJECT_FILES
   file-posix.cc
   file-win32.cc
   file.cc
-  files.cc
   handshake.cc
   inout.cc
   log.cc
@@ -58,6 +57,7 @@ set(PROJECT_FILES
   subprocess-posix.cc
   subprocess-win32.cc
   torrent-ctor.cc
+  torrent-files.cc
   torrent-magnet.cc
   torrent-metainfo.cc
   torrent.cc
@@ -171,7 +171,6 @@ set(${PROJECT_NAME}_PRIVATE_HEADERS
     fdlimit.h
     file-info.h
     file-piece-map.h
-    files.h
     handshake.h
     history.h
     inout.h
@@ -195,6 +194,7 @@ set(${PROJECT_NAME}_PRIVATE_HEADERS
     session.h
     stats.h
     subprocess.h
+    torrent-files.h
     torrent-magnet.h
     torrent-metainfo.h
     torrent.h

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 #include <dirent.h>
 #include <fcntl.h> /* O_LARGEFILE, posix_fadvise(), [posix_]fallocate(), fcntl() */
 #include <libgen.h> /* basename(), dirname() */
@@ -549,14 +551,17 @@ bool tr_sys_path_remove(char const* path, tr_error** error)
 {
     TR_ASSERT(path != nullptr);
 
-    bool const ret = remove(path) != -1;
+    auto const ret = remove(path);
+    auto const ok = ret == 0;
+    std::cerr << __FILE__ << ':' << __LINE__ << " remove [" << path << "] ret " << ret << std::endl;
 
-    if (!ret)
+    if (!ok)
     {
+        std::cerr << __FILE__ << ':' << __LINE__ << ' ' << tr_strerror(errno) << ' ' << errno << std::endl;
         set_system_error(error, errno);
     }
 
-    return ret;
+    return ok;
 }
 
 char* tr_sys_path_native_separators(char* path)

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -18,8 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <iostream>
-
 #include <dirent.h>
 #include <fcntl.h> /* O_LARGEFILE, posix_fadvise(), [posix_]fallocate(), fcntl() */
 #include <libgen.h> /* basename(), dirname() */
@@ -551,17 +549,14 @@ bool tr_sys_path_remove(char const* path, tr_error** error)
 {
     TR_ASSERT(path != nullptr);
 
-    auto const ret = remove(path);
-    auto const ok = ret == 0;
-    std::cerr << __FILE__ << ':' << __LINE__ << " remove [" << path << "] ret " << ret << std::endl;
+    bool const ret = remove(path) != -1;
 
-    if (!ok)
+    if (!ret)
     {
-        std::cerr << __FILE__ << ':' << __LINE__ << ' ' << tr_strerror(errno) << ' ' << errno << std::endl;
         set_system_error(error, errno);
     }
 
-    return ok;
+    return ret;
 }
 
 char* tr_sys_path_native_separators(char* path)

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -116,7 +116,7 @@ int readOrWriteBytes(
             // We didn't find the file that we want to write to.
             // Let's figure out where it goes so that we can create it.
             auto const base = tor->currentDir();
-            auto const suffix = tor->session->isIncompleteFileNamingEnabled ? tr_files::PartialFileSuffix : ""sv;
+            auto const suffix = tor->session->isIncompleteFileNamingEnabled ? tr_torrent_files::PartialFileSuffix : ""sv;
             found = { {}, tr_pathbuf{ base, "/"sv, tor->fileSubpath(file_index), suffix }, std::size(base) };
         }
 

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -298,15 +298,11 @@ void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdi
     // OK we've removed the local data.
     // What's left are empty folders, junk, and user-generated files.
     // Remove the first two categories and leave the third alone.
-    auto const remove_junk = [&func](char const* filename)
+    auto const remove_junk = [](char const* filename)
     {
-        if (isEmptyDirectory(filename))
+        if (isEmptyDirectory(filename) || isJunkFile(filename))
         {
             tr_sys_path_remove(filename);
-        }
-        else if (isDirectory(filename) || isJunkFile(filename))
-        {
-            func(filename);
         }
     };
     for (auto const& filename : top_files)

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -9,56 +9,56 @@
 
 #include "transmission.h"
 
-#include "files.h"
+#include "torrent-files.h"
 
-bool tr_files::empty() const noexcept
+bool tr_torrent_files::empty() const noexcept
 {
     return std::empty(files_);
 }
 
-size_t tr_files::size() const noexcept
+size_t tr_torrent_files::size() const noexcept
 {
     return std::size(files_);
 }
 
-uint64_t tr_files::size(tr_file_index_t file_index) const
+uint64_t tr_torrent_files::size(tr_file_index_t file_index) const
 {
     return files_.at(file_index).size_;
 }
 
-std::string const& tr_files::path(tr_file_index_t file_index) const
+std::string const& tr_torrent_files::path(tr_file_index_t file_index) const
 {
     return files_.at(file_index).path_;
 }
 
-void tr_files::setPath(tr_file_index_t file_index, std::string_view path)
+void tr_torrent_files::setPath(tr_file_index_t file_index, std::string_view path)
 {
     files_.at(file_index).setPath(path);
 }
 
-void tr_files::reserve(size_t n_files)
+void tr_torrent_files::reserve(size_t n_files)
 {
     files_.reserve(n_files);
 }
 
-void tr_files::shrinkToFit()
+void tr_torrent_files::shrinkToFit()
 {
     files_.shrink_to_fit();
 }
 
-tr_file_index_t tr_files::add(std::string_view path, uint64_t size)
+tr_file_index_t tr_torrent_files::add(std::string_view path, uint64_t size)
 {
     auto const file_index = static_cast<tr_file_index_t>(std::size(files_));
     files_.emplace_back(path, size);
     return file_index;
 }
 
-void tr_files::clear() noexcept
+void tr_torrent_files::clear() noexcept
 {
     files_.clear();
 }
 
-std::optional<tr_files::FoundFile> tr_files::find(
+std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     tr_file_index_t file_index,
     std::string_view const* search_paths,
     size_t n_paths) const
@@ -87,7 +87,7 @@ std::optional<tr_files::FoundFile> tr_files::find(
     return {};
 }
 
-bool tr_files::hasAnyLocalData(std::string_view const* search_paths, size_t n_paths) const
+bool tr_torrent_files::hasAnyLocalData(std::string_view const* search_paths, size_t n_paths) const
 {
     for (tr_file_index_t i = 0, n = size(); i < n; ++i)
     {

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -7,56 +7,16 @@
 #include <string>
 #include <string_view>
 
+#include <fmt/format.h>
+
 #include "transmission.h"
 
+#include "error.h"
+#include "log.h"
 #include "torrent-files.h"
+#include "utils.h"
 
-bool tr_torrent_files::empty() const noexcept
-{
-    return std::empty(files_);
-}
-
-size_t tr_torrent_files::size() const noexcept
-{
-    return std::size(files_);
-}
-
-uint64_t tr_torrent_files::size(tr_file_index_t file_index) const
-{
-    return files_.at(file_index).size_;
-}
-
-std::string const& tr_torrent_files::path(tr_file_index_t file_index) const
-{
-    return files_.at(file_index).path_;
-}
-
-void tr_torrent_files::setPath(tr_file_index_t file_index, std::string_view path)
-{
-    files_.at(file_index).setPath(path);
-}
-
-void tr_torrent_files::reserve(size_t n_files)
-{
-    files_.reserve(n_files);
-}
-
-void tr_torrent_files::shrinkToFit()
-{
-    files_.shrink_to_fit();
-}
-
-tr_file_index_t tr_torrent_files::add(std::string_view path, uint64_t size)
-{
-    auto const file_index = static_cast<tr_file_index_t>(std::size(files_));
-    files_.emplace_back(path, size);
-    return file_index;
-}
-
-void tr_torrent_files::clear() noexcept
-{
-    files_.clear();
-}
+///
 
 std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     tr_file_index_t file_index,
@@ -89,7 +49,7 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
 
 bool tr_torrent_files::hasAnyLocalData(std::string_view const* search_paths, size_t n_paths) const
 {
-    for (tr_file_index_t i = 0, n = size(); i < n; ++i)
+    for (tr_file_index_t i = 0, n = fileCount(); i < n; ++i)
     {
         if (find(i, search_paths, n_paths))
         {
@@ -98,4 +58,79 @@ bool tr_torrent_files::hasAnyLocalData(std::string_view const* search_paths, siz
     }
 
     return false;
+}
+
+///
+
+bool tr_torrent_files::move(
+    std::string_view old_top_in,
+    std::string_view top_in,
+    double volatile* setme_progress,
+    std::string_view log_name,
+    tr_error** error) const
+{
+    if (setme_progress != nullptr)
+    {
+        *setme_progress = 0.0;
+    }
+
+    auto const old_top = tr_pathbuf{ old_top_in };
+    auto const top = tr_pathbuf{ top_in };
+    tr_logAddTrace(fmt::format(FMT_STRING("Moving files from '{:s}' to '{:s}'"), old_top, top), log_name);
+
+    if (tr_sys_path_is_same(old_top, top))
+    {
+        return true;
+    }
+
+    if (!tr_sys_dir_create(top, TR_SYS_DIR_CREATE_PARENTS, 0777, error))
+    {
+        return false;
+    }
+
+    auto const search_paths = std::array<std::string_view, 1>{ old_top.sv() };
+
+    auto const total_size = totalSize();
+    auto err = bool{};
+    auto bytes_moved = uint64_t{};
+
+    for (tr_file_index_t i = 0, n = fileCount(); i < n; ++i)
+    {
+        auto const found = find(i, std::data(search_paths), std::size(search_paths));
+        if (!found)
+        {
+            continue;
+        }
+
+        auto const& old_path = found->filename();
+        auto const path = tr_pathbuf{ top, '/', found->subpath() };
+        tr_logAddTrace(fmt::format(FMT_STRING("Found file #{:d} '{:s}'"), i, old_path), log_name);
+
+        if (tr_sys_path_is_same(old_path, path))
+        {
+            continue;
+        }
+
+        tr_logAddTrace(fmt::format(FMT_STRING("Moving file #{:d} to '{:s}'"), i, old_path, path), log_name);
+        if (!tr_moveFile(old_path, path, error))
+        {
+            err = true;
+            break;
+        }
+
+        if (setme_progress != nullptr && total_size > 0U)
+        {
+            bytes_moved += fileSize(i);
+            *setme_progress = static_cast<double>(bytes_moved) / total_size;
+        }
+    }
+
+    if (!err)
+    {
+        // FIXME
+        // remove away the leftover subdirectories in the old location */
+        // tr_torrentDeleteLocalData(tor, tr_sys_path_remove);
+    }
+
+    return !err;
 }

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -103,7 +103,6 @@ bool isJunkFile(std::string_view filename)
 
 } // unnamed namespace
 
-
 ///
 
 std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 
@@ -15,6 +16,8 @@
 #include "log.h"
 #include "torrent-files.h"
 #include "utils.h"
+
+using namespace std::literals;
 
 ///
 
@@ -133,4 +136,156 @@ bool tr_torrent_files::move(
     }
 
     return !err;
+}
+
+///
+
+namespace
+{
+
+using file_func_t = std::function<void(char const* filename)>;
+
+bool isDirectory(char const* path)
+{
+    auto info = tr_sys_path_info{};
+    return tr_sys_path_get_info(path, 0, &info) && (info.type == TR_SYS_PATH_IS_DIRECTORY);
+}
+
+void depthFirstWalk(char const* path, file_func_t const& func, std::optional<int> max_depth = {})
+{
+    // fmt::print("{:s}:{:d} in depth-first walk '{:s}' max_depth '{}'\n", __FILE__, __LINE__, path, max_depth ? *max_depth : -1);
+    if (isDirectory(path) && (!max_depth || *max_depth > 0))
+    {
+        if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR)
+        {
+            char const* name_cstr = nullptr;
+            while ((name_cstr = tr_sys_dir_read_name(odir)) != nullptr)
+            {
+                auto const name = std::string_view{ name_cstr };
+                if (name == "." || name == "..")
+                {
+                    continue;
+                }
+
+                depthFirstWalk(tr_pathbuf{ path, '/', name }.c_str(), func, max_depth ? *max_depth - 1 : max_depth);
+            }
+
+            tr_sys_dir_close(odir);
+        }
+    }
+
+    // fmt::print("{:s}:{:d} calling func on '{:s}'\n", __FILE__, __LINE__, path);
+    func(path);
+}
+
+bool isJunkFile(std::string_view filename)
+{
+    auto const base = tr_sys_path_basename(filename);
+
+#ifdef __APPLE__
+    // check for resource forks. <http://support.apple.com/kb/TA20578>
+    if (tr_strvStartsWith(base, "._"sv))
+    {
+        return true;
+    }
+#endif
+
+    auto constexpr Files = std::array<std::string_view, 3>{
+        ".DS_Store"sv,
+        "Thumbs.db"sv,
+        "desktop.ini"sv,
+    };
+
+    return std::find(std::begin(Files), std::end(Files), base) != std::end(Files);
+}
+
+} // unnamed namespace
+
+/**
+ * This convoluted code does something (seemingly) simple:
+ * remove the torrent's local files.
+ *
+ * Fun complications:
+ * 1. Try to preserve the directory hierarchy in the recycle bin.
+ * 2. If there are nontorrent files, don't delete them...
+ * 3. ...unless the other files are "junk", such as .DS_Store
+ */
+void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdir_prefix, tr_fileFunc func) const
+{
+    auto const parent = tr_pathbuf{ parent_in };
+    fmt::print("{:s}:{:d} remove torrent files from '{:s}'\n", __FILE__, __LINE__, parent);
+
+    // don't try to delete local data if the directory's gone missing
+    if (!tr_sys_path_exists(parent))
+    {
+        return;
+    }
+
+    // make a tmpdir
+    auto tmpdir = tr_pathbuf{ parent, '/', tmpdir_prefix, "__XXXXXX"sv };
+    tr_sys_dir_create_temp(std::data(tmpdir));
+    fmt::print("{:s}:{:d} made tmpdir '{:s}'\n", __FILE__, __LINE__, tmpdir);
+
+    // move the local data to the tmpdir
+    auto const search_paths = std::array<std::string_view, 1>{ parent.sv() };
+    for (tr_file_index_t idx = 0, n_files = fileCount(); idx < n_files; ++idx)
+    {
+        if (auto const found = find(idx, std::data(search_paths), std::size(search_paths)); found)
+        {
+            auto const target = tr_pathbuf{ tmpdir, '/', found->subpath() };
+            tr_moveFile(found->filename(), target);
+            fmt::print("{:s}:{:d} move '{:s}' -> '{:s}'\n", __FILE__, __LINE__, found->filename(), target);
+        }
+    }
+
+    // Make a list of the top-level torrent files & folders
+    // because we'll need it below in the 'remove junk' phase
+    auto top_files = std::set<std::string>{};
+    depthFirstWalk(
+        tmpdir,
+        [&tmpdir, &top_files](char const* filename)
+        {
+            if (tmpdir != filename)
+            {
+                fmt::print("{:s}:{:d} top-level file found: '{:s}'\n", __FILE__, __LINE__, filename);
+                top_files.emplace(filename);
+            }
+        },
+        1);
+
+    auto const func_wrapper = [&tmpdir, &func](char const* filename)
+    {
+        if (tmpdir != filename)
+        {
+            fmt::print("{:s}:{:d} calling the remove func on '{:s}'\n", __FILE__, __LINE__, filename);
+            func(filename, nullptr);
+        }
+    };
+
+    // Remove the tmpdir.
+    // Since `func` might send files to a recycle bin, try to preserve
+    // the folder hierarchy by removing top-level files & folders first.
+    // But that can fail -- e.g. `func` might refuse to remove nonempty
+    // directories -- so plan B is to remove everything bottom-up.
+    depthFirstWalk(tmpdir, func_wrapper, 1);
+    fmt::print("{:s}:{:d} now moving depth-first through all\n", __FILE__, __LINE__);
+    depthFirstWalk(tmpdir, func_wrapper);
+    tr_sys_path_remove(tmpdir);
+
+    // OK we've removed the local data.
+    // What's left are empty folders, junk, and user-generated files.
+    // Remove the first two categories and leave the third alone.
+    auto const remove_junk = [&func](char const* filename)
+    {
+        fmt::print("{:s}:{:d} removeJunk '{:s}'\n", __FILE__, __LINE__, filename);
+        if (isDirectory(filename) || isJunkFile(filename))
+        {
+            fmt::print("{:s}:{:d} calling the remove func on '{:s}'\n", __FILE__, __LINE__, filename);
+            func(filename, nullptr);
+        }
+    };
+    for (auto const& filename : top_files)
+    {
+        depthFirstWalk(filename.c_str(), remove_junk);
+    }
 }

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -5,15 +5,12 @@
 
 #pragma once
 
-#include <cstdint>
+#include <cstdint> // uint64_t
 #include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
-
-#warning nocommit
-#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -76,7 +73,6 @@ public:
 
     tr_file_index_t add(std::string_view path, uint64_t file_size)
     {
-        fmt::print("{:s}:{:d} add '{:s}'\n", __FILE__, __LINE__, path);
         auto const ret = static_cast<tr_file_index_t>(std::size(files_));
         files_.emplace_back(path, file_size);
         total_size_ += file_size;
@@ -91,7 +87,6 @@ public:
         tr_error** error = nullptr) const;
 
     using FileFunc = std::function<void(char const* filename)>;
-
     void remove(std::string_view top_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
 
     struct FoundFile : public tr_sys_path_info

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -11,6 +11,9 @@
 #include <string_view>
 #include <vector>
 
+#warning nocommit
+#include <fmt/format.h>
+
 #include "transmission.h"
 
 #include "file.h"
@@ -72,6 +75,7 @@ public:
 
     tr_file_index_t add(std::string_view path, uint64_t file_size)
     {
+        fmt::print("{:s}:{:d} add '{:s}'\n", __FILE__, __LINE__, path);
         auto const ret = static_cast<tr_file_index_t>(std::size(files_));
         files_.emplace_back(path, file_size);
         total_size_ += file_size;
@@ -84,6 +88,8 @@ public:
         double volatile* setme_progress,
         std::string_view log_name = "",
         tr_error** error = nullptr) const;
+
+    void remove(std::string_view top_in, std::string_view tmpdir_prefix, tr_fileFunc func) const;
 
     struct FoundFile : public tr_sys_path_info
     {

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -89,7 +90,9 @@ public:
         std::string_view log_name = "",
         tr_error** error = nullptr) const;
 
-    void remove(std::string_view top_in, std::string_view tmpdir_prefix, tr_fileFunc func) const;
+    using FileFunc = std::function<void(char const* filename)>;
+
+    void remove(std::string_view top_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
 
     struct FoundFile : public tr_sys_path_info
     {

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -19,7 +19,7 @@
 /**
  * A simple ordered collection of files.
  */
-struct tr_files
+struct tr_torrent_files
 {
 public:
     [[nodiscard]] bool empty() const noexcept;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -148,7 +148,7 @@ std::string tr_torrent_metainfo::fixWebseedUrl(tr_torrent_metainfo const& tm, st
 {
     url = tr_strvStrip(url);
 
-    if (std::size(tm.files_) > 1 && !std::empty(url) && url.back() != '/')
+    if (tm.fileCount() > 1U && !std::empty(url) && url.back() != '/')
     {
         return std::string{ url } + '/';
     }

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -14,8 +14,8 @@
 #include "transmission.h"
 
 #include "block-info.h"
-#include "files.h"
 #include "magnet-metainfo.h"
+#include "torrent-files.h"
 #include "tr-strbuf.h"
 
 struct tr_error;
@@ -44,11 +44,11 @@ public:
     }
     [[nodiscard]] auto fileCount() const noexcept
     {
-        return std::size(files());
+        return files().fileCount();
     }
     [[nodiscard]] auto fileSize(tr_file_index_t i) const
     {
-        return files().size(i);
+        return files().fileSize(i);
     }
     [[nodiscard]] auto const& fileSubpath(tr_file_index_t i) const
     {
@@ -208,7 +208,7 @@ private:
 
     tr_block_info block_info_ = tr_block_info{ 0, 0 };
 
-    tr_files files_;
+    tr_torrent_files files_;
 
     std::vector<tr_sha1_digest_t> pieces_;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -18,9 +18,6 @@
 #include <unordered_map>
 #include <vector>
 
-#warning nocommit
-#include <iostream>
-
 #ifndef _WIN32
 #include <sys/wait.h> /* wait() */
 #include <unistd.h> /* fork(), execvp(), _exit() */
@@ -1653,8 +1650,10 @@ static void removeTorrentInEventThread(tr_torrent* tor, bool delete_flag, tr_fil
             delete_func = tr_sys_path_remove;
         }
 
-        std::cerr << __FILE__ << ':' << __LINE__ << " current dir [" << tor->currentDir().sv() << ']' << std::endl;
-        auto const delete_func_wrapper = [&delete_func](char const* filename){ delete_func(filename, nullptr); };
+        auto const delete_func_wrapper = [&delete_func](char const* filename)
+        {
+            delete_func(filename, nullptr);
+        };
         tor->metainfo_.files().remove(tor->currentDir(), tor->name(), delete_func_wrapper);
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1654,7 +1654,8 @@ static void removeTorrentInEventThread(tr_torrent* tor, bool delete_flag, tr_fil
         }
 
         std::cerr << __FILE__ << ':' << __LINE__ << " current dir [" << tor->currentDir().sv() << ']' << std::endl;
-        tor->metainfo_.files().remove(tor->currentDir(), tor->name(), delete_func);
+        auto const delete_func_wrapper = [&delete_func](char const* filename){ delete_func(filename, nullptr); };
+        tor->metainfo_.files().remove(tor->currentDir(), tor->name(), delete_func_wrapper);
     }
 
     tr_torrentClearCompletenessCallback(tor);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -368,7 +368,7 @@ public:
         metainfo_.setFileSubpath(i, subpath);
     }
 
-    [[nodiscard]] std::optional<tr_files::FoundFile> findFile(tr_file_index_t file_index) const;
+    [[nodiscard]] std::optional<tr_torrent_files::FoundFile> findFile(tr_file_index_t file_index) const;
 
     [[nodiscard]] bool hasAnyLocalData() const;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -559,6 +559,16 @@ public:
         this->error_string = errmsg;
     }
 
+    void setDownloadDir(std::string_view path)
+    {
+        download_dir = path;
+        markEdited();
+        setDirty();
+        refreshCurrentDir();
+    }
+
+    void refreshCurrentDir();
+
     void setVerifyState(tr_verify_state state);
 
     void setDateActive(time_t t);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -306,7 +306,7 @@ template<typename... T, typename std::enable_if_t<(std::is_convertible_v<T, std:
 }
 
 template<typename T>
-[[nodiscard]] constexpr bool tr_strvContains(std::string_view sv, T key) // c++23
+[[nodiscard]] constexpr bool tr_strvContains(std::string_view sv, T key) noexcept // c++23
 {
     return sv.find(key) != sv.npos;
 }

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(libtransmission-test
     peer-mgr-wishlist-test.cc
     peer-msgs-test.cc
     quark-test.cc
+    remove-test.cc
     rename-test.cc
     rpc-test.cc
     session-test.cc

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -58,7 +58,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
     auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
     auto path = tr_pathbuf{};
 
-    path.assign(incomplete_dir, '/', tr_torrentFile(tor, 0).name, ".part"sv);
+    path.assign(incomplete_dir, '/', tr_torrentFile(tor, 0).name, tr_torrent_files::PartialFileSuffix);
     EXPECT_EQ(path, makeString(tr_torrentFindFile(tor, 0)));
     path.assign(incomplete_dir, '/', tr_torrentFile(tor, 1).name);
     EXPECT_EQ(path, makeString(tr_torrentFindFile(tor, 1)));

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <cstdio>
 #include <set>
 #include <string_view>
 #include <utility>
@@ -19,6 +20,125 @@
 using namespace std::literals;
 using RemoveTest = libtransmission::test::SandboxedTest;
 using SubpathAndSize = std::pair<std::string_view, uint64_t>;
+
+namespace
+{
+
+auto constexpr AliceFiles = std::array<SubpathAndSize, 106>{{
+    { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_abbyy.gz", 24582ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_chocr.html.gz", 22527ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.txt", 2039ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.xml", 28144ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr.html", 56942ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_pageindex.json.gz", 40ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_searchtext.txt.gz", 943ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_jp2.zip", 1499986ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_page_numbers.json", 136ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_scandata.xml", 538ULL },
+    { "alice_in_wonderland_librivox/Alice_in_Wonderland_thumb.jpg", 26987ULL },
+    { "alice_in_wonderland_librivox/__ia_thumb.jpg", 16557ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.json", 13740ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.storj-store.trigger", 0ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_128kb.m3u", 984ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_64kb.m3u", 1044ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.sqlite", 20480ULL },
+    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.xml", 2805ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01.mp3", 10249859ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01.ogg", 7509828ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01.png", 10779ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01_64kb.mp3", 5124992ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01_esshigh.json.gz", 1977ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01_esslow.json.gz", 29258ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_01_spectrogram.png", 234022ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02.mp3", 11772312ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02.ogg", 5148365ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02.png", 10962ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02_64kb.mp3", 5886455ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02_esshigh.json.gz", 1980ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02_esslow.json.gz", 30287ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_02_spectrogram.png", 326161ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03.mp3", 17024560ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03.ogg", 12046177ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03.png", 8725ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03_64kb.mp3", 8512448ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03_esshigh.json.gz", 1966ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03_esslow.json.gz", 34110ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_03_spectrogram.png", 218264ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04.mp3", 19087768ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04.ogg", 9880920ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04.png", 6055ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04_64kb.mp3", 9544016ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04_esshigh.json.gz", 1967ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04_esslow.json.gz", 36154ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_04_spectrogram.png", 282145ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05.mp3", 12946949ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05.ogg", 7470734ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05.png", 12061ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05_64kb.mp3", 6473687ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05_esshigh.json.gz", 1963ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05_esslow.json.gz", 31048ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_05_spectrogram.png", 304150ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06.mp3", 12413304ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06.ogg", 7154040ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06.png", 11383ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06_64kb.mp3", 6206820ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06_esshigh.json.gz", 1942ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06_esslow.json.gz", 30295ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_06_spectrogram.png", 288601ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07.mp3", 16742808ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07.ogg", 10513847ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07.png", 8180ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07_64kb.mp3", 8371136ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07_esshigh.json.gz", 1963ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07_esslow.json.gz", 33992ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_07_spectrogram.png", 233725ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08.mp3", 12784781ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08.ogg", 9306961ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08.png", 11470ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08_64kb.mp3", 6392576ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08_esshigh.json.gz", 1973ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08_esslow.json.gz", 31964ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_08_spectrogram.png", 233626ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09.mp3", 14528920ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09.ogg", 8062952ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09.png", 9439ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09_64kb.mp3", 7264466ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09_esshigh.json.gz", 1946ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09_esslow.json.gz", 32295ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_09_spectrogram.png", 282898ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10.mp3", 21894203ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10.ogg", 15226220ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10.png", 8796ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10_64kb.mp3", 10947200ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10_esshigh.json.gz", 1970ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10_esslow.json.gz", 37062ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_10_spectrogram.png", 221277ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11.mp3", 9919894ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11.ogg", 7676067ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11.png", 7140ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11_64kb.mp3", 4959296ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11_esshigh.json.gz", 1959ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11_esslow.json.gz", 28694ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_11_spectrogram.png", 229471ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12.mp3", 12359368ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12.ogg", 8065179ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12.png", 11074ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12_64kb.mp3", 6179840ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12_esshigh.json.gz", 1981ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
+    { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
+    { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
+}};
+
+void sysPathRemove(char const* filename)
+{
+    tr_sys_path_remove(filename, nullptr);
+}
+
+} // unnamed namespace
 
 static auto getSubtreeContents(std::string_view parent_dir)
 {
@@ -68,7 +188,7 @@ TEST_F(RemoveTest, RemovesSingleFile)
     EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 
     // now remove the files
-    files.remove(parent, "tmpdir_prefix"sv, tr_sys_path_remove);
+    files.remove(parent, "tmpdir_prefix"sv, sysPathRemove);
 
     // after remove, the subtree should be:
     expected_subtree_contents = std::set<std::string>{
@@ -81,118 +201,10 @@ TEST_F(RemoveTest, RemovesSubtree)
 {
     // test setup: define a single-file torrent, no folders
     static auto constexpr Content = "Hello, World!"sv;
-    static auto constexpr Files = std::array<SubpathAndSize, 106>{{
-        { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_abbyy.gz", 24582ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_chocr.html.gz", 22527ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.txt", 2039ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.xml", 28144ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr.html", 56942ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_pageindex.json.gz", 40ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_searchtext.txt.gz", 943ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_jp2.zip", 1499986ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_page_numbers.json", 136ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_scandata.xml", 538ULL },
-        { "alice_in_wonderland_librivox/Alice_in_Wonderland_thumb.jpg", 26987ULL },
-        { "alice_in_wonderland_librivox/__ia_thumb.jpg", 16557ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.json", 13740ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.storj-store.trigger", 0ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_128kb.m3u", 984ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_64kb.m3u", 1044ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.sqlite", 20480ULL },
-        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.xml", 2805ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01.mp3", 10249859ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01.ogg", 7509828ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01.png", 10779ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01_64kb.mp3", 5124992ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01_esshigh.json.gz", 1977ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01_esslow.json.gz", 29258ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_01_spectrogram.png", 234022ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02.mp3", 11772312ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02.ogg", 5148365ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02.png", 10962ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02_64kb.mp3", 5886455ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02_esshigh.json.gz", 1980ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02_esslow.json.gz", 30287ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_02_spectrogram.png", 326161ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03.mp3", 17024560ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03.ogg", 12046177ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03.png", 8725ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03_64kb.mp3", 8512448ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03_esshigh.json.gz", 1966ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03_esslow.json.gz", 34110ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_03_spectrogram.png", 218264ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04.mp3", 19087768ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04.ogg", 9880920ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04.png", 6055ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04_64kb.mp3", 9544016ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04_esshigh.json.gz", 1967ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04_esslow.json.gz", 36154ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_04_spectrogram.png", 282145ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05.mp3", 12946949ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05.ogg", 7470734ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05.png", 12061ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05_64kb.mp3", 6473687ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05_esshigh.json.gz", 1963ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05_esslow.json.gz", 31048ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_05_spectrogram.png", 304150ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06.mp3", 12413304ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06.ogg", 7154040ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06.png", 11383ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06_64kb.mp3", 6206820ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06_esshigh.json.gz", 1942ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06_esslow.json.gz", 30295ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_06_spectrogram.png", 288601ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07.mp3", 16742808ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07.ogg", 10513847ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07.png", 8180ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07_64kb.mp3", 8371136ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07_esshigh.json.gz", 1963ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07_esslow.json.gz", 33992ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_07_spectrogram.png", 233725ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08.mp3", 12784781ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08.ogg", 9306961ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08.png", 11470ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08_64kb.mp3", 6392576ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08_esshigh.json.gz", 1973ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08_esslow.json.gz", 31964ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_08_spectrogram.png", 233626ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09.mp3", 14528920ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09.ogg", 8062952ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09.png", 9439ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09_64kb.mp3", 7264466ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09_esshigh.json.gz", 1946ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09_esslow.json.gz", 32295ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_09_spectrogram.png", 282898ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10.mp3", 21894203ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10.ogg", 15226220ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10.png", 8796ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10_64kb.mp3", 10947200ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10_esshigh.json.gz", 1970ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10_esslow.json.gz", 37062ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_10_spectrogram.png", 221277ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11.mp3", 9919894ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11.ogg", 7676067ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11.png", 7140ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11_64kb.mp3", 4959296ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11_esshigh.json.gz", 1959ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11_esslow.json.gz", 28694ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_11_spectrogram.png", 229471ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12.mp3", 12359368ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12.ogg", 8065179ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12.png", 11074ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12_64kb.mp3", 6179840ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12_esshigh.json.gz", 1981ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
-        { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
-        { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
-    }};
 
     // test setup: create the `tr_torrent_files`
     auto files = tr_torrent_files{};
-    for (auto const& file : Files)
+    for (auto const& file : AliceFiles)
     {
         auto const& [filename, size] = file;
         files.add(filename, size);
@@ -214,8 +226,7 @@ TEST_F(RemoveTest, RemovesSubtree)
     EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 
     // now remove the files
-    files.remove(parent, "tmpdir_prefix"sv, tr_sys_path_remove);
-    sync();
+    files.remove(parent, "tmpdir_prefix"sv, sysPathRemove);
 
     // after remove, the subtree should be:
     expected_subtree_contents = std::set<std::string>{ std::string{ parent } };
@@ -224,6 +235,72 @@ TEST_F(RemoveTest, RemovesSubtree)
 
 TEST_F(RemoveTest, RemovesSubtreeIfPossible)
 {
+    // test setup: define a single-file torrent, no folders
+    static auto constexpr Content = "Hello, World!"sv;
+
+    // test setup: create the `tr_torrent_files`
+    auto files = tr_torrent_files{};
+    for (auto const& file : AliceFiles)
+    {
+        auto const& [filename, size] = file;
+        files.add(filename, size);
+    }
+
+    // test setup: populate the filesystem
+    auto const parent = sandboxDir();
+    auto expected_subtree_contents = std::set<std::string>{};
+    for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
+    {
+        auto const filename = tr_pathbuf{ parent, '/', files.path(i) };
+        createFileWithContents(filename, std::data(Content), std::size(Content));
+        expected_subtree_contents.emplace(filename);
+    }
+    expected_subtree_contents.emplace(tr_pathbuf{ parent });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history/files"sv });
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+
+    auto const recycle_bin = tr_pathbuf{ parent, "/Trash"sv };
+    tr_sys_dir_create(recycle_bin, TR_SYS_DIR_CREATE_PARENTS, 0777);
+
+    auto const recycle_func = [&recycle_bin](char const* filename)
+    {
+        auto const newpath = tr_pathbuf{ recycle_bin, '/', tr_sys_path_basename(filename) };
+        auto const ret = rename(filename, newpath);
+        fmt::print(FMT_STRING("{:s}:{:d} mv '{:s}' '{:s} returned {:d}'\n"), __FILE__, __LINE__, filename, newpath, ret);
+        if (ret != 0)
+        {
+            fmt::print(FMT_STRING("{:s}:{:d} {:s} ({:d})'\n"), __FILE__, __LINE__, tr_strerror(errno), errno);
+        }
+    };
+
+    files.remove(parent, "tmpdir_prefix"sv, recycle_func);
+
+    // after remove, the subtree should be:
+    expected_subtree_contents.clear();
+    for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
+    {
+        expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, '/', files.path(i) });
+    }
+    expected_subtree_contents.emplace(parent);
+    expected_subtree_contents.emplace(recycle_bin);
+    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history/files"sv });
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+
+    std::cerr << "actual" << std::endl;
+    for (auto const& file : getSubtreeContents(parent))
+    {
+        std::cerr << file << std::endl;
+    }
+
+    std::cerr << std::endl << std::endl << "expected" << std::endl;
+    for (auto const& file : expected_subtree_contents)
+    {
+        std::cerr << file << std::endl;
+    }
 }
 
 TEST_F(RemoveTest, RemovesFilesIfUnableToRemoveSubtree)

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -1,0 +1,46 @@
+// This file Copyright (C) 2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0), GPLv3 (SPDX: GPL-3.0),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include "transmission.h"
+
+#include "torrent-files.h"
+#include "file.h"
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+using RemoveTest = libtransmission::test::SandboxedTest;
+
+TEST_F(RemoveTest, RemovesSingleFile)
+{
+}
+
+TEST_F(RemoveTest, RemovesSubtree)
+{
+}
+
+TEST_F(RemoveTest, RemovesSubtreeIfPossible)
+{
+}
+
+TEST_F(RemoveTest, RemovesFilesIfUnableToRemoveSubtree)
+{
+}
+
+TEST_F(RemoveTest, RemovesLeftoverJunk)
+{
+}
+
+TEST_F(RemoveTest, CleansUpTmpdirWhenDone)
+{
+}
+
+TEST_F(RemoveTest, DoesNotRemoveOtherFilesInSubtree)
+{
+}
+
+TEST_F(RemoveTest, DoesNotRemoveSiblingFiles)
+{
+}

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -18,248 +18,254 @@
 #include "test-fixtures.h"
 
 using namespace std::literals;
-using RemoveTest = libtransmission::test::SandboxedTest;
 using SubpathAndSize = std::pair<std::string_view, uint64_t>;
 
-namespace
+class RemoveTest: public libtransmission::test::SandboxedTest
 {
+protected:
 
-auto constexpr AliceFiles = std::array<SubpathAndSize, 106>{{
-    { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_abbyy.gz", 24582ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_chocr.html.gz", 22527ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.txt", 2039ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.xml", 28144ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr.html", 56942ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_pageindex.json.gz", 40ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_searchtext.txt.gz", 943ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_jp2.zip", 1499986ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_page_numbers.json", 136ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_scandata.xml", 538ULL },
-    { "alice_in_wonderland_librivox/Alice_in_Wonderland_thumb.jpg", 26987ULL },
-    { "alice_in_wonderland_librivox/__ia_thumb.jpg", 16557ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.json", 13740ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.storj-store.trigger", 0ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_128kb.m3u", 984ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_64kb.m3u", 1044ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.sqlite", 20480ULL },
-    { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.xml", 2805ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01.mp3", 10249859ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01.ogg", 7509828ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01.png", 10779ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01_64kb.mp3", 5124992ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01_esshigh.json.gz", 1977ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01_esslow.json.gz", 29258ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_01_spectrogram.png", 234022ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02.mp3", 11772312ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02.ogg", 5148365ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02.png", 10962ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02_64kb.mp3", 5886455ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02_esshigh.json.gz", 1980ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02_esslow.json.gz", 30287ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_02_spectrogram.png", 326161ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03.mp3", 17024560ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03.ogg", 12046177ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03.png", 8725ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03_64kb.mp3", 8512448ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03_esshigh.json.gz", 1966ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03_esslow.json.gz", 34110ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_03_spectrogram.png", 218264ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04.mp3", 19087768ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04.ogg", 9880920ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04.png", 6055ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04_64kb.mp3", 9544016ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04_esshigh.json.gz", 1967ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04_esslow.json.gz", 36154ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_04_spectrogram.png", 282145ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05.mp3", 12946949ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05.ogg", 7470734ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05.png", 12061ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05_64kb.mp3", 6473687ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05_esshigh.json.gz", 1963ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05_esslow.json.gz", 31048ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_05_spectrogram.png", 304150ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06.mp3", 12413304ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06.ogg", 7154040ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06.png", 11383ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06_64kb.mp3", 6206820ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06_esshigh.json.gz", 1942ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06_esslow.json.gz", 30295ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_06_spectrogram.png", 288601ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07.mp3", 16742808ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07.ogg", 10513847ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07.png", 8180ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07_64kb.mp3", 8371136ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07_esshigh.json.gz", 1963ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07_esslow.json.gz", 33992ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_07_spectrogram.png", 233725ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08.mp3", 12784781ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08.ogg", 9306961ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08.png", 11470ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08_64kb.mp3", 6392576ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08_esshigh.json.gz", 1973ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08_esslow.json.gz", 31964ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_08_spectrogram.png", 233626ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09.mp3", 14528920ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09.ogg", 8062952ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09.png", 9439ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09_64kb.mp3", 7264466ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09_esshigh.json.gz", 1946ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09_esslow.json.gz", 32295ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_09_spectrogram.png", 282898ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10.mp3", 21894203ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10.ogg", 15226220ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10.png", 8796ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10_64kb.mp3", 10947200ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10_esshigh.json.gz", 1970ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10_esslow.json.gz", 37062ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_10_spectrogram.png", 221277ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11.mp3", 9919894ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11.ogg", 7676067ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11.png", 7140ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11_64kb.mp3", 4959296ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11_esshigh.json.gz", 1959ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11_esslow.json.gz", 28694ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_11_spectrogram.png", 229471ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12.mp3", 12359368ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12.ogg", 8065179ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12.png", 11074ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12_64kb.mp3", 6179840ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12_esshigh.json.gz", 1981ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
-    { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
-    { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
-}};
+    static constexpr std::string_view Content = "Hello, World!"sv;
 
-void sysPathRemove(char const* filename)
-{
-    tr_sys_path_remove(filename, nullptr);
-}
-
-} // unnamed namespace
-
-static auto getSubtreeContents(std::string_view parent_dir)
-{
-    auto filenames = std::set<std::string>{};
-
-    auto file_func = [&filenames](const char* filename)
+    static void sysPathRemove(char const* filename)
     {
-        filenames.emplace(filename);
-    };
+        tr_sys_path_remove(filename, nullptr);
+    }
 
-    libtransmission::test::depthFirstWalk(tr_pathbuf{ parent_dir }, file_func);
+    static auto aliceFiles()
+    {
+        static constexpr std::array<SubpathAndSize, 106> AliceFiles = {{
+            { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_abbyy.gz", 24582ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_chocr.html.gz", 22527ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.txt", 2039ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.xml", 28144ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr.html", 56942ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_pageindex.json.gz", 40ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_searchtext.txt.gz", 943ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_jp2.zip", 1499986ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_page_numbers.json", 136ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_scandata.xml", 538ULL },
+            { "alice_in_wonderland_librivox/Alice_in_Wonderland_thumb.jpg", 26987ULL },
+            { "alice_in_wonderland_librivox/__ia_thumb.jpg", 16557ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.json", 13740ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.storj-store.trigger", 0ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_128kb.m3u", 984ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_64kb.m3u", 1044ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.sqlite", 20480ULL },
+            { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.xml", 2805ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01.mp3", 10249859ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01.ogg", 7509828ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01.png", 10779ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01_64kb.mp3", 5124992ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01_esshigh.json.gz", 1977ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01_esslow.json.gz", 29258ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_01_spectrogram.png", 234022ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02.mp3", 11772312ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02.ogg", 5148365ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02.png", 10962ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02_64kb.mp3", 5886455ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02_esshigh.json.gz", 1980ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02_esslow.json.gz", 30287ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_02_spectrogram.png", 326161ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03.mp3", 17024560ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03.ogg", 12046177ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03.png", 8725ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03_64kb.mp3", 8512448ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03_esshigh.json.gz", 1966ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03_esslow.json.gz", 34110ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_03_spectrogram.png", 218264ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04.mp3", 19087768ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04.ogg", 9880920ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04.png", 6055ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04_64kb.mp3", 9544016ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04_esshigh.json.gz", 1967ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04_esslow.json.gz", 36154ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_04_spectrogram.png", 282145ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05.mp3", 12946949ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05.ogg", 7470734ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05.png", 12061ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05_64kb.mp3", 6473687ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05_esshigh.json.gz", 1963ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05_esslow.json.gz", 31048ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_05_spectrogram.png", 304150ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06.mp3", 12413304ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06.ogg", 7154040ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06.png", 11383ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06_64kb.mp3", 6206820ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06_esshigh.json.gz", 1942ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06_esslow.json.gz", 30295ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_06_spectrogram.png", 288601ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07.mp3", 16742808ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07.ogg", 10513847ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07.png", 8180ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07_64kb.mp3", 8371136ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07_esshigh.json.gz", 1963ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07_esslow.json.gz", 33992ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_07_spectrogram.png", 233725ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08.mp3", 12784781ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08.ogg", 9306961ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08.png", 11470ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08_64kb.mp3", 6392576ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08_esshigh.json.gz", 1973ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08_esslow.json.gz", 31964ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_08_spectrogram.png", 233626ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09.mp3", 14528920ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09.ogg", 8062952ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09.png", 9439ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09_64kb.mp3", 7264466ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09_esshigh.json.gz", 1946ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09_esslow.json.gz", 32295ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_09_spectrogram.png", 282898ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10.mp3", 21894203ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10.ogg", 15226220ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10.png", 8796ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10_64kb.mp3", 10947200ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10_esshigh.json.gz", 1970ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10_esslow.json.gz", 37062ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_10_spectrogram.png", 221277ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11.mp3", 9919894ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11.ogg", 7676067ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11.png", 7140ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11_64kb.mp3", 4959296ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11_esshigh.json.gz", 1959ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11_esslow.json.gz", 28694ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_11_spectrogram.png", 229471ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12.mp3", 12359368ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12.ogg", 8065179ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12.png", 11074ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12_64kb.mp3", 6179840ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12_esshigh.json.gz", 1981ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
+            { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
+            { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
+        }};
 
-    return filenames;
-}
+        auto files = tr_torrent_files{};
+
+        for (auto const& file : AliceFiles)
+        {
+            auto const& [filename, size] = file;
+            files.add(filename, size);
+        }
+
+        return files;
+    }
+
+    static auto ubuntuFiles()
+    {
+        static auto constexpr Files = std::array<SubpathAndSize, 1>{{
+            { "ubuntu-20.04.4-desktop-amd64.iso"sv, 3379068928ULL }
+        }};
+
+        auto files = tr_torrent_files{};
+
+        for (auto const& file : Files)
+        {
+            auto const& [filename, size] = file;
+            files.add(filename, size);
+        }
+
+        return files;
+    }
+
+    auto createFiles(tr_torrent_files const& files, char const* parent)
+    {
+        auto paths = std::set<std::string>{};
+
+        for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
+        {
+            auto filename = tr_pathbuf{ parent, '/', files.path(i) };
+            createFileWithContents(filename, std::data(Content), std::size(Content));
+            paths.emplace(filename);
+
+            while (!tr_sys_path_is_same(parent, filename))
+            {
+                filename = tr_sys_path_dirname(filename);
+                paths.emplace(filename);
+            }
+        }
+
+        return paths;
+    }
+
+    static auto getSubtreeContents(std::string_view parent_dir)
+    {
+        auto filenames = std::set<std::string>{};
+
+        auto file_func = [&filenames](const char* filename)
+        {
+            filenames.emplace(filename);
+        };
+
+        libtransmission::test::depthFirstWalk(tr_pathbuf{ parent_dir }, file_func);
+
+        return filenames;
+    }
+};
 
 TEST_F(RemoveTest, RemovesSingleFile)
 {
-    // test setup: define a single-file torrent, no folders
-    static auto constexpr Content = "Hello, World!"sv;
-    static auto constexpr Files = std::array<SubpathAndSize, 1>{{
-        { "ubuntu-20.04.4-desktop-amd64.iso"sv, 3379068928ULL }
-    }};
-
-    // test setup: create the `tr_torrent_files`
-    auto files = tr_torrent_files{};
-    for (auto const& file : Files)
-    {
-        auto const& [filename, size] = file;
-        files.add(filename, size);
-    }
-
-    // test setup: populate the filesystem
     auto const parent = sandboxDir();
-    auto expected_subtree_contents = std::set<std::string>{
-        std::string{ parent }
-    };
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 
-    auto const filename = tr_pathbuf{ parent, '/', files.path(0) };
-    createFileWithContents(filename, std::data(Content), std::size(Content));
+    auto expected_tree = std::set<std::string>{ parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 
-    // before remove, the subtree should be:
-    expected_subtree_contents = std::set<std::string>{
-        std::string{ parent },
-        std::string{ filename }
-    };
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+    auto const files = ubuntuFiles();
+    expected_tree = createFiles(files, parent.c_str());
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 
-    // now remove the files
     files.remove(parent, "tmpdir_prefix"sv, sysPathRemove);
-
-    // after remove, the subtree should be:
-    expected_subtree_contents = std::set<std::string>{
-        std::string{ parent }
-    };
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+    expected_tree = { parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 }
 
 TEST_F(RemoveTest, RemovesSubtree)
 {
-    // test setup: define a single-file torrent, no folders
-    static auto constexpr Content = "Hello, World!"sv;
-
-    // test setup: create the `tr_torrent_files`
-    auto files = tr_torrent_files{};
-    for (auto const& file : AliceFiles)
-    {
-        auto const& [filename, size] = file;
-        files.add(filename, size);
-    }
-
-    // test setup: populate the filesystem
     auto const parent = sandboxDir();
-    auto expected_subtree_contents = std::set<std::string>{};
-    for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
-    {
-        auto const filename = tr_pathbuf{ parent, '/', files.path(i) };
-        createFileWithContents(filename, std::data(Content), std::size(Content));
-        expected_subtree_contents.emplace(filename);
-    }
-    expected_subtree_contents.emplace(tr_pathbuf{ parent });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history/files"sv });
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 
-    // now remove the files
+    auto expected_tree = std::set<std::string>{ parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+
+    auto const files = aliceFiles();
+    expected_tree = createFiles(files, parent.c_str());
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+
     files.remove(parent, "tmpdir_prefix"sv, sysPathRemove);
+    expected_tree = { parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+}
 
-    // after remove, the subtree should be:
-    expected_subtree_contents = std::set<std::string>{ std::string{ parent } };
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+TEST_F(RemoveTest, RemovesLeftoverJunk)
+{
+    auto const parent = sandboxDir();
+
+    auto expected_tree = std::set<std::string>{ parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+
+    auto const files = aliceFiles();
+    expected_tree = createFiles(files, parent.c_str());
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+
+    // add in a junk file
+    auto const junk_file = tr_pathbuf{ parent, "/alice_in_wonderland_librivox/.DS_Store"sv };
+    createFileWithContents(junk_file, std::data(Content), std::size(Content));
+    expected_tree.emplace(junk_file);
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
+
+    files.remove(parent, "tmpdir_prefix"sv, sysPathRemove);
+    expected_tree = { parent };
+    EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 }
 
 TEST_F(RemoveTest, RemovesSubtreeIfPossible)
 {
-    // test setup: define a single-file torrent, no folders
-    static auto constexpr Content = "Hello, World!"sv;
-
-    // test setup: create the `tr_torrent_files`
-    auto files = tr_torrent_files{};
-    for (auto const& file : AliceFiles)
-    {
-        auto const& [filename, size] = file;
-        files.add(filename, size);
-    }
-
-    // test setup: populate the filesystem
     auto const parent = sandboxDir();
-    auto expected_subtree_contents = std::set<std::string>{};
-    for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
-    {
-        auto const filename = tr_pathbuf{ parent, '/', files.path(i) };
-        createFileWithContents(filename, std::data(Content), std::size(Content));
-        expected_subtree_contents.emplace(filename);
-    }
-    expected_subtree_contents.emplace(tr_pathbuf{ parent });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history/files"sv });
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+    auto const files = aliceFiles();
+
+    auto expected_directory_tree = createFiles(files, parent.c_str());
+    EXPECT_EQ(expected_directory_tree, getSubtreeContents(parent));
 
     auto const recycle_bin = tr_pathbuf{ parent, "/Trash"sv };
     tr_sys_dir_create(recycle_bin, TR_SYS_DIR_CREATE_PARENTS, 0777);
@@ -278,17 +284,17 @@ TEST_F(RemoveTest, RemovesSubtreeIfPossible)
     files.remove(parent, "tmpdir_prefix"sv, recycle_func);
 
     // after remove, the subtree should be:
-    expected_subtree_contents.clear();
+    expected_directory_tree.clear();
     for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
     {
-        expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, '/', files.path(i) });
+        expected_directory_tree.emplace(tr_pathbuf{ recycle_bin, '/', files.path(i) });
     }
-    expected_subtree_contents.emplace(parent);
-    expected_subtree_contents.emplace(recycle_bin);
-    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history"sv });
-    expected_subtree_contents.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history/files"sv });
-    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+    expected_directory_tree.emplace(parent);
+    expected_directory_tree.emplace(recycle_bin);
+    expected_directory_tree.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox"sv });
+    expected_directory_tree.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history"sv });
+    expected_directory_tree.emplace(tr_pathbuf{ recycle_bin, "/alice_in_wonderland_librivox/history/files"sv });
+    EXPECT_EQ(expected_directory_tree, getSubtreeContents(parent));
 
     std::cerr << "actual" << std::endl;
     for (auto const& file : getSubtreeContents(parent))
@@ -297,18 +303,10 @@ TEST_F(RemoveTest, RemovesSubtreeIfPossible)
     }
 
     std::cerr << std::endl << std::endl << "expected" << std::endl;
-    for (auto const& file : expected_subtree_contents)
+    for (auto const& file : expected_directory_tree)
     {
         std::cerr << file << std::endl;
     }
-}
-
-TEST_F(RemoveTest, RemovesFilesIfUnableToRemoveSubtree)
-{
-}
-
-TEST_F(RemoveTest, RemovesLeftoverJunk)
-{
 }
 
 TEST_F(RemoveTest, CleansUpTmpdirWhenDone)

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -79,6 +79,147 @@ TEST_F(RemoveTest, RemovesSingleFile)
 
 TEST_F(RemoveTest, RemovesSubtree)
 {
+    // test setup: define a single-file torrent, no folders
+    static auto constexpr Content = "Hello, World!"sv;
+    static auto constexpr Files = std::array<SubpathAndSize, 106>{{
+        { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_abbyy.gz", 24582ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_chocr.html.gz", 22527ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.txt", 2039ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_djvu.xml", 28144ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr.html", 56942ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_pageindex.json.gz", 40ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_hocr_searchtext.txt.gz", 943ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_jp2.zip", 1499986ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_page_numbers.json", 136ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_scandata.xml", 538ULL },
+        { "alice_in_wonderland_librivox/Alice_in_Wonderland_thumb.jpg", 26987ULL },
+        { "alice_in_wonderland_librivox/__ia_thumb.jpg", 16557ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.json", 13740ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox.storj-store.trigger", 0ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_128kb.m3u", 984ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_64kb.m3u", 1044ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.sqlite", 20480ULL },
+        { "alice_in_wonderland_librivox/alice_in_wonderland_librivox_meta.xml", 2805ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01.mp3", 10249859ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01.ogg", 7509828ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01.png", 10779ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01_64kb.mp3", 5124992ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01_esshigh.json.gz", 1977ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01_esslow.json.gz", 29258ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_01_spectrogram.png", 234022ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02.mp3", 11772312ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02.ogg", 5148365ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02.png", 10962ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02_64kb.mp3", 5886455ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02_esshigh.json.gz", 1980ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02_esslow.json.gz", 30287ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_02_spectrogram.png", 326161ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03.mp3", 17024560ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03.ogg", 12046177ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03.png", 8725ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03_64kb.mp3", 8512448ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03_esshigh.json.gz", 1966ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03_esslow.json.gz", 34110ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_03_spectrogram.png", 218264ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04.mp3", 19087768ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04.ogg", 9880920ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04.png", 6055ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04_64kb.mp3", 9544016ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04_esshigh.json.gz", 1967ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04_esslow.json.gz", 36154ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_04_spectrogram.png", 282145ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05.mp3", 12946949ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05.ogg", 7470734ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05.png", 12061ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05_64kb.mp3", 6473687ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05_esshigh.json.gz", 1963ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05_esslow.json.gz", 31048ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_05_spectrogram.png", 304150ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06.mp3", 12413304ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06.ogg", 7154040ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06.png", 11383ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06_64kb.mp3", 6206820ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06_esshigh.json.gz", 1942ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06_esslow.json.gz", 30295ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_06_spectrogram.png", 288601ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07.mp3", 16742808ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07.ogg", 10513847ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07.png", 8180ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07_64kb.mp3", 8371136ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07_esshigh.json.gz", 1963ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07_esslow.json.gz", 33992ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_07_spectrogram.png", 233725ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08.mp3", 12784781ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08.ogg", 9306961ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08.png", 11470ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08_64kb.mp3", 6392576ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08_esshigh.json.gz", 1973ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08_esslow.json.gz", 31964ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_08_spectrogram.png", 233626ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09.mp3", 14528920ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09.ogg", 8062952ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09.png", 9439ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09_64kb.mp3", 7264466ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09_esshigh.json.gz", 1946ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09_esslow.json.gz", 32295ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_09_spectrogram.png", 282898ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10.mp3", 21894203ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10.ogg", 15226220ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10.png", 8796ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10_64kb.mp3", 10947200ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10_esshigh.json.gz", 1970ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10_esslow.json.gz", 37062ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_10_spectrogram.png", 221277ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11.mp3", 9919894ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11.ogg", 7676067ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11.png", 7140ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11_64kb.mp3", 4959296ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11_esshigh.json.gz", 1959ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11_esslow.json.gz", 28694ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_11_spectrogram.png", 229471ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12.mp3", 12359368ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12.ogg", 8065179ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12.png", 11074ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12_64kb.mp3", 6179840ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12_esshigh.json.gz", 1981ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
+        { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
+        { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
+    }};
+
+    // test setup: create the `tr_torrent_files`
+    auto files = tr_torrent_files{};
+    for (auto const& file : Files)
+    {
+        auto const& [filename, size] = file;
+        files.add(filename, size);
+    }
+
+    // test setup: populate the filesystem
+    auto const parent = sandboxDir();
+    auto expected_subtree_contents = std::set<std::string>{};
+    for (tr_file_index_t i = 0, n = files.fileCount(); i < n; ++i)
+    {
+        auto const filename = tr_pathbuf{ parent, '/', files.path(i) };
+        createFileWithContents(filename, std::data(Content), std::size(Content));
+        expected_subtree_contents.emplace(filename);
+    }
+    expected_subtree_contents.emplace(tr_pathbuf{ parent });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history"sv });
+    expected_subtree_contents.emplace(tr_pathbuf{ parent, "/alice_in_wonderland_librivox/history/files"sv });
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+
+    // now remove the files
+    files.remove(parent, "tmpdir_prefix"sv, tr_sys_path_remove);
+    sync();
+
+    // after remove, the subtree should be:
+    expected_subtree_contents = std::set<std::string>{ std::string{ parent } };
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 }
 
 TEST_F(RemoveTest, RemovesSubtreeIfPossible)

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -3,18 +3,78 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <array>
+#include <set>
+#include <string_view>
+#include <utility>
+
 #include "transmission.h"
 
-#include "torrent-files.h"
 #include "file.h"
+#include "torrent-files.h"
+#include "tr-strbuf.h"
 
 #include "test-fixtures.h"
 
 using namespace std::literals;
 using RemoveTest = libtransmission::test::SandboxedTest;
+using SubpathAndSize = std::pair<std::string_view, uint64_t>;
+
+static auto getSubtreeContents(std::string_view parent_dir)
+{
+    auto filenames = std::set<std::string>{};
+
+    auto file_func = [&filenames](const char* filename)
+    {
+        filenames.emplace(filename);
+    };
+
+    libtransmission::test::depthFirstWalk(tr_pathbuf{ parent_dir }, file_func);
+
+    return filenames;
+}
 
 TEST_F(RemoveTest, RemovesSingleFile)
 {
+    // test setup: define a single-file torrent, no folders
+    static auto constexpr Content = "Hello, World!"sv;
+    static auto constexpr Files = std::array<SubpathAndSize, 1>{{
+        { "ubuntu-20.04.4-desktop-amd64.iso"sv, 3379068928ULL }
+    }};
+
+    // test setup: create the `tr_torrent_files`
+    auto files = tr_torrent_files{};
+    for (auto const& file : Files)
+    {
+        auto const& [filename, size] = file;
+        files.add(filename, size);
+    }
+
+    // test setup: populate the filesystem
+    auto const parent = sandboxDir();
+    auto expected_subtree_contents = std::set<std::string>{
+        std::string{ parent }
+    };
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+
+    auto const filename = tr_pathbuf{ parent, '/', files.path(0) };
+    createFileWithContents(filename, std::data(Content), std::size(Content));
+
+    // before remove, the subtree should be:
+    expected_subtree_contents = std::set<std::string>{
+        std::string{ parent },
+        std::string{ filename }
+    };
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
+
+    // now remove the files
+    files.remove(parent, "tmpdir_prefix"sv, tr_sys_path_remove);
+
+    // after remove, the subtree should be:
+    expected_subtree_contents = std::set<std::string>{
+        std::string{ parent }
+    };
+    EXPECT_EQ(expected_subtree_contents, getSubtreeContents(parent));
 }
 
 TEST_F(RemoveTest, RemovesSubtree)

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -20,10 +20,9 @@
 using namespace std::literals;
 using SubpathAndSize = std::pair<std::string_view, uint64_t>;
 
-class RemoveTest: public libtransmission::test::SandboxedTest
+class RemoveTest : public libtransmission::test::SandboxedTest
 {
 protected:
-
     static constexpr std::string_view Content = "Hello, World!"sv;
 
     static void sysPathRemove(char const* filename)
@@ -33,7 +32,7 @@ protected:
 
     static auto aliceFiles()
     {
-        static constexpr std::array<SubpathAndSize, 106> AliceFiles = {{
+        static constexpr std::array<SubpathAndSize, 106> AliceFiles = { {
             { "alice_in_wonderland_librivox/AliceInWonderland_librivox.m4b", 87525736ULL },
             { "alice_in_wonderland_librivox/Alice_in_Wonderland.jpg", 81464ULL },
             { "alice_in_wonderland_librivox/Alice_in_Wonderland.pdf", 185367ULL },
@@ -140,7 +139,7 @@ protected:
             { "alice_in_wonderland_librivox/wonderland_ch_12_esslow.json.gz", 30975ULL },
             { "alice_in_wonderland_librivox/wonderland_ch_12_spectrogram.png", 235568ULL },
             { "alice_in_wonderland_librivox/history/files/alice_in_wonderland_librivox.storj-store.trigger.~1~", 0ULL },
-        }};
+        } };
 
         auto files = tr_torrent_files{};
 
@@ -155,9 +154,8 @@ protected:
 
     static auto ubuntuFiles()
     {
-        static auto constexpr Files = std::array<SubpathAndSize, 1>{{
-            { "ubuntu-20.04.4-desktop-amd64.iso"sv, 3379068928ULL }
-        }};
+        static auto constexpr Files = std::array<SubpathAndSize, 1>{ { { "ubuntu-20.04.4-desktop-amd64.iso"sv,
+                                                                         3379068928ULL } } };
 
         auto files = tr_torrent_files{};
 

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -194,7 +194,7 @@ protected:
     {
         auto filenames = std::set<std::string>{};
 
-        auto file_func = [&filenames](const char* filename)
+        auto file_func = [&filenames](char const* filename)
         {
             filenames.emplace(filename);
         };

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -39,6 +39,32 @@ namespace libtransmission
 namespace test
 {
 
+using file_func_t = std::function<void(char const* filename)>;
+
+static void depthFirstWalk(char const* path, file_func_t func)
+{
+    auto info = tr_sys_path_info{};
+    if (tr_sys_path_get_info(path, 0, &info) && (info.type == TR_SYS_PATH_IS_DIRECTORY))
+    {
+        if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR)
+        {
+            char const* name;
+            while ((name = tr_sys_dir_read_name(odir)) != nullptr)
+            {
+                if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
+                {
+                    auto const filename = tr_strvPath(path, name);
+                    depthFirstWalk(tr_strvPath(path, name).c_str(), func);
+                }
+            }
+
+            tr_sys_dir_close(odir);
+        }
+    }
+
+    func(path);
+}
+
 inline std::string makeString(char*&& s)
 {
     auto const ret = std::string(s != nullptr ? s : "");
@@ -114,32 +140,6 @@ protected:
         tr_sys_dir_create_temp(std::data(path));
         tr_sys_path_native_separators(std::data(path));
         return path;
-    }
-
-    using file_func_t = std::function<void(char const* filename)>;
-
-    static void depthFirstWalk(char const* path, file_func_t func)
-    {
-        auto info = tr_sys_path_info{};
-        if (tr_sys_path_get_info(path, 0, &info) && (info.type == TR_SYS_PATH_IS_DIRECTORY))
-        {
-            if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR)
-            {
-                char const* name;
-                while ((name = tr_sys_dir_read_name(odir)) != nullptr)
-                {
-                    if (strcmp(name, ".") != 0 && strcmp(name, "..") != 0)
-                    {
-                        auto const filename = tr_strvPath(path, name);
-                        depthFirstWalk(tr_strvPath(path, name).c_str(), func);
-                    }
-                }
-
-                tr_sys_dir_close(odir);
-            }
-        }
-
-        func(path);
     }
 
     static void rimraf(std::string const& path, bool verbose = false)
@@ -227,14 +227,14 @@ protected:
         errno = tmperr;
     }
 
-    void createFileWithContents(std::string const& path, void const* payload, size_t n) const
+    void createFileWithContents(std::string_view path, void const* payload, size_t n) const
     {
         auto const tmperr = errno;
 
         buildParentDir(path);
 
         auto const fd = tr_sys_file_open(
-            path.c_str(),
+            tr_pathbuf{ path },
             TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
             0600,
             nullptr);

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -541,7 +541,6 @@ TEST_F(VariantTest, dictFindType)
 TEST_F(VariantTest, variantFromBufFuzz)
 {
     auto buf = std::vector<char>{};
-    auto top = tr_variant{};
 
     for (size_t i = 0; i < 100000; ++i)
     {
@@ -550,7 +549,16 @@ TEST_F(VariantTest, variantFromBufFuzz)
         auto const sv = std::string_view{ std::data(buf), std::size(buf) };
         // std::cerr << '[' << tr_base64_encode({ std::data(buf), std::size(buf) }) << ']' << std::endl;
 
-        tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, sv, nullptr, nullptr);
-        tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, sv, nullptr, nullptr);
+        if (auto top = tr_variant{};
+            tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, sv, nullptr, nullptr))
+        {
+            tr_variantFree(&top);
+        }
+
+        if (auto top = tr_variant{};
+            tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, sv, nullptr, nullptr))
+        {
+            tr_variantFree(&top);
+        }
     }
 }


### PR DESCRIPTION
Third in a small series of refactors to reduce coupling & dependencies in our file management code. Previous in this series: #2906 and #2911.

---

This PR extracts `tr_torrentSetLocation()` and `tr_torrentDeleteLocalData()` implementations from `tr_torrent` into the smaller class `tr_torrent_files` where they are more decoupled from the rest of libtransmission -- e.g. unit tests that don't involve spinning up a `tr_session` are now possible.

`tr_torrent_files::remove()`, has several new tests to check for edge cases. I'm looking forward to seeing how they play on non-Linux CI boxes... :lady_beetle: 