### PR TITLE
fixup: more libfmt usage regressions

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -909,7 +909,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
             else if (haveUnchecked == 0)
             {
                 str = fmt::format(
-                    _("{current_size} ({percent_done}% of {percent_available}% available"),
+                    _("{current_size} ({percent_done}% of {percent_available}% available)"),
                     fmt::arg("current_size", total),
                     fmt::arg("percent_done", buf2),
                     fmt::arg("percent_available", avail));

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1113,7 +1113,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
         return;
     }
 
-    logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(hanshake_sv)));
+    logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(handshake_sv)));
 
     /* does the peer prefer encrypted connections? */
     auto i = int64_t{};

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1097,27 +1097,23 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
 static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuffer* inbuf)
 {
-    auto* const tmp = tr_new(char, len);
-    tr_peerIoReadBytes(msgs->io, inbuf, tmp, len);
     msgs->peerSentLtepHandshake = true;
 
+    // LTEP messages are usually just a couple hundred bytes,
+    // so try using a strbuf to handle it on the stack
+    auto tmp = tr_strbuf<char, 512>{};
+    tmp.resize(len);
+    tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
+    auto const handshake_sv = tmp.sv();
+
     auto val = tr_variant{};
-    if (!tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, { tmp, len }) || !tr_variantIsDict(&val))
+    if (!tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, handshake_sv) || !tr_variantIsDict(&val))
     {
         logtrace(msgs, "GET  extended-handshake, couldn't get dictionary");
-        tr_free(tmp);
         return;
     }
 
-    /* arbitrary limit, should be more than enough */
-    if (len <= 4096)
-    {
-        logtrace(msgs, fmt::format(FMT_STRING("here is the handshake: [{:{}.{}s}]"), tmp, len, len));
-    }
-    else
-    {
-        logtrace(msgs, fmt::format(FMT_STRING("handshake length is too big ({:d}), printing skipped"), len));
-    }
+    logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(hanshake_sv)));
 
     /* does the peer prefer encrypted connections? */
     auto i = int64_t{};
@@ -1203,7 +1199,6 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
     }
 
     tr_variantFree(&val);
-    tr_free(tmp);
 }
 
 static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* inbuf)


### PR DESCRIPTION
Fix a couple of places where I broke the user-visible strings while migrating them over to libfmt. Previous related fixups: #2913