### PR TITLE
refactor: remove tr_url_parsed_t.portstr

### DIFF
--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -89,19 +89,6 @@ constexpr auto tr_saveFile(std::string_view filename, ContiguousRange const& x, 
     return tr_saveFile(filename, std::string_view{ std::data(x), std::size(x) }, error);
 }
 
-template<typename... T, typename std::enable_if_t<(std::is_convertible_v<T, std::string_view> && ...), bool> = true>
-std::string& tr_buildBuf(std::string& setme, T... args)
-{
-    setme.clear();
-    auto const n = (std::size(std::string_view{ args }) + ...);
-    if (setme.capacity() < n)
-    {
-        setme.reserve(n);
-    }
-    ((setme += args), ...);
-    return setme;
-}
-
 /**
  * @brief Get disk capacity and free disk space (in bytes) for the specified folder.
  * @return struct with free and total as zero or positive integer on success, -1 in case of error.

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -335,8 +335,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         auto remain = parsed.authority;
         parsed.host = tr_strvSep(&remain, ':');
         parsed.sitename = getSiteName(parsed.host);
-        parsed.portstr = !std::empty(remain) ? remain : getPortForScheme(parsed.scheme);
-        parsed.port = parsePort(parsed.portstr);
+        parsed.port = parsePort(!std::empty(remain) ? remain : getPortForScheme(parsed.scheme));
     }
 
     //  The path is terminated by the first question mark ("?") or

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint> // uint16_t
 #include <optional>
 #include <string>
 #include <string_view>
@@ -33,12 +34,11 @@ struct tr_url_parsed_t
     std::string_view authority; // "example.com:80"
     std::string_view host; // "example.com"
     std::string_view sitename; // "example"
-    std::string_view portstr; // "80"
     std::string_view path; // /"over/there"
     std::string_view query; // "name=ferret"
     std::string_view fragment; // "nose"
     std::string_view full; // "http://example.com:80/over/there?name=ferret#nose"
-    int port = -1; // 80
+    uint16_t port = 0;
 };
 
 std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url);

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -33,7 +33,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("1"sv, parsed->host);
     EXPECT_EQ("1"sv, parsed->sitename);
     EXPECT_EQ(""sv, parsed->path);
-    EXPECT_EQ("80"sv, parsed->portstr);
     EXPECT_EQ(""sv, parsed->query);
     EXPECT_EQ(""sv, parsed->fragment);
     EXPECT_EQ(80, parsed->port);
@@ -47,7 +46,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("/some/path"sv, parsed->path);
     EXPECT_EQ(""sv, parsed->query);
     EXPECT_EQ(""sv, parsed->fragment);
-    EXPECT_EQ("80"sv, parsed->portstr);
     EXPECT_EQ(80, parsed->port);
 
     url = "http://www.some-tracker.org:8080/some/path"sv;
@@ -59,7 +57,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("/some/path"sv, parsed->path);
     EXPECT_EQ(""sv, parsed->query);
     EXPECT_EQ(""sv, parsed->fragment);
-    EXPECT_EQ("8080"sv, parsed->portstr);
     EXPECT_EQ(8080, parsed->port);
 
     url = "http://www.some-tracker.org:8080/some/path?key=val&foo=bar#fragment"sv;
@@ -71,7 +68,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("/some/path"sv, parsed->path);
     EXPECT_EQ("key=val&foo=bar"sv, parsed->query);
     EXPECT_EQ("fragment"sv, parsed->fragment);
-    EXPECT_EQ("8080"sv, parsed->portstr);
     EXPECT_EQ(8080, parsed->port);
 
     url =
@@ -94,7 +90,6 @@ TEST_F(WebUtilsTest, urlParse)
         "&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80"
         "&ws=http%3A%2F%2Ftransmissionbt.com"sv,
         parsed->query);
-    EXPECT_EQ(""sv, parsed->portstr);
 
     // test a host whose public suffix contains >1 dot
     url = "https://www.example.co.uk:8080/some/path"sv;
@@ -104,7 +99,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("example"sv, parsed->sitename);
     EXPECT_EQ("www.example.co.uk"sv, parsed->host);
     EXPECT_EQ("/some/path"sv, parsed->path);
-    EXPECT_EQ("8080"sv, parsed->portstr);
     EXPECT_EQ(8080, parsed->port);
 
     // test a host that lacks a subdomain
@@ -115,7 +109,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("some-tracker"sv, parsed->sitename);
     EXPECT_EQ("some-tracker.co.uk"sv, parsed->host);
     EXPECT_EQ("/some/other/path"sv, parsed->path);
-    EXPECT_EQ("80"sv, parsed->portstr);
     EXPECT_EQ(80, parsed->port);
 
     // test a host with an IP address
@@ -126,7 +119,6 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("127.0.0.1"sv, parsed->sitename);
     EXPECT_EQ("127.0.0.1"sv, parsed->host);
     EXPECT_EQ("/some/path"sv, parsed->path);
-    EXPECT_EQ("8080"sv, parsed->portstr);
     EXPECT_EQ(8080, parsed->port);
 }
 


### PR DESCRIPTION
This field was redundant with `tr_url_parsed.port`, so remove it