### PR TITLE
refactor: remove tr_announce_list.tracker_info.scrape

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -90,11 +90,11 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
     if (auto const scrape_str = announceToScrape(announce_url_sv); scrape_str)
     {
         tracker.scrape_str = *scrape_str;
-        tracker.scrape = *tr_urlParseTracker(tracker.scrape_str.sv());
     }
 
     auto const it = std::lower_bound(std::begin(trackers_), std::end(trackers_), tracker);
     trackers_.insert(it, tracker);
+
     return true;
 }
 

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -26,14 +26,13 @@ public:
     struct tracker_info
     {
         tr_url_parsed_t announce;
-        tr_url_parsed_t scrape;
         tr_interned_string announce_str;
         tr_interned_string scrape_str;
         tr_interned_string host;
         tr_tracker_tier_t tier = 0;
         tr_tracker_id_t id = 0;
 
-        [[nodiscard]] int compare(tracker_info const& that) const // <=>
+        [[nodiscard]] constexpr int compare(tracker_info const& that) const noexcept // <=>
         {
             if (this->tier != that.tier)
             {
@@ -48,12 +47,12 @@ public:
             return 0;
         }
 
-        [[nodiscard]] bool operator<(tracker_info const& that) const
+        [[nodiscard]] constexpr bool operator<(tracker_info const& that) const noexcept
         {
             return compare(that) < 0;
         }
 
-        [[nodiscard]] bool operator==(tracker_info const& that) const
+        [[nodiscard]] constexpr bool operator==(tracker_info const& that) const noexcept
         {
             return compare(that) == 0;
         }

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -34,7 +34,7 @@ TEST_F(AnnounceListTest, canAdd)
     EXPECT_EQ(1, announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
     EXPECT_EQ(Announce, tracker.announce.full);
-    EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape.full);
+    EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape_str.sv());
     EXPECT_EQ(Tier, tracker.tier);
     EXPECT_EQ("example.org:443"sv, tracker.host.sv());
 }
@@ -87,7 +87,7 @@ TEST_F(AnnounceListTest, canAddUdp)
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
     EXPECT_EQ(Announce, tracker.announce.full);
-    EXPECT_EQ("udp://example.org/"sv, tracker.scrape.full);
+    EXPECT_EQ("udp://example.org/"sv, tracker.scrape_str.sv());
     EXPECT_EQ(Tier, tracker.tier);
 }
 

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -70,11 +70,11 @@ TEST(MagnetMetainfo, magnetParse)
         auto it = std::begin(mm.announceList());
         EXPECT_EQ(0U, it->tier);
         EXPECT_EQ("http://tracker.openbittorrent.com/announce"sv, it->announce.full);
-        EXPECT_EQ("http://tracker.openbittorrent.com/scrape"sv, it->scrape.full);
+        EXPECT_EQ("http://tracker.openbittorrent.com/scrape"sv, it->scrape_str.sv());
         ++it;
         EXPECT_EQ(1U, it->tier);
         EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce.full);
-        EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape.full);
+        EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape_str.sv());
         EXPECT_EQ(1U, mm.webseedCount());
         EXPECT_EQ("http://server.webseed.org/path/to/file"sv, mm.webseed(0));
         EXPECT_EQ("Display Name"sv, mm.name());

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -339,7 +339,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         // build the full scrape URL
         auto escaped = std::array<char, TR_SHA1_DIGEST_LEN * 3 + 1>{};
         tr_http_escape_sha1(std::data(escaped), metainfo.infoHash());
-        auto const scrape = tracker.scrape.full;
+        auto const scrape = tracker.scrape_str.sv();
         auto const url = tr_urlbuf{ scrape,
                                     tr_strvContains(scrape, '?') ? '&' : '?',
                                     "info_hash="sv,


### PR DESCRIPTION
`tr_url_parsed_t` is pretty large -- 134 bytes -- so remove the unused instance that held the parsed scrape URL.