### PR TITLE
refactor: remove tr_announce_list::tracker info.announce

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -81,7 +81,7 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
     }
 
     auto tracker = tracker_info{};
-    tracker.announce_str = announce_url_sv;
+    tracker.announce = announce_url_sv;
     tracker.tier = getTier(tier, *announce);
     tracker.id = nextUniqueId();
     tracker.host = fmt::format(FMT_STRING("{:s}:{:d}"), announce->host, announce->port);
@@ -89,7 +89,7 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
 
     if (auto const scrape_str = announceToScrape(announce_url_sv); scrape_str)
     {
-        tracker.scrape_str = *scrape_str;
+        tracker.scrape = *scrape_str;
     }
 
     auto const it = std::lower_bound(std::begin(trackers_), std::end(trackers_), tracker);
@@ -117,7 +117,7 @@ void tr_announce_list::add(tr_announce_list const& src)
             ++tgt_tier;
         }
 
-        tgt.add(tracker.announce_str.sv(), tgt_tier);
+        tgt.add(tracker.announce.sv(), tgt_tier);
     }
 }
 
@@ -191,7 +191,7 @@ tr_announce_list::trackers_t::iterator tr_announce_list::find(std::string_view a
 {
     auto const test = [&announce](auto const& tracker)
     {
-        return announce == tracker.announce_str.sv();
+        return announce == tracker.announce.sv();
     };
     return std::find_if(std::begin(trackers_), std::end(trackers_), test);
 }
@@ -203,7 +203,7 @@ tr_tracker_tier_t tr_announce_list::getTier(tr_tracker_tier_t tier, tr_url_parse
 {
     auto const is_sibling = [&announce](auto const& tracker)
     {
-        auto const tracker_announce = tracker.announce_str.sv();
+        auto const tracker_announce = tracker.announce.sv();
 
         // fast test to avoid tr_urlParse()ing most trackers
         if (!tr_strvContains(tracker_announce, announce.host))
@@ -226,7 +226,7 @@ bool tr_announce_list::canAdd(tr_url_parsed_t const& announce)
     // "http://tracker/announce" + "http://tracker:80/announce"
     auto const is_same = [&announce](auto const& tracker)
     {
-        auto const tracker_announce = tracker.announce_str.sv();
+        auto const tracker_announce = tracker.announce.sv();
 
         // fast test to avoid tr_urlParse()ing most trackers
         if (!tr_strvContains(tracker_announce, announce.host))
@@ -257,7 +257,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
     // add the new fields
     if (this->size() == 1)
     {
-        tr_variantDictAddQuark(&metainfo, TR_KEY_announce, at(0).announce_str.quark());
+        tr_variantDictAddQuark(&metainfo, TR_KEY_announce, at(0).announce.quark());
     }
     else if (this->size() > 1)
     {
@@ -274,7 +274,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
                 current_tier = tracker.tier;
             }
 
-            tr_variantListAddQuark(tracker_list, tracker.announce_str.quark());
+            tr_variantListAddQuark(tracker_list, tracker.announce.quark());
         }
     }
 
@@ -340,7 +340,7 @@ std::string tr_announce_list::toString() const
             text += '\n';
         }
 
-        text += tracker.announce_str.sv();
+        text += tracker.announce.sv();
         text += '\n';
 
         current_tier = tracker.tier;

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -25,9 +25,8 @@ class tr_announce_list
 public:
     struct tracker_info
     {
-        // tr_url_parsed_t announce;
-        tr_interned_string announce_str;
-        tr_interned_string scrape_str;
+        tr_interned_string announce;
+        tr_interned_string scrape;
         tr_interned_string host; // 'example.org:80'
         tr_interned_string sitename; // 'example'
         tr_tracker_tier_t tier = 0;
@@ -40,7 +39,7 @@ public:
                 return this->tier < that.tier ? -1 : 1;
             }
 
-            if (int const i{ this->announce_str.compare(that.announce_str) }; i != 0)
+            if (int const i{ this->announce.compare(that.announce) }; i != 0)
             {
                 return i;
             }

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -25,10 +25,11 @@ class tr_announce_list
 public:
     struct tracker_info
     {
-        tr_url_parsed_t announce;
+        // tr_url_parsed_t announce;
         tr_interned_string announce_str;
         tr_interned_string scrape_str;
-        tr_interned_string host;
+        tr_interned_string host; // 'example.org:80'
+        tr_interned_string sitename; // 'example'
         tr_tracker_tier_t tier = 0;
         tr_tracker_id_t id = 0;
 
@@ -39,9 +40,9 @@ public:
                 return this->tier < that.tier ? -1 : 1;
             }
 
-            if (this->announce.full != that.announce.full)
+            if (int const i{ this->announce_str.compare(that.announce_str) }; i != 0)
             {
-                return this->announce.full < that.announce.full ? -1 : 1;
+                return i;
             }
 
             return 0;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -231,9 +231,9 @@ struct tr_tracker
 {
     explicit tr_tracker(tr_announcer* announcer, tr_announce_list::tracker_info const& info)
         : host{ info.host }
-        , announce_url{ info.announce_str }
+        , announce_url{ info.announce }
         , sitename{ info.sitename }
-        , scrape_info{ std::empty(info.scrape_str) ? nullptr : tr_announcerGetScrapeInfo(announcer, info.scrape_str) }
+        , scrape_info{ std::empty(info.scrape) ? nullptr : tr_announcerGetScrapeInfo(announcer, info.scrape) }
         , id{ info.id }
     {
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -232,7 +232,7 @@ struct tr_tracker
     explicit tr_tracker(tr_announcer* announcer, tr_announce_list::tracker_info const& info)
         : host{ info.host }
         , announce_url{ info.announce_str }
-        , sitename{ info.announce.sitename }
+        , sitename{ info.sitename }
         , scrape_info{ std::empty(info.scrape_str) ? nullptr : tr_announcerGetScrapeInfo(announcer, info.scrape_str) }
         , id{ info.id }
     {

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -169,7 +169,7 @@ tr_urlbuf tr_magnet_metainfo::magnet() const
     for (auto const& tracker : this->announceList())
     {
         s += "&tr="sv;
-        tr_http_escape(std::back_inserter(s), tracker.announce_str.sv(), true);
+        tr_http_escape(std::back_inserter(s), tracker.announce.sv(), true);
     }
 
     for (auto const& webseed : webseed_urls_)

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -169,7 +169,7 @@ tr_urlbuf tr_magnet_metainfo::magnet() const
     for (auto const& tracker : this->announceList())
     {
         s += "&tr="sv;
-        tr_http_escape(std::back_inserter(s), tracker.announce.full, true);
+        tr_http_escape(std::back_inserter(s), tracker.announce_str.sv(), true);
     }
 
     for (auto const& webseed : webseed_urls_)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -404,9 +404,9 @@ static void addTrackers(tr_torrent const* tor, tr_variant* trackers)
     for (auto const& tracker : tor->announceList())
     {
         auto* const d = tr_variantListAddDict(trackers, 5);
-        tr_variantDictAddQuark(d, TR_KEY_announce, tracker.announce_str.quark());
+        tr_variantDictAddQuark(d, TR_KEY_announce, tracker.announce.quark());
         tr_variantDictAddInt(d, TR_KEY_id, tracker.id);
-        tr_variantDictAddQuark(d, TR_KEY_scrape, tracker.scrape_str.quark());
+        tr_variantDictAddQuark(d, TR_KEY_scrape, tracker.scrape.quark());
         tr_variantDictAddStrView(d, TR_KEY_sitename, tracker.sitename);
         tr_variantDictAddInt(d, TR_KEY_tier, tracker.tier);
     }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -407,7 +407,7 @@ static void addTrackers(tr_torrent const* tor, tr_variant* trackers)
         tr_variantDictAddQuark(d, TR_KEY_announce, tracker.announce_str.quark());
         tr_variantDictAddInt(d, TR_KEY_id, tracker.id);
         tr_variantDictAddQuark(d, TR_KEY_scrape, tracker.scrape_str.quark());
-        tr_variantDictAddStrView(d, TR_KEY_sitename, tracker.announce.sitename);
+        tr_variantDictAddStrView(d, TR_KEY_sitename, tracker.sitename);
         tr_variantDictAddInt(d, TR_KEY_tier, tracker.tier);
     }
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -207,7 +207,7 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
         auto const n = std::size(announce_list);
         if (n == 1)
         {
-            tr_variantDictAddStr(top, TR_KEY_announce, announce_list.at(0).announce_str.sv());
+            tr_variantDictAddStr(top, TR_KEY_announce, announce_list.at(0).announce.sv());
         }
         else
         {
@@ -221,7 +221,7 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
                     tier_variant = tr_variantListAddList(announce_list_variant, n);
                 }
 
-                tr_variantListAddStr(tier_variant, tracker.announce_str.sv());
+                tr_variantListAddStr(tier_variant, tracker.announce.sv());
             }
         }
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2118,7 +2118,7 @@ bool tr_torrent::setTrackerList(std::string_view text)
         if (std::any_of(
                 std::begin(this->announceList()),
                 std::end(this->announceList()),
-                [error_url](auto const& tracker) { return tracker.announce_str == error_url; }))
+                [error_url](auto const& tracker) { return tracker.announce == error_url; }))
         {
             tr_torrentClearError(this);
         }

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -172,7 +172,7 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
 #warning handle tiers?
         for (auto const& tracker : announce_list)
         {
-            [listSection appendFormat:@"<tr><td>%s<td></tr>", tracker.announce_str.c_str()];
+            [listSection appendFormat:@"<tr><td>%s<td></tr>", tracker.announce.c_str()];
         }
 
         [listSection appendString:@"</table>"];

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -33,7 +33,7 @@ TEST_F(AnnounceListTest, canAdd)
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(1, announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce.full);
+    EXPECT_EQ(Announce, tracker.announce_str.sv());
     EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape_str.sv());
     EXPECT_EQ(Tier, tracker.tier);
     EXPECT_EQ("example.org:443"sv, tracker.host.sv());
@@ -57,11 +57,11 @@ TEST_F(AnnounceListTest, groupsSiblingsIntoSameTier)
     EXPECT_EQ(Tier1, announce_list.at(0).tier);
     EXPECT_EQ(Tier1, announce_list.at(1).tier);
     EXPECT_EQ(Tier1, announce_list.at(2).tier);
-    EXPECT_EQ(Announce1, announce_list.at(1).announce.full);
-    EXPECT_EQ(Announce2, announce_list.at(0).announce.full);
-    EXPECT_EQ(Announce3, announce_list.at(2).announce.full);
-    EXPECT_EQ("example.org:443"sv, announce_list.at(1).host.sv());
-    EXPECT_EQ("example.org:80"sv, announce_list.at(0).host.sv());
+    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce2, announce_list.at(1).announce_str.sv());
+    EXPECT_EQ(Announce3, announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("example.org:443"sv, announce_list.at(0).host.sv());
+    EXPECT_EQ("example.org:80"sv, announce_list.at(1).host.sv());
     EXPECT_EQ("example.org:999"sv, announce_list.at(2).host.sv());
 }
 
@@ -73,7 +73,7 @@ TEST_F(AnnounceListTest, canAddWithoutScrape)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce.full);
+    EXPECT_EQ(Announce, tracker.announce_str.sv());
     EXPECT_TRUE(std::empty(tracker.scrape_str));
     EXPECT_EQ(Tier, tracker.tier);
 }
@@ -86,7 +86,7 @@ TEST_F(AnnounceListTest, canAddUdp)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce.full);
+    EXPECT_EQ(Announce, tracker.announce_str.sv());
     EXPECT_EQ("udp://example.org/"sv, tracker.scrape_str.sv());
     EXPECT_EQ(Tier, tracker.tier);
 }
@@ -132,9 +132,9 @@ TEST_F(AnnounceListTest, canSet)
     EXPECT_EQ(Tiers[0], announce_list.at(0).tier);
     EXPECT_EQ(Tiers[1], announce_list.at(1).tier);
     EXPECT_EQ(Tiers[2], announce_list.at(2).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce.full);
-    EXPECT_EQ(Urls[1], announce_list.at(1).announce.full);
-    EXPECT_EQ(Urls[2], announce_list.at(2).announce.full);
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(1).announce_str.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(2).announce_str.sv());
     auto const expected_tiers = std::set<tr_tracker_tier_t>(std::begin(Tiers), std::end(Tiers));
     auto const tiers = announce_list.tiers();
     EXPECT_EQ(expected_tiers, tiers);
@@ -157,12 +157,12 @@ TEST_F(AnnounceListTest, canSetUnsortedWithBackupsInTiers)
     EXPECT_EQ(1U, announce_list.at(3).tier);
     EXPECT_EQ(2U, announce_list.at(4).tier);
     EXPECT_EQ(2U, announce_list.at(5).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce.full);
-    EXPECT_EQ(Urls[3], announce_list.at(1).announce.full);
-    EXPECT_EQ(Urls[1], announce_list.at(2).announce.full);
-    EXPECT_EQ(Urls[4], announce_list.at(3).announce.full);
-    EXPECT_EQ(Urls[2], announce_list.at(4).announce.full);
-    EXPECT_EQ(Urls[5], announce_list.at(5).announce.full);
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Urls[3], announce_list.at(1).announce_str.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(2).announce_str.sv());
+    EXPECT_EQ(Urls[4], announce_list.at(3).announce_str.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(4).announce_str.sv());
+    EXPECT_EQ(Urls[5], announce_list.at(5).announce_str.sv());
 
     // confirm that each has a unique id
     auto ids = std::set<tr_tracker_id_t>{};
@@ -187,8 +187,8 @@ TEST_F(AnnounceListTest, canSetExceptDuplicate)
     EXPECT_EQ(2U, announce_list.size());
     EXPECT_EQ(Tiers[0], announce_list.at(1).tier);
     EXPECT_EQ(Tiers[1], announce_list.at(0).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(1).announce.full);
-    EXPECT_EQ(Urls[1], announce_list.at(0).announce.full);
+    EXPECT_EQ(Urls[0], announce_list.at(1).announce_str.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canSetExceptInvalid)
@@ -205,8 +205,8 @@ TEST_F(AnnounceListTest, canSetExceptInvalid)
     EXPECT_EQ(2U, announce_list.size());
     EXPECT_EQ(Tiers[0], announce_list.at(0).tier);
     EXPECT_EQ(Tiers[2], announce_list.at(1).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce.full);
-    EXPECT_EQ(Urls[2], announce_list.at(1).announce.full);
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(1).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canRemoveById)
@@ -235,7 +235,7 @@ TEST_F(AnnounceListTest, canNotRemoveByInvalidId)
 
     EXPECT_FALSE(announce_list.remove(id + 1));
     EXPECT_EQ(1U, std::size(announce_list));
-    EXPECT_EQ(Announce, announce_list.at(0).announce.full);
+    EXPECT_EQ(Announce, announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canRemoveByAnnounce)
@@ -273,7 +273,7 @@ TEST_F(AnnounceListTest, canReplace)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_TRUE(announce_list.replace(announce_list.at(0).id, Announce2));
-    EXPECT_EQ(Announce2, announce_list.at(0).announce.full);
+    EXPECT_EQ(Announce2, announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceInvalidId)
@@ -285,7 +285,7 @@ TEST_F(AnnounceListTest, canNotReplaceInvalidId)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id + 1, Announce2));
-    EXPECT_EQ(Announce1, announce_list.at(0).announce.full);
+    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceWithInvalidAnnounce)
@@ -297,7 +297,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithInvalidAnnounce)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce2));
-    EXPECT_EQ(Announce1, announce_list.at(0).announce.full);
+    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceWithDuplicate)
@@ -308,7 +308,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithDuplicate)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce));
-    EXPECT_EQ(Announce, announce_list.at(0).announce.full);
+    EXPECT_EQ(Announce, announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, announceToScrape)
@@ -399,7 +399,7 @@ TEST_F(AnnounceListTest, SingleAnnounce)
     auto constexpr Text = "https://www.example.com/a/announce";
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(1U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
 }
 
 TEST_F(AnnounceListTest, parseThreeTier)
@@ -415,11 +415,11 @@ TEST_F(AnnounceListTest, parseThreeTier)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
     EXPECT_EQ(fmt::format("{:s}\n", Text), announce_list.toString());
 }
@@ -437,11 +437,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithTrailingLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
     EXPECT_EQ(Text, announce_list.toString());
 }
@@ -468,11 +468,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithExcessLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -501,11 +501,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithWhitespace)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -530,11 +530,11 @@ TEST_F(AnnounceListTest, parseThreeTierCrLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -566,25 +566,25 @@ TEST_F(AnnounceListTest, parseMultiTrackerInTier)
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(9U, std::size(announce_list));
 
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.full);
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.full);
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
     EXPECT_EQ(0U, announce_list.at(1).tier);
 
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.full);
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(2).tier);
-    EXPECT_EQ("https://www.example.com/d/announce", announce_list.at(3).announce.full);
+    EXPECT_EQ("https://www.example.com/d/announce", announce_list.at(3).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(3).tier);
-    EXPECT_EQ("https://www.example.com/e/announce", announce_list.at(4).announce.full);
+    EXPECT_EQ("https://www.example.com/e/announce", announce_list.at(4).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(4).tier);
-    EXPECT_EQ("https://www.example.com/f/announce", announce_list.at(5).announce.full);
+    EXPECT_EQ("https://www.example.com/f/announce", announce_list.at(5).announce_str.sv());
     EXPECT_EQ(1U, announce_list.at(5).tier);
 
-    EXPECT_EQ("https://www.example.com/g/announce", announce_list.at(6).announce.full);
+    EXPECT_EQ("https://www.example.com/g/announce", announce_list.at(6).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(6).tier);
-    EXPECT_EQ("https://www.example.com/h/announce", announce_list.at(7).announce.full);
+    EXPECT_EQ("https://www.example.com/h/announce", announce_list.at(7).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(7).tier);
-    EXPECT_EQ("https://www.example.com/i/announce", announce_list.at(8).announce.full);
+    EXPECT_EQ("https://www.example.com/i/announce", announce_list.at(8).announce_str.sv());
     EXPECT_EQ(2U, announce_list.at(8).tier);
 
     EXPECT_EQ(Text, announce_list.toString());

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -33,8 +33,8 @@ TEST_F(AnnounceListTest, canAdd)
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(1, announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce_str.sv());
-    EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape_str.sv());
+    EXPECT_EQ(Announce, tracker.announce.sv());
+    EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape.sv());
     EXPECT_EQ(Tier, tracker.tier);
     EXPECT_EQ("example.org:443"sv, tracker.host.sv());
 }
@@ -57,9 +57,9 @@ TEST_F(AnnounceListTest, groupsSiblingsIntoSameTier)
     EXPECT_EQ(Tier1, announce_list.at(0).tier);
     EXPECT_EQ(Tier1, announce_list.at(1).tier);
     EXPECT_EQ(Tier1, announce_list.at(2).tier);
-    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
-    EXPECT_EQ(Announce2, announce_list.at(1).announce_str.sv());
-    EXPECT_EQ(Announce3, announce_list.at(2).announce_str.sv());
+    EXPECT_EQ(Announce1, announce_list.at(0).announce.sv());
+    EXPECT_EQ(Announce2, announce_list.at(1).announce.sv());
+    EXPECT_EQ(Announce3, announce_list.at(2).announce.sv());
     EXPECT_EQ("example.org:443"sv, announce_list.at(0).host.sv());
     EXPECT_EQ("example.org:80"sv, announce_list.at(1).host.sv());
     EXPECT_EQ("example.org:999"sv, announce_list.at(2).host.sv());
@@ -73,8 +73,8 @@ TEST_F(AnnounceListTest, canAddWithoutScrape)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce_str.sv());
-    EXPECT_TRUE(std::empty(tracker.scrape_str));
+    EXPECT_EQ(Announce, tracker.announce.sv());
+    EXPECT_TRUE(std::empty(tracker.scrape));
     EXPECT_EQ(Tier, tracker.tier);
 }
 
@@ -86,8 +86,8 @@ TEST_F(AnnounceListTest, canAddUdp)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     auto const tracker = announce_list.at(0);
-    EXPECT_EQ(Announce, tracker.announce_str.sv());
-    EXPECT_EQ("udp://example.org/"sv, tracker.scrape_str.sv());
+    EXPECT_EQ(Announce, tracker.announce.sv());
+    EXPECT_EQ("udp://example.org/"sv, tracker.scrape.sv());
     EXPECT_EQ(Tier, tracker.tier);
 }
 
@@ -132,9 +132,9 @@ TEST_F(AnnounceListTest, canSet)
     EXPECT_EQ(Tiers[0], announce_list.at(0).tier);
     EXPECT_EQ(Tiers[1], announce_list.at(1).tier);
     EXPECT_EQ(Tiers[2], announce_list.at(2).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
-    EXPECT_EQ(Urls[1], announce_list.at(1).announce_str.sv());
-    EXPECT_EQ(Urls[2], announce_list.at(2).announce_str.sv());
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(1).announce.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(2).announce.sv());
     auto const expected_tiers = std::set<tr_tracker_tier_t>(std::begin(Tiers), std::end(Tiers));
     auto const tiers = announce_list.tiers();
     EXPECT_EQ(expected_tiers, tiers);
@@ -157,12 +157,12 @@ TEST_F(AnnounceListTest, canSetUnsortedWithBackupsInTiers)
     EXPECT_EQ(1U, announce_list.at(3).tier);
     EXPECT_EQ(2U, announce_list.at(4).tier);
     EXPECT_EQ(2U, announce_list.at(5).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
-    EXPECT_EQ(Urls[3], announce_list.at(1).announce_str.sv());
-    EXPECT_EQ(Urls[1], announce_list.at(2).announce_str.sv());
-    EXPECT_EQ(Urls[4], announce_list.at(3).announce_str.sv());
-    EXPECT_EQ(Urls[2], announce_list.at(4).announce_str.sv());
-    EXPECT_EQ(Urls[5], announce_list.at(5).announce_str.sv());
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce.sv());
+    EXPECT_EQ(Urls[3], announce_list.at(1).announce.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(2).announce.sv());
+    EXPECT_EQ(Urls[4], announce_list.at(3).announce.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(4).announce.sv());
+    EXPECT_EQ(Urls[5], announce_list.at(5).announce.sv());
 
     // confirm that each has a unique id
     auto ids = std::set<tr_tracker_id_t>{};
@@ -187,8 +187,8 @@ TEST_F(AnnounceListTest, canSetExceptDuplicate)
     EXPECT_EQ(2U, announce_list.size());
     EXPECT_EQ(Tiers[0], announce_list.at(1).tier);
     EXPECT_EQ(Tiers[1], announce_list.at(0).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(1).announce_str.sv());
-    EXPECT_EQ(Urls[1], announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Urls[0], announce_list.at(1).announce.sv());
+    EXPECT_EQ(Urls[1], announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canSetExceptInvalid)
@@ -205,8 +205,8 @@ TEST_F(AnnounceListTest, canSetExceptInvalid)
     EXPECT_EQ(2U, announce_list.size());
     EXPECT_EQ(Tiers[0], announce_list.at(0).tier);
     EXPECT_EQ(Tiers[2], announce_list.at(1).tier);
-    EXPECT_EQ(Urls[0], announce_list.at(0).announce_str.sv());
-    EXPECT_EQ(Urls[2], announce_list.at(1).announce_str.sv());
+    EXPECT_EQ(Urls[0], announce_list.at(0).announce.sv());
+    EXPECT_EQ(Urls[2], announce_list.at(1).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canRemoveById)
@@ -235,7 +235,7 @@ TEST_F(AnnounceListTest, canNotRemoveByInvalidId)
 
     EXPECT_FALSE(announce_list.remove(id + 1));
     EXPECT_EQ(1U, std::size(announce_list));
-    EXPECT_EQ(Announce, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce, announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canRemoveByAnnounce)
@@ -273,7 +273,7 @@ TEST_F(AnnounceListTest, canReplace)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_TRUE(announce_list.replace(announce_list.at(0).id, Announce2));
-    EXPECT_EQ(Announce2, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce2, announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceInvalidId)
@@ -285,7 +285,7 @@ TEST_F(AnnounceListTest, canNotReplaceInvalidId)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id + 1, Announce2));
-    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce1, announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceWithInvalidAnnounce)
@@ -297,7 +297,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithInvalidAnnounce)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce1, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce2));
-    EXPECT_EQ(Announce1, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce1, announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, canNotReplaceWithDuplicate)
@@ -308,7 +308,7 @@ TEST_F(AnnounceListTest, canNotReplaceWithDuplicate)
     auto announce_list = tr_announce_list{};
     EXPECT_TRUE(announce_list.add(Announce, Tier));
     EXPECT_FALSE(announce_list.replace(announce_list.at(0).id, Announce));
-    EXPECT_EQ(Announce, announce_list.at(0).announce_str.sv());
+    EXPECT_EQ(Announce, announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, announceToScrape)
@@ -399,7 +399,7 @@ TEST_F(AnnounceListTest, SingleAnnounce)
     auto constexpr Text = "https://www.example.com/a/announce";
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(1U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
 }
 
 TEST_F(AnnounceListTest, parseThreeTier)
@@ -415,11 +415,11 @@ TEST_F(AnnounceListTest, parseThreeTier)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
     EXPECT_EQ(fmt::format("{:s}\n", Text), announce_list.toString());
 }
@@ -437,11 +437,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithTrailingLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
     EXPECT_EQ(Text, announce_list.toString());
 }
@@ -468,11 +468,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithExcessLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -501,11 +501,11 @@ TEST_F(AnnounceListTest, parseThreeTierWithWhitespace)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -530,11 +530,11 @@ TEST_F(AnnounceListTest, parseThreeTierCrLf)
 
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(3U, std::size(announce_list));
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(1U, announce_list.at(1).tier);
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(2U, announce_list.at(2).tier);
 
     auto constexpr ExpectedText =
@@ -566,25 +566,25 @@ TEST_F(AnnounceListTest, parseMultiTrackerInTier)
     EXPECT_TRUE(announce_list.parse(Text));
     EXPECT_EQ(9U, std::size(announce_list));
 
-    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/a/announce", announce_list.at(0).announce.sv());
     EXPECT_EQ(0U, announce_list.at(0).tier);
-    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/b/announce", announce_list.at(1).announce.sv());
     EXPECT_EQ(0U, announce_list.at(1).tier);
 
-    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/c/announce", announce_list.at(2).announce.sv());
     EXPECT_EQ(1U, announce_list.at(2).tier);
-    EXPECT_EQ("https://www.example.com/d/announce", announce_list.at(3).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/d/announce", announce_list.at(3).announce.sv());
     EXPECT_EQ(1U, announce_list.at(3).tier);
-    EXPECT_EQ("https://www.example.com/e/announce", announce_list.at(4).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/e/announce", announce_list.at(4).announce.sv());
     EXPECT_EQ(1U, announce_list.at(4).tier);
-    EXPECT_EQ("https://www.example.com/f/announce", announce_list.at(5).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/f/announce", announce_list.at(5).announce.sv());
     EXPECT_EQ(1U, announce_list.at(5).tier);
 
-    EXPECT_EQ("https://www.example.com/g/announce", announce_list.at(6).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/g/announce", announce_list.at(6).announce.sv());
     EXPECT_EQ(2U, announce_list.at(6).tier);
-    EXPECT_EQ("https://www.example.com/h/announce", announce_list.at(7).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/h/announce", announce_list.at(7).announce.sv());
     EXPECT_EQ(2U, announce_list.at(7).tier);
-    EXPECT_EQ("https://www.example.com/i/announce", announce_list.at(8).announce_str.sv());
+    EXPECT_EQ("https://www.example.com/i/announce", announce_list.at(8).announce.sv());
     EXPECT_EQ(2U, announce_list.at(8).tier);
 
     EXPECT_EQ(Text, announce_list.toString());

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -69,11 +69,11 @@ TEST(MagnetMetainfo, magnetParse)
         EXPECT_EQ(2U, std::size(mm.announceList()));
         auto it = std::begin(mm.announceList());
         EXPECT_EQ(0U, it->tier);
-        EXPECT_EQ("http://tracker.openbittorrent.com/announce"sv, it->announce.full);
+        EXPECT_EQ("http://tracker.openbittorrent.com/announce"sv, it->announce_str.sv());
         EXPECT_EQ("http://tracker.openbittorrent.com/scrape"sv, it->scrape_str.sv());
         ++it;
         EXPECT_EQ(1U, it->tier);
-        EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce.full);
+        EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce_str.sv());
         EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape_str.sv());
         EXPECT_EQ(1U, mm.webseedCount());
         EXPECT_EQ("http://server.webseed.org/path/to/file"sv, mm.webseed(0));

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -69,12 +69,12 @@ TEST(MagnetMetainfo, magnetParse)
         EXPECT_EQ(2U, std::size(mm.announceList()));
         auto it = std::begin(mm.announceList());
         EXPECT_EQ(0U, it->tier);
-        EXPECT_EQ("http://tracker.openbittorrent.com/announce"sv, it->announce_str.sv());
-        EXPECT_EQ("http://tracker.openbittorrent.com/scrape"sv, it->scrape_str.sv());
+        EXPECT_EQ("http://tracker.openbittorrent.com/announce"sv, it->announce.sv());
+        EXPECT_EQ("http://tracker.openbittorrent.com/scrape"sv, it->scrape.sv());
         ++it;
         EXPECT_EQ(1U, it->tier);
-        EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce_str.sv());
-        EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape_str.sv());
+        EXPECT_EQ("http://tracker.opentracker.org/announce", it->announce.sv());
+        EXPECT_EQ("http://tracker.opentracker.org/scrape", it->scrape.sv());
         EXPECT_EQ(1U, mm.webseedCount());
         EXPECT_EQ("http://server.webseed.org/path/to/file"sv, mm.webseed(0));
         EXPECT_EQ("Display Name"sv, mm.name());

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -235,7 +235,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
                 ++print_tier;
             }
 
-            printf("  %" TR_PRIsv "\n", TR_PRIsv_ARG(tracker.announce_str.sv()));
+            printf("  %" TR_PRIsv "\n", TR_PRIsv_ARG(tracker.announce.sv()));
         }
 
         /**
@@ -331,7 +331,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
     for (auto const& tracker : metainfo.announceList())
     {
-        if (std::empty(tracker.scrape_str))
+        if (std::empty(tracker.scrape))
         {
             continue;
         }
@@ -339,7 +339,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         // build the full scrape URL
         auto escaped = std::array<char, TR_SHA1_DIGEST_LEN * 3 + 1>{};
         tr_http_escape_sha1(std::data(escaped), metainfo.infoHash());
-        auto const scrape = tracker.scrape_str.sv();
+        auto const scrape = tracker.scrape.sv();
         auto const url = tr_urlbuf{ scrape,
                                     tr_strvContains(scrape, '?') ? '&' : '?',
                                     "info_hash="sv,

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -235,7 +235,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
                 ++print_tier;
             }
 
-            printf("  %" TR_PRIsv "\n", TR_PRIsv_ARG(tracker.announce.full));
+            printf("  %" TR_PRIsv "\n", TR_PRIsv_ARG(tracker.announce_str.sv()));
         }
 
         /**


### PR DESCRIPTION
`tr_url_parsed_t` is pretty large -- 134 bytes -- so remove the parsed announce URL from `tr_announce_list::tracker_info`.