### PR TITLE
build: pass cmake compiler values to submodules

### DIFF
--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -106,7 +106,9 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
                 -Wno-dev # We don't want to be warned over unused variables
                 "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}"
                 "-DCMAKE_USER_MAKE_RULES_OVERRIDE=${CMAKE_USER_MAKE_RULES_OVERRIDE}"
+                "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                 "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}"
+                "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                 "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}"
                 "-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}"
                 "-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>"


### PR DESCRIPTION
This is needed for consistent building when using compiler-specific tooling such as address sanitizer flags.