### PR TITLE
refactor: make tr_peerMgr.webseeds a std::vector

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -495,7 +495,7 @@ static int countActiveWebseeds(tr_swarm* s)
     return std::count_if(
         std::begin(s->webseeds),
         std::end(s->webseeds),
-        [&now](auto const& webseed){ return webseed->is_transferring_pieces(now, TR_DOWN, nullptr); });
+        [&now](auto const& webseed) { return webseed->is_transferring_pieces(now, TR_DOWN, nullptr); });
 }
 
 // TODO: if we keep this, add equivalent API to ActiveRequest


### PR DESCRIPTION
Trying to remove the last instances of `tr_ptrArray` so that it can be removed. This PR removes one of the remaining four by making `tr_peerMsgs.webseeds` a `std::vector`.