### PR TITLE
fix: uninintialized field tr_torrent_files.total_size_

### DIFF
--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -147,5 +147,5 @@ private:
     };
 
     std::vector<file_t> files_;
-    uint64_t total_size_;
+    uint64_t total_size_ = 0;
 };


### PR DESCRIPTION
Found by Coverity.