### PR TITLE
refactor: use std::vector<tr_quark> for torrent labels

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -104,7 +104,7 @@ static void saveLabels(tr_variant* dict, tr_torrent const* tor)
     tr_variant* list = tr_variantDictAddList(dict, TR_KEY_labels, std::size(labels));
     for (auto const& label : labels)
     {
-        tr_variantListAddStr(list, label);
+        tr_variantListAddQuark(list, label);
     }
 }
 
@@ -116,16 +116,19 @@ static auto loadLabels(tr_variant* dict, tr_torrent* tor)
         return tr_resume::fields_t{};
     }
 
-    int const n = tr_variantListSize(list);
-    for (int i = 0; i < n; ++i)
+    auto const n = tr_variantListSize(list);
+    auto labels = std::vector<tr_quark>{};
+    labels.reserve(n);
+    for (size_t i = 0; i < n; ++i)
     {
         auto sv = std::string_view{};
         if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv))
         {
-            tor->labels.emplace(sv);
+            labels.emplace_back(tr_quark_new(sv));
         }
     }
 
+    tor->setLabels(std::data(labels), std::size(labels));
     return tr_resume::Labels;
 }
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -41,7 +41,7 @@ struct tr_ctor
 
     tr_priority_t priority = TR_PRI_NORMAL;
 
-    tr_labels_t labels = {};
+    tr_torrent::labels_t labels = {};
 
     struct optional_args optional_args[2];
 
@@ -329,12 +329,12 @@ tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
 ****
 ***/
 
-void tr_ctorSetLabels(tr_ctor* ctor, tr_labels_t&& labels)
+void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels)
 {
-    ctor->labels = std::move(labels);
+    ctor->labels = { labels, labels + n_labels };
 }
 
-tr_labels_t tr_ctorGetLabels(tr_ctor const* ctor)
+tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor)
 {
     return ctor->labels;
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -717,7 +717,8 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->error = TR_STAT_OK;
     tor->finishedSeedingByIdle = false;
 
-    tor->labels = tr_ctorGetLabels(ctor);
+    auto const& labels = tr_ctorGetLabels(ctor);
+    tor->setLabels(std::data(labels), std::size(labels));
 
     tor->uniqueId = session->torrents().add(tor);
 
@@ -1926,13 +1927,13 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 ****
 ***/
 
-void tr_torrentSetLabels(tr_torrent* tor, tr_labels_t&& labels)
+void tr_torrent::setLabels(tr_quark const* new_labels, size_t n_labels)
 {
-    TR_ASSERT(tr_isTorrent(tor));
-    auto const lock = tor->unique_lock();
-
-    tor->labels = std::move(labels);
-    tor->setDirty();
+    auto const lock = unique_lock();
+    auto const sorted_unique = std::set<tr_quark>{ new_labels, new_labels + n_labels };
+    this->labels = { std::begin(sorted_unique), std::end(sorted_unique) };
+    this->labels.shrink_to_fit();
+    this->setDirty();
 }
 
 /***

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -14,7 +14,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 #include "transmission.h"
@@ -41,8 +40,6 @@ struct tr_session;
 struct tr_torrent;
 struct tr_torrent_announcer;
 
-using tr_labels_t = std::unordered_set<std::string>;
-
 /**
 ***  Package-visible ctor API
 **/
@@ -59,13 +56,9 @@ tr_session* tr_ctorGetSession(tr_ctor const* ctor);
 
 bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDir);
 
-tr_labels_t tr_ctorGetLabels(tr_ctor const* ctor);
-
 /**
 ***
 **/
-
-void tr_torrentSetLabels(tr_torrent* tor, tr_labels_t&& labels);
 
 void tr_torrentChangeMyPort(tr_torrent* session);
 
@@ -573,6 +566,8 @@ public:
 
     void setDateActive(time_t t);
 
+    void setLabels(tr_quark const* labels, size_t n_labels);
+
     /** Return the mime-type (e.g. "audio/x-flac") that matches more of the
         torrent's content than any other mime-type. */
     [[nodiscard]] std::string_view primaryMimeType() const;
@@ -707,7 +702,8 @@ public:
     tr_idlelimit idleLimitMode = TR_IDLELIMIT_GLOBAL;
     bool finishedSeedingByIdle = false;
 
-    tr_labels_t labels;
+    using labels_t = std::vector<tr_quark>;
+    labels_t labels;
 
     std::string group;
     /* Set the bandwidth group the torrent belongs to */
@@ -761,7 +757,8 @@ tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string const& filename, tr_error** error);
 bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string const& filename, tr_error** error);
-void tr_ctorSetLabels(tr_ctor* ctor, tr_labels_t&& labels);
+void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels);
+tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);
 
 #define tr_logAddCriticalTor(tor, msg) tr_logAddCritical(msg, (tor)->name())
 #define tr_logAddErrorTor(tor, msg) tr_logAddError(msg, (tor)->name())


### PR DESCRIPTION
Fixes #2939 