### PR TITLE
build: re-enable cert str34 c clang tidy

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -13,6 +13,8 @@ Checks: >
   -cert-str34-c,
   clang-analyzer-core.*,
   clang-analyzer-cplusplus.*,
+  clang-analyzer-deadcode.*,
+  clang-analyzer-optin.cplusplus.*,
   clang-analyzer-security.*,
   clang-analyzer-valist.*,
   cppcoreguidelines-init-variables,

--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -10,7 +10,6 @@ Checks: >
   -cert-err33-c,
   -cert-err34-c,
   -cert-err58-cpp,
-  -cert-str34-c,
   clang-analyzer-core.*,
   clang-analyzer-cplusplus.*,
   clang-analyzer-deadcode.*,


### PR DESCRIPTION
small housekeeping PR: re-enable a clang-tidy test that we didn't need to have disabled.