### PR TITLE
refactor: add a tr_port safety class

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -19,6 +19,7 @@
 #include "transmission.h"
 
 #include "interned-string.h"
+#include "net.h"
 #include "peer-mgr.h" // tr_pex
 #include "web-utils.h"
 
@@ -134,7 +135,7 @@ struct tr_announce_request
     bool partial_seed = false;
 
     /* the port we listen for incoming peers on */
-    int port = 0;
+    tr_port port;
 
     /* per-session key */
     int key = 0;

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -71,7 +71,7 @@ static tr_urlbuf announce_url_new(tr_session const* session, tr_announce_request
         fmt::arg("sep", tr_strvContains(req->announce_url.sv(), '?') ? '&' : '?'),
         fmt::arg("info_hash", std::data(escaped_info_hash)),
         fmt::arg("peer_id", std::string_view{ std::data(req->peer_id), std::size(req->peer_id) }),
-        fmt::arg("port", req->port),
+        fmt::arg("port", req->port.host()),
         fmt::arg("uploaded", req->up),
         fmt::arg("downloaded", req->down),
         fmt::arg("left", req->leftUntilComplete),
@@ -211,7 +211,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             }
             else if (key == "port"sv)
             {
-                pex_.port = htons(uint16_t(value));
+                pex_.port.setHost(static_cast<uint16_t>(value));
             }
             else
             {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -877,7 +877,7 @@ static tr_announce_request* announce_request_new(
     TR_ASSERT(current_tracker != nullptr);
 
     auto* const req = new tr_announce_request();
-    req->port = tr_sessionGetPublicPeerPort(announcer->session);
+    req->port = announcer->session->peerPort();
     req->announce_url = current_tracker->announce_url;
     req->tracker_id = current_tracker->tracker_id;
     req->info_hash = tor->infoHash();

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -15,6 +15,7 @@
  */
 
 #include "natpmp.h"
+#include "net.h" // tr_port
 
 enum tr_natpmp_state
 {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -71,6 +71,82 @@ struct tr_address;
 
 [[nodiscard]] int tr_address_compare(tr_address const* a, tr_address const* b) noexcept;
 
+/**
+ * Literally just a port number.
+ *
+ * Exists so that you never have to wonder what byte order a port variable is in.
+ */
+class tr_port
+{
+private:
+    uint16_t hport_ = 0;
+
+    tr_port(uint16_t hport)
+        : hport_{ hport }
+    {
+    }
+
+public:
+    tr_port() noexcept = default;
+
+    [[nodiscard]] static tr_port fromHost(uint16_t hport) noexcept
+    {
+        return tr_port{ hport };
+    }
+
+    [[nodiscard]] static tr_port fromNetwork(uint16_t nport) noexcept
+    {
+        return tr_port{ ntohs(nport) };
+    }
+
+    [[nodiscard]] constexpr uint16_t host() const noexcept
+    {
+        return hport_;
+    }
+
+    [[nodiscard]] uint16_t network() const noexcept
+    {
+        return htons(hport_);
+    }
+
+    constexpr void setHost(uint16_t hport) noexcept
+    {
+        hport_ = hport;
+    }
+
+    void setNetwork(uint16_t nport) noexcept
+    {
+        hport_ = ntohs(nport);
+    }
+
+    [[nodiscard]] static std::pair<tr_port, uint8_t const*> fromCompact(uint8_t const* compact) noexcept;
+
+    [[nodiscard]] constexpr auto operator<(tr_port const& that) const noexcept
+    {
+        return hport_ < that.hport_;
+    }
+
+    [[nodiscard]] constexpr auto operator==(tr_port const& that) const noexcept
+    {
+        return hport_ == that.hport_;
+    }
+
+    [[nodiscard]] constexpr auto operator!=(tr_port const& that) const noexcept
+    {
+        return hport_ != that.hport_;
+    }
+
+    [[nodiscard]] constexpr auto empty() const noexcept
+    {
+        return hport_ == 0;
+    }
+
+    constexpr void clear() noexcept
+    {
+        hport_ = 0;
+    }
+};
+
 struct tr_address
 {
     static tr_address from_4byte_ipv4(std::string_view in);

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -9,9 +9,11 @@
 #endif
 
 #include <cstddef> // size_t
+#include <cstdint> // uint8_t
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility> // std::pair
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -78,18 +80,10 @@ struct tr_address;
  */
 class tr_port
 {
-private:
-    uint16_t hport_ = 0;
-
-    tr_port(uint16_t hport)
-        : hport_{ hport }
-    {
-    }
-
 public:
     tr_port() noexcept = default;
 
-    [[nodiscard]] static tr_port fromHost(uint16_t hport) noexcept
+    [[nodiscard]] constexpr static tr_port fromHost(uint16_t hport) noexcept
     {
         return tr_port{ hport };
     }
@@ -145,6 +139,14 @@ public:
     {
         hport_ = 0;
     }
+
+private:
+    constexpr tr_port(uint16_t hport) noexcept
+        : hport_{ hport }
+    {
+    }
+
+    uint16_t hport_ = 0;
 };
 
 struct tr_address

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -16,6 +16,7 @@
 #include "bitfield.h"
 #include "history.h"
 #include "interned-string.h"
+#include "net.h" // tr_port
 
 /**
  * @addtogroup peers Peers

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -59,6 +59,8 @@ auto constexpr Bitfield = uint8_t{ 5 };
 auto constexpr Request = uint8_t{ 6 };
 auto constexpr Piece = uint8_t{ 7 };
 auto constexpr Cancel = uint8_t{ 8 };
+
+// http://bittorrent.org/beps/bep_0005.html
 auto constexpr Port = uint8_t{ 9 };
 
 // https://www.bittorrent.org/beps/bep_0006.html
@@ -197,7 +199,7 @@ static void pexPulse(evutil_socket_t fd, short what, void* vmsgs);
 static void protocolSendCancel(tr_peerMsgsImpl* msgs, struct peer_request const& req);
 static void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke);
 static void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index);
-static void protocolSendPort(tr_peerMsgsImpl* msgs, uint16_t port);
+static void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port);
 static void sendInterest(tr_peerMsgsImpl* msgs, bool b);
 static void sendLtepHandshake(tr_peerMsgsImpl* msgs);
 static void tellPeerWhatWeHave(tr_peerMsgsImpl* msgs);
@@ -600,7 +602,7 @@ public:
     uint16_t pexCount = 0;
     uint16_t pexCount6 = 0;
 
-    tr_port dht_port = 0;
+    tr_port dht_port;
 
     EncryptionPreference encryption_preference = EncryptionPreference::Unknown;
 
@@ -738,14 +740,14 @@ static void protocolSendCancel(tr_peerMsgsImpl* msgs, peer_request const& req)
     pokeBatchPeriod(msgs, ImmediatePriorityIntervalSecs);
 }
 
-static void protocolSendPort(tr_peerMsgsImpl* msgs, uint16_t port)
+static void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port)
 {
     struct evbuffer* out = msgs->outMessages;
 
-    logtrace(msgs, fmt::format(FMT_STRING("sending Port {:d}"), port));
+    logtrace(msgs, fmt::format(FMT_STRING("sending Port {:d}"), port.host()));
     evbuffer_add_uint32(out, 3);
     evbuffer_add_uint8(out, BtPeerMsgs::Port);
-    evbuffer_add_uint16(out, port);
+    evbuffer_add_uint16(out, port.network());
 }
 
 static void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index)
@@ -1045,7 +1047,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     // port number of the other side. Note that there is no need for the
     // receiving side of the connection to send this extension message,
     // since its port number is already known.
-    tr_variantDictAddInt(&val, TR_KEY_p, tr_sessionGetPublicPeerPort(msgs->session));
+    tr_variantDictAddInt(&val, TR_KEY_p, msgs->session->peerPort().host());
 
     // http://bittorrent.org/beps/bep_0010.html
     // An integer, the number of outstanding request messages this
@@ -1171,7 +1173,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
     /* get peer's listening port */
     if (tr_variantDictFindInt(&val, TR_KEY_p, &i))
     {
-        pex.port = htons((uint16_t)i);
+        pex.port.setHost(i);
         msgs->publishClientGotPort(pex.port);
         logtrace(msgs, fmt::format(FMT_STRING("peer's port is now {:d}"), i));
     }
@@ -1747,14 +1749,23 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
         break;
 
     case BtPeerMsgs::Port:
-        logtrace(msgs, "Got a BtPeerMsgs::Port");
-        tr_peerIoReadUint16(msgs->io, inbuf, &msgs->dht_port);
-
-        if (msgs->dht_port > 0)
+        // http://bittorrent.org/beps/bep_0005.html
+        // Peers supporting the DHT set the last bit of the 8-byte reserved flags
+        // exchanged in the BitTorrent protocol handshake. Peer receiving a handshake
+        // indicating the remote peer supports the DHT should send a PORT message.
+        // It begins with byte 0x09 and has a two byte payload containing the UDP
+        // port of the DHT node in network byte order.
         {
-            tr_dhtAddNode(msgs->session, tr_peerAddress(msgs), msgs->dht_port, false);
-        }
+            logtrace(msgs, "Got a BtPeerMsgs::Port");
 
+            auto nport = uint16_t{};
+            tr_peerIoReadUint16(msgs->io, inbuf, &nport);
+            if (auto const dht_port = tr_port::fromNetwork(nport); !std::empty(dht_port))
+            {
+                msgs->dht_port = dht_port;
+                tr_dhtAddNode(msgs->session, tr_peerAddress(msgs), msgs->dht_port, false);
+            }
+        }
         break;
 
     case BtPeerMsgs::FextSuggest:

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -92,8 +92,8 @@ static void natPulse(tr_shared* s, bool do_check)
         session->private_peer_port = received_private_port;
         tr_logAddInfo(fmt::format(
             _("Mapped private port {private_port} to public port {public_port}"),
-            fmt::arg("public_port", session->public_peer_port),
-            fmt::arg("private_port", session->private_peer_port)));
+            fmt::arg("public_port", session->public_peer_port.host()),
+            fmt::arg("private_port", session->private_peer_port.host())));
     }
 
     s->upnpStatus = tr_upnpPulse(

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -9,15 +9,10 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include "transmission.h"
-
-/**
- * @addtogroup port_forwarding Port Forwarding
- * @{
- */
+#include "net.h" // tr_port
 
 struct tr_bindsockets;
-
+struct tr_session;
 struct tr_shared;
 
 tr_shared* tr_sharedInit(tr_session*);
@@ -33,5 +28,3 @@ tr_port tr_sharedGetPeerPort(tr_shared const* s);
 bool tr_sharedTraversalIsEnabled(tr_shared const* s);
 
 int tr_sharedTraversalStatus(tr_shared const*);
-
-/** @} */

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -605,14 +605,13 @@ static char const* tr_rpc_address_to_string(tr_rpc_address const& addr, char* bu
 
 static std::string tr_rpc_address_with_port(tr_rpc_server const* server)
 {
-
     char addr_buf[TrUnixAddrStrLen];
     tr_rpc_address_to_string(*server->bindAddress, addr_buf, sizeof(addr_buf));
 
     std::string addr_port_str{ addr_buf };
     if (server->bindAddress->type != TR_RPC_AF_UNIX)
     {
-        addr_port_str.append(":" + std::to_string(tr_rpcGetPort(server)));
+        addr_port_str.append(":" + std::to_string(server->port().host()));
     }
     return addr_port_str;
 }
@@ -740,11 +739,11 @@ static void startServer(tr_rpc_server* server)
 
     char const* address = tr_rpcGetBindAddress(server);
 
-    tr_port const port = server->port;
+    auto const port = server->port();
 
     bool const success = server->bindAddress->type == TR_RPC_AF_UNIX ?
         bindUnixSocket(base, httpd, address, server->rpc_socket_mode) :
-        (evhttp_bind_socket(httpd, address, port) != -1);
+        (evhttp_bind_socket(httpd, address, port.host()) != -1);
 
     auto const addr_port_str = tr_rpc_address_with_port(server);
 
@@ -840,24 +839,19 @@ static void restartServer(tr_rpc_server* const server)
     }
 }
 
-void tr_rpcSetPort(tr_rpc_server* server, tr_port port)
+void tr_rpc_server::setPort(tr_port port) noexcept
 {
-    TR_ASSERT(server != nullptr);
-
-    if (server->port != port)
+    if (port_ == port)
     {
-        server->port = port;
-
-        if (server->isEnabled)
-        {
-            tr_runInEventThread(server->session, restartServer, server);
-        }
+        return;
     }
-}
 
-tr_port tr_rpcGetPort(tr_rpc_server const* server)
-{
-    return server->port;
+    port_ = port;
+
+    if (isEnabled)
+    {
+        tr_runInEventThread(session, restartServer, this);
+    }
 }
 
 void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url)
@@ -1048,7 +1042,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
     else
     {
-        this->port = (tr_port)i;
+        this->port_.setHost(i);
     }
 
     key = TR_KEY_rpc_url;

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -35,6 +35,13 @@ public:
     tr_rpc_server& operator=(tr_rpc_server&) = delete;
     tr_rpc_server& operator=(tr_rpc_server&&) = delete;
 
+    [[nodiscard]] constexpr tr_port port() const noexcept
+    {
+        return port_;
+    }
+
+    void setPort(tr_port) noexcept;
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::list<std::string> hostWhitelist;
@@ -56,7 +63,7 @@ public:
     static int constexpr DefaultRpcSocketMode = 0750;
     int rpc_socket_mode = DefaultRpcSocketMode;
 
-    tr_port port = 0;
+    tr_port port_;
 
     bool isAntiBruteForceEnabled = false;
     bool isEnabled = false;
@@ -68,10 +75,6 @@ public:
 void tr_rpcSetEnabled(tr_rpc_server* server, bool isEnabled);
 
 bool tr_rpcIsEnabled(tr_rpc_server const* server);
-
-void tr_rpcSetPort(tr_rpc_server* server, tr_port port);
-
-tr_port tr_rpcGetPort(tr_rpc_server const* server);
 
 void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1381,8 +1381,8 @@ static char const* portTest(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    auto const port = tr_sessionGetPeerPort(session);
-    auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port);
+    auto const port = session->peerPort();
+    auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port.host());
     session->web->fetch({ url, onPortTested, idle_data });
     return nullptr;
 }
@@ -1943,7 +1943,7 @@ static char const* sessionSet(
 
     if (tr_variantDictFindInt(args_in, TR_KEY_peer_port, &i))
     {
-        tr_sessionSetPeerPort(session, i);
+        session->setPeerPort(tr_port::fromHost(i));
     }
 
     if (tr_variantDictFindBool(args_in, TR_KEY_port_forwarding_enabled, &boolVal))
@@ -2222,7 +2222,7 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_peer_port:
-        tr_variantDictAddInt(d, key, tr_sessionGetPeerPort(s));
+        tr_variantDictAddInt(d, key, s->peerPort().host());
         break;
 
     case TR_KEY_peer_port_random_on_start:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -86,7 +86,10 @@ static auto constexpr BandwidthGroupsFilename = "bandwidth-groups.json"sv;
 
 static tr_port getRandomPort(tr_session const* s)
 {
-    return tr_port(tr_rand_int_weak(s->randomPortHigh - s->randomPortLow + 1) + s->randomPortLow);
+    auto const lower = std::min(s->randomPortLow.host(), s->randomPortHigh.host());
+    auto const upper = std::max(s->randomPortLow.host(), s->randomPortHigh.host());
+    auto const range = upper - lower;
+    return tr_port::fromHost(lower + tr_rand_int_weak(range + 1));
 }
 
 /* Generate a peer id : "-TRxyzb-" + 12 random alphanumeric
@@ -421,10 +424,10 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddInt(d, TR_KEY_message_level, tr_logGetLevel());
     tr_variantDictAddInt(d, TR_KEY_peer_limit_global, s->peerLimit);
     tr_variantDictAddInt(d, TR_KEY_peer_limit_per_torrent, s->peerLimitPerTorrent);
-    tr_variantDictAddInt(d, TR_KEY_peer_port, tr_sessionGetPeerPort(s));
+    tr_variantDictAddInt(d, TR_KEY_peer_port, s->peerPort().host());
     tr_variantDictAddBool(d, TR_KEY_peer_port_random_on_start, s->isPortRandom);
-    tr_variantDictAddInt(d, TR_KEY_peer_port_random_low, s->randomPortLow);
-    tr_variantDictAddInt(d, TR_KEY_peer_port_random_high, s->randomPortHigh);
+    tr_variantDictAddInt(d, TR_KEY_peer_port_random_low, s->randomPortLow.host());
+    tr_variantDictAddInt(d, TR_KEY_peer_port_random_high, s->randomPortHigh.host());
     tr_variantDictAddStr(d, TR_KEY_peer_socket_tos, tr_netTosToName(s->peer_socket_tos_));
     tr_variantDictAddStr(d, TR_KEY_peer_congestion_algorithm, s->peerCongestionAlgorithm());
     tr_variantDictAddBool(d, TR_KEY_pex_enabled, s->isPexEnabled);
@@ -975,12 +978,12 @@ static void sessionSetImpl(struct init_data* const data)
     /* incoming peer port */
     if (tr_variantDictFindInt(settings, TR_KEY_peer_port_random_low, &i))
     {
-        session->randomPortLow = i;
+        session->randomPortLow.setHost(i);
     }
 
     if (tr_variantDictFindInt(settings, TR_KEY_peer_port_random_high, &i))
     {
-        session->randomPortHigh = i;
+        session->randomPortHigh.setHost(i);
     }
 
     if (tr_variantDictFindBool(settings, TR_KEY_peer_port_random_on_start, &boolVal))
@@ -988,12 +991,16 @@ static void sessionSetImpl(struct init_data* const data)
         tr_sessionSetPeerPortRandomOnStart(session, boolVal);
     }
 
-    if (!tr_variantDictFindInt(settings, TR_KEY_peer_port, &i))
     {
-        i = session->private_peer_port;
-    }
+        auto peer_port = session->private_peer_port;
 
-    setPeerPort(session, boolVal ? getRandomPort(session) : i);
+        if (auto port = int64_t{}; tr_variantDictFindInt(settings, TR_KEY_peer_port, &port))
+        {
+            peer_port.setHost(static_cast<uint16_t>(port));
+        }
+
+        setPeerPort(session, boolVal ? getRandomPort(session) : peer_port);
+    }
 
     if (tr_variantDictFindBool(settings, TR_KEY_port_forwarding_enabled, &boolVal))
     {
@@ -1244,25 +1251,25 @@ static void setPeerPort(tr_session* session, tr_port port)
     tr_runInEventThread(session, peerPortChanged, session);
 }
 
-void tr_sessionSetPeerPort(tr_session* session, tr_port port)
+void tr_sessionSetPeerPort(tr_session* session, uint16_t hport)
 {
-    if (tr_isSession(session) && session->private_peer_port != port)
+    if (auto const port = tr_port::fromHost(hport); tr_isSession(session) && session->private_peer_port != port)
     {
         setPeerPort(session, port);
     }
 }
 
-tr_port tr_sessionGetPeerPort(tr_session const* session)
+uint16_t tr_sessionGetPeerPort(tr_session const* session)
 {
-    return tr_isSession(session) ? session->public_peer_port : 0;
+    return tr_isSession(session) ? session->public_peer_port.host() : 0U;
 }
 
-tr_port tr_sessionSetPeerPortRandom(tr_session* session)
+uint16_t tr_sessionSetPeerPortRandom(tr_session* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_sessionSetPeerPort(session, getRandomPort(session));
-    return session->private_peer_port;
+    session->setPeerPort(getRandomPort(session));
+    return session->private_peer_port.host();
 }
 
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random)
@@ -2555,18 +2562,21 @@ bool tr_sessionIsRPCEnabled(tr_session const* session)
     return tr_rpcIsEnabled(session->rpc_server_.get());
 }
 
-void tr_sessionSetRPCPort(tr_session* session, tr_port port)
+void tr_sessionSetRPCPort(tr_session* session, uint16_t hport)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetPort(session->rpc_server_.get(), port);
+    if (session->rpc_server_)
+    {
+        session->rpc_server_->setPort(tr_port::fromHost(hport));
+    }
 }
 
-tr_port tr_sessionGetRPCPort(tr_session const* session)
+uint16_t tr_sessionGetRPCPort(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcGetPort(session->rpc_server_.get());
+    return session->rpc_server_ ? session->rpc_server_->port().host() : uint16_t{};
 }
 
 void tr_sessionSetRPCUrl(tr_session* session, char const* url)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -337,6 +337,16 @@ public:
      */
     tr_port public_peer_port;
 
+    [[nodiscard]] constexpr auto peerPort() const noexcept
+    {
+        return public_peer_port;
+    }
+
+    constexpr auto setPeerPort(tr_port port) noexcept
+    {
+        public_peer_port = port;
+    }
+
     tr_port randomPortLow;
     tr_port randomPortHigh;
 
@@ -425,11 +435,6 @@ private:
     bool blocklist_enabled_ = false;
     bool incomplete_dir_enabled_ = false;
 };
-
-constexpr tr_port tr_sessionGetPublicPeerPort(tr_session const* session)
-{
-    return session->public_peer_port;
-}
 
 bool tr_sessionAllowsDHT(tr_session const* session);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -687,12 +687,12 @@ static bool isNewTorrentASeed(tr_torrent* tor)
 
 static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 {
-    auto const lock = tor->unique_lock();
-
     tr_session* session = tr_ctorGetSession(ctor);
     TR_ASSERT(session != nullptr);
-
     tor->session = session;
+
+    auto const lock = tor->unique_lock();
+
     tor->queuePosition = tr_sessionCountTorrents(session);
 
     torrentInitFromInfoDict(tor);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -164,8 +164,7 @@ static void dht_boostrap_from_file(tr_session* session)
         auto hport = uint16_t{};
         line_stream >> addrstr >> hport;
 
-        using PortLimits = std::numeric_limits<uint16_t>;
-        if (line_stream.bad() || std::empty(addrstr) || hport < PortLimits::min() || hport > PortLimits::max())
+        if (line_stream.bad() || std::empty(addrstr))
         {
             tr_logAddWarn(fmt::format(_("Couldn't parse line: '{line}'"), fmt::arg("line", line)));
         }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -23,7 +23,7 @@ using in_port_t = uint16_t; /* all missing */
 #include <event2/event.h>
 #include <event2/util.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "transmission.h"
 
@@ -263,9 +263,8 @@ int tr_lpdInit(tr_session* ss, tr_address* /*tr_addr*/)
     TR_ASSERT(lpd_announceInterval > 0);
     TR_ASSERT(lpd_announceScope > 0);
 
-    lpd_port = tr_sessionGetPeerPort(ss);
-
-    if (lpd_port <= 0)
+    lpd_port = ss->peerPort();
+    if (std::empty(lpd_port))
     {
         return -1;
     }
@@ -438,7 +437,7 @@ bool tr_lpdSendAnnounce(tr_torrent const* t)
         1,
         lpd_mcastGroup,
         lpd_mcastPort,
-        lpd_port,
+        lpd_port.host(),
         tr_strupper(t->infoHashString()));
 
     // send the query out using [lpd_socket2]
@@ -484,7 +483,6 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
     char value[MaxValueLen] = { 0 };
     char hashString[MaxHashLen] = { 0 };
     int res = 0;
-    int peerPort = 0;
 
     if (peer != nullptr && msg != nullptr)
     {
@@ -505,12 +503,13 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
         }
 
         /* determine announced peer port, refuse if value too large */
-        if (sscanf(value, "%d", &peerPort) != 1 || peerPort > (in_port_t)-1)
+        int peer_port = 0;
+        if (sscanf(value, "%d", &peer_port) != 1 || peer_port > (in_port_t)-1)
         {
             return 0;
         }
 
-        peer->port = htons(peerPort);
+        peer->port.setHost(peer_port);
         res = -1; /* signal caller side-effect to peer->port via return != 0 */
 
         if (!lpd_extractParam(params, "Infohash", MaxHashLen, hashString))
@@ -524,14 +523,16 @@ static int tr_lpdConsiderAnnounce(tr_pex* peer, char const* const msg)
         {
             /* we found a suitable peer, add it to the torrent */
             tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, peer, 1);
-            tr_logAddDebugTor(tor, fmt::format("Found a local peer from LPD ({})", peer->addr.to_string(peerPort)));
+            tr_logAddDebugTor(
+                tor,
+                fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), peer->addr.to_string(peer->port)));
 
             /* periodic reconnectPulse() deals with the rest... */
 
             return 1;
         }
 
-        tr_logAddDebug(fmt::format("Cannot serve torrent #{}", hashString));
+        tr_logAddDebug(fmt::format(FMT_STRING("Cannot serve torrent #{:s}"), hashString));
     }
 
     return res;

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -161,7 +161,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
         memcpy(&sin6.sin6_addr, ipv6, 16);
     }
 
-    sin6.sin6_port = htons(ss->udp_port);
+    sin6.sin6_port = ss->udp_port.network();
 
     rc = bind(s, (struct sockaddr*)&sin6, sizeof(sin6));
 
@@ -277,9 +277,8 @@ void tr_udpInit(tr_session* ss)
     TR_ASSERT(ss->udp_socket == TR_BAD_SOCKET);
     TR_ASSERT(ss->udp6_socket == TR_BAD_SOCKET);
 
-    ss->udp_port = tr_sessionGetPeerPort(ss);
-
-    if (ss->udp_port <= 0)
+    ss->udp_port = ss->peerPort();
+    if (std::empty(ss->udp_port))
     {
         return;
     }
@@ -302,7 +301,7 @@ void tr_udpInit(tr_session* ss)
             memcpy(&sin.sin_addr, &public_addr->addr.addr4, sizeof(struct in_addr));
         }
 
-        sin.sin_port = htons(ss->udp_port);
+        sin.sin_port = ss->udp_port.network();
         int const rc = bind(ss->udp_socket, (struct sockaddr*)&sin, sizeof(sin));
 
         if (rc == -1)

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -85,7 +85,7 @@ static void incoming(void* vsession, struct UTPSocket* s)
     auto* const from = (struct sockaddr*)&from_storage;
     socklen_t fromlen = sizeof(from_storage);
     tr_address addr;
-    tr_port port = 0;
+    tr_port port;
 
     if (!tr_sessionIsUTPEnabled(session))
     {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -32,7 +32,6 @@ using tr_piece_index_t = uint32_t;
 /* Assuming a 16 KiB block (tr_block_info::BlockSize), a 32-bit block index gives us a maximum torrent size of 64 TiB.
  * When we ever need to grow past that, change tr_block_index_t and  tr_piece_index_t to uint64_t. */
 using tr_block_index_t = uint32_t;
-using tr_port = uint16_t;
 using tr_tracker_tier_t = uint32_t;
 using tr_tracker_id_t = uint32_t;
 using tr_byte_index_t = uint64_t;
@@ -329,12 +328,12 @@ bool tr_sessionIsRPCEnabled(tr_session const* session);
 /** @brief Specify which port to listen for RPC requests on.
     @see tr_sessionInit()
     @see tr_sessionGetRPCPort */
-void tr_sessionSetRPCPort(tr_session* session, tr_port port);
+void tr_sessionSetRPCPort(tr_session* session, uint16_t port);
 
 /** @brief Get which port to listen for RPC requests on.
     @see tr_sessionInit()
     @see tr_sessionSetRPCPort */
-tr_port tr_sessionGetRPCPort(tr_session const* session);
+uint16_t tr_sessionGetRPCPort(tr_session const* session);
 
 /**
  * @brief Specify which base URL to use.
@@ -491,11 +490,11 @@ void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled);
 
 bool tr_sessionIsPortForwardingEnabled(tr_session const* session);
 
-void tr_sessionSetPeerPort(tr_session* session, tr_port port);
+void tr_sessionSetPeerPort(tr_session* session, uint16_t port);
 
-tr_port tr_sessionGetPeerPort(tr_session const* session);
+uint16_t tr_sessionGetPeerPort(tr_session const* session);
 
-tr_port tr_sessionSetPeerPortRandom(tr_session* session);
+uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
 
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
 
@@ -1262,7 +1261,7 @@ struct tr_peer_stat
     bool isIncoming;
 
     uint8_t from;
-    tr_port port;
+    uint16_t port;
 
     char addr[TR_INET6_ADDRSTRLEN];
     char flagStr[32];

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -203,7 +203,8 @@ auto parsePort(std::string_view port_sv)
 {
     auto const port = tr_parseNum<int>(port_sv);
 
-    return port && *port >= std::numeric_limits<tr_port>::min() && *port <= std::numeric_limits<tr_port>::max() ? *port : -1;
+    using PortLimits = std::numeric_limits<uint16_t>;
+    return port && PortLimits::min() <= *port && *port <= PortLimits::max() ? *port : -1;
 }
 
 constexpr std::string_view getPortForScheme(std::string_view scheme)

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -450,7 +450,7 @@
 
 - (void)setPort:(id)sender
 {
-    tr_port const port = [sender intValue];
+    uint16_t const port = [sender intValue];
     [self.fDefaults setInteger:port forKey:@"BindPort"];
     tr_sessionSetPeerPort(self.fHandle, port);
 
@@ -460,7 +460,7 @@
 
 - (void)randomPort:(id)sender
 {
-    tr_port const port = tr_sessionSetPeerPortRandom(self.fHandle);
+    auto const port = tr_sessionSetPeerPortRandom(self.fHandle);
     [self.fDefaults setInteger:port forKey:@"BindPort"];
     self.fPortField.intValue = port;
 
@@ -1392,7 +1392,7 @@
     [self.fDefaults setBool:autoStart forKey:@"AutoStartDownload"];
 
     //port
-    tr_port const port = tr_sessionGetPeerPort(self.fHandle);
+    auto const port = tr_sessionGetPeerPort(self.fHandle);
     [self.fDefaults setInteger:port forKey:@"BindPort"];
 
     BOOL const nat = tr_sessionIsPortForwardingEnabled(self.fHandle);

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -244,7 +244,7 @@ void Session::updatePref(int key)
         case Prefs::RPC_PORT:
             if (session_ != nullptr)
             {
-                tr_sessionSetRPCPort(session_, static_cast<tr_port>(prefs_.getInt(key)));
+                tr_sessionSetRPCPort(session_, static_cast<uint16_t>(prefs_.getInt(key)));
             }
 
             break;


### PR DESCRIPTION
This is a very simple little class -- literally just a wrapper around a `uint16_t`.

It exists to ensure the byte ordering never gets mixed up.