### PR TITLE
Support hardened runtime on macOS by disabling library validation for Sparkle

### DIFF
--- a/macosx/Transmission.entitlements
+++ b/macosx/Transmission.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
This change solves #2497, with the conflicts resolved and the proper file used for entitlements.

Explanations:
- when using `cmake install`, the executable Transmission.app is codesigned only on the surface: it does **not** opt into a hardened runtime environment.
- when using `Xcode build`, the executable Transmission.app **is** codesigned with hardened runtime environment (`-o runtime`). But that prevents Transmission to run due to the presence of Sparkle binary:
https://github.com/transmission/transmission/blob/main/macosx/Sparkle.framework/Versions/A/Sparkle

Multiple solutions:
a. Either build Sparkle from source ourselves (Swift Package Manager Sparkle package or git submodule) instead of using the precompiled and presigned one: https://github.com/sparkle-project/Sparkle
b. or allow hardened runtime environment with the exclusion of library validation (adopted solution in this pull request).
c. or require a 99 USD annual fee for the Apple Developer Program, and "sign for development" instead of "sign to run locally"

This library validation exception (solution "b"):
- has zero impact on `cmake install`, since it isn't codesigning using hardened runtime environment
- solves running Transmission.app built from Xcode