### PR TITLE
refactor: add tr_address::fromCompact()

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -253,7 +253,8 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             }
             else if (key == "external ip"sv && std::size(value) == 4)
             {
-                response_.external_ip = tr_address::from_4byte_ipv4(value);
+                auto const [addr, out] = tr_address::fromCompact4(reinterpret_cast<uint8_t const*>(std::data(value)));
+                response_.external_ip = addr;
             }
             else
             {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -151,19 +151,12 @@ private:
 
 struct tr_address
 {
-    static tr_address from_4byte_ipv4(std::string_view in);
+    [[nodiscard]] static std::optional<tr_address> from_string(std::string_view str);
+    [[nodiscard]] static std::pair<tr_address, uint8_t const*> fromCompact4(uint8_t const* compact) noexcept;
+    [[nodiscard]] static std::pair<tr_address, uint8_t const*> fromCompact6(uint8_t const* compact) noexcept;
 
-    static std::optional<tr_address> from_string(std::string_view str);
-
-    std::string to_string() const;
-    std::string to_string(tr_port port) const;
-
-    tr_address_type type;
-    union
-    {
-        struct in6_addr addr6;
-        struct in_addr addr4;
-    } addr;
+    [[nodiscard]] std::string to_string() const;
+    [[nodiscard]] std::string to_string(tr_port port) const;
 
     [[nodiscard]] int compare(tr_address const& that) const noexcept
     {
@@ -184,6 +177,13 @@ struct tr_address
     {
         return compare(that) > 0;
     }
+
+    tr_address_type type;
+    union
+    {
+        struct in6_addr addr6;
+        struct in_addr addr4;
+    } addr;
 };
 
 extern tr_address const tr_inaddr_any;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1128,9 +1128,7 @@ std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLe
 
     for (size_t i = 0; i < n; ++i)
     {
-        pex[i].addr.type = TR_AF_INET;
-        std::copy_n(walk, 4, reinterpret_cast<uint8_t*>(&pex[i].addr.addr));
-        walk += 4;
+        std::tie(pex[i].addr, walk) = tr_address::fromCompact4(walk);
         std::tie(pex[i].port, walk) = tr_port::fromCompact(walk);
 
         if (added_f != nullptr && n == added_f_len)
@@ -1150,9 +1148,7 @@ std::vector<tr_pex> tr_peerMgrCompact6ToPex(void const* compact, size_t compactL
 
     for (size_t i = 0; i < n; ++i)
     {
-        pex[i].addr.type = TR_AF_INET6;
-        std::copy_n(walk, 16, reinterpret_cast<uint8_t*>(&pex[i].addr.addr.addr6.s6_addr));
-        walk += 16;
+        std::tie(pex[i].addr, walk) = tr_address::fromCompact6(walk);
         std::tie(pex[i].port, walk) = tr_port::fromCompact(walk);
 
         if (added_f != nullptr && n == added_f_len)

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -10,7 +10,6 @@
 #include <cstring> /* memcpy(), memset(), memchr(), strlen() */
 #include <ctime>
 #include <fstream>
-#include <limits>
 #include <sstream>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Works similarly to `tr_port::fromCompact()`; this is for building ipv4 and ipv6 addresses from compact format in BitTorrent messages