### PR TITLE
refactor: partially c++ifiy tr_rpc_server

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -387,7 +387,7 @@ static bool isIPAddressWithOptionalPort(char const* host)
 static bool isHostnameAllowed(tr_rpc_server const* server, struct evhttp_request* req)
 {
     /* If password auth is enabled, any hostname is permitted. */
-    if (server->isPasswordEnabled)
+    if (server->isPasswordEnabled())
     {
         return true;
     }
@@ -438,7 +438,7 @@ static bool test_session_id(tr_rpc_server* server, evhttp_request const* req)
 
 static bool isAuthorized(tr_rpc_server const* server, char const* auth_header)
 {
-    if (!server->isPasswordEnabled)
+    if (!server->isPasswordEnabled())
     {
         return true;
     }
@@ -947,15 +947,10 @@ std::string const& tr_rpcGetPassword(tr_rpc_server const* server)
     return server->salted_password;
 }
 
-void tr_rpcSetPasswordEnabled(tr_rpc_server* server, bool isEnabled)
+void tr_rpc_server::setPasswordEnabled(bool enabled) noexcept
 {
-    server->isPasswordEnabled = isEnabled;
-    tr_logAddDebug(fmt::format("setting password-enabled to '{}'", isEnabled));
-}
-
-bool tr_rpcIsPasswordEnabled(tr_rpc_server const* server)
-{
-    return server->isPasswordEnabled;
+    is_password_enabled_ = enabled;
+    tr_logAddDebug(fmt::format("setting password-enabled to '{}'", enabled));
 }
 
 char const* tr_rpcGetBindAddress(tr_rpc_server const* server)
@@ -1084,7 +1079,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
     else
     {
-        tr_rpcSetPasswordEnabled(this, boolVal);
+        this->setPasswordEnabled(boolVal);
     }
 
     key = TR_KEY_rpc_whitelist;
@@ -1186,7 +1181,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
             tr_logAddInfo(_("Whitelist enabled"));
         }
 
-        if (this->isPasswordEnabled)
+        if (this->isPasswordEnabled())
         {
             tr_logAddInfo(_("Password required"));
         }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -469,7 +469,7 @@ static void handle_request(struct evhttp_request* req, void* arg)
     {
         evhttp_add_header(req->output_headers, "Server", MY_REALM);
 
-        if (server->isAntiBruteForceEnabled() && server->login_attempts_ >= server->antiBruteForceThreshold)
+        if (server->isAntiBruteForceEnabled() && server->login_attempts_ >= server->anti_brute_force_limit_)
         {
             send_simple_response(req, 403, "<p>Too many unsuccessful login attempts. Please restart transmission-daemon.</p>");
             return;
@@ -964,16 +964,6 @@ void tr_rpc_server::setAntiBruteForceEnabled(bool enabled) noexcept
     }
 }
 
-int tr_rpcGetAntiBruteForceThreshold(tr_rpc_server const* server)
-{
-    return server->antiBruteForceThreshold;
-}
-
-void tr_rpcSetAntiBruteForceThreshold(tr_rpc_server* server, int badRequests)
-{
-    server->antiBruteForceThreshold = badRequests;
-}
-
 /****
 *****  LIFE CYCLE
 ****/
@@ -1125,7 +1115,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
     else
     {
-        tr_rpcSetAntiBruteForceThreshold(this, i);
+        this->setAntiBruteForceLimit(i);
     }
 
     key = TR_KEY_rpc_socket_mode;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -458,7 +458,7 @@ static bool isAuthorized(tr_rpc_server const* server, char const* auth_header)
     auto decoded = std::string_view{ decoded_str };
     auto const username = tr_strvSep(&decoded, ':');
     auto const password = decoded;
-    return server->username == username && tr_ssha1_matches(server->salted_password_, password);
+    return server->username() == username && tr_ssha1_matches(server->salted_password_, password);
 }
 
 static void handle_request(struct evhttp_request* req, void* arg)
@@ -919,15 +919,10 @@ static void tr_rpcSetRPCSocketMode(tr_rpc_server* server, int socket_mode)
 *****  PASSWORD
 ****/
 
-void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username)
+void tr_rpc_server::setUsername(std::string_view username) noexcept
 {
-    server->username = username;
-    tr_logAddDebug(fmt::format("setting our username to '{}'", server->username));
-}
-
-std::string const& tr_rpcGetUsername(tr_rpc_server const* server)
-{
-    return server->username;
+    username_ = username;
+    tr_logAddDebug(fmt::format(FMT_STRING("setting our username to '{:s}'"), username_));
 }
 
 static bool isSalted(std::string_view password)
@@ -1082,7 +1077,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
     else
     {
-        tr_rpcSetUsername(this, sv);
+        this->setUsername(sv);
     }
 
     key = TR_KEY_rpc_password;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -368,7 +368,7 @@ static bool isAddressAllowed(tr_rpc_server const* server, char const* address)
 {
     auto const& src = server->whitelist;
 
-    return !server->isWhitelistEnabled ||
+    return !server->isWhitelistEnabled() ||
         std::any_of(std::begin(src), std::end(src), [&address](auto const& s) { return tr_wildmat(address, s); });
 }
 
@@ -902,16 +902,6 @@ std::string const& tr_rpcGetWhitelist(tr_rpc_server const* server)
     return server->whitelistStr;
 }
 
-void tr_rpcSetWhitelistEnabled(tr_rpc_server* server, bool isEnabled)
-{
-    server->isWhitelistEnabled = isEnabled;
-}
-
-bool tr_rpcGetWhitelistEnabled(tr_rpc_server const* server)
-{
-    return server->isWhitelistEnabled;
-}
-
 static void tr_rpcSetHostWhitelistEnabled(tr_rpc_server* server, bool isEnabled)
 {
     server->isHostWhitelistEnabled = isEnabled;
@@ -1063,7 +1053,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
     else
     {
-        tr_rpcSetWhitelistEnabled(this, boolVal);
+        this->setWhitelistEnabled(boolVal);
     }
 
     key = TR_KEY_rpc_host_whitelist_enabled;
@@ -1183,7 +1173,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
 
     if (bindAddress->type == TR_RPC_AF_UNIX)
     {
-        this->isWhitelistEnabled = false;
+        this->setWhitelistEnabled(false);
         this->isHostWhitelistEnabled = false;
     }
 
@@ -1193,7 +1183,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
         tr_logAddInfo(fmt::format(_("Serving RPC and Web requests on {address}"), fmt::arg("address", rpc_uri)));
         tr_runInEventThread(session, startServer, this);
 
-        if (this->isWhitelistEnabled)
+        if (this->isWhitelistEnabled())
         {
             tr_logAddInfo(_("Whitelist enabled"));
         }

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -73,11 +73,19 @@ public:
 
     void setPasswordEnabled(bool enabled) noexcept;
 
+    [[nodiscard]] constexpr auto const& getSaltedPassword()
+    {
+        return salted_password_;
+    }
+
+    void setPassword(std::string_view salted) noexcept;
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
     std::vector<std::string> whitelist;
     std::string salted_password;
+    std::string salted_password_;
     std::string username;
     std::string whitelist_str_;
     std::string url;
@@ -110,10 +118,6 @@ std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 int tr_rpcSetTest(tr_rpc_server const* server, char const* whitelist, char** allocme_errmsg);
 
 int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
-
-void tr_rpcSetPassword(tr_rpc_server* server, std::string_view password);
-
-std::string const& tr_rpcGetPassword(tr_rpc_server const* server);
 
 void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -87,6 +87,16 @@ public:
 
     void setAntiBruteForceEnabled(bool enabled) noexcept;
 
+    [[nodiscard]] constexpr auto getAntiBruteForceLimit() const noexcept
+    {
+        return anti_brute_force_limit_;
+    }
+
+    constexpr void setAntiBruteForceLimit(int limit) noexcept
+    {
+        anti_brute_force_limit_ = limit;
+    }
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
@@ -103,7 +113,7 @@ public:
     struct evhttp* httpd = nullptr;
     tr_session* const session;
 
-    int antiBruteForceThreshold = 0;
+    int anti_brute_force_limit_ = 0;
     int login_attempts_ = 0;
     int start_retry_counter = 0;
     static int constexpr DefaultRpcSocketMode = 0750;
@@ -129,9 +139,5 @@ int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
 void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username);
 
 std::string const& tr_rpcGetUsername(tr_rpc_server const* server);
-
-int tr_rpcGetAntiBruteForceThreshold(tr_rpc_server const* server);
-
-void tr_rpcSetAntiBruteForceThreshold(tr_rpc_server* server, int badRequests);
 
 char const* tr_rpcGetBindAddress(tr_rpc_server const* server);

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -106,9 +106,10 @@ public:
 
     std::shared_ptr<libdeflate_compressor> compressor;
 
+    [[nodiscard]] std::string getBindAddress() const;
+
     std::vector<std::string> hostWhitelist;
-    std::vector<std::string> whitelist;
-    std::string salted_password;
+    std::vector<std::string> whitelist_;
     std::string salted_password_;
     std::string username_;
     std::string whitelist_str_;
@@ -139,8 +140,4 @@ void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
 
 std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 
-int tr_rpcSetTest(tr_rpc_server const* server, char const* whitelist, char** allocme_errmsg);
-
 int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
-
-char const* tr_rpcGetBindAddress(tr_rpc_server const* server);

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -66,6 +66,13 @@ public:
 
     void setWhitelist(std::string_view whitelist) noexcept;
 
+    [[nodiscard]] constexpr auto const& username() const noexcept
+    {
+        return username_;
+    }
+
+    void setUsername(std::string_view username) noexcept;
+
     [[nodiscard]] constexpr auto isPasswordEnabled() const noexcept
     {
         return is_password_enabled_;
@@ -103,7 +110,7 @@ public:
     std::vector<std::string> whitelist;
     std::string salted_password;
     std::string salted_password_;
-    std::string username;
+    std::string username_;
     std::string whitelist_str_;
     std::string url;
 
@@ -135,9 +142,5 @@ std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 int tr_rpcSetTest(tr_rpc_server const* server, char const* whitelist, char** allocme_errmsg);
 
 int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
-
-void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username);
-
-std::string const& tr_rpcGetUsername(tr_rpc_server const* server);
 
 char const* tr_rpcGetBindAddress(tr_rpc_server const* server);

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -80,6 +80,13 @@ public:
 
     void setPassword(std::string_view salted) noexcept;
 
+    [[nodiscard]] constexpr auto isAntiBruteForceEnabled() const noexcept
+    {
+        return is_anti_brute_force_enabled_;
+    }
+
+    void setAntiBruteForceEnabled(bool enabled) noexcept;
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
@@ -97,14 +104,14 @@ public:
     tr_session* const session;
 
     int antiBruteForceThreshold = 0;
-    int loginattempts = 0;
+    int login_attempts_ = 0;
     int start_retry_counter = 0;
     static int constexpr DefaultRpcSocketMode = 0750;
     int rpc_socket_mode = DefaultRpcSocketMode;
 
     tr_port port_;
 
-    bool isAntiBruteForceEnabled = false;
+    bool is_anti_brute_force_enabled_ = false;
     bool is_enabled_ = false;
     bool isHostWhitelistEnabled = false;
     bool is_password_enabled_ = false;
@@ -122,10 +129,6 @@ int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
 void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username);
 
 std::string const& tr_rpcGetUsername(tr_rpc_server const* server);
-
-bool tr_rpcGetAntiBruteForceEnabled(tr_rpc_server const* server);
-
-void tr_rpcSetAntiBruteForceEnabled(tr_rpc_server* server, bool is_enabled);
 
 int tr_rpcGetAntiBruteForceThreshold(tr_rpc_server const* server);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -42,12 +42,22 @@ public:
 
     void setPort(tr_port) noexcept;
 
-    [[nodiscard]] constexpr bool isEnabled() const noexcept
+    [[nodiscard]] constexpr auto isEnabled() const noexcept
     {
         return is_enabled_;
     }
 
     void setEnabled(bool is_enabled);
+
+    [[nodiscard]] constexpr auto isWhitelistEnabled() const noexcept
+    {
+        return is_whitelist_enabled_;
+    }
+
+    constexpr void setWhitelistEnabled(bool is_whitelist_enabled) noexcept
+    {
+        is_whitelist_enabled_ = is_whitelist_enabled;
+    }
 
     std::shared_ptr<libdeflate_compressor> compressor;
 
@@ -76,7 +86,7 @@ public:
     bool is_enabled_ = false;
     bool isHostWhitelistEnabled = false;
     bool isPasswordEnabled = false;
-    bool isWhitelistEnabled = false;
+    bool is_whitelist_enabled_ = false;
 };
 
 void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
@@ -84,10 +94,6 @@ void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
 std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 
 int tr_rpcSetTest(tr_rpc_server const* server, char const* whitelist, char** allocme_errmsg);
-
-void tr_rpcSetWhitelistEnabled(tr_rpc_server* server, bool isEnabled);
-
-bool tr_rpcGetWhitelistEnabled(tr_rpc_server const* server);
 
 void tr_rpcSetWhitelist(tr_rpc_server* server, std::string_view whitelist);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -59,13 +59,20 @@ public:
         is_whitelist_enabled_ = is_whitelist_enabled;
     }
 
+    [[nodiscard]] constexpr auto const& whitelist() const noexcept
+    {
+        return whitelist_str_;
+    }
+
+    void setWhitelist(std::string_view whitelist) noexcept;
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
     std::vector<std::string> whitelist;
     std::string salted_password;
     std::string username;
-    std::string whitelistStr;
+    std::string whitelist_str_;
     std::string url;
 
     std::unique_ptr<struct tr_rpc_address> bindAddress;
@@ -95,11 +102,7 @@ std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 
 int tr_rpcSetTest(tr_rpc_server const* server, char const* whitelist, char** allocme_errmsg);
 
-void tr_rpcSetWhitelist(tr_rpc_server* server, std::string_view whitelist);
-
 int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);
-
-std::string const& tr_rpcGetWhitelist(tr_rpc_server const* server);
 
 void tr_rpcSetPassword(tr_rpc_server* server, std::string_view password);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -66,6 +66,13 @@ public:
 
     void setWhitelist(std::string_view whitelist) noexcept;
 
+    [[nodiscard]] constexpr auto isPasswordEnabled() const noexcept
+    {
+        return is_password_enabled_;
+    }
+
+    void setPasswordEnabled(bool enabled) noexcept;
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
@@ -92,7 +99,7 @@ public:
     bool isAntiBruteForceEnabled = false;
     bool is_enabled_ = false;
     bool isHostWhitelistEnabled = false;
-    bool isPasswordEnabled = false;
+    bool is_password_enabled_ = false;
     bool is_whitelist_enabled_ = false;
 };
 
@@ -111,10 +118,6 @@ std::string const& tr_rpcGetPassword(tr_rpc_server const* server);
 void tr_rpcSetUsername(tr_rpc_server* server, std::string_view username);
 
 std::string const& tr_rpcGetUsername(tr_rpc_server const* server);
-
-void tr_rpcSetPasswordEnabled(tr_rpc_server* server, bool isEnabled);
-
-bool tr_rpcIsPasswordEnabled(tr_rpc_server const* session);
 
 bool tr_rpcGetAntiBruteForceEnabled(tr_rpc_server const* server);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -42,6 +42,13 @@ public:
 
     void setPort(tr_port) noexcept;
 
+    [[nodiscard]] constexpr bool isEnabled() const noexcept
+    {
+        return is_enabled_;
+    }
+
+    void setEnabled(bool is_enabled);
+
     std::shared_ptr<libdeflate_compressor> compressor;
 
     std::vector<std::string> hostWhitelist;
@@ -66,15 +73,11 @@ public:
     tr_port port_;
 
     bool isAntiBruteForceEnabled = false;
-    bool isEnabled = false;
+    bool is_enabled_ = false;
     bool isHostWhitelistEnabled = false;
     bool isPasswordEnabled = false;
     bool isWhitelistEnabled = false;
 };
-
-void tr_rpcSetEnabled(tr_rpc_server* server, bool isEnabled);
-
-bool tr_rpcIsEnabled(tr_rpc_server const* server);
 
 void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -115,6 +115,11 @@ public:
 
     [[nodiscard]] std::string getBindAddress() const;
 
+    [[nodiscard]] constexpr auto socketMode() const noexcept
+    {
+        return socket_mode_;
+    }
+
     std::vector<std::string> hostWhitelist;
     std::vector<std::string> whitelist_;
     std::string salted_password_;
@@ -132,7 +137,7 @@ public:
     int login_attempts_ = 0;
     int start_retry_counter = 0;
     static int constexpr DefaultRpcSocketMode = 0750;
-    int rpc_socket_mode = DefaultRpcSocketMode;
+    int socket_mode_ = DefaultRpcSocketMode;
 
     tr_port port_;
 
@@ -142,5 +147,3 @@ public:
     bool is_password_enabled_ = false;
     bool is_whitelist_enabled_ = false;
 };
-
-int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -64,21 +64,21 @@ public:
         return whitelist_str_;
     }
 
-    void setWhitelist(std::string_view whitelist) noexcept;
+    void setWhitelist(std::string_view whitelist);
 
     [[nodiscard]] constexpr auto const& username() const noexcept
     {
         return username_;
     }
 
-    void setUsername(std::string_view username) noexcept;
+    void setUsername(std::string_view username);
 
     [[nodiscard]] constexpr auto isPasswordEnabled() const noexcept
     {
         return is_password_enabled_;
     }
 
-    void setPasswordEnabled(bool enabled) noexcept;
+    void setPasswordEnabled(bool enabled);
 
     [[nodiscard]] constexpr auto const& getSaltedPassword()
     {
@@ -106,6 +106,13 @@ public:
 
     std::shared_ptr<libdeflate_compressor> compressor;
 
+    [[nodiscard]] constexpr auto const& url() const noexcept
+    {
+        return url_;
+    }
+
+    void setUrl(std::string_view url);
+
     [[nodiscard]] std::string getBindAddress() const;
 
     std::vector<std::string> hostWhitelist;
@@ -113,7 +120,7 @@ public:
     std::string salted_password_;
     std::string username_;
     std::string whitelist_str_;
-    std::string url;
+    std::string url_;
 
     std::unique_ptr<struct tr_rpc_address> bindAddress;
 
@@ -135,9 +142,5 @@ public:
     bool is_password_enabled_ = false;
     bool is_whitelist_enabled_ = false;
 };
-
-void tr_rpcSetUrl(tr_rpc_server* server, std::string_view url);
-
-std::string const& tr_rpcGetUrl(tr_rpc_server const* server);
 
 int tr_rpcGetRPCSocketMode(tr_rpc_server const* server);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -445,7 +445,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_password, tr_sessionGetRPCPassword(s));
     tr_variantDictAddInt(d, TR_KEY_rpc_port, tr_sessionGetRPCPort(s));
-    tr_variantDictAddInt(d, TR_KEY_rpc_socket_mode, tr_rpcGetRPCSocketMode(s->rpc_server_.get()));
+    tr_variantDictAddInt(d, TR_KEY_rpc_socket_mode, s->rpc_server_->socketMode());
     tr_variantDictAddStr(d, TR_KEY_rpc_url, tr_sessionGetRPCUrl(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_username, tr_sessionGetRPCUsername(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_whitelist, tr_sessionGetRPCWhitelist(s));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2643,14 +2643,14 @@ void tr_sessionSetRPCUsername(tr_session* session, char const* username)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetUsername(session->rpc_server_.get(), username != nullptr ? username : "");
+    session->rpc_server_->setUsername(username != nullptr ? username : "");
 }
 
 char const* tr_sessionGetRPCUsername(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcGetUsername(session->rpc_server_.get()).c_str();
+    return session->rpc_server_->username().c_str();
 }
 
 void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool enabled)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2531,12 +2531,7 @@ char const* tr_blocklistGetURL(tr_session const* session)
 
 void tr_session::setRpcWhitelist(std::string_view whitelist) const
 {
-    tr_rpcSetWhitelist(this->rpc_server_.get(), whitelist);
-}
-
-std::string const& tr_session::rpcWhitelist() const
-{
-    return tr_rpcGetWhitelist(this->rpc_server_.get());
+    this->rpc_server_->setWhitelist(whitelist);
 }
 
 void tr_session::useRpcWhitelist(bool enabled) const
@@ -2613,7 +2608,7 @@ char const* tr_sessionGetRPCWhitelist(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->rpcWhitelist().c_str();
+    return session->rpc_server_->whitelist().c_str();
 }
 
 void tr_sessionSetRPCWhitelistEnabled(tr_session* session, bool enabled)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2786,14 +2786,14 @@ void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool is_enabled)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetAntiBruteForceEnabled(session->rpc_server_.get(), is_enabled);
+    session->rpc_server_->setAntiBruteForceEnabled(is_enabled);
 }
 
 bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcGetAntiBruteForceEnabled(session->rpc_server_.get());
+    return session->rpc_server_->isAntiBruteForceEnabled();
 }
 
 int tr_sessionGetAntiBruteForceThreshold(tr_session const* session)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2775,11 +2775,19 @@ int tr_sessionGetQueueStalledMinutes(tr_session const* session)
     return session->queueStalledMinutes;
 }
 
-void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int bad_requests)
+void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int limit)
 {
     TR_ASSERT(tr_isSession(session));
-    TR_ASSERT(bad_requests > 0);
-    tr_rpcSetAntiBruteForceThreshold(session->rpc_server_.get(), bad_requests);
+    TR_ASSERT(limit > 0);
+
+    session->rpc_server_->setAntiBruteForceLimit(limit);
+}
+
+int tr_sessionGetAntiBruteForceThreshold(tr_session const* session)
+{
+    TR_ASSERT(tr_isSession(session));
+
+    return session->rpc_server_->getAntiBruteForceLimit();
 }
 
 void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool is_enabled)
@@ -2794,13 +2802,6 @@ bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session)
     TR_ASSERT(tr_isSession(session));
 
     return session->rpc_server_->isAntiBruteForceEnabled();
-}
-
-int tr_sessionGetAntiBruteForceThreshold(tr_session const* session)
-{
-    TR_ASSERT(tr_isSession(session));
-
-    return tr_rpcGetAntiBruteForceThreshold(session->rpc_server_.get());
 }
 
 std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction, size_t num_wanted)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -441,7 +441,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_ratio_limit_enabled, s->isRatioLimited);
     tr_variantDictAddBool(d, TR_KEY_rename_partial_files, tr_sessionIsIncompleteFileNamingEnabled(s));
     tr_variantDictAddBool(d, TR_KEY_rpc_authentication_required, tr_sessionIsRPCPasswordEnabled(s));
-    tr_variantDictAddStr(d, TR_KEY_rpc_bind_address, tr_sessionGetRPCBindAddress(s));
+    tr_variantDictAddStr(d, TR_KEY_rpc_bind_address, s->rpc_server_->getBindAddress());
     tr_variantDictAddBool(d, TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_password, tr_sessionGetRPCPassword(s));
     tr_variantDictAddInt(d, TR_KEY_rpc_port, tr_sessionGetRPCPort(s));
@@ -2665,13 +2665,6 @@ bool tr_sessionIsRPCPasswordEnabled(tr_session const* session)
     TR_ASSERT(tr_isSession(session));
 
     return session->rpc_server_->isPasswordEnabled();
-}
-
-char const* tr_sessionGetRPCBindAddress(tr_session const* session)
-{
-    TR_ASSERT(tr_isSession(session));
-
-    return tr_rpcGetBindAddress(session->rpc_server_.get());
 }
 
 /****

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2629,14 +2629,14 @@ void tr_sessionSetRPCPassword(tr_session* session, char const* password)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetPassword(session->rpc_server_.get(), password != nullptr ? password : "");
+    session->rpc_server_->setPassword(password != nullptr ? password : "");
 }
 
 char const* tr_sessionGetRPCPassword(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcGetPassword(session->rpc_server_.get()).c_str();
+    return session->rpc_server_->getSaltedPassword().c_str();
 }
 
 void tr_sessionSetRPCUsername(tr_session* session, char const* username)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2653,18 +2653,18 @@ char const* tr_sessionGetRPCUsername(tr_session const* session)
     return tr_rpcGetUsername(session->rpc_server_.get()).c_str();
 }
 
-void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool isEnabled)
+void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool enabled)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetPasswordEnabled(session->rpc_server_.get(), isEnabled);
+    session->rpc_server_->setPasswordEnabled(enabled);
 }
 
 bool tr_sessionIsRPCPasswordEnabled(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcIsPasswordEnabled(session->rpc_server_.get());
+    return session->rpc_server_->isPasswordEnabled();
 }
 
 char const* tr_sessionGetRPCBindAddress(tr_session const* session)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2549,18 +2549,18 @@ bool tr_session::useRpcWhitelist() const
     return tr_rpcGetWhitelistEnabled(this->rpc_server_.get());
 }
 
-void tr_sessionSetRPCEnabled(tr_session* session, bool isEnabled)
+void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetEnabled(session->rpc_server_.get(), isEnabled);
+    session->rpc_server_->setEnabled(is_enabled);
 }
 
 bool tr_sessionIsRPCEnabled(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcIsEnabled(session->rpc_server_.get());
+    return session->rpc_server_->isEnabled();
 }
 
 void tr_sessionSetRPCPort(tr_session* session, uint16_t hport)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2541,12 +2541,12 @@ std::string const& tr_session::rpcWhitelist() const
 
 void tr_session::useRpcWhitelist(bool enabled) const
 {
-    tr_rpcSetWhitelistEnabled(this->rpc_server_.get(), enabled);
+    this->rpc_server_->setWhitelistEnabled(enabled);
 }
 
 bool tr_session::useRpcWhitelist() const
 {
-    return tr_rpcGetWhitelistEnabled(this->rpc_server_.get());
+    return this->rpc_server_->isWhitelistEnabled();
 }
 
 void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2579,14 +2579,14 @@ void tr_sessionSetRPCUrl(tr_session* session, char const* url)
 {
     TR_ASSERT(tr_isSession(session));
 
-    tr_rpcSetUrl(session->rpc_server_.get(), url != nullptr ? url : "");
+    session->rpc_server_->setUrl(url != nullptr ? url : "");
 }
 
 char const* tr_sessionGetRPCUrl(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return tr_rpcGetUrl(session->rpc_server_.get()).c_str();
+    return session->rpc_server_->url().c_str();
 }
 
 void tr_sessionSetRPCCallback(tr_session* session, tr_rpc_func func, void* user_data)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -223,8 +223,6 @@ public:
 
     void setRpcWhitelist(std::string_view whitelist) const;
 
-    std::string const& rpcWhitelist() const;
-
     void useRpcWhitelist(bool enabled) const;
 
     [[nodiscard]] bool useRpcWhitelist() const;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -389,8 +389,6 @@ void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool isEnabled);
 
 bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
 
-char const* tr_sessionGetRPCBindAddress(tr_session const* session);
-
 void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers);
 
 enum tr_rpc_callback_type


### PR DESCRIPTION
Replace the older C-style API methods to be class methods.

Old: `tr_rpcServerDoFoo(tr_rpc_server*, ...);`

New: `tr_rpc_server::doFoo(...);`