### PR TITLE
Specify the umask and IPC socket permission as strings.

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -55,7 +55,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **rename-partial-files:** Boolean (default = true) Postfix partially downloaded files with ".part".
  * **start-added-torrents:** Boolean (default = true) Start torrents as soon as they are added.
  * **trash-original-torrent-files:** Boolean (default = false) Delete torrents added from the watch directory.
- * **umask:** Number (default = 18) Sets transmission's file mode creation mask. See [the umask(2) manpage](https://developer.apple.com/documentation/Darwin/Reference/ManPages/man2/umask.2.html) for more information. Users who want their saved torrents to be world-writable may want to set this value to 0. Bear in mind that the JSON markup language only accepts numbers in base 10, so the standard umask(2) octal notation "022" is written in settings.json as 18.
+ * **umask:** String (default = "022") Sets Transmission's file mode creation mask. See [the umask(2) manpage](https://developer.apple.com/documentation/Darwin/Reference/ManPages/man2/umask.2.html) for more information. Users who want their saved torrents to be world-writable may want to set this value to "0".
  * **watch-dir:** String
  * **watch-dir-enabled:** Boolean (default = false) Watch a directory for torrent files and add them to transmission.
    _Note: When **watch-dir-enabled** is true, only the transmission-daemon, transmission-gtk, and transmission-qt applications will monitor **watch-dir** for new .torrent files and automatically load them._

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1084,8 +1084,20 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     }
 
     key = TR_KEY_rpc_socket_mode;
+    bool is_missing_rpc_socket_mode_key = true;
 
-    if (!tr_variantDictFindInt(settings, key, &i))
+    if (tr_variantDictFindStrView(settings, key, &sv))
+    {
+        /* Read the socket permission as a string representing an octal number. */
+        is_missing_rpc_socket_mode_key = false;
+        std::from_chars(sv.data(), sv.data() + sv.size(), i, 8);
+    }
+    else if (tr_variantDictFindInt(settings, key, &i))
+    {
+        /* Or as a base 10 integer to remain compatible with the old settings format. */
+        is_missing_rpc_socket_mode_key = false;
+    }
+    if (is_missing_rpc_socket_mode_key)
     {
         missing_settings_key(key);
     }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1090,7 +1090,7 @@ tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     {
         /* Read the socket permission as a string representing an octal number. */
         is_missing_rpc_socket_mode_key = false;
-        std::from_chars(sv.data(), sv.data() + sv.size(), i, 8);
+        i = tr_parseNum<int>(sv, 8).value_or(tr_rpc_server::DefaultRpcSocketMode);
     }
     else if (tr_variantDictFindInt(settings, key, &i))
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -796,8 +796,16 @@ static void sessionSetImpl(struct init_data* const data)
 
 #ifndef _WIN32
 
-    if (tr_variantDictFindInt(settings, TR_KEY_umask, &i))
+    if (tr_variantDictFindStrView(settings, TR_KEY_umask, &sv))
     {
+        /* Read a umask as a string representing an octal number. */
+        std::from_chars(sv.data(), sv.data() + sv.size(), i, 8);
+        session->umask = (mode_t)i;
+        umask(session->umask);
+    }
+    else if (tr_variantDictFindInt(settings, TR_KEY_umask, &i))
+    {
+        /* Or as a base 10 integer to remain compatible with the old settings format. */
         session->umask = (mode_t)i;
         umask(session->umask);
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -79,6 +79,7 @@ static auto constexpr DefaultPrefetchEnabled = bool{ false };
 static auto constexpr DefaultCacheSizeMB = int{ 4 };
 static auto constexpr DefaultPrefetchEnabled = bool{ true };
 #endif
+static auto constexpr DefaultUmask = int{ 022 };
 static auto constexpr SaveIntervalSecs = int{ 360 };
 
 static void bandwidthGroupRead(tr_session* session, std::string_view config_dir);
@@ -390,7 +391,7 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddInt(d, TR_KEY_alt_speed_time_day, TR_SCHED_ALL);
     tr_variantDictAddInt(d, TR_KEY_speed_limit_up, 100);
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, false);
-    tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:#o}", 022));
+    tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:#o}", DefaultUmask));
     tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, 14);
     tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv4, TR_DEFAULT_BIND_ADDRESS_IPV4);
     tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv6, TR_DEFAULT_BIND_ADDRESS_IPV6);
@@ -799,7 +800,7 @@ static void sessionSetImpl(struct init_data* const data)
     if (tr_variantDictFindStrView(settings, TR_KEY_umask, &sv))
     {
         /* Read a umask as a string representing an octal number. */
-        session->umask = tr_parseNum<mode_t>(sv, 8).value_or(022);
+        session->umask = tr_parseNum<mode_t>(sv, 8).value_or(DefaultUmask);
         umask(session->umask);
     }
     else if (tr_variantDictFindInt(settings, TR_KEY_umask, &i))

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -371,7 +371,7 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_rpc_host_whitelist_enabled, true);
     tr_variantDictAddInt(d, TR_KEY_rpc_port, TR_DEFAULT_RPC_PORT);
     tr_variantDictAddStrView(d, TR_KEY_rpc_url, TR_DEFAULT_RPC_URL_STR);
-    tr_variantDictAddInt(d, TR_KEY_rpc_socket_mode, tr_rpc_server::DefaultRpcSocketMode);
+    tr_variantDictAddStr(d, TR_KEY_rpc_socket_mode, fmt::format("{:#o}", tr_rpc_server::DefaultRpcSocketMode));
     tr_variantDictAddBool(d, TR_KEY_scrape_paused_torrents_enabled, true);
     tr_variantDictAddStrView(d, TR_KEY_script_torrent_added_filename, "");
     tr_variantDictAddBool(d, TR_KEY_script_torrent_added_enabled, false);
@@ -446,7 +446,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_password, tr_sessionGetRPCPassword(s));
     tr_variantDictAddInt(d, TR_KEY_rpc_port, tr_sessionGetRPCPort(s));
-    tr_variantDictAddInt(d, TR_KEY_rpc_socket_mode, s->rpc_server_->socketMode());
+    tr_variantDictAddStr(d, TR_KEY_rpc_socket_mode, fmt::format("{:#o}", s->rpc_server_.get()->socket_mode_));
     tr_variantDictAddStr(d, TR_KEY_rpc_url, tr_sessionGetRPCUrl(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_username, tr_sessionGetRPCUsername(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_whitelist, tr_sessionGetRPCWhitelist(s));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -446,7 +446,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_password, tr_sessionGetRPCPassword(s));
     tr_variantDictAddInt(d, TR_KEY_rpc_port, tr_sessionGetRPCPort(s));
-    tr_variantDictAddStr(d, TR_KEY_rpc_socket_mode, fmt::format("{:#o}", s->rpc_server_.get()->socket_mode_));
+    tr_variantDictAddStr(d, TR_KEY_rpc_socket_mode, fmt::format("{:#o}", s->rpc_server_->socket_mode_));
     tr_variantDictAddStr(d, TR_KEY_rpc_url, tr_sessionGetRPCUrl(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_username, tr_sessionGetRPCUsername(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_whitelist, tr_sessionGetRPCWhitelist(s));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -390,7 +390,7 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddInt(d, TR_KEY_alt_speed_time_day, TR_SCHED_ALL);
     tr_variantDictAddInt(d, TR_KEY_speed_limit_up, 100);
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, false);
-    tr_variantDictAddInt(d, TR_KEY_umask, 022);
+    tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:#o}", 022));
     tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, 14);
     tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv4, TR_DEFAULT_BIND_ADDRESS_IPV4);
     tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv6, TR_DEFAULT_BIND_ADDRESS_IPV6);
@@ -463,7 +463,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddInt(d, TR_KEY_alt_speed_time_day, tr_sessionGetAltSpeedDay(s));
     tr_variantDictAddInt(d, TR_KEY_speed_limit_up, tr_sessionGetSpeedLimit_KBps(s, TR_UP));
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, tr_sessionIsSpeedLimited(s, TR_UP));
-    tr_variantDictAddInt(d, TR_KEY_umask, s->umask);
+    tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:#o}", s->umask));
     tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, s->uploadSlotsPerTorrent);
     tr_variantDictAddStr(d, TR_KEY_bind_address_ipv4, tr_address_to_string(&s->bind_ipv4->addr));
     tr_variantDictAddStr(d, TR_KEY_bind_address_ipv6, tr_address_to_string(&s->bind_ipv6->addr));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -799,8 +799,7 @@ static void sessionSetImpl(struct init_data* const data)
     if (tr_variantDictFindStrView(settings, TR_KEY_umask, &sv))
     {
         /* Read a umask as a string representing an octal number. */
-        std::from_chars(sv.data(), sv.data() + sv.size(), i, 8);
-        session->umask = (mode_t)i;
+        session->umask = tr_parseNum<mode_t>(sv, 8).value_or(022);
         umask(session->umask);
     }
     else if (tr_variantDictFindInt(settings, TR_KEY_umask, &i))


### PR DESCRIPTION
The umask and IPC socket permission will now be stored as strings representing octal numbers in the settings file.
They now can also be loaded from such a string as well as from the old base 10 number to remain backwards compatibility.
The octal format is more familiar to the users of Unix-like operating systems than the previous base 10 version of the same number, since those systems represent their file system permissions in octal.

I could not find automated tests for the settings file to which I could have added own tests, but I tested everything manually and very thoroughly. Normal permissions, empty strings, strings containing non-octal numbers or numbers representing a number bigger than 777 and so on.
The new format handles all these cases exactly as the old format did. Which means that some of them are unchecked and produce bogus settings but there are no new errors or new behaviour introduced (apart from being able to specify the same things as a string).
I tested all the same input (except for the empty string and the non-octal numbers obviously) as regular JSON integers with this new version as well as with version 3.0.

Additionally I updated the affected part of the documentation.

Closes: #2904
