### PR TITLE
Replacing references to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Different distributions may choose to package any or all of these tools in one o
 
 Transmission has an Xcode project file (Transmission.xcodeproj) for building in Xcode.
 
+For a more detailed description, and dependencies, visit: https://github.com/transmission/transmission/tree/main/docs
+
 ### Building a Transmission release from the command line
 
     $ tar xf transmission-3.00.tar.xz

--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ Different distributions may choose to package any or all of these tools in one o
 
 Transmission has an Xcode project file (Transmission.xcodeproj) for building in Xcode.
 
-For a more detailed description, and dependencies, visit: https://github.com/transmission/transmission/wiki
-
 ### Building a Transmission release from the command line
 
-    $ tar xf transmission-2.92.tar.xz
-    $ cd transmission-2.92
+    $ tar xf transmission-3.00.tar.xz
+    $ cd transmission-3.00
     $ mkdir build
     $ cd build
     $ # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary.

--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -65,7 +65,6 @@ Prefer unencrypted peer connections.
 Set a script to run when the torrent finishes
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
-See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .It Fl h Fl -help
 Prints a short usage summary.
 .It Fl m Fl -portmap

--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -65,6 +65,7 @@ Prefer unencrypted peer connections.
 Set a script to run when the torrent finishes
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
+See https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md for more information.
 .It Fl h Fl -help
 Prints a short usage summary.
 .It Fl m Fl -portmap

--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -60,7 +60,6 @@ Dump transmission-daemon's settings to stderr.
 Run in the foreground and print errors to stderr.
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
-See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .It Fl er Fl -encryption-required
 Encrypt all peer connections.
 .It Fl ep Fl -encryption-preferred
@@ -151,7 +150,6 @@ The config-dir used when neither
 nor
 .Op Fl g
 is specified.
-See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .El
 .Sh AUTHORS
 .An -nosplit

--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -60,6 +60,7 @@ Dump transmission-daemon's settings to stderr.
 Run in the foreground and print errors to stderr.
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
+See https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md for more information.
 .It Fl er Fl -encryption-required
 Encrypt all peer connections.
 .It Fl ep Fl -encryption-preferred
@@ -150,6 +151,7 @@ The config-dir used when neither
 nor
 .Op Fl g
 is specified.
+See https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md for more information.
 .El
 .Sh AUTHORS
 .An -nosplit

--- a/gtk/transmission-gtk.1
+++ b/gtk/transmission-gtk.1
@@ -47,7 +47,6 @@ Start with all torrents paused
 Start minimized in notification area
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
-See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .El
 .Pp
 Multiple .torrent files may be added at startup

--- a/gtk/transmission-gtk.1
+++ b/gtk/transmission-gtk.1
@@ -47,6 +47,7 @@ Start with all torrents paused
 Start minimized in notification area
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
+See https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md for more information.
 .El
 .Pp
 Multiple .torrent files may be added at startup

--- a/qt/transmission-qt.1
+++ b/qt/transmission-qt.1
@@ -23,6 +23,7 @@ information on the BitTorrent protocol see http://www.bittorrent.org/
 Show help options
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
+See https://github.com/transmission/transmission/blob/main/docs/Configuration-Files.md for more information.
 .It Fl m Fl -minimized
 Start minimized in notification area
 .It Fl p Fl -port Ar port

--- a/qt/transmission-qt.1
+++ b/qt/transmission-qt.1
@@ -23,7 +23,6 @@ information on the BitTorrent protocol see http://www.bittorrent.org/
 Show help options
 .It Fl g Fl -config-dir Ar directory
 Where to look for configuration files. This can be used to swap between using the cli, daemon, gtk, and qt clients.
-See https://github.com/transmission/transmission/wiki/Configuration-Files for more information.
 .It Fl m Fl -minimized
 Start minimized in notification area
 .It Fl p Fl -port Ar port


### PR DESCRIPTION
Some admin removed the wiki at:
https://github.com/transmission/transmission/wiki

So let's remove the references to it as well.