### PR TITLE
refactor: intern tr_torrent.bandwidth_group_

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -138,14 +138,14 @@ static auto loadLabels(tr_variant* dict, tr_torrent* tor)
 
 static void saveGroup(tr_variant* dict, tr_torrent const* tor)
 {
-    tr_variantDictAddStrView(dict, TR_KEY_group, tor->group);
+    tr_variantDictAddStrView(dict, TR_KEY_group, tor->bandwidthGroup());
 }
 
 static auto loadGroup(tr_variant* dict, tr_torrent* tor)
 {
-    if (std::string_view groupName; tr_variantDictFindStrView(dict, TR_KEY_group, &groupName) && !groupName.empty())
+    if (std::string_view group_name; tr_variantDictFindStrView(dict, TR_KEY_group, &group_name) && !std::empty(group_name))
     {
-        tor->setGroup(groupName);
+        tor->setBandwidthGroup(group_name);
         return tr_resume::Group;
     }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -562,7 +562,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         break;
 
     case TR_KEY_group:
-        tr_variantInitStrView(initme, tor->group);
+        tr_variantInitStrView(initme, tor->bandwidthGroup().sv());
         break;
 
     case TR_KEY_hashString:
@@ -1162,7 +1162,7 @@ static char const* torrentSet(
 
         if (std::string_view group; tr_variantDictFindStrView(args_in, TR_KEY_group, &group))
         {
-            tor->setGroup(group);
+            tor->setBandwidthGroup(group);
         }
 
         if (errmsg == nullptr && tr_variantDictFindList(args_in, TR_KEY_labels, &tmp_variant))

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1932,21 +1932,21 @@ void tr_torrent::setLabels(tr_quark const* new_labels, size_t n_labels)
 ****
 ***/
 
-void tr_torrent::setGroup(std::string_view group_name)
+void tr_torrent::setBandwidthGroup(std::string_view bandwidth_group) noexcept
 {
-    group_name = tr_strvStrip(group_name);
+    bandwidth_group = tr_strvStrip(bandwidth_group);
 
     auto const lock = this->unique_lock();
 
-    if (std::empty(group_name))
+    if (std::empty(bandwidth_group))
     {
-        this->group = ""sv;
+        this->bandwidth_group_ = tr_interned_string{};
         this->bandwidth_.setParent(&this->session->top_bandwidth_);
     }
     else
     {
-        this->group = group_name;
-        this->bandwidth_.setParent(&this->session->getBandwidthGroup(group_name));
+        this->bandwidth_group_ = bandwidth_group;
+        this->bandwidth_.setParent(&this->session->getBandwidthGroup(bandwidth_group));
     }
 
     this->setDirty();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -716,7 +716,13 @@ public:
     using labels_t = std::vector<tr_quark>;
     labels_t labels;
 
-    std::string group;
+    void setBandwidthGroup(std::string_view group_name) noexcept;
+
+    [[nodiscard]] constexpr tr_interned_string const& bandwidthGroup() const noexcept
+    {
+        return bandwidth_group_;
+    }
+
     /* Set the bandwidth group the torrent belongs to */
     void setGroup(std::string_view groupName);
 
@@ -733,6 +739,7 @@ public:
     tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
 private:
+    tr_interned_string bandwidth_group_;
     tr_verify_state verify_state_ = TR_VERIFY_NONE;
     float verify_progress_ = -1;
 


### PR DESCRIPTION
Most use cases involve either (a) using the default group or (b) sharing
a group with other torrents. In both cases, using a tr_quark is cheaper
than a std::string.