### PR TITLE
Fix QuickLook

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -237,7 +237,6 @@
 		A2D77451154CC25700A62B93 /* WebSeedTableView.h in Headers */ = {isa = PBXBuildFile; fileRef = A2D7744F154CC25700A62B93 /* WebSeedTableView.h */; };
 		A2D77452154CC25700A62B93 /* WebSeedTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D77450154CC25700A62B93 /* WebSeedTableView.mm */; };
 		A2D77453154CC72B00A62B93 /* WebSeedTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D77450154CC25700A62B93 /* WebSeedTableView.mm */; };
-		A2D8CFBA15F82DFA0056E93D /* NSApplicationAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = A29D84031049C25600D1987A /* NSApplicationAdditions.mm */; };
 		A2D8CFBB15F82E030056E93D /* NSStringAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DE5CC9C0980656F00BE280E /* NSStringAdditions.mm */; };
 		A2DF37070C220D03006523C1 /* CreatorWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2DF37050C220D03006523C1 /* CreatorWindowController.mm */; };
 		A2E384DA130DFB3A001F501B /* templates.h in Headers */ = {isa = PBXBuildFile; fileRef = A2E384D2130DFB3A001F501B /* templates.h */; };
@@ -1257,10 +1256,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2F35BBC15C5A0A100EBF632 /* QuickLook.framework in Frameworks */,
-				C88771AD2803EE7B005C7523 /* libz.tbd in Frameworks */,
 				A2F35BE115C5A7ED00EBF632 /* Cocoa.framework in Frameworks */,
 				A2F35BE315C5A7F900EBF632 /* Foundation.framework in Frameworks */,
 				A2F35BD415C5A19A00EBF632 /* libtransmission.a in Frameworks */,
+				C88771AD2803EE7B005C7523 /* libz.tbd in Frameworks */,
 				C88771B12803EE86005C7523 /* libiconv.tbd in Frameworks */,
 				55869932257074FE00F77A43 /* libcurl.tbd in Frameworks */,
 			);
@@ -3103,9 +3102,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2D8CFBB15F82E030056E93D /* NSStringAdditions.mm in Sources */,
-				A2D8CFBA15F82DFA0056E93D /* NSApplicationAdditions.mm in Sources */,
 				A29304EE15D7497C00B1F726 /* main.cc in Sources */,
+				A2D8CFBB15F82E030056E93D /* NSStringAdditions.mm in Sources */,
 				A2F35BCA15C5A0A100EBF632 /* GenerateThumbnailForURL.mm in Sources */,
 				A2F35BCC15C5A0A100EBF632 /* GeneratePreviewForURL.mm in Sources */,
 			);

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <algorithm> // std::sort()
 #include <cstddef>
 #include <cstdint> // uint64_t
 #include <functional>
@@ -72,9 +73,14 @@ public:
         total_size_ = uint64_t{};
     }
 
-    void sortByPath()
+    auto sorted() const
     {
-        std::sort(files_.begin(), files_.end(), [](const auto& lhs, const auto& rhs) { return lhs.path_ < rhs.path_; });
+        auto ret = *this;
+        std::sort(
+            std::begin(ret.files_),
+            std::end(ret.files_),
+            [](auto const& lhs, auto const& rhs) { return lhs.path_ < rhs.path_; });
+        return ret;
     }
 
     tr_file_index_t add(std::string_view path, uint64_t file_size)

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint> // uint64_t
 #include <functional>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -73,13 +74,18 @@ public:
         total_size_ = uint64_t{};
     }
 
-    auto sorted() const
+    auto sortedByPath() const
     {
-        auto ret = *this;
-        std::sort(
-            std::begin(ret.files_),
-            std::end(ret.files_),
-            [](auto const& lhs, auto const& rhs) { return lhs.path_ < rhs.path_; });
+        auto ret = std::vector<std::pair<std::string /*path*/, uint64_t /*size*/>>{};
+        ret.reserve(std::size(files_));
+        std::transform(
+            std::begin(files_),
+            std::end(files_),
+            std::back_inserter(ret),
+            [](auto const& in) { return std::make_pair(in.path_, in.size_); });
+
+        std::sort(std::begin(ret), std::end(ret), [](auto const& lhs, auto const& rhs) { return lhs.first < rhs.first; });
+
         return ret;
     }
 

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -72,6 +72,11 @@ public:
         total_size_ = uint64_t{};
     }
 
+    void sortByPath()
+    {
+        std::sort(files_.begin(), files_.end(), [](const auto& lhs, const auto& rhs) { return lhs.path_ < rhs.path_; });
+    }
+
     tr_file_index_t add(std::string_view path, uint64_t file_size)
     {
         auto const ret = static_cast<tr_file_index_t>(std::size(files_));

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -49,7 +49,6 @@
 #include "torrent-metainfo.h"
 #include "torrent.h"
 #include "tr-assert.h"
-#include "tr-assert.h"
 #include "trevent.h" /* tr_runInEventThread() */
 #include "utils.h"
 #include "variant.h"

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -5,7 +5,6 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 
-#import "NSApplicationAdditions.h"
 #import "NSStringAdditions.h"
 
 @interface NSString (Private)

--- a/macosx/QuickLookPlugin/CMakeLists.txt
+++ b/macosx/QuickLookPlugin/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(trmacql)
 
 set(${PROJECT_NAME}_SOURCES
-    ../NSApplicationAdditions.mm
     ../NSStringAdditions.mm
     GeneratePreviewForURL.mm
     GenerateThumbnailForURL.mm

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -183,7 +183,6 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
 
     if (is_multifile)
     {
-        auto const files = metainfo.files().sorted();
         NSMutableString* listSection = [NSMutableString string];
         [listSection appendString:@"<table>"];
 
@@ -192,14 +191,14 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
         [listSection appendFormat:@"<tr><th>%@</th></tr>", fileTitleString];
 
 #warning display folders?
-        for (tr_file_index_t i = 0; i < n_files; ++i)
+        for (auto const& [path, size] : metainfo.sortedByPath())
         {
-            NSString* fullFilePath = [NSString stringWithUTF8String:files.path(i).c_str()];
+            NSString* fullFilePath = [NSString stringWithUTF8String:path.c_str()];
             NSCAssert([fullFilePath hasPrefix:[name stringByAppendingString:@"/"]], @"Expected file path %@ to begin with %@/", fullFilePath, name);
 
             NSString* shortenedFilePath = [fullFilePath substringFromIndex:[name length] + 1];
             NSString* shortenedFilePathAndSize = [NSString
-                stringWithFormat:@"%@ - %@", shortenedFilePath, [NSString stringForFileSize:files.fileSize(i)]];
+                stringWithFormat:@"%@ - %@", shortenedFilePath, [NSString stringForFileSize:size]];
 
             NSUInteger const width = 16;
             [listSection appendFormat:@"<tr><td><img class=\"icon\" src=\"%@\" width=\"%ld\" height=\"%ld\" />%@<td></tr>",

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -183,8 +183,7 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
 
     if (is_multifile)
     {
-        tr_torrent_files files = metainfo.files();
-        files.sortByPath();
+        auto const files = metainfo.files().sorted();
         NSMutableString* listSection = [NSMutableString string];
         [listSection appendString:@"<table>"];
 

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -191,7 +191,7 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
         [listSection appendFormat:@"<tr><th>%@</th></tr>", fileTitleString];
 
 #warning display folders?
-        for (auto const& [path, size] : metainfo.sortedByPath())
+        for (auto const& [path, size] : metainfo.files().sortedByPath())
         {
             NSString* fullFilePath = [NSString stringWithUTF8String:path.c_str()];
             NSCAssert([fullFilePath hasPrefix:[name stringByAppendingString:@"/"]], @"Expected file path %@ to begin with %@/", fullFilePath, name);

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -10,8 +10,10 @@
 
 #import "NSStringAdditions.h"
 
-extern "C" OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options);
-extern "C" void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
+QL_EXTERN_C_BEGIN
+OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options);
+void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
+QL_EXTERN_C_END
 
 NSString* generateIconData(NSString* fileExtension, NSUInteger width, NSMutableDictionary* allImgProps)
 {

--- a/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
+++ b/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
@@ -2,8 +2,10 @@
 #import <CoreFoundation/CFPlugInCOM.h>
 #import <QuickLook/QuickLook.h>
 
-extern "C" OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize);
-extern "C" void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
+QL_EXTERN_C_BEGIN
+OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize);
+void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
+QL_EXTERN_C_END
 
 /* -----------------------------------------------------------------------------
     Generate a thumbnail for file

--- a/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
+++ b/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
@@ -1,9 +1,9 @@
 #import <CoreFoundation/CoreFoundation.h>
-#import <CoreServices/CoreServices.h>
+#import <CoreFoundation/CFPlugInCOM.h>
 #import <QuickLook/QuickLook.h>
 
-OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize);
-void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
+extern "C" OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize);
+extern "C" void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
 
 /* -----------------------------------------------------------------------------
     Generate a thumbnail for file

--- a/macosx/QuickLookPlugin/QuickLookPlugin-Prefix.pch
+++ b/macosx/QuickLookPlugin/QuickLookPlugin-Prefix.pch
@@ -1,4 +1,5 @@
 #ifdef __OBJC__
 #import <Cocoa/Cocoa.h>
+#import <CoreFoundation/CFPlugInCOM.h>
 #import <QuickLook/QuickLook.h>
 #endif

--- a/macosx/QuickLookPlugin/main.cc
+++ b/macosx/QuickLookPlugin/main.cc
@@ -29,24 +29,25 @@
 //	typedefs
 // -----------------------------------------------------------------------------
 
+QL_EXTERN_C_BEGIN
 // The thumbnail generation function to be implemented in GenerateThumbnailForURL.c
-extern "C" OSStatus GenerateThumbnailForURL(
+OSStatus GenerateThumbnailForURL(
     void* thisInterface,
     QLThumbnailRequestRef thumbnail,
     CFURLRef url,
     CFStringRef contentTypeUTI,
     CFDictionaryRef options,
     CGSize maxSize);
-extern "C" void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
+void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
 
 // The preview generation function to be implemented in GeneratePreviewForURL.c
-extern "C" OSStatus GeneratePreviewForURL(
+OSStatus GeneratePreviewForURL(
     void* thisInterface,
     QLPreviewRequestRef preview,
     CFURLRef url,
     CFStringRef contentTypeUTI,
     CFDictionaryRef options);
-extern "C" void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
+void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
 
 // The layout for an instance of QuickLookGeneratorPlugIn
 typedef struct __QuickLookGeneratorPluginType
@@ -62,12 +63,13 @@ typedef struct __QuickLookGeneratorPluginType
 //	Forward declaration for the IUnknown implementation.
 //
 
-extern "C" QuickLookGeneratorPluginType* AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
-extern "C" void DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType* thisInstance);
-extern "C" HRESULT QuickLookGeneratorQueryInterface(void* thisInstance, REFIID iid, LPVOID* ppv);
-extern "C" void* QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
-extern "C" ULONG QuickLookGeneratorPluginAddRef(void* thisInstance);
-extern "C" ULONG QuickLookGeneratorPluginRelease(void* thisInstance);
+QuickLookGeneratorPluginType* AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
+void DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType* thisInstance);
+HRESULT QuickLookGeneratorQueryInterface(void* thisInstance, REFIID iid, LPVOID* ppv);
+void* QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
+ULONG QuickLookGeneratorPluginAddRef(void* thisInstance);
+ULONG QuickLookGeneratorPluginRelease(void* thisInstance);
+QL_EXTERN_C_END
 
 // -----------------------------------------------------------------------------
 //	myInterfaceFtbl	definition

--- a/macosx/QuickLookPlugin/main.cc
+++ b/macosx/QuickLookPlugin/main.cc
@@ -9,7 +9,6 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreFoundation/CFPlugInCOM.h>
-#include <CoreServices/CoreServices.h>
 #include <QuickLook/QuickLook.h>
 
 // -----------------------------------------------------------------------------
@@ -31,23 +30,23 @@
 // -----------------------------------------------------------------------------
 
 // The thumbnail generation function to be implemented in GenerateThumbnailForURL.c
-OSStatus GenerateThumbnailForURL(
+extern "C" OSStatus GenerateThumbnailForURL(
     void* thisInterface,
     QLThumbnailRequestRef thumbnail,
     CFURLRef url,
     CFStringRef contentTypeUTI,
     CFDictionaryRef options,
     CGSize maxSize);
-void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
+extern "C" void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
 
 // The preview generation function to be implemented in GeneratePreviewForURL.c
-OSStatus GeneratePreviewForURL(
+extern "C" OSStatus GeneratePreviewForURL(
     void* thisInterface,
     QLPreviewRequestRef preview,
     CFURLRef url,
     CFStringRef contentTypeUTI,
     CFDictionaryRef options);
-void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
+extern "C" void CancelPreviewGeneration(void* thisInterface, QLPreviewRequestRef preview);
 
 // The layout for an instance of QuickLookGeneratorPlugIn
 typedef struct __QuickLookGeneratorPluginType
@@ -63,12 +62,12 @@ typedef struct __QuickLookGeneratorPluginType
 //	Forward declaration for the IUnknown implementation.
 //
 
-QuickLookGeneratorPluginType* AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
-void DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType* thisInstance);
-HRESULT QuickLookGeneratorQueryInterface(void* thisInstance, REFIID iid, LPVOID* ppv);
-void* QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
-ULONG QuickLookGeneratorPluginAddRef(void* thisInstance);
-ULONG QuickLookGeneratorPluginRelease(void* thisInstance);
+extern "C" QuickLookGeneratorPluginType* AllocQuickLookGeneratorPluginType(CFUUIDRef inFactoryID);
+extern "C" void DeallocQuickLookGeneratorPluginType(QuickLookGeneratorPluginType* thisInstance);
+extern "C" HRESULT QuickLookGeneratorQueryInterface(void* thisInstance, REFIID iid, LPVOID* ppv);
+extern "C" void* QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID);
+extern "C" ULONG QuickLookGeneratorPluginAddRef(void* thisInstance);
+extern "C" ULONG QuickLookGeneratorPluginRelease(void* thisInstance);
 
 // -----------------------------------------------------------------------------
 //	myInterfaceFtbl	definition


### PR DESCRIPTION
1. Fix QuickLook execution. I believe broken by #1830 since the fix is to add the missing `extern "C"` when compiling as C++.
2. Fix displaying size, which was an in-code warning-todo since 093d968b95e17f678e3b7a3490e64d80de130243. Adopted uTorrent format: filename separated from size by " - ".
3. Fix sorting alphabetically (#45)
4. Removes unnecessary `NSApplicationAdditions.mm` from QuickLookPlugin

Tested on macOS Mojave and macOS Monterey.
Fixes #45.