### PR TITLE
refactor: use smaller integral types in some structs

### DIFF
--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -156,10 +156,10 @@ bool refreshFilesForeach(
     auto const old_progress = iter->get_value(file_cols.prog);
     auto const old_size = iter->get_value(file_cols.size);
 
-    auto new_enabled = old_enabled;
+    auto new_enabled = int{};
     auto new_have = old_have;
-    auto new_priority = old_priority;
-    auto new_progress = old_progress;
+    auto new_priority = int{};
+    auto new_progress = int{};
     auto new_size = old_size;
 
     if (is_file)

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -121,10 +121,10 @@ bool tr_peerIsSeed(tr_peer const* peer);
 
 struct tr_swarm_stats
 {
-    int activePeerCount[2];
-    int activeWebseedCount;
-    int peerCount;
-    int peerFromCount[TR_PEER_FROM__MAX];
+    uint16_t active_peer_count[2];
+    uint16_t active_webseed_count;
+    uint16_t peer_count;
+    uint16_t peer_from_count[TR_PEER_FROM__MAX];
 };
 
 void tr_swarmGetStats(tr_swarm const* swarm, tr_swarm_stats* setme);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -742,7 +742,7 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
 
     if ((fieldsToLoad & tr_resume::MaxPeers) != 0 && tr_variantDictFindInt(&top, TR_KEY_max_peers, &i))
     {
-        tor->maxConnectedPeers = i;
+        tor->max_connected_peers = static_cast<uint16_t>(i);
         fields_loaded |= tr_resume::MaxPeers;
     }
 
@@ -873,7 +873,7 @@ static auto setFromCtor(tr_torrent* tor, tr_resume::fields_t fields, tr_ctor con
         }
     }
 
-    if (((fields & tr_resume::MaxPeers) != 0) && tr_ctorGetPeerLimit(ctor, mode, &tor->maxConnectedPeers))
+    if (((fields & tr_resume::MaxPeers) != 0) && tr_ctorGetPeerLimit(ctor, mode, &tor->max_connected_peers))
     {
         ret |= tr_resume::MaxPeers;
     }
@@ -943,7 +943,7 @@ void save(tr_torrent* tor)
 
     tr_variantDictAddInt(&top, TR_KEY_downloaded, tor->downloadedPrev + tor->downloadedCur);
     tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->uploadedPrev + tor->uploadedCur);
-    tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->maxConnectedPeers);
+    tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->max_connected_peers);
     tr_variantDictAddInt(&top, TR_KEY_bandwidth_priority, tr_torrentGetPriority(tor));
     tr_variantDictAddBool(&top, TR_KEY_paused, !tor->isRunning && !tor->isQueued());
     savePeers(&top, tor);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -654,7 +654,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
     case TR_KEY_peersFrom:
         {
             tr_variantInitDict(initme, 7);
-            int const* f = st->peersFrom;
+            auto const* f = st->peersFrom;
             tr_variantDictAddInt(initme, TR_KEY_fromCache, f[TR_PEER_FROM_RESUME]);
             tr_variantDictAddInt(initme, TR_KEY_fromDht, f[TR_PEER_FROM_DHT]);
             tr_variantDictAddInt(initme, TR_KEY_fromIncoming, f[TR_PEER_FROM_INCOMING]);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1045,14 +1045,14 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->errorString = tor->error_string.c_str();
 
     s->manualAnnounceTime = tr_announcerNextManualAnnounce(tor);
-    s->peersConnected = swarm_stats.peerCount;
-    s->peersSendingToUs = swarm_stats.activePeerCount[TR_DOWN];
-    s->peersGettingFromUs = swarm_stats.activePeerCount[TR_UP];
-    s->webseedsSendingToUs = swarm_stats.activeWebseedCount;
+    s->peersConnected = swarm_stats.peer_count;
+    s->peersSendingToUs = swarm_stats.active_peer_count[TR_DOWN];
+    s->peersGettingFromUs = swarm_stats.active_peer_count[TR_UP];
+    s->webseedsSendingToUs = swarm_stats.active_webseed_count;
 
     for (int i = 0; i < TR_PEER_FROM__MAX; i++)
     {
-        s->peersFrom[i] = swarm_stats.peerFromCount[i];
+        s->peersFrom[i] = swarm_stats.peer_from_count[i];
     }
 
     s->rawUploadSpeed_KBps = tr_toSpeedKBps(tor->bandwidth_.getRawSpeedBytesPerSecond(now, TR_UP));
@@ -1980,13 +1980,13 @@ void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority)
 ****
 ***/
 
-void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t maxConnectedPeers)
+void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tor->maxConnectedPeers != maxConnectedPeers)
+    if (tor->max_connected_peers != max_connected_peers)
     {
-        tor->maxConnectedPeers = maxConnectedPeers;
+        tor->max_connected_peers = max_connected_peers;
 
         tor->setDirty();
     }
@@ -1996,7 +1996,7 @@ uint16_t tr_torrentGetPeerLimit(tr_torrent const* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    return tor->maxConnectedPeers;
+    return tor->max_connected_peers;
 }
 
 /***

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -73,7 +73,7 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor);
 /** save a torrent's .resume file if it's changed since the last time it was saved */
 void tr_torrentSave(tr_torrent* tor);
 
-enum tr_verify_state
+enum tr_verify_state : uint8_t
 {
     TR_VERIFY_NONE,
     TR_VERIFY_WAIT,
@@ -699,7 +699,7 @@ public:
     void markEdited();
     void markChanged();
 
-    uint16_t maxConnectedPeers = TR_DEFAULT_PEER_LIMIT_TORRENT;
+    uint16_t max_connected_peers = TR_DEFAULT_PEER_LIMIT_TORRENT;
 
     time_t lastStatTime = 0;
     tr_stat stats = {};


### PR DESCRIPTION
ex: `tr_peer_stats`, `peer_atom`, `tr_stat`.

Also, sort those structs' fields to reduce the gaps / padding