### PR TITLE
refactor: make tr_recentHistory a template class

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -12,6 +12,7 @@
 #include <ctime>
 #include <deque>
 #include <map>
+#include <numeric>
 #include <set>
 #include <string>
 #include <string_view>

--- a/libtransmission/benc.h
+++ b/libtransmission/benc.h
@@ -9,7 +9,6 @@
 #include <cerrno>
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
-#include <cstdlib>
 #include <optional>
 #include <string_view>
 #include <utility> // make_pair

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -12,7 +12,6 @@
 #include <climits> /* PATH_MAX */
 #include <cstdint> /* SIZE_MAX */
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <string_view>
 #include <string>

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -103,11 +103,11 @@ public:
        For BitTorrent peers, this is the app name derived from the `v' string in LTEP's handshake dictionary */
     tr_interned_string client;
 
-    tr_recentHistory blocksSentToClient;
-    tr_recentHistory blocksSentToPeer;
+    tr_recentHistory<uint16_t> blocksSentToClient;
+    tr_recentHistory<uint16_t> blocksSentToPeer;
 
-    tr_recentHistory cancelsSentToClient;
-    tr_recentHistory cancelsSentToPeer;
+    tr_recentHistory<uint16_t> cancelsSentToClient;
+    tr_recentHistory<uint16_t> cancelsSentToPeer;
 };
 
 /** Update the tr_peer.progress field based on the 'have' bitset. */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -10,8 +10,9 @@
 #include <cstdint>
 #include <cstdlib> /* qsort */
 #include <ctime> // time_t
-#include <tuple> // std::tie
 #include <iterator> // std::back_inserter
+#include <numeric> // std::accumulate
+#include <tuple> // std::tie
 #include <utility>
 #include <vector>
 
@@ -1921,7 +1922,6 @@ static void rechokeDownloads(tr_swarm* s)
         {
             auto const* const peer = static_cast<tr_peer const*>(tr_ptrArrayNth(&s->peers, i));
             auto const b = peer->blocksSentToClient.count(now, CancelHistorySec);
-            auto const c = peer->cancelsSentToPeer.count(now, CancelHistorySec);
 
             if (b == 0) /* ignore unresponsive peers, as described above */
             {
@@ -1929,7 +1929,7 @@ static void rechokeDownloads(tr_swarm* s)
             }
 
             blocks += b;
-            cancels += c;
+            cancels += peer->cancelsSentToPeer.count(now, CancelHistorySec);
         }
 
         if (cancels > 0)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -9,7 +9,6 @@
 #include <condition_variable>
 #include <csignal>
 #include <cstdint>
-#include <cstdlib>
 #include <ctime>
 #include <iterator> // std::back_inserter
 #include <list>

--- a/tests/libtransmission/history-test.cc
+++ b/tests/libtransmission/history-test.cc
@@ -10,7 +10,7 @@
 
 TEST(History, recentHistory)
 {
-    auto h = tr_recentHistory{};
+    auto h = tr_recentHistory<size_t, 60>{};
 
     h.add(10000, 1);
     EXPECT_EQ(0U, h.count(12000, 1000));


### PR DESCRIPTION
This gives more flexibility on the size of the count bins, so we can save space on smaller counts