### PR TITLE
refactor: remove unused tr_torrent fields

### DIFF
--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -252,8 +252,8 @@ private:
         std::vector<tr_peerIo*>& peer_pool);
 
     mutable std::array<Band, 2> band_ = {};
-    Bandwidth* parent_ = nullptr;
     std::vector<Bandwidth*> children_;
+    Bandwidth* parent_ = nullptr;
     tr_peerIo* peer_ = nullptr;
     tr_priority_t priority_ = 0;
 };

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -96,7 +96,6 @@ public:
     [[nodiscard]] bool isValid() const;
 
 private:
-    std::vector<uint8_t> flags_;
     [[nodiscard]] size_t countFlags() const noexcept;
     [[nodiscard]] size_t countFlags(size_t begin, size_t end) const noexcept;
 
@@ -119,6 +118,8 @@ private:
     void rebuildTrueCount() noexcept;
     void incrementTrueCount(size_t inc) noexcept;
     void decrementTrueCount(size_t dec) noexcept;
+
+    std::vector<uint8_t> flags_;
 
     size_t bit_count_ = 0;
     size_t true_count_ = 0;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1092,30 +1092,30 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 
     switch (s->activity)
     {
-    /* etaXLSpeed exists because if we use the piece speed directly,
+    /* etaSpeed exists because if we use the piece speed directly,
      * brief fluctuations cause the ETA to jump all over the place.
      * so, etaXLSpeed is a smoothed-out version of the piece speed
      * to dampen the effect of fluctuations */
     case TR_STATUS_DOWNLOAD:
-        if (tor->etaDLSpeedCalculatedAt + 800 < now)
+        if (tor->etaSpeedCalculatedAt + 800 < now)
         {
-            tor->etaDLSpeed_Bps = tor->etaDLSpeedCalculatedAt + 4000 < now ?
+            tor->etaSpeed_Bps = tor->etaSpeedCalculatedAt + 4000 < now ?
                 pieceDownloadSpeed_Bps : /* if no recent previous speed, no need to smooth */
-                (tor->etaDLSpeed_Bps * 4.0 + pieceDownloadSpeed_Bps) / 5.0; /* smooth across 5 readings */
-            tor->etaDLSpeedCalculatedAt = now;
+                (tor->etaSpeed_Bps * 4.0 + pieceDownloadSpeed_Bps) / 5.0; /* smooth across 5 readings */
+            tor->etaSpeedCalculatedAt = now;
         }
 
         if (s->leftUntilDone > s->desiredAvailable && tor->webseedCount() < 1)
         {
             s->eta = TR_ETA_NOT_AVAIL;
         }
-        else if (tor->etaDLSpeed_Bps == 0)
+        else if (tor->etaSpeed_Bps == 0)
         {
             s->eta = TR_ETA_UNKNOWN;
         }
         else
         {
-            s->eta = s->leftUntilDone / tor->etaDLSpeed_Bps;
+            s->eta = s->leftUntilDone / tor->etaSpeed_Bps;
         }
 
         s->etaIdle = TR_ETA_NOT_AVAIL;
@@ -1128,27 +1128,27 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
         }
         else
         {
-            if (tor->etaULSpeedCalculatedAt + 800 < now)
+            if (tor->etaSpeedCalculatedAt + 800 < now)
             {
-                tor->etaULSpeed_Bps = tor->etaULSpeedCalculatedAt + 4000 < now ?
+                tor->etaSpeed_Bps = tor->etaSpeedCalculatedAt + 4000 < now ?
                     pieceUploadSpeed_Bps : /* if no recent previous speed, no need to smooth */
-                    (tor->etaULSpeed_Bps * 4.0 + pieceUploadSpeed_Bps) / 5.0; /* smooth across 5 readings */
-                tor->etaULSpeedCalculatedAt = now;
+                    (tor->etaSpeed_Bps * 4.0 + pieceUploadSpeed_Bps) / 5.0; /* smooth across 5 readings */
+                tor->etaSpeedCalculatedAt = now;
             }
 
-            if (tor->etaULSpeed_Bps == 0)
+            if (tor->etaSpeed_Bps == 0)
             {
                 s->eta = TR_ETA_UNKNOWN;
             }
             else
             {
-                s->eta = seedRatioBytesLeft / tor->etaULSpeed_Bps;
+                s->eta = seedRatioBytesLeft / tor->etaSpeed_Bps;
             }
         }
 
         {
             auto seedIdleMinutes = uint16_t{};
-            s->etaIdle = tor->etaULSpeed_Bps < 1 && tr_torrentGetSeedIdle(tor, &seedIdleMinutes) ?
+            s->etaIdle = tor->etaSpeed_Bps < 1 && tr_torrentGetSeedIdle(tor, &seedIdleMinutes) ?
                 seedIdleMinutes * 60 - s->idleSecs :
                 TR_ETA_NOT_AVAIL;
         }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -837,8 +837,6 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
         if (!tor->hasMetainfo() && !doStart)
         {
-            tor->prefetchMagnetMetadata = true;
-
             auto opts = torrent_start_opts{};
             opts.bypass_queue = true;
             opts.has_local_data = has_local_data;
@@ -1594,7 +1592,6 @@ void tr_torrentStop(tr_torrent* tor)
 
     tor->isRunning = false;
     tor->isStopping = false;
-    tor->prefetchMagnetMetadata = false;
     tor->setDirty();
     tr_runInEventThread(tor->session, stopTorrent, tor);
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -611,6 +611,11 @@ public:
     // TODO(ckerr): make private once some of torrent.cc's `tr_torrentFoo()` methods are member functions
     tr_completion completion;
 
+    // true iff the piece was verified more recently than any of the piece's
+    // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
+    // it means that piece needs to be checked before its data is used.
+    tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
+
     tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
     tr_file_priorities file_priorities_{ &fpm_ };
     tr_files_wanted files_wanted_{ &fpm_ };
@@ -622,11 +627,6 @@ public:
 
     // when Transmission thinks the torrent's files were last changed
     std::vector<time_t> file_mtimes_;
-
-    // true iff the piece was verified more recently than any of the piece's
-    // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
-    // it means that piece needs to be checked before its data is used.
-    tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
     tr_sha1_digest_t obfuscated_hash = {};
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -688,8 +688,7 @@ public:
     uint64_t corruptCur = 0;
     uint64_t corruptPrev = 0;
 
-    uint64_t etaDLSpeedCalculatedAt = 0;
-    uint64_t etaULSpeedCalculatedAt = 0;
+    uint64_t etaSpeedCalculatedAt = 0;
 
     tr_interned_string error_announce_url;
 
@@ -706,8 +705,7 @@ public:
 
     tr_stat_errtype error = TR_STAT_OK;
 
-    unsigned int etaDLSpeed_Bps = 0;
-    unsigned int etaULSpeed_Bps = 0;
+    unsigned int etaSpeed_Bps = 0;
 
     int secondsDownloading = 0;
     int secondsSeeding = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -727,8 +727,6 @@ public:
 
     uint16_t idleLimitMinutes = 0;
 
-    bool dhtAnnounceInProgress = false;
-
     bool finishedSeedingByIdle = false;
 
     bool isDeleting = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -739,7 +739,6 @@ public:
     bool isStopping = false;
     bool startAfterVerify = false;
 
-    bool prefetchMagnetMetadata = false;
     bool magnetVerify = false;
 
 private:

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -728,7 +728,6 @@ public:
     uint16_t idleLimitMinutes = 0;
 
     bool dhtAnnounceInProgress = false;
-    bool dhtAnnounce6InProgress = false;
 
     bool finishedSeedingByIdle = false;
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -625,7 +625,6 @@ static void callback(void* /*ignore*/, int event, unsigned char const* info_hash
             else
             {
                 tr_logAddTraceTor(tor, "IPv6 DHT announce done");
-                tor->dhtAnnounce6InProgress = false;
             }
         }
     }
@@ -693,10 +692,6 @@ static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
     if (af == AF_INET)
     {
         tor->dhtAnnounceInProgress = true;
-    }
-    else
-    {
-        tor->dhtAnnounce6InProgress = true;
     }
 
     return AnnounceResult::OK;

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -620,7 +620,6 @@ static void callback(void* /*ignore*/, int event, unsigned char const* info_hash
             if (event == DHT_EVENT_SEARCH_DONE)
             {
                 tr_logAddTraceTor(tor, "IPv4 DHT announce done");
-                tor->dhtAnnounceInProgress = false;
             }
             else
             {
@@ -688,11 +687,6 @@ static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
             af == AF_INET6 ? "IPv6" : "IPv4",
             tr_dhtPrintableStatus(status),
             numnodes));
-
-    if (af == AF_INET)
-    {
-        tor->dhtAnnounceInProgress = true;
-    }
 
     return AnnounceResult::OK;
 }


### PR DESCRIPTION
There were a few fields in `tr_torrent` that were only assigned to; never read. Remove them.