### PR TITLE
Allow partial hash match in RPC `ids` argument

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -113,8 +113,10 @@ Request arguments: `ids`, which specifies which torrents to use.
 All torrents are used if the `ids` argument is omitted.
 
 `ids` should be one of the following:
+
 1. an integer referring to a torrent id
-2. a list of torrent id numbers, SHA1 hash strings, or both
+2. a list of torrent id numbers, SHA1 hash strings (may be partial, as long as
+   each string matches a single torrent), or both
 3. a string, `recently-active`, for recently-active torrents
 
 Response arguments: none

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -49,7 +49,7 @@ public:
     // These convenience functions use get(tr_sha1_digest_t const&)
     // after parsing the magnet link to get the info hash. If you have
     // the info hash already, use get() instead to avoid excess parsing.
-    [[nodiscard]] tr_torrent* get(std::string_view magnet_link);
+    [[nodiscard]] tr_torrent* get(std::string_view str);
 
     template<typename T>
     [[nodiscard]] bool contains(T const& key) const


### PR DESCRIPTION
A hex string in `ids` argument that is shorter that 40 chars may match the start of the torrent hash (like git). The minimum size is 4 chars. 

If more that one torrent matches, none are selected.

This is useful for `transmission-remote -t`, allowing typing a few characters from the start of the hash, rather than copy/paste of the whole hash.