### PR TITLE
Address some core build warnings

### DIFF
--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -59,7 +59,7 @@ static void handle_signal(int sig)
         break;
 
     default:
-        assert("Unexpected signal");
+        assert("Unexpected signal" && 0);
     }
 }
 

--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -131,7 +131,7 @@ static char const* getdev(std::string_view path)
 
     for (int i = 0; i < n; i++)
     {
-        if (mnt[i].f_mntonname != nullptr && path == mnt[i].f_mntonname)
+        if (path == mnt[i].f_mntonname)
         {
             return mnt[i].f_mntfromname;
         }


### PR DESCRIPTION
>daemon/daemon-posix.cc:62:16: warning: implicit conversion turns string literal into bool: 'const char [18]' to 'bool' [-Wstring-conversion]

>libtransmission/platform-quota.cc:134:20: warning: comparison of array 'mnt[i].f_mntonname' not equal to a null pointer is always true [-Wtautological-pointer-compare]