### PR TITLE
Fix "Port checker returned invalid status: 0"

### DIFF
--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -11,11 +11,19 @@ typedef NS_ENUM(unsigned int, port_status_t) { //
     PORT_STATUS_ERROR
 };
 
+@protocol PortCheckerDelegate;
+
 @interface PortChecker : NSObject
 
 @property(nonatomic, readonly) port_status_t status;
 
-- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(id)delegate;
+- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(NSObject<PortCheckerDelegate>*)delegate;
 - (void)cancelProbe;
+
+@end
+
+@protocol PortCheckerDelegate<NSObject>
+
+- (void)portCheckerDidFinishProbing:(PortChecker*)portChecker;
 
 @end

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -9,7 +9,7 @@
 
 @interface PortChecker ()
 
-@property(nonatomic, weak) id fDelegate;
+@property(nonatomic, weak) NSObject<PortCheckerDelegate>* fDelegate;
 @property(nonatomic) port_status_t fStatus;
 
 @property(nonatomic) NSURLConnection* fConnection;
@@ -25,7 +25,7 @@
 
 @implementation PortChecker
 
-- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(id)delegate
+- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(NSObject<PortCheckerDelegate>*)delegate
 {
     if ((self = [super init]))
     {

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -6,7 +6,9 @@
 
 #include <libtransmission/transmission.h>
 
-@interface PrefsController : NSWindowController<NSToolbarDelegate>
+@protocol PortCheckerDelegate;
+
+@interface PrefsController : NSWindowController<NSToolbarDelegate, PortCheckerDelegate>
 
 @property(nonatomic, readonly) NSArray<NSString*>* sounds;
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -475,6 +475,8 @@
         self.fPortStatusField.stringValue = NSLocalizedString(@"Port check site is down", "Preferences -> Network -> port status");
         self.fPortStatusImage.image = [NSImage imageNamed:NSImageNameStatusPartiallyAvailable];
         break;
+    case PORT_STATUS_CHECKING:
+        break;
     default:
         NSAssert1(NO, @"Port checker returned invalid status: %d", self.fPortChecker.status);
         break;


### PR DESCRIPTION
Fix an assertion call that happened to me: the callback is asynchronous, so the status can be any status, including PORT_STATUS_CHECKING.
Also fix the warnings on undeclared selectors by adopting a delegate protocol.