### PR TITLE
Add ⌘C support

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -655,7 +655,7 @@
     }
     NSPasteboard* pasteBoard = NSPasteboard.generalPasteboard;
     NSString* links = [[selectedTorrents valueForKeyPath:@"magnetLink"] componentsJoinedByString:@"\n"];
-    [pasteBoard declareTypes:@[NSStringPboardType] owner:nil];
+    [pasteBoard declareTypes:@[ NSStringPboardType ] owner:nil];
     [pasteBoard setString:links forType:NSStringPboardType];
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -640,6 +640,25 @@
     return [self.fTorrentCell iconRectForBounds:[self rectOfRow:row]];
 }
 
+- (BOOL)acceptsFirstResponder
+{
+    // add support to `copy:`
+    return YES;
+}
+
+- (void)copy:(id)sender
+{
+    NSArray<Torrent*>* selectedTorrents = self.selectedTorrents;
+    if (selectedTorrents.count == 0)
+    {
+        return;
+    }
+    NSPasteboard* pasteBoard = NSPasteboard.generalPasteboard;
+    NSString* links = [[selectedTorrents valueForKeyPath:@"magnetLink"] componentsJoinedByString:@"\n"];
+    [pasteBoard declareTypes:@[NSStringPboardType] owner:nil];
+    [pasteBoard setString:links forType:NSStringPboardType];
+}
+
 - (void)paste:(id)sender
 {
     NSURL* url;


### PR DESCRIPTION
Minimal implementation support for #439.
It could be improved slightly to support returning multiple types of objects, like both NSString and NSURL, but I haven't found the use case, so it should be fine like that.

Fix #439.