### PR TITLE
fix: compiler warnings

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -357,9 +357,13 @@ void tr_bitfield::set(size_t nth, bool value)
 
     /* Already tested that val != nth bit so just swap */
     auto& byte = flags_[nth >> 3U];
+#ifdef TR_ENABLE_ASSERTS
     auto const old_byte_pop = doPopcount(byte);
+#endif
     byte ^= 0x80 >> (nth & 7U);
+#ifdef TR_ENABLE_ASSERTS
     auto const new_byte_pop = doPopcount(byte);
+#endif
 
     if (value)
     {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -376,7 +376,7 @@ size_t BlocklistFile::setContent(char const* filename)
 }
 
 #ifdef TR_ENABLE_ASSERTS
-void BlocklistFile::assertValidRules(std::vector<IPv4Range>& ranges)
+void BlocklistFile::assertValidRules(std::vector<IPv4Range> const& ranges)
 {
     for (auto const& r : ranges)
     {

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -111,7 +111,7 @@ private:
 
 #ifdef TR_ENABLE_ASSERTS
     /// @brief Sanity checks: make sure the rules are sorted in ascending order and don't overlap
-    void assertValidRules(std::vector<IPv4Range>& ranges);
+    static void assertValidRules(std::vector<IPv4Range> const& ranges);
 #endif
 
     bool is_enabled_;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -100,10 +100,12 @@ struct tr_rpc_address
 
 static int constexpr DeflateLevel = 6; // medium / default
 
+#ifdef TR_ENABLE_ASSERTS
 static bool constexpr tr_rpc_address_is_valid(tr_rpc_address const& a)
 {
     return a.type == TR_RPC_AF_INET || a.type == TR_RPC_AF_INET6 || a.type == TR_RPC_AF_UNIX;
 }
+#endif
 
 /***
 ****

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -235,6 +235,7 @@ private:
 ****
 ***/
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 int DetailsDialog::prev_tab_index_ = 0;
 
 DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const& model, QWidget* parent)

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -426,10 +426,10 @@ QMenu* MainWindow::createOptionsMenu()
 
         menu->addSeparator();
 
-        for (auto const KBps : { 50, 100, 250, 500, 1000, 2500, 5000, 10000 })
+        for (auto const kps : { 50, 100, 250, 500, 1000, 2500, 5000, 10000 })
         {
-            auto* const action = menu->addAction(Formatter::get().speedToString(Speed::fromKBps(KBps)));
-            action->setProperty(PrefVariantsKey, QVariantList{ pref, KBps, enabled_pref, true });
+            auto* const action = menu->addAction(Formatter::get().speedToString(Speed::fromKBps(kps)));
+            action->setProperty(PrefVariantsKey, QVariantList{ pref, kps, enabled_pref, true });
             connect(action, &QAction::triggered, this, qOverload<>(&MainWindow::onSetPrefs));
         }
     };

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -66,7 +66,7 @@ protected:
 
 TEST_F(BlocklistTest, parsing)
 {
-    EXPECT_EQ(0, tr_blocklistGetRuleCount(session_));
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 
     // init the blocklist
     auto const path = tr_pathbuf{ tr_sessionGetConfigDir(session_), "/blocklists/level1" };


### PR DESCRIPTION
Fix a handful of minor compiler warnings that had snuck into the codebase over the last month or so.