### PR TITLE
fix: silence unexpected key warnings in torrent file parser

### DIFF
--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -253,7 +253,7 @@ void tr_open_files::closeAll()
 
 void tr_open_files::closeTorrent(tr_torrent_id_t tor_id)
 {
-    return pool_.erase_if([&tor_id](Key const& key, Val const&) { return key.first == tor_id; });
+    return pool_.erase_if([&tor_id](Key const& key, Val const& /*unused*/) { return key.first == tor_id; });
 }
 
 void tr_open_files::closeFile(tr_torrent_id_t tor_id, tr_file_index_t file_num)

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -620,8 +620,8 @@ private:
     static constexpr std::string_view AnnounceKey = "announce"sv;
     static constexpr std::string_view AnnounceListKey = "announce-list"sv;
     static constexpr std::string_view AttrKey = "attr"sv;
-    static constexpr std::string_view AzureusPropertiesKey = "azureus_properties"sv;
     static constexpr std::string_view AzureusPrivatePropertiesKey = "azureus_private_properties"sv;
+    static constexpr std::string_view AzureusPropertiesKey = "azureus_properties"sv;
     static constexpr std::string_view ChecksumKey = "checksum"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;
@@ -632,8 +632,7 @@ private:
     static constexpr std::string_view EncodedRateKey = "encoded rate"sv;
     static constexpr std::string_view EncodingKey = "encoding"sv;
     static constexpr std::string_view EntropyKey = "entropy"sv;
-    static constexpr std::string_view ErrCallbackKey = "err-callback"sv;
-    static constexpr std::string_view LogCallbackKey = "log-callback"sv;
+    static constexpr std::string_view ErrCallbackKey = "err_callback"sv;
     static constexpr std::string_view FileDurationKey = "file-duration"sv;
     static constexpr std::string_view FileMediaKey = "file-media"sv;
     static constexpr std::string_view FileTreeKey = "file tree"sv;
@@ -643,6 +642,7 @@ private:
     static constexpr std::string_view InfoKey = "info"sv;
     static constexpr std::string_view LengthKey = "length"sv;
     static constexpr std::string_view LibtorrentResumeKey = "libtorrent_resume"sv;
+    static constexpr std::string_view LogCallbackKey = "log_callback"sv;
     static constexpr std::string_view MagnetInfoKey = "magnet-info"sv;
     static constexpr std::string_view Md5sumKey = "md5sum"sv;
     static constexpr std::string_view MetaVersionKey = "meta version"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -489,8 +489,10 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathIs(InfoKey, Sha1Key) || //
             pathIs(InfoKey, UniqueKey) || //
             pathIs(InfoKey, XCrossSeedKey) || //
+            pathIs(LocaleKey) || //
             pathIs(LogCallbackKey) || //
             pathIs(PublisherUrlKey) || //
+            pathIs(TitleKey) || //
             pathStartsWith(AzureusPrivatePropertiesKey) || //
             pathStartsWith(AzureusPropertiesKey) || //
             pathStartsWith(InfoKey, FileDurationKey) || //
@@ -653,6 +655,7 @@ private:
     static constexpr std::string_view InfoKey = "info"sv;
     static constexpr std::string_view LengthKey = "length"sv;
     static constexpr std::string_view LibtorrentResumeKey = "libtorrent_resume"sv;
+    static constexpr std::string_view LocaleKey = "locale"sv;
     static constexpr std::string_view LogCallbackKey = "log_callback"sv;
     static constexpr std::string_view MagnetInfoKey = "magnet-info"sv;
     static constexpr std::string_view Md5Key = "md5"sv;
@@ -673,6 +676,7 @@ private:
     static constexpr std::string_view PublisherUrlKey = "publisher-url"sv;
     static constexpr std::string_view Sha1Key = "sha1"sv;
     static constexpr std::string_view SourceKey = "source"sv;
+    static constexpr std::string_view TitleKey = "title"sv;
     static constexpr std::string_view UniqueKey = "unique"sv;
     static constexpr std::string_view UrlListKey = "url-list"sv;
     static constexpr std::string_view VcodecKey = "vcodec"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -324,7 +324,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
                 unhandled = true;
             }
         }
-        else if (pathIs(CreationDateKey))
+        else if (pathIs(CreationDateKey) || pathIs(InfoKey, CreationDateKey))
         {
             tm_.date_created_ = value;
         }
@@ -347,7 +347,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         }
         else if (
             pathIs(DurationKey) || pathIs(EncodedRateKey) || pathIs(HeightKey) || pathIs(InfoKey, EntropyKey) ||
-            pathIs(ProfilesKey, HeightKey) || pathIs(ProfilesKey, WidthKey) || pathIs(WidthKey) ||
+            pathIs(InfoKey, UniqueKey) || pathIs(ProfilesKey, HeightKey) || pathIs(ProfilesKey, WidthKey) || pathIs(WidthKey) ||
             pathStartsWith(AzureusPropertiesKey) || pathStartsWith(InfoKey, FileDurationKey) ||
             pathStartsWith(InfoKey, FileMediaKey) || pathStartsWith(InfoKey, ProfilesKey))
         {
@@ -402,6 +402,10 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             {
                 // currently unused. TODO support for bittorrent v2
                 // TODO https://github.com/transmission/transmission/issues/458
+            }
+            else if (pathIs(InfoKey, FilesKey, ""sv, Md5sumKey) || pathStartsWith(InfoKey, FilesKey, ""sv, PathUtf8Key))
+            {
+                // unused by Transmission
             }
             else
             {
@@ -458,7 +462,8 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         }
         else if (
             pathIs(ChecksumKey) || pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || pathIs(InfoKey, PublisherUrlKey) ||
-            pathIs(PublisherUrlKey) || pathStartsWith(AzureusPropertiesKey) || pathStartsWith(InfoKey, ProfilesKey))
+            pathIs(PublisherUrlKey) || pathStartsWith(AzureusPropertiesKey) || pathStartsWith(InfoKey, ProfilesKey) ||
+            pathStartsWith(LibtorrentResumeKey))
         {
             // unused by Transmission
         }
@@ -614,12 +619,14 @@ private:
     static constexpr std::string_view HttpSeedsKey = "httpseeds"sv;
     static constexpr std::string_view InfoKey = "info"sv;
     static constexpr std::string_view LengthKey = "length"sv;
+    static constexpr std::string_view LibtorrentResumeKey = "libtorrent_resume"sv;
     static constexpr std::string_view Md5sumKey = "md5sum"sv;
     static constexpr std::string_view MetaVersionKey = "meta version"sv;
     static constexpr std::string_view MtimeKey = "mtime"sv;
     static constexpr std::string_view NameKey = "name"sv;
     static constexpr std::string_view NameUtf8Key = "name.utf-8"sv;
     static constexpr std::string_view PathKey = "path"sv;
+    static constexpr std::string_view PathUtf8Key = "path.utf-8"sv;
     static constexpr std::string_view PieceLayersKey = "piece layers"sv;
     static constexpr std::string_view PieceLengthKey = "piece length"sv;
     static constexpr std::string_view PiecesKey = "pieces"sv;
@@ -629,6 +636,7 @@ private:
     static constexpr std::string_view PublisherKey = "publisher"sv;
     static constexpr std::string_view PublisherUrlKey = "publisher-url"sv;
     static constexpr std::string_view SourceKey = "source"sv;
+    static constexpr std::string_view UniqueKey = "unique"sv;
     static constexpr std::string_view UrlListKey = "url-list"sv;
     static constexpr std::string_view VcodecKey = "vcodec"sv;
     static constexpr std::string_view WidthKey = "width"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -482,7 +482,6 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
-            pathIs(InfoKey, CollectionsKey) || //
             pathIs(InfoKey, Ed2kKey) || //
             pathIs(InfoKey, EntropyKey) || //
             pathIs(InfoKey, Md5sumKey) || //
@@ -496,6 +495,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathIs(TitleKey) || //
             pathStartsWith(AzureusPrivatePropertiesKey) || //
             pathStartsWith(AzureusPropertiesKey) || //
+            pathStartsWith(InfoKey, CollectionsKey) || //
             pathStartsWith(InfoKey, FileDurationKey) || //
             pathStartsWith(InfoKey, ProfilesKey) || //
             pathStartsWith(LibtorrentResumeKey) || //

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -482,6 +482,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
+            pathIs(InfoKey, CollectionsKey) || //
             pathIs(InfoKey, Ed2kKey) || //
             pathIs(InfoKey, EntropyKey) || //
             pathIs(InfoKey, Md5sumKey) || //
@@ -634,6 +635,7 @@ private:
     static constexpr std::string_view AzureusPrivatePropertiesKey = "azureus_private_properties"sv;
     static constexpr std::string_view AzureusPropertiesKey = "azureus_properties"sv;
     static constexpr std::string_view ChecksumKey = "checksum"sv;
+    static constexpr std::string_view CollectionsKey = "collections"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;
     static constexpr std::string_view Crc32Key = "crc32"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -475,6 +475,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || //
             pathIs(InfoKey, PublisherUrlKey) || //
             pathIs(InfoKey, UniqueKey) || //
+            pathIs(InfoKey, XCrossSeedKey) || //
             pathIs(LogCallbackKey) || //
             pathIs(PublisherUrlKey) || //
             pathStartsWith(AzureusPrivatePropertiesKey) || //
@@ -663,6 +664,7 @@ private:
     static constexpr std::string_view UrlListKey = "url-list"sv;
     static constexpr std::string_view VcodecKey = "vcodec"sv;
     static constexpr std::string_view WidthKey = "width"sv;
+    static constexpr std::string_view XCrossSeedKey = "x_cross_seed"sv;
 };
 
 bool tr_torrent_metainfo::parseBenc(std::string_view benc, tr_error** error)

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -346,10 +346,19 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             // TODO https://github.com/transmission/transmission/issues/458
         }
         else if (
-            pathIs(DurationKey) || pathIs(EncodedRateKey) || pathIs(HeightKey) || pathIs(InfoKey, EntropyKey) ||
-            pathIs(InfoKey, UniqueKey) || pathIs(ProfilesKey, HeightKey) || pathIs(ProfilesKey, WidthKey) || pathIs(WidthKey) ||
-            pathStartsWith(AzureusPropertiesKey) || pathStartsWith(InfoKey, FileDurationKey) ||
-            pathStartsWith(InfoKey, FileMediaKey) || pathStartsWith(InfoKey, ProfilesKey))
+            pathIs(DurationKey) || //
+            pathIs(EncodedRateKey) || //
+            pathIs(HeightKey) || //
+            pathIs(InfoKey, EntropyKey) || //
+            pathIs(InfoKey, UniqueKey) || //
+            pathIs(ProfilesKey, HeightKey) || //
+            pathIs(ProfilesKey, WidthKey) || //
+            pathIs(WidthKey) || //
+            pathStartsWith(AzureusPropertiesKey) || //
+            pathStartsWith(InfoKey, FileDurationKey) || //
+            pathStartsWith(InfoKey, FileMediaKey) || //
+            pathStartsWith(InfoKey, ProfilesKey) || //
+            pathStartsWith(LibtorrentResumeKey))
         {
             // unused by Transmission
         }
@@ -461,9 +470,19 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             tm_.announceList().add(value, tier_);
         }
         else if (
-            pathIs(ChecksumKey) || pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || pathIs(InfoKey, PublisherUrlKey) ||
-            pathIs(PublisherUrlKey) || pathStartsWith(AzureusPropertiesKey) || pathStartsWith(InfoKey, ProfilesKey) ||
-            pathStartsWith(LibtorrentResumeKey))
+            pathIs(ChecksumKey) || //
+            pathIs(ErrCallbackKey) || //
+            pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || //
+            pathIs(InfoKey, PublisherUrlKey) || //
+            pathIs(InfoKey, UniqueKey) || //
+            pathIs(LogCallbackKey) || //
+            pathIs(PublisherUrlKey) || //
+            pathStartsWith(AzureusPrivatePropertiesKey) || //
+            pathStartsWith(AzureusPropertiesKey) || //
+            pathStartsWith(InfoKey, FileDurationKey) || //
+            pathStartsWith(InfoKey, ProfilesKey) || //
+            pathStartsWith(LibtorrentResumeKey) || //
+            pathStartsWith(MagnetInfoKey))
         {
             // unused by Transmission
         }
@@ -601,6 +620,7 @@ private:
     static constexpr std::string_view AnnounceListKey = "announce-list"sv;
     static constexpr std::string_view AttrKey = "attr"sv;
     static constexpr std::string_view AzureusPropertiesKey = "azureus_properties"sv;
+    static constexpr std::string_view AzureusPrivatePropertiesKey = "azureus_private_properties"sv;
     static constexpr std::string_view ChecksumKey = "checksum"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;
@@ -611,6 +631,8 @@ private:
     static constexpr std::string_view EncodedRateKey = "encoded rate"sv;
     static constexpr std::string_view EncodingKey = "encoding"sv;
     static constexpr std::string_view EntropyKey = "entropy"sv;
+    static constexpr std::string_view ErrCallbackKey = "err-callback"sv;
+    static constexpr std::string_view LogCallbackKey = "log-callback"sv;
     static constexpr std::string_view FileDurationKey = "file-duration"sv;
     static constexpr std::string_view FileMediaKey = "file-media"sv;
     static constexpr std::string_view FileTreeKey = "file tree"sv;
@@ -620,6 +642,7 @@ private:
     static constexpr std::string_view InfoKey = "info"sv;
     static constexpr std::string_view LengthKey = "length"sv;
     static constexpr std::string_view LibtorrentResumeKey = "libtorrent_resume"sv;
+    static constexpr std::string_view MagnetInfoKey = "magnet-info"sv;
     static constexpr std::string_view Md5sumKey = "md5sum"sv;
     static constexpr std::string_view MetaVersionKey = "meta version"sv;
     static constexpr std::string_view MtimeKey = "mtime"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -634,7 +634,7 @@ private:
     static constexpr std::string_view ChecksumKey = "checksum"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;
-    static constexpr std::string_view Crc32Key = "crc"sv;
+    static constexpr std::string_view Crc32Key = "crc32"sv;
     static constexpr std::string_view CreatedByKey = "created by"sv;
     static constexpr std::string_view CreatedByUtf8Key = "created by.utf-8"sv;
     static constexpr std::string_view CreationDateKey = "creation date"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -411,7 +411,11 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
                 // currently unused. TODO support for bittorrent v2
                 // TODO https://github.com/transmission/transmission/issues/458
             }
-            else if (pathIs(InfoKey, FilesKey, ""sv, Md5sumKey) || pathStartsWith(InfoKey, FilesKey, ""sv, PathUtf8Key))
+            else if (
+                pathIs(InfoKey, FilesKey, ""sv, Ed2kKey) || //
+                pathIs(InfoKey, FilesKey, ""sv, Md5sumKey) || //
+                pathIs(InfoKey, FilesKey, ""sv, Sha1Key) || //
+                pathStartsWith(InfoKey, FilesKey, ""sv, PathUtf8Key))
             {
                 // unused by Transmission
             }
@@ -468,6 +472,10 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         {
             tm_.announceList().add(value, tier_);
         }
+        else if (curdepth == 2 && (pathStartsWith(HttpSeedsKey) || pathStartsWith(UrlListKey)))
+        {
+            tm_.addWebseed(value);
+        }
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
@@ -486,10 +494,6 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathStartsWith(MagnetInfoKey))
         {
             // unused by Transmission
-        }
-        else if (curdepth == 2 && (pathStartsWith(HttpSeedsKey) || pathStartsWith(UrlListKey)))
-        {
-            tm_.addWebseed(value);
         }
         else
         {
@@ -629,6 +633,7 @@ private:
     static constexpr std::string_view CreatedByUtf8Key = "created by.utf-8"sv;
     static constexpr std::string_view CreationDateKey = "creation date"sv;
     static constexpr std::string_view DurationKey = "duration"sv;
+    static constexpr std::string_view Ed2kKey = "ed2k"sv;
     static constexpr std::string_view EncodedRateKey = "encoded rate"sv;
     static constexpr std::string_view EncodingKey = "encoding"sv;
     static constexpr std::string_view EntropyKey = "entropy"sv;
@@ -659,6 +664,7 @@ private:
     static constexpr std::string_view ProfilesKey = "profiles"sv;
     static constexpr std::string_view PublisherKey = "publisher"sv;
     static constexpr std::string_view PublisherUrlKey = "publisher-url"sv;
+    static constexpr std::string_view Sha1Key = "sha1"sv;
     static constexpr std::string_view SourceKey = "source"sv;
     static constexpr std::string_view UniqueKey = "unique"sv;
     static constexpr std::string_view UrlListKey = "url-list"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -412,8 +412,11 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
                 // TODO https://github.com/transmission/transmission/issues/458
             }
             else if (
+                pathIs(InfoKey, FilesKey, ""sv, Crc32Key) || //
                 pathIs(InfoKey, FilesKey, ""sv, Ed2kKey) || //
+                pathIs(InfoKey, FilesKey, ""sv, Md5Key) || //
                 pathIs(InfoKey, FilesKey, ""sv, Md5sumKey) || //
+                pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || // (why a string?)
                 pathIs(InfoKey, FilesKey, ""sv, Sha1Key) || //
                 pathStartsWith(InfoKey, FilesKey, ""sv, PathUtf8Key))
             {
@@ -479,9 +482,11 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
+            pathIs(InfoKey, Ed2kKey) || //
             pathIs(InfoKey, EntropyKey) || //
             pathIs(InfoKey, Md5sumKey) || //
             pathIs(InfoKey, PublisherUrlKey) || //
+            pathIs(InfoKey, Sha1Key) || //
             pathIs(InfoKey, UniqueKey) || //
             pathIs(InfoKey, XCrossSeedKey) || //
             pathIs(LogCallbackKey) || //
@@ -629,6 +634,7 @@ private:
     static constexpr std::string_view ChecksumKey = "checksum"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;
+    static constexpr std::string_view Crc32Key = "crc"sv;
     static constexpr std::string_view CreatedByKey = "created by"sv;
     static constexpr std::string_view CreatedByUtf8Key = "created by.utf-8"sv;
     static constexpr std::string_view CreationDateKey = "creation date"sv;
@@ -649,6 +655,7 @@ private:
     static constexpr std::string_view LibtorrentResumeKey = "libtorrent_resume"sv;
     static constexpr std::string_view LogCallbackKey = "log_callback"sv;
     static constexpr std::string_view MagnetInfoKey = "magnet-info"sv;
+    static constexpr std::string_view Md5Key = "md5"sv;
     static constexpr std::string_view Md5sumKey = "md5sum"sv;
     static constexpr std::string_view MetaVersionKey = "meta version"sv;
     static constexpr std::string_view MtimeKey = "mtime"sv;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -349,7 +349,6 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathIs(DurationKey) || //
             pathIs(EncodedRateKey) || //
             pathIs(HeightKey) || //
-            pathIs(InfoKey, EntropyKey) || //
             pathIs(InfoKey, UniqueKey) || //
             pathIs(ProfilesKey, HeightKey) || //
             pathIs(ProfilesKey, WidthKey) || //
@@ -472,7 +471,8 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
-            pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || //
+            pathIs(InfoKey, EntropyKey) || //
+            pathIs(InfoKey, Md5sumKey) || //
             pathIs(InfoKey, PublisherUrlKey) || //
             pathIs(InfoKey, UniqueKey) || //
             pathIs(InfoKey, XCrossSeedKey) || //


### PR DESCRIPTION
There are a _lot_ of nonstandard torrent keys out there and each of them generates a log message in the new torrent parser that landed yesterday in fe288b45e500ebfdcfe4ca3b98572f119f64b035.

The code could silently ignore anything that it's not explicitly looking for, but this archaeology is mildly interesting so I'm going to add checks to silence all the nonstandard keys that I can find in my test torrents, then wait and see if any other keys show up in the wild.