### PR TITLE
fix: ESPIPE "illegal seek" error while seeding

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -313,7 +313,7 @@ static tr_socket_t createSocket(tr_session* session, int domain, int type)
     if ((evutil_make_socket_nonblocking(sockfd) == -1) || !session->incPeerCount())
     {
         tr_netClose(session, sockfd);
-        return {};
+        return TR_BAD_SOCKET;
     }
 
     if (static bool buf_logged = false; !buf_logged)
@@ -474,7 +474,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
     static int const domains[NUM_TR_AF_INET_TYPES] = { AF_INET, AF_INET6 };
     struct sockaddr_storage sock;
 
-    tr_socket_t const fd = socket(domains[addr->type], SOCK_STREAM, 0);
+    auto const fd = socket(domains[addr->type], SOCK_STREAM, 0);
     if (fd == TR_BAD_SOCKET)
     {
         *errOut = sockerrno;
@@ -573,7 +573,7 @@ bool tr_net_hasIPv6(tr_port port)
     if (!alreadyDone)
     {
         int err = 0;
-        tr_socket_t fd = tr_netBindTCPImpl(&tr_in6addr_any, port, true, &err);
+        auto const fd = tr_netBindTCPImpl(&tr_in6addr_any, port, true, &err);
 
         if (fd != TR_BAD_SOCKET || err != EAFNOSUPPORT) /* we support ipv6 */
         {
@@ -600,7 +600,7 @@ tr_socket_t tr_netAccept(tr_session* session, tr_socket_t listening_sockfd, tr_a
     // accept the incoming connection
     struct sockaddr_storage sock;
     socklen_t len = sizeof(struct sockaddr_storage);
-    auto sockfd = accept(listening_sockfd, (struct sockaddr*)&sock, &len);
+    auto const sockfd = accept(listening_sockfd, (struct sockaddr*)&sock, &len);
     if (sockfd == TR_BAD_SOCKET)
     {
         return TR_BAD_SOCKET;
@@ -655,7 +655,7 @@ static int get_source_address(struct sockaddr const* dst, socklen_t dst_len, str
         return 0;
     }
 
-    int save = errno;
+    auto const save = errno;
     evutil_closesocket(s);
     errno = save;
     return -1;

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -26,7 +26,7 @@ union tr_peer_socket_handle
 
 struct tr_peer_socket
 {
-    enum tr_peer_socket_type type;
+    enum tr_peer_socket_type type = TR_PEER_SOCKET_TYPE_NONE;
     union tr_peer_socket_handle handle;
 };
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -59,7 +59,7 @@ struct tr_fdInfo;
 
 struct tr_bindinfo
 {
-    int socket = TR_BAD_SOCKET;
+    tr_socket_t socket = TR_BAD_SOCKET;
     tr_address addr = {};
     struct event* ev = nullptr;
 };

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -59,9 +59,9 @@ struct tr_fdInfo;
 
 struct tr_bindinfo
 {
-    int socket;
-    tr_address addr;
-    struct event* ev;
+    int socket = TR_BAD_SOCKET;
+    tr_address addr = {};
+    struct event* ev = nullptr;
 };
 
 struct tr_turtle_info
@@ -343,8 +343,8 @@ public:
 
     /* The UDP sockets used for the DHT and uTP. */
     tr_port udp_port;
-    tr_socket_t udp_socket;
-    tr_socket_t udp6_socket;
+    tr_socket_t udp_socket = TR_BAD_SOCKET;
+    tr_socket_t udp6_socket = TR_BAD_SOCKET;
     unsigned char* udp6_bound;
     struct event* udp_event;
     struct event* udp6_event;

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -14,7 +14,6 @@
 using in_port_t = uint16_t; /* all missing */
 #else
 #include <ctime>
-#include <unistd.h> /* close() */
 #include <sys/types.h>
 #include <sys/socket.h> /* socket(), bind() */
 #include <netinet/in.h> /* sockaddr_in */

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -118,7 +118,6 @@ static void rebind_ipv6(tr_session* ss, bool force)
 {
     struct sockaddr_in6 sin6;
     unsigned char const* ipv6 = tr_globalIPv6(ss);
-    tr_socket_t s = TR_BAD_SOCKET;
     int rc = -1;
     int one = 1;
 
@@ -140,7 +139,7 @@ static void rebind_ipv6(tr_session* ss, bool force)
         return;
     }
 
-    s = socket(PF_INET6, SOCK_DGRAM, 0);
+    auto const s = socket(PF_INET6, SOCK_DGRAM, 0);
 
     if (s == TR_BAD_SOCKET)
     {


### PR DESCRIPTION
The root cause was a bug in 0a3018d706494d4327876b4dcda5a7f56baf0fef where  `createSocket()` would return `{}` isntead of `TR_BAD_SOCKET` in some error cases. This `{}` value was zero, so the calling code wound up unintentionally manipulating stdin.

This PR adds some other correctness changes made while tracking the problem down, e.g. const correctness and ensuring that `tr_socket_t` member fields in libtransmission classes are initialized to `TR_BAD_SOCKET`.