### PR TITLE
refactor: make tr_peerIoGetAddress() a member function

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -244,7 +244,7 @@ void Bandwidth::allocate(tr_direction dir, unsigned int period_msec)
      * or (2) the next Bandwidth::allocate () call, when we start over again. */
     for (auto* io : tmp)
     {
-        tr_peerIoSetEnabled(io, dir, tr_peerIoHasBandwidthLeft(io, dir));
+        tr_peerIoSetEnabled(io, dir, io->hasBandwidthLeft(dir));
     }
 
     for (auto* io : tmp)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -267,9 +267,9 @@ static handshake_parse_err_t parseHandshake(tr_handshake* handshake, struct evbu
     *** Extensions
     **/
 
-    tr_peerIoEnableDHT(handshake->io, HANDSHAKE_HAS_DHT(reserved));
-    tr_peerIoEnableLTEP(handshake->io, HANDSHAKE_HAS_LTEP(reserved));
-    tr_peerIoEnableFEXT(handshake->io, HANDSHAKE_HAS_FASTEXT(reserved));
+    handshake->io->enableDHT(HANDSHAKE_HAS_DHT(reserved));
+    handshake->io->enableLTEP(HANDSHAKE_HAS_LTEP(reserved));
+    handshake->io->enableFEXT(HANDSHAKE_HAS_FASTEXT(reserved));
 
     return HANDSHAKE_OK;
 }
@@ -637,9 +637,9 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
     *** Extensions
     **/
 
-    tr_peerIoEnableDHT(handshake->io, HANDSHAKE_HAS_DHT(reserved));
-    tr_peerIoEnableLTEP(handshake->io, HANDSHAKE_HAS_LTEP(reserved));
-    tr_peerIoEnableFEXT(handshake->io, HANDSHAKE_HAS_FASTEXT(reserved));
+    handshake->io->enableDHT(HANDSHAKE_HAS_DHT(reserved));
+    handshake->io->enableLTEP(HANDSHAKE_HAS_LTEP(reserved));
+    handshake->io->enableFEXT(HANDSHAKE_HAS_FASTEXT(reserved));
 
     /* torrent hash */
     auto hash = tr_sha1_digest_t{};

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -815,7 +815,7 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     if (auto const* const tor = tr_torrentFindFromObfuscatedHash(handshake->session, obfuscated_hash); tor != nullptr)
     {
         bool const clientIsSeed = tor->isDone();
-        bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, tr_peerIoGetAddress(handshake->io, nullptr));
+        bool const peerIsSeed = tr_peerMgrPeerIsSeed(tor, handshake->io->address());
         tr_logAddTraceHand(
             handshake,
             fmt::format("got INCOMING connection's encrypted handshake for torrent [{}]", tor->name()));
@@ -1140,7 +1140,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
         /* Don't mark a peer as non-uTP unless it's really a connect failure. */
         if ((errcode == ETIMEDOUT || errcode == ECONNREFUSED) && tr_isTorrent(tor))
         {
-            tr_peerMgrSetUtpFailed(tor, tr_peerIoGetAddress(io, nullptr), true);
+            tr_peerMgrSetUtpFailed(tor, io->address(), true);
         }
 
         if (tr_peerIoReconnect(handshake->io) == 0)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -904,35 +904,9 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io)
     }
 }
 
-tr_address const* tr_peerIoGetAddress(tr_peerIo const* io, tr_port* port)
-{
-    TR_ASSERT(tr_isPeerIo(io));
-
-    if (port != nullptr)
-    {
-        *port = io->port;
-    }
-
-    return &io->addr;
-}
-
 std::string tr_peerIo::addrStr() const
 {
     return tr_isPeerIo(this) ? this->addr.readable(this->port) : "error";
-}
-
-char const* tr_peerIoGetAddrStr(tr_peerIo const* io, char* buf, size_t buflen)
-{
-    if (tr_isPeerIo(io))
-    {
-        tr_address_and_port_to_string(buf, buflen, &io->addr, io->port);
-    }
-    else
-    {
-        tr_strlcpy(buf, "error", buflen);
-    }
-
-    return buf;
 }
 
 void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* userData)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -936,7 +936,8 @@ int tr_peerIoReconnect(tr_peerIo* io)
 
     io_close_socket(io);
 
-    io->socket = tr_netOpenPeerSocket(session, &io->addr, io->port, io->is_seed);
+    auto const [addr, port] = io->socketAddress();
+    io->socket = tr_netOpenPeerSocket(session, &addr, port, io->is_seed);
 
     if (io->socket.type != TR_PEER_SOCKET_TYPE_TCP)
     {
@@ -947,7 +948,7 @@ int tr_peerIoReconnect(tr_peerIo* io)
     io->event_write = event_new(session->event_base, io->socket.handle.tcp, EV_WRITE, event_write_cb, io);
 
     event_enable(io, pendingEvents);
-    io->session->setSocketTOS(io->socket.handle.tcp, io->addr.type);
+    io->session->setSocketTOS(io->socket.handle.tcp, addr.type);
     maybeSetCongestionAlgorithm(io->socket.handle.tcp, session->peerCongestionAlgorithm());
 
     return 0;

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -487,7 +487,7 @@ static void utp_on_state_change(void* vio, int state)
     if (state == UTP_STATE_CONNECT)
     {
         tr_logAddTraceIo(io, "utp_on_state_change -- changed to connected");
-        io->utpSupported = true;
+        io->utp_supported_ = true;
     }
     else if (state == UTP_STATE_WRITABLE)
     {
@@ -906,7 +906,7 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io)
 
 std::string tr_peerIo::addrStr() const
 {
-    return tr_isPeerIo(this) ? this->addr.readable(this->port) : "error";
+    return tr_isPeerIo(this) ? this->addr_.readable(this->port_) : "error";
 }
 
 void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* userData)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -927,7 +927,7 @@ void tr_peerIoClear(tr_peerIo* io)
 int tr_peerIoReconnect(tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
-    TR_ASSERT(!tr_peerIoIsIncoming(io));
+    TR_ASSERT(!io->isIncoming());
 
     tr_session* session = tr_peerIoGetSession(io);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -937,7 +937,7 @@ int tr_peerIoReconnect(tr_peerIo* io)
     io_close_socket(io);
 
     auto const [addr, port] = io->socketAddress();
-    io->socket = tr_netOpenPeerSocket(session, &addr, port, io->is_seed);
+    io->socket = tr_netOpenPeerSocket(session, &addr, port, io->isSeed());
 
     if (io->socket.type != TR_PEER_SOCKET_TYPE_TCP)
     {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -114,6 +114,11 @@ public:
         return inbuf.get();
     }
 
+    [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
+    {
+        return bandwidth->clamp(dir, 1024) > 0;
+    }
+
     tr_crypto crypto;
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
@@ -341,11 +346,6 @@ static inline void tr_peerIoSetParent(tr_peerIo* io, Bandwidth* parent)
 }
 
 void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
-
-static inline bool tr_peerIoHasBandwidthLeft(tr_peerIo const* io, tr_direction dir)
-{
-    return io->bandwidth->clamp(dir, 1024) > 0;
-}
 
 static inline unsigned int tr_peerIoGetPieceSpeed_Bps(tr_peerIo const* io, uint64_t now, tr_direction dir)
 {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -119,6 +119,11 @@ public:
         return bandwidth->clamp(dir, 1024) > 0;
     }
 
+    [[nodiscard]] auto getPieceSpeed_Bps(uint64_t now, tr_direction dir) noexcept
+    {
+        return bandwidth->getPieceSpeedBytesPerSecond(now, dir);
+    }
+
     tr_crypto crypto;
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
@@ -346,11 +351,6 @@ static inline void tr_peerIoSetParent(tr_peerIo* io, Bandwidth* parent)
 }
 
 void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
-
-static inline unsigned int tr_peerIoGetPieceSpeed_Bps(tr_peerIo const* io, uint64_t now, tr_direction dir)
-{
-    return io->bandwidth->getPieceSpeedBytesPerSecond(now, dir);
-}
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -79,16 +79,16 @@ public:
         tr_session* session_in,
         tr_sha1_digest_t const* torrent_hash,
         bool is_incoming,
-        tr_address const& addr_in,
-        tr_port port_in,
-        bool is_seed_in,
+        tr_address const& addr,
+        tr_port port,
+        bool is_seed,
         time_t current_time)
         : crypto{ torrent_hash, is_incoming }
         , session{ session_in }
         , time_created{ current_time }
-        , is_seed{ is_seed_in }
-        , addr_{ addr_in }
-        , port_{ port_in }
+        , addr_{ addr }
+        , port_{ port }
+        , is_seed_{ is_seed }
     {
     }
 
@@ -159,6 +159,11 @@ public:
         return utp_supported_;
     }
 
+    [[nodiscard]] constexpr auto isSeed() const noexcept
+    {
+        return is_seed_;
+    }
+
     tr_crypto crypto;
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
@@ -200,13 +205,13 @@ public:
 
     tr_priority_t priority = TR_PRI_NORMAL;
 
-    bool const is_seed;
-
     bool utp_supported_ = false;
 
 private:
     tr_address const addr_;
     tr_port const port_;
+
+    bool const is_seed_;
 
     bool dht_supported_ = false;
     bool extended_protocol_supported_ = false;

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -84,11 +84,11 @@ public:
         bool is_seed_in,
         time_t current_time)
         : crypto{ torrent_hash, is_incoming }
-        , addr{ addr_in }
         , session{ session_in }
         , time_created{ current_time }
-        , port{ port_in }
         , is_seed{ is_seed_in }
+        , addr{ addr_in }
+        , port{ port_in }
     {
     }
 
@@ -110,8 +110,6 @@ public:
     }
 
     tr_crypto crypto;
-
-    tr_address const addr;
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
     // like this one isn't being used just for assertions, but also in
@@ -150,8 +148,6 @@ public:
 
     short int pendingEvents = 0;
 
-    tr_port const port;
-
     tr_priority_t priority = TR_PRI_NORMAL;
 
     bool const is_seed;
@@ -159,6 +155,10 @@ public:
     bool extendedProtocolSupported = false;
     bool fastExtensionSupported = false;
     bool utpSupported = false;
+
+private:
+    tr_address const addr;
+    tr_port const port;
 };
 
 /**
@@ -194,7 +194,8 @@ void tr_peerIoUnrefImpl(char const* file, int line, tr_peerIo* io);
 
 constexpr bool tr_isPeerIo(tr_peerIo const* io)
 {
-    return io != nullptr && io->magic_number == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 && tr_address_is_valid(&io->addr);
+    return io != nullptr && io->magic_number == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 &&
+        tr_address_is_valid(&io->address());
 }
 
 /**

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility> // std::make_pair
 
 #include <event2/buffer.h>
 
@@ -26,7 +27,7 @@
 
 #include "bandwidth.h"
 #include "crypto.h"
-#include "net.h" /* tr_address */
+#include "net.h" // tr_address
 #include "peer-socket.h"
 #include "tr-assert.h"
 
@@ -89,6 +90,16 @@ public:
         , port{ port_in }
         , is_seed{ is_seed_in }
     {
+    }
+
+    [[nodiscard]] constexpr tr_address const& address() const noexcept
+    {
+        return addr;
+    }
+
+    [[nodiscard]] constexpr std::pair<tr_address, tr_port> socketAddress() const noexcept
+    {
+        return std::make_pair(addr, port);
     }
 
     std::string addrStr() const;
@@ -236,10 +247,6 @@ constexpr tr_session* tr_peerIoGetSession(tr_peerIo* io)
 
     return io->session;
 }
-
-char const* tr_peerIoGetAddrStr(tr_peerIo const* io, char* buf, size_t buflen);
-
-struct tr_address const* tr_peerIoGetAddress(tr_peerIo const* io, tr_port* port);
 
 std::optional<tr_sha1_digest_t> tr_peerIoGetTorrentHash(tr_peerIo const* io);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -129,7 +129,7 @@ public:
         this->fastExtensionSupported = flag;
     }
 
-    constexpr auto supportsFEXT() const noexcept
+    [[nodiscard]] constexpr auto supportsFEXT() const noexcept
     {
         return this->fastExtensionSupported;
     }
@@ -139,7 +139,7 @@ public:
         this->extendedProtocolSupported = flag;
     }
 
-    constexpr auto supportsLTEP() const noexcept
+    [[nodiscard]] constexpr auto supportsLTEP() const noexcept
     {
         return this->extendedProtocolSupported;
     }
@@ -149,12 +149,12 @@ public:
         this->dhtSupported = flag;
     }
 
-    constexpr auto supportsDHT() const noexcept
+    [[nodiscard]] constexpr auto supportsDHT() const noexcept
     {
         return this->dhtSupported;
     }
 
-    constexpr auto supportsUTP() const noexcept
+    [[nodiscard]] constexpr auto supportsUTP() const noexcept
     {
         return this->utpSupported;
     }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -124,6 +124,41 @@ public:
         return bandwidth->getPieceSpeedBytesPerSecond(now, dir);
     }
 
+    constexpr void enableFEXT(bool flag) noexcept
+    {
+        this->fastExtensionSupported = flag;
+    }
+
+    constexpr auto supportsFEXT() const noexcept
+    {
+        return this->fastExtensionSupported;
+    }
+
+    constexpr void enableLTEP(bool flag) noexcept
+    {
+        this->extendedProtocolSupported = flag;
+    }
+
+    constexpr auto supportsLTEP() const noexcept
+    {
+        return this->extendedProtocolSupported;
+    }
+
+    constexpr void enableDHT(bool flag) noexcept
+    {
+        this->dhtSupported = flag;
+    }
+
+    constexpr auto supportsDHT() const noexcept
+    {
+        return this->dhtSupported;
+    }
+
+    constexpr auto supportsUTP() const noexcept
+    {
+        return this->utpSupported;
+    }
+
     tr_crypto crypto;
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
@@ -166,14 +201,16 @@ public:
     tr_priority_t priority = TR_PRI_NORMAL;
 
     bool const is_seed;
-    bool dhtSupported = false;
-    bool extendedProtocolSupported = false;
-    bool fastExtensionSupported = false;
+
     bool utpSupported = false;
 
 private:
     tr_address const addr;
     tr_port const port;
+
+    bool dhtSupported = false;
+    bool extendedProtocolSupported = false;
+    bool fastExtensionSupported = false;
 };
 
 /**
@@ -211,45 +248,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
 {
     return io != nullptr && io->magic_number == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 &&
         tr_address_is_valid(&io->address());
-}
-
-/**
-***
-**/
-
-constexpr void tr_peerIoEnableFEXT(tr_peerIo* io, bool flag)
-{
-    io->fastExtensionSupported = flag;
-}
-
-constexpr bool tr_peerIoSupportsFEXT(tr_peerIo const* io)
-{
-    return io->fastExtensionSupported;
-}
-
-constexpr void tr_peerIoEnableLTEP(tr_peerIo* io, bool flag)
-{
-    io->extendedProtocolSupported = flag;
-}
-
-constexpr bool tr_peerIoSupportsLTEP(tr_peerIo const* io)
-{
-    return io->extendedProtocolSupported;
-}
-
-constexpr void tr_peerIoEnableDHT(tr_peerIo* io, bool flag)
-{
-    io->dhtSupported = flag;
-}
-
-constexpr bool tr_peerIoSupportsDHT(tr_peerIo const* io)
-{
-    return io->dhtSupported;
-}
-
-constexpr bool tr_peerIoSupportsUTP(tr_peerIo const* io)
-{
-    return io->utpSupported;
 }
 
 /**

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -104,6 +104,11 @@ public:
 
     std::string addrStr() const;
 
+    [[nodiscard]] constexpr bool isIncoming() noexcept
+    {
+        return crypto.is_incoming;
+    }
+
     [[nodiscard]] auto getReadBuffer() noexcept
     {
         return inbuf.get();
@@ -254,11 +259,6 @@ std::optional<tr_sha1_digest_t> tr_peerIoGetTorrentHash(tr_peerIo const* io);
 void tr_peerIoSetTorrentHash(tr_peerIo* io, tr_sha1_digest_t const& info_hash);
 
 int tr_peerIoReconnect(tr_peerIo* io);
-
-constexpr bool tr_peerIoIsIncoming(tr_peerIo const* io)
-{
-    return io->crypto.is_incoming;
-}
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -87,19 +87,19 @@ public:
         , session{ session_in }
         , time_created{ current_time }
         , is_seed{ is_seed_in }
-        , addr{ addr_in }
-        , port{ port_in }
+        , addr_{ addr_in }
+        , port_{ port_in }
     {
     }
 
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
-        return addr;
+        return addr_;
     }
 
     [[nodiscard]] constexpr std::pair<tr_address, tr_port> socketAddress() const noexcept
     {
-        return std::make_pair(addr, port);
+        return std::make_pair(addr_, port_);
     }
 
     std::string addrStr() const;
@@ -126,37 +126,37 @@ public:
 
     constexpr void enableFEXT(bool flag) noexcept
     {
-        this->fastExtensionSupported = flag;
+        fast_extension_supported_ = flag;
     }
 
     [[nodiscard]] constexpr auto supportsFEXT() const noexcept
     {
-        return this->fastExtensionSupported;
+        return fast_extension_supported_;
     }
 
     constexpr void enableLTEP(bool flag) noexcept
     {
-        this->extendedProtocolSupported = flag;
+        extended_protocol_supported_ = flag;
     }
 
     [[nodiscard]] constexpr auto supportsLTEP() const noexcept
     {
-        return this->extendedProtocolSupported;
+        return extended_protocol_supported_;
     }
 
     constexpr void enableDHT(bool flag) noexcept
     {
-        this->dhtSupported = flag;
+        dht_supported_ = flag;
     }
 
     [[nodiscard]] constexpr auto supportsDHT() const noexcept
     {
-        return this->dhtSupported;
+        return dht_supported_;
     }
 
     [[nodiscard]] constexpr auto supportsUTP() const noexcept
     {
-        return this->utpSupported;
+        return utp_supported_;
     }
 
     tr_crypto crypto;
@@ -202,15 +202,15 @@ public:
 
     bool const is_seed;
 
-    bool utpSupported = false;
+    bool utp_supported_ = false;
 
 private:
-    tr_address const addr;
-    tr_port const port;
+    tr_address const addr_;
+    tr_port const port_;
 
-    bool dhtSupported = false;
-    bool extendedProtocolSupported = false;
-    bool fastExtensionSupported = false;
+    bool dht_supported_ = false;
+    bool extended_protocol_supported_ = false;
+    bool fast_extension_supported_ = false;
 };
 
 /**

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1008,7 +1008,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
 
     auto const [addr, port] = result.io->socketAddress();
 
-    if (tr_peerIoIsIncoming(result.io))
+    if (result.io->isIncoming())
     {
         manager->incoming_handshakes.erase(addr);
     }
@@ -1050,7 +1050,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
         atom->piece_data_time = 0;
         atom->lastConnectionAt = tr_time();
 
-        if (!tr_peerIoIsIncoming(result.io))
+        if (!result.io->isIncoming())
         {
             atom->flags |= ADDED_F_CONNECTABLE;
             atom->flags2 &= ~MyflagUnreachable;
@@ -1067,7 +1067,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
         {
             tr_logAddTraceSwarm(s, fmt::format("banned peer {} tried to reconnect", tr_atomAddrStr(atom)));
         }
-        else if (tr_peerIoIsIncoming(result.io) && s->peerCount() >= getMaxPeerCount(s->tor))
+        else if (result.io->isIncoming() && s->peerCount() >= getMaxPeerCount(s->tor))
         {
             /* too many peers already */
         }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -85,11 +85,11 @@ tr_peerMgr* tr_peerMgrNew(tr_session* session);
 
 void tr_peerMgrFree(tr_peerMgr* manager);
 
-bool tr_peerMgrPeerIsSeed(tr_torrent const* tor, tr_address const* addr);
+bool tr_peerMgrPeerIsSeed(tr_torrent const* tor, tr_address const& addr);
 
-void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const* addr);
+void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr);
 
-void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const* addr, bool failed);
+void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const& addr, bool failed);
 
 std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_peer const* peer, size_t numwant);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -302,7 +302,7 @@ public:
 
     bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
     {
-        auto const Bps = tr_peerIoGetPieceSpeed_Bps(io, now, direction);
+        auto const Bps = io->getPieceSpeed_Bps(now, direction);
 
         if (setme_Bps != nullptr)
         {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -255,9 +255,8 @@ public:
 
         if (tr_peerIoSupportsUTP(io))
         {
-            tr_address const* addr = tr_peerIoGetAddress(io, nullptr);
-            tr_peerMgrSetUtpSupported(torrent, addr);
-            tr_peerMgrSetUtpFailed(torrent, addr, false);
+            tr_peerMgrSetUtpSupported(torrent, io->address());
+            tr_peerMgrSetUtpFailed(torrent, io->address(), false);
         }
 
         if (tr_peerIoSupportsLTEP(io))
@@ -270,9 +269,7 @@ public:
         if (tr_dhtEnabled(torrent->session) && tr_peerIoSupportsDHT(io))
         {
             /* Only send PORT over IPv6 when the IPv6 DHT is running (BEP-32). */
-            struct tr_address const* addr = tr_peerIoGetAddress(io, nullptr);
-
-            if (addr->type == TR_AF_INET || tr_globalIPv6(nullptr) != nullptr)
+            if (io->address().type == TR_AF_INET || tr_globalIPv6(nullptr) != nullptr)
             {
                 protocolSendPort(this, tr_dhtPort(torrent->session));
             }
@@ -907,12 +904,11 @@ static void updateFastSet(tr_peerMsgs*)
 
     if (fext && peerIsNeedy && !msgs->haveFastSet)
     {
-        struct tr_address const* addr = tr_peerIoGetAddress(msgs->io, nullptr);
         tr_info const* inf = &msgs->torrent->info;
         size_t const numwant = std::min(MAX_FAST_SET_SIZE, inf->pieceCount);
 
         /* build the fast set */
-        msgs->fastsetSize = tr_generateAllowedSet(msgs->fastset, numwant, inf->pieceCount, inf->hash, addr);
+        msgs->fastsetSize = tr_generateAllowedSet(msgs->fastset, numwant, inf->pieceCount, inf->hash, msgs->io->address());
         msgs->haveFastSet = true;
 
         /* send it to the peer */
@@ -1156,7 +1152,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
         {
             /* Mysterious µTorrent extension that we don't grok.  However,
                it implies support for µTP, so use it to indicate that. */
-            tr_peerMgrSetUtpFailed(msgs->torrent, tr_peerIoGetAddress(msgs->io, nullptr), false);
+            tr_peerMgrSetUtpFailed(msgs->torrent, msgs->io->address(), false);
         }
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -349,7 +349,7 @@ public:
 
     [[nodiscard]] bool is_incoming_connection() const override
     {
-        return tr_peerIoIsIncoming(io);
+        return io->isIncoming();
     }
 
     [[nodiscard]] bool is_active(tr_direction direction) const override
@@ -1178,14 +1178,14 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
 
     uint8_t const* addr = nullptr;
     auto addr_len = size_t{};
-    if (tr_peerIoIsIncoming(msgs->io) && tr_variantDictFindRaw(&val, TR_KEY_ipv4, &addr, &addr_len) && addr_len == 4)
+    if (msgs->io->isIncoming() && tr_variantDictFindRaw(&val, TR_KEY_ipv4, &addr, &addr_len) && addr_len == 4)
     {
         pex.addr.type = TR_AF_INET;
         memcpy(&pex.addr.addr.addr4, addr, 4);
         tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, &pex, 1);
     }
 
-    if (tr_peerIoIsIncoming(msgs->io) && tr_variantDictFindRaw(&val, TR_KEY_ipv6, &addr, &addr_len) && addr_len == 16)
+    if (msgs->io->isIncoming() && tr_variantDictFindRaw(&val, TR_KEY_ipv6, &addr, &addr_len) && addr_len == 16)
     {
         pex.addr.type = TR_AF_INET6;
         memcpy(&pex.addr.addr.addr6, addr, 16);


### PR DESCRIPTION
Some mild C++ification of `tr_peerIo`. There is still a lot of work to do in that class; this is just some prepwork for another refactor that removes `tr_ptrArray` from peer-mgr.cc.