### PR TITLE
Updated macOS segmented control alignment and popup button style

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		3C7A11990D0B2EE300B5701F /* natpmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11930D0B2EE300B5701F /* natpmp.c */; };
 		3C7A119A0D0B2EE300B5701F /* natpmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11940D0B2EE300B5701F /* natpmp.h */; };
 		4394AC670C74FB6000F367E8 /* ptrarray.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4394AC640C74FB6000F367E8 /* ptrarray.cc */; };
+		45A7D3292843B54D00F0C32A /* GroupPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */; };
+		45A7D32C2843B55F00F0C32A /* PriorityPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */; };
 		4D043A7F090AE979009FEDA8 /* TransmissionDocument.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */; };
 		4D118E1A08CB46B20033958F /* PrefsController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D118E1908CB46B20033958F /* PrefsController.mm */; };
 		4D1838DD09DEC0E80047D688 /* libtransmission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D18389709DEC0030047D688 /* libtransmission.a */; };
@@ -616,6 +618,10 @@
 		3C7A11930D0B2EE300B5701F /* natpmp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = natpmp.c; sourceTree = "<group>"; };
 		3C7A11940D0B2EE300B5701F /* natpmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = natpmp.h; sourceTree = "<group>"; };
 		4394AC640C74FB6000F367E8 /* ptrarray.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ptrarray.cc; sourceTree = "<group>"; };
+		45A7D3272843B54D00F0C32A /* GroupPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupPopUpButtonCell.h; sourceTree = "<group>"; };
+		45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupPopUpButtonCell.mm; sourceTree = "<group>"; };
+		45A7D32A2843B55F00F0C32A /* PriorityPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityPopUpButtonCell.h; sourceTree = "<group>"; };
+		45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PriorityPopUpButtonCell.mm; sourceTree = "<group>"; };
 		4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = TransmissionDocument.icns; path = Images/TransmissionDocument.icns; sourceTree = "<group>"; };
 		4D118E1808CB46B20033958F /* PrefsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefsController.h; sourceTree = "<group>"; };
 		4D118E1908CB46B20033958F /* PrefsController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PrefsController.mm; sourceTree = "<group>"; };
@@ -1457,6 +1463,10 @@
 				A20BFFB60D091CC700CE5D2B /* ToolbarSegmentedCell.mm */,
 				A22180960D148A71007D09ED /* GroupsPrefsController.h */,
 				A22180970D148A71007D09ED /* GroupsPrefsController.mm */,
+				45A7D3272843B54D00F0C32A /* GroupPopUpButtonCell.h */,
+				45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */,
+				45A7D32A2843B55F00F0C32A /* PriorityPopUpButtonCell.h */,
+				45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */,
 				A2FB701A0D95CAEA0001F331 /* GroupsController.h */,
 				A2FB701B0D95CAEA0001F331 /* GroupsController.mm */,
 				A2451E6616ACE4EB00586E0E /* FileRenameSheetController.h */,
@@ -3032,6 +3042,7 @@
 				A257C1820CAD3003004E121C /* PeerTableView.mm in Sources */,
 				A2A6321B0CD9751700E3DA60 /* BadgeView.mm in Sources */,
 				A2ED7D8F0CEF431B00970975 /* FilterButton.mm in Sources */,
+				45A7D32C2843B55F00F0C32A /* PriorityPopUpButtonCell.mm in Sources */,
 				A25892640CF1F7E800CCCDDF /* StatsWindowController.mm in Sources */,
 				A2C89D600CFCBF57004CC2BC /* ButtonToolbarItem.mm in Sources */,
 				A219798B0D07B78400438EA7 /* GroupToolbarItem.mm in Sources */,
@@ -3040,6 +3051,7 @@
 				A26AF21A0D2DA35A00FF7140 /* FileOutlineController.mm in Sources */,
 				A26AF2840D2DC27C00FF7140 /* AddWindowController.mm in Sources */,
 				A2FB701C0D95CAEA0001F331 /* GroupsController.mm in Sources */,
+				45A7D3292843B54D00F0C32A /* GroupPopUpButtonCell.mm in Sources */,
 				A2D307A40D9EC6870051FD27 /* BlocklistDownloader.mm in Sources */,
 				A2725B6E0DE5C4F5003445E7 /* FileListNode.mm in Sources */,
 				A2725D5D0DE7507C003445E7 /* TrackerTableView.mm in Sources */,

--- a/macosx/GroupPopUpButtonCell.h
+++ b/macosx/GroupPopUpButtonCell.h
@@ -1,0 +1,9 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <Cocoa/Cocoa.h>
+
+@interface GroupPopUpButtonCell : NSPopUpButtonCell
+
+@end

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -12,7 +12,7 @@
 {
     NSRect imageFrame = cellFrame;
     imageFrame.origin.x -= FRAME_INSET;
-    
+
     [super drawImageWithFrame:imageFrame inView:controlView];
 }
 
@@ -20,7 +20,7 @@
 {
     NSRect textFrame = cellFrame;
     textFrame.origin.y += FRAME_INSET / 2;
-    
+
     [super drawTitleWithFrame:textFrame inView:controlView];
 }
 

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -1,0 +1,27 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import "GroupPopUpButtonCell.h"
+
+#define FRAME_INSET 2.0
+
+@implementation GroupPopUpButtonCell
+
+- (void)drawImageWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    NSRect imageFrame = cellFrame;
+    imageFrame.origin.x -= FRAME_INSET;
+    
+    [super drawImageWithFrame:imageFrame inView:controlView];
+}
+
+- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    NSRect textFrame = cellFrame;
+    textFrame.origin.y += FRAME_INSET / 2;
+    
+    [super drawTitleWithFrame:textFrame inView:controlView];
+}
+
+@end

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -8,7 +8,7 @@
 
 @implementation GroupPopUpButtonCell
 
-- (void)drawImageWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+- (void)drawImageWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect imageFrame = cellFrame;
     imageFrame.origin.x -= FRAME_INSET;
@@ -16,7 +16,7 @@
     [super drawImageWithFrame:imageFrame inView:controlView];
 }
 
-- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect textFrame = cellFrame;
     textFrame.origin.y += FRAME_INSET / 2;

--- a/macosx/PriorityPopUpButtonCell.h
+++ b/macosx/PriorityPopUpButtonCell.h
@@ -1,0 +1,9 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <Cocoa/Cocoa.h>
+
+@interface PriorityPopUpButtonCell : NSPopUpButtonCell
+
+@end

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -1,0 +1,19 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import "PriorityPopUpButtonCell.h"
+
+#define FRAME_INSET 2.0
+
+@implementation PriorityPopUpButtonCell
+
+- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    NSRect textFrame = cellFrame;
+    textFrame.origin.x += 2 * FRAME_INSET;
+    
+    [super drawTitleWithFrame:textFrame inView:controlView];
+}
+
+@end

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -12,7 +12,7 @@
 {
     NSRect textFrame = cellFrame;
     textFrame.origin.x += 2 * FRAME_INSET;
-    
+
     [super drawTitleWithFrame:textFrame inView:controlView];
 }
 

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -8,7 +8,7 @@
 
 @implementation PriorityPopUpButtonCell
 
-- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+- (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect textFrame = cellFrame;
     textFrame.origin.x += 2 * FRAME_INSET;

--- a/macosx/da.lproj/AddMagnetWindow.xib
+++ b/macosx/da.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="410" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="410" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="374" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="374" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="143" height="18"/>
+                        <rect key="frame" x="18" y="21" width="146" height="18"/>
                         <buttonCell key="cell" type="check" title="Start overførslen nu" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="306" y="12" width="90" height="32"/>
+                        <rect key="frame" x="313" y="12" width="84" height="32"/>
                         <buttonCell key="cell" type="push" title="Tilføj" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="216" y="12" width="90" height="32"/>
+                        <rect key="frame" x="231" y="12" width="84" height="32"/>
                         <buttonCell key="cell" type="push" title="Annuller" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="84" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="84" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Magnet Link" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="376" height="103"/>
+                        <rect key="frame" x="17" y="55" width="376" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="374" height="101"/>
+                            <rect key="frame" x="3" y="3" width="370" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="69" y="36" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Ingen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="66" y="32" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Ingen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="83" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="83" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Download til:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="53" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="53" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Priotet:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="69" y="9" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Høj" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="66" y="6" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Høj" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="53" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="53" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Gruppe:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="98" y="62" width="199" height="30"/>
+                                    <rect key="frame" x="96" y="58" width="199" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="197" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="193" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="159" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="159" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="297" y="63" width="68" height="28"/>
+                                    <rect key="frame" x="294" y="58" width="70" height="27"/>
                                     <buttonCell key="cell" type="push" title="Andet..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/da.lproj/AddWindow.xib
+++ b/macosx/da.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/da.lproj/PrefsWindow.xib
+++ b/macosx/da.lproj/PrefsWindow.xib
@@ -1081,10 +1081,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1099,7 +1099,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="KwC-x2-hD4">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1715,6 +1715,7 @@
             <connections>
                 <outlet property="nextKeyView" destination="1429" id="1636"/>
             </connections>
+            <point key="canvasLocation" x="616" y="154"/>
         </customView>
         <customView id="66" userLabel="Network">
             <rect key="frame" x="0.0" y="0.0" width="542" height="220"/>
@@ -1924,10 +1925,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1951,7 +1952,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="uYt-KS-e9s">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>

--- a/macosx/de.lproj/AddMagnetWindow.xib
+++ b/macosx/de.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="410" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="410" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="374" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="374" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="145" height="18"/>
+                        <rect key="frame" x="18" y="21" width="149" height="18"/>
                         <buttonCell key="cell" type="check" title="Automatisch starten" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="286" y="12" width="110" height="32"/>
+                        <rect key="frame" x="293" y="12" width="104" height="32"/>
                         <buttonCell key="cell" type="push" title="Hinzufügen" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="176" y="12" width="110" height="32"/>
+                        <rect key="frame" x="191" y="12" width="104" height="32"/>
                         <buttonCell key="cell" type="push" title="Abbrechen" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="87" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="87" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="magnet-Link" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="376" height="103"/>
+                        <rect key="frame" x="17" y="55" width="376" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="374" height="101"/>
+                            <rect key="frame" x="3" y="3" width="370" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="73" y="36" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Keine" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="69" y="32" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Keine" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="78" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="78" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Laden nach:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="57" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="56" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Priorität:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="73" y="9" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Hoch" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="69" y="6" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Hoch" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="57" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="56" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Gruppe:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="93" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="91" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="287" y="63" width="78" height="28"/>
+                                    <rect key="frame" x="284" y="58" width="80" height="27"/>
                                     <buttonCell key="cell" type="push" title="Ändern ..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/de.lproj/AddWindow.xib
+++ b/macosx/de.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -202,7 +202,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="336" y="9" width="122" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -235,7 +235,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="336" y="36" width="122" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/de.lproj/PrefsWindow.xib
+++ b/macosx/de.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1081,10 +1082,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1103,7 +1104,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="IOr-J0-Ikz">
                         <rect key="frame" x="1" y="1" width="158" height="197"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="158" height="197"/>
@@ -1917,10 +1918,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="115" y="81" width="69" height="23"/>
+                    <rect key="frame" x="114" y="81" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1948,7 +1949,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="mfY-sh-Bfh">
                         <rect key="frame" x="1" y="1" width="333" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="333" height="76"/>
@@ -2186,7 +2187,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/en.lproj/AddMagnetWindow.xib
+++ b/macosx/en.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="414" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="378" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="378" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="130" height="18"/>
+                        <rect key="frame" x="18" y="21" width="134" height="18"/>
                         <buttonCell key="cell" type="check" title="Start when added" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="318" y="12" width="82" height="32"/>
+                        <rect key="frame" x="325" y="12" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="236" y="12" width="82" height="32"/>
+                        <rect key="frame" x="251" y="12" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="84" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="84" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Magnet Link" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="380" height="103"/>
+                        <rect key="frame" x="17" y="55" width="380" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="378" height="101"/>
+                            <rect key="frame" x="3" y="3" width="374" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="68" y="36" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="65" y="32" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="84" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="84" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Download to:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="52" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="52" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Priority:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="68" y="9" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="High" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="65" y="6" width="99" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="High" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="52" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="52" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Group:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="99" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="97" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="293" y="63" width="76" height="28"/>
+                                    <rect key="frame" x="290" y="58" width="78" height="27"/>
                                     <buttonCell key="cell" type="push" title="Change…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/en.lproj/AddWindow.xib
+++ b/macosx/en.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/en.lproj/PrefsWindow.xib
+++ b/macosx/en.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1082,10 +1083,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1100,7 +1101,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="F5C-Uu-ttQ">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1915,10 +1916,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1942,7 +1943,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="DtM-n3-Fsk">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2180,7 +2181,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/es.lproj/AddMagnetWindow.xib
+++ b/macosx/es.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Ventana" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Ventana" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="421" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="421" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="385" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="385" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="191" height="18"/>
+                        <rect key="frame" x="18" y="21" width="195" height="18"/>
                         <buttonCell key="cell" type="check" title="Comenzar cuando se añada" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="313" y="12" width="94" height="32"/>
+                        <rect key="frame" x="320" y="12" width="88" height="32"/>
                         <buttonCell key="cell" type="push" title="Añadir" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="219" y="12" width="94" height="32"/>
+                        <rect key="frame" x="234" y="12" width="88" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancelar" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="99" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="100" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Enlace magnet" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Caja" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="387" height="103"/>
+                        <rect key="frame" x="17" y="55" width="387" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="385" height="101"/>
+                            <rect key="frame" x="3" y="3" width="381" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="79" y="36" width="108" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Ninguno" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="76" y="32" width="109" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Ninguno" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="89" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="89" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Descargar en:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="63" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="63" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Prioridad:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="79" y="9" width="108" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="76" y="6" width="109" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="63" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="63" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Grupo:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="104" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="102" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="298" y="63" width="78" height="28"/>
+                                    <rect key="frame" x="295" y="58" width="80" height="27"/>
                                     <buttonCell key="cell" type="push" title="Cambiar…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/es.lproj/AddWindow.xib
+++ b/macosx/es.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="131" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="131" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/es.lproj/PrefsWindow.xib
+++ b/macosx/es.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1081,10 +1082,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1099,7 +1100,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="fRP-Wa-RJL">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1926,10 +1927,10 @@ los límites globales de ancho de banda</string>
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1953,7 +1954,7 @@ los límites globales de ancho de banda</string>
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="BUU-B1-SiU">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2179,7 +2180,7 @@ los límites globales de ancho de banda</string>
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/fr.lproj/AddMagnetWindow.xib
+++ b/macosx/fr.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Fenêtre" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Fenêtre" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="419" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="419" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="383" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="383" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="159" height="18"/>
+                        <rect key="frame" x="18" y="21" width="163" height="18"/>
                         <buttonCell key="cell" type="check" title="Démarrer tout de suite" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="318" y="12" width="87" height="32"/>
+                        <rect key="frame" x="325" y="12" width="81" height="32"/>
                         <buttonCell key="cell" type="push" title="Ajouter" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="231" y="12" width="87" height="32"/>
+                        <rect key="frame" x="246" y="12" width="81" height="32"/>
                         <buttonCell key="cell" type="push" title="Annuler" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="87" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="87" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Lien aimanté" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="385" height="103"/>
+                        <rect key="frame" x="17" y="55" width="385" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="383" height="101"/>
+                            <rect key="frame" x="3" y="3" width="379" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="73" y="36" width="105" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Aucun" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="69" y="32" width="107" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Aucun" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="86" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="86" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sauver dans :" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="57" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="56" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Priorité :" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="73" y="9" width="105" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Haute" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="69" y="6" width="107" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Haute" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="57" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="56" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Groupe :" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="101" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="99" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="295" y="63" width="79" height="28"/>
+                                    <rect key="frame" x="292" y="58" width="81" height="27"/>
                                     <buttonCell key="cell" type="push" title="Modifier..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/fr.lproj/AddWindow.xib
+++ b/macosx/fr.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="250" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Normale" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Normale" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="250" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/fr.lproj/PrefsWindow.xib
+++ b/macosx/fr.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1080,10 +1081,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1102,7 +1103,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="MnG-c7-ejh">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1927,10 +1928,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1958,7 +1959,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="Gef-FS-zLw">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2184,7 +2185,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/it.lproj/AddMagnetWindow.xib
+++ b/macosx/it.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Finestra" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Finestra" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="410" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="410" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="374" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="374" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="149" height="18"/>
+                        <rect key="frame" x="18" y="21" width="153" height="18"/>
                         <buttonCell key="cell" type="check" title="Avvia il trasferimento" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="311" y="12" width="85" height="32"/>
+                        <rect key="frame" x="318" y="12" width="79" height="32"/>
                         <buttonCell key="cell" type="push" title="Agg." bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="226" y="12" width="85" height="32"/>
+                        <rect key="frame" x="241" y="12" width="79" height="32"/>
                         <buttonCell key="cell" type="push" title="Annulla" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="166" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="166" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Collegamento magnetico" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="376" height="103"/>
+                        <rect key="frame" x="17" y="55" width="376" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="374" height="101"/>
+                            <rect key="frame" x="3" y="3" width="370" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="70" y="36" width="110" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Nessuno" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="67" y="32" width="111" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Nessuno" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="67" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="67" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Scarica in:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="54" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="54" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Priorità:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="70" y="9" width="110" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="67" y="6" width="111" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="54" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="54" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Gruppo:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="82" y="62" width="208" height="30"/>
+                                    <rect key="frame" x="80" y="58" width="208" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="206" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="202" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="168" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="168" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="290" y="63" width="75" height="28"/>
+                                    <rect key="frame" x="287" y="58" width="77" height="27"/>
                                     <buttonCell key="cell" type="push" title="Cambia…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/it.lproj/AddWindow.xib
+++ b/macosx/it.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/it.lproj/PrefsWindow.xib
+++ b/macosx/it.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1080,10 +1081,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1098,7 +1099,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="Cuv-DU-r7J">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1923,10 +1924,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1950,7 +1951,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="Sjl-RN-E6v">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2176,7 +2177,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/nl.lproj/AddMagnetWindow.xib
+++ b/macosx/nl.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Venster" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Venster" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="419" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="419" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="383" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="383" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="103" height="18"/>
+                        <rect key="frame" x="18" y="21" width="107" height="18"/>
                         <buttonCell key="cell" type="check" title="Start transfer" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="311" y="12" width="94" height="32"/>
+                        <rect key="frame" x="318" y="12" width="88" height="32"/>
                         <buttonCell key="cell" type="push" title="Voeg toe" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="217" y="12" width="94" height="32"/>
+                        <rect key="frame" x="232" y="12" width="88" height="32"/>
                         <buttonCell key="cell" type="push" title="Annuleer" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="84" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="84" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Magnet Link" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="385" height="103"/>
+                        <rect key="frame" x="17" y="55" width="385" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="383" height="101"/>
+                            <rect key="frame" x="3" y="3" width="379" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="76" y="36" width="104" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Geen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="73" y="32" width="106" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Geen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="98" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="98" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Download naar:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="60" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="60" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Prioriteit:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="76" y="9" width="104" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Hoog" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="73" y="6" width="106" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Hoog" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="60" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="60" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Groep:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="113" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="111" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="307" y="63" width="67" height="28"/>
+                                    <rect key="frame" x="304" y="58" width="69" height="27"/>
                                     <buttonCell key="cell" type="push" title="Wijzig…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/nl.lproj/AddWindow.xib
+++ b/macosx/nl.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="250" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Normaal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Normaal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" inset="2" selectedItem="89" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="250" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/nl.lproj/PrefsWindow.xib
+++ b/macosx/nl.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -975,6 +976,7 @@
                     </connections>
                 </tabView>
             </subviews>
+            <point key="canvasLocation" x="139" y="155"/>
         </customView>
         <customView id="1760" userLabel="Groups">
             <rect key="frame" x="0.0" y="0.0" width="542" height="240"/>
@@ -1080,10 +1082,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1102,7 +1104,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="97f-WE-FbD">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1915,10 +1917,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1946,7 +1948,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" id="Jr7-t4-4VJ">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2184,7 +2186,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/pt_PT.lproj/AddMagnetWindow.xib
+++ b/macosx/pt_PT.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="410" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="410" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="374" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="374" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="136" height="18"/>
+                        <rect key="frame" x="18" y="21" width="140" height="18"/>
                         <buttonCell key="cell" type="check" title="Iniciar ao adicionar" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="299" y="12" width="97" height="32"/>
+                        <rect key="frame" x="306" y="12" width="91" height="32"/>
                         <buttonCell key="cell" type="push" title="Adicionar" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="202" y="12" width="97" height="32"/>
+                        <rect key="frame" x="217" y="12" width="91" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancelar" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="107" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="107" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Ligação Magnet" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="376" height="103"/>
+                        <rect key="frame" x="17" y="55" width="376" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="374" height="101"/>
+                            <rect key="frame" x="3" y="3" width="370" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="87" y="36" width="108" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Nenhum" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="83" y="32" width="109" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Nenhum" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="79" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="79" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Guardar em:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="71" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="70" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Prioridade:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="87" y="9" width="108" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="83" y="6" width="109" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Alta" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="71" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="70" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Grupo:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="94" y="62" width="201" height="30"/>
+                                    <rect key="frame" x="92" y="58" width="201" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="199" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="195" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="161" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="161" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="295" y="63" width="70" height="28"/>
+                                    <rect key="frame" x="292" y="58" width="72" height="27"/>
                                     <buttonCell key="cell" type="push" title="Alterar…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/pt_PT.lproj/AddWindow.xib
+++ b/macosx/pt_PT.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" tag="1" inset="2" selectedItem="89" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" tag="1" inset="2" selectedItem="89" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/pt_PT.lproj/PrefsWindow.xib
+++ b/macosx/pt_PT.lproj/PrefsWindow.xib
@@ -1081,10 +1081,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1103,7 +1103,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="OrK-Ic-Ogf">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1928,10 +1928,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32">
                                 <nil key="label"/>
@@ -1959,7 +1959,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="dlE-NG-X9B">
                         <rect key="frame" x="1" y="1" width="355" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="355" height="76"/>

--- a/macosx/ru.lproj/AddMagnetWindow.xib
+++ b/macosx/ru.lproj/AddMagnetWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,8 +32,8 @@
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="428" height="232"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="428" height="226"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
+                <rect key="frame" x="0.0" y="0.0" width="428" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
@@ -104,7 +104,7 @@ Gw
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="90" y="32" width="137" height="25"/>
-                                    <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -134,7 +134,7 @@ Gw
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="90" y="6" width="137" height="25"/>
-                                    <popUpButtonCell key="cell" type="push" title="Высокий" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <popUpButtonCell key="cell" type="push" title="Высокий" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -202,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="291" y="59" width="91" height="27"/>
+                                    <rect key="frame" x="291" y="58" width="91" height="27"/>
                                     <buttonCell key="cell" type="push" title="Изменить…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -275,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
         <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/ru.lproj/AddWindow.xib
+++ b/macosx/ru.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="244" y="15" width="140" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="244" y="43" width="140" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/ru.lproj/PrefsWindow.xib
+++ b/macosx/ru.lproj/PrefsWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1084,10 +1085,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1102,7 +1103,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="Dpq-ph-lQx">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1941,10 +1942,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1968,7 +1969,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="cNg-WR-Fyn">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>
@@ -2194,7 +2195,7 @@
         <image name="NSAddTemplate" width="14" height="13"/>
         <image name="NSRemoveTemplate" width="14" height="4"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
-        <image name="TortoiseTemplate" width="128" height="128"/>
+        <image name="TortoiseTemplate" width="18" height="18"/>
         <image name="imageCell:1782:image" width="18" height="18">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05T

--- a/macosx/tr.lproj/AddMagnetWindow.xib
+++ b/macosx/tr.lproj/AddMagnetWindow.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,25 +27,25 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="AddMagnetWindow" animationBehavior="default" tabbingMode="disallowed" id="1" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="173" y="705" width="411" height="232"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" verticalHuggingPriority="750" id="2">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <view key="contentView" verticalHuggingPriority="750" misplaced="YES" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="411" height="232"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                        <rect key="frame" x="20" y="195" width="16" height="16"/>
+                        <rect key="frame" x="20" y="190" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="1zx-Cs-Swd"/>
                             <constraint firstAttribute="height" constant="16" id="TGc-Go-KGZ"/>
                         </constraints>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="Magnet" id="8"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="18" y="165" width="375" height="22"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
+                        <rect key="frame" x="18" y="161" width="375" height="21"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="370" id="5E7-V5-l02"/>
                         </constraints>
@@ -57,14 +56,14 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                        <rect key="frame" x="18" y="21" width="118" height="18"/>
+                        <rect key="frame" x="18" y="21" width="122" height="18"/>
                         <buttonCell key="cell" type="check" title="İndirmeyi başlat" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="18">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="19">
-                        <rect key="frame" x="312" y="12" width="85" height="32"/>
+                        <rect key="frame" x="319" y="12" width="79" height="32"/>
                         <buttonCell key="cell" type="push" title="Ekle" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="20">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -77,7 +76,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                        <rect key="frame" x="227" y="12" width="85" height="32"/>
+                        <rect key="frame" x="242" y="12" width="79" height="32"/>
                         <buttonCell key="cell" type="push" title="Vazgeç" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="22">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,8 +88,8 @@ Gw
                             <action selector="cancelAdd:" target="-2" id="32"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                        <rect key="frame" x="42" y="195" width="124" height="17"/>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
+                        <rect key="frame" x="42" y="190" width="123" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Mıknatıslı Bağlantı" id="101">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,14 +97,14 @@ Gw
                         </textFieldCell>
                     </textField>
                     <box borderType="line" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                        <rect key="frame" x="17" y="56" width="377" height="103"/>
+                        <rect key="frame" x="17" y="55" width="377" height="100"/>
                         <view key="contentView" id="xWJ-qu-F1m">
-                            <rect key="frame" x="1" y="1" width="375" height="101"/>
+                            <rect key="frame" x="3" y="3" width="371" height="94"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="33">
-                                    <rect key="frame" x="70" y="36" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Hiçbiri" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34">
+                                    <rect key="frame" x="67" y="32" width="98" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Hiçbiri" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="2zq-5y-smI" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35">
@@ -117,16 +116,16 @@ Gw
                                         </menu>
                                     </popUpButtonCell>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="12" y="71" width="80" height="17"/>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                                    <rect key="frame" x="10" y="67" width="80" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Şuraya indir:" id="15">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="12" y="15" width="54" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
+                                    <rect key="frame" x="10" y="13" width="54" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Öncelik:" id="91">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,8 +133,8 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="85">
-                                    <rect key="frame" x="70" y="9" width="97" height="26"/>
-                                    <popUpButtonCell key="cell" type="push" title="Yüksek" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86">
+                                    <rect key="frame" x="67" y="6" width="98" height="25"/>
+                                    <popUpButtonCell key="cell" type="push" title="Yüksek" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="90" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -156,8 +155,8 @@ Gw
                                         <action selector="changePriority:" target="-2" id="98"/>
                                     </connections>
                                 </popUpButton>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
-                                    <rect key="frame" x="12" y="42" width="54" height="17"/>
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="40">
+                                    <rect key="frame" x="10" y="39" width="54" height="16"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Öbek:" id="41">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -165,13 +164,13 @@ Gw
                                     </textFieldCell>
                                 </textField>
                                 <box horizontalHuggingPriority="249" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                    <rect key="frame" x="95" y="62" width="194" height="30"/>
+                                    <rect key="frame" x="93" y="58" width="194" height="30"/>
                                     <view key="contentView" id="29A-0C-qoo">
-                                        <rect key="frame" x="1" y="1" width="192" height="28"/>
+                                        <rect key="frame" x="3" y="3" width="188" height="24"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                                                <rect key="frame" x="30" y="8" width="154" height="14"/>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                                                <rect key="frame" x="28" y="6" width="154" height="14"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="DBq-4X-8Uk"/>
                                                 </constraints>
@@ -182,7 +181,7 @@ Gw
                                                 </textFieldCell>
                                             </textField>
                                             <imageView translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                                <rect key="frame" x="10" y="7" width="16" height="16"/>
+                                                <rect key="frame" x="8" y="5" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="16" id="46x-pe-IRn"/>
                                                     <constraint firstAttribute="width" constant="16" id="xF7-UN-BfS"/>
@@ -203,7 +202,7 @@ Gw
                                     </constraints>
                                 </box>
                                 <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="289" y="63" width="77" height="28"/>
+                                    <rect key="frame" x="286" y="58" width="79" height="27"/>
                                     <buttonCell key="cell" type="push" title="Değiştir..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="16">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -276,11 +275,11 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="GroupsNoneTemplate" width="16" height="16"/>
         <image name="Magnet" width="32" height="32"/>
-        <image name="NSApplicationIcon" width="128" height="128"/>
+        <image name="NSApplicationIcon" width="32" height="32"/>
         <image name="PriorityHighTemplate" width="12" height="12"/>
         <image name="PriorityLowTemplate" width="12" height="12"/>
         <image name="PriorityNormalTemplate" width="12" height="12"/>
+        <image name="circle.dashed" catalog="system" width="15" height="15"/>
     </resources>
 </document>

--- a/macosx/tr.lproj/AddWindow.xib
+++ b/macosx/tr.lproj/AddWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,7 +201,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="85">
                                     <rect key="frame" x="253" y="15" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="86" customClass="PriorityPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="87">
@@ -234,7 +234,7 @@ Gw
                                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="33">
                                     <rect key="frame" x="253" y="43" width="125" height="26"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
-                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34">
+                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" id="34" customClass="GroupPopUpButtonCell">
                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="menu"/>
                                         <menu key="menu" title="OtherViews" id="35"/>

--- a/macosx/tr.lproj/PrefsWindow.xib
+++ b/macosx/tr.lproj/PrefsWindow.xib
@@ -1082,10 +1082,10 @@
                     </connections>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1772">
-                    <rect key="frame" x="20" y="19" width="69" height="23"/>
+                    <rect key="frame" x="19" y="19" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1773">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1773">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" tag="1"/>
@@ -1100,7 +1100,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="D6N-I2-fEN">
                         <rect key="frame" x="1" y="1" width="141" height="169"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="18" id="1774">
                                 <rect key="frame" x="0.0" y="0.0" width="141" height="169"/>
@@ -1925,10 +1925,10 @@
                     </textFieldCell>
                 </textField>
                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1534">
-                    <rect key="frame" x="103" y="67" width="69" height="23"/>
+                    <rect key="frame" x="102" y="67" width="71" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="smallSquare" trackingMode="momentary" id="1535">
-                        <font key="font" metaFont="system"/>
+                    <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="roundRect" trackingMode="momentary" id="1535">
+                        <font key="font" metaFont="cellTitle"/>
                         <segments>
                             <segment image="NSAddTemplate" width="32"/>
                             <segment image="NSRemoveTemplate" width="32" enabled="NO" tag="1"/>
@@ -1952,7 +1952,7 @@
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" id="sre-eV-u9A">
                         <rect key="frame" x="1" y="1" width="306" height="76"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" id="1521">
                                 <rect key="frame" x="0.0" y="0.0" width="306" height="76"/>


### PR DESCRIPTION
addresses the following request: https://github.com/transmission/transmission/issues/3143:
<img width="654" alt="Screen Shot 2022-05-29 at 4 29 36 pm" src="https://user-images.githubusercontent.com/7323792/170874563-b9f6d5d1-4b44-4596-9347-c8e990827275.png">
<img width="654" alt="Screen Shot 2022-05-29 at 4 29 46 pm" src="https://user-images.githubusercontent.com/7323792/170874567-b64d3651-6214-4063-af71-eb155bf5dffa.png">
<img width="528" alt="Screen Shot 2022-05-29 at 4 30 33 pm" src="https://user-images.githubusercontent.com/7323792/170874724-6d9502a5-5c7d-4b62-afdf-95251ca0443d.png">
<img width="545" alt="Screen Shot 2022-05-29 at 4 30 04 pm" src="https://user-images.githubusercontent.com/7323792/170874727-b112020b-ffa1-421e-aba2-d65499883ed5.png">

