### PR TITLE
perf: avoid some unnecessary psl domain strdups

### DIFF
--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -252,12 +252,12 @@ bool tr_isValidTrackerScheme(std::string_view scheme)
     return std::find(std::begin(Schemes), std::end(Schemes), scheme) != std::end(Schemes);
 }
 
-bool isAsciiLowerCase(std::string_view host)
+bool isAsciiNonUpperCase(std::string_view host)
 {
     return std::all_of(
         std::begin(host),
         std::end(host),
-        [](unsigned char ch) { return (ch < 128) && (std::islower(ch) != 0); });
+        [](unsigned char ch) { return (ch < 128) && (std::isupper(ch) == 0); });
 }
 
 // www.example.com -> example
@@ -282,7 +282,7 @@ std::string_view getSiteName(std::string_view host)
     }
 
     // is it a registered name?
-    if (isAsciiLowerCase(host))
+    if (isAsciiNonUpperCase(host))
     {
         if (char const* const top = psl_registrable_domain(psl_builtin(), std::data(szhost)); top != nullptr)
         {


### PR DESCRIPTION
We were incorrectly duplicating most domains because the "do we need to convert before feeding to psl" test incorrectly returned true for many domains.