### PR TITLE
perf: use std::string_view for compile-time UserAgent

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -138,9 +138,9 @@ std::optional<std::string> tr_session::WebMediator::cookieFile() const
     return std::string{ path };
 }
 
-std::optional<std::string> tr_session::WebMediator::userAgent() const
+std::optional<std::string_view> tr_session::WebMediator::userAgent() const
 {
-    return fmt::format(FMT_STRING("{:s}/{:s}"), TR_NAME, SHORT_VERSION_STRING);
+    return TR_NAME "/" SHORT_VERSION_STRING;
 }
 
 std::optional<std::string> tr_session::WebMediator::publicAddress() const

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -396,7 +396,7 @@ public:
 
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddress() const override;
-        [[nodiscard]] std::optional<std::string> userAgent() const override;
+        [[nodiscard]] std::optional<std::string_view> userAgent() const override;
         [[nodiscard]] unsigned int clamp(int bandwidth_tag, unsigned int byte_count) const override;
         void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
         // runs the tr_web::fetch response callback in the libtransmission thread

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -115,7 +115,7 @@ public:
         }
 
         // Return the preferred user aagent, or nullopt to not use one
-        [[nodiscard]] virtual std::optional<std::string> userAgent() const
+        [[nodiscard]] virtual std::optional<std::string_view> userAgent() const
         {
             return std::nullopt;
         }


### PR DESCRIPTION
A pretty small perf refactor: use a compile-time `std::string_view` for the User-Agent string provided to libcurl, instead of generating a new std::string from libfmt each time.