### PR TITLE
perf: avoid std::string temporaries in sessionLoadTorrent()

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2045,14 +2045,11 @@ static void sessionLoadTorrents(struct sessionLoadTorrentsData* const data)
             auto const path = tr_pathbuf{ dirname_sv, "/"sv, name };
 
             // is a magnet link?
-            if (!tr_ctorSetMetainfoFromFile(data->ctor, std::string{ path }, nullptr))
+            if (!tr_ctorSetMetainfoFromFile(data->ctor, path.sv(), nullptr))
             {
                 if (auto buf = std::vector<char>{}; tr_loadFile(path, buf))
                 {
-                    tr_ctorSetMetainfoFromMagnetLink(
-                        data->ctor,
-                        std::string{ std::data(buf), std::size(buf) }.c_str(),
-                        nullptr);
+                    tr_ctorSetMetainfoFromMagnetLink(data->ctor, std::string_view{ std::data(buf), std::size(buf) }, nullptr);
                 }
             }
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -66,7 +66,7 @@ struct tr_ctor
 ****
 ***/
 
-bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string const& filename, tr_error** error)
+bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error)
 {
     if (std::empty(filename))
     {
@@ -97,11 +97,16 @@ bool tr_ctorSetMetainfo(tr_ctor* ctor, char const* metainfo, size_t len, tr_erro
     return ctor->metainfo.parseBenc(contents_sv, error);
 }
 
-bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, char const* magnet_link, tr_error** error)
+bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view magnet_link, tr_error** error)
 {
     ctor->torrent_filename.clear();
     ctor->metainfo = {};
-    return ctor->metainfo.parseMagnet(magnet_link != nullptr ? magnet_link : "", error);
+    return ctor->metainfo.parseMagnet(magnet_link, error);
+}
+
+bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, char const* magnet_link, tr_error** error)
+{
+    return tr_ctorSetMetainfoFromMagnetLink(ctor, std::string_view{ magnet_link != nullptr ? magnet_link : "" }, error);
 }
 
 char const* tr_ctorGetSourceFile(tr_ctor const* ctor)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -774,8 +774,8 @@ tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 
 tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 
-bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string const& filename, tr_error** error);
-bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string const& filename, tr_error** error);
+bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error);
+bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view filename, tr_error** error);
 void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels);
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);
 


### PR DESCRIPTION
This is a minor performance patch that replaces a few `std::string` temporaries with `std::string_view` in `sessionLoadTorrent()`.