### PR TITLE
refactor: add tr_peerMsgs.networkSocket()

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -76,6 +76,8 @@ public:
 
     virtual bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const = 0;
 
+    [[nodiscard]] virtual std::string readable() const = 0;
+
     /* whether or not we should free this peer soon.
        NOTE: private to peer-mgr.c */
     bool doPurge = false;

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -106,8 +106,6 @@ constexpr bool tr_isPex(tr_pex const* pex)
     return pex && tr_address_is_valid(&pex->addr);
 }
 
-tr_address const* tr_peerAddress(tr_peer const*);
-
 tr_peerMgr* tr_peerMgrNew(tr_session* session);
 
 void tr_peerMgrFree(tr_peerMgr* manager);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -371,6 +371,17 @@ public:
         return io->time_created < timestamp;
     }
 
+    [[nodiscard]] std::pair<tr_address, tr_port> socketAddress() const override
+    {
+        return io->socketAddress();
+    }
+
+    [[nodiscard]] std::string readable() const override
+    {
+        auto const [addr, port] = socketAddress();
+        return addr.readable(port);
+    }
+
     void cancel_block_request(tr_block_index_t block) override
     {
         protocolSendCancel(this, blockToReq(torrent, block));
@@ -1755,7 +1766,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
             if (auto const dht_port = tr_port::fromNetwork(nport); !std::empty(dht_port))
             {
                 msgs->dht_port = dht_port;
-                tr_dhtAddNode(msgs->session, tr_peerAddress(msgs), msgs->dht_port, false);
+                tr_dhtAddNode(msgs->session, &msgs->io->address(), msgs->dht_port, false);
             }
         }
         break;

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -52,6 +52,8 @@ public:
 
     [[nodiscard]] virtual bool is_connection_older_than(time_t time) const noexcept = 0;
 
+    [[nodiscard]] virtual std::pair<tr_address, tr_port> socketAddress() const = 0;
+
     virtual void cancel_block_request(tr_block_index_t block) = 0;
 
     virtual void set_choke(bool peer_is_choked) = 0;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -198,6 +198,16 @@ public:
         return is_active;
     }
 
+    [[nodiscard]] std::string readable() const override
+    {
+        if (auto const parsed = tr_urlParse(base_url); parsed)
+        {
+            return fmt::format(FMT_STRING("{:s}:{:d}"), parsed->host, parsed->port);
+        }
+
+        return base_url;
+    }
+
     void gotPieceData(uint32_t n_bytes)
     {
         bandwidth.notifyBandwidthConsumed(TR_DOWN, n_bytes, true, tr_time_msec());


### PR DESCRIPTION
Start decoupling tr_peer from tr_peer_atom.

Not a fix for #3166 yet, but lays some groundwork for the upcoming fix.