### PR TITLE
more FullScreen fixes, and some toolbar animation fixes

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -54,6 +54,7 @@
 #import "NSStringAdditions.h"
 #import "ExpandedPathToPathTransformer.h"
 #import "ExpandedPathToIconTransformer.h"
+#import "MainWindow.h"
 
 #define TOOLBAR_CREATE @"Toolbar Create"
 #define TOOLBAR_OPEN_FILE @"Toolbar Open"
@@ -230,7 +231,7 @@ static void removeKeRangerRansomware()
 
 @interface Controller ()
 
-@property(nonatomic) IBOutlet NSWindow* fWindow;
+@property(nonatomic) IBOutlet MainWindow* fWindow;
 @property(nonatomic) IBOutlet TorrentTableView* fTableView;
 
 @property(nonatomic) IBOutlet NSMenuItem* fOpenIgnoreDownloadFolder;
@@ -4252,7 +4253,7 @@ static void removeKeRangerRansomware()
 
     if (@available(macOS 11.0, *))
     {
-        // not needed
+        button.bordered = NO;
     }
     else
     {
@@ -4351,7 +4352,7 @@ static void removeKeRangerRansomware()
 
         if (@available(macOS 11.0, *))
         {
-            // not needed
+            segmentedCell.bezeled = NO;
         }
         else
         {
@@ -4402,7 +4403,7 @@ static void removeKeRangerRansomware()
 
         if (@available(macOS 11.0, *))
         {
-            // not needed
+            segmentedCell.bezeled = NO;
         }
         else
         {
@@ -5188,7 +5189,7 @@ static void removeKeRangerRansomware()
 
 - (void)setWindowSizeToFit
 {
-    if ([self.fDefaults boolForKey:@"AutoSize"])
+    if ([self.fDefaults boolForKey:@"AutoSize"] && self.fWindow.isFullScreen == NO)
     {
         NSScrollView* scrollView = self.fTableView.enclosingScrollView;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -5167,6 +5167,25 @@ static void removeKeRangerRansomware()
     return frame;
 }
 
+- (void)windowWillEnterFullScreen:(NSNotification*)notification
+{
+    // temporarily disable AutoSize
+    NSSize contentMinSize = self.fWindow.contentMinSize;
+    contentMinSize.height = self.minWindowContentSizeAllowed;
+
+    self.fWindow.contentMinSize = contentMinSize;
+
+    NSSize contentMaxSize = self.fWindow.contentMaxSize;
+    contentMaxSize.height = FLT_MAX;
+    self.fWindow.contentMaxSize = contentMaxSize;
+}
+
+- (void)windowDidExitFullScreen:(NSNotification*)notification
+{
+    // restore auotsize setting
+    [self updateForAutoSize];
+}
+
 - (void)setWindowSizeToFit
 {
     if ([self.fDefaults boolForKey:@"AutoSize"])

--- a/macosx/MainWindow.h
+++ b/macosx/MainWindow.h
@@ -1,0 +1,11 @@
+// This file Copyright © 2008-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <Cocoa/Cocoa.h>
+
+@interface MainWindow : NSWindow
+
+- (BOOL)isFullScreen;
+
+@end

--- a/macosx/Mainwindow.mm
+++ b/macosx/Mainwindow.mm
@@ -1,0 +1,37 @@
+// This file Copyright © 2008-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import "MainWindow.h"
+
+#define BIG_SUR_TOOLBARHEIGHT 28.0
+
+@implementation MainWindow
+
+- (void)toggleToolbarShown:(id)sender
+{
+    NSRect frame = self.frame;
+
+    //fix window sizing when toggling toolbar
+    if (@available(macOS 10.11, *))
+    {
+        if (self.toolbar.isVisible == YES)
+        {
+            frame.size.height += BIG_SUR_TOOLBARHEIGHT;
+        }
+        else
+        {
+            frame.size.height -= BIG_SUR_TOOLBARHEIGHT;
+        }
+    }
+    [self setFrame:frame display:YES animate:NO];
+
+    [super toggleToolbarShown:sender];
+}
+
+- (BOOL)isFullScreen
+{
+    return (self.styleMask & NSFullScreenWindowMask);
+}
+
+@end

--- a/macosx/da.lproj/MainMenu.xib
+++ b/macosx/da.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/de.lproj/MainMenu.xib
+++ b/macosx/de.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/en.lproj/MainMenu.xib
+++ b/macosx/en.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>
@@ -171,7 +171,7 @@
             <connections>
                 <outlet property="menu" destination="29" id="2687"/>
             </connections>
-            <point key="canvasLocation" x="139" y="125"/>
+            <point key="canvasLocation" x="138.5" y="125"/>
         </window>
         <menu title="MainMenu" systemMenu="main" id="29" userLabel="MainMenu">
             <items>
@@ -698,6 +698,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139" y="340"/>
         </menu>
         <customObject id="206" userLabel="Controller" customClass="Controller">
             <connections>
@@ -828,6 +829,7 @@ CA
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="117" y="-300"/>
         </menu>
         <menu title="Menu" id="589" userLabel="ContextNoRowMenu">
             <items>

--- a/macosx/es.lproj/MainMenu.xib
+++ b/macosx/es.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/fr.lproj/MainMenu.xib
+++ b/macosx/fr.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/it.lproj/MainMenu.xib
+++ b/macosx/it.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/nl.lproj/MainMenu.xib
+++ b/macosx/nl.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/pt_PT.lproj/MainMenu.xib
+++ b/macosx/pt_PT.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/ru.lproj/MainMenu.xib
+++ b/macosx/ru.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>

--- a/macosx/tr.lproj/MainMenu.xib
+++ b/macosx/tr.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission">
+        <window title="Transmission" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="TransmissionWindow" animationBehavior="default" tabbingMode="disallowed" id="21" userLabel="Transmission" customClass="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="71" y="712" width="515" height="248"/>


### PR DESCRIPTION
Fixes #1906.
Fixes #1903.

* Fixes for toggling status Bar, Groups, Compact view and Toolbar while in Fullscreen mode.
* Fixes window size when toggling Toolbar.
* Fixes toolbar button artefacts when toggling toolbar
