### PR TITLE
Fix: "Cannot begin activity without reason string or empty reason string"

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -778,7 +778,7 @@ static void removeKeRangerRansomware()
     NSApp.servicesProvider = self;
 
     self.fNoNapActivity = [NSProcessInfo.processInfo beginActivityWithOptions:NSActivityUserInitiatedAllowingIdleSystemSleep
-                                                                       reason:NSLocalizedString(@"No napping on the job!", nil)];
+                                                                       reason:@"No napping on the job!"];
 
     //register for dock icon drags (has to be in applicationDidFinishLaunching: to work)
     [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self andSelector:@selector(handleOpenContentsEvent:replyEvent:)


### PR DESCRIPTION
Fixes a crash on startup with some regional settings (I'm using French).