### PR TITLE
daemon: deprecated --log-error -> --log-level=error

### DIFF
--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 User=transmission
 Type=notify
-ExecStart=/usr/bin/transmission-daemon -f --log-error
+ExecStart=/usr/bin/transmission-daemon -f --log-level=error
 ExecReload=/bin/kill -s HUP $MAINPID
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true


### PR DESCRIPTION
I noticed that on startup the system.d service warns 
```
Jun 05 05:07:40 schwarzschild transmission-daemon[15562]: WARN: --log-error is deprecated. Use --log-level=error
```
which is easily fixed.