### PR TITLE
fix: mark non-c-strings for gettext i18n

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -933,6 +933,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
             else if (haveUnchecked == 0)
             {
                 str = fmt::format(
+                    // xgettext:no-c-format
                     _("{current_size} ({percent_done}% of {percent_available}% available)"),
                     fmt::arg("current_size", total),
                     fmt::arg("percent_done", buf2),
@@ -941,6 +942,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
             else
             {
                 str = fmt::format(
+                    // xgettext:no-c-format
                     _("{current_size} ({percent_done}% of {percent_available}% available; {unverified_size} unverified)"),
                     fmt::arg("current_size", total),
                     fmt::arg("percent_done", buf2),

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -60,6 +60,7 @@ auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const
     {
         // 50 MB of 200 MB (25%), uploaded 30 MB (Ratio: X%, Goal: Y%)
         gstr += fmt::format(
+            // xgettext:no-c-format
             _("{current_size} of {complete_size} ({percent_complete}%), uploaded {uploaded_size} (Ratio: {ratio}, Goal: {seed_ratio})"),
             fmt::arg("current_size", tr_strlsize(haveTotal)),
             fmt::arg("complete_size", tr_strlsize(total_size)),
@@ -71,6 +72,7 @@ auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const
     else if (!isSeed) // partial seed, no seed ratio
     {
         gstr += fmt::format(
+            // xgettext:no-c-format
             _("{current_size} of {complete_size} ({percent_complete}%), uploaded {uploaded_size} (Ratio: {ratio})"),
             fmt::arg("current_size", tr_strlsize(haveTotal)),
             fmt::arg("complete_size", tr_strlsize(total_size)),
@@ -166,6 +168,7 @@ std::string getShortStatusString(
 
     case TR_STATUS_CHECK:
         return fmt::format(
+            // xgettext:no-c-format
             _("Verifying local data ({percent_done}% tested)"),
             fmt::arg("percent_done", tr_truncd(st->recheckProgress * 100.0, 1)));
 
@@ -219,6 +222,7 @@ auto getActivityString(
         {
             return fmt::format(
                 ngettext(
+                    // xgettext:no-c-format
                     "Downloading metadata from {active_count} connected peer ({percent_done:d}% done)",
                     "Downloading metadata from {active_count} connected peers ({percent_done:d}% done)",
                     st->peersConnected),


### PR DESCRIPTION
This fixes the strings erroneously marked as c-strings by gettext, so they make translation possible.

Fixes #3203.