### PR TITLE
fix: macOS build warning "cannot find protocol definition for 'PortCheckerDelegate'"

### DIFF
--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -108,7 +108,7 @@
         self.fLocationImageView.image = nil;
     }
 
-#warning when 10.7-only, switch to auto layout
+    // TODO: adopt auto layout instead
     [self.fMagnetLinkLabel sizeToFit];
 
     CGFloat const downloadToLabelOldWidth = self.fDownloadToLabel.frame.size.width;

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -790,7 +790,7 @@ static void removeKeRangerRansomware()
     NSUserNotification* launchNotification = notification.userInfo[NSApplicationLaunchUserNotificationKey];
     if (launchNotification)
     {
-        [self userNotificationCenter:nil didActivateNotification:launchNotification];
+        [self userNotificationCenter:NSUserNotificationCenter.defaultUserNotificationCenter didActivateNotification:launchNotification];
     }
 
     //auto importing

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -425,6 +425,10 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
         break;
     case FILE_PRIORITY_LOW_TAG:
         priority = TR_PRI_LOW;
+        break;
+    default:
+        NSAssert1(NO, @"Unknown sender tag: %ld", [sender tag]);
+        return;
     }
 
     NSIndexSet* indexSet = self.fOutline.selectedRowIndexes;
@@ -569,6 +573,9 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
         case FILE_PRIORITY_LOW_TAG:
             priority = TR_PRI_LOW;
             break;
+        default:
+            NSAssert1(NO, @"Unknown menuItem tag: %ld", menuItem.tag);
+            return NO;
         }
 
         BOOL current = NO, canChange = NO;

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -59,6 +59,9 @@
     case 2:
         priority = TR_PRI_HIGH;
         break;
+    default:
+        NSAssert1(NO, @"Unknown segment: %ld", segment);
+        return;
     }
 
     FileListNode* node = self.representedObject;

--- a/macosx/PrefsController.h
+++ b/macosx/PrefsController.h
@@ -3,10 +3,9 @@
 // License text can be found in the licenses/ folder.
 
 #import <Cocoa/Cocoa.h>
+#import "PortChecker.h"
 
 #include <libtransmission/transmission.h>
-
-@protocol PortCheckerDelegate;
 
 @interface PrefsController : NSWindowController<NSToolbarDelegate, PortCheckerDelegate>
 


### PR DESCRIPTION
Just fixing macOS warnings which are apparent when building with `make`