### PR TITLE
Update the AUTHORS file.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,11 +20,13 @@ Project Contributors
   Malcolm Jarvis <mjarvis@transmissionbt.com> (Web client)
   Kevin Glowacz <kjg@transmissionbt.com> (Web client)
   Rashid Eissing (Mac OS X Transfers preferences icon)
+  Dean Ostetto
   Rick Patrick (Mac OS X images)
   Jonas Rask (Mac OS X Globe icon)
   Erick Turnquist (IPv6 code, support)
   Maarten Van Coile (Wiki Wrangler, troubleshooting, support)
   James "Kibo" Parry (Updated Mac Retina images)
+  Max Zettlmeißl <max@zettlmeissl.de>
 
 Previous Developers
   Eric Petit <eric@lapsus.org> (Project originator)


### PR DESCRIPTION
Readd Dean Ostetto who was wrongly removed.

Add myself, since the proper authorship information in the Git history
is lost when squashing the commits.
My contributions so far are: Pull request #2875 merged with commit hash
`738431169cce5cc60e935df44d0616891162dee9`, pull request #2889 merged with
commit hash `8d11f0bc22ec7e1f87e573d1232e8faa72e745a3`, pull request #2900
merged with commit hash `7c76d40a4d8748199903cf0a9d7cd0e38ec9e3f1` and
pull request #2984 merged with commit hash `d8c5c6572559136569f00e0c9c3cb068b6256938`.

All are currently attributed to `maxz <6818198+maxz@users.noreply.github.com>`,
while I expected them to be attributed to `Max Zettlmeißl <max@zettlmeissl.de>`.