### PR TITLE
fix: filename too long warning when adding magnet links

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1690,12 +1690,13 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         }
         else
         {
-            // these two tr_ctorSet*() functions require zero-terminated strings
-            auto const filename_sz = std::string{ filename };
-
-            if (!tr_ctorSetMetainfoFromFile(ctor, filename_sz.c_str(), nullptr))
+            if (tr_sys_path_exists(tr_pathbuf{ filename }))
             {
-                tr_ctorSetMetainfoFromMagnetLink(ctor, filename_sz.c_str(), nullptr);
+                tr_ctorSetMetainfoFromFile(ctor, filename);
+            }
+            else
+            {
+                tr_ctorSetMetainfoFromMagnetLink(ctor, filename);
             }
         }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -774,8 +774,8 @@ tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 
 tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 
-bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error);
-bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view filename, tr_error** error);
+bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error = nullptr);
+bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view filename, tr_error** error = nullptr);
 void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels);
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);
 


### PR DESCRIPTION
Fixes #3117.