### PR TITLE
replace macOS Groups indicators with dots

### DIFF
--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -16,10 +16,10 @@
 #define IMAGE_SIZE_MIN 16.0
 #define ERROR_IMAGE_SIZE 20.0
 
-#define GROUP_IMAGE_SIZE_REG 16.0
-#define GROUP_IMAGE_SIZE_MIN 10.0
-#define GROUP_PADDING_REG 32.0
-#define GROUP_PADDING_MIN 16.0
+#define GROUP_IMAGE_SIZE_REG 10.0
+#define GROUP_IMAGE_SIZE_MIN 6.0
+#define GROUP_PADDING_REG 22.0
+#define GROUP_PADDING_MIN 14.0
 
 #define NORMAL_BUTTON_WIDTH 14.0
 #define ACTION_BUTTON_WIDTH 16.0
@@ -319,7 +319,7 @@
     {
         NSRect groupRect = [self groupIconRectForBounds:iconRect];
         NSColor* groupColor = [GroupsController.groups colorForIndex:groupValue];
-        NSImage* icon = [NSImage discIconWithColor:groupColor insetFactor:0.4];
+        NSImage* icon = [NSImage discIconWithColor:groupColor insetFactor:0];
         [icon drawInRect:groupRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0f];
     }
 
@@ -855,9 +855,9 @@
 {
     BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
     CGFloat const imageSize = minimal ? GROUP_IMAGE_SIZE_MIN : GROUP_IMAGE_SIZE_REG;
-    CGFloat const padding = minimal ? GROUP_PADDING_MIN + 2.5 : GROUP_PADDING_REG + 1.0;
+    CGFloat const padding = minimal ? GROUP_PADDING_MIN + 2 : GROUP_PADDING_REG + 1.5;
 
-    return NSMakeRect(NSMidX(bounds) - padding, NSMidY(bounds) - imageSize * 0.5, imageSize, imageSize);
+    return NSMakeRect(NSMinX(bounds) - padding * 0.5, NSMidY(bounds) - imageSize * 0.5, imageSize, imageSize);
 }
 
 - (NSAttributedString*)attributedTitle

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -16,9 +16,10 @@
 #define IMAGE_SIZE_MIN 16.0
 #define ERROR_IMAGE_SIZE 20.0
 
-#define GROUP_IMAGE_WIDTH 4.0
-#define GROUP_INSET_REG 4.0
-#define GROUP_PADDING_REG 22.0
+#define GROUP_IMAGE_SIZE_REG 16.0
+#define GROUP_IMAGE_SIZE_MIN 10.0
+#define GROUP_PADDING_REG 32.0
+#define GROUP_PADDING_MIN 16.0
 
 #define NORMAL_BUTTON_WIDTH 14.0
 #define ACTION_BUTTON_WIDTH 16.0
@@ -125,19 +126,19 @@
 
 - (NSRect)iconRectForBounds:(NSRect)bounds
 {
-    CGFloat const imageSize = [self.fDefaults boolForKey:@"SmallView"] ? IMAGE_SIZE_MIN : IMAGE_SIZE_REG;
+    BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
+    CGFloat const imageSize = minimal ? IMAGE_SIZE_MIN : IMAGE_SIZE_REG;
+    CGFloat const padding = minimal ? GROUP_PADDING_MIN : GROUP_PADDING_REG;
 
-    return NSMakeRect(NSMinX(bounds) + PADDING_HORIZONTAL, ceil(NSMidY(bounds) - imageSize * 0.5), imageSize, imageSize);
+    return NSMakeRect(NSMinX(bounds) + (padding * 0.5) + PADDING_HORIZONTAL, ceil(NSMidY(bounds) - imageSize * 0.5), imageSize, imageSize);
 }
 
 - (NSRect)actionRectForBounds:(NSRect)bounds
 {
-    BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
-
     NSRect iconRect = [self iconRectForBounds:bounds];
-    iconRect.origin.x += minimal ? 0.0 : GROUP_INSET_REG * 2 + GROUP_IMAGE_WIDTH;
+    NSRect actionRect = [self actionButtonRectForBounds:iconRect];
 
-    return iconRect;
+    return actionRect;
 }
 
 - (NSCellHitResult)hitTestForEvent:(NSEvent*)event inRect:(NSRect)cellFrame ofView:(NSView*)controlView
@@ -312,33 +313,14 @@
     //group coloring
     NSRect const parentRect = [self iconRectForBounds:cellFrame];
     NSRect iconRect = NSMakeRect(parentRect.origin.x, parentRect.origin.y, parentRect.size.width, parentRect.size.height);
-    iconRect.origin.x += minimal ? 0 : GROUP_INSET_REG * 3;
 
     NSInteger const groupValue = torrent.groupValue;
     if (groupValue != -1)
     {
-        NSRect groupRect = NSInsetRect(parentRect, -1.0, -2.0);
-        if (!minimal)
-        {
-            groupRect.size.height = cellFrame.size.height - (GROUP_INSET_REG * 4);
-            groupRect.size.width = GROUP_INSET_REG;
-            groupRect.origin.y -= GROUP_INSET_REG * 2;
-            groupRect.origin.x += GROUP_INSET_REG;
-        }
-        CGFloat const radius = GROUP_INSET_REG / 2;
-
-        CGFloat fractionOfBlendedColor = 0.05;
-        NSColor *groupColor = [GroupsController.groups colorForIndex:groupValue],
-                *darkGroupColor = [groupColor blendedColorWithFraction:fractionOfBlendedColor ofColor:NSColor.controlTextColor];
-
-        NSBezierPath* groupPath = [NSBezierPath bezierPathWithRoundedRect:groupRect xRadius:radius yRadius:radius];
-
-        [groupPath setLineWidth:1.0];
-        [darkGroupColor setStroke];
-        [groupPath stroke];
-
-        [groupColor setFill];
-        [groupPath fill];
+        NSRect groupRect = [self groupIconRectForBounds:iconRect];
+        NSColor* groupColor = [GroupsController.groups colorForIndex:groupValue];
+        NSImage* icon = [NSImage discIconWithColor:groupColor insetFactor:0.4];
+        [icon drawInRect:groupRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0f];
     }
 
     BOOL const error = torrent.anyErrorOrWarning;
@@ -473,10 +455,8 @@
 #warning image should use new gear
         if (!self.fTracking && self.hoverAction)
         {
-            NSRect actionRect = NSMakeRect(cellFrame.origin.x, cellFrame.origin.y, cellFrame.size.width, cellFrame.size.height);
-            actionRect.origin.x += minimal ? 0.0 : GROUP_INSET_REG * 3;
             NSImage* actionImage = [NSImage imageNamed:@"ActionHover"];
-            [actionImage drawInRect:[self actionButtonRectForBounds:actionRect] fromRect:NSZeroRect
+            [actionImage drawInRect:[self actionButtonRectForBounds:iconRect] fromRect:NSZeroRect
                           operation:NSCompositingOperationSourceOver
                            fraction:1.0
                      respectFlipped:YES
@@ -757,6 +737,7 @@
 
     if (minimal)
     {
+        result.origin.x += GROUP_PADDING_MIN;
         result.origin.y = ceil(NSMidY(bounds) - NSHeight(result) * 0.5);
         result.size.width = rightBound - NSMinX(result) - PADDING_BETWEEN_TITLE_AND_MIN_STATUS;
     }
@@ -817,7 +798,7 @@
 - (NSRect)barRectMinForBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + IMAGE_SIZE_MIN + PADDING_BETWEEN_IMAGE_AND_BAR;
+    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + IMAGE_SIZE_MIN + GROUP_PADDING_MIN + PADDING_BETWEEN_IMAGE_AND_BAR;
     result.origin.y = NSMinY(bounds) + PADDING_BETWEEN_BAR_AND_EDGE_MIN;
     result.size.height = NSHeight(bounds) - 2.0 * PADDING_BETWEEN_BAR_AND_EDGE_MIN;
     result.size.width = NSMaxX(bounds) - NSMinX(result) - PADDING_BETWEEN_BAR_AND_EDGE_MIN;
@@ -867,10 +848,16 @@
 
 - (NSRect)actionButtonRectForBounds:(NSRect)bounds
 {
-    NSRect const iconRect = [self iconRectForBounds:bounds];
+    return NSMakeRect(NSMidX(bounds) - ACTION_BUTTON_WIDTH * 0.5, NSMidY(bounds) - ACTION_BUTTON_WIDTH * 0.5, ACTION_BUTTON_WIDTH, ACTION_BUTTON_WIDTH);
+}
 
-    //in minimal view the rect will be the icon rect, but avoid the extra defaults lookup with some cheap math
-    return NSMakeRect(NSMidX(iconRect) - ACTION_BUTTON_WIDTH * 0.5, NSMidY(iconRect) - ACTION_BUTTON_WIDTH * 0.5, ACTION_BUTTON_WIDTH, ACTION_BUTTON_WIDTH);
+- (NSRect)groupIconRectForBounds:(NSRect)bounds
+{
+    BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
+    CGFloat const imageSize = minimal ? GROUP_IMAGE_SIZE_MIN : GROUP_IMAGE_SIZE_REG;
+    CGFloat const padding = minimal ? GROUP_PADDING_MIN + 2.5 : GROUP_PADDING_REG + 1.0;
+
+    return NSMakeRect(NSMidX(bounds) - padding, NSMidY(bounds) - imageSize * 0.5, imageSize, imageSize);
 }
 
 - (NSAttributedString*)attributedTitle


### PR DESCRIPTION
the current Group indicator PR #3183 uses bars. I feel using circles is a better fit with the overall theme of Transmission #3224 and macOS. Also added a similar style for the Compact view.
Uses the group icons images from @Coeur
<img width="735" alt="minimal" src="https://user-images.githubusercontent.com/7323792/173236611-db0bd4bd-3add-4a04-a4be-3a2c012f116d.png">
<img width="735" alt="regular" src="https://user-images.githubusercontent.com/7323792/173236610-4bc85822-216a-455a-9ef9-65bdba484683.png">
<img width="1032" alt="Screen Shot 2022-06-12 at 3 48 48 pm" src="https://user-images.githubusercontent.com/7323792/173236446-ae2d160b-36f9-4c8b-bb3a-c66895f1a9ae.png">

