### PR TITLE
keep labels in order added, rather than alphabetically

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -119,7 +119,7 @@ static auto loadLabels(tr_variant* dict, tr_torrent* tor)
         }
     }
 
-    tor->setLabels(std::data(labels), std::size(labels));
+    tor->setLabels(labels);
     return tr_resume::Labels;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -979,7 +979,7 @@ static char const* setLabels(tr_torrent* tor, tr_variant* list)
         return errmsg;
     }
 
-    tor->setLabels(std::data(labels), std::size(labels));
+    tor->setLabels(labels);
     return nullptr;
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -11,7 +11,6 @@
 #include <csignal> /* signal() */
 #include <ctime>
 #include <map>
-#include <set>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -1914,11 +1913,11 @@ void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
     auto const lock = unique_lock();
     this->labels.clear();
 
-    for (auto l : new_labels)
+    for (auto label : new_labels)
     {
-            if (std::find(std::begin(this->labels), std::end(this->labels), l) == std::end(this->labels))
+            if (std::find(std::begin(this->labels), std::end(this->labels), label) == std::end(this->labels))
             {
-                    this->labels.push_back(l);
+                    this->labels.push_back(label);
             }
     }
     this->labels.shrink_to_fit();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1912,8 +1912,12 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 void tr_torrent::setLabels(tr_quark const* new_labels, size_t n_labels)
 {
     auto const lock = unique_lock();
-    auto const sorted_unique = std::set<tr_quark>{ new_labels, new_labels + n_labels };
-    this->labels = { std::begin(sorted_unique), std::end(sorted_unique) };
+    this->labels = std::vector<tr_quark>{};
+    for (size_t i = 0; i < n_labels; i++) {
+            if (std::find(this->labels.begin(), this->labels.end(), new_labels[i]) == this->labels.end()) {
+                    this->labels.push_back(new_labels[i]);
+            }
+    }
     this->labels.shrink_to_fit();
     this->setDirty();
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1914,8 +1914,10 @@ void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
     auto const lock = unique_lock();
     this->labels.clear();
 
-    for (auto l : new_labels) {
-            if (std::find(std::begin(this->labels), std::end(this->labels), l) == std::end(this->labels)) {
+    for (auto l : new_labels)
+    {
+            if (std::find(std::begin(this->labels), std::end(this->labels), l) == std::end(this->labels))
+            {
                     this->labels.push_back(l);
             }
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -714,7 +714,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->finishedSeedingByIdle = false;
 
     auto const& labels = tr_ctorGetLabels(ctor);
-    tor->setLabels(std::data(labels), std::size(labels));
+    tor->setLabels(labels);
 
     tor->uniqueId = session->torrents().add(tor);
 
@@ -1909,13 +1909,14 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 ****
 ***/
 
-void tr_torrent::setLabels(tr_quark const* new_labels, size_t n_labels)
+void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
 {
     auto const lock = unique_lock();
     this->labels = std::vector<tr_quark>{};
-    for (size_t i = 0; i < n_labels; i++) {
-            if (std::find(this->labels.begin(), this->labels.end(), new_labels[i]) == this->labels.end()) {
-                    this->labels.push_back(new_labels[i]);
+
+    for (auto l : new_labels) {
+            if (std::find(this->labels.begin(), this->labels.end(), l) == this->labels.end()) {
+                    this->labels.push_back(l);
             }
     }
     this->labels.shrink_to_fit();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1912,10 +1912,10 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
 {
     auto const lock = unique_lock();
-    this->labels = std::vector<tr_quark>{};
+    this->labels.clear();
 
     for (auto l : new_labels) {
-            if (std::find(this->labels.begin(), this->labels.end(), l) == this->labels.end()) {
+            if (std::find(std::begin(this->labels), std::end(this->labels), l) == std::end(this->labels)) {
                     this->labels.push_back(l);
             }
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -581,7 +581,7 @@ public:
 
     void setDateActive(time_t t);
 
-    void setLabels(tr_quark const* labels, size_t n_labels);
+    void setLabels(std::vector<tr_quark> const& new_labels);
 
     /** Return the mime-type (e.g. "audio/x-flac") that matches more of the
         torrent's content than any other mime-type. */


### PR DESCRIPTION
Proposed PR makes Transmission to avoid reordering labels (because of using transitional `std::set`).

Removing duplicates implemented using trivial algorithm with `O(N^2)` complexity, but it should be ok since labels vector usually pretty small. 