### PR TITLE
[macOS] Fix Group auto-assigning based on NSPredicate

### DIFF
--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -424,6 +424,7 @@ GroupsController* fGroupsInstance = nil;
     }
 
     NSPredicate* predicate = [self autoAssignRulesForIndex:index];
+    [predicate allowEvaluation];
     BOOL eval = NO;
     @try
     {

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -2175,4 +2175,10 @@ bool trashDataFile(char const* filename, tr_error** error)
     }
 }
 
+// For backward comatibility for previously saved Group Predicates.
+- (NSArray<FileListNode*>*)fFlatFileList
+{
+    return self.flatFileList;
+}
+
 @end

--- a/macosx/da.lproj/GroupRules.xib
+++ b/macosx/da.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Enhver fil" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Enhver tracker" id="162">

--- a/macosx/de.lproj/GroupRules.xib
+++ b/macosx/de.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Name einer Datei" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Genutzter Tracker" id="162">

--- a/macosx/en.lproj/GroupRules.xib
+++ b/macosx/en.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Any File" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Any Tracker" id="162">

--- a/macosx/es.lproj/GroupRules.xib
+++ b/macosx/es.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Cualquier archivo" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Cualquier tracker" id="162">

--- a/macosx/fr.lproj/GroupRules.xib
+++ b/macosx/fr.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Un fichier" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Un trackeur" id="162">

--- a/macosx/it.lproj/GroupRules.xib
+++ b/macosx/it.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Un qualsiasi file" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Un qualsiasi server traccia" id="162">

--- a/macosx/nl.lproj/GroupRules.xib
+++ b/macosx/nl.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Elk bestand" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Elke tracker" id="162">

--- a/macosx/pt_PT.lproj/GroupRules.xib
+++ b/macosx/pt_PT.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Qualquer ficheiro" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Qualquer tracker" id="162">

--- a/macosx/ru.lproj/GroupRules.xib
+++ b/macosx/ru.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Любой файл" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="Любой трекер" id="162">

--- a/macosx/tr.lproj/GroupRules.xib
+++ b/macosx/tr.lproj/GroupRules.xib
@@ -135,7 +135,7 @@ Gw
                                         <predicateEditorRowTemplate rowType="simple" id="147" customClass="PredicateEditorRowTemplateAny">
                                             <array key="leftExpressionObject">
                                                 <expression type="keyPath">
-                                                    <string key="keyPath">fFlatFileList.name</string>
+                                                    <string key="keyPath">flatFileList.name</string>
                                                 </expression>
                                                 <expression type="keyPath">
                                                     <string key="keyPath">allTrackersFlat</string>
@@ -148,7 +148,7 @@ Gw
                                                     <items>
                                                         <menuItem title="Dosya" state="on" id="161">
                                                             <expression key="representedObject" type="keyPath">
-                                                                <string key="keyPath">fFlatFileList.name</string>
+                                                                <string key="keyPath">flatFileList.name</string>
                                                             </expression>
                                                         </menuItem>
                                                         <menuItem title="İzleyici" id="162">


### PR DESCRIPTION
Rename issue after [this commit](https://github.com/transmission/transmission/commit/54d1a02e92d020374692d4fdb3a3d60eccd07560#diff-e7ff71cde5aad9e2a4a4a8d5994b8d10dc20400248a1dffb896ce322ebc9c543)
Allow execution of `NSPredicate` restored from new APIs in `NSKeyedUnarchiver` after [this commit](https://github.com/transmission/transmission/commit/aafedcaae11ef73a7008a4013c9a99cd3ad97bd8#diff-397f92b949bd7ee562d28e0a10c8ebd03d6bb24889e89efe302d484c9d6211ef)

Possibly fixes #3099.