### PR TITLE
[macOS] Fix assert on save for WARN and TRACE log levels in Log window.

### DIFF
--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -588,11 +588,17 @@
     case TR_LOG_ERROR:
         levelString = NSLocalizedString(@"Error", "Message window -> level");
         break;
+    case TR_LOG_WARN:
+        levelString = NSLocalizedString(@"Warn", "Message window -> level");
+        break;
     case TR_LOG_INFO:
         levelString = NSLocalizedString(@"Info", "Message window -> level");
         break;
     case TR_LOG_DEBUG:
         levelString = NSLocalizedString(@"Debug", "Message window -> level");
+        break;
+    case TR_LOG_TRACE:
+        levelString = NSLocalizedString(@"Trace", "Message window -> level");
         break;
     default:
         NSAssert1(NO, @"Unknown message log level: %ld", level);

--- a/macosx/en.lproj/Localizable.strings
+++ b/macosx/en.lproj/Localizable.strings
@@ -1048,7 +1048,8 @@
 /* Status Bar -> status menu */
 "Total Transfer" = "Total Transfer";
 
-/* Message window -> level string */
+/* Message window -> level
+   Message window -> level string */
 "Trace" = "Trace";
 
 /* Filter Bar -> filter menu */
@@ -1126,7 +1127,8 @@
 /* Torrent -> status string */
 "Waiting to seed" = "Waiting to seed";
 
-/* Message window -> level string */
+/* Message window -> level
+   Message window -> level string */
 "Warn" = "Warn";
 
 /* Drag overlay -> url */


### PR DESCRIPTION
Fixes #3286 
