### PR TITLE
[macOS] Hide NSPopover Arrow for Torrent options.

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -53,6 +53,7 @@
 @property(nonatomic) NSAnimation* fPiecesBarAnimation;
 
 @property(nonatomic) BOOL fActionPopoverShown;
+@property(nonatomic) NSView* fPositioningView;
 
 - (BOOL)pointInGroupStatusRect:(NSPoint)point;
 
@@ -775,6 +776,22 @@
     [popover showRelativeToRect:rect ofView:self preferredEdge:NSMaxYEdge];
     [infoViewController setInfoForTorrents:@[ torrent ]];
     [infoViewController updateInfo];
+
+    CGFloat width = NSWidth(rect);
+
+    if (NSMinX(self.window.frame) < width || NSMaxX(self.window.screen.frame) - NSMinX(self.window.frame) < 72)
+    {
+        // Ugly hack to hide NSPopover arrow.
+        self.fPositioningView = [[NSView alloc] initWithFrame:rect];
+        self.fPositioningView.identifier = @"positioningView";
+        [self addSubview:self.fPositioningView];
+        [popover showRelativeToRect:self.fPositioningView.bounds ofView:self.fPositioningView preferredEdge:NSMaxYEdge];
+        self.fPositioningView.bounds = NSOffsetRect(self.fPositioningView.bounds, 0, NSHeight(self.fPositioningView.bounds));
+    }
+    else
+    {
+        [popover showRelativeToRect:rect ofView:self preferredEdge:NSMaxYEdge];
+    }
 }
 
 //don't show multiple popovers when clicking the gear button repeatedly
@@ -783,8 +800,10 @@
     self.fActionPopoverShown = YES;
 }
 
-- (void)popoverWillClose:(NSNotification*)notification
+- (void)popoverDidClose:(NSNotification*)notification
 {
+    [self.fPositioningView removeFromSuperview];
+    self.fPositioningView = nil;
     self.fActionPopoverShown = NO;
 }
 


### PR DESCRIPTION
Fixes #3293


P.S.
I think I should make solution more general and extract the logic to a separate class.

I want to illustrate:
![NSPopoverSafeZone](https://user-images.githubusercontent.com/8330119/173460673-104a83ba-6415-4c34-805c-efd02ed6d1ed.png)
If target view is not in the safe zone - NSPopover should be detached.
More specifically - target view rect should be inside safe zone rect for arrow to be displayed.

[There's already some APIs available for it](https://developer.apple.com/documentation/appkit/nsscreen/1388369-visibleframe?language=objc)
