### PR TITLE
macOS remove GearshapeTemplate from CMakeLists.txt

### DIFF
--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -248,7 +248,6 @@ set(${PROJECT_NAME}_HIDPI_IMAGES
     DownArrowTemplate
     EllipsisTemplate
     FavIcon
-    GearshapeTemplate
     Globe
     Groups
     InfoActivity


### PR DESCRIPTION
Icon was removed from project in #3178