### PR TITLE
refactor: make tr_sessionGetEncryption() const

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2121,7 +2121,7 @@ static constexpr std::string_view getEncryptionModeString(tr_encryption_mode mod
     }
 }
 
-static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
+static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
 {
     switch (key)
     {
@@ -2302,27 +2302,27 @@ static void addSessionField(tr_session* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_script_torrent_added_filename:
-        tr_variantDictAddStr(d, key, tr_sessionGetScript(s, TR_SCRIPT_ON_TORRENT_ADDED));
+        tr_variantDictAddStr(d, key, s->script(TR_SCRIPT_ON_TORRENT_ADDED));
         break;
 
     case TR_KEY_script_torrent_added_enabled:
-        tr_variantDictAddBool(d, key, tr_sessionIsScriptEnabled(s, TR_SCRIPT_ON_TORRENT_ADDED));
+        tr_variantDictAddBool(d, key, s->useScript(TR_SCRIPT_ON_TORRENT_ADDED));
         break;
 
     case TR_KEY_script_torrent_done_filename:
-        tr_variantDictAddStr(d, key, tr_sessionGetScript(s, TR_SCRIPT_ON_TORRENT_DONE));
+        tr_variantDictAddStr(d, key, s->script(TR_SCRIPT_ON_TORRENT_DONE));
         break;
 
     case TR_KEY_script_torrent_done_enabled:
-        tr_variantDictAddBool(d, key, tr_sessionIsScriptEnabled(s, TR_SCRIPT_ON_TORRENT_DONE));
+        tr_variantDictAddBool(d, key, s->useScript(TR_SCRIPT_ON_TORRENT_DONE));
         break;
 
     case TR_KEY_script_torrent_done_seeding_filename:
-        tr_variantDictAddStr(d, key, tr_sessionGetScript(s, TR_SCRIPT_ON_TORRENT_DONE_SEEDING));
+        tr_variantDictAddStr(d, key, s->script(TR_SCRIPT_ON_TORRENT_DONE_SEEDING));
         break;
 
     case TR_KEY_script_torrent_done_seeding_enabled:
-        tr_variantDictAddBool(d, key, tr_sessionIsScriptEnabled(s, TR_SCRIPT_ON_TORRENT_DONE_SEEDING));
+        tr_variantDictAddBool(d, key, s->useScript(TR_SCRIPT_ON_TORRENT_DONE_SEEDING));
         break;
 
     case TR_KEY_queue_stalled_enabled:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -190,7 +190,7 @@ void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 ****
 ***/
 
-tr_encryption_mode tr_sessionGetEncryption(tr_session* session)
+tr_encryption_mode tr_sessionGetEncryption(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
@@ -472,8 +472,8 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_anti_brute_force_enabled, tr_sessionGetAntiBruteForceEnabled(s));
     for (auto const& [enabled_key, script_key, script] : tr_session::Scripts)
     {
-        tr_variantDictAddBool(d, enabled_key, tr_sessionIsScriptEnabled(s, script));
-        tr_variantDictAddStr(d, script_key, tr_sessionGetScript(s, script));
+        tr_variantDictAddBool(d, enabled_key, s->useScript(script));
+        tr_variantDictAddStr(d, script_key, s->script(script));
     }
 }
 
@@ -1278,7 +1278,7 @@ void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random)
     session->isPortRandom = random;
 }
 
-bool tr_sessionGetPeerPortRandomOnStart(tr_session* session)
+bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -478,7 +478,7 @@ void tr_sessionSetLPDEnabled(tr_session* session, bool enabled);
 void tr_sessionSetCacheLimit_MB(tr_session* session, int mb);
 int tr_sessionGetCacheLimit_MB(tr_session const* session);
 
-tr_encryption_mode tr_sessionGetEncryption(tr_session* session);
+tr_encryption_mode tr_sessionGetEncryption(tr_session const* session);
 void tr_sessionSetEncryption(tr_session* session, tr_encryption_mode mode);
 
 /***********************************************************************
@@ -497,7 +497,7 @@ uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
 
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
 
-bool tr_sessionGetPeerPortRandomOnStart(tr_session* session);
+bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session);
 
 enum tr_port_forwarding
 {


### PR DESCRIPTION
a minor cleanup refactor: `const`ify a couple of public methods that should've been const but had been overlooked.