### PR TITLE
Raise minimum supported target to macOS 10.13 (High Sierra)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 # The value of this variable should be set prior to the first project() command invocation.
 # See: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
 if(CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 
 project(transmission)

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2687,7 +2687,7 @@
 				};
 			};
 			buildConfigurationList = 4DF0C59A089918A300DD8943 /* Build configuration list for PBXProject "Transmission" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 10.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -3597,8 +3597,16 @@
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
+				USER_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/libnatpmp",
+					"third-party/miniupnpc",
+				);
 			};
 			name = Debug;
 		};
@@ -3623,7 +3631,10 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -3643,7 +3654,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -3665,7 +3680,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -3684,7 +3703,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -3742,7 +3765,7 @@
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
 				INFOPLIST_PREFIX_HEADER = libtransmission/version.h;
 				INFOPLIST_PREPROCESS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -3812,8 +3835,16 @@
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
+				USER_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/libnatpmp",
+					"third-party/miniupnpc",
+				);
 			};
 			name = Release;
 		};
@@ -3832,7 +3863,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};
@@ -3857,7 +3892,10 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -3915,7 +3953,7 @@
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
 				INFOPLIST_PREFIX_HEADER = libtransmission/version.h;
 				INFOPLIST_PREPROCESS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-DFMT_HEADER_ONLY",
@@ -4014,7 +4052,7 @@
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
 				INFOPLIST_PREFIX_HEADER = libtransmission/version.h;
 				INFOPLIST_PREPROCESS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -4048,7 +4086,10 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = Transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Release - Debug";
@@ -4068,7 +4109,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4099,8 +4144,16 @@
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
-				USER_HEADER_SEARCH_PATHS = "$(inherited) third-party/libnatpmp third-party/miniupnpc";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
+				USER_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/libnatpmp",
+					"third-party/miniupnpc",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4122,7 +4175,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4141,7 +4198,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4209,7 +4270,10 @@
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Debug;
@@ -4232,7 +4296,10 @@
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = "Release - Debug";
@@ -4255,7 +4322,10 @@
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
 			name = Release;
@@ -4318,7 +4388,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};
@@ -4337,7 +4411,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};
@@ -4470,7 +4548,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -4489,7 +4571,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4508,7 +4594,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};
@@ -4527,7 +4617,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -4546,7 +4640,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4565,7 +4663,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};
@@ -4584,7 +4686,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Debug;
 		};
@@ -4603,7 +4709,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = "Release - Debug";
 		};
@@ -4622,7 +4732,11 @@
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "$(inherited) third-party/fmt/include third-party/libevent/include";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"third-party/fmt/include",
+					"third-party/libevent/include",
+				);
 			};
 			name = Release;
 		};

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3565,15 +3565,8 @@ static void removeKeRangerRansomware()
     if ([pasteboard.types containsObject:TORRENT_TABLE_VIEW_DATA_TYPE])
     {
         NSIndexSet* indexes;
-        if (@available(macOS 10.13, *))
-        {
-            indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]
-                                                           error:nil];
-        }
-        else
-        {
-            indexes = [NSKeyedUnarchiver unarchiveObjectWithData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]];
-        }
+        indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]
+                                                       error:nil];
 
         //get the torrents to move
         NSMutableArray* movingTorrents = [NSMutableArray arrayWithCapacity:indexes.count];

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3564,7 +3564,8 @@ static void removeKeRangerRansomware()
     NSPasteboard* pasteboard = info.draggingPasteboard;
     if ([pasteboard.types containsObject:TORRENT_TABLE_VIEW_DATA_TYPE])
     {
-        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE] error:nil];
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]
+                                                                   error:nil];
 
         //get the torrents to move
         NSMutableArray* movingTorrents = [NSMutableArray arrayWithCapacity:indexes.count];

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3564,9 +3564,7 @@ static void removeKeRangerRansomware()
     NSPasteboard* pasteboard = info.draggingPasteboard;
     if ([pasteboard.types containsObject:TORRENT_TABLE_VIEW_DATA_TYPE])
     {
-        NSIndexSet* indexes;
-        indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]
-                                                       error:nil];
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE] error:nil];
 
         //get the torrents to move
         NSMutableArray* movingTorrents = [NSMutableArray arrayWithCapacity:indexes.count];

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -42,22 +42,15 @@ GroupsController* fGroupsInstance = nil;
         NSData* data;
         if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"GroupDicts"]))
         {
-            if (@available(macOS 10.13, *))
-            {
-                _fGroups = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSMutableArray.class,
-                                                                                              NSMutableDictionary.class,
-                                                                                              NSNumber.class,
-                                                                                              NSColor.class,
-                                                                                              NSString.class,
-                                                                                              NSPredicate.class,
-                                                                                              nil]
-                                                               fromData:data
-                                                                  error:nil];
-            }
-            else
-            {
-                _fGroups = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-            }
+            _fGroups = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSMutableArray.class,
+                                                                                          NSMutableDictionary.class,
+                                                                                          NSNumber.class,
+                                                                                          NSColor.class,
+                                                                                          NSString.class,
+                                                                                          NSPredicate.class,
+                                                                                          nil]
+                                                           fromData:data
+                                                              error:nil];
         }
         else if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"Groups"])) //handle old groups
         {

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -122,15 +122,8 @@
     if ([pasteboard.types containsObject:GROUP_TABLE_VIEW_DATA_TYPE])
     {
         NSIndexSet* indexes;
-        if (@available(macOS 10.13, *))
-        {
-            indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]
-                                                           error:nil];
-        }
-        else
-        {
-            indexes = [NSKeyedUnarchiver unarchiveObjectWithData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]];
-        }
+        indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]
+                                                       error:nil];
         NSInteger oldRow = indexes.firstIndex;
 
         if (oldRow < newRow)

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -121,7 +121,8 @@
     NSPasteboard* pasteboard = info.draggingPasteboard;
     if ([pasteboard.types containsObject:GROUP_TABLE_VIEW_DATA_TYPE])
     {
-        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE] error:nil];
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]
+                                                                   error:nil];
         NSInteger oldRow = indexes.firstIndex;
 
         if (oldRow < newRow)

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -121,9 +121,7 @@
     NSPasteboard* pasteboard = info.draggingPasteboard;
     if ([pasteboard.types containsObject:GROUP_TABLE_VIEW_DATA_TYPE])
     {
-        NSIndexSet* indexes;
-        indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]
-                                                       error:nil];
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE] error:nil];
         NSInteger oldRow = indexes.firstIndex;
 
         if (oldRow < newRow)

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -206,14 +206,7 @@
         break;
 
     case TR_LOG_DEBUG:
-        if (@available(macOS 10.12, *))
-        {
-            color = NSColor.systemTealColor;
-        }
-        else
-        {
-            color = NSColor.cyanColor;
-        }
+        color = NSColor.systemTealColor;
         break;
 
     case TR_LOG_TRACE:

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -320,7 +320,7 @@
         NSRect groupRect = [self groupIconRectForBounds:iconRect];
         NSColor* groupColor = [GroupsController.groups colorForIndex:groupValue];
         NSImage* icon = [NSImage discIconWithColor:groupColor insetFactor:0];
-        [icon drawInRect:groupRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0f];
+        [icon drawInRect:groupRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0f];
     }
 
     BOOL const error = torrent.anyErrorOrWarning;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -74,14 +74,7 @@
         NSData* groupData;
         if ((groupData = [_fDefaults dataForKey:@"CollapsedGroupIndexes"]))
         {
-            if (@available(macOS 10.13, *))
-            {
-                _fCollapsedGroups = [NSKeyedUnarchiver unarchivedObjectOfClass:NSMutableIndexSet.class fromData:groupData error:nil];
-            }
-            else
-            {
-                _fCollapsedGroups = [NSKeyedUnarchiver unarchiveObjectWithData:groupData];
-            }
+            _fCollapsedGroups = [NSKeyedUnarchiver unarchivedObjectOfClass:NSMutableIndexSet.class fromData:groupData error:nil];
         }
         else if ((groupData = [_fDefaults dataForKey:@"CollapsedGroups"])) //handle old groups
         {


### PR DESCRIPTION
Looking at all comments in https://github.com/transmission/transmission/issues/3302 there seems to be a general agreement that 10.13 is a conservative value for `MACOSX_DEPLOYMENT_TARGET`. The corresponding Xcode is 10.