### PR TITLE
Web client: fix broken state and labels filter.

### DIFF
--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -395,7 +395,7 @@ export class Torrent extends EventTarget {
     if (pass) {
       // pass if this torrent has any of these labels
       const torrent_labels = this.getLabels();
-      if (torrent_labels.length > 0) {
+      if (labels.length > 0) {
         pass = labels.some((label) => torrent_labels.includes(label));
       }
     }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -199,6 +199,7 @@ export class Transmission extends EventTarget {
     e.value = this.prefs.filter_mode;
     e.addEventListener('change', (event_) => {
       this.prefs.filter_mode = event_.target.value;
+      this.refilterAllSoon();
     });
 
     //if (!isMobileDevice) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1082,7 +1082,7 @@ TODO: fix this when notifications get fixed
 
   setFilterTracker(sitename) {
     const e = document.querySelector('#filter-tracker');
-    e.value = sitename ? Transmission._getReadableDomain(sitename) : 'all';
+    e.value = sitename;
 
     this.filterTracker = sitename;
     this.refilterAllSoon();


### PR DESCRIPTION
I noticed that filtering in web client is broken. Proposed PR fixes state and labels filters. 
Tracker filter is broken too, I'm working on getting it fixed and planning to provide PR later.

Updated.
Fixed tracker filter withing a commit in the scope of the current PR. Fix is much simpler than I initially thought.