### PR TITLE
refactor: use tr_torrent_id_t

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -109,7 +109,7 @@ private:
         guint info,
         guint time_);
 
-    bool on_rpc_changed_idle(tr_rpc_callback_type type, int torrent_id);
+    bool on_rpc_changed_idle(tr_rpc_callback_type type, tr_torrent_id_t torrent_id);
 
     void placeWindowFromPrefs();
     void presentMainWindow();
@@ -137,7 +137,7 @@ private:
     void on_add_torrent(tr_ctor* ctor);
     void on_prefs_changed(tr_quark key);
 
-    std::vector<int> get_selected_torrent_ids() const;
+    std::vector<tr_torrent_id_t> get_selected_torrent_ids() const;
     tr_torrent* get_first_selected_torrent() const;
     counts_data get_selected_torrent_counts() const;
 
@@ -193,7 +193,7 @@ void gtr_window_present(T const& window)
 ****
 ***/
 
-std::string get_details_dialog_key(std::vector<int> const& id_list)
+std::string get_details_dialog_key(std::vector<tr_torrent_id_t> const& id_list)
 {
     auto tmp = id_list;
     std::sort(tmp.begin(), tmp.end());
@@ -210,9 +210,9 @@ std::string get_details_dialog_key(std::vector<int> const& id_list)
 
 } // namespace
 
-std::vector<int> Application::Impl::get_selected_torrent_ids() const
+std::vector<tr_torrent_id_t> Application::Impl::get_selected_torrent_ids() const
 {
-    std::vector<int> ids;
+    std::vector<tr_torrent_id_t> ids;
     sel_->selected_foreach([&ids](auto const& /*path*/, auto const& iter)
                            { ids.push_back(iter->get_value(torrent_cols.torrent_id)); });
     return ids;
@@ -393,7 +393,7 @@ void Application::Impl::on_main_window_size_allocated(Gtk::Allocation& /*alloc*/
 **** listen to changes that come from RPC
 ***/
 
-bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, int torrent_id)
+bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torrent_id_t torrent_id)
 {
     switch (type)
     {
@@ -1335,7 +1335,7 @@ bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method
 
 void Application::Impl::remove_selected(bool delete_files)
 {
-    std::vector<int> l;
+    auto l = std::vector<tr_torrent_id_t>{};
 
     sel_->selected_foreach([&l](auto const& /*path*/, auto const& iter)
                            { l.push_back(iter->get_value(torrent_cols.torrent_id)); });

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -24,7 +24,7 @@ public:
 
     static std::unique_ptr<DetailsDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 
-    void set_torrents(std::vector<int> const& torrent_ids);
+    void set_torrents(std::vector<tr_torrent_id_t> const& torrent_ids);
 
 protected:
     DetailsDialog(Gtk::Window& parent, Glib::RefPtr<Session> const& core);

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -21,7 +21,7 @@
 void gtr_confirm_remove(
     Gtk::Window& parent,
     Glib::RefPtr<Session> const& core,
-    std::vector<int> const& torrent_ids,
+    std::vector<tr_torrent_id_t> const& torrent_ids,
     bool delete_files)
 {
     int connected = 0;

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -16,5 +16,5 @@ class Session;
 void gtr_confirm_remove(
     Gtk::Window& parent,
     Glib::RefPtr<Session> const& core,
-    std::vector<int> const& torrent_ids,
+    std::vector<tr_torrent_id_t> const& torrent_ids,
     bool delete_files);

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -80,12 +80,12 @@ FileModelColumns const file_cols;
 class FileList::Impl
 {
 public:
-    Impl(FileList& widget, Glib::RefPtr<Session> const& core, int torrent_id);
+    Impl(FileList& widget, Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id);
     ~Impl();
 
     TR_DISABLE_COPY_MOVE(Impl)
 
-    void set_torrent(int torrent_id);
+    void set_torrent(tr_torrent_id_t tor_id);
 
 private:
     void clearData();
@@ -110,7 +110,7 @@ private:
     // GtkWidget* top_ = nullptr; // == widget_
     Gtk::TreeView* view_ = nullptr;
     Glib::RefPtr<Gtk::TreeStore> store_;
-    int torrent_id_ = 0;
+    tr_torrent_id_t torrent_id_ = {};
     sigc::connection timeout_tag_;
 };
 
@@ -470,9 +470,9 @@ void buildTree(FileRowNode& node, build_data& build)
 
 } // namespace
 
-void FileList::set_torrent(int torrent_id)
+void FileList::set_torrent(tr_torrent_id_t tor_id)
 {
-    impl_->set_torrent(torrent_id);
+    impl_->set_torrent(tor_id);
 }
 
 struct PairHash
@@ -484,14 +484,14 @@ struct PairHash
     }
 };
 
-void FileList::Impl::set_torrent(int torrentId)
+void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
 {
     /* unset the old fields */
     clearData();
 
     /* instantiate the model */
     store_ = Gtk::TreeStore::create(file_cols);
-    torrent_id_ = torrentId;
+    torrent_id_ = tor_id;
 
     /* populate the model */
     if (torrent_id_ > 0)
@@ -831,13 +831,13 @@ void FileList::Impl::cell_edited_callback(Glib::ustring const& path_string, Glib
         rename_data.release());
 }
 
-FileList::FileList(Glib::RefPtr<Session> const& core, int torrent_id)
+FileList::FileList(Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id)
     : Gtk::ScrolledWindow()
-    , impl_(std::make_unique<Impl>(*this, core, torrent_id))
+    , impl_(std::make_unique<Impl>(*this, core, tor_id))
 {
 }
 
-FileList::Impl::Impl(FileList& widget, Glib::RefPtr<Session> const& core, int torrent_id)
+FileList::Impl::Impl(FileList& widget, Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id)
     : widget_(widget)
     , core_(core)
 {
@@ -956,7 +956,7 @@ FileList::Impl::Impl(FileList& widget, Glib::RefPtr<Session> const& core, int to
     widget_.add(*view_);
     widget_.set_size_request(-1, 200);
 
-    set_torrent(torrent_id);
+    set_torrent(tor_id);
 }
 
 FileList::~FileList() = default;

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -16,13 +16,13 @@ class Session;
 class FileList : public Gtk::ScrolledWindow
 {
 public:
-    FileList(Glib::RefPtr<Session> const& core, int torrent_id);
+    FileList(Glib::RefPtr<Session> const& core, tr_torrent_id_t torrent_id);
     ~FileList() override;
 
     TR_DISABLE_COPY_MOVE(FileList)
 
     void clear();
-    void set_torrent(int torrent_id);
+    void set_torrent(tr_torrent_id_t torrent_id);
 
 private:
     class Impl;

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -30,7 +30,7 @@ auto const NotificationsDbusCoreInterface = Glib::ustring("org.freedesktop.Notif
 struct TrNotification
 {
     Glib::RefPtr<Session> core;
-    int torrent_id = 0;
+    tr_torrent_id_t torrent_id = {};
 };
 
 Glib::RefPtr<Gio::DBus::Proxy> proxy;
@@ -162,7 +162,7 @@ void notify_callback(Glib::RefPtr<Gio::AsyncResult>& res, TrNotification const& 
 
 } // namespace
 
-void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, int torrent_id)
+void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id)
 {
     if (gtr_pref_flag_get(TR_KEY_torrent_complete_sound_enabled))
     {
@@ -184,9 +184,9 @@ void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, int torrent
 
     g_return_if_fail(proxy != nullptr);
 
-    auto const* const tor = core->find_torrent(torrent_id);
+    auto const* const tor = core->find_torrent(tor_id);
 
-    auto const n = TrNotification{ core, torrent_id };
+    auto const n = TrNotification{ core, tor_id };
 
     std::vector<Glib::ustring> actions;
     if (server_supports_actions)
@@ -220,7 +220,7 @@ void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, int torrent
             -1));
 }
 
-void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, int torrent_id)
+void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id)
 {
     g_return_if_fail(proxy != nullptr);
 
@@ -229,7 +229,7 @@ void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, int torrent_id)
         return;
     }
 
-    auto const* const tor = core->find_torrent(torrent_id);
+    auto const* const tor = core->find_torrent(tor_id);
 
     std::vector<Glib::ustring> actions;
     if (server_supports_actions)
@@ -238,7 +238,7 @@ void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, int torrent_id)
         actions.emplace_back(_("Start Now"));
     }
 
-    auto const n = TrNotification{ core, torrent_id };
+    auto const n = TrNotification{ core, tor_id };
 
     proxy->call(
         "Notify",

--- a/gtk/Notify.h
+++ b/gtk/Notify.h
@@ -7,10 +7,12 @@
 
 #include <glibmm.h>
 
+#include <libtransmission/transmission.h>
+
 class Session;
 
 void gtr_notify_init();
 
-void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, int torrent_id);
+void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id);
 
-void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, int torrent_id);
+void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, tr_torrent_id_t tor_id);

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -30,7 +30,7 @@ std::string previousLocation;
 class RelocateDialog::Impl
 {
 public:
-    Impl(RelocateDialog& dialog, Glib::RefPtr<Session> const& core, std::vector<int> const& torrent_ids);
+    Impl(RelocateDialog& dialog, Glib::RefPtr<Session> const& core, std::vector<tr_torrent_id_t> const& torrent_ids);
     ~Impl();
 
     TR_DISABLE_COPY_MOVE(Impl)
@@ -44,7 +44,7 @@ private:
 private:
     RelocateDialog& dialog_;
     Glib::RefPtr<Session> const core_;
-    std::vector<int> torrent_ids_;
+    std::vector<tr_torrent_id_t> torrent_ids_;
 
     int done_ = 0;
     bool do_move_ = false;
@@ -141,12 +141,15 @@ void RelocateDialog::Impl::onResponse(int response)
 std::unique_ptr<RelocateDialog> RelocateDialog::create(
     Gtk::Window& parent,
     Glib::RefPtr<Session> const& core,
-    std::vector<int> const& torrent_ids)
+    std::vector<tr_torrent_id_t> const& torrent_ids)
 {
     return std::unique_ptr<RelocateDialog>(new RelocateDialog(parent, core, torrent_ids));
 }
 
-RelocateDialog::RelocateDialog(Gtk::Window& parent, Glib::RefPtr<Session> const& core, std::vector<int> const& torrent_ids)
+RelocateDialog::RelocateDialog(
+    Gtk::Window& parent,
+    Glib::RefPtr<Session> const& core,
+    std::vector<tr_torrent_id_t> const& torrent_ids)
     : Gtk::Dialog(_("Set Torrent Location"), parent, true)
     , impl_(std::make_unique<Impl>(*this, core, torrent_ids))
 {
@@ -154,7 +157,10 @@ RelocateDialog::RelocateDialog(Gtk::Window& parent, Glib::RefPtr<Session> const&
 
 RelocateDialog::~RelocateDialog() = default;
 
-RelocateDialog::Impl::Impl(RelocateDialog& dialog, Glib::RefPtr<Session> const& core, std::vector<int> const& torrent_ids)
+RelocateDialog::Impl::Impl(
+    RelocateDialog& dialog,
+    Glib::RefPtr<Session> const& core,
+    std::vector<tr_torrent_id_t> const& torrent_ids)
     : dialog_(dialog)
     , core_(core)
     , torrent_ids_(torrent_ids)

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -24,10 +24,10 @@ public:
     static std::unique_ptr<RelocateDialog> create(
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core,
-        std::vector<int> const& torrent_ids);
+        std::vector<tr_torrent_id_t> const& torrent_ids);
 
 protected:
-    RelocateDialog(Gtk::Window& parent, Glib::RefPtr<Session> const& core, std::vector<int> const& torrent_ids);
+    RelocateDialog(Gtk::Window& parent, Glib::RefPtr<Session> const& core, std::vector<tr_torrent_id_t> const& torrent_ids);
 
 private:
     class Impl;

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -882,10 +882,10 @@ Glib::ustring get_collated_name(tr_torrent const* tor)
 struct metadata_callback_data
 {
     Session* core;
-    int torrent_id;
+    tr_torrent_id_t torrent_id;
 };
 
-Gtk::TreeModel::iterator find_row_from_torrent_id(Glib::RefPtr<Gtk::TreeModel> const& model, int id)
+Gtk::TreeModel::iterator find_row_from_torrent_id(Glib::RefPtr<Gtk::TreeModel> const& model, tr_torrent_id_t id)
 {
     for (auto const& row : model->children())
     {
@@ -1234,7 +1234,7 @@ void Session::Impl::torrents_added()
     signal_add_error.emit(ERR_NO_MORE_TORRENTS, {});
 }
 
-void Session::torrent_changed(int id)
+void Session::torrent_changed(tr_torrent_id_t id)
 {
     auto const model = impl_->get_raw_model();
 
@@ -1244,7 +1244,7 @@ void Session::torrent_changed(int id)
     }
 }
 
-void Session::remove_torrent(int id, bool delete_local_data)
+void Session::remove_torrent(tr_torrent_id_t id, bool delete_local_data)
 {
     auto* tor = find_torrent(id);
 
@@ -1390,7 +1390,7 @@ void Session::update()
     impl_->update();
 }
 
-void Session::start_now(int id)
+void Session::start_now(tr_torrent_id_t id)
 {
     tr_variant top;
     tr_variantInitDict(&top, 2);
@@ -1752,7 +1752,7 @@ size_t Session::Impl::get_active_torrent_count() const
     return activeCount;
 }
 
-tr_torrent* Session::find_torrent(int id) const
+tr_torrent* Session::find_torrent(tr_torrent_id_t id) const
 {
     tr_torrent* tor = nullptr;
 
@@ -1764,7 +1764,7 @@ tr_torrent* Session::find_torrent(int id) const
     return tor;
 }
 
-void Session::open_folder(int torrent_id)
+void Session::open_folder(tr_torrent_id_t torrent_id)
 {
     auto const* tor = find_torrent(torrent_id);
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -47,7 +47,7 @@ public:
 
     size_t get_torrent_count() const;
 
-    tr_torrent* find_torrent(int id) const;
+    tr_torrent* find_torrent(tr_torrent_id_t id) const;
 
     /******
     *******
@@ -84,14 +84,14 @@ public:
      */
     void torrents_added();
 
-    void torrent_changed(int id);
+    void torrent_changed(tr_torrent_id_t id);
 
     /******
     *******
     ******/
 
     /* remove a torrent */
-    void remove_torrent(int id, bool delete_files);
+    void remove_torrent(tr_torrent_id_t id, bool delete_files);
 
     /* update the model with current torrent status */
     void update();
@@ -99,7 +99,7 @@ public:
     /**
      * Attempts to start a torrent immediately.
      */
-    void start_now(int id);
+    void start_now(tr_torrent_id_t id);
 
     /**
     ***  Set a preference value, save the prefs file, and emit the "prefs-changed" signal
@@ -120,7 +120,7 @@ public:
 
     void exec(tr_variant const* benc);
 
-    void open_folder(int torrent_id);
+    void open_folder(tr_torrent_id_t torrent_id);
 
     sigc::signal<void(ErrorCode, Glib::ustring const&)>& signal_add_error();
     sigc::signal<void(tr_ctor*)>& signal_add_prompt();
@@ -148,7 +148,7 @@ public:
 
     Gtk::TreeModelColumn<Glib::ustring> name_collated;
     Gtk::TreeModelColumn<gpointer> torrent;
-    Gtk::TreeModelColumn<int> torrent_id;
+    Gtk::TreeModelColumn<tr_torrent_id_t> torrent_id;
     Gtk::TreeModelColumn<double> speed_up;
     Gtk::TreeModelColumn<double> speed_down;
     Gtk::TreeModelColumn<int> active_peers_up;

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -24,7 +24,7 @@
 
 Cache::Key Cache::makeKey(tr_torrent const* torrent, tr_block_info::Location loc) noexcept
 {
-    return std::make_pair(torrent->uniqueId, loc.block);
+    return std::make_pair(torrent->id(), loc.block);
 }
 
 std::pair<Cache::CIter, Cache::CIter> Cache::findContiguous(CIter const begin, CIter const end, CIter const iter) noexcept
@@ -213,7 +213,7 @@ int Cache::flushSpan(CIter const begin, CIter const end)
 int Cache::flushFile(tr_torrent* torrent, tr_file_index_t i)
 {
     auto const compare = CompareCacheBlockByKey{};
-    auto const tor_id = torrent->uniqueId;
+    auto const tor_id = torrent->id();
     auto const [block_begin, block_end] = tr_torGetFileBlockSpan(torrent, i);
 
     return flushSpan(
@@ -224,7 +224,7 @@ int Cache::flushFile(tr_torrent* torrent, tr_file_index_t i)
 int Cache::flushTorrent(tr_torrent* torrent)
 {
     auto const compare = CompareCacheBlockByKey{};
-    auto const tor_id = torrent->uniqueId;
+    auto const tor_id = torrent->id();
 
     return flushSpan(
         std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, 0), compare),

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -120,7 +120,7 @@ int readOrWriteBytes(
     ****  Find the fd
     ***/
 
-    auto fd = session->openFiles().get(tor->uniqueId, file_index, do_write);
+    auto fd = session->openFiles().get(tor->id(), file_index, do_write);
     auto filename = tr_pathbuf{};
     if (!fd && !getFilename(filename, tor, file_index, io_mode))
     {
@@ -132,7 +132,7 @@ int readOrWriteBytes(
         // open (and maybe create) the file
         auto const prealloc = (!do_write || !tor->fileIsWanted(file_index)) ? TR_PREALLOCATE_NONE :
                                                                               tor->session->preallocationMode;
-        fd = session->openFiles().get(tor->uniqueId, file_index, do_write, filename, prealloc, file_size);
+        fd = session->openFiles().get(tor->id(), file_index, do_write, filename, prealloc, file_size);
         if (fd && do_write)
         {
             // make a note that we just created a file

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2927,11 +2927,11 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
 void tr_session::closeTorrentFiles(tr_torrent* tor) noexcept
 {
     this->cache->flushTorrent(tor);
-    openFiles().closeTorrent(tor->uniqueId);
+    openFiles().closeTorrent(tor->id());
 }
 
 void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noexcept
 {
     this->cache->flushFile(tor, file_num);
-    openFiles().closeFile(tor->uniqueId, file_num);
+    openFiles().closeFile(tor->id(), file_num);
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -73,9 +73,9 @@ uint64_t tr_torrentTotalSize(tr_torrent const* tor)
     return tor->totalSize();
 }
 
-int tr_torrentId(tr_torrent const* tor)
+tr_torrent_id_t tr_torrentId(tr_torrent const* tor)
 {
-    return tor != nullptr ? tor->uniqueId : -1;
+    return tor != nullptr ? tor->id() : -1;
 }
 
 tr_torrent* tr_torrentFindFromId(tr_session* session, int id)
@@ -715,7 +715,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     auto const& labels = tr_ctorGetLabels(ctor);
     tor->setLabels(labels);
 
-    tor->uniqueId = session->torrents().add(tor);
+    tor->unique_id_ = session->torrents().add(tor);
 
     tr_peerMgrAddTorrent(session->peerMgr, tor);
 
@@ -1028,7 +1028,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     }
 
     tr_stat* const s = &tor->stats;
-    s->id = tor->uniqueId;
+    s->id = tor->id();
     s->activity = tr_torrentGetActivity(tor);
     s->error = tor->error;
     s->queuePosition = tor->queuePosition;
@@ -1915,10 +1915,10 @@ void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
 
     for (auto label : new_labels)
     {
-            if (std::find(std::begin(this->labels), std::end(this->labels), label) == std::end(this->labels))
-            {
-                    this->labels.push_back(label);
-            }
+        if (std::find(std::begin(this->labels), std::end(this->labels), label) == std::end(this->labels))
+        {
+            this->labels.push_back(label);
+        }
     }
     this->labels.shrink_to_fit();
     this->setDirty();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -579,6 +579,11 @@ public:
         return {};
     }
 
+    [[nodiscard]] constexpr auto id() const noexcept
+    {
+        return unique_id_;
+    }
+
     void setDateActive(time_t t);
 
     void setLabels(std::vector<tr_quark> const& new_labels);
@@ -712,7 +717,7 @@ public:
 
     int queuePosition = 0;
 
-    int uniqueId = 0;
+    tr_torrent_id_t unique_id_ = 0;
 
     tr_completeness completeness = TR_LEECH;
 

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -25,12 +25,12 @@ class tr_torrents
 {
 public:
     // returns a fast lookup id for `tor`
-    [[nodiscard]] int add(tr_torrent* tor);
+    [[nodiscard]] tr_torrent_id_t add(tr_torrent* tor);
 
     void remove(tr_torrent const* tor, time_t current_time);
 
     // O(1)
-    [[nodiscard]] tr_torrent* get(int id);
+    [[nodiscard]] tr_torrent* get(tr_torrent_id_t id);
 
     // O(log n)
     [[nodiscard]] tr_torrent const* get(tr_sha1_digest_t const& hash) const;
@@ -57,7 +57,7 @@ public:
         return get(key) != nullptr;
     }
 
-    [[nodiscard]] std::vector<int> removedSince(time_t) const;
+    [[nodiscard]] std::vector<tr_torrent_id_t> removedSince(time_t) const;
 
     [[nodiscard]] auto cbegin() const noexcept
     {
@@ -100,7 +100,7 @@ public:
 private:
     std::vector<tr_torrent*> by_hash_;
 
-    // This is a lookup table where by_id_[id]->uniqueId == id.
+    // This is a lookup table where by_id_[id]->id() == id.
     // There is a small tradeoff here -- lookup is O(1) at the cost
     // of a wasted slot in the lookup table whenever a torrent is
     // removed. This improves speed for all use cases at the cost of
@@ -114,5 +114,5 @@ private:
     // may be testing for >0 as a validity check.
     std::vector<tr_torrent*> by_id_{ nullptr };
 
-    std::vector<std::pair<int, time_t>> removed_;
+    std::vector<std::pair<tr_torrent_id_t, time_t>> removed_;
 };

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -985,7 +985,7 @@ uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* torrent);
  * IDs are fast lookup keys, but are not persistent between sessions.
  * If you need that, use tr_torrentView().hash_string.
  */
-int tr_torrentId(tr_torrent const* torrent);
+tr_torrent_id_t tr_torrentId(tr_torrent const* torrent);
 
 tr_torrent* tr_torrentFindFromId(tr_session* session, int id);
 
@@ -1346,7 +1346,7 @@ struct tr_tracker_view
     int seederCount; // number of seeders the tracker knows of, or -1 if unknown
 
     int tier; // which tier this tracker is in
-    int id; // unique transmission-generated ID for use in libtransmission API
+    tr_torrent_id_t id; // unique transmission-generated ID for use in libtransmission API
 
     tr_tracker_state announceState; // whether we're announcing, waiting to announce, etc.
     tr_tracker_state scrapeState; // whether we're scraping, waiting to scrape, etc.
@@ -1612,7 +1612,7 @@ struct tr_stat
 
     /** The torrent's unique Id.
         @see tr_torrentId() */
-    int id;
+    tr_torrent_id_t id;
 
     /** Number of seconds since the last activity (or since started).
         -1 if activity is not seeding or downloading. */

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -334,9 +334,9 @@ void DetailsDialog::refreshModel()
 void DetailsDialog::onTorrentsEdited(torrent_ids_t const& ids)
 {
     // std::set_intersection requires sorted inputs
-    auto a = std::vector<int>{ ids.begin(), ids.end() };
+    auto a = std::vector<tr_torrent_id_t>{ ids.begin(), ids.end() };
     std::sort(std::begin(a), std::end(a));
-    auto b = std::vector<int>{ ids_.begin(), ids_.end() };
+    auto b = std::vector<tr_torrent_id_t>{ ids_.begin(), ids_.end() };
     std::sort(std::begin(b), std::end(b));
 
     // are any of the edited torrents on display here?

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -627,7 +627,7 @@ public:
     fields_t update(tr_quark const* keys, tr_variant const* const* values, size_t n);
 
 private:
-    int const id_;
+    tr_torrent_id_t const id_;
 
     bool download_limited_ = {};
     bool honors_session_limits_ = {};

--- a/qt/Typedefs.h
+++ b/qt/Typedefs.h
@@ -2,4 +2,6 @@
 
 #include <unordered_set>
 
-using torrent_ids_t = std::unordered_set<int>;
+#include <libtransmission/transmission.h>
+
+using torrent_ids_t = std::unordered_set<tr_torrent_id_t>;

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -33,7 +33,7 @@ TEST_F(TorrentsTest, simpleTests)
 
     auto const id = torrents.add(tor);
     EXPECT_GT(id, 0);
-    tor->uniqueId = id;
+    tor->unique_id_ = id;
 
     EXPECT_TRUE(std::empty(torrents.removedSince(0)));
     EXPECT_FALSE(std::empty(torrents));
@@ -68,8 +68,8 @@ TEST_F(TorrentsTest, rangedLoop)
         auto tm = tr_torrent_metainfo{};
         EXPECT_TRUE(tm.parseTorrentFile(path));
         auto* const tor = new tr_torrent{ std::move(tm) };
-        tor->uniqueId = torrents.add(tor);
-        EXPECT_EQ(tor, torrents.get(tor->uniqueId));
+        tor->unique_id_ = torrents.add(tor);
+        EXPECT_EQ(tor, torrents.get(tor->id()));
         torrents_set.insert(tor);
     }
 
@@ -99,7 +99,7 @@ TEST_F(TorrentsTest, removedSince)
         auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', name };
         auto tm = tr_torrent_metainfo{};
         auto* const tor = new tr_torrent{ std::move(tm) };
-        tor->uniqueId = torrents.add(tor);
+        tor->unique_id_ = torrents.add(tor);
         torrents_v.push_back(tor);
     }
 
@@ -108,18 +108,18 @@ TEST_F(TorrentsTest, removedSince)
     for (size_t i = 0; i < 4; ++i)
     {
         auto* const tor = torrents_v[i];
-        EXPECT_EQ(tor, torrents.get(tor->uniqueId));
+        EXPECT_EQ(tor, torrents.get(tor->id()));
         torrents.remove(torrents_v[i], TimeRemoved[i]);
-        EXPECT_EQ(nullptr, torrents.get(tor->uniqueId));
+        EXPECT_EQ(nullptr, torrents.get(tor->id()));
     }
 
-    auto remove = std::vector<int>{};
-    remove = { torrents_v[3]->uniqueId };
+    auto remove = std::vector<tr_torrent_id_t>{};
+    remove = { torrents_v[3]->id() };
     EXPECT_EQ(remove, torrents.removedSince(300));
     EXPECT_EQ(remove, torrents.removedSince(201));
-    remove = { torrents_v[1]->uniqueId, torrents_v[2]->uniqueId, torrents_v[3]->uniqueId };
+    remove = { torrents_v[1]->id(), torrents_v[2]->id(), torrents_v[3]->id() };
     EXPECT_EQ(remove, torrents.removedSince(200));
-    remove = { torrents_v[0]->uniqueId, torrents_v[1]->uniqueId, torrents_v[2]->uniqueId, torrents_v[3]->uniqueId };
+    remove = { torrents_v[0]->id(), torrents_v[1]->id(), torrents_v[2]->id(), torrents_v[3]->id() };
     EXPECT_EQ(remove, torrents.removedSince(50));
 
     std::for_each(std::begin(torrents_v), std::end(torrents_v), [](auto* tor) { delete tor; });


### PR DESCRIPTION
A minor cleanup PR: use the semantic type `tr_torrent_id_t` instead of `int` when referring to torrents by ID.

Since the former is an alias to the latter this doesn't involve any functional changes; it just expresses intent more clearly.