### PR TITLE
Set torrent file's metainfo for magnets

### DIFF
--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -236,8 +236,20 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
     }
 }
 
-void tr_torrentUseMetainfo(tr_torrent* tor, tr_torrent_metainfo const* metainfo)
+bool tr_torrentUseMetainfoFromFile(
+    tr_torrent* tor,
+    tr_torrent_metainfo const* metainfo,
+    std::string_view filename_in,
+    tr_error** error)
 {
+    // add .torrent file
+    auto const oldpath = tr_pathbuf{ filename_in };
+    auto const newpath = tr_pathbuf{ tor->torrentFile() };
+    if (!tr_sys_path_copy(oldpath, newpath, error))
+    {
+        return false;
+    }
+
     // remove .magnet file
     tr_sys_path_remove(tor->magnetFile());
 
@@ -256,6 +268,8 @@ void tr_torrentUseMetainfo(tr_torrent* tor, tr_torrent_metainfo const* metainfo)
         tor->startAfterVerify = false;
     }
     tor->markEdited();
+
+    return true;
 }
 
 static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_error** error)

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -236,6 +236,28 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
     }
 }
 
+void tr_torrentUseMetainfo(tr_torrent* tor, tr_torrent_metainfo const* metainfo)
+{
+    // remove .magnet file
+    tr_sys_path_remove(tor->magnetFile());
+
+    // tor should keep this metainfo
+    tor->setMetainfo(*metainfo);
+
+    if (tor->incompleteMetadata)
+    {
+        incompleteMetadataFree(tor->incompleteMetadata);
+        tor->incompleteMetadata = nullptr;
+    }
+    tor->isStopping = true;
+    tor->magnetVerify = true;
+    if (tr_sessionGetPaused(tor->session))
+    {
+        tor->startAfterVerify = false;
+    }
+    tor->markEdited();
+}
+
 static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_error** error)
 {
     // test the info_dict checksum

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -239,13 +239,11 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
 bool tr_torrentUseMetainfoFromFile(
     tr_torrent* tor,
     tr_torrent_metainfo const* metainfo,
-    std::string_view filename_in,
+    char const* filename_in,
     tr_error** error)
 {
     // add .torrent file
-    auto const oldpath = tr_pathbuf{ filename_in };
-    auto const newpath = tr_pathbuf{ tor->torrentFile() };
-    if (!tr_sys_path_copy(oldpath, newpath, error))
+    if (!tr_sys_path_copy(filename_in, tor->torrentFile(), error))
     {
         return false;
     }

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -31,4 +31,8 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 
-void tr_torrentUseMetainfo(tr_torrent* tor, tr_torrent_metainfo const* metainfo);
+bool tr_torrentUseMetainfoFromFile(
+    tr_torrent* tor,
+    tr_torrent_metainfo const* metainfo,
+    std::string_view filename,
+    tr_error** error);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -34,5 +34,5 @@ double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 bool tr_torrentUseMetainfoFromFile(
     tr_torrent* tor,
     tr_torrent_metainfo const* metainfo,
-    std::string_view filename,
+    char const* filename,
     tr_error** error);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -16,6 +16,7 @@
 #include "transmission.h"
 
 struct tr_torrent;
+struct tr_torrent_metainfo;
 
 // defined by BEP #9
 inline constexpr int METADATA_PIECE_SIZE = 1024 * 16;
@@ -29,3 +30,5 @@ bool tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now, int* setme);
 bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
+
+void tr_torrentUseMetainfo(tr_torrent* tor, tr_torrent_metainfo const* metainfo);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -111,25 +111,26 @@ tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, tr_sha1_digest
     return nullptr;
 }
 
-bool tr_torrentSetMetainfoFromFileIfMagnet(tr_torrent* tor, tr_torrent_metainfo* metainfo, char const* filename)
+bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo* metainfo, char const* filename)
 {
     if (tr_torrentHasMetadata(tor))
     {
         return false;
     }
-    tr_error* error = nullptr;
 
+    tr_error* error = nullptr;
     tr_torrentUseMetainfoFromFile(tor, metainfo, filename, &error);
 
     if (error != nullptr)
     {
         tor->setLocalError(fmt::format(
-            _("Couldn't copy '{path_in}' to '{path_out}': {error} ({error_code})"),
-            fmt::arg("path_in", filename),
-            fmt::arg("path_out", tor->torrentFile()),
+            _("Couldn't use metaInfo from '{path}' for '{magnet}': {error} ({error_code})"),
+            fmt::arg("path", filename),
+            fmt::arg("magnet", tor->magnet()),
             fmt::arg("error", error->message),
             fmt::arg("error_code", error->code)));
         tr_error_clear(&error);
+        return false;
     }
 
     return true;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -111,6 +111,16 @@ tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, tr_sha1_digest
     return nullptr;
 }
 
+bool tr_torrentSetMetainfoIfMagnet(tr_torrent* torrent, tr_torrent_metainfo const* metainfo)
+{
+    if (!tr_torrentHasMetadata(torrent))
+    {
+        tr_torrentUseMetainfo(torrent, metainfo);
+        return true;
+    }
+    return false;
+}
+
 bool tr_torrent::isPieceTransferAllowed(tr_direction direction) const
 {
     TR_ASSERT(tr_isDirection(direction));

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -998,7 +998,7 @@ tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* link);
  * @return True if torrent was a magnet and metainfo was set.
  *
  */
-bool tr_torrentSetMetainfoIfMagnet(tr_torrent* torrent, tr_torrent_metainfo const* metainfo);
+bool tr_torrentSetMetainfoFromFileIfMagnet(tr_torrent* torrent, tr_torrent_metainfo* metainfo, char const* filename);
 
 /**
  * @return this torrent's name.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -994,6 +994,13 @@ tr_torrent* tr_torrentFindFromMetainfo(tr_session*, tr_torrent_metainfo const*);
 tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* link);
 
 /**
+ * @brief Set metainfo if torrent is a magnet.
+ * @return True if torrent was a magnet and metainfo was set.
+ *
+ */
+bool tr_torrentSetMetainfoIfMagnet(tr_torrent* torrent, tr_torrent_metainfo const* metainfo);
+
+/**
  * @return this torrent's name.
  */
 char const* tr_torrentName(tr_torrent const*);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -994,11 +994,11 @@ tr_torrent* tr_torrentFindFromMetainfo(tr_session*, tr_torrent_metainfo const*);
 tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* link);
 
 /**
- * @brief Set metainfo if torrent is a magnet.
- * @return True if torrent was a magnet and metainfo was set.
+ * @brief Set metainfo if possible.
+ * @return True if given metainfo was set.
  *
  */
-bool tr_torrentSetMetainfoFromFileIfMagnet(tr_torrent* torrent, tr_torrent_metainfo* metainfo, char const* filename);
+bool tr_torrentSetMetainfoFromFile(tr_torrent* torrent, tr_torrent_metainfo* metainfo, char const* filename);
 
 /**
  * @return this torrent's name.

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -13,15 +13,9 @@
 
 @class AddMagnetWindowController;
 @class AddWindowController;
-@class Badger;
-@class DragOverlayWindow;
-@class FilterBarController;
-@class InfoWindowController;
 @class MessageWindowController;
 @class PrefsController;
-@class StatusBarController;
 @class Torrent;
-@class URLSheetWindowController;
 
 typedef NS_ENUM(unsigned int, addType) { //
     ADD_MANUAL,

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1114,8 +1114,12 @@ static void removeKeRangerRansomware()
         auto foundTorrent = tr_torrentFindFromMetainfo(self.fLib, &metainfo);
         if (foundTorrent != nullptr) // dupe torrent
         {
-            // if foundTorrent is a magnet, fill it with file's metainfo
-            if (!tr_torrentSetMetainfoFromFileIfMagnet(foundTorrent, &metainfo, torrentPath.UTF8String))
+            if (tr_torrentHasMetadata(foundTorrent))
+            {
+                [self duplicateOpenAlert:@(metainfo.name().c_str())];
+            }
+            // foundTorrent is a magnet, fill it with file's metainfo
+            else if (!tr_torrentSetMetainfoFromFile(foundTorrent, &metainfo, torrentPath.UTF8String))
             {
                 [self duplicateOpenAlert:@(metainfo.name().c_str())];
             }

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1115,7 +1115,7 @@ static void removeKeRangerRansomware()
         if (foundTorrent != nullptr) // dupe torrent
         {
             // if foundTorrent is a magnet, fill it with file's metainfo
-            if (!tr_torrentSetMetainfoIfMagnet(foundTorrent, &metainfo))
+            if (!tr_torrentSetMetainfoFromFileIfMagnet(foundTorrent, &metainfo, torrentPath.UTF8String))
             {
                 [self duplicateOpenAlert:@(metainfo.name().c_str())];
             }

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1111,9 +1111,14 @@ static void removeKeRangerRansomware()
             continue;
         }
 
-        if (tr_torrentFindFromMetainfo(self.fLib, &metainfo) != nullptr) // dupe torrent
+        auto foundTorrent = tr_torrentFindFromMetainfo(self.fLib, &metainfo);
+        if (foundTorrent != nullptr) // dupe torrent
         {
-            [self duplicateOpenAlert:@(metainfo.name().c_str())];
+            // if foundTorrent is a magnet, fill it with file's metainfo
+            if (!tr_torrentSetMetainfoIfMagnet(foundTorrent, &metainfo))
+            {
+                [self duplicateOpenAlert:@(metainfo.name().c_str())];
+            }
             continue;
         }
 


### PR DESCRIPTION
1. Open a magnet link
2. Open a corresponding torrent file

Expectation: metainfo should be added to Transmission

Actual result: metainfo is still missing and you get a popup about duplicate entry