### PR TITLE
macOS fix Toolbar show/hide on macOS Mojave

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3C7A11980D0B2EE300B5701F /* getgateway.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11920D0B2EE300B5701F /* getgateway.h */; };
 		3C7A11990D0B2EE300B5701F /* natpmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11930D0B2EE300B5701F /* natpmp.c */; };
 		3C7A119A0D0B2EE300B5701F /* natpmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11940D0B2EE300B5701F /* natpmp.h */; };
+		457AF8EB28604AFC00BCF74F /* Toolbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 457AF8EA28604AFC00BCF74F /* Toolbar.mm */; };
 		45A7D3292843B54D00F0C32A /* GroupPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */; };
 		45A7D32C2843B55F00F0C32A /* PriorityPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */; };
 		4D043A7F090AE979009FEDA8 /* TransmissionDocument.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */; };
@@ -613,6 +614,8 @@
 		3C7A11920D0B2EE300B5701F /* getgateway.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = getgateway.h; sourceTree = "<group>"; };
 		3C7A11930D0B2EE300B5701F /* natpmp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = natpmp.c; sourceTree = "<group>"; };
 		3C7A11940D0B2EE300B5701F /* natpmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = natpmp.h; sourceTree = "<group>"; };
+		457AF8E928604AFC00BCF74F /* Toolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Toolbar.h; sourceTree = "<group>"; };
+		457AF8EA28604AFC00BCF74F /* Toolbar.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Toolbar.mm; sourceTree = "<group>"; };
 		45A7D3272843B54D00F0C32A /* GroupPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupPopUpButtonCell.h; sourceTree = "<group>"; };
 		45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupPopUpButtonCell.mm; sourceTree = "<group>"; };
 		45A7D32A2843B55F00F0C32A /* PriorityPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityPopUpButtonCell.h; sourceTree = "<group>"; };
@@ -1452,6 +1455,8 @@
 				A2B5B4E81880665E0071A66A /* ShareTorrentFileHelper.mm */,
 				A21979890D07B78400438EA7 /* GroupToolbarItem.h */,
 				A219798A0D07B78400438EA7 /* GroupToolbarItem.mm */,
+				457AF8E928604AFC00BCF74F /* Toolbar.h */,
+				457AF8EA28604AFC00BCF74F /* Toolbar.mm */,
 				A20BFFB50D091CC700CE5D2B /* ToolbarSegmentedCell.h */,
 				A20BFFB60D091CC700CE5D2B /* ToolbarSegmentedCell.mm */,
 				A22180960D148A71007D09ED /* GroupsPrefsController.h */,
@@ -3016,6 +3021,7 @@
 				A25E74660AF5097D006F11AE /* ExpandedPathToIconTransformer.mm in Sources */,
 				A2265F420B5EF5F40093DDA5 /* FileNameCell.mm in Sources */,
 				A2A1CB7A0BF29D5500AE959F /* PeerProgressIndicatorCell.mm in Sources */,
+				457AF8EB28604AFC00BCF74F /* Toolbar.mm in Sources */,
 				A2385DD40BFE06C800B24EF6 /* DragOverlayWindow.mm in Sources */,
 				A2FB057F0BFEB6800095564D /* DragOverlayView.mm in Sources */,
 				E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */,

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -166,6 +166,7 @@ set(${PROJECT_NAME}_HEADERS
     StatsWindowController.h
     StatusBarController.h
     StatusBarView.h
+    Toolbar.h
     ToolbarSegmentedCell.h
     Torrent.h
     TorrentCell.h

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -95,6 +95,7 @@ set(${PROJECT_NAME}_SOURCES
     StatsWindowController.mm
     StatusBarController.mm
     StatusBarView.mm
+    Toolbar.mm
     ToolbarSegmentedCell.mm
     Torrent.mm
     TorrentCell.mm

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -162,6 +162,7 @@ typedef NS_ENUM(unsigned int, addType) { //
 
 - (void)setWindowSizeToFit;
 - (void)updateForAutoSize;
+- (void)updateWindowAfterToolbarChange;
 - (void)removeStackViewHeightConstraints;
 @property(nonatomic, readonly) CGFloat minScrollViewHeightAllowed;
 @property(nonatomic, readonly) CGFloat toolbarHeight;

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -5029,7 +5029,7 @@ static void removeKeRangerRansomware()
     if (!self.isFullScreen && [self.fDefaults boolForKey:@"AutoSize"])
     {
         //macOS Big Sur shows the unified toolbar by default
-        //and we only need to "fix" the laout when showing the toolbar
+        //and we only need to "fix" the layout when showing the toolbar
         if (@available(macOS 11.0, *))
         {
             if (!self.fWindow.toolbar.isVisible)

--- a/macosx/Toolbar.h
+++ b/macosx/Toolbar.h
@@ -1,0 +1,9 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <AppKit/AppKit.h>
+
+@interface Toolbar : NSToolbar
+
+@end

--- a/macosx/Toolbar.mm
+++ b/macosx/Toolbar.mm
@@ -1,0 +1,18 @@
+// This file Copyright © 2007-2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import "Toolbar.h"
+
+@implementation Toolbar
+
+- (void)setVisible:(BOOL)visible
+{
+    //we need to redraw the main window after each change
+    //otherwise we get strange drawing issues, leading to a potential crash
+    [NSNotificationCenter.defaultCenter postNotificationName:@"ToolbarDidChange" object:nil];
+
+    [super setVisible:visible];
+}
+
+@end


### PR DESCRIPTION
since refactoring to use Autolayout, systems using the older style **Expanded** NSToolbar have issues when Showing/Hiding the toolbar. This PR addresses that