### PR TITLE
Update links in macOS credits

### DIFF
--- a/macosx/Credits.rtf
+++ b/macosx/Credits.rtf
@@ -4,7 +4,7 @@
 \red0\green0\blue0;\red0\green0\blue0;\red127\green127\blue127;}
 {\*\expandedcolortbl;;\cssrgb\c0\c0\c0\c84706\cname headerTextColor;\cssrgb\c0\c0\c0\cname textColor;\cssrgb\c0\c0\c0\c84706\cname labelColor;
 \cssrgb\c0\c0\c0\c24706\cname tertiaryLabelColor;\cssrgb\c0\c0\c0\c49804\cname secondaryLabelColor;\csgenericrgb\c49804\c49804\c49804;}
-\paperw12240\paperh15840\vieww14160\viewh15100\viewkind0
+\vieww14160\viewh15100\viewkind0
 \pard\tx440\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li100\slleading40\sb40\qc\partightenfactor0
 
 \f0\b\fs28 \cf2 The Transmission Project
@@ -148,8 +148,8 @@
 
 \f0\b \cf2 Third-Party Resources
 \f1\b0 \
-\cf3 	\cf4 Nick Mathewson and Niels Provos for libevent. <{\field{\*\fldinst{HYPERLINK "http://monkey.org/~provos/libevent/"}}{\fldrslt http://monkey.org/~provos/libevent/}}>\cf3 \
+\cf3 	\cf4 Nick Mathewson and Niels Provos for libevent. <{\field{\*\fldinst{HYPERLINK "https://libevent.org/"}}{\fldrslt https://libevent.org/}}>\cf3 \
 	\cf4 Greg Hazel of BitTorrent Inc. for libutp. <{\field{\*\fldinst{HYPERLINK "https://github.com/bittorrent/libutp"}}{\fldrslt https://github.com/bittorrent/libutp}}>\cf3 \
 	\cf4 Thomas Bernard for MiniUPnP and libnatpmp. <{\field{\*\fldinst{HYPERLINK "http://miniupnp.tuxfamily.org/"}}{\fldrslt http://miniupnp.tuxfamily.org/}}>\cf3 \
-	\cf4 Andy Matuschak for Sparkle. <{\field{\*\fldinst{HYPERLINK "http://sparkle.andymatuschak.org/"}}{\fldrslt http://sparkle.andymatuschak.org/}}>\cf3 \
+	\cf4 Andy Matuschak for Sparkle. <{\field{\*\fldinst{HYPERLINK "https://sparkle-project.org/"}}{\fldrslt https://sparkle-project.org/}}>\cf3 \
 	\cf4 Bryan D K Jones for VDKQueue. <{\field{\*\fldinst{HYPERLINK "https://github.com/bdkjones/VDKQueue"}}{\fldrslt https://github.com/bdkjones/VDKQueue}}>}


### PR DESCRIPTION
Fix links for libevent and Sparkle, which were out of date (libevent link was redirected, sparkle link was not reachable anymore).