### PR TITLE
macOS remove gradient from PiecesView

### DIFF
--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -77,7 +77,6 @@ enum
         _fExtraBorder = (width - ((_fWidth + BETWEEN) * _fAcross + BETWEEN)) / 2;
     }
 
-    
     NSImage* back = [[NSImage alloc] initWithSize:self.bounds.size];
     self.image = back;
 

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -28,9 +28,6 @@ enum
 
 @property(nonatomic) int8_t* fPieces;
 
-@property(nonatomic) NSColor* fGreenAvailabilityColor;
-@property(nonatomic) NSColor* fBluePieceColor;
-
 @property(nonatomic) NSInteger fNumPieces;
 @property(nonatomic) NSInteger fAcross;
 @property(nonatomic) NSInteger fWidth;
@@ -49,11 +46,6 @@ enum
 
 - (void)awakeFromNib
 {
-    //store box colors
-    self.fGreenAvailabilityColor = NSColor.systemGreenColor;
-    self.fBluePieceColor = NSColor.systemBlueColor;
-
-    //actually draw the box
     self.torrent = nil;
 }
 
@@ -149,7 +141,7 @@ enum
                 }
                 else
                 {
-                    pieceColor = self.fBluePieceColor;
+                    pieceColor = NSColor.systemBlueColor;
                     self.fPieces[index] = PIECE_FINISHED;
                 }
             }
@@ -166,7 +158,7 @@ enum
         {
             if (first || self.fPieces[index] != PIECE_HIGH_PEERS)
             {
-                pieceColor = self.fGreenAvailabilityColor;
+                pieceColor = NSColor.systemGreenColor;
                 self.fPieces[index] = PIECE_HIGH_PEERS;
             }
         }
@@ -174,7 +166,7 @@ enum
         {
             //always redraw "mixed"
             CGFloat percent = showAvailability ? (CGFloat)pieces[index] / HIGH_PEERS : piecesPercent[index];
-            NSColor* fullColor = showAvailability ? self.fGreenAvailabilityColor : self.fBluePieceColor;
+            NSColor* fullColor = showAvailability ? NSColor.systemGreenColor : NSColor.systemBlueColor;
             pieceColor = [defaultColor blendedColorWithFraction:percent ofColor:fullColor];
             self.fPieces[index] = PIECE_SOME;
         }

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -39,6 +39,13 @@ enum
 
 @implementation PiecesView
 
+- (void)drawRect:(NSRect)dirtyRect
+{
+    [[NSColor.controlTextColor colorWithAlphaComponent:0.2] setFill];
+    NSRectFill(dirtyRect);
+    [super drawRect:dirtyRect];
+}
+
 - (void)awakeFromNib
 {
     //store box colors
@@ -70,14 +77,8 @@ enum
         _fExtraBorder = (width - ((_fWidth + BETWEEN) * _fAcross + BETWEEN)) / 2;
     }
 
+    
     NSImage* back = [[NSImage alloc] initWithSize:self.bounds.size];
-    [back lockFocus];
-
-    NSGradient* gradient = [[NSGradient alloc] initWithStartingColor:[NSColor colorWithCalibratedWhite:0.0 alpha:0.4]
-                                                         endingColor:[NSColor colorWithCalibratedWhite:0.2 alpha:0.4]];
-    [gradient drawInRect:self.bounds angle:90.0];
-    [back unlockFocus];
-
     self.image = back;
 
     [self setNeedsDisplay];

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -8,6 +8,7 @@
 #import "PiecesView.h"
 #import "Torrent.h"
 #import "InfoWindowController.h"
+#import "NSApplicationAdditions.h"
 
 #define MAX_ACROSS 18
 #define BETWEEN 1.0
@@ -49,11 +50,17 @@ enum
 - (void)awakeFromNib
 {
     //store box colors
-    self.fGreenAvailabilityColor = [NSColor colorWithCalibratedRed:0.0 green:1.0 blue:0.4 alpha:1.0];
-    self.fBluePieceColor = [NSColor colorWithCalibratedRed:0.0 green:0.4 blue:0.8 alpha:1.0];
+    self.fGreenAvailabilityColor = NSColor.systemGreenColor;
+    self.fBluePieceColor = NSColor.systemBlueColor;
 
     //actually draw the box
     self.torrent = nil;
+}
+
+- (void)viewDidChangeEffectiveAppearance
+{
+    [self setTorrent:_torrent];
+    [self updateView];
 }
 
 - (void)dealloc
@@ -123,6 +130,8 @@ enum
     NSRect fillRects[self.fNumPieces];
     NSColor* fillColors[self.fNumPieces];
 
+    NSColor* defaultColor = [NSApp isDarkMode] ? NSColor.blackColor : NSColor.whiteColor;
+
     NSInteger usedCount = 0;
 
     for (NSInteger index = 0; index < self.fNumPieces; index++)
@@ -135,7 +144,7 @@ enum
             {
                 if (!first && self.fPieces[index] != PIECE_FLASHING)
                 {
-                    pieceColor = NSColor.orangeColor;
+                    pieceColor = NSColor.systemOrangeColor;
                     self.fPieces[index] = PIECE_FLASHING;
                 }
                 else
@@ -149,7 +158,7 @@ enum
         {
             if (first || self.fPieces[index] != PIECE_NONE)
             {
-                pieceColor = NSColor.whiteColor;
+                pieceColor = defaultColor;
                 self.fPieces[index] = PIECE_NONE;
             }
         }
@@ -166,7 +175,7 @@ enum
             //always redraw "mixed"
             CGFloat percent = showAvailability ? (CGFloat)pieces[index] / HIGH_PEERS : piecesPercent[index];
             NSColor* fullColor = showAvailability ? self.fGreenAvailabilityColor : self.fBluePieceColor;
-            pieceColor = [NSColor.whiteColor blendedColorWithFraction:percent ofColor:fullColor];
+            pieceColor = [defaultColor blendedColorWithFraction:percent ofColor:fullColor];
             self.fPieces[index] = PIECE_SOME;
         }
 


### PR DESCRIPTION
* remove gradient from pieces view background image - This looks out of place on macOS Monterey
* add Dark mode support to pieces view background image - This is only a very subtle change

<img width="396" alt="darkempty" src="https://user-images.githubusercontent.com/7323792/175547508-045ae342-e05e-499f-a249-a96ad671a6f0.png">
<img width="396" alt="lightempty" src="https://user-images.githubusercontent.com/7323792/175547518-759bb2b1-e621-4ea0-9ee0-ecfd4638b501.png">
<img width="396" alt="light" src="https://user-images.githubusercontent.com/7323792/175547530-05987ba4-fc36-427c-9f6f-f4ceb6731cbb.png">
<img width="396" alt="dark" src="https://user-images.githubusercontent.com/7323792/175547536-e560122d-3c4a-4539-8ec8-7e76411030f5.png">

