### PR TITLE
Fix: Flexibility of the Encryption column

### DIFF
--- a/macosx/InfoPeersView.xib
+++ b/macosx/InfoPeersView.xib
@@ -126,14 +126,14 @@
                                         <sortDescriptor key="sortDescriptorPrototype" selector="localizedStandardCompare:" sortKey="Client"/>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="Encryption" editable="NO" width="14" minWidth="14" maxWidth="14" id="15">
+                                    <tableColumn identifier="Encryption" editable="NO" width="30" minWidth="14" maxWidth="50" id="15">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
-                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="EC395120-CCB1-4E1A-B7DA-654C92A76156" id="16"/>
+                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" id="16"/>
                                         <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="Encryption" ascending="NO"/>
+                                        <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                     </tableColumn>
                                     <tableColumn identifier="Progress" editable="NO" width="32" minWidth="10" maxWidth="1000" id="14">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="%">

--- a/macosx/InfoPeersView.xib
+++ b/macosx/InfoPeersView.xib
@@ -128,12 +128,13 @@
                                     </tableColumn>
                                     <tableColumn identifier="Encryption" editable="NO" width="30" minWidth="14" maxWidth="50" id="15">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
-                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" id="16"/>
+                                        <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="EC395120-CCB1-4E1A-B7DA-654C92A76156" id="16"/>
                                         <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="Encryption" ascending="NO"/>
-                                        <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+										<tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                     </tableColumn>
                                     <tableColumn identifier="Progress" editable="NO" width="32" minWidth="10" maxWidth="1000" id="14">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="%">


### PR DESCRIPTION
This is a minor _code change_ and not an icon fix, that will be of little interest to most. I'm not sure if i explained this particularly well the first time around. I'll try again.

This illustrates the current values for how the columns in the Peer Inspector can be maximised.

![SCR-20220619-pqn](https://user-images.githubusercontent.com/69029666/175335362-6d73f66d-9750-4916-9959-f5747056a02a.png)

That 0 is the encryption column, and because it currently can't be minimised further, or maximised at all, it becomes stuck next to everything if it is moved from the far right of the inspector window.

![SCR-20220608-gmv](https://user-images.githubusercontent.com/69029666/172523221-f6f3ef6d-988a-4858-bb1f-fe50aa0548e9.png)

This PR resolves that by adding maximum values to that column. This is how it looks on my current build.

![SCR-20220624-4t0](https://user-images.githubusercontent.com/69029666/175336764-2174738f-b040-4ce6-b124-ee7b0bd152e6.png)

