### PR TITLE
Rename Mac OS X to macOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,11 +3,11 @@ https://transmissionbt.com/
 
 Lead Developers <dev@transmissionbt.com>
   Charles Kerr, Mnemosyne LLC <charles@charleskerr.com> (Daemon, Backend, GTK+, QT clients)
-  Mitchell Livingston, Digital Ignition LLC <livings124@transmissionbt.com> (Mac OS X client)
+  Mitchell Livingston, Digital Ignition LLC <livings124@transmissionbt.com> (macOS client)
   Mike Gelfand <mike@transmissionbt.com>
 
 Project Contributors
-  John Clay <john@transmissionbt.com> (Website maintenance and troubleshooting, Mac OS X help documentation)
+  John Clay <john@transmissionbt.com> (Website maintenance and troubleshooting, macOS help documentation)
   Hugo van Heuven, madebysofa (Main icon design)
   Andreas Nilsson (GNOME adaptation of main icon)
   Rodger Werner ("Big Sur" adaptation of main icon)
@@ -19,10 +19,10 @@ Project Contributors
   Kendall Hopkins <SoftwareElves@gmail.com> (Web client)
   Malcolm Jarvis <mjarvis@transmissionbt.com> (Web client)
   Kevin Glowacz <kjg@transmissionbt.com> (Web client)
-  Rashid Eissing (Mac OS X Transfers preferences icon)
+  Rashid Eissing (macOS Transfers preferences icon)
   Dean Ostetto
-  Rick Patrick (Mac OS X images)
-  Jonas Rask (Mac OS X Globe icon)
+  Rick Patrick (macOS images)
+  Jonas Rask (macOS Globe icon)
   Erick Turnquist (IPv6 code, support)
   Maarten Van Coile (Wiki Wrangler, troubleshooting, support)
   James "Kibo" Parry (Updated Mac Retina images)
@@ -33,7 +33,7 @@ Previous Developers
   Josh Elsasser <josh@elsasser.org> (Daemon, Backend, GTK+ client)
   Bryan Varner <bryan@varnernet.com> (BeOS client)
 
-Mac OS X Translators, current release:
+macOS Translators, current release:
   Jorge Carrasco (Spanish)
   Etienne Samson (French)
   Marco Cavazzuti (Italian)

--- a/docs/Bug-Submission.md
+++ b/docs/Bug-Submission.md
@@ -43,9 +43,9 @@ If you are experiencing slow speeds and you have been through the documentation,
  * Is your incoming peer port open or closed?
    The "Peers" and "Tracker" tabs are in the dialog named "Inspector" on the Mac GUI and "Torrent Properties" on the GTK+ GUI.
 
-### Crash on the Mac ###
-If you have problems on the Mac version then please do these extra steps:
-  * Make sure your system is updated to the latest version of your operating system. Note as of version 1.60, Transmission requires Mac OS X 10.5 or later.
+### Crash on macOS ###
+If you have problems on the macOS version then please do these extra steps:
+  * Make sure your system is updated to the latest version of your operating system.
   * If you are running a nightly build, set the language to English. The localization will sometimes crash the nightly builds until they are updated (right before an official release).
   * macOS collects two pieces of crash information that can help us fix the crash:
      1. In Console.app, look under LOG FILES > ~/Library/Logs/ > CrashReporter > for Transmission. If you find one, include it in your forum post.

--- a/docs/Port-Forwarding-Guide.md
+++ b/docs/Port-Forwarding-Guide.md
@@ -14,13 +14,6 @@ If this does not happen, you can add Transmission to Leopard's firewall manually
  1. Click the "+" button and select Transmission from you applications folder.
  1. Make sure the pull down menu is set to "Allow incoming connections".
 
-### On Mac OS X 10.4 and older
- 1. Open Transmission, go to Preferences >> Network and note down the number for the port. Then quit Transmission.
- 1. Open System Prefs >> Sharing >> Firewall. Click "New." In the "Port Name" pop-up menu, select Other, and fill in the settings as follows:
-  * TCP Port Number(s): the port you chose in step 1 - (default is 51413).
-  * Description: Transmission
- 3. Click OK.
-
 ### On Unix
  * For instructions on how to use it, open a Terminal and open the man page of your firewall. (e.g. 'man ufw, man firewalld')
  * You need to ensure that Transmission's port (displayed in preferences) is forwarded in the firewall.

--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -2,7 +2,7 @@
 ## Introduction
 Thanks to the powerful [RPC](./rpc-spec.md), `transmission-remote` can talk to any client that has the RPC enabled. This means that a script written using `transmission-remote` or [RPC](./rpc-spec.md) can, without rewrite, communicate with all the Transmission clients: Mac, Linux, Windows, and headless.
 
-Mac OS users may wonder whether there will be AppleScript scripts, the answer is ''no''. Although AppleScript is a nice technology, it's a pain to implement. However, macOS is a Unix after all, so any script you find here will also work on the Mac. Even from within AppleScript, you can run these scripts by typing: `do shell script "path/to/script"`.
+macOS users may wonder whether there will be AppleScript scripts, the answer is ''no''. Although AppleScript is a nice technology, it's a pain to implement. However, macOS is a Unix after all, so any script you find here will also work on macOS. Even from within AppleScript, you can run these scripts by typing: `do shell script "path/to/script"`.
 
 ## How-To
 If you are interested at writing scripts for Transmission, have a look at the following pages:

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1279,7 +1279,7 @@ void Application::Impl::show_about_dialog()
     auto const uri = Glib::ustring("https://transmissionbt.com/");
     auto const authors = std::vector<Glib::ustring>({
         "Charles Kerr (Backend; GTK+)",
-        "Mitchell Livingston (Backend; OS X)",
+        "Mitchell Livingston (Backend; macOS)",
         "Mike Gelfand",
     });
 

--- a/macosx/Credits.rtf
+++ b/macosx/Credits.rtf
@@ -4,7 +4,7 @@
 \red0\green0\blue0;\red0\green0\blue0;\red127\green127\blue127;}
 {\*\expandedcolortbl;;\cssrgb\c0\c0\c0\c84706\cname headerTextColor;\cssrgb\c0\c0\c0\cname textColor;\cssrgb\c0\c0\c0\c84706\cname labelColor;
 \cssrgb\c0\c0\c0\c24706\cname tertiaryLabelColor;\cssrgb\c0\c0\c0\c49804\cname secondaryLabelColor;\csgenericrgb\c49804\c49804\c49804;}
-\vieww14160\viewh15100\viewkind0
+\vieww16840\viewh15100\viewkind0
 \pard\tx440\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li100\slleading40\sb40\qc\partightenfactor0
 
 \f0\b\fs28 \cf2 The Transmission Project
@@ -20,7 +20,7 @@
 \fs20 \cf5  \cf6 (Daemon, Backend, GTK+ client)
 \fs24 \cf0 \
 \cf4 	Mitchell Livingston, Digital Ignition LLC <{\field{\*\fldinst{HYPERLINK "mailto:livings124@transmissionbt.com"}}{\fldrslt livings124@transmissionbt.com}}>
-\fs20 \cf3  \cf6 (Mac OS X client)
+\fs20 \cf3  \cf6 (macOS client)
 \fs24 \cf0 \
 \cf3 	\cf4 Mike Gelfand <{\field{\*\fldinst{HYPERLINK "mailto:mike@transmissionbt.com"}}{\fldrslt mike@transmissionbt.com}}>\cf0 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
@@ -32,7 +32,7 @@
 \cf0 	\cf4 John Clay
 \fs20  
 \fs24 <{\field{\*\fldinst{HYPERLINK "mailto:john@transmissionbt.com"}}{\fldrslt john@transmissionbt.com}}>
-\fs20 \cf5  \cf6 (Website maintenance and troubleshooting, Mac OS X help documentation)
+\fs20 \cf5  \cf6 (Website maintenance and troubleshooting, macOS help documentation)
 \fs24 \cf0 \
 	\cf4 Hugo van Heuven, madebysofa
 \fs20 \cf7  \cf6 (Main icon design)
@@ -68,13 +68,13 @@
 \fs20  \cf6 (Web client)\cf7 \
 
 \fs24 \cf0 	\cf4 Rashid Eissing
-\fs20 \cf3  \cf6 (Mac OS X Transfers preferences icon)\cf7 \
+\fs20 \cf3  \cf6 (macOS Transfers preferences icon)\cf7 \
 
 \fs24 \cf0 	\cf4 Rick Patrick
-\fs20  \cf6 (Mac OS X images)\cf7 \
+\fs20  \cf6 (macOS images)\cf7 \
 
 \fs24 \cf0 	\cf4 Jonas Rask
-\fs20 \cf7  \cf6 (Mac OS X Globe icon)\cf7 \
+\fs20 \cf7  \cf6 (macOS Globe icon)\cf7 \
 
 \fs24 \cf0 	\cf4 Erick Turnquist\cf0  
 \fs20 \cf6 (IPv6 code, support)\cf7 \
@@ -83,7 +83,7 @@
 \fs20 \cf7  \cf6 (Wiki Wrangler, troubleshooting, support)\cf7 \
 
 \fs24 \cf0 	\cf4 James "Kibo" Parry
-\fs20 \cf3  \cf6 (Updated Mac Retina images)
+\fs20 \cf3  \cf6 (Updated macOS Retina images)
 \fs24 \cf0 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 \cf0 \
@@ -104,7 +104,7 @@
 \cf0 \
 \pard\tx440\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li100\slleading40\sb40\partightenfactor0
 
-\f0\b \cf2 Mac OS X Translators
+\f0\b \cf2 macOS Translators
 \f1\b0 \
 \cf0 	\cf4 Jorge Carrasco\cf7  
 \fs20 \cf6 (Spanish)\cf7 \

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -55,7 +55,7 @@ void AboutDialog::showCredits()
         this,
         tr("Credits"),
         QString::fromUtf8("Charles Kerr (Backend; Daemon; GTK+; Qt)\n"
-                          "Mitchell Livingston (OS X)\n"
+                          "Mitchell Livingston (macOS)\n"
                           "Mike Gelfand\n"));
 }
 


### PR DESCRIPTION
- Update “Mac OS X” or “Mac OS” or “OS X” to the current naming: macOS.
- Except in older release notes, and historical information.
- Remove outdated info in two places (for Transmission 1.60, and Mac OS X 10.4 and older)