### PR TITLE
refactor: tr_peerMsgs.percentDone()

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -78,6 +78,8 @@ public:
 
     [[nodiscard]] virtual std::string readable() const = 0;
 
+    [[nodiscard]] virtual bool hasPiece(tr_piece_index_t piece) const noexcept = 0;
+
     /* whether or not we should free this peer soon.
        NOTE: private to peer-mgr.c */
     bool doPurge = false;
@@ -92,15 +94,7 @@ public:
 
     tr_swarm* const swarm;
 
-    /** how complete the peer's copy of the torrent is. [0.0...1.0] */
-    float progress = 0.0f;
-
     tr_bitfield blame;
-    tr_bitfield have;
-
-    /* the client name.
-       For BitTorrent peers, this is the app name derived from the `v' string in LTEP's handshake dictionary */
-    tr_interned_string client;
 
     tr_recentHistory<uint16_t> blocksSentToClient;
     tr_recentHistory<uint16_t> blocksSentToPeer;
@@ -108,11 +102,6 @@ public:
     tr_recentHistory<uint16_t> cancelsSentToClient;
     tr_recentHistory<uint16_t> cancelsSentToPeer;
 };
-
-/** Update the tr_peer.progress field based on the 'have' bitset. */
-void tr_peerUpdateProgress(tr_torrent* tor, tr_peer*);
-
-bool tr_peerIsSeed(tr_peer const* peer);
 
 /***
 ****

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -74,33 +74,40 @@ public:
     tr_peer(tr_torrent const* tor, peer_atom* atom = nullptr);
     virtual ~tr_peer();
 
-    virtual bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const = 0;
+    virtual bool isTransferringPieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const = 0;
 
     [[nodiscard]] virtual std::string readable() const = 0;
 
     [[nodiscard]] virtual bool hasPiece(tr_piece_index_t piece) const noexcept = 0;
 
-    /* whether or not we should free this peer soon.
-       NOTE: private to peer-mgr.c */
-    bool doPurge = false;
-
-    /* number of bad pieces they've contributed to */
-    uint8_t strikes = 0;
-
     tr_session* const session;
-
-    /* Hook to private peer-mgr information */
-    peer_atom* const atom;
 
     tr_swarm* const swarm;
 
+    tr_recentHistory<uint16_t> blocks_sent_to_peer;
+
+    tr_recentHistory<uint16_t> cancels_sent_to_client;
+
+/// The following fields are only to be used in peer-mgr.cc.
+/// TODO(ckerr): refactor them out of tr_peer
+
+    // hook to private peer-mgr information
+    peer_atom* const atom;
+
+    // whether or not this peer sent us any given block
     tr_bitfield blame;
 
-    tr_recentHistory<uint16_t> blocksSentToClient;
-    tr_recentHistory<uint16_t> blocksSentToPeer;
+    // whether or not we should free this peer soon.
+    bool do_purge = false;
 
-    tr_recentHistory<uint16_t> cancelsSentToClient;
-    tr_recentHistory<uint16_t> cancelsSentToPeer;
+    // how many bad pieces this piece has contributed to
+    uint8_t strikes = 0;
+
+    // how many blocks this peer has sent us
+    tr_recentHistory<uint16_t> blocks_sent_to_client;
+
+    // how many requests we made to this peer and then canceled
+    tr_recentHistory<uint16_t> cancels_sent_to_peer;
 };
 
 /***

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -296,7 +296,7 @@ public:
         evbuffer_free(this->outMessages);
     }
 
-    bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
+    bool isTransferringPieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
     {
         auto const Bps = io->getPieceSpeed_Bps(now, direction);
 
@@ -1781,7 +1781,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
             tr_peerIoReadUint32(msgs->io, inbuf, &r.index);
             tr_peerIoReadUint32(msgs->io, inbuf, &r.offset);
             tr_peerIoReadUint32(msgs->io, inbuf, &r.length);
-            msgs->cancelsSentToClient.add(tr_time(), 1);
+            msgs->cancels_sent_to_client.add(tr_time(), 1);
             logtrace(msgs, fmt::format(FMT_STRING("got a Cancel {:d}:{:d}->{:d}"), r.index, r.offset, r.length));
 
             auto& requests = msgs->peer_requested_;
@@ -2310,7 +2310,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
                 tr_peerIoWriteBuf(msgs->io, out, true);
                 bytesWritten += n;
                 msgs->clientSentAnythingAt = now;
-                msgs->blocksSentToPeer.add(tr_time(), 1);
+                msgs->blocks_sent_to_peer.add(tr_time(), 1);
             }
 
             evbuffer_free(out);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -161,10 +161,6 @@ public:
         , bandwidth(&tor->bandwidth_)
         , pulse_timer(evtimer_new(session->event_base, &tr_webseed::onTimer, this), event_free)
     {
-        // init parent bits
-        have.setHasAll();
-        tr_peerUpdateProgress(tor, this);
-
         startTimer();
     }
 
@@ -207,6 +203,11 @@ public:
         }
 
         return base_url;
+    }
+
+    [[nodiscard]] bool hasPiece(tr_piece_index_t /*piece*/) const noexcept override
+    {
+        return true;
     }
 
     void gotPieceData(uint32_t n_bytes)

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -176,7 +176,7 @@ public:
         return tr_torrentFindFromId(session, torrent_id);
     }
 
-    [[nodiscard]] bool is_transferring_pieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
+    [[nodiscard]] bool isTransferringPieces(uint64_t now, tr_direction direction, unsigned int* setme_Bps) const override
     {
         unsigned int Bps = 0;
         bool is_active = false;
@@ -529,6 +529,6 @@ tr_webseed_view tr_webseedView(tr_peer const* peer)
     }
 
     auto bytes_per_second = unsigned{ 0 };
-    auto const is_downloading = peer->is_transferring_pieces(tr_time_msec(), TR_DOWN, &bytes_per_second);
+    auto const is_downloading = peer->isTransferringPieces(tr_time_msec(), TR_DOWN, &bytes_per_second);
     return { w->base_url.c_str(), is_downloading, bytes_per_second };
 }


### PR DESCRIPTION
This moves the `progress` and `have` fields out of the `tr_peer` parent class down into BitTorrent peer subclass, since webseeds by definition are always  seeds and don't need these fields.
