### PR TITLE
fixup! refactor: tr_peerMsgs.percentDone() (#3363)

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1757,7 +1757,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
             logtrace(msgs, "got a bitfield");
             auto tmp = std::vector<uint8_t>(msglen);
             tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
-            msgs->have_ = tr_bitfield{ msgs->torrent->hasMetainfo() ? msgs->torrent->pieceCount() : std::size(tmp) };
+            msgs->have_ = tr_bitfield{ msgs->torrent->hasMetainfo() ? msgs->torrent->pieceCount() : std::size(tmp) * 8 };
             msgs->have_.setRaw(std::data(tmp), std::size(tmp));
             msgs->publishClientGotBitfield(&msgs->have_);
             msgs->invalidatePercentDone();


### PR DESCRIPTION
fix: assertion on magnet link receiving a have bitfield from peers