### PR TITLE
Fix Warn -> Warning

### DIFF
--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -71,7 +71,7 @@
 
     //set images and text for popup button items
     [self.fLevelButton itemAtIndex:LEVEL_ERROR].title = NSLocalizedString(@"Error", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_WARN].title = NSLocalizedString(@"Warn", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LEVEL_WARN].title = NSLocalizedString(@"Warning", "Message window -> level string");
     [self.fLevelButton itemAtIndex:LEVEL_INFO].title = NSLocalizedString(@"Info", "Message window -> level string");
     [self.fLevelButton itemAtIndex:LEVEL_DEBUG].title = NSLocalizedString(@"Debug", "Message window -> level string");
     [self.fLevelButton itemAtIndex:LEVEL_TRACE].title = NSLocalizedString(@"Trace", "Message window -> level string");
@@ -582,7 +582,7 @@
         levelString = NSLocalizedString(@"Error", "Message window -> level");
         break;
     case TR_LOG_WARN:
-        levelString = NSLocalizedString(@"Warn", "Message window -> level");
+        levelString = NSLocalizedString(@"Warning", "Message window -> level");
         break;
     case TR_LOG_INFO:
         levelString = NSLocalizedString(@"Info", "Message window -> level");

--- a/macosx/da.lproj/Localizable.strings
+++ b/macosx/da.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "";
+"Warning" = "";
 
 /* Drag overlay -> url */
 "Web Address" = "Webadresse";

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "";
+"Warning" = "";
 
 /* Drag overlay -> url */
 "Web Address" = "Web-Adresse";

--- a/macosx/en.lproj/Localizable.strings
+++ b/macosx/en.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "Warn";
+"Warning" = "Warn";
 
 /* Drag overlay -> url */
 "Web Address" = "Web Address";

--- a/macosx/en.lproj/Localizable.strings
+++ b/macosx/en.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warning" = "Warn";
+"Warning" = "Warning";
 
 /* Drag overlay -> url */
 "Web Address" = "Web Address";

--- a/macosx/es.lproj/Localizable.strings
+++ b/macosx/es.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "Advertencia";
+"Warning" = "Advertencia";
 
 /* Drag overlay -> url */
 "Web Address" = "Dirección web";

--- a/macosx/fr.lproj/Localizable.strings
+++ b/macosx/fr.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "Avertir";
+"Warning" = "Avertissement";
 
 /* Drag overlay -> url */
 "Web Address" = "Adresse Web";

--- a/macosx/it.lproj/Localizable.strings
+++ b/macosx/it.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "";
+"Warning" = "";
 
 /* Drag overlay -> url */
 "Web Address" = "Sito web";

--- a/macosx/nl.lproj/Localizable.strings
+++ b/macosx/nl.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "";
+"Warning" = "";
 
 /* Drag overlay -> url */
 "Web Address" = "Webadres";

--- a/macosx/pt_PT.lproj/Localizable.strings
+++ b/macosx/pt_PT.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "";
+"Warning" = "";
 
 /* Drag overlay -> url */
 "Web Address" = "Endereço web";

--- a/macosx/ru.lproj/Localizable.strings
+++ b/macosx/ru.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "Предупреждение";
+"Warning" = "Предупреждение";
 
 /* Drag overlay -> url */
 "Web Address" = "URL";

--- a/macosx/tr.lproj/Localizable.strings
+++ b/macosx/tr.lproj/Localizable.strings
@@ -1126,7 +1126,7 @@
 
 /* Message window -> level
    Message window -> level string */
-"Warn" = "Uyar";
+"Warning" = "Uyar";
 
 /* Drag overlay -> url */
 "Web Address" = "URL";


### PR DESCRIPTION
Discussion is in #3280.

Translators at Transifex prefer an unambiguous "Warning" as a noun for translation than a suspicious "Warn" as a verb that needs to be translated like a noun.