### PR TITLE
refactor: add tr_peer.canRequest()

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -89,6 +89,19 @@ public:
 
     virtual void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) = 0;
 
+    struct RequestLimit
+    {
+        // How many blocks we could request.
+        size_t max_spans = 0;
+
+        // How many spans those blocks could be in.
+        // This is for webseeds, which make parallel requests.
+        size_t max_blocks = 0;
+    };
+
+    // how many blocks could we request from this peer right now?
+    [[nodiscard]] virtual RequestLimit canRequest() const noexcept = 0;
+
     tr_session* const session;
 
     tr_swarm* const swarm;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -658,7 +658,47 @@ public:
         }
     }
 
+    // how many blocks could we request from this peer right now?
+    [[nodiscard]] RequestLimit canRequest() const noexcept override
+    {
+        auto const max_blocks = maxAvailableReqs();
+        return RequestLimit{ max_blocks, max_blocks };
+    }
+
 private:
+    [[nodiscard]] size_t maxAvailableReqs() const
+    {
+        if (torrent->isDone() || !torrent->hasMetainfo() || client_is_choked_ || !client_is_interested_)
+        {
+            return 0;
+        }
+
+        // Get the rate limit we should use.
+        // TODO: this needs to consider all the other peers as well...
+        uint64_t const now = tr_time_msec();
+        auto rate_Bps = tr_peerGetPieceSpeed_Bps(this, now, TR_PEER_TO_CLIENT);
+        if (tr_torrentUsesSpeedLimit(torrent, TR_PEER_TO_CLIENT))
+        {
+            rate_Bps = std::min(rate_Bps, torrent->speedLimitBps(TR_PEER_TO_CLIENT));
+        }
+
+        // honor the session limits, if enabled
+        auto irate_Bps = unsigned{};
+        if (tr_torrentUsesSessionLimits(torrent) &&
+            tr_sessionGetActiveSpeedLimit_Bps(torrent->session, TR_PEER_TO_CLIENT, &irate_Bps))
+        {
+            rate_Bps = std::min(rate_Bps, irate_Bps);
+        }
+
+        // use this desired rate to figure out how
+        // many requests we should send to this peer
+        size_t constexpr Floor = 32;
+        size_t constexpr Seconds = RequestBufSecs;
+        size_t const estimated_blocks_in_period = (rate_Bps * Seconds) / tr_block_info::BlockSize;
+        size_t const ceil = reqq ? *reqq : 250;
+        return std::clamp(estimated_blocks_in_period, Floor, ceil);
+    }
+
     void protocolSendRequest(struct peer_request const& req)
     {
         TR_ASSERT(isValidRequest(req));
@@ -2088,40 +2128,7 @@ static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
 
 static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
 {
-    tr_torrent const* const torrent = msgs->torrent;
-
-    /* there are lots of reasons we might not want to request any blocks... */
-    if (torrent->isDone() || !torrent->hasMetainfo() || msgs->client_is_choked_ || !msgs->client_is_interested_)
-    {
-        msgs->desired_request_count = 0;
-    }
-    else
-    {
-        /* Get the rate limit we should use.
-         * TODO: this needs to consider all the other peers as well... */
-        uint64_t const now = tr_time_msec();
-        auto rate_Bps = tr_peerGetPieceSpeed_Bps(msgs, now, TR_PEER_TO_CLIENT);
-        if (tr_torrentUsesSpeedLimit(torrent, TR_PEER_TO_CLIENT))
-        {
-            rate_Bps = std::min(rate_Bps, torrent->speedLimitBps(TR_PEER_TO_CLIENT));
-        }
-
-        /* honor the session limits, if enabled */
-        auto irate_Bps = unsigned{};
-        if (tr_torrentUsesSessionLimits(torrent) &&
-            tr_sessionGetActiveSpeedLimit_Bps(torrent->session, TR_PEER_TO_CLIENT, &irate_Bps))
-        {
-            rate_Bps = std::min(rate_Bps, irate_Bps);
-        }
-
-        /* use this desired rate to figure out how
-         * many requests we should send to this peer */
-        size_t constexpr Floor = 32;
-        size_t constexpr Seconds = RequestBufSecs;
-        size_t const estimated_blocks_in_period = (rate_Bps * Seconds) / tr_block_info::BlockSize;
-        size_t const ceil = msgs->reqq ? *msgs->reqq : 250;
-        msgs->desired_request_count = std::clamp(estimated_blocks_in_period, Floor, ceil);
-    }
+    msgs->desired_request_count = msgs->canRequest().max_blocks;
 }
 
 static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)


### PR DESCRIPTION
No functional changes.

This is another PR in a small series (previous: #3384) to lay groundwork for #3372 by adding API to `tr_peer`. This PR exposes the peer's preferences of how many blocks it could request right now (e.g. by looking at the peer's reqq).

Essentially, what's happening here 3372 will change how & when we decide what blocks to request from which peers:

- Currently this is done bottom-up when the `tr_peer` decides that it's time and requests a list from the manager.

- 3372 will change it to be top-down where the manager decides that it's time and sends the peer a list.