### PR TITLE
Update fmt to 9.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	branch = post-3.0.0-transmission
 [submodule "third-party/fmt"]
 	path = third-party/fmt
-	url = https://github.com/transmission/fmt.git
+	url = https://github.com/fmtlib/fmt.git
 [submodule "third-party/fast_float"]
 	path = third-party/fast_float
 	url = https://github.com/transmission/fast_float

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,8 @@
 	branch = post-3.0.0-transmission
 [submodule "third-party/fmt"]
 	path = third-party/fmt
-	url = https://github.com/fmtlib/fmt.git
+	url = https://github.com/transmission/fmt.git
+	branch = 9-x-y
 [submodule "third-party/fast_float"]
 	path = third-party/fast_float
 	url = https://github.com/transmission/fast_float


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/3414

This is a proposal for testing the update to 9.0.0
It switches the submodule to the upstream repo, if we want to retain the fork it needs to be updated