### PR TITLE
refactor: use std::deque for tr_peerIo.outbuf_info

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1202,6 +1202,8 @@ int tr_peerIoFlushOutgoingProtocolMsgs(tr_peerIo* io)
 {
     size_t byteCount = 0;
 
+    /* count up how many bytes are used by non-piece-data messages
+       at the front of our outbound queue */
     for (auto const& [n_bytes, is_piece_data] : io->outbuf_info)
     {
         if (is_piece_data)

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -16,6 +16,7 @@
 #include <cstddef> // size_t
 #include <cstdint> // uintX_t
 #include <ctime>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <string>
@@ -34,7 +35,6 @@
 class tr_peerIo;
 struct tr_bandwidth;
 struct struct_utp_context;
-struct tr_datatype;
 
 /**
  * @addtogroup networked_io Networked IO
@@ -204,7 +204,7 @@ public:
     tr_evbuffer_ptr const inbuf = tr_evbuffer_ptr{ evbuffer_new() };
     tr_evbuffer_ptr const outbuf = tr_evbuffer_ptr{ evbuffer_new() };
 
-    struct tr_datatype* outbuf_datatypes = nullptr;
+    std::deque<std::pair<size_t /*n_bytes*/, bool /*is_piece_data*/>> outbuf_info;
 
     struct event* event_read = nullptr;
     struct event* event_write = nullptr;


### PR DESCRIPTION
minor refactor to `tr_peerIo` to use a std container instead of a bespoke datatype.

TBH this is just nibbling around the real problem. I want to make `tr_peerIo` testable but there are so many interdependencies that I'm starting with these baby steps. :angry: 