### PR TITLE
refactor: migrate tr_crypto C functions to members

### DIFF
--- a/libtransmission/crypto.h
+++ b/libtransmission/crypto.h
@@ -36,7 +36,7 @@ struct tr_crypto
     tr_crypto(tr_crypto const&) = delete;
     tr_crypto(tr_crypto&&) = delete;
 
-    constexpr void setTorrentHash(tr_sha1_digest_t hash) noexcept
+    void setTorrentHash(tr_sha1_digest_t hash) noexcept
     {
         torrent_hash_ = hash;
     }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -107,11 +107,6 @@ public:
 
     std::string addrStr() const;
 
-    [[nodiscard]] constexpr bool isIncoming() noexcept
-    {
-        return crypto.is_incoming;
-    }
-
     [[nodiscard]] auto getReadBuffer() noexcept
     {
         return inbuf.get();
@@ -183,6 +178,21 @@ public:
     }
 
     tr_crypto crypto;
+
+    [[nodiscard]] constexpr auto isIncoming() noexcept
+    {
+        return crypto.isIncoming();
+    }
+
+    constexpr void setTorrentHash(tr_sha1_digest_t hash) noexcept
+    {
+        crypto.setTorrentHash(hash);
+    }
+
+    [[nodiscard]] constexpr auto const& torrentHash() const noexcept
+    {
+        return crypto.torrentHash();
+    }
 
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
     // like this one isn't being used just for assertions, but also in
@@ -284,10 +294,6 @@ constexpr tr_session* tr_peerIoGetSession(tr_peerIo* io)
 
     return io->session;
 }
-
-std::optional<tr_sha1_digest_t> tr_peerIoGetTorrentHash(tr_peerIo const* io);
-
-void tr_peerIoSetTorrentHash(tr_peerIo* io, tr_sha1_digest_t const& info_hash);
 
 int tr_peerIoReconnect(tr_peerIo* io);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -184,7 +184,7 @@ public:
         return crypto.isIncoming();
     }
 
-    constexpr void setTorrentHash(tr_sha1_digest_t hash) noexcept
+    void setTorrentHash(tr_sha1_digest_t hash) noexcept
     {
         crypto.setTorrentHash(hash);
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1084,7 +1084,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
     bool success = false;
     auto* manager = static_cast<tr_peerMgr*>(result.userData);
 
-    auto const hash = tr_peerIoGetTorrentHash(result.io);
+    auto const hash = result.io->torrentHash();
     tr_swarm* const s = hash ? getExistingSwarm(manager, *hash) : nullptr;
 
     auto const [addr, port] = result.io->socketAddress();
@@ -2771,7 +2771,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     {
         tr_handshake* handshake = tr_handshakeNew(io, mgr->session->encryptionMode, on_handshake_done, mgr);
 
-        TR_ASSERT(tr_peerIoGetTorrentHash(io));
+        TR_ASSERT(io->torrentHash());
 
         tr_peerIoUnref(io); /* balanced by the initial ref in tr_peerIoNewOutgoing() */
 

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -19,18 +19,6 @@
 #define tr_x509_store_t tr_x509_store_t_
 #define tr_x509_cert_t tr_x509_cert_t_
 #define tr_crypto tr_crypto_
-#define tr_cryptoConstruct tr_cryptoConstruct_
-#define tr_cryptoDestruct tr_cryptoDestruct_
-#define tr_cryptoSetTorrentHash tr_cryptoSetTorrentHash_
-#define tr_cryptoGetTorrentHash tr_cryptoGetTorrentHash_
-#define tr_cryptoHasTorrentHash tr_cryptoHasTorrentHash_
-#define tr_cryptoComputeSecret tr_cryptoComputeSecret_
-#define tr_cryptoGetMyPublicKey tr_cryptoGetMyPublicKey_
-#define tr_cryptoDecryptInit tr_cryptoDecryptInit_
-#define tr_cryptoDecrypt tr_cryptoDecrypt_
-#define tr_cryptoEncryptInit tr_cryptoEncryptInit_
-#define tr_cryptoEncrypt tr_cryptoEncrypt_
-#define tr_cryptoSecretKeySha1 tr_cryptoSecretKeySha1_
 #define tr_sha1 tr_sha1_
 #define tr_sha1_init tr_sha1_init_
 #define tr_sha1_update tr_sha1_update_
@@ -84,18 +72,6 @@
 #undef tr_x509_store_t
 #undef tr_x509_cert_t
 #undef tr_crypto
-#undef tr_cryptoConstruct
-#undef tr_cryptoDestruct
-#undef tr_cryptoSetTorrentHash
-#undef tr_cryptoGetTorrentHash
-#undef tr_cryptoHasTorrentHash
-#undef tr_cryptoComputeSecret
-#undef tr_cryptoGetMyPublicKey
-#undef tr_cryptoDecryptInit
-#undef tr_cryptoDecrypt
-#undef tr_cryptoEncryptInit
-#undef tr_cryptoEncrypt
-#undef tr_cryptoSecretKeySha1
 #undef tr_sha1
 #undef tr_sha1_init
 #undef tr_sha1_update
@@ -142,18 +118,6 @@
 #define tr_x509_store_t_ tr_x509_store_t
 #define tr_x509_cert_t_ tr_x509_cert_t
 #define tr_crypto_ tr_crypto
-#define tr_cryptoConstruct_ tr_cryptoConstruct
-#define tr_cryptoDestruct_ tr_cryptoDestruct
-#define tr_cryptoSetTorrentHash_ tr_cryptoSetTorrentHash
-#define tr_cryptoGetTorrentHash_ tr_cryptoGetTorrentHash
-#define tr_cryptoHasTorrentHash_ tr_cryptoHasTorrentHash
-#define tr_cryptoComputeSecret_ tr_cryptoComputeSecret
-#define tr_cryptoGetMyPublicKey_ tr_cryptoGetMyPublicKey
-#define tr_cryptoDecryptInit_ tr_cryptoDecryptInit
-#define tr_cryptoDecrypt_ tr_cryptoDecrypt
-#define tr_cryptoEncryptInit_ tr_cryptoEncryptInit
-#define tr_cryptoEncrypt_ tr_cryptoEncrypt
-#define tr_cryptoSecretKeySha1_ tr_cryptoSecretKeySha1
 #define tr_sha1_ tr_sha1
 #define tr_sha1_init_ tr_sha1_init
 #define tr_sha1_update_ tr_sha1_update


### PR DESCRIPTION
No functional changes.

This is prerequisite work necessary to make tr_handshake testable. I plan to record peer data for replay in unit tests; but before we can compare test result network traffic to prerecorded network traffic, the unit teats need to be able to inject non-random PadA and PadB segments during PE/MSE handshakes. Otherwise the comparisons in the unit tests will always fail.