### PR TITLE
Minor Gtk metainfo changes

### DIFF
--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -18,14 +18,14 @@ Copyright 2017 Endless Mobile, Inc.
       distribute large amounts of data between multiple users.
     </p>
     <p>
-      Transmission is a BitTorrent client with an easy-to-use frontend on top a
+      Transmission is a BitTorrent client with an easy-to-use interface on top of a
       cross-platform backend.
-      Native frontends are available for macOS and Windows, as well as command line and
-      web frontends.
+      Native interfaces are available for macOS, Linux, and Windows, as well as command line binaries and
+      a web GUI.
     </p>
     <p>
       Notable features of Transmission include support for Local Peer Discovery, encryption,
-      DHT, µTP, PEX and Magnet Link.
+      DHT, µTP, PEX and Magnet links.
     </p>
   </description>
   <url type="homepage">https://transmissionbt.com/</url>


### PR DESCRIPTION
The body text omitted Linux as a platform; and a bit repetitious with its use of frontend/backend. Fixed.