### PR TITLE
refactor: decouple tr_handshake

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1140,15 +1140,15 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
 
     if (io->socket.type == TR_PEER_SOCKET_TYPE_UTP && !io->isIncoming() && handshake->state == AWAITING_YB)
     {
-        /* This peer probably doesn't speak uTP. */
+        // the peer probably doesn't speak uTP.
 
         auto const hash = io->torrentHash();
-        auto* const tor = hash ? handshake->session->torrents().get(*hash) : nullptr;
+        auto const info = hash ? handshake->mediator->torrentInfo(*hash) : std::nullopt;
 
         /* Don't mark a peer as non-uTP unless it's really a connect failure. */
-        if ((errcode == ETIMEDOUT || errcode == ECONNREFUSED) && tr_isTorrent(tor))
+        if ((errcode == ETIMEDOUT || errcode == ECONNREFUSED) && info)
         {
-            tr_peerMgrSetUtpFailed(tor, io->address(), true);
+            handshake->mediator->setUTPFailed(*hash, io->address());
         }
 
         if (tr_peerIoReconnect(handshake->io) == 0)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -24,7 +24,6 @@
 #include "session.h"
 #include "torrent.h"
 #include "tr-assert.h"
-#include "tr-dht.h"
 #include "utils.h"
 
 using namespace std::literals;
@@ -207,7 +206,7 @@ static bool buildHandshakeMessage(tr_handshake* handshake, uint8_t* buf)
     /* Note that this doesn't depend on whether the torrent is private.
      * We don't accept DHT peers for a private torrent,
      * but we participate in the DHT regardless. */
-    if (tr_dhtEnabled(handshake->session))
+    if (handshake->mediator->isDHTEnabled())
     {
         HANDSHAKE_SET_DHT(walk);
     }

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -108,6 +108,11 @@ enum handshake_state_t
 
 struct tr_handshake
 {
+    tr_handshake(std::shared_ptr<tr_handshake_mediator> mediator_in)
+        : mediator{ std::move(mediator_in) }
+    {
+    }
+
     ~tr_handshake()
     {
         if (io != nullptr)
@@ -122,6 +127,8 @@ struct tr_handshake
     {
         return io->isIncoming();
     }
+
+    std::shared_ptr<tr_handshake_mediator> const mediator;
 
     bool haveReadAnythingFromPeer;
     bool haveSentBitTorrentHandshake;
@@ -1191,6 +1198,7 @@ static void handshakeTimeout(evutil_socket_t /*s*/, short /*type*/, void* handsh
 }
 
 tr_handshake* tr_handshakeNew(
+    std::shared_ptr<tr_handshake_mediator> mediator,
     tr_peerIo* io,
     tr_encryption_mode encryptionMode,
     tr_handshake_done_func done_func,
@@ -1198,7 +1206,7 @@ tr_handshake* tr_handshakeNew(
 {
     tr_session* session = tr_peerIoGetSession(io);
 
-    auto* const handshake = new tr_handshake{};
+    auto* const handshake = new tr_handshake{ std::move(mediator) };
     handshake->io = io;
     handshake->crypto = tr_peerIoGetCrypto(io);
     handshake->encryptionMode = encryptionMode;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -15,8 +15,8 @@
 #include <fmt/format.h>
 
 #include "transmission.h"
+
 #include "clients.h"
-#include "crypto-utils.h"
 #include "handshake.h"
 #include "log.h"
 #include "peer-io.h"

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -20,7 +20,6 @@
 #include "handshake.h"
 #include "log.h"
 #include "peer-io.h"
-#include "session.h"
 #include "tr-assert.h"
 #include "utils.h"
 
@@ -131,7 +130,6 @@ struct tr_handshake
     bool haveSentBitTorrentHandshake;
     tr_peerIo* io;
     tr_crypto* crypto;
-    tr_session* session;
     handshake_state_t state;
     tr_encryption_mode encryptionMode;
     uint16_t pad_c_len;
@@ -1196,16 +1194,13 @@ tr_handshake* tr_handshakeNew(
     tr_handshake_done_func done_func,
     void* done_func_user_data)
 {
-    tr_session* session = tr_peerIoGetSession(io);
-
     auto* const handshake = new tr_handshake{ std::move(mediator) };
     handshake->io = io;
     handshake->crypto = tr_peerIoGetCrypto(io);
     handshake->encryptionMode = encryptionMode;
     handshake->done_func = done_func;
     handshake->done_func_user_data = done_func_user_data;
-    handshake->session = session;
-    handshake->timeout_timer = evtimer_new(session->event_base, handshakeTimeout, handshake);
+    handshake->timeout_timer = evtimer_new(handshake->mediator->eventBase(), handshakeTimeout, handshake);
     tr_timerAdd(*handshake->timeout_timer, HANDSHAKE_TIMEOUT_SEC, 0);
 
     tr_peerIoRef(io); /* balanced by the unref in ~tr_handshake() */

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -14,6 +14,8 @@
 
 #include "transmission.h"
 
+#include "net.h" // tr_address
+
 /** @addtogroup peers Peers
     @{ */
 
@@ -44,6 +46,8 @@ public:
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const = 0;
 
     [[nodiscard]] virtual bool isDHTEnabled() const = 0;
+
+    virtual void setUTPFailed(tr_sha1_digest_t const& info_hash, tr_address) = 0;
 };
 
 /* returns true on success, false on error */

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -41,7 +41,9 @@ public:
         tr_peer_id_t client_peer_id;
     };
 
-    virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) = 0;
+    [[nodiscard]] virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const = 0;
+
+    [[nodiscard]] virtual bool isDHTEnabled() const = 0;
 };
 
 /* returns true on success, false on error */

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <optional>
+#include <memory>
 
 #include "transmission.h"
 
@@ -32,11 +33,17 @@ struct tr_handshake_result
     std::optional<tr_peer_id_t> peer_id;
 };
 
+class tr_handshake_mediator
+{
+public:
+};
+
 /* returns true on success, false on error */
 using tr_handshake_done_func = bool (*)(tr_handshake_result const& result);
 
 /** @brief create a new handshake */
 tr_handshake* tr_handshakeNew(
+    std::shared_ptr<tr_handshake_mediator> mediator,
     tr_peerIo* io,
     tr_encryption_mode encryption_mode,
     tr_handshake_done_func when_done,

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -24,6 +24,7 @@ class tr_peerIo;
 /** @brief opaque struct holding hanshake state information.
            freed when the handshake is completed. */
 struct tr_handshake;
+struct event_base;
 
 struct tr_handshake_result
 {
@@ -49,6 +50,8 @@ public:
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const = 0;
 
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfoFromObfuscated(tr_sha1_digest_t const& info_hash) const = 0;
+
+    [[nodiscard]] virtual event_base* eventBase() const = 0;
 
     [[nodiscard]] virtual bool isDHTEnabled() const = 0;
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -36,6 +36,12 @@ struct tr_handshake_result
 class tr_handshake_mediator
 {
 public:
+    struct torrent_info
+    {
+        tr_peer_id_t client_peer_id;
+    };
+
+    virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) = 0;
 };
 
 /* returns true on success, false on error */

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -40,12 +40,19 @@ class tr_handshake_mediator
 public:
     struct torrent_info
     {
+        tr_sha1_digest_t info_hash;
         tr_peer_id_t client_peer_id;
+        tr_torrent_id_t id;
+        bool is_done;
     };
 
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const = 0;
 
+    [[nodiscard]] virtual std::optional<torrent_info> torrentInfoFromObfuscated(tr_sha1_digest_t const& info_hash) const = 0;
+
     [[nodiscard]] virtual bool isDHTEnabled() const = 0;
+
+    [[nodiscard]] virtual bool isPeerKnownSeed(tr_torrent_id_t tor_id, tr_address addr) const = 0;
 
     virtual void setUTPFailed(tr_sha1_digest_t const& info_hash, tr_address) = 0;
 };

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -92,6 +92,14 @@ public:
         return tr_dhtEnabled(&session_);
     }
 
+    void setUTPFailed(tr_sha1_digest_t const& info_hash, tr_address addr) override
+    {
+        if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
+        {
+            tr_peerMgrSetUtpFailed(tor, addr, true);
+        }
+    }
+
 private:
     tr_session& session_;
 };

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -63,8 +63,31 @@ static auto constexpr CancelHistorySec = int{ 60 };
 ***
 **/
 
-class tr_handshake_mediator_impl : public tr_handshake_mediator
+class tr_handshake_mediator_impl final : public tr_handshake_mediator
 {
+public:
+    tr_handshake_mediator_impl(tr_session& session)
+        : session_{ session }
+    {
+    }
+
+    virtual ~tr_handshake_mediator_impl() = default;
+
+    std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) override
+    {
+        auto* const tor = session_.torrents().get(info_hash);
+        if (tor == nullptr)
+        {
+            return {};
+        }
+
+        auto info = torrent_info{};
+        info.client_peer_id = tr_torrentGetPeerId(tor);
+        return info;
+    }
+
+private:
+    tr_session& session_;
 };
 
 /**
@@ -1197,7 +1220,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     }
     else /* we don't have a connection to them yet... */
     {
-        auto mediator = std::make_shared<tr_handshake_mediator_impl>();
+        auto mediator = std::make_shared<tr_handshake_mediator_impl>(*session);
         tr_peerIo* const io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket);
         tr_handshake* const handshake = tr_handshakeNew(mediator, io, session->encryptionMode, on_handshake_done, manager);
 
@@ -2774,7 +2797,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     }
     else
     {
-        auto mediator = std::make_shared<tr_handshake_mediator_impl>();
+        auto mediator = std::make_shared<tr_handshake_mediator_impl>(*mgr->session);
         tr_handshake* handshake = tr_handshakeNew(mediator, io, mgr->session->encryptionMode, on_handshake_done, mgr);
 
         TR_ASSERT(io->torrentHash());

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -45,6 +45,7 @@
 #include "stats.h" /* tr_statsAddUploaded, tr_statsAddDownloaded */
 #include "torrent.h"
 #include "tr-assert.h"
+#include "tr-dht.h"
 #include "tr-utp.h"
 #include "utils.h"
 #include "webseed.h"
@@ -73,7 +74,7 @@ public:
 
     virtual ~tr_handshake_mediator_impl() = default;
 
-    std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) override
+    [[nodiscard]] std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const override
     {
         auto* const tor = session_.torrents().get(info_hash);
         if (tor == nullptr)
@@ -84,6 +85,11 @@ public:
         auto info = torrent_info{};
         info.client_peer_id = tr_torrentGetPeerId(tor);
         return info;
+    }
+
+    [[nodiscard]] bool isDHTEnabled() const override
+    {
+        return tr_dhtEnabled(&session_);
     }
 
 private:

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -63,6 +63,10 @@ static auto constexpr CancelHistorySec = int{ 60 };
 ***
 **/
 
+class tr_handshake_mediator_impl : public tr_handshake_mediator
+{
+};
+
 /**
  * Peer information that should be kept even before we've connected and
  * after we've disconnected. These are kept in a pool of peer_atoms to decide
@@ -1193,8 +1197,9 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     }
     else /* we don't have a connection to them yet... */
     {
+        auto mediator = std::make_shared<tr_handshake_mediator_impl>();
         tr_peerIo* const io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket);
-        tr_handshake* const handshake = tr_handshakeNew(io, session->encryptionMode, on_handshake_done, manager);
+        tr_handshake* const handshake = tr_handshakeNew(mediator, io, session->encryptionMode, on_handshake_done, manager);
 
         tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
 
@@ -2769,7 +2774,8 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     }
     else
     {
-        tr_handshake* handshake = tr_handshakeNew(io, mgr->session->encryptionMode, on_handshake_done, mgr);
+        auto mediator = std::make_shared<tr_handshake_mediator_impl>();
+        tr_handshake* handshake = tr_handshakeNew(mediator, io, mgr->session->encryptionMode, on_handshake_done, mgr);
 
         TR_ASSERT(io->torrentHash());
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -122,6 +122,11 @@ public:
         return tor != nullptr && tr_peerMgrPeerIsSeed(tor, addr);
     }
 
+    [[nodiscard]] event_base* eventBase() const override
+    {
+        return session_.event_base;
+    }
+
 private:
     tr_session& session_;
 };

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -110,8 +110,6 @@ tr_peerMgr* tr_peerMgrNew(tr_session* session);
 
 void tr_peerMgrFree(tr_peerMgr* manager);
 
-bool tr_peerMgrPeerIsSeed(tr_torrent const* tor, tr_address const& addr);
-
 void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr);
 
 void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const& addr, bool failed);


### PR DESCRIPTION
No functional changes.

This adds a shim between the handshake code and the rest of the codebase to improve decoupling so that a followup PR can add handshake unit tests / regression tests.

The handshake code no longer directly relies on tr_torrent, tr_session, tr_dht, or tr_peerMgr.