### PR TITLE
option to disable TCP

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1095,7 +1095,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
             handshake->mediator->setUTPFailed(*hash, io->address());
         }
 
-        if (tr_peerIoReconnect(handshake->io) == 0)
+        if (handshake->mediator->allowsTCP() && tr_peerIoReconnect(handshake->io) == 0)
         {
             auto msg = std::array<uint8_t, HANDSHAKE_SIZE>{};
             buildHandshakeMessage(handshake, std::data(msg));
@@ -1109,7 +1109,8 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
      * have encountered a peer that doesn't do encryption... reconnect and
      * try a plaintext handshake */
     if ((handshake->state == AWAITING_YB || handshake->state == AWAITING_VC) &&
-        handshake->encryption_mode != TR_ENCRYPTION_REQUIRED && tr_peerIoReconnect(handshake->io) == 0)
+        handshake->encryption_mode != TR_ENCRYPTION_REQUIRED && handshake->mediator->allowsTCP() &&
+        tr_peerIoReconnect(handshake->io) == 0)
     {
         auto msg = std::array<uint8_t, HANDSHAKE_SIZE>{};
         tr_logAddTraceHand(handshake, "handshake failed, trying plaintext...");

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -57,6 +57,8 @@ public:
 
     [[nodiscard]] virtual bool isDHTEnabled() const = 0;
 
+    [[nodiscard]] virtual bool allowsTCP() const = 0;
+
     [[nodiscard]] virtual bool isPeerKnownSeed(tr_torrent_id_t tor_id, tr_address addr) const = 0;
 
     [[nodiscard]] virtual size_t pad(void* setme, size_t max_bytes) const = 0;

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -284,6 +284,11 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
 {
     TR_ASSERT(tr_address_is_valid(addr));
 
+    if (!session->allowsTCP())
+    {
+        return {};
+    }
+
     if (!tr_address_is_valid_for_peers(addr, port))
     {
         return {};

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -511,6 +511,7 @@ tr_peerIo* tr_peerIoNew(
 #else
     TR_ASSERT(socket.type == TR_PEER_SOCKET_TYPE_TCP);
 #endif
+    TR_ASSERT(session->allowsTCP() || socket.type != TR_PEER_SOCKET_TYPE_TCP);
 
     if (socket.type == TR_PEER_SOCKET_TYPE_TCP)
     {
@@ -588,6 +589,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
 {
     TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_address_is_valid(addr));
+    TR_ASSERT(utp || session->allowsTCP());
 
     auto socket = tr_peer_socket{};
 
@@ -831,6 +833,7 @@ int tr_peerIoReconnect(tr_peerIo* io)
 {
     TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(!io->isIncoming());
+    TR_ASSERT(io->session->allowsTCP());
 
     tr_session* session = tr_peerIoGetSession(io);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -113,6 +113,11 @@ public:
         return tr_dhtEnabled(&session_);
     }
 
+    [[nodiscard]] bool allowsTCP() const override
+    {
+        return session_.allowsTCP();
+    }
+
     void setUTPFailed(tr_sha1_digest_t const& info_hash, tr_address addr) override
     {
         if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
@@ -2822,6 +2827,11 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
            originally came from PEX and doesn't have the uTP flag, skip the
            uTP connection attempt.  Are we being optimistic here? */
         utp = utp && (atom.flags & ADDED_F_UTP_FLAGS) != 0;
+    }
+
+    if (!utp && !mgr->session->allowsTCP())
+    {
+        return;
     }
 
     tr_logAddTraceSwarm(s, fmt::format("Starting an OUTGOING {} connection with {}", utp ? " µTP" : "TCP", atom.readable()));

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr my_static = std::array<std::string_view, 398>{ ""sv,
+auto constexpr my_static = std::array<std::string_view, 399>{ ""sv,
                                                               "activeTorrentCount"sv,
                                                               "activity-date"sv,
                                                               "activityDate"sv,
@@ -361,6 +361,7 @@ auto constexpr my_static = std::array<std::string_view, 398>{ ""sv,
                                                               "status"sv,
                                                               "statusbar-stats"sv,
                                                               "tag"sv,
+                                                              "tcp-enabled"sv,
                                                               "tier"sv,
                                                               "time-checked"sv,
                                                               "torrent-added"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -364,6 +364,7 @@ enum
     TR_KEY_status,
     TR_KEY_statusbar_stats,
     TR_KEY_tag,
+    TR_KEY_tcp_enabled,
     TR_KEY_tier,
     TR_KEY_time_checked,
     TR_KEY_torrent_added,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2184,6 +2184,10 @@ static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         tr_variantDictAddBool(d, key, s->allowsPEX());
         break;
 
+    case TR_KEY_tcp_enabled:
+        tr_variantDictAddBool(d, key, s->allowsTCP());
+        break;
+
     case TR_KEY_utp_enabled:
         tr_variantDictAddBool(d, key, s->allowsUTP());
         break;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -603,6 +603,11 @@ public:
         return is_pex_enabled_;
     }
 
+    [[nodiscard]] auto constexpr allowsTCP() const noexcept
+    {
+        return is_tcp_enabled_;
+    }
+
     [[nodiscard]] bool allowsUTP() const noexcept;
 
     [[nodiscard]] auto constexpr allowsPrefetch() const noexcept
@@ -805,6 +810,7 @@ private:
     bool is_pex_enabled_ = false;
     bool is_dht_enabled_ = false;
     bool is_lpd_enabled_ = false;
+    bool is_tcp_enabled_ = true;
 
     bool is_idle_limited_ = false;
     bool is_prefetch_enabled_ = false;

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -78,6 +78,11 @@ public:
         return false;
     }
 
+    [[nodiscard]] bool allowsTCP() const override
+    {
+        return true;
+    }
+
     [[nodiscard]] bool isPeerKnownSeed(tr_torrent_id_t /*tor_id*/, tr_address /*addr*/) const override
     {
         return false;

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -93,7 +93,7 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 
     // what we expected
-    auto const expected_keys = std::array<tr_quark, 58>{
+    auto const expected_keys = std::array<tr_quark, 59>{
         TR_KEY_alt_speed_down,
         TR_KEY_alt_speed_enabled,
         TR_KEY_alt_speed_time_begin,
@@ -148,6 +148,7 @@ TEST_F(RpcTest, sessionGet)
         TR_KEY_speed_limit_up,
         TR_KEY_speed_limit_up_enabled,
         TR_KEY_start_added_torrents,
+        TR_KEY_tcp_enabled,
         TR_KEY_trash_original_torrent_files,
         TR_KEY_units,
         TR_KEY_utp_enabled,


### PR DESCRIPTION
This adds an option to disable TCP connections. This is desirable for several reasons, but in my case it is due to congestion. Even one TCP connection can cause congestion on a normally functioning router and ISP, so the proposed solution in #1519 is not sufficient.

A few notes on this patch:

- it does not disconnect existing TCP connections or in progress handshakes when toggled
- it might disable web-seeds. unclear if this is desirable or not
- I only added UI for English on macOS, because those are what I use
