### PR TITLE
tr_makeMetaInfo: new anonymize option (closes #3420)

### DIFF
--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -315,6 +315,7 @@ void MakeDialog::Impl::onResponse(int response)
                 0,
                 useComment ? comment.c_str() : nullptr,
                 isPrivate,
+                false,
                 useSource ? source.c_str() : nullptr);
         }
     }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -501,8 +501,11 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
             tr_variantDictAddStr(&top, TR_KEY_comment, builder->comment);
         }
 
-        tr_variantDictAddStrView(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
-        tr_variantDictAddInt(&top, TR_KEY_creation_date, time(nullptr));
+        if (! builder->anonymize)
+        {
+          tr_variantDictAddStrView(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
+          tr_variantDictAddInt(&top, TR_KEY_creation_date, time(nullptr));
+        }
         tr_variantDictAddStrView(&top, TR_KEY_encoding, "UTF-8");
         makeInfoDict(tr_variantDictAddDict(&top, TR_KEY_info, 666), builder);
     }
@@ -577,6 +580,7 @@ void tr_makeMetaInfo(
     int webseedCount,
     char const* comment,
     bool isPrivate,
+    bool anonymize,
     char const* source)
 {
     /* free any variables from a previous run */
@@ -613,6 +617,7 @@ void tr_makeMetaInfo(
 
     builder->comment = tr_strdup(comment);
     builder->isPrivate = isPrivate;
+    builder->anonymize = anonymize;
     builder->source = tr_strdup(source);
 
     builder->outputFile = !tr_str_is_empty(outputFile) ? tr_strdup(outputFile) :

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -501,10 +501,10 @@ static void tr_realMakeMetaInfo(tr_metainfo_builder* builder)
             tr_variantDictAddStr(&top, TR_KEY_comment, builder->comment);
         }
 
-        if (! builder->anonymize)
+        if (!builder->anonymize)
         {
-          tr_variantDictAddStrView(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
-          tr_variantDictAddInt(&top, TR_KEY_creation_date, time(nullptr));
+            tr_variantDictAddStrView(&top, TR_KEY_created_by, TR_NAME "/" LONG_VERSION_STRING);
+            tr_variantDictAddInt(&top, TR_KEY_creation_date, time(nullptr));
         }
         tr_variantDictAddStrView(&top, TR_KEY_encoding, "UTF-8");
         makeInfoDict(tr_variantDictAddDict(&top, TR_KEY_info, 666), builder);

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -62,6 +62,7 @@ struct tr_metainfo_builder
     char* outputFile;
     bool isPrivate;
     char* source;
+    bool anonymize;
 
     /**
     ***  These are set inside tr_makeMetaInfo() so the client
@@ -128,4 +129,5 @@ void tr_makeMetaInfo(
     int n_webseeds,
     char const* comment,
     bool is_private,
+    bool anonymize,
     char const* source);

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -626,6 +626,7 @@ NSMutableSet* creatorWindowControllerSet = nil;
         0,
         self.fCommentView.string.UTF8String,
         self.fPrivateCheck.state == NSControlStateValueOn,
+        NO,
         self.fSource.stringValue.UTF8String);
     tr_free(trackerInfo);
 

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -193,6 +193,7 @@ void MakeDialog::makeTorrent()
         0,
         comment.isEmpty() ? nullptr : comment.toUtf8().constData(),
         ui_.privateCheck->isChecked(),
+        false,
         source.isNull() ? nullptr : source.toUtf8().constData());
 
     // pop up the dialog

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -42,6 +42,7 @@ protected:
         size_t const payloadSize,
         char const* comment,
         bool isPrivate,
+        bool anonymize,
         std::string_view source)
     {
 
@@ -69,8 +70,10 @@ protected:
             webseedCount,
             comment,
             isPrivate,
+            anonymize,
             std::string(source).c_str());
         EXPECT_EQ(isPrivate, builder->isPrivate);
+        EXPECT_EQ(anonymize, builder->anonymize);
         EXPECT_EQ(torrent_file, builder->outputFile);
         EXPECT_STREQ(comment, builder->comment);
         EXPECT_EQ(source, builder->source);
@@ -110,6 +113,7 @@ protected:
         size_t const payload_count,
         char const* comment,
         bool const is_private,
+        bool const anonymize,
         char const* source)
     {
         // create the top temp directory
@@ -158,8 +162,10 @@ protected:
             webseed_count,
             comment,
             is_private,
+            anonymize,
             source);
         EXPECT_EQ(is_private, builder->isPrivate);
+        EXPECT_EQ(anonymize, builder->anonymize);
         EXPECT_EQ(torrent_file, builder->outputFile);
         EXPECT_STREQ(comment, builder->comment);
         EXPECT_STREQ(source, builder->source);
@@ -197,6 +203,7 @@ protected:
         size_t const max_file_size,
         char const* comment,
         bool const is_private,
+        bool const anonymize,
         char const* source)
     {
         // build random payloads
@@ -223,6 +230,7 @@ protected:
             payload_count,
             comment,
             is_private,
+            anonymize,
             source);
 
         // cleanup
@@ -249,6 +257,7 @@ TEST_F(MakemetaTest, singleFile)
     auto const payload = std::string{ "Hello, World!\n" };
     char const* const comment = "This is the comment";
     bool const is_private = false;
+    bool const anonymize = false;
     auto metainfo = tr_torrent_metainfo{};
     testSingleFileImpl(
         metainfo,
@@ -260,6 +269,7 @@ TEST_F(MakemetaTest, singleFile)
         payload.size(),
         comment,
         is_private,
+        anonymize,
         "TESTME"sv);
 }
 
@@ -273,6 +283,7 @@ TEST_F(MakemetaTest, webseed)
     auto const payload = std::string{ "Hello, World!\n" };
     char const* const comment = "This is the comment";
     bool const is_private = false;
+    bool const anonymize = false;
     auto metainfo = tr_torrent_metainfo{};
     testSingleFileImpl(
         metainfo,
@@ -284,6 +295,7 @@ TEST_F(MakemetaTest, webseed)
         payload.size(),
         comment,
         is_private,
+        anonymize,
         "TESTME"sv);
 }
 
@@ -300,6 +312,7 @@ TEST_F(MakemetaTest, singleFileDifferentSourceFlags)
     auto const payload = std::string{ "Hello, World!\n" };
     char const* const comment = "This is the comment";
     bool const is_private = false;
+    bool const anonymize = false;
 
     auto metainfo_foobar = tr_torrent_metainfo{};
     testSingleFileImpl(
@@ -312,6 +325,7 @@ TEST_F(MakemetaTest, singleFileDifferentSourceFlags)
         payload.size(),
         comment,
         is_private,
+        anonymize,
         "FOOBAR"sv);
 
     auto metainfo_testme = tr_torrent_metainfo{};
@@ -325,6 +339,7 @@ TEST_F(MakemetaTest, singleFileDifferentSourceFlags)
         payload.size(),
         comment,
         is_private,
+        anonymize,
         "TESTME"sv);
 
     EXPECT_NE(metainfo_foobar.infoHash(), metainfo_testme.infoHash());
@@ -345,6 +360,7 @@ TEST_F(MakemetaTest, singleDirectoryRandomPayload)
     ++tracker_count;
     char const* const comment = "This is the comment";
     bool const is_private = false;
+    bool const anonymize = false;
     char const* const source = "TESTME";
 
     for (size_t i = 0; i < 10; ++i)
@@ -358,6 +374,7 @@ TEST_F(MakemetaTest, singleDirectoryRandomPayload)
             DefaultMaxFileSize,
             comment,
             is_private,
+            anonymize,
             source);
     }
 }

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -35,7 +35,7 @@ char constexpr Usage[] = "Usage: transmission-create [options] <file|directory>"
 
 uint32_t constexpr KiB = 1024;
 
-auto constexpr Options = std::array<tr_option, 9>{
+auto constexpr Options = std::array<tr_option, 10>{
     { { 'p', "private", "Allow this torrent to only be used with the specified tracker(s)", "p", false, nullptr },
       { 'r', "source", "Set the source for private trackers", "r", true, "<source>" },
       { 'o', "outfile", "Save the generated .torrent to this filename", "o", true, "<file>" },
@@ -43,6 +43,7 @@ auto constexpr Options = std::array<tr_option, 9>{
       { 'c', "comment", "Add a comment", "c", true, "<comment>" },
       { 't', "tracker", "Add a tracker's announce URL", "t", true, "<url>" },
       { 'w', "webseed", "Add a webseed URL", "w", true, "<url>" },
+      { 'x', "anonymize", "Omit \"Creation date\" and \"Created by\" info", nullptr, false, nullptr},
       { 'V', "version", "Show version number and exit", "V", false, nullptr },
       { 0, nullptr, nullptr, nullptr, false, nullptr } }
 };
@@ -58,6 +59,7 @@ struct app_options
     uint32_t piecesize_kib = 0;
     bool is_private = false;
     bool show_version = false;
+    bool anonymize = false;
 };
 
 int parseCommandLine(app_options& options, int argc, char const* const* argv)
@@ -109,6 +111,10 @@ int parseCommandLine(app_options& options, int argc, char const* const* argv)
 
         case 'r':
             options.source = optarg;
+            break;
+
+        case 'x':
+            options.anonymize = true;
             break;
 
         case TR_OPT_UNK:
@@ -241,6 +247,7 @@ int tr_main(int argc, char* argv[])
         static_cast<int>(std::size(options.webseeds)),
         options.comment,
         options.is_private,
+        options.anonymize,
         options.source);
 
     uint32_t last = UINT32_MAX;

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -43,7 +43,7 @@ auto constexpr Options = std::array<tr_option, 10>{
       { 'c', "comment", "Add a comment", "c", true, "<comment>" },
       { 't', "tracker", "Add a tracker's announce URL", "t", true, "<url>" },
       { 'w', "webseed", "Add a webseed URL", "w", true, "<url>" },
-      { 'x', "anonymize", "Omit \"Creation date\" and \"Created by\" info", nullptr, false, nullptr},
+      { 'x', "anonymize", "Omit \"Creation date\" and \"Created by\" info", nullptr, false, nullptr },
       { 'V', "version", "Show version number and exit", "V", false, nullptr },
       { 0, nullptr, nullptr, nullptr, false, nullptr } }
 };

--- a/utils/transmission-create.1
+++ b/utils/transmission-create.1
@@ -38,6 +38,10 @@ Add a tracker's
 to the .torrent. Most torrents will have at least one
 .Ar announce URL.
 To add more than one, use this option multiple times.
+.It Fl -anonymize
+Omit the optional "created by" and "created date" keys from the
+generated torrent which otherwise default to the Transmission version
+number and the current date.
 .El
 .Sh AUTHORS
 .An -nosplit


### PR DESCRIPTION
* libtransmission/makemeta.cc (tr_makeMetaInfo): new argument omitPII.
  (tr_realMakeMetaInfo): skip addition of TR_KEY_created_by and
  TR_KEY_creation_date if omitting PII.
* libtransmission/makemeta.h (tr_metainfo_builder, tr_makeMetaInfo):
  new omitPII field and function argument.
* macosx/CreatorWindowController.mm: adjust call to tr_makeMetaInfo
  default to false (maintains previous behaviour)
* gtk/MakeDialog.cc: adjust call to tr_makeMetaInfo default to false
  (maintains previous behaviour)
* qt/MakeDialog.cc: adjust call to tr_makeMetaInfo default to false
  (maintains previous behaviour)
* tests/libtransmission/makemeta-test.cc: adjust calls to
  tr_makeMetaInfo defaulting to false.
* utils/create.cc: new '--omit-pii' option without one letter form.
* utils/transmission-create.1: document new '--omit-pii' option.