### PR TITLE
Add announce-ip and announce-ip-enabled parameters.

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -32,6 +32,10 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
 ```
 
 ### Options
+#### IP Announce
+ * **announce-ip:** String (default = "") Alternative IP address to announce to tracker.
+ * **announce-ip-enabled:** Boolean (default = false) When enabled **announce-ip** value is used instead of client's address visible to tracker for announcement requests.
+
 #### Bandwidth
  * **alt-speed-enabled:** Boolean (default = false, aka 'Turtle Mode')
    _Note: Clicking the "Turtle" in the GUI when the [scheduler](#Scheduling) is enabled, will only temporarily remove the scheduled limit until the next cycle._

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -124,9 +124,11 @@ static std::string format_ipv6_url_arg(unsigned char const* ipv6_address)
     return arg;
 }
 
-static std::string format_ip_arg(std::string const& ip)
+static std::string format_ip_arg(std::string_view ip)
 {
-    return "&ip="s + ip;
+    auto arg = std::string{ "&ip="sv };
+    arg += ip;
+    return arg;
 }
 
 static void verboseLog(std::string_view description, tr_direction direction, std::string_view message)

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -124,6 +124,11 @@ static std::string format_ipv6_url_arg(unsigned char const* ipv6_address)
     return arg;
 }
 
+static std::string format_ip_arg(std::string const& ip)
+{
+    return "&ip="s + ip;
+}
+
 static void verboseLog(std::string_view description, tr_direction direction, std::string_view message)
 {
     auto& out = std::cerr;
@@ -437,7 +442,11 @@ void tr_tracker_http_announce(
     static bool const use_curl_workaround = curl_version_info(CURLVERSION_NOW)->version_num < CURL_VERSION_BITS(7, 77, 0);
     if (use_curl_workaround)
     {
-        if (ipv6 != nullptr)
+        if (session->useAnnounceIP())
+        {
+            options.url += format_ip_arg(session->announceIP());
+        }
+        else if (ipv6 != nullptr)
         {
             if (auto public_ipv4 = session->externalIP(); public_ipv4.has_value())
             {
@@ -451,7 +460,16 @@ void tr_tracker_http_announce(
     }
     else
     {
-        if (ipv6 != nullptr)
+        if (session->useAnnounceIP() || ipv6 == nullptr)
+        {
+            if (session->useAnnounceIP())
+            {
+                options.url += format_ip_arg(session->announceIP());
+            }
+            d->requests_sent_count = 1;
+            do_make_request(""sv, std::move(options));
+        }
+        else
         {
             d->requests_sent_count = 2;
 
@@ -470,11 +488,6 @@ void tr_tracker_http_announce(
             }
             options.ip_proto = tr_web::FetchOptions::IPProtocol::V6;
             do_make_request("IPv6"sv, std::move(options));
-        }
-        else
-        {
-            d->requests_sent_count = 1;
-            do_make_request(""sv, std::move(options));
         }
     }
 }

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -84,7 +84,8 @@ static int tau_sendto(tr_session const* session, struct evutil_addrinfo* ai, tr_
 
 static uint32_t announce_ip(tr_session const* session)
 {
-    if (!session->useAnnounceIP()) {
+    if (!session->useAnnounceIP())
+    {
         return 0;
     }
 

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -82,6 +82,23 @@ static int tau_sendto(tr_session const* session, struct evutil_addrinfo* ai, tr_
     return sendto(sockfd, static_cast<char const*>(buf), buflen, 0, ai->ai_addr, ai->ai_addrlen);
 }
 
+static uint32_t announce_ip(tr_session const* session)
+{
+    if (!session->useAnnounceIP()) {
+        return 0;
+    }
+
+    tr_address ta;
+    // Since size of IP field is only 4 bytes long we can announce
+    // only IPv4 addresses.
+    if (!tr_address_from_string(&ta, session->announceIP()) || (ta.type != TR_AF_INET))
+    {
+        return 0;
+    }
+
+    return ta.addr.addr4.s_addr;
+}
+
 /****
 *****
 ****/
@@ -351,6 +368,7 @@ static tau_announce_event get_tau_announce_event(tr_announce_event e)
 }
 
 static tau_announce_request make_tau_announce_request(
+    tr_session const* session,
     tr_announce_request const* in,
     tr_announce_response_func callback,
     void* user_data)
@@ -367,7 +385,7 @@ static tau_announce_request make_tau_announce_request(
     evbuffer_add_hton_64(buf, in->leftUntilComplete);
     evbuffer_add_hton_64(buf, in->up);
     evbuffer_add_hton_32(buf, get_tau_announce_event(in->event));
-    evbuffer_add_hton_32(buf, 0);
+    evbuffer_add_hton_32(buf, announce_ip(session));
     evbuffer_add_hton_32(buf, in->key);
     evbuffer_add_hton_32(buf, in->numwant);
     evbuffer_add_hton_16(buf, in->port.host());
@@ -902,7 +920,7 @@ void tr_tracker_udp_announce(
         return;
     }
 
-    tracker->announces.push_back(make_tau_announce_request(request, response_func, user_data));
+    tracker->announces.push_back(make_tau_announce_request(session, request, response_func, user_data));
     tau_tracker_upkeep_ex(tracker, false);
 }
 

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
+auto constexpr my_static = std::array<std::string_view, 394>{ ""sv,
                                                               "activeTorrentCount"sv,
                                                               "activity-date"sv,
                                                               "activityDate"sv,
@@ -37,6 +37,8 @@ auto constexpr my_static = std::array<std::string_view, 392>{ ""sv,
                                                               "alt-speed-time-end"sv,
                                                               "alt-speed-up"sv,
                                                               "announce"sv,
+                                                              "announce-ip"sv,
+                                                              "announce-ip-enabled"sv,
                                                               "announce-list"sv,
                                                               "announceState"sv,
                                                               "anti-brute-force-enabled"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -40,6 +40,8 @@ enum
     TR_KEY_alt_speed_time_end, /* rpc, settings */
     TR_KEY_alt_speed_up, /* rpc, settings */
     TR_KEY_announce, /* metainfo */
+    TR_KEY_announce_ip, /* metainfo, settings */
+    TR_KEY_announce_ip_enabled, /* metainfo, settings */
     TR_KEY_announce_list, /* metainfo */
     TR_KEY_announceState, /* rpc */
     TR_KEY_anti_brute_force_enabled, /* rpc */

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -395,6 +395,8 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_trash_original_torrent_files, false);
     tr_variantDictAddInt(d, TR_KEY_anti_brute_force_threshold, 100);
     tr_variantDictAddBool(d, TR_KEY_anti_brute_force_enabled, true);
+    tr_variantDictAddStr(d, TR_KEY_announce_ip, "");
+    tr_variantDictAddBool(d, TR_KEY_announce_ip_enabled, false);
 }
 
 void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
@@ -468,6 +470,8 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_trash_original_torrent_files, tr_sessionGetDeleteSource(s));
     tr_variantDictAddInt(d, TR_KEY_anti_brute_force_threshold, tr_sessionGetAntiBruteForceThreshold(s));
     tr_variantDictAddBool(d, TR_KEY_anti_brute_force_enabled, tr_sessionGetAntiBruteForceEnabled(s));
+    tr_variantDictAddStr(d, TR_KEY_announce_ip, s->announceIP());
+    tr_variantDictAddBool(d, TR_KEY_announce_ip_enabled, s->useAnnounceIP());
     for (auto const& [enabled_key, script_key, script] : tr_session::Scripts)
     {
         tr_variantDictAddBool(d, enabled_key, s->useScript(script));
@@ -1131,6 +1135,19 @@ static void sessionSetImpl(struct init_data* const data)
     if (tr_variantDictFindBool(settings, TR_KEY_anti_brute_force_enabled, &boolVal))
     {
         tr_sessionSetAntiBruteForceEnabled(session, boolVal);
+    }
+
+    /*
+     * Announce IP.
+     */
+    if (tr_variantDictFindStrView(settings, TR_KEY_announce_ip, &sv))
+    {
+        session->setAnnounceIP(sv);
+    }
+
+    if (tr_variantDictFindBool(settings, TR_KEY_announce_ip_enabled, &boolVal))
+    {
+        session->useAnnounceIP(boolVal);
     }
 
     data->done_cv.notify_one();

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -395,7 +395,7 @@ void tr_sessionGetDefaultSettings(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_trash_original_torrent_files, false);
     tr_variantDictAddInt(d, TR_KEY_anti_brute_force_threshold, 100);
     tr_variantDictAddBool(d, TR_KEY_anti_brute_force_enabled, true);
-    tr_variantDictAddStr(d, TR_KEY_announce_ip, "");
+    tr_variantDictAddStrView(d, TR_KEY_announce_ip, "");
     tr_variantDictAddBool(d, TR_KEY_announce_ip_enabled, false);
 }
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -288,6 +288,28 @@ public:
     void closeTorrentFiles(tr_torrent* tor) noexcept;
     void closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noexcept;
 
+    // announce ip
+
+    [[nodiscard]] constexpr auto const& announceIP() const noexcept
+    {
+        return announce_ip_;
+    }
+
+    void setAnnounceIP(std::string_view ip)
+    {
+        announce_ip_ = ip;
+    }
+
+    [[nodiscard]] constexpr auto useAnnounceIP() const noexcept
+    {
+        return announce_ip_enabled_;
+    }
+
+    constexpr void useAnnounceIP(bool enabled) noexcept
+    {
+        announce_ip_enabled_ = enabled;
+    }
+
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
@@ -463,6 +485,9 @@ private:
     bool incomplete_dir_enabled_ = false;
 
     tr_open_files open_files_;
+
+    std::string announce_ip_;
+    bool announce_ip_enabled_ = false;
 };
 
 bool tr_sessionAllowsDHT(tr_session const* session);


### PR DESCRIPTION
This PR adds possibility to user to set custom announce IP address. Announce IP is sent using `ip` URL parameter. UDP announce works for IPv4 addresses only. It addresses https://github.com/transmission/transmission/issues/2477 feature request.

I used https://github.com/transmission/transmission/pull/655 as a reference -- this PR in face a core part of https://github.com/transmission/transmission/pull/655 without GTK/QT clients' changes. It is intended that user will edit `settings.json` and set IP manually. `settings.json` example:
```
    "announce-ip": "11.22.33.44",
    "announce-ip-enabled": true,
```

- - - 
Since it is related to IP announce I'd like to ask a question here. Announce IP using `ipv4` and `ipv6` parameters looks like outdated legacy mechanism. I did a brief research and I'm not sure it is used by modern trackers. Should we consider its deprecation?