### PR TITLE
fixup! refactor: use fmt to build the GTK client's user-visible strings (#2788)

### DIFF
--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -223,8 +223,8 @@ auto getActivityString(
             return fmt::format(
                 ngettext(
                     // xgettext:no-c-format
-                    "Downloading metadata from {active_count} connected peer ({percent_done:d}% done)",
-                    "Downloading metadata from {active_count} connected peers ({percent_done:d}% done)",
+                    "Downloading metadata from {active_count} connected peer ({percent_done}% done)",
+                    "Downloading metadata from {active_count} connected peers ({percent_done}% done)",
                     st->peersConnected),
                 fmt::arg("active_count", st->peersConnected),
                 fmt::arg("percent_done", tr_strpercent(st->metadataPercentComplete * 100.0)));


### PR DESCRIPTION
fix: invalid fmt type when downloading metadata

CC @mikedld since this changes the strings for translation again :dizzy_face: 