### PR TITLE
Use std::optional for torrent date_created to support epoch date (closes #3421)

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -600,9 +600,9 @@ void gtr_text_buffer_set_text(Glib::RefPtr<Gtk::TextBuffer> const& b, Glib::ustr
     }
 }
 
-[[nodiscard]] std::string get_date_string(time_t t)
+[[nodiscard]] std::string get_date_string(std::optional<time_t> const& t)
 {
-    return t == 0 ? _("N/A") : fmt::format(FMT_STRING("{:%x}"), fmt::localtime(t));
+    return t ? fmt::format(FMT_STRING("{:%x}"), fmt::localtime(t.value())) : _("N/A");
 }
 
 [[nodiscard]] std::string get_date_time_string(time_t t)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -515,7 +515,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         break;
 
     case TR_KEY_dateCreated:
-        tr_variantInitInt(initme, tor->dateCreated());
+        tr_variantInitInt(initme, tor->dateCreated().value());
         break;
 
     case TR_KEY_desiredAvailable:

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -197,9 +197,9 @@ static void tr_buildMetainfoExceptInfoDict(tr_torrent_metainfo const& tm, tr_var
         tr_variantDictAddStr(top, TR_KEY_created_by, val);
     }
 
-    if (auto const val = tm.dateCreated(); val != 0)
+    if (auto const& val = tm.dateCreated())
     {
-        tr_variantDictAddInt(top, TR_KEY_creation_date, val);
+        tr_variantDictAddInt(top, TR_KEY_creation_date, val.value());
     }
 
     if (auto const& announce_list = tm.announceList(); !std::empty(announce_list))

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -7,6 +7,7 @@
 
 #include <cstdint> // uint32_t, uint64_t
 #include <ctime>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -230,7 +231,7 @@ private:
     std::string creator_;
     std::string source_;
 
-    time_t date_created_ = 0;
+    std::optional<time_t> date_created_ = {};
 
     // Offset + size of the bencoded info dict subset of the bencoded data.
     // Used when loading pieces of it to sent to magnet peers.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -20,6 +20,7 @@
 ****
 ***/
 
+#include <optional>
 #include <stdbool.h> /* bool */
 #include <stddef.h> /* size_t */
 #include <stdint.h> /* uintN_t */
@@ -1425,7 +1426,7 @@ struct tr_torrent_view
 
     uint64_t total_size; // total size of the torrent, in bytes
 
-    time_t date_created;
+    std::optional<time_t> date_created;
 
     uint32_t piece_size;
     tr_piece_index_t n_pieces;

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -92,8 +92,8 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
     [htmlString appendFormat:@"<p>%@</p>", fileSizeString];
 
     auto const date_created = metainfo.dateCreated();
-    NSString* dateCreatedString = date_created > 0 ?
-        [NSDateFormatter localizedStringFromDate:[NSDate dateWithTimeIntervalSince1970:date_created] dateStyle:NSDateFormatterLongStyle
+    NSString* dateCreatedString = date_created ?
+        [NSDateFormatter localizedStringFromDate:[NSDate dateWithTimeIntervalSince1970:date_created.value()] dateStyle:NSDateFormatterLongStyle
                                        timeStyle:NSDateFormatterShortStyle] :
         nil;
     auto const& creator = metainfo.creator();

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -769,7 +769,7 @@ bool trashDataFile(char const* filename, tr_error** error)
 - (NSDate*)dateCreated
 {
     auto const date = tr_torrentView(self.fHandle).date_created;
-    return date > 0 ? [NSDate dateWithTimeIntervalSince1970:date] : nil;
+    return date ? [NSDate dateWithTimeIntervalSince1970:date.value()] : nil;
 }
 
 - (NSInteger)pieceSize

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <ctime>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -162,9 +163,9 @@ int parseCommandLine(app_opts& opts, int argc, char const* const* argv)
     return 0;
 }
 
-[[nodiscard]] auto toString(time_t now)
+[[nodiscard]] auto toString(std::optional<time_t> const& date)
 {
-    return now == 0 ? "Unknown" : fmt::format("{:%a %b %d %T %Y}", fmt::localtime(now));
+    return date ? fmt::format("{:%a %b %d %T %Y}", fmt::localtime(date.value())) : "Unknown";
 }
 
 bool compareSecondField(std::string_view l, std::string_view r)


### PR DESCRIPTION
As discussed in #3421, a value of zero for the date created field is interpreted as missing/unknown which prevents handling a date with an actual value of zero, i.e., the date for epoch.

I didn't actually build with all the options, only the cli, but still tried to fix the qt, gtk, and macosx. I don't trust myself to get it all right on the first go and I guess the build bots will let me know soon.