### PR TITLE
refactor: replace per-torrent callbacks with per-session ones.

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -828,6 +828,11 @@ Session::Impl::Impl(Session& core, tr_session* session)
     on_pref_changed(TR_KEY_peer_limit_global);
     on_pref_changed(TR_KEY_inhibit_desktop_hibernation);
     signal_prefs_changed.connect([this](auto key) { on_pref_changed(key); });
+
+    tr_sessionSetMetadataCallback(
+        session,
+        [](auto* /*session*/, auto* tor2, gpointer impl) { static_cast<Impl*>(impl)->on_torrent_metadata_changed(tor2); },
+        this);
 }
 
 tr_session* Session::close()
@@ -987,10 +992,6 @@ void Session::Impl::add_torrent(tr_torrent* tor, bool do_notify)
             gtr_notify_torrent_added(get_core_ptr(), tr_torrentId(tor));
         }
 
-        tr_torrentSetMetadataCallback(
-            tor,
-            [](auto* tor2, gpointer impl) { static_cast<Impl*>(impl)->on_torrent_metadata_changed(tor2); },
-            this);
         tr_torrentSetCompletenessCallback(
             tor,
             [](auto* tor2, auto completeness, bool was_running, gpointer impl)

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -831,7 +831,13 @@ Session::Impl::Impl(Session& core, tr_session* session)
 
     tr_sessionSetMetadataCallback(
         session,
-        [](auto* /*session*/, auto* tor2, gpointer impl) { static_cast<Impl*>(impl)->on_torrent_metadata_changed(tor2); },
+        [](auto* /*session*/, auto* tor, gpointer impl) { static_cast<Impl*>(impl)->on_torrent_metadata_changed(tor); },
+        this);
+
+    tr_sessionSetCompletenessCallback(
+        session,
+        [](auto* tor, auto completeness, bool was_running, gpointer impl)
+        { static_cast<Impl*>(impl)->on_torrent_completeness_changed(tor, completeness, was_running); },
         this);
 }
 
@@ -991,12 +997,6 @@ void Session::Impl::add_torrent(tr_torrent* tor, bool do_notify)
         {
             gtr_notify_torrent_added(get_core_ptr(), tr_torrentId(tor));
         }
-
-        tr_torrentSetCompletenessCallback(
-            tor,
-            [](auto* tor2, auto completeness, bool was_running, gpointer impl)
-            { static_cast<Impl*>(impl)->on_torrent_completeness_changed(tor2, completeness, was_running); },
-            this);
     }
 }
 

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -93,20 +93,6 @@ bool check_ccrypto_result(CCCryptorStatus result, char const* file, int line)
 
 #define check_result(result) check_ccrypto_result((result), __FILE__, __LINE__)
 
-bool check_ccrypto_pointer(void const* pointer, CCCryptorStatus const* result, char const* file, int line)
-{
-    bool const ret = pointer != nullptr;
-
-    if (!ret)
-    {
-        log_ccrypto_error(*result, file, line);
-    }
-
-    return ret;
-}
-
-#define check_pointer(pointer, result) check_ccrypto_pointer((pointer), (result), __FILE__, __LINE__)
-
 } // namespace
 
 /***

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2546,11 +2546,7 @@ void queuePulse(tr_session* session, tr_direction dir)
         for (auto* tor : tr_sessionGetNextQueuedTorrents(session, dir, n))
         {
             tr_torrentStartNow(tor);
-
-            if (tor->queue_started_callback != nullptr)
-            {
-                (*tor->queue_started_callback)(tor, tor->queue_started_user_data);
-            }
+            session->onQueuedTorrentStarted(tor);
         }
     }
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -3004,3 +3004,8 @@ void tr_sessionSetIdleLimitHitCallback(tr_session* session, tr_session_idle_limi
 {
     session->setIdleLimitHitCallback(cb, user_data);
 }
+
+void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func func, void* user_data)
+{
+    session->setMetadataCallback(func, user_data);
+}

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2990,7 +2990,17 @@ void tr_session::initConfigDir(std::string_view config_dir)
     tr_sys_dir_create(torrent_dir_, TR_SYS_DIR_CREATE_PARENTS, 0777);
 }
 
-void tr_sessionSetQueueStartCallback(tr_session* session, void (*callback)(tr_session*, tr_torrent*), void* user_data)
+void tr_sessionSetQueueStartCallback(tr_session* session, void (*cb)(tr_session*, tr_torrent*, void*), void* user_data)
 {
-    session->setQueueStartCallback(callback, user_data);
+    session->setQueueStartCallback(cb, user_data);
+}
+
+void tr_sessionSetRatioLimitHitCallback(tr_session* session, tr_session_ratio_limit_hit_func cb, void* user_data)
+{
+    session->setRatioLimitHitCallback(cb, user_data);
+}
+
+void tr_sessionSetIdleLimitHitCallback(tr_session* session, tr_session_idle_limit_hit_func cb, void* user_data)
+{
+    session->setIdleLimitHitCallback(cb, user_data);
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -3009,3 +3009,8 @@ void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func
 {
     session->setMetadataCallback(func, user_data);
 }
+
+void tr_sessionSetCompletenessCallback(tr_session* session, tr_torrent_completeness_func cb, void* user_data)
+{
+    session->setTorrentCompletenessCallback(cb, user_data);
+}

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2968,3 +2968,29 @@ void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noe
     this->cache->flushFile(tor, file_num);
     openFiles().closeFile(tor->id(), file_num);
 }
+
+///
+
+void tr_session::initConfigDir(std::string_view config_dir)
+{
+    TR_ASSERT(std::empty(config_dir_));
+
+#if defined(__APPLE__) || defined(_WIN32)
+    auto constexpr ResumeSubdir = "Resume"sv;
+    auto constexpr TorrentSubdir = "Torrents"sv;
+#else
+    auto constexpr ResumeSubdir = "resume"sv;
+    auto constexpr TorrentSubdir = "torrents"sv;
+#endif
+
+    config_dir_ = config_dir;
+    resume_dir_ = tr_strvPath(config_dir, ResumeSubdir);
+    torrent_dir_ = tr_strvPath(config_dir, TorrentSubdir);
+    tr_sys_dir_create(resume_dir_, TR_SYS_DIR_CREATE_PARENTS, 0777);
+    tr_sys_dir_create(torrent_dir_, TR_SYS_DIR_CREATE_PARENTS, 0777);
+}
+
+void tr_sessionSetQueueStartCallback(tr_session* session, void (*callback)(tr_session*, tr_torrent*), void* user_data)
+{
+    session->setQueueStartCallback(callback, user_data);
+}

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2971,25 +2971,6 @@ void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noe
 
 ///
 
-void tr_session::initConfigDir(std::string_view config_dir)
-{
-    TR_ASSERT(std::empty(config_dir_));
-
-#if defined(__APPLE__) || defined(_WIN32)
-    auto constexpr ResumeSubdir = "Resume"sv;
-    auto constexpr TorrentSubdir = "Torrents"sv;
-#else
-    auto constexpr ResumeSubdir = "resume"sv;
-    auto constexpr TorrentSubdir = "torrents"sv;
-#endif
-
-    config_dir_ = config_dir;
-    resume_dir_ = tr_strvPath(config_dir, ResumeSubdir);
-    torrent_dir_ = tr_strvPath(config_dir, TorrentSubdir);
-    tr_sys_dir_create(resume_dir_, TR_SYS_DIR_CREATE_PARENTS, 0777);
-    tr_sys_dir_create(torrent_dir_, TR_SYS_DIR_CREATE_PARENTS, 0777);
-}
-
 void tr_sessionSetQueueStartCallback(tr_session* session, void (*cb)(tr_session*, tr_torrent*, void*), void* user_data)
 {
     session->setQueueStartCallback(cb, user_data);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -310,7 +310,7 @@ public:
         announce_ip_enabled_ = enabled;
     }
 
-    //
+    // callbacks
 
     using queue_start_callback_t = void (*)(tr_session*, tr_torrent*, void* user_data);
 
@@ -325,6 +325,34 @@ public:
         if (queue_start_callback_ != nullptr)
         {
             queue_start_callback_(this, tor, queue_start_user_data_);
+        }
+    }
+
+    void setIdleLimitHitCallback(tr_session_idle_limit_hit_func cb, void* user_data)
+    {
+        idle_limit_hit_callback_ = cb;
+        idle_limit_hit_user_data_ = user_data;
+    }
+
+    void onIdleLimitHit(tr_torrent* tor)
+    {
+        if (idle_limit_hit_callback_ != nullptr)
+        {
+            idle_limit_hit_callback_(this, tor, idle_limit_hit_user_data_);
+        }
+    }
+
+    void setRatioLimitHitCallback(tr_session_ratio_limit_hit_func cb, void* user_data)
+    {
+        ratio_limit_hit_cb_ = cb;
+        ratio_limit_hit_user_data_ = user_data;
+    }
+
+    void onRatioLimitHit(tr_torrent* tor)
+    {
+        if (ratio_limit_hit_cb_ != nullptr)
+        {
+            ratio_limit_hit_cb_(this, tor, ratio_limit_hit_user_data_);
         }
     }
 
@@ -498,6 +526,15 @@ private:
     std::string peer_congestion_algorithm_;
     std::optional<tr_address> external_ip_;
 
+    queue_start_callback_t queue_start_callback_ = nullptr;
+    void* queue_start_user_data_ = nullptr;
+
+    tr_session_idle_limit_hit_func idle_limit_hit_callback_ = nullptr;
+    void* idle_limit_hit_user_data_ = nullptr;
+
+    tr_session_ratio_limit_hit_func ratio_limit_hit_cb_ = nullptr;
+    void* ratio_limit_hit_user_data_ = nullptr;
+
     std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_;
     bool blocklist_enabled_ = false;
     bool incomplete_dir_enabled_ = false;
@@ -506,9 +543,6 @@ private:
 
     std::string announce_ip_;
     bool announce_ip_enabled_ = false;
-
-    queue_start_callback_t queue_start_callback_ = nullptr;
-    void* queue_start_user_data_ = nullptr;
 };
 
 bool tr_sessionAllowsDHT(tr_session const* session);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -310,6 +310,24 @@ public:
         announce_ip_enabled_ = enabled;
     }
 
+    //
+
+    using queue_start_callback_t = void (*)(tr_session*, tr_torrent*, void* user_data);
+
+    void setQueueStartCallback(queue_start_callback_t cb, void* user_data)
+    {
+        queue_start_callback_ = cb;
+        queue_start_user_data_ = user_data;
+    }
+
+    void onQueuedTorrentStarted(tr_torrent* tor)
+    {
+        if (queue_start_callback_ != nullptr)
+        {
+            queue_start_callback_(this, tor, queue_start_user_data_);
+        }
+    }
+
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
@@ -488,6 +506,9 @@ private:
 
     std::string announce_ip_;
     bool announce_ip_enabled_ = false;
+
+    queue_start_callback_t queue_start_callback_ = nullptr;
+    void* queue_start_user_data_ = nullptr;
 };
 
 bool tr_sessionAllowsDHT(tr_session const* session);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -356,6 +356,20 @@ public:
         }
     }
 
+    void setMetadataCallback(tr_session_metadata_func cb, void* user_data)
+    {
+        got_metadata_cb_ = cb;
+        got_metadata_user_data_ = user_data;
+    }
+
+    void onMetadataCompleted(tr_torrent* tor)
+    {
+        if (got_metadata_cb_ != nullptr)
+        {
+            got_metadata_cb_(this, tor, got_metadata_user_data_);
+        }
+    }
+
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
@@ -534,6 +548,9 @@ private:
 
     tr_session_ratio_limit_hit_func ratio_limit_hit_cb_ = nullptr;
     void* ratio_limit_hit_user_data_ = nullptr;
+
+    tr_session_metadata_func got_metadata_cb_ = nullptr;
+    void* got_metadata_user_data_ = nullptr;
 
     std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_;
     bool blocklist_enabled_ = false;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -370,6 +370,20 @@ public:
         }
     }
 
+    void setTorrentCompletenessCallback(tr_torrent_completeness_func cb, void* user_data)
+    {
+        completeness_func_ = cb;
+        completeness_func_user_data_ = user_data;
+    }
+
+    void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness completeness, bool was_running)
+    {
+        if (completeness_func_ != nullptr)
+        {
+            completeness_func_(tor, completeness, was_running, completeness_func_user_data_);
+        }
+    }
+
 public:
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
@@ -551,6 +565,9 @@ private:
 
     tr_session_metadata_func got_metadata_cb_ = nullptr;
     void* got_metadata_user_data_ = nullptr;
+
+    tr_torrent_completeness_func completeness_func_ = nullptr;
+    void* completeness_func_user_data_ = nullptr;
 
     std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_;
     bool blocklist_enabled_ = false;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2576,12 +2576,6 @@ static void torrentSetQueued(tr_torrent* tor, bool queued)
     }
 }
 
-void tr_torrentSetQueueStartCallback(tr_torrent* torrent, void (*callback)(tr_torrent*, void*), void* user_data)
-{
-    torrent->queue_started_callback = callback;
-    torrent->queue_started_user_data = user_data;
-}
-
 /***
 ****
 ****  RENAME

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -486,14 +486,8 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor)
     if (tr_torrentIsSeedRatioDone(tor))
     {
         tr_logAddInfoTor(tor, _("Seed ratio reached; pausing torrent"));
-
         tor->isStopping = true;
-
-        /* maybe notify the client */
-        if (tor->ratio_limit_hit_func != nullptr)
-        {
-            (*tor->ratio_limit_hit_func)(tor, tor->ratio_limit_hit_func_user_data);
-        }
+        tor->session->onRatioLimitHit(tor);
     }
     /* if we're seeding and reach our inactivity limit, stop the torrent */
     else if (tr_torrentIsSeedIdleLimitDone(tor))
@@ -502,12 +496,7 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor)
 
         tor->isStopping = true;
         tor->finishedSeedingByIdle = true;
-
-        /* maybe notify the client */
-        if (tor->idle_limit_hit_func != nullptr)
-        {
-            (*tor->idle_limit_hit_func)(tor, tor->idle_limit_hit_func_user_data);
-        }
+        tor->session->onIdleLimitHit(tor);
     }
 
     if (tor->isStopping)
@@ -1728,22 +1717,6 @@ void tr_torrentSetCompletenessCallback(tr_torrent* tor, tr_torrent_completeness_
 void tr_torrentClearCompletenessCallback(tr_torrent* torrent)
 {
     tr_torrentSetCompletenessCallback(torrent, nullptr, nullptr);
-}
-
-void tr_torrentSetRatioLimitHitCallback(tr_torrent* tor, tr_torrent_ratio_limit_hit_func func, void* user_data)
-{
-    TR_ASSERT(tr_isTorrent(tor));
-
-    tor->ratio_limit_hit_func = func;
-    tor->ratio_limit_hit_func_user_data = user_data;
-}
-
-void tr_torrentSetIdleLimitHitCallback(tr_torrent* tor, tr_torrent_idle_limit_hit_func func, void* user_data)
-{
-    TR_ASSERT(tr_isTorrent(tor));
-
-    tor->idle_limit_hit_func = func;
-    tor->idle_limit_hit_func_user_data = user_data;
 }
 
 static std::string buildLabelsString(tr_torrent const* tor)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -573,8 +573,6 @@ struct torrent_start_opts
 
 static void torrentStart(tr_torrent* tor, torrent_start_opts opts);
 
-static void tr_torrentFireMetadataCompleted(tr_torrent* tor);
-
 static void torrentInitFromInfoDict(tr_torrent* tor)
 {
     tor->completion = tr_completion{ tor, &tor->blockInfo() };
@@ -602,7 +600,7 @@ void tr_torrent::setMetainfo(tr_torrent_metainfo const& tm)
 
     torrentInitFromInfoDict(this);
     tr_peerMgrOnTorrentGotMetainfo(this);
-    tr_torrentFireMetadataCompleted(this);
+    session->onMetadataCompleted(this);
     this->setDirty();
 }
 
@@ -1862,28 +1860,6 @@ void tr_torrent::recheckCompleteness()
             callScriptIfEnabled(this, TR_SCRIPT_ON_TORRENT_DONE);
         }
     }
-}
-
-/***
-****
-***/
-
-static void tr_torrentFireMetadataCompleted(tr_torrent* tor)
-{
-    TR_ASSERT(tr_isTorrent(tor));
-
-    if (tor->metadata_func != nullptr)
-    {
-        (*tor->metadata_func)(tor, tor->metadata_func_user_data);
-    }
-}
-
-void tr_torrentSetMetadataCallback(tr_torrent* tor, tr_torrent_metadata_func func, void* user_data)
-{
-    TR_ASSERT(tr_isTorrent(tor));
-
-    tor->metadata_func = func;
-    tor->metadata_func_user_data = user_data;
 }
 
 /**

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -660,9 +660,6 @@ public:
      * other peers */
     struct tr_incomplete_metadata* incompleteMetadata = nullptr;
 
-    tr_torrent_completeness_func completeness_func = nullptr;
-    void* completeness_func_user_data = nullptr;
-
     time_t peer_id_creation_time_ = 0;
 
     time_t dhtAnnounceAt = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -672,9 +672,6 @@ public:
     tr_torrent_idle_limit_hit_func idle_limit_hit_func = nullptr;
     void* idle_limit_hit_func_user_data = nullptr;
 
-    void* queue_started_user_data = nullptr;
-    void (*queue_started_callback)(tr_torrent*, void* queue_started_user_data) = nullptr;
-
     time_t peer_id_creation_time_ = 0;
 
     time_t dhtAnnounceAt = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -666,12 +666,6 @@ public:
     tr_torrent_completeness_func completeness_func = nullptr;
     void* completeness_func_user_data = nullptr;
 
-    tr_torrent_ratio_limit_hit_func ratio_limit_hit_func = nullptr;
-    void* ratio_limit_hit_func_user_data = nullptr;
-
-    tr_torrent_idle_limit_hit_func idle_limit_hit_func = nullptr;
-    void* idle_limit_hit_func_user_data = nullptr;
-
     time_t peer_id_creation_time_ = 0;
 
     time_t dhtAnnounceAt = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -660,9 +660,6 @@ public:
      * other peers */
     struct tr_incomplete_metadata* incompleteMetadata = nullptr;
 
-    tr_torrent_metadata_func metadata_func = nullptr;
-    void* metadata_func_user_data = nullptr;
-
     tr_torrent_completeness_func completeness_func = nullptr;
     void* completeness_func_user_data = nullptr;
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -696,7 +696,7 @@ void tr_sessionSetQueueStalledEnabled(tr_session*, bool);
 bool tr_sessionGetQueueStalledEnabled(tr_session const*);
 
 /** @brief Set a callback that is invoked when the queue starts a torrent */
-void tr_sessionSetQueueStartCallback(tr_torrent* torrent, void (*callback)(tr_session*, tr_torrent*, void*), void* user_data);
+void tr_sessionSetQueueStartCallback(tr_session*, void (*callback)(tr_session*, tr_torrent*, void*), void* user_data);
 
 /***
 ****
@@ -1218,7 +1218,7 @@ void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func
  *
  * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
-void tr_sessionSetRatioLimitHitCallback(tr_torrent* torrent, tr_session_ratio_limit_hit_func func, void* user_data);
+void tr_sessionSetRatioLimitHitCallback(tr_session* torrent, tr_session_ratio_limit_hit_func func, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's idle limit
@@ -1227,7 +1227,7 @@ void tr_sessionSetRatioLimitHitCallback(tr_torrent* torrent, tr_session_ratio_li
  *
  * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
-void tr_sessionSetIdleLimitHitCallback(tr_torrent* torrent, tr_session_idle_limit_hit_func func, void* user_data);
+void tr_sessionSetIdleLimitHitCallback(tr_session* torrent, tr_session_idle_limit_hit_func func, void* user_data);
 
 /**
  * MANUAL ANNOUNCE

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -695,11 +695,8 @@ void tr_sessionSetQueueStalledEnabled(tr_session*, bool);
 /** @return true if we're torrents idle for over N minutes will be flagged as 'stalled' */
 bool tr_sessionGetQueueStalledEnabled(tr_session const*);
 
-/**
-**/
-
 /** @brief Set a callback that is invoked when the queue starts a torrent */
-void tr_torrentSetQueueStartCallback(tr_torrent* torrent, void (*callback)(tr_torrent*, void*), void* user_data);
+void tr_sessionSetQueueStartCallback(tr_torrent* torrent, void (*callback)(tr_session*, tr_torrent*, void*), void* user_data);
 
 /***
 ****

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1182,9 +1182,9 @@ using tr_torrent_completeness_func = void (*)( //
     bool wasRunning,
     void* user_data);
 
-using tr_torrent_ratio_limit_hit_func = void (*)(tr_torrent* torrent, void* user_data);
+using tr_session_ratio_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
 
-using tr_torrent_idle_limit_hit_func = void (*)(tr_torrent* torrent, void* user_data);
+using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's "completeness"
@@ -1220,7 +1220,7 @@ void tr_torrentSetMetadataCallback(tr_torrent* tor, tr_torrent_metadata_func fun
  *
  * Has the same restrictions as tr_torrentSetCompletenessCallback
  */
-void tr_torrentSetRatioLimitHitCallback(tr_torrent* torrent, tr_torrent_ratio_limit_hit_func func, void* user_data);
+void tr_sessionSetRatioLimitHitCallback(tr_torrent* torrent, tr_session_ratio_limit_hit_func func, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's idle limit
@@ -1229,7 +1229,7 @@ void tr_torrentSetRatioLimitHitCallback(tr_torrent* torrent, tr_torrent_ratio_li
  *
  * Has the same restrictions as tr_torrentSetCompletenessCallback
  */
-void tr_torrentSetIdleLimitHitCallback(tr_torrent* torrent, tr_torrent_idle_limit_hit_func func, void* user_data);
+void tr_sessionSetIdleLimitHitCallback(tr_torrent* torrent, tr_session_idle_limit_hit_func func, void* user_data);
 
 /**
  * MANUAL ANNOUNCE

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1203,7 +1203,7 @@ void tr_torrentSetCompletenessCallback(tr_torrent* torrent, tr_torrent_completen
 
 void tr_torrentClearCompletenessCallback(tr_torrent* torrent);
 
-using tr_torrent_metadata_func = void (*)(tr_torrent* torrent, void* user_data);
+using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torrent, void* user_data);
 
 /**
  * Register to be notified whenever a torrent changes from
@@ -1211,7 +1211,7 @@ using tr_torrent_metadata_func = void (*)(tr_torrent* torrent, void* user_data);
  * This happens when a magnet link finishes downloading
  * metadata from its peers.
  */
-void tr_torrentSetMetadataCallback(tr_torrent* tor, tr_torrent_metadata_func func, void* user_data);
+void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func func, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's ratio limit

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1199,9 +1199,7 @@ using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent
  *
  * @see tr_completeness
  */
-void tr_torrentSetCompletenessCallback(tr_torrent* torrent, tr_torrent_completeness_func func, void* user_data);
-
-void tr_torrentClearCompletenessCallback(tr_torrent* torrent);
+void tr_sessionSetCompletenessCallback(tr_session* session, tr_torrent_completeness_func func, void* user_data);
 
 using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torrent, void* user_data);
 
@@ -1218,7 +1216,7 @@ void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func
  * has been hit. This will be called when the torrent's
  * ul/dl ratio has met or exceeded the designated ratio limit.
  *
- * Has the same restrictions as tr_torrentSetCompletenessCallback
+ * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
 void tr_sessionSetRatioLimitHitCallback(tr_torrent* torrent, tr_session_ratio_limit_hit_func func, void* user_data);
 
@@ -1227,7 +1225,7 @@ void tr_sessionSetRatioLimitHitCallback(tr_torrent* torrent, tr_session_ratio_li
  * has been hit. This will be called when the seeding torrent's
  * idle time has met or exceeded the designated idle limit.
  *
- * Has the same restrictions as tr_torrentSetCompletenessCallback
+ * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
 void tr_sessionSetIdleLimitHitCallback(tr_torrent* torrent, tr_session_idle_limit_hit_func func, void* user_data);
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -399,11 +399,11 @@ void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
     auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent mmm];
+        [torrent metadataRetrieved];
     });
 }
 
-void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool wasRunning, void* user_data)
+void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool wasRunning, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -363,7 +363,7 @@ void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:str];
+    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent startQueue];
@@ -374,7 +374,7 @@ void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:str];
+    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent idleLimitHit];
@@ -385,7 +385,7 @@ void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:str];
+    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent ratioLimitHit];
@@ -396,7 +396,7 @@ void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:str];
+    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent mmm];
@@ -407,7 +407,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:str];
+    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent completenessChange:status wasRunning:wasRunning];

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -359,6 +359,17 @@ static void removeKeRangerRansomware()
     }
 }
 
+void startQueueCallback(tr_session* session, tr_torrent* tor, void* vself)
+{
+    auto* controller = (__bridge Controller*)(vself);
+    auto const hashstr = @(tr_torrentView(tor).hash_string);
+    auto* torrent = [controller torrentForHash:str];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [torrent startQueue];
+    });
+}
+
 - (instancetype)init
 {
     if ((self = [super init]))

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -363,54 +363,64 @@ void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent startQueue];
+        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
+        {
+            [torrent startQueue];
+        }
     });
 }
 
 void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 {
-    auto* controller = (__bridge Controller*)(vself);
+    auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent idleLimitHit];
+        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
+        {
+            [torrent idleLimitHit];
+        }
     });
 }
 
 void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 {
-    auto* controller = (__bridge Controller*)(vself);
+    auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent ratioLimitHit];
+        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
+        {
+            [torrent ratioLimitHit];
+        }
     });
 }
 
 void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
 {
-    auto* controller = (__bridge Controller*)(vself);
+    auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent metadataRetrieved];
+        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
+        {
+            [torrent metadataRetrieved];
+        }
     });
 }
 
 void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool wasRunning, void* vself)
 {
-    auto* controller = (__bridge Controller*)(vself);
+    auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
-    auto* torrent = [controller torrentForHash:hashstr];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [torrent completenessChange:status wasRunning:wasRunning];
+        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
+        {
+            [torrent completenessChange:status wasRunning:wasRunning];
+        }
     });
 }
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -369,6 +369,7 @@ void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
         [torrent startQueue];
     });
 }
+
 void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
@@ -377,6 +378,17 @@ void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent idleLimitHit];
+    });
+}
+
+void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
+{
+    auto* controller = (__bridge Controller*)(vself);
+    auto const hashstr = @(tr_torrentView(tor).hash_string);
+    auto* torrent = [controller torrentForHash:str];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [torrent ratioLimitHit];
     });
 }
 
@@ -535,8 +547,9 @@ void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
         _fConfigDirectory = @(default_config_dir);
         tr_free(default_config_dir);
 
-        tr_sessionSetQueueStartCallback(_fLib, onStartQueue, (__bridge void*)(self));
         tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));
+        tr_sessionSetQueueStartCallback(_fLib, onStartQueue, (__bridge void*)(self));
+        tr_sessionSetRatioLimitHitCallback(_fLib, onRatioLimitHit, (__bridge void*)(self));
 
         NSApp.delegate = self;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -392,6 +392,17 @@ void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
     });
 }
 
+void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
+{
+    auto* controller = (__bridge Controller*)(vself);
+    auto const hashstr = @(tr_torrentView(tor).hash_string);
+    auto* torrent = [controller torrentForHash:str];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [torrent mmm];
+    });
+}
+
 - (instancetype)init
 {
     if ((self = [super init]))
@@ -550,6 +561,7 @@ void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
         tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));
         tr_sessionSetQueueStartCallback(_fLib, onStartQueue, (__bridge void*)(self));
         tr_sessionSetRatioLimitHitCallback(_fLib, onRatioLimitHit, (__bridge void*)(self));
+        tr_sessionSetMetadataCallback(_fLib, onMetadataCompleted, (__bridge void*)(self));
 
         NSApp.delegate = self;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -359,7 +359,7 @@ static void removeKeRangerRansomware()
     }
 }
 
-void startQueueCallback(tr_session* session, tr_torrent* tor, void* vself)
+void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
@@ -367,6 +367,16 @@ void startQueueCallback(tr_session* session, tr_torrent* tor, void* vself)
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [torrent startQueue];
+    });
+}
+void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
+{
+    auto* controller = (__bridge Controller*)(vself);
+    auto const hashstr = @(tr_torrentView(tor).hash_string);
+    auto* torrent = [controller torrentForHash:str];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [torrent idleLimitHit];
     });
 }
 
@@ -524,6 +534,9 @@ void startQueueCallback(tr_session* session, tr_torrent* tor, void* vself)
         tr_variantFree(&settings);
         _fConfigDirectory = @(default_config_dir);
         tr_free(default_config_dir);
+
+        tr_sessionSetQueueStartCallback(_fLib, onStartQueue, (__bridge void*)(self));
+        tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));
 
         NSApp.delegate = self;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -403,6 +403,17 @@ void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
     });
 }
 
+void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool wasRunning, void* user_data)
+{
+    auto* controller = (__bridge Controller*)(vself);
+    auto const hashstr = @(tr_torrentView(tor).hash_string);
+    auto* torrent = [controller torrentForHash:str];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [torrent completenessChange:status wasRunning:wasRunning];
+    });
+}
+
 - (instancetype)init
 {
     if ((self = [super init]))
@@ -562,6 +573,7 @@ void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
         tr_sessionSetQueueStartCallback(_fLib, onStartQueue, (__bridge void*)(self));
         tr_sessionSetRatioLimitHitCallback(_fLib, onRatioLimitHit, (__bridge void*)(self));
         tr_sessionSetMetadataCallback(_fLib, onMetadataCompleted, (__bridge void*)(self));
+        tr_sessionSetCompletenessCallback(_fLib, onTorrentCompletenessChanged, (__bridge void*)(self));
 
         NSApp.delegate = self;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -365,10 +365,8 @@ void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
     auto const hashstr = @(tr_torrentView(tor).hash_string);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
-        {
-            [torrent startQueue];
-        }
+        auto* const torrent = [controller torrentForHash:hashstr];
+        [torrent startQueue];
     });
 }
 
@@ -378,10 +376,8 @@ void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
     auto const hashstr = @(tr_torrentView(tor).hash_string);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
-        {
-            [torrent idleLimitHit];
-        }
+        auto* const torrent = [controller torrentForHash:hashstr];
+        [torrent idleLimitHit];
     });
 }
 
@@ -391,10 +387,8 @@ void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
     auto const hashstr = @(tr_torrentView(tor).hash_string);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
-        {
-            [torrent ratioLimitHit];
-        }
+        auto* const torrent = [controller torrentForHash:hashstr];
+        [torrent ratioLimitHit];
     });
 }
 
@@ -404,10 +398,8 @@ void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
     auto const hashstr = @(tr_torrentView(tor).hash_string);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
-        {
-            [torrent metadataRetrieved];
-        }
+        auto* const torrent = [controller torrentForHash:hashstr];
+        [torrent metadataRetrieved];
     });
 }
 
@@ -417,10 +409,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     auto const hashstr = @(tr_torrentView(tor).hash_string);
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (auto* const torrent = [controller torrentForHash:hashstr]; torrent != nullptr)
-        {
-            [torrent completenessChange:status wasRunning:wasRunning];
-        }
+        auto* const torrent = [controller torrentForHash:hashstr];
+        [torrent completenessChange:status wasRunning:wasRunning];
     });
 }
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 - (void)wakeUp;
 - (void)idleLimitHit;
 - (void)ratioLimitHit;
+- (void)metadataRetrieved;
 
 @property(nonatomic) NSUInteger queuePosition;
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -47,6 +47,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 - (void)startQueue;
 - (void)sleep;
 - (void)wakeUp;
+- (void)idleLimitHit;
 
 @property(nonatomic) NSUInteger queuePosition;
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 - (void)idleLimitHit;
 - (void)ratioLimitHit;
 - (void)metadataRetrieved;
+- (void)completenessChange:(tr_completeness)status wasRunning:(BOOL)wasRunning;
 
 @property(nonatomic) NSUInteger queuePosition;
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 - (void)sleep;
 - (void)wakeUp;
 - (void)idleLimitHit;
+- (void)ratioLimitHit;
 
 @property(nonatomic) NSUInteger queuePosition;
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
 - (void)startTransferNoQueue;
 - (void)startTransfer;
 - (void)stopTransfer;
+- (void)startQueue;
 - (void)sleep;
 - (void)wakeUp;
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -88,13 +88,6 @@ void completenessChangeCallback(tr_torrent* torrent, tr_completeness status, boo
     });
 }
 
-void metadataCallback(tr_torrent* torrent, void* torrentData)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [(__bridge Torrent*)torrentData metadataRetrieved];
-    });
-}
-
 void renameCallback(tr_torrent* torrent, char const* oldPathCharString, char const* newNameCharString, int error, void* contextInfo)
 {
     @autoreleasepool
@@ -1791,7 +1784,6 @@ bool trashDataFile(char const* filename, tr_error** error)
     }
 
     tr_torrentSetCompletenessCallback(self.fHandle, completenessChangeCallback, (__bridge void*)(self));
-    tr_torrentSetMetadataCallback(self.fHandle, metadataCallback, (__bridge void*)(self));
 
     _fResumeOnWake = NO;
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -95,13 +95,6 @@ void ratioLimitHitCallback(tr_torrent* torrent, void* torrentData)
     });
 }
 
-void idleLimitHitCallback(tr_torrent* torrent, void* torrentData)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [(__bridge Torrent*)torrentData idleLimitHit];
-    });
-}
-
 void metadataCallback(tr_torrent* torrent, void* torrentData)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1806,7 +1799,6 @@ bool trashDataFile(char const* filename, tr_error** error)
 
     tr_torrentSetCompletenessCallback(self.fHandle, completenessChangeCallback, (__bridge void*)(self));
     tr_torrentSetRatioLimitHitCallback(self.fHandle, ratioLimitHitCallback, (__bridge void*)(self));
-    tr_torrentSetIdleLimitHitCallback(self.fHandle, idleLimitHitCallback, (__bridge void*)(self));
     tr_torrentSetMetadataCallback(self.fHandle, metadataCallback, (__bridge void*)(self));
 
     _fResumeOnWake = NO;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -64,7 +64,6 @@
 - (void)sortFileList:(NSMutableArray<FileListNode*>*)fileNodes;
 
 - (void)startQueue;
-- (void)completenessChange:(tr_completeness)status wasRunning:(BOOL)wasRunning;
 - (void)ratioLimitHit;
 - (void)idleLimitHit;
 - (void)metadataRetrieved;
@@ -80,13 +79,6 @@
 - (void)setTimeMachineExclude:(BOOL)exclude;
 
 @end
-
-void completenessChangeCallback(tr_torrent* torrent, tr_completeness status, bool wasRunning, void* torrentData)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [(__bridge Torrent*)torrentData completenessChange:status wasRunning:wasRunning];
-    });
-}
 
 void renameCallback(tr_torrent* torrent, char const* oldPathCharString, char const* newNameCharString, int error, void* contextInfo)
 {
@@ -1782,8 +1774,6 @@ bool trashDataFile(char const* filename, tr_error** error)
             return nil;
         }
     }
-
-    tr_torrentSetCompletenessCallback(self.fHandle, completenessChangeCallback, (__bridge void*)(self));
 
     _fResumeOnWake = NO;
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -81,13 +81,6 @@
 
 @end
 
-void startQueueCallback(tr_torrent* torrent, void* torrentData)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [(__bridge Torrent*)torrentData startQueue];
-    });
-}
-
 void completenessChangeCallback(tr_torrent* torrent, tr_completeness status, bool wasRunning, void* torrentData)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1811,7 +1804,6 @@ bool trashDataFile(char const* filename, tr_error** error)
         }
     }
 
-    tr_torrentSetQueueStartCallback(self.fHandle, startQueueCallback, (__bridge void*)(self));
     tr_torrentSetCompletenessCallback(self.fHandle, completenessChangeCallback, (__bridge void*)(self));
     tr_torrentSetRatioLimitHitCallback(self.fHandle, ratioLimitHitCallback, (__bridge void*)(self));
     tr_torrentSetIdleLimitHitCallback(self.fHandle, idleLimitHitCallback, (__bridge void*)(self));

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -88,13 +88,6 @@ void completenessChangeCallback(tr_torrent* torrent, tr_completeness status, boo
     });
 }
 
-void ratioLimitHitCallback(tr_torrent* torrent, void* torrentData)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [(__bridge Torrent*)torrentData ratioLimitHit];
-    });
-}
-
 void metadataCallback(tr_torrent* torrent, void* torrentData)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1798,7 +1791,6 @@ bool trashDataFile(char const* filename, tr_error** error)
     }
 
     tr_torrentSetCompletenessCallback(self.fHandle, completenessChangeCallback, (__bridge void*)(self));
-    tr_torrentSetRatioLimitHitCallback(self.fHandle, ratioLimitHitCallback, (__bridge void*)(self));
     tr_torrentSetMetadataCallback(self.fHandle, metadataCallback, (__bridge void*)(self));
 
     _fResumeOnWake = NO;

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -74,7 +74,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
     {
         *static_cast<tr_completeness*>(vc) = c;
     };
-    tr_torrentSetCompletenessCallback(tor, zeroes_completeness_func, &completeness);
+    tr_sessionSetCompletenessCallback(session_, zeroes_completeness_func, &completeness);
 
     struct TestIncompleteDirData
     {


### PR DESCRIPTION
A minor space-saving measure: This change removes 10 pointers from each tr_torrent object.

I'd appeciate code review for the `macos/Controller.*` and `macos/Torrent.*` changes from anyone in @transmission/contributors :smiley_cat: 