### PR TITLE
fix: silence "couldn't read file" warnings

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2874,7 +2874,8 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 {
     auto const filename = tr_pathbuf{ config_dir, "/"sv, BandwidthGroupsFilename };
     auto groups_dict = tr_variant{};
-    if (!tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename, nullptr) || !tr_variantIsDict(&groups_dict))
+    if (!tr_sys_path_exists(filename) || !tr_variantFromFile(&groups_dict, TR_VARIANT_PARSE_JSON, filename, nullptr) ||
+        !tr_variantIsDict(&groups_dict))
     {
         return;
     }


### PR DESCRIPTION
These warnings were harmless but annoying,  so this PR fixes the two that I know of.

- bandwidth-groups.txt
- user-dirs.dirs

Fixes #3500.