### PR TITLE
refactor: remove tr_strvPath()

### DIFF
--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -121,7 +121,7 @@ static std::string xdgConfigHome()
         return ret;
     }
 
-    return tr_strvPath(getHomeDir(), ".config"sv);
+    return fmt::format("{:s}/.config"sv, getHomeDir());
 }
 
 void tr_setConfigDir(tr_session* session, std::string_view config_dir)
@@ -135,8 +135,8 @@ void tr_setConfigDir(tr_session* session, std::string_view config_dir)
 #endif
 
     session->config_dir = config_dir;
-    session->resume_dir = tr_strvPath(config_dir, ResumeSubdir);
-    session->torrent_dir = tr_strvPath(config_dir, TorrentSubdir);
+    session->resume_dir = fmt::format("{:s}/{:s}"sv, config_dir, ResumeSubdir);
+    session->torrent_dir = fmt::format("{:s}/{:s}"sv, config_dir, TorrentSubdir);
     tr_sys_dir_create(session->resume_dir, TR_SYS_DIR_CREATE_PARENTS, 0777);
     tr_sys_dir_create(session->torrent_dir, TR_SYS_DIR_CREATE_PARENTS, 0777);
 }
@@ -168,23 +168,23 @@ char const* tr_getDefaultConfigDir(char const* appname)
         {
 #ifdef __APPLE__
 
-            s = tr_strvDup(tr_strvPath(getHomeDir(), "Library", "Application Support", appname));
+            s = tr_strvDup(fmt::format("{:s}/Library/Application Support/{:s}"sv, getHomeDir(), appname));
 
 #elif defined(_WIN32)
 
             char* appdata = win32_get_known_folder(FOLDERID_LocalAppData);
-            s = tr_strvDup(tr_strvPath(appdata, appname));
+            s = tr_strvDup(fmt::format("{:s}/{:s}"sv, appdata, appname));
             tr_free(appdata);
 
 #elif defined(__HAIKU__)
 
             char buf[PATH_MAX];
             find_directory(B_USER_SETTINGS_DIRECTORY, -1, true, buf, sizeof(buf));
-            s = tr_strvDup(tr_strvPath(buf, appname));
+            s = tr_strvDup(fmt::format("{:s}/{:s}"sv, buf, appname);
 
 #else
 
-            s = tr_strvDup(tr_strvPath(xdgConfigHome(), appname));
+            s = tr_strvDup(fmt::format("{:s}/{:s}"sv, xdgConfigHome(), appname));
 
 #endif
         }
@@ -196,7 +196,7 @@ char const* tr_getDefaultConfigDir(char const* appname)
 static std::string getXdgEntryFromUserDirs(std::string_view key)
 {
     auto content = std::vector<char>{};
-    auto const filename = tr_strvPath(xdgConfigHome(), "user-dirs.dirs"sv);
+    auto const filename = fmt::format("{:s}/{:s}"sv, xdgConfigHome(), "user-dirs.dirs"sv);
     if (!tr_sys_path_exists(filename) || !tr_loadFile(filename, content) || std::empty(content))
     {
         return {};
@@ -248,9 +248,9 @@ char const* tr_getDefaultDownloadDir()
         if (user_dir == nullptr)
         {
 #ifdef __HAIKU__
-            user_dir = tr_strvDup(tr_strvPath(getHomeDir(), "Desktop"));
+            user_dir = tr_strvDup(fmt::format("{:s}/Desktop"sv, getHomeDir()));
 #else
-            user_dir = tr_strvDup(tr_strvPath(getHomeDir(), "Downloads"));
+            user_dir = tr_strvDup(fmt::format("{:s}/Downloads"sv, getHomeDir()));
 #endif
         }
     }
@@ -371,7 +371,7 @@ char const* tr_getWebClientDir([[maybe_unused]] tr_session const* session)
         }
         else
         {
-            candidates.emplace_back(tr_strvPath(getHomeDir(), ".local"sv, "share"sv));
+            candidates.emplace_back(fmt::format("{:s}/.local/share"sv, getHomeDir()));
         }
         tr_free(tmp);
 
@@ -419,7 +419,7 @@ std::string tr_getSessionIdDir()
 #else
 
     char* program_data_dir = win32_get_known_folder_ex(FOLDERID_ProgramData, KF_FLAG_CREATE);
-    auto const result = tr_strvPath(program_data_dir, "Transmission");
+    auto result = fmt::format("{:s}/Transmission"sv, program_data_dir);
     tr_free(program_data_dir);
     tr_sys_dir_create(result, 0, 0);
     return result;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2665,11 +2665,11 @@ static void renameTorrentFileString(tr_torrent* tor, char const* oldpath, char c
     {
         if (oldpath_len >= std::size(subpath))
         {
-            name = tr_strvPath(newname);
+            name = newname;
         }
         else
         {
-            name = tr_strvPath(newname, subpath.substr(oldpath_len + 1));
+            name = fmt::format(FMT_STRING("{:s}/{:s}"sv), newname, subpath.substr(oldpath_len + 1));
         }
     }
     else
@@ -2683,11 +2683,11 @@ static void renameTorrentFileString(tr_torrent* tor, char const* oldpath, char c
 
         if (oldpath_len >= std::size(subpath))
         {
-            name = tr_strvPath(tmp, newname);
+            name = fmt::format(FMT_STRING("{:s}/{:s}"sv), tmp, newname);
         }
         else
         {
-            name = tr_strvPath(tmp, newname, subpath.substr(oldpath_len + 1));
+            name = fmt::format(FMT_STRING("{:s}/{:s}/{:s}"sv), tmp, newname, subpath.substr(oldpath_len + 1));
         }
     }
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -232,27 +232,6 @@ template<typename T>
 ****  std::string_view utils
 ***/
 
-template<typename... T, typename std::enable_if_t<(std::is_convertible_v<T, std::string_view> && ...), bool> = true>
-[[nodiscard]] std::string tr_strvPath(T... args)
-{
-    auto setme = std::string{};
-    auto const n_args = sizeof...(args);
-    auto const n = n_args + (std::size(std::string_view{ args }) + ...);
-    if (setme.capacity() < n)
-    {
-        setme.reserve(n);
-    }
-
-    auto const foo = [&setme](std::string_view a)
-    {
-        setme += a;
-        setme += TR_PATH_DELIMITER;
-    };
-    (foo(args), ...);
-    setme.resize(setme.size() - 1);
-    return setme;
-}
-
 template<typename T>
 [[nodiscard]] constexpr bool tr_strvContains(std::string_view sv, T key) noexcept // c++23
 {

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -122,18 +122,6 @@ TEST_F(UtilsTest, trStrvDup)
     tr_free(str);
 }
 
-TEST_F(UtilsTest, trStrvPath)
-{
-    EXPECT_EQ("foo" TR_PATH_DELIMITER_STR "bar", tr_strvPath("foo", "bar"));
-    EXPECT_EQ(TR_PATH_DELIMITER_STR "foo" TR_PATH_DELIMITER_STR "bar", tr_strvPath("", "foo", "bar"));
-
-    EXPECT_EQ("", tr_strvPath(""sv));
-    EXPECT_EQ("foo"sv, tr_strvPath("foo"sv));
-    EXPECT_EQ(
-        "foo" TR_PATH_DELIMITER_STR "bar" TR_PATH_DELIMITER_STR "baz" TR_PATH_DELIMITER_STR "mum"sv,
-        tr_strvPath("foo"sv, "bar", std::string{ "baz" }, "mum"sv));
-}
-
 TEST_F(UtilsTest, trStrvUtf8Clean)
 {
     auto in = "hello world"sv;


### PR DESCRIPTION
no functional changes; just removing a utility function that's not needed because we can use fmt::format()