### PR TITLE
[macOS] Revamp Toolbar Segments

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4163,14 +4163,33 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
 
-        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
-        segmentedControl.cell = [[ToolbarSegmentedCell alloc] init];
-        groupItem.view = segmentedControl;
-        NSSegmentedCell* segmentedCell = (NSSegmentedCell*)segmentedControl.cell;
-        segmentedControl.segmentStyle = NSSegmentStyleSeparated;
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:TOOLBAR_PAUSE_ALL];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:TOOLBAR_RESUME_ALL];
 
+        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
+        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
+        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
         segmentedControl.segmentCount = 2;
-        segmentedCell.trackingMode = NSSegmentSwitchTrackingMomentary;
+
+        [segmentedControl setTag:TOOLBAR_PAUSE_TAG forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedControl setImage:[NSImage systemSymbol:@"pause.circle.fill" withFallback:@"ToolbarPauseAllTemplate"]
+                        forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedControl setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip")
+                          forSegment:TOOLBAR_PAUSE_TAG];
+
+        [segmentedControl setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
+        [segmentedControl setImage:[NSImage systemSymbol:@"arrow.clockwise.circle.fill" withFallback:@"ToolbarResumeAllTemplate"]
+                        forSegment:TOOLBAR_RESUME_TAG];
+        [segmentedControl setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
+                          forSegment:TOOLBAR_RESUME_TAG];
+
+        groupItem.label = NSLocalizedString(@"Apply All", "All toolbar item -> label");
+        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
+        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
+        groupItem.subitems = @[ itemPause, itemResume ];
+        groupItem.view = segmentedControl;
+        groupItem.target = self;
+        groupItem.action = @selector(allToolbarClicked:);
 
         if (@available(macOS 11.0, *))
         {
@@ -4183,31 +4202,10 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             groupItem.maxSize = groupSize;
         }
 
-        groupItem.label = NSLocalizedString(@"Apply All", "All toolbar item -> label");
-        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
-        groupItem.target = self;
-        groupItem.action = @selector(allToolbarClicked:);
-
-        groupItem.identifiers = @[ TOOLBAR_PAUSE_ALL, TOOLBAR_RESUME_ALL ];
-
-        [segmentedCell setTag:TOOLBAR_PAUSE_TAG forSegment:TOOLBAR_PAUSE_TAG];
-        [segmentedControl setImage:[NSImage largeSystemSymbol:@"pause.circle.fill" withFallback:@"ToolbarPauseAllTemplate"]
-                        forSegment:TOOLBAR_PAUSE_TAG];
-        [segmentedCell setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip") forSegment:TOOLBAR_PAUSE_TAG];
-
-        [segmentedCell setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
-        [segmentedControl setImage:[NSImage imageNamed:@"ToolbarResumeAllTemplate"] forSegment:TOOLBAR_RESUME_TAG];
-        [segmentedControl setImage:[NSImage largeSystemSymbol:@"arrow.clockwise.circle.fill" withFallback:@"ToolbarResumeAllTemplate"]
-                        forSegment:TOOLBAR_RESUME_TAG];
-        [segmentedCell setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
-                       forSegment:TOOLBAR_RESUME_TAG];
-
         [groupItem createMenu:@[
             NSLocalizedString(@"Pause All", "All toolbar item -> label"),
             NSLocalizedString(@"Resume All", "All toolbar item -> label")
         ]];
-
-        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
 
         return groupItem;
     }
@@ -4215,13 +4213,34 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
 
-        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
-        segmentedControl.cell = [[ToolbarSegmentedCell alloc] init];
-        groupItem.view = segmentedControl;
-        NSSegmentedCell* segmentedCell = (NSSegmentedCell*)segmentedControl.cell;
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:TOOLBAR_PAUSE_SELECTED];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:TOOLBAR_RESUME_SELECTED];
 
+        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
+        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
+        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
         segmentedControl.segmentCount = 2;
-        segmentedCell.trackingMode = NSSegmentSwitchTrackingMomentary;
+
+        [segmentedControl setTag:TOOLBAR_PAUSE_TAG forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedControl setImage:[NSImage systemSymbol:@"pause" withFallback:@"ToolbarPauseSelectedTemplate"]
+                        forSegment:TOOLBAR_PAUSE_TAG];
+        [segmentedControl setToolTip:NSLocalizedString(@"Pause selected transfers", "Selected toolbar item -> tooltip")
+                          forSegment:TOOLBAR_PAUSE_TAG];
+
+        [segmentedControl setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
+        [segmentedControl setImage:[NSImage systemSymbol:@"arrow.clockwise" withFallback:@"ToolbarResumeSelectedTemplate"]
+                        forSegment:TOOLBAR_RESUME_TAG];
+        [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
+                          forSegment:TOOLBAR_RESUME_TAG];
+
+        groupItem.view = segmentedControl;
+        groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
+        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
+        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
+        groupItem.subitems = @[ itemPause, itemResume ];
+        groupItem.view = segmentedControl;
+        groupItem.target = self;
+        groupItem.action = @selector(selectedToolbarClicked:);
 
         if (@available(macOS 11.0, *))
         {
@@ -4234,31 +4253,10 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             groupItem.maxSize = groupSize;
         }
 
-        groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
-        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
-        groupItem.target = self;
-        groupItem.action = @selector(selectedToolbarClicked:);
-
-        groupItem.identifiers = @[ TOOLBAR_PAUSE_SELECTED, TOOLBAR_RESUME_SELECTED ];
-
-        [segmentedCell setTag:TOOLBAR_PAUSE_TAG forSegment:TOOLBAR_PAUSE_TAG];
-        [segmentedControl setImage:[NSImage largeSystemSymbol:@"pause" withFallback:@"ToolbarPauseSelectedTemplate"]
-                        forSegment:TOOLBAR_PAUSE_TAG];
-        [segmentedCell setToolTip:NSLocalizedString(@"Pause selected transfers", "Selected toolbar item -> tooltip")
-                       forSegment:TOOLBAR_PAUSE_TAG];
-
-        [segmentedCell setTag:TOOLBAR_RESUME_TAG forSegment:TOOLBAR_RESUME_TAG];
-        [segmentedControl setImage:[NSImage systemSymbol:@"arrow.clockwise" withFallback:@"ToolbarResumeSelectedTemplate"]
-                        forSegment:TOOLBAR_RESUME_TAG];
-        [segmentedCell setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
-                       forSegment:TOOLBAR_RESUME_TAG];
-
         [groupItem createMenu:@[
             NSLocalizedString(@"Pause Selected", "Selected toolbar item -> label"),
             NSLocalizedString(@"Resume Selected", "Selected toolbar item -> label")
         ]];
-
-        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
 
         return groupItem;
     }
@@ -4316,9 +4314,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)allToolbarClicked:(id)sender
 {
-    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ?
-        [(NSSegmentedCell*)[sender cell] tagForSegment:[sender selectedSegment]] :
-        ((NSControl*)sender).tag;
+    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
+                                                                             ((NSControl*)sender).tag;
     switch (tagValue)
     {
     case TOOLBAR_PAUSE_TAG:
@@ -4332,9 +4329,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)selectedToolbarClicked:(id)sender
 {
-    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ?
-        [(NSSegmentedCell*)[sender cell] tagForSegment:[sender selectedSegment]] :
-        ((NSControl*)sender).tag;
+    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
+                                                                             ((NSControl*)sender).tag;
     switch (tagValue)
     {
     case TOOLBAR_PAUSE_TAG:

--- a/macosx/GroupToolbarItem.h
+++ b/macosx/GroupToolbarItem.h
@@ -4,9 +4,7 @@
 
 #import <AppKit/AppKit.h>
 
-@interface GroupToolbarItem : NSToolbarItem
-
-@property(nonatomic, copy) NSArray* identifiers;
+@interface GroupToolbarItem : NSToolbarItemGroup
 
 - (void)createMenu:(NSArray*)labels;
 

--- a/macosx/GroupToolbarItem.mm
+++ b/macosx/GroupToolbarItem.mm
@@ -10,10 +10,11 @@
 {
     NSSegmentedControl* control = (NSSegmentedControl*)self.view;
 
-    for (NSInteger i = 0; i < control.segmentCount; i++)
+    NSInteger const count = self.subitems.count;
+    for (NSInteger i = 0; i < count; i++)
     {
-        [control setEnabled:[self.target validateToolbarItem:[[NSToolbarItem alloc] initWithItemIdentifier:self.identifiers[i]]]
-                 forSegment:i];
+        NSToolbarItem* item = self.subitems[i];
+        [control setEnabled:[self.target validateToolbarItem:item] forSegment:i];
     }
 }
 
@@ -25,7 +26,7 @@
 
     menu.autoenablesItems = NO;
 
-    NSInteger const count = ((NSSegmentedControl*)self.view).segmentCount;
+    NSInteger const count = self.subitems.count;
     for (NSInteger i = 0; i < count; i++)
     {
         NSMenuItem* addItem = [[NSMenuItem alloc] initWithTitle:labels[i] action:self.action keyEquivalent:@""];
@@ -42,11 +43,11 @@
 {
     NSMenuItem* menuItem = super.menuFormRepresentation;
 
-    NSInteger const count = ((NSSegmentedControl*)self.view).segmentCount;
+    NSInteger const count = self.subitems.count;
     for (NSInteger i = 0; i < count; i++)
     {
-        [menuItem.submenu itemAtIndex:i].enabled = [self.target
-            validateToolbarItem:[[NSToolbarItem alloc] initWithItemIdentifier:self.identifiers[i]]];
+        NSToolbarItem* item = self.subitems[i];
+        [menuItem.submenu itemAtIndex:i].enabled = [self.target validateToolbarItem:item];
     }
 
     return menuItem;


### PR DESCRIPTION
Fixes #3498
Will be simplified a lot when deployment target is 10.15

<img width="841" alt="image" src="https://user-images.githubusercontent.com/8330119/180378219-b2d911f7-e84c-4214-be95-d0ea95e6ff8d.png">

<img width="937" alt="image" src="https://user-images.githubusercontent.com/8330119/180378261-890d85aa-292a-42ec-95fb-d85d892491ad.png">
