### PR TITLE
refactor: make tr_session's directory fields private

### DIFF
--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -118,11 +118,6 @@ static std::string xdgConfigHome()
     return fmt::format("{:s}/.config"sv, getHomeDir());
 }
 
-char const* tr_sessionGetConfigDir(tr_session const* session)
-{
-    return session->configDir().c_str();
-}
-
 char* tr_getDefaultConfigDir(char const* appname)
 {
     if (auto* dir = tr_env_get_string("TRANSMISSION_HOME", nullptr); dir != nullptr)

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -118,31 +118,9 @@ static std::string xdgConfigHome()
     return fmt::format("{:s}/.config"sv, getHomeDir());
 }
 
-void tr_setConfigDir(tr_session* session, std::string_view config_dir)
-{
-#if defined(__APPLE__) || defined(_WIN32)
-    auto constexpr ResumeSubdir = "Resume"sv;
-    auto constexpr TorrentSubdir = "Torrents"sv;
-#else
-    auto constexpr ResumeSubdir = "resume"sv;
-    auto constexpr TorrentSubdir = "torrents"sv;
-#endif
-
-    session->config_dir = config_dir;
-    session->resume_dir = fmt::format("{:s}/{:s}"sv, config_dir, ResumeSubdir);
-    session->torrent_dir = fmt::format("{:s}/{:s}"sv, config_dir, TorrentSubdir);
-    tr_sys_dir_create(session->resume_dir, TR_SYS_DIR_CREATE_PARENTS, 0777);
-    tr_sys_dir_create(session->torrent_dir, TR_SYS_DIR_CREATE_PARENTS, 0777);
-}
-
 char const* tr_sessionGetConfigDir(tr_session const* session)
 {
-    return session->config_dir.c_str();
-}
-
-char const* tr_getTorrentDir(tr_session const* session)
-{
-    return session->torrent_dir.c_str();
+    return session->configDir().c_str();
 }
 
 char* tr_getDefaultConfigDir(char const* appname)
@@ -265,7 +243,7 @@ std::string tr_getWebClientDir([[maybe_unused]] tr_session const* session)
 #ifdef BUILD_MAC_CLIENT
 
     // look in the Application Support folder
-    if (auto path = tr_pathbuf{ session->config_dir, "/public_html"sv }; isWebClientDir(path))
+    if (auto path = tr_pathbuf{ session->configDir(), "/public_html"sv }; isWebClientDir(path))
     {
         return std::string{ path };
     }

--- a/libtransmission/platform.h
+++ b/libtransmission/platform.h
@@ -10,32 +10,11 @@
 #endif
 
 #include <string>
-#include <string_view>
 
 struct tr_session;
-
-/**
- * @addtogroup tr_session Session
- * @{
- */
-
-/**
- * @brief invoked by tr_sessionInit() to set up the locations of the resume, torrent, and clutch directories.
- * @see tr_getResumeDir()
- * @see tr_getTorrentDir()
- * @see tr_getWebClientDir()
- */
-void tr_setConfigDir(tr_session* session, std::string_view config_dir);
-
-/** @brief return the directory where torrent files are stored */
-char const* tr_getTorrentDir(tr_session const*);
 
 /** @brief return the directory where the Web Client's web ui files are kept */
 std::string tr_getWebClientDir(tr_session const*);
 
 /** @brief return the directory where session id lock files are stored */
 std::string tr_getSessionIdDir();
-
-/** @} */
-
-/* @} */

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -655,7 +655,7 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
     auto const wasDirty = tor->isDirty;
 
     auto const migrated = tr_torrent_metainfo::migrateFile(
-        tor->session->resume_dir,
+        tor->session->resumeDir(),
         tor->name(),
         tor->infoHashString(),
         ".resume"sv);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2171,7 +2171,7 @@ static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_config_dir:
-        tr_variantDictAddStr(d, key, tr_sessionGetConfigDir(s));
+        tr_variantDictAddStr(d, key, s->configDir());
         break;
 
     case TR_KEY_default_trackers:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1444,7 +1444,7 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 
     // tr_blocklistSetContent needs a source file,
     // so save content into a tmpfile
-    auto const filename = tr_pathbuf{ session->config_dir, "/blocklist.tmp"sv };
+    auto const filename = tr_pathbuf{ session->configDir(), "/blocklist.tmp"sv };
     if (tr_error* error = nullptr; !tr_saveFile(filename, content, &error))
     {
         tr_idle_function_done(

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1204,6 +1204,13 @@ char const* tr_sessionGetDownloadDir(tr_session const* session)
     return session->downloadDir().c_str();
 }
 
+char const* tr_sessionGetConfigDir(tr_session const* session)
+{
+    TR_ASSERT(tr_isSession(session));
+
+    return session->configDir().c_str();
+}
+
 /***
 ****
 ***/

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -130,7 +130,24 @@ public:
         return is_closing_;
     }
 
-    // download dir
+    // paths
+
+    void initConfigDir(std::string_view config_dir);
+
+    [[nodiscard]] constexpr auto const& configDir() const noexcept
+    {
+        return config_dir_;
+    }
+
+    [[nodiscard]] constexpr auto const& torrentDir() const noexcept
+    {
+        return torrent_dir_;
+    }
+
+    [[nodiscard]] constexpr auto const& resumeDir() const noexcept
+    {
+        return resume_dir_;
+    }
 
     [[nodiscard]] constexpr auto const& downloadDir() const noexcept
     {
@@ -473,10 +490,6 @@ public:
     tr_port randomPortLow;
     tr_port randomPortHigh;
 
-    std::string config_dir;
-    std::string resume_dir;
-    std::string torrent_dir;
-
     std::vector<std::unique_ptr<BlocklistFile>> blocklists;
     struct tr_peerMgr* peerMgr = nullptr;
     struct tr_shared* shared = nullptr;
@@ -547,11 +560,17 @@ private:
     tr_torrents torrents_;
 
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
-    std::string blocklist_url_;
+
+    std::string config_dir_;
     std::string download_dir_;
-    std::string default_trackers_str_;
     std::string incomplete_dir_;
+    std::string resume_dir_;
+    std::string torrent_dir_;
+
+    std::string blocklist_url_;
+    std::string default_trackers_str_;
     std::string peer_congestion_algorithm_;
+
     std::optional<tr_address> external_ip_;
 
     queue_start_callback_t queue_start_callback_ = nullptr;

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -34,14 +34,14 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
 {
     auto top = tr_variant{};
 
-    auto filename = tr_pathbuf{ session->config_dir, "/stats.json"sv };
+    auto filename = tr_pathbuf{ session->configDir(), "/stats.json"sv };
     bool loaded = tr_variantFromFile(&top, TR_VARIANT_PARSE_JSON, filename.sv(), nullptr);
 
     if (!loaded)
     {
         // maybe the user just upgraded from an old version of Transmission
         // that was still using stats.benc
-        filename.assign(session->config_dir, "/stats.benc");
+        filename.assign(session->configDir(), "/stats.benc");
         loaded = tr_variantFromFile(&top, TR_VARIANT_PARSE_BENC, filename.sv(), nullptr);
     }
 
@@ -80,7 +80,7 @@ static void loadCumulativeStats(tr_session const* session, tr_session_stats* set
 
 static void saveCumulativeStats(tr_session const* session, tr_session_stats const* s)
 {
-    auto const filename = tr_pathbuf{ session->config_dir, "/stats.json"sv };
+    auto const filename = tr_pathbuf{ session->configDir(), "/stats.json"sv };
     auto top = tr_variant{};
     tr_variantInitDict(&top, 5);
     tr_variantDictAddInt(&top, TR_KEY_downloaded_bytes, s->downloadedBytes);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -753,7 +753,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
         if (resume_file_was_migrated)
         {
-            tr_torrent_metainfo::migrateFile(session->torrent_dir, tor->name(), tor->infoHashString(), ".torrent"sv);
+            tr_torrent_metainfo::migrateFile(session->torrentDir(), tor->name(), tor->infoHashString(), ".torrent"sv);
         }
     }
 
@@ -1611,9 +1611,9 @@ static void closeTorrent(tr_torrent* const tor)
 
     if (tor->isDeleting)
     {
-        tr_torrent_metainfo::removeFile(tor->session->torrent_dir, tor->name(), tor->infoHashString(), ".torrent"sv);
-        tr_torrent_metainfo::removeFile(tor->session->torrent_dir, tor->name(), tor->infoHashString(), ".magnet"sv);
-        tr_torrent_metainfo::removeFile(tor->session->resume_dir, tor->name(), tor->infoHashString(), ".resume"sv);
+        tr_torrent_metainfo::removeFile(tor->session->torrentDir(), tor->name(), tor->infoHashString(), ".torrent"sv);
+        tr_torrent_metainfo::removeFile(tor->session->torrentDir(), tor->name(), tor->infoHashString(), ".magnet"sv);
+        tr_torrent_metainfo::removeFile(tor->session->resumeDir(), tor->name(), tor->infoHashString(), ".resume"sv);
     }
 
     tor->isRunning = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -450,17 +450,17 @@ public:
 
     [[nodiscard]] auto torrentFile() const
     {
-        return metainfo_.torrentFile(this->session->torrent_dir);
+        return metainfo_.torrentFile(session->torrentDir());
     }
 
     [[nodiscard]] auto magnetFile() const
     {
-        return metainfo_.magnetFile(this->session->torrent_dir);
+        return metainfo_.magnetFile(session->torrentDir());
     }
 
     [[nodiscard]] auto resumeFile() const
     {
-        return metainfo_.resumeFile(this->session->resume_dir);
+        return metainfo_.resumeFile(session->resumeDir());
     }
 
     [[nodiscard]] auto magnet() const

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -146,7 +146,7 @@ static void dht_boostrap_from_file(tr_session* session)
     }
 
     // check for a manual bootstrap file.
-    auto in = std::ifstream{ tr_pathbuf{ session->config_dir, "/dht.bootstrap"sv } };
+    auto in = std::ifstream{ tr_pathbuf{ session->configDir(), "/dht.bootstrap"sv } };
     if (!in.is_open())
     {
         return;
@@ -292,7 +292,7 @@ int tr_dhtInit(tr_session* ss)
     }
 
     auto benc = tr_variant{};
-    auto const dat_file = tr_pathbuf{ ss->config_dir, "/dht.dat"sv };
+    auto const dat_file = tr_pathbuf{ ss->configDir(), "/dht.dat"sv };
     auto const ok = tr_variantFromFile(&benc, TR_VARIANT_PARSE_BENC, dat_file.sv());
 
     bool have_id = false;
@@ -443,7 +443,7 @@ void tr_dhtUninit(tr_session* ss)
             tr_variantDictAddRaw(&benc, TR_KEY_nodes6, compact6, out6 - compact6);
         }
 
-        auto const dat_file = tr_pathbuf{ ss->config_dir, "/dht.dat" };
+        auto const dat_file = tr_pathbuf{ ss->configDir(), "/dht.dat"sv };
         tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file.sv());
         tr_variantFree(&benc);
     }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -704,7 +704,7 @@ void tr_sessionSetQueueStartCallback(tr_session*, void (*callback)(tr_session*, 
 ***/
 
 /**
- *  Load all the torrents in tr_getTorrentDir().
+ *  Load all the torrents in the session's torrent folder.
  *  This can be used at startup to kickstart all the torrents
  *  from the previous session.
  */

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -69,7 +69,7 @@ TEST_F(BlocklistTest, parsing)
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 
     // init the blocklist
-    auto const path = tr_pathbuf{ tr_sessionGetConfigDir(session_), "/blocklists/level1" };
+    auto const path = tr_pathbuf{ session_->configDir(), "/blocklists/level1"sv };
     createFileWithContents(path, Contents1);
     tr_sessionReloadBlocklists(session_);
     EXPECT_TRUE(tr_blocklistExists(session_));
@@ -105,7 +105,7 @@ TEST_F(BlocklistTest, parsing)
 TEST_F(BlocklistTest, updating)
 {
     // init the session
-    auto const path = tr_pathbuf{ tr_sessionGetConfigDir(session_), "/blocklists/level1" };
+    auto const path = tr_pathbuf{ session_->configDir(), "/blocklists/level1"sv };
 
     // no blocklist to start with...
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -50,7 +50,7 @@ class FileTest : public SessionTest
 protected:
     auto createTestDir(std::string const& child_name)
     {
-        auto test_dir = tr_pathbuf{ tr_sessionGetConfigDir(session_), '/', child_name };
+        auto test_dir = tr_pathbuf{ session_->configDir(), '/', child_name };
         tr_sys_dir_create(test_dir, 0, 0777);
         return test_dir;
     }

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -156,7 +156,7 @@ using MoveTest = SessionTest;
 
 TEST_F(MoveTest, setLocation)
 {
-    auto const target_dir = tr_pathbuf{ tr_sessionGetConfigDir(session_), "/target"sv };
+    auto const target_dir = tr_pathbuf{ session_->configDir(), "/target"sv };
     tr_sys_dir_create(target_dir.data(), TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
 
     // init a torrent.

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -170,7 +170,7 @@ TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
     // supplant older ones.
     for (int i = 0; i < LargerThanCacheLimit; ++i)
     {
-        auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt", i) };
+        auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, i) };
         EXPECT_TRUE(session_->openFiles().get(TorId, i, true, filename, TR_PREALLOCATE_FULL, std::size(Contents)));
     }
 
@@ -182,7 +182,7 @@ TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
     auto sorted = std::array<bool, LargerThanCacheLimit>{};
     for (int i = 0; i < LargerThanCacheLimit; ++i)
     {
-        auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt", i) };
+        auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, i) };
         results[i] = !!session_->openFiles().get(TorId, i, false);
     }
     sorted = results;

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -246,7 +246,7 @@ TEST_F(RemoveTest, RemovesLeftoverJunk)
     EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 
     // add a junk file *inside of* the torrent's top directory.
-    auto const junk_file = tr_pathbuf{ parent, "/alice_in_wonderland_librivox/", JunkBasename };
+    auto const junk_file = tr_pathbuf{ parent, "/alice_in_wonderland_librivox/"sv, JunkBasename };
     createFileWithContents(junk_file, std::data(Content), std::size(Content));
     expected_tree.emplace(junk_file);
     EXPECT_EQ(expected_tree, getSubtreeContents(parent));
@@ -295,7 +295,7 @@ TEST_F(RemoveTest, LeavesNonJunkAlone)
     EXPECT_EQ(expected_tree, getSubtreeContents(parent));
 
     // add a non-junk file.
-    auto const nonjunk_file = tr_pathbuf{ parent, "/alice_in_wonderland_librivox/", NonJunkBasename };
+    auto const nonjunk_file = tr_pathbuf{ parent, "/alice_in_wonderland_librivox/"sv, NonJunkBasename };
     createFileWithContents(nonjunk_file, std::data(Content), std::size(Content));
     expected_tree.emplace(nonjunk_file);
     EXPECT_EQ(expected_tree, getSubtreeContents(parent));


### PR DESCRIPTION
No functional changes; this is another pathname cleanup refactor in libtransmission.