### PR TITLE
macOS small layout fixes to Info Window

### DIFF
--- a/macosx/Base.lproj/InfoActivityView.xib
+++ b/macosx/Base.lproj/InfoActivityView.xib
@@ -49,13 +49,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Activity">
-            <rect key="frame" x="0.0" y="0.0" width="389" height="376"/>
+            <rect key="frame" x="0.0" y="0.0" width="389" height="358"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2aX-cc-oXC">
-                    <rect key="frame" x="12" y="12" width="357" height="352"/>
+                    <rect key="frame" x="12" y="12" width="357" height="334"/>
                     <subviews>
                         <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Vhd-qH-kFK">
-                            <rect key="frame" x="0.0" y="148" width="357" height="204"/>
+                            <rect key="frame" x="0.0" y="136" width="357" height="198"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="28" customClass="InfoTextField">
                                     <rect key="frame" x="75" y="120" width="23" height="14"/>
@@ -98,7 +98,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                    <rect key="frame" x="-2" y="190" width="52" height="14"/>
+                                    <rect key="frame" x="-2" y="184" width="52" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Transfer" id="50">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -130,7 +130,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <imageView verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="19" customClass="PiecesView">
-                                    <rect key="frame" x="264" y="95" width="93" height="93"/>
+                                    <rect key="frame" x="264" y="89" width="93" height="93"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="93" id="bsS-qa-kx6"/>
                                         <constraint firstAttribute="width" constant="93" id="euA-Qi-kqQ"/>
@@ -283,11 +283,11 @@
                                 <constraint firstItem="7" firstAttribute="top" secondItem="21" secondAttribute="bottom" constant="2" id="ilY-p5-mSk"/>
                                 <constraint firstItem="23" firstAttribute="trailing" secondItem="21" secondAttribute="trailing" id="isL-nM-3an"/>
                                 <constraint firstItem="27" firstAttribute="trailing" secondItem="21" secondAttribute="trailing" id="kB4-js-TsY"/>
-                                <constraint firstItem="21" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="8" symbolic="YES" id="kfY-4b-78o"/>
+                                <constraint firstItem="21" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="2" id="kfY-4b-78o"/>
                                 <constraint firstItem="18" firstAttribute="leading" secondItem="Vhd-qH-kFK" secondAttribute="leading" id="lIw-C6-37q"/>
                                 <constraint firstItem="22" firstAttribute="leading" secondItem="20" secondAttribute="leading" id="qEp-oT-lvl"/>
                                 <constraint firstItem="11" firstAttribute="top" secondItem="Vhd-qH-kFK" secondAttribute="top" id="qJC-LH-Ja3"/>
-                                <constraint firstAttribute="height" constant="204" id="qul-ec-RYB"/>
+                                <constraint firstAttribute="height" constant="198" id="qul-ec-RYB"/>
                                 <constraint firstItem="29" firstAttribute="trailing" secondItem="21" secondAttribute="trailing" id="rCV-0c-u3g"/>
                                 <constraint firstItem="29" firstAttribute="top" secondItem="23" secondAttribute="bottom" constant="2" id="rXV-7x-Lp4"/>
                                 <constraint firstItem="20" firstAttribute="leading" secondItem="21" secondAttribute="trailing" constant="8" symbolic="YES" id="t6g-E7-H8Z"/>
@@ -300,10 +300,10 @@
                             </constraints>
                         </customView>
                         <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="WMr-Dh-mdg">
-                            <rect key="frame" x="0.0" y="0.0" width="139" height="140"/>
+                            <rect key="frame" x="0.0" y="0.0" width="139" height="128"/>
                             <subviews>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="-2" y="72" width="76" height="14"/>
+                                    <rect key="frame" x="-2" y="66" width="76" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Last Activity:" id="51">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -311,7 +311,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="13" customClass="InfoTextField">
-                                    <rect key="frame" x="78" y="88" width="23" height="14"/>
+                                    <rect key="frame" x="78" y="82" width="23" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" placeholderString="N/A" id="47">
                                         <dateFormatter key="formatter" dateStyle="long" timeStyle="short" doesRelativeDateFormatting="YES" id="48"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -344,7 +344,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="9" customClass="InfoTextField">
-                                    <rect key="frame" x="78" y="72" width="23" height="14"/>
+                                    <rect key="frame" x="78" y="66" width="23" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" placeholderString="N/A" id="52">
                                         <dateFormatter key="formatter" dateStyle="long" timeStyle="short" doesRelativeDateFormatting="YES" id="53"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -353,7 +353,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="14">
-                                    <rect key="frame" x="-2" y="88" width="76" height="14"/>
+                                    <rect key="frame" x="-2" y="82" width="76" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Completed:" id="46">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -361,7 +361,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="16">
-                                    <rect key="frame" x="-2" y="104" width="76" height="14"/>
+                                    <rect key="frame" x="-2" y="98" width="76" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Added:" id="43">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -369,7 +369,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                                    <rect key="frame" x="-2" y="126" width="37" height="14"/>
+                                    <rect key="frame" x="-2" y="114" width="37" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Dates" id="42">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -377,7 +377,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="15" customClass="InfoTextField">
-                                    <rect key="frame" x="78" y="104" width="23" height="14"/>
+                                    <rect key="frame" x="78" y="98" width="23" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" placeholderString="N/A" id="44">
                                         <dateFormatter key="formatter" dateStyle="long" timeStyle="short" doesRelativeDateFormatting="YES" id="45"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -386,7 +386,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="84">
-                                    <rect key="frame" x="-2" y="38" width="79" height="14"/>
+                                    <rect key="frame" x="-2" y="32" width="79" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Time Elapsed" id="85">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -403,7 +403,7 @@
                                 </textField>
                             </subviews>
                             <constraints>
-                                <constraint firstAttribute="height" constant="140" id="0cq-xb-XX1"/>
+                                <constraint firstAttribute="height" constant="128" id="0cq-xb-XX1"/>
                                 <constraint firstItem="16" firstAttribute="leading" secondItem="WMr-Dh-mdg" secondAttribute="leading" id="1J9-Ex-MeX"/>
                                 <constraint firstAttribute="width" priority="750" constant="139" id="5Cn-Uu-9zL"/>
                                 <constraint firstItem="83" firstAttribute="trailing" secondItem="16" secondAttribute="trailing" id="5vW-J5-ACR"/>
@@ -419,13 +419,13 @@
                                 <constraint firstItem="15" firstAttribute="centerY" secondItem="16" secondAttribute="centerY" id="IDq-8e-yQq"/>
                                 <constraint firstItem="15" firstAttribute="leading" secondItem="16" secondAttribute="trailing" constant="8" symbolic="YES" id="KX1-pV-ovD"/>
                                 <constraint firstItem="81" firstAttribute="trailing" secondItem="16" secondAttribute="trailing" id="NZM-WQ-gdt"/>
-                                <constraint firstItem="16" firstAttribute="top" secondItem="17" secondAttribute="bottom" constant="8" symbolic="YES" id="R5d-8B-DmS"/>
+                                <constraint firstItem="16" firstAttribute="top" secondItem="17" secondAttribute="bottom" constant="2" id="R5d-8B-DmS"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9" secondAttribute="trailing" constant="12" id="RBi-Tl-ZXD"/>
                                 <constraint firstItem="10" firstAttribute="top" secondItem="14" secondAttribute="bottom" constant="2" id="TCV-si-Njm"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="80" secondAttribute="trailing" constant="12" id="UJm-QD-jfz"/>
                                 <constraint firstItem="82" firstAttribute="leading" secondItem="15" secondAttribute="leading" id="UTr-TC-Noy"/>
                                 <constraint firstItem="84" firstAttribute="leading" secondItem="WMr-Dh-mdg" secondAttribute="leading" id="VKJ-Ud-LTH"/>
-                                <constraint firstItem="83" firstAttribute="top" secondItem="84" secondAttribute="bottom" constant="8" symbolic="YES" id="ZZe-1h-wfg"/>
+                                <constraint firstItem="83" firstAttribute="top" secondItem="84" secondAttribute="bottom" constant="2" id="ZZe-1h-wfg"/>
                                 <constraint firstItem="14" firstAttribute="trailing" secondItem="16" secondAttribute="trailing" id="aR3-Z4-wEJ"/>
                                 <constraint firstItem="83" firstAttribute="width" secondItem="16" secondAttribute="width" id="bHw-lY-ld0"/>
                                 <constraint firstItem="81" firstAttribute="width" secondItem="16" secondAttribute="width" id="buf-vo-5gD"/>

--- a/macosx/Base.lproj/InfoOptionsView.xib
+++ b/macosx/Base.lproj/InfoOptionsView.xib
@@ -43,13 +43,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Options">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="328"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="304"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="250" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KYq-Jm-g2s">
-                    <rect key="frame" x="12" y="12" width="318" height="304"/>
+                    <rect key="frame" x="12" y="12" width="318" height="280"/>
                     <subviews>
                         <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="2Ow-Hq-XLB">
-                            <rect key="frame" x="0.0" y="154" width="234" height="150"/>
+                            <rect key="frame" x="0.0" y="142" width="234" height="138"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="17">
                                     <rect key="frame" x="112" y="56" width="45" height="19"/>
@@ -73,7 +73,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                                    <rect key="frame" x="-2" y="114" width="92" height="14"/>
+                                    <rect key="frame" x="-2" y="108" width="92" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Transfer Priority:" id="47">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -111,7 +111,7 @@
                                     </connections>
                                 </button>
                                 <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                                    <rect key="frame" x="96" y="111" width="74" height="17"/>
+                                    <rect key="frame" x="96" y="105" width="74" height="17"/>
                                     <popUpButtonCell key="cell" type="roundRect" title="Normal" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="51" id="48">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -162,7 +162,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                                    <rect key="frame" x="-2" y="136" width="46" height="14"/>
+                                    <rect key="frame" x="-2" y="124" width="46" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Priority" id="46">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="20">
-                                    <rect key="frame" x="-2" y="80" width="114" height="14"/>
+                                    <rect key="frame" x="-2" y="74" width="114" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Transfer Bandwidth" id="23">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,17 +192,17 @@
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="20" secondAttribute="trailing" constant="12" id="HHX-UQ-91e"/>
                                 <constraint firstItem="6" firstAttribute="leading" secondItem="20" secondAttribute="leading" id="LFB-jF-yvx"/>
                                 <constraint firstItem="6" firstAttribute="top" secondItem="8" secondAttribute="bottom" constant="6" symbolic="YES" id="Lqh-x0-69w"/>
-                                <constraint firstItem="4" firstAttribute="top" secondItem="5" secondAttribute="bottom" constant="8" symbolic="YES" id="Miw-ol-Mcg"/>
+                                <constraint firstItem="4" firstAttribute="top" secondItem="5" secondAttribute="bottom" constant="2" id="Miw-ol-Mcg"/>
                                 <constraint firstItem="7" firstAttribute="leading" secondItem="20" secondAttribute="leading" id="OOc-G7-fPZ"/>
                                 <constraint firstItem="8" firstAttribute="leading" secondItem="20" secondAttribute="leading" id="OhE-Qd-w6k"/>
                                 <constraint firstItem="18" firstAttribute="leading" secondItem="19" secondAttribute="trailing" constant="8" symbolic="YES" id="S5P-KO-hGP"/>
                                 <constraint firstItem="19" firstAttribute="leading" secondItem="8" secondAttribute="trailing" constant="8" symbolic="YES" id="aaC-kM-T6U"/>
-                                <constraint firstAttribute="height" constant="150" id="b9c-Te-lmA"/>
+                                <constraint firstAttribute="height" constant="138" id="b9c-Te-lmA"/>
                                 <constraint firstItem="16" firstAttribute="baseline" secondItem="17" secondAttribute="baseline" id="e3N-Sa-qha"/>
                                 <constraint firstItem="19" firstAttribute="top" secondItem="17" secondAttribute="bottom" constant="3" id="eU4-3f-Xfh"/>
                                 <constraint firstItem="3" firstAttribute="baseline" secondItem="4" secondAttribute="baseline" id="fwe-NM-gM0"/>
                                 <constraint firstItem="19" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8" secondAttribute="trailing" constant="8" symbolic="YES" id="h0n-55-xaP"/>
-                                <constraint firstItem="7" firstAttribute="top" secondItem="20" secondAttribute="bottom" constant="8" symbolic="YES" id="hPy-7L-dOS"/>
+                                <constraint firstItem="7" firstAttribute="top" secondItem="20" secondAttribute="bottom" constant="2" id="hPy-7L-dOS"/>
                                 <constraint firstItem="20" firstAttribute="leading" secondItem="5" secondAttribute="leading" id="iVL-rC-C74"/>
                                 <constraint firstItem="3" firstAttribute="leading" secondItem="4" secondAttribute="trailing" constant="8" symbolic="YES" id="iX3-rl-dZ9"/>
                                 <constraint firstItem="16" firstAttribute="leading" secondItem="17" secondAttribute="trailing" constant="8" symbolic="YES" id="ly5-VI-U80"/>
@@ -221,10 +221,10 @@
                             </constraints>
                         </customView>
                         <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="wfz-WZ-zVG">
-                            <rect key="frame" x="0.0" y="0.0" width="318" height="146"/>
+                            <rect key="frame" x="0.0" y="0.0" width="318" height="134"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="21">
-                                    <rect key="frame" x="-2" y="132" width="87" height="14"/>
+                                    <rect key="frame" x="-2" y="120" width="87" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Seeding Limits" id="22">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -232,7 +232,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="80">
-                                    <rect key="frame" x="60" y="85" width="122" height="20"/>
+                                    <rect key="frame" x="60" y="79" width="122" height="20"/>
                                     <popUpButtonCell key="cell" type="roundRect" title="Global Setting" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" preferredEdge="maxY" selectedItem="87" id="84">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -249,7 +249,7 @@
                                     </connections>
                                 </popUpButton>
                                 <button horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="113">
-                                    <rect key="frame" x="-1" y="57" width="307" height="24"/>
+                                    <rect key="frame" x="-1" y="51" width="307" height="24"/>
                                     <buttonCell key="cell" type="check" title="Remove from the transfer list when seeding completes" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" allowsMixedState="YES" inset="2" id="114">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -267,7 +267,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="14">
-                                    <rect key="frame" x="-2" y="24" width="60" height="14"/>
+                                    <rect key="frame" x="-2" y="18" width="60" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Advanced" id="31">
                                         <font key="font" metaFont="smallSystemBold"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -275,7 +275,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                                    <rect key="frame" x="60" y="107" width="122" height="17"/>
+                                    <rect key="frame" x="60" y="101" width="122" height="17"/>
                                     <popUpButtonCell key="cell" type="roundRect" title="Global Setting" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" preferredEdge="maxY" selectedItem="41" id="38">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystem"/>
@@ -292,7 +292,7 @@
                                     </connections>
                                 </popUpButton>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="97">
-                                    <rect key="frame" x="241" y="88" width="46" height="14"/>
+                                    <rect key="frame" x="241" y="82" width="46" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="minutes" id="98">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -300,7 +300,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="81">
-                                    <rect key="frame" x="190" y="86" width="45" height="19"/>
+                                    <rect key="frame" x="190" y="80" width="45" height="19"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="82">
                                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="83">
                                             <real key="minimum" value="1"/>
@@ -316,7 +316,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="107">
-                                    <rect key="frame" x="188" y="88" width="86" height="14"/>
+                                    <rect key="frame" x="188" y="82" width="4" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="108">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" white="0.41999999999999998" alpha="1" colorSpace="calibratedWhite"/>
@@ -332,7 +332,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                                    <rect key="frame" x="190" y="108" width="45" height="19"/>
+                                    <rect key="frame" x="190" y="102" width="45" height="19"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="45" id="T2I-PK-5JP"/>
                                     </constraints>
@@ -353,7 +353,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="109">
-                                    <rect key="frame" x="188" y="110" width="86" height="14"/>
+                                    <rect key="frame" x="188" y="104" width="4" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="110">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" white="0.41999999999999998" alpha="1" colorSpace="calibratedWhite"/>
@@ -361,7 +361,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="15">
-                                    <rect key="frame" x="-2" y="110" width="56" height="14"/>
+                                    <rect key="frame" x="-2" y="104" width="56" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Ratio:" id="30">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -390,7 +390,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="79">
-                                    <rect key="frame" x="-2" y="88" width="56" height="14"/>
+                                    <rect key="frame" x="-2" y="82" width="56" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Inactivity:" id="89">
                                         <font key="font" metaFont="smallSystem"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -409,7 +409,7 @@
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="97" secondAttribute="trailing" constant="12" id="7eh-EI-gCP"/>
                                 <constraint firstItem="21" firstAttribute="leading" secondItem="wfz-WZ-zVG" secondAttribute="leading" id="7tt-pl-FzN"/>
                                 <constraint firstItem="80" firstAttribute="top" relation="greaterThanOrEqual" secondItem="9" secondAttribute="bottom" constant="3" id="8hV-tH-PNW"/>
-                                <constraint firstAttribute="height" constant="146" id="9TO-VB-aNs"/>
+                                <constraint firstAttribute="height" constant="134" id="9TO-VB-aNs"/>
                                 <constraint firstItem="10" firstAttribute="baseline" secondItem="9" secondAttribute="baseline" id="9kM-ee-Q2F"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="21" secondAttribute="trailing" constant="12" id="CJv-g8-noI"/>
                                 <constraint firstItem="9" firstAttribute="baseline" secondItem="15" secondAttribute="baseline" id="CPh-qS-N0b"/>
@@ -426,8 +426,8 @@
                                 <constraint firstItem="14" firstAttribute="leading" secondItem="21" secondAttribute="leading" id="ObU-aT-0wx"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="10" secondAttribute="trailing" constant="12" id="R5b-jk-BEF"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="11" secondAttribute="trailing" constant="12" id="RKs-Xy-IaA"/>
-                                <constraint firstItem="15" firstAttribute="top" secondItem="21" secondAttribute="bottom" constant="8" symbolic="YES" id="RNc-bD-3aw"/>
-                                <constraint firstItem="13" firstAttribute="top" secondItem="14" secondAttribute="bottom" constant="8" symbolic="YES" id="Sho-3h-Fd9"/>
+                                <constraint firstItem="15" firstAttribute="top" secondItem="21" secondAttribute="bottom" constant="2" id="RNc-bD-3aw"/>
+                                <constraint firstItem="13" firstAttribute="top" secondItem="14" secondAttribute="bottom" constant="2" id="Sho-3h-Fd9"/>
                                 <constraint firstItem="97" firstAttribute="leading" secondItem="81" secondAttribute="trailing" constant="8" symbolic="YES" id="Ufh-zo-hpw"/>
                                 <constraint firstItem="9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="15" secondAttribute="trailing" constant="8" symbolic="YES" id="Ujo-Cq-MY3"/>
                                 <constraint firstItem="113" firstAttribute="leading" secondItem="21" secondAttribute="leading" id="Vsx-6P-joV"/>


### PR DESCRIPTION
unifies the margin between headers and content on the **Activity** tab and the **Options** tab in the **Info Window**

Fixes #3489.

**The General tab (unchanged):**
<img width="427" alt="general" src="https://user-images.githubusercontent.com/7323792/180720979-27698b55-695d-4ffc-a68c-773f12ea8d9f.png">

**Info Window - Activity/Options tabs Current:**
<img width="427" alt="activity old" src="https://user-images.githubusercontent.com/7323792/180721191-5b081695-f821-4ae3-9a2b-1e744387e072.png">
<img width="427" alt="options old" src="https://user-images.githubusercontent.com/7323792/180721201-435b7f64-6023-4e54-b79f-fdba69c3e853.png">

**Info Window - Activity/Options tabs with this PR:**
<img width="427" alt="activity new" src="https://user-images.githubusercontent.com/7323792/180721317-14716f21-9a08-4cee-a0b0-e3cc65fd6b16.png">
<img width="427" alt="options new" src="https://user-images.githubusercontent.com/7323792/180721354-ecb72f3b-6dff-4732-a7dd-6e5add976b83.png">

