### PR TITLE
refactor: remove tr_address_from_string()

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -258,7 +258,10 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             }
             else if (key == "ip")
             {
-                tr_address_from_string(&pex_.addr, value);
+                if (auto const addr = tr_address::fromString(value); addr)
+                {
+                    pex_.addr = *addr;
+                }
             }
             else if (key == "peer id")
             {

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -89,15 +89,10 @@ static uint32_t announce_ip(tr_session const* session)
         return 0;
     }
 
-    tr_address ta;
     // Since size of IP field is only 4 bytes long we can announce
     // only IPv4 addresses.
-    if (!tr_address_from_string(&ta, session->announceIP()) || (ta.type != TR_AF_INET))
-    {
-        return 0;
-    }
-
-    return ta.addr.addr4.s_addr;
+    auto const addr = tr_address::fromString(session->announceIP());
+    return addr && addr->type == TR_AF_INET ? addr->addr.addr4.s_addr : 0;
 }
 
 /****

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -92,7 +92,7 @@ static uint32_t announce_ip(tr_session const* session)
     // Since size of IP field is only 4 bytes long we can announce
     // only IPv4 addresses.
     auto const addr = tr_address::fromString(session->announceIP());
-    return addr && addr->type == TR_AF_INET ? addr->addr.addr4.s_addr : 0;
+    return addr && addr->isIPv4() ? addr->addr.addr4.s_addr : 0;
 }
 
 /****

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -155,9 +155,9 @@ bool BlocklistFile::parseLine1(std::string_view line, struct IPv4Range* range)
     {
         return false;
     }
-    if (auto addr = tr_address{}; tr_address_from_string(&addr, line.substr(0, pos)))
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
     {
-        range->begin_ = ntohl(addr.addr.addr4.s_addr);
+        range->begin_ = ntohl(addr->addr.addr4.s_addr);
     }
     else
     {
@@ -166,9 +166,9 @@ bool BlocklistFile::parseLine1(std::string_view line, struct IPv4Range* range)
     line = line.substr(pos + 1);
 
     // parse the trailing 'y.y.y.y'
-    if (auto addr = tr_address{}; tr_address_from_string(&addr, line))
+    if (auto const addr = tr_address::fromString(line); addr)
     {
-        range->end_ = ntohl(addr.addr.addr4.s_addr);
+        range->end_ = ntohl(addr->addr.addr4.s_addr);
     }
     else
     {
@@ -193,9 +193,9 @@ bool BlocklistFile::parseLine2(std::string_view line, struct IPv4Range* range)
         return false;
     }
 
-    if (auto addr = tr_address{}; tr_address_from_string(&addr, line.substr(0, pos)))
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
     {
-        range->begin_ = ntohl(addr.addr.addr4.s_addr);
+        range->begin_ = ntohl(addr->addr.addr4.s_addr);
     }
     else
     {
@@ -209,9 +209,9 @@ bool BlocklistFile::parseLine2(std::string_view line, struct IPv4Range* range)
         return false;
     }
 
-    if (auto addr = tr_address{}; tr_address_from_string(&addr, line.substr(0, pos)))
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
     {
-        range->end_ = ntohl(addr.addr.addr4.s_addr);
+        range->end_ = ntohl(addr->addr.addr4.s_addr);
     }
     else
     {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -112,7 +112,7 @@ bool BlocklistFile::hasAddress(tr_address const& addr)
 {
     TR_ASSERT(tr_address_is_valid(&addr));
 
-    if (!is_enabled_ || addr.type == TR_AF_INET6)
+    if (!is_enabled_ || !addr.isIPv4())
     {
         return false;
     }

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -201,10 +201,6 @@ struct tr_address
 extern tr_address const tr_inaddr_any;
 extern tr_address const tr_in6addr_any;
 
-bool tr_address_from_string(tr_address* setme, char const* string);
-
-bool tr_address_from_string(tr_address* dst, std::string_view src);
-
 bool tr_address_from_sockaddr_storage(tr_address* setme, tr_port* port, struct sockaddr_storage const* src);
 
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -290,7 +290,7 @@ public:
         if (tr_dhtEnabled(torrent->session) && io->supportsDHT())
         {
             /* Only send PORT over IPv6 when the IPv6 DHT is running (BEP-32). */
-            if (io->address().type == TR_AF_INET || tr_globalIPv6(nullptr) != nullptr)
+            if (io->address().isIPv4() || tr_globalIPv6(nullptr) != nullptr)
             {
                 protocolSendPort(this, tr_dhtPort(torrent->session));
             }
@@ -1005,7 +1005,7 @@ size_t tr_generateAllowedSet(tr_piece_index_t* setmePieces, size_t desiredSetSiz
 
     size_t setSize = 0;
 
-    if (addr->type == TR_AF_INET)
+    if (addr->isIPv4())
     {
         uint8_t w[SHA_DIGEST_LENGTH + 4];
         uint8_t* walk = w;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -977,7 +977,7 @@ static void sessionSetImpl(struct init_data* const data)
 
         if (tr_variantDictFindStrView(settings, TR_KEY_bind_address_ipv4, &sv))
         {
-            if (auto const addr = tr_address::fromString(sv); addr && addr->type == TR_AF_INET)
+            if (auto const addr = tr_address::fromString(sv); addr && addr->isIPv4())
             {
                 b.addr = *addr;
             }
@@ -991,7 +991,7 @@ static void sessionSetImpl(struct init_data* const data)
 
         if (tr_variantDictFindStrView(settings, TR_KEY_bind_address_ipv6, &sv))
         {
-            if (auto const addr = tr_address::fromString(sv); addr && addr->type == TR_AF_INET6)
+            if (auto const addr = tr_address::fromString(sv); addr && addr->isIPv6())
             {
                 b.addr = *addr;
             }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -530,7 +530,7 @@ tr_port tr_dhtPort(tr_session* ss)
 
 bool tr_dhtAddNode(tr_session* ss, tr_address const* address, tr_port port, bool bootstrap)
 {
-    int af = address->type == TR_AF_INET ? AF_INET : AF_INET6;
+    int af = address->isIPv4() ? AF_INET : AF_INET6;
 
     if (!tr_dhtEnabled(ss))
     {
@@ -545,7 +545,7 @@ bool tr_dhtAddNode(tr_session* ss, tr_address const* address, tr_port port, bool
         return false;
     }
 
-    if (address->type == TR_AF_INET)
+    if (address->isIPv4())
     {
         struct sockaddr_in sin;
         memset(&sin, 0, sizeof(sin));
@@ -556,7 +556,7 @@ bool tr_dhtAddNode(tr_session* ss, tr_address const* address, tr_port port, bool
         return true;
     }
 
-    if (address->type == TR_AF_INET6)
+    if (address->isIPv6())
     {
         struct sockaddr_in6 sin6;
         memset(&sin6, 0, sizeof(sin6));

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -33,8 +33,7 @@ using namespace std::literals;
 
 bool tr_addressIsIP(char const* str)
 {
-    tr_address tmp;
-    return tr_address_from_string(&tmp, str);
+    return str != nullptr && tr_address::fromString(str).has_value();
 }
 
 char const* tr_webGetResponseStr(long code)
@@ -271,15 +270,14 @@ std::string_view getSiteName(std::string_view host)
         return host;
     }
 
-    // psl needs a zero-terminated hostname
-    auto const szhost = tr_urlbuf{ host };
-
     // is it an IP?
-    auto addr = tr_address{};
-    if (tr_address_from_string(&addr, std::data(szhost)))
+    if (auto const addr = tr_address::fromString(host); addr)
     {
         return host;
     }
+
+    // psl needs a zero-terminated hostname
+    auto const szhost = tr_urlbuf{ host };
 
     // is it a registered name?
     if (isAsciiNonUpperCase(host))

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -59,8 +59,8 @@ protected:
 
     bool addressIsBlocked(char const* address_str)
     {
-        struct tr_address addr = {};
-        return !tr_address_from_string(&addr, address_str) || tr_sessionIsAddressBlocked(session_, &addr);
+        auto const addr = tr_address::fromString(address_str);
+        return !addr || tr_sessionIsAddressBlocked(session_, &addr.value());
     }
 };
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -60,7 +60,7 @@ protected:
     bool addressIsBlocked(char const* address_str)
     {
         auto const addr = tr_address::fromString(address_str);
-        return !addr || tr_sessionIsAddressBlocked(session_, &addr.value());
+        return !addr || tr_sessionIsAddressBlocked(session_, &*addr);
     }
 };
 

--- a/tests/libtransmission/peer-msgs-test.cc
+++ b/tests/libtransmission/peer-msgs-test.cc
@@ -14,7 +14,6 @@ TEST(PeerMsgs, placeholder)
 #if 0
 
     auto infohash = tr_sha1_digest_t{};
-    struct tr_address addr;
     tr_piece_index_t pieceCount = 1313;
     size_t numwant;
     size_t numgot;
@@ -23,7 +22,7 @@ TEST(PeerMsgs, placeholder)
 
     memset(std::data(infohash), 0xaa, std::size(infohash));
 
-    tr_address_from_string(&addr, "80.4.4.200");
+    auto const addr = tr_address::fromString("80.4.4.200");
 
     numwant = 7;
     numgot = tr_generateAllowedSet(buf, numwant, pieceCount, infohash, &addr);


### PR DESCRIPTION
It's a redundant function: use `tr_address::fromString()` instead