### PR TITLE
refactor: remove tr_runInEventThread() temp data structs

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2341,24 +2341,9 @@ tr_bandwidth& tr_session::getBandwidthGroup(std::string_view name)
 ****
 ***/
 
-struct port_forwarding_data
-{
-    bool enabled;
-    struct tr_shared* shared;
-};
-
-static void setPortForwardingEnabled(struct port_forwarding_data* const data)
-{
-    tr_sharedTraversalEnable(data->shared, data->enabled);
-    tr_free(data);
-}
-
 void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled)
 {
-    auto* const d = tr_new0(struct port_forwarding_data, 1);
-    d->shared = session->shared;
-    d->enabled = enabled;
-    tr_runInEventThread(session, setPortForwardingEnabled, d);
+    tr_runInEventThread(session, tr_sharedTraversalEnable, session->shared, enabled);
 }
 
 bool tr_sessionIsPortForwardingEnabled(tr_session const* session)


### PR DESCRIPTION
Before trevent.cc got refactored, functions invoked via `tr_runInEventThread()` had to take a single `void*` callback data argument. 

Since the refactor, `tr_runInEventThread()` captures and forwards the arguments along to the event thread. We no longer need to create temporary `void*` user data struct that holds all the args.