### PR TITLE
fix: clang-tidy misc-const-correctness warnings

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -143,7 +143,7 @@ static void verboseLog(std::string_view description, tr_direction direction, std
 
     auto const direction_sv = direction == TR_DOWN ? "<< "sv : ">> "sv;
     out << description << std::endl << "[raw]"sv << direction_sv;
-    for (unsigned char ch : message)
+    for (unsigned char const ch : message)
     {
         if (isprint(ch) != 0)
         {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -790,7 +790,7 @@ static void tier_announce_event_push(tr_tier* tier, tr_announce_event e, time_t 
          * dump everything leading up to it except "completed" */
         if (e == TR_ANNOUNCE_EVENT_STOPPED)
         {
-            bool has_completed = std::count(std::begin(events), std::end(events), TR_ANNOUNCE_EVENT_COMPLETED) != 0;
+            bool const has_completed = std::count(std::begin(events), std::end(events), TR_ANNOUNCE_EVENT_COMPLETED) != 0;
             events.clear();
             if (has_completed)
             {
@@ -1222,7 +1222,7 @@ static void tierAnnounce(tr_announcer* announcer, tr_tier* tier)
     time_t const now = tr_time();
 
     tr_torrent* tor = tier->tor;
-    tr_announce_event announce_event = tier_announce_event_pull(tier);
+    tr_announce_event const announce_event = tier_announce_event_pull(tier);
     tr_announce_request* req = announce_request_new(announcer, tor, tier, announce_event);
 
     auto* const data = new announce_data{ tier->id, now, announce_event, announcer->session, tor->isRunning };

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -48,7 +48,7 @@ void setAllTrue(uint8_t* array, size_t bit_count)
            1 to replace -bitcount as linters warn about negating
            unsigned types. Any compiler will optimize ~x + 1 to -x in
            the backend. */
-        uint32_t shift = ((~bit_count) + 1) & 7U;
+        uint32_t const shift = ((~bit_count) + 1) & 7U;
         array[n - 1] = Val << shift;
     }
 }

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -122,7 +122,7 @@ bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext)
 
 static size_t base64_alloc_size(std::string_view input)
 {
-    size_t ret_length = 4 * ((std::size(input) + 2) / 3);
+    size_t ret_length = 4 * ((std::size(input) + 2) / 3); // NOLINT misc-const-correctness
 #ifdef USE_SYSTEM_B64
     // Additional space is needed for newlines if we're using unpatched libb64
     ret_length += ret_length / 72 + 1;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -289,7 +289,7 @@ bool tr_sys_path_exists(char const* path, tr_error** error)
 {
     TR_ASSERT(path != nullptr);
 
-    bool ret = access(path, F_OK) != -1;
+    bool const ret = access(path, F_OK) != -1;
 
     if (!ret)
     {
@@ -479,7 +479,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 #else /* USE_COPYFILE */
 
     /* Other OSes require us to copy between file descriptors, so open them. */
-    tr_sys_file_t in = tr_sys_file_open(src_path, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, error);
+    tr_sys_file_t const in = tr_sys_file_open(src_path, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, error);
     if (in == TR_BAD_SYS_FILE)
     {
         tr_error_prefix(error, "Unable to open source file: ");
@@ -494,7 +494,11 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         return false;
     }
 
-    tr_sys_file_t out = tr_sys_file_open(dst_path, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0666, error);
+    tr_sys_file_t const out = tr_sys_file_open(
+        dst_path,
+        TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
+        0666,
+        error);
     if (out == TR_BAD_SYS_FILE)
     {
         tr_error_prefix(error, "Unable to open destination file: ");
@@ -900,7 +904,7 @@ bool tr_sys_file_flush(tr_sys_file_t handle, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
 
-    bool ret = fsync(handle) != -1;
+    bool const ret = fsync(handle) != -1;
 
     if (!ret)
     {
@@ -914,7 +918,7 @@ bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
 
-    bool ret = ftruncate(handle, size) != -1;
+    bool const ret = ftruncate(handle, size) != -1;
 
     if (!ret)
     {
@@ -1114,7 +1118,7 @@ bool tr_sys_file_unmap(void const* address, uint64_t size, tr_error** error)
     TR_ASSERT(address != nullptr);
     TR_ASSERT(size > 0);
 
-    bool ret = munmap((void*)address, size) != -1;
+    bool const ret = munmap((void*)address, size) != -1;
 
     if (!ret)
     {
@@ -1357,7 +1361,7 @@ bool tr_sys_dir_close(tr_sys_dir_t handle, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_DIR);
 
-    bool ret = closedir((DIR*)handle) != -1;
+    bool const ret = closedir((DIR*)handle) != -1;
 
     if (!ret)
     {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1087,7 +1087,7 @@ void tr_handshakeAbort(tr_handshake* handshake)
 
 static void gotError(tr_peerIo* io, short what, void* vhandshake)
 {
-    int errcode = errno;
+    int const errcode = errno;
     auto* handshake = static_cast<tr_handshake*>(vhandshake);
 
     if (io->socket.type == TR_PEER_SOCKET_TYPE_UTP && !io->isIncoming() && handshake->state == AWAITING_YB)

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -58,7 +58,7 @@ void base32_to_sha1(uint8_t* out, char const* in, size_t const inlen)
     size_t offset = 0;
     for (size_t i = 0; i < inlen; ++i)
     {
-        int lookup = in[i] - '0';
+        int const lookup = in[i] - '0';
 
         /* Skip chars outside the lookup table */
         if (lookup < 0)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -365,7 +365,7 @@ void tr_peerIo::readBufferAdd(void const* data, size_t n_bytes)
 
 static size_t utp_get_rb_size(tr_peerIo* const io)
 {
-    size_t bytes = io->bandwidth().clamp(TR_DOWN, UtpReadBufferSize);
+    size_t const bytes = io->bandwidth().clamp(TR_DOWN, UtpReadBufferSize);
 
     tr_logAddTraceIo(io, fmt::format("utp_get_rb_size is saying it's ready to read {} bytes", bytes));
     return UtpReadBufferSize - bytes;
@@ -833,7 +833,7 @@ int tr_peerIoReconnect(tr_peerIo* io)
 
     tr_session* session = tr_peerIoGetSession(io);
 
-    short int pendingEvents = io->pendingEvents;
+    short int const pendingEvents = io->pendingEvents;
     event_disable(io, EV_READ | EV_WRITE);
 
     io_close_socket(io);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1155,7 +1155,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
 {
     TR_ASSERT(result.io != nullptr);
 
-    bool ok = result.isConnected;
+    bool const ok = result.isConnected;
     bool success = false;
     auto* manager = static_cast<tr_peerMgr*>(result.userData);
 
@@ -1314,7 +1314,7 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t
 
 std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLen, uint8_t const* added_f, size_t added_f_len)
 {
-    size_t n = compactLen / 6;
+    size_t const n = compactLen / 6;
     auto const* walk = static_cast<uint8_t const*>(compact);
     auto pex = std::vector<tr_pex>(n);
 
@@ -1334,7 +1334,7 @@ std::vector<tr_pex> tr_peerMgrCompactToPex(void const* compact, size_t compactLe
 
 std::vector<tr_pex> tr_peerMgrCompact6ToPex(void const* compact, size_t compactLen, uint8_t const* added_f, size_t added_f_len)
 {
-    size_t n = compactLen / 18;
+    size_t const n = compactLen / 18;
     auto const* walk = static_cast<uint8_t const*>(compact);
     auto pex = std::vector<tr_pex>(n);
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -307,7 +307,7 @@ static char const* torrentRemove(
     auto delete_flag = bool{ false };
     (void)tr_variantDictFindBool(args_in, TR_KEY_delete_local_data, &delete_flag);
 
-    tr_rpc_callback_type type = delete_flag ? TR_RPC_TORRENT_TRASHING : TR_RPC_TORRENT_REMOVING;
+    tr_rpc_callback_type const type = delete_flag ? TR_RPC_TORRENT_TRASHING : TR_RPC_TORRENT_REMOVING;
 
     for (auto* tor : getTorrents(session, args_in))
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1535,9 +1535,9 @@ static void turtleCheckClock(tr_session* s, struct tr_turtle_info* t)
 {
     TR_ASSERT(t->isClockEnabled);
 
-    bool enabled = getInTurtleTime(t);
-    tr_auto_switch_state_t newAutoTurtleState = autoSwitchState(enabled);
-    bool alreadySwitched = t->autoTurtleState == newAutoTurtleState;
+    bool const enabled = getInTurtleTime(t);
+    tr_auto_switch_state_t const newAutoTurtleState = autoSwitchState(enabled);
+    bool const alreadySwitched = t->autoTurtleState == newAutoTurtleState;
 
     if (!alreadySwitched)
     {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -133,7 +133,7 @@ void* tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, size_t* len)
     TR_ASSERT(info_dict_size > 0);
 
     char* ret = nullptr;
-    if (size_t o = piece * METADATA_PIECE_SIZE; tr_sys_file_seek(fd, tor->infoDictOffset() + o, TR_SEEK_SET, nullptr))
+    if (size_t const o = piece * METADATA_PIECE_SIZE; tr_sys_file_seek(fd, tor->infoDictOffset() + o, TR_SEEK_SET, nullptr))
     {
         size_t const l = o + METADATA_PIECE_SIZE <= info_dict_size ? METADATA_PIECE_SIZE : info_dict_size - o;
 
@@ -423,7 +423,7 @@ bool tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now, int* setme_pi
         int const piece = m->piecesNeeded[0].piece;
         tr_removeElementFromArray(m->piecesNeeded, 0, sizeof(struct metadata_node), m->piecesNeededCount);
 
-        int i = m->piecesNeededCount - 1;
+        int const i = m->piecesNeededCount - 1;
         m->piecesNeeded[i].piece = piece;
         m->piecesNeeded[i].requestedAt = now;
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -343,7 +343,7 @@ int tr_dhtInit(tr_session* ss)
         tr_rand_buffer(myid, 20);
     }
 
-    if (int rc = dht_init(ss->udp_socket, ss->udp6_socket, myid, nullptr); rc < 0)
+    if (int const rc = dht_init(ss->udp_socket, ss->udp6_socket, myid, nullptr); rc < 0)
     {
         tr_free(nodes6);
         tr_free(nodes);
@@ -406,7 +406,7 @@ void tr_dhtUninit(tr_session* ss)
         struct sockaddr_in6 sins6[MaxNodes];
         int num = MaxNodes;
         int num6 = MaxNodes;
-        int n = dht_get_nodes(sins, &num, sins6, &num6);
+        int const n = dht_get_nodes(sins, &num, sins6, &num6);
         tr_logAddTrace(fmt::format("Saving {} ({} + {}) nodes", n, num, num6));
 
         tr_variant benc;
@@ -530,7 +530,7 @@ tr_port tr_dhtPort(tr_session* ss)
 
 bool tr_dhtAddNode(tr_session* ss, tr_address const* address, tr_port port, bool bootstrap)
 {
-    int af = address->isIPv4() ? AF_INET : AF_INET6;
+    int const af = address->isIPv4() ? AF_INET : AF_INET6;
 
     if (!tr_dhtEnabled(ss))
     {
@@ -730,7 +730,7 @@ void tr_dhtCallback(unsigned char* buf, int buflen, struct sockaddr* from, sockl
     }
 
     time_t tosleep = 0;
-    int rc = dht_periodic(buf, buflen, from, fromlen, &tosleep, callback, nullptr);
+    int const rc = dht_periodic(buf, buflen, from, fromlen, &tosleep, callback, nullptr);
 
     if (rc < 0)
     {

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -139,7 +139,7 @@ static char const* lpd_extractHeader(char const* s, struct lpd_protocolVersion* 
 
     int major = -1;
     int minor = -1;
-    size_t len = strlen(s);
+    size_t const len = strlen(s);
 
     /* something might be rotten with this chunk of data */
     if (len == 0 || len > lpd_maxDatagramLength)
@@ -644,7 +644,7 @@ static void event_callback(evutil_socket_t /*s*/, short type, void* /*user_data*
         char foreignMsg[lpd_maxDatagramLength + 1];
 
         /* process local announcement from foreign peer */
-        int res = recvfrom(
+        int const res = recvfrom(
             lpd_socket,
             foreignMsg,
             lpd_maxDatagramLength,

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -92,7 +92,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
 
 void tr_udpSetSocketBuffers(tr_session* session)
 {
-    bool utp = tr_sessionIsUTPEnabled(session);
+    bool const utp = tr_sessionIsUTPEnabled(session);
 
     if (session->udp_socket != TR_BAD_SOCKET)
     {
@@ -232,7 +232,7 @@ static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void*
     auto* session = static_cast<tr_session*>(vsession);
 
     socklen_t fromlen = sizeof(from);
-    int rc = recvfrom(s, reinterpret_cast<char*>(buf), 4096 - 1, 0, (struct sockaddr*)&from, &fromlen);
+    int const rc = recvfrom(s, reinterpret_cast<char*>(buf), 4096 - 1, 0, (struct sockaddr*)&from, &fromlen);
 
     /* Since most packets we receive here are ÂµTP, make quick inline
        checks for the other protocols. The logic is as follows:

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -190,7 +190,7 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
     auto const port_str = fmt::format(FMT_STRING("{:d}"), port.host());
 
 #if (MINIUPNPC_API_VERSION >= 8)
-    int err = UPNP_AddPortMapping(
+    int const err = UPNP_AddPortMapping(
         handle->urls.controlURL,
         handle->data.first.servicetype,
         port_str.c_str(),
@@ -201,7 +201,7 @@ static int tr_upnpAddPortMapping(tr_upnp const* handle, char const* proto, tr_po
         nullptr,
         nullptr);
 #else
-    int err = UPNP_AddPortMapping(
+    int const err = UPNP_AddPortMapping(
         handle->urls.controlURL,
         handle->data.first.servicetype,
         port_str.c_str(),

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1115,7 +1115,7 @@ static char* formatter_get_size_str(formatter_units const& u, char* buf, uint64_
         unit = &u[3];
     }
 
-    double value = double(bytes) / unit->value;
+    double const value = double(bytes) / unit->value;
     auto const* const units = std::data(unit->name);
 
     auto precision = int{};

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -173,7 +173,7 @@ Application::Application(int& argc, char** argv)
 
     // try to delegate the work to an existing copy of Transmission
     // before starting ourselves...
-    InteropHelper interop_client;
+    InteropHelper const interop_client;
 
     if (interop_client.isConnected())
     {
@@ -225,7 +225,7 @@ Application::Application(int& argc, char** argv)
     }
 
     // ensure our config directory exists
-    QDir dir(config_dir);
+    QDir const dir(config_dir);
 
     if (!dir.exists())
     {
@@ -666,6 +666,6 @@ int tr_main(int argc, char** argv)
     Application::setAttribute(Qt::AA_EnableHighDpiScaling);
     Application::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-    Application app(argc, argv);
+    Application const app(argc, argv);
     return QApplication::exec();
 }

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -679,7 +679,7 @@ void DetailsDialog::refreshUI()
     }
     else
     {
-        int baseline = torrents[0]->getETA();
+        int const baseline = torrents[0]->getETA();
 
         for (Torrent const* const t : torrents)
         {
@@ -830,7 +830,7 @@ void DetailsDialog::refreshUI()
 
     if (!torrents.empty())
     {
-        bool b = torrents[0]->isPrivate();
+        bool const b = torrents[0]->isPrivate();
         string = b ? tr("Private to this tracker -- DHT and PEX disabled") : tr("Public torrent");
 
         for (Torrent const* const t : torrents)
@@ -1021,7 +1021,7 @@ void DetailsDialog::refreshUI()
 
         // myBandwidthPriorityCombo
         uniform = true;
-        int baseline_int = baseline.getBandwidthPriority();
+        int const baseline_int = baseline.getBandwidthPriority();
 
         for (Torrent const* const tor : torrents)
         {
@@ -1032,7 +1032,7 @@ void DetailsDialog::refreshUI()
             }
         }
 
-        int i = uniform ? ui_.bandwidthPriorityCombo->findData(baseline_int) : -1;
+        int const i = uniform ? ui_.bandwidthPriorityCombo->findData(baseline_int) : -1;
 
         setIfIdle(ui_.bandwidthPriorityCombo, i);
 
@@ -1100,7 +1100,7 @@ void DetailsDialog::refreshUI()
     for (Torrent const* const t : torrents)
     {
         QString const id_str(QString::number(t->id()));
-        PeerList peers = t->peers();
+        PeerList const peers = t->peers();
 
         for (Peer const& peer : peers)
         {
@@ -1405,7 +1405,7 @@ void DetailsDialog::onRemoveTrackerClicked()
 {
     // make a map of torrentIds to announce URLs to remove
     QItemSelectionModel* selection_model = ui_.trackersView->selectionModel();
-    QModelIndexList selected_rows = selection_model->selectedRows();
+    QModelIndexList const selected_rows = selection_model->selectedRows();
     QMultiMap<int, int> torrent_id_to_tracker_ids;
 
     for (QModelIndex const& i : selected_rows)
@@ -1456,8 +1456,8 @@ void DetailsDialog::initOptionsTab()
     cr->addLayout(ui_.peerConnectionsSectionLayout);
     cr->update();
 
-    void (QComboBox::*combo_index_changed)(int) = &QComboBox::currentIndexChanged;
-    void (QSpinBox::*spin_value_changed)(int) = &QSpinBox::valueChanged;
+    void (QComboBox::*const combo_index_changed)(int) = &QComboBox::currentIndexChanged;
+    void (QSpinBox::*const spin_value_changed)(int) = &QSpinBox::valueChanged;
     connect(ui_.bandwidthPriorityCombo, combo_index_changed, this, &DetailsDialog::onBandwidthPriorityChanged);
     connect(ui_.idleCombo, combo_index_changed, this, &DetailsDialog::onIdleModeChanged);
     connect(ui_.idleSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -89,7 +89,7 @@ void FaviconCache::ensureCacheDirHasBeenScanned()
     cache_dir.mkpath(cache_dir.absolutePath());
     for (auto const& sitename : cache_dir.entryList(QDir::Files | QDir::Readable))
     {
-        QPixmap pixmap(cache_dir.absoluteFilePath(sitename));
+        QPixmap const pixmap(cache_dir.absoluteFilePath(sitename));
         if (!pixmap.isNull())
         {
             pixmaps_[sitename] = scale(pixmap);
@@ -200,7 +200,7 @@ void FaviconCache::onRequestFinished(QNetworkReply* reply)
         pixmaps_[sitename] = scale(pixmap);
 
         // save it on disk...
-        QDir cache_dir(getCacheDir());
+        QDir const cache_dir(getCacheDir());
         cache_dir.mkpath(cache_dir.absolutePath());
         QFile file(cache_dir.absoluteFilePath(sitename));
         file.open(QIODevice::WriteOnly);

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -49,7 +49,7 @@ public:
 
     QString const& next()
     {
-        int new_slash_index = path_.lastIndexOf(SlashChar, slash_index_);
+        int const new_slash_index = path_.lastIndexOf(SlashChar, slash_index_);
         token_.truncate(0);
         token_.append(&path_.data()[new_slash_index + 1], slash_index_ - new_slash_index);
         slash_index_ = new_slash_index - 1;
@@ -365,7 +365,7 @@ void FileTreeModel::addFile(
             if (child == nullptr)
             {
                 added = true;
-                QModelIndex parent_index(indexOf(item, 0));
+                QModelIndex const parent_index(indexOf(item, 0));
                 int const n(item->childCount());
 
                 beginInsertRows(parent_index, n, n);

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -118,7 +118,7 @@ void FileTreeView::resizeEvent(QResizeEvent* event)
         }
 
         QString const header_text = model_->headerData(column, Qt::Horizontal).toString();
-        int header_width = Utils::measureHeaderItem(this->header(), header_text);
+        int const header_width = Utils::measureHeaderItem(this->header(), header_text);
 
         int const width = std::max(min_width, std::max(item_width, header_width));
         setColumnWidth(column, width);

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -29,7 +29,7 @@ FilterBarComboBox::FilterBarComboBox(QWidget* parent)
 
 QSize FilterBarComboBox::minimumSizeHint() const
 {
-    QFontMetrics fm(fontMetrics());
+    QFontMetrics const fm(fontMetrics());
     QSize const text_size = fm.size(0, itemText(0));
     QSize const count_size = fm.size(0, itemData(0, CountStringRole).toString());
     return calculateSize(text_size, count_size);
@@ -37,7 +37,7 @@ QSize FilterBarComboBox::minimumSizeHint() const
 
 QSize FilterBarComboBox::sizeHint() const
 {
-    QFontMetrics fm(fontMetrics());
+    QFontMetrics const fm(fontMetrics());
     QSize max_text_size(0, 0);
     QSize max_count_size(0, 0);
 

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -82,7 +82,7 @@ QIcon IconCache::getMimeTypeIcon(QString const& mime_type_name, bool multifile) 
 
     if (!multifile)
     {
-        QMimeDatabase mime_db;
+        QMimeDatabase const mime_db;
         auto const type = mime_db.mimeTypeForName(mime_type_name);
         icon = getThemeIcon(type.iconName());
 
@@ -196,7 +196,7 @@ QIcon IconCache::getMimeIcon(QString const& filename) const
     QIcon& icon = ext_to_icon_[ext];
     if (icon.isNull()) // cache miss
     {
-        QMimeDatabase mime_db;
+        QMimeDatabase const mime_db;
         auto const type = mime_db.mimeTypeForFile(filename, QMimeDatabase::MatchExtension);
         if (icon.isNull())
         {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -113,7 +113,7 @@ QIcon MainWindow::addEmblem(QIcon base_icon, QStringList const& emblem_names) co
             QRect(QPoint(0, 0), size));
 
         QPixmap pixmap = base_icon.pixmap(size);
-        QPixmap emblem_pixmap = emblem_icon.pixmap(emblem_size);
+        QPixmap const emblem_pixmap = emblem_icon.pixmap(emblem_size);
         QPainter(&pixmap).drawPixmap(emblem_rect, emblem_pixmap, emblem_pixmap.rect());
 
         icon.addPixmap(pixmap);
@@ -436,7 +436,7 @@ QMenu* MainWindow::createOptionsMenu()
     auto const init_seed_ratio_sub_menu =
         [this](QMenu* menu, QAction*& off_action, QAction*& on_action, int pref, int enabled_pref)
     {
-        std::array<double, 7> stock_ratios = { 0.25, 0.50, 0.75, 1, 1.5, 2, 3 };
+        static constexpr std::array<double, 7> StockRatios = { 0.25, 0.50, 0.75, 1, 1.5, 2, 3 };
         auto const current_value = prefs_.get<double>(pref);
 
         auto* action_group = new QActionGroup(this);
@@ -455,7 +455,7 @@ QMenu* MainWindow::createOptionsMenu()
 
         menu->addSeparator();
 
-        for (double const i : stock_ratios)
+        for (double const i : StockRatios)
         {
             QAction* action = menu->addAction(Formatter::get().ratioToString(i));
             action->setProperty(PrefVariantsKey, QVariantList{ pref, i, enabled_pref, true });
@@ -492,7 +492,7 @@ QMenu* MainWindow::createOptionsMenu()
 
 QMenu* MainWindow::createStatsModeMenu()
 {
-    std::array<QPair<QAction*, QString>, 4> stats_modes = {
+    std::array<QPair<QAction*, QString>, 4> const stats_modes = {
         qMakePair(ui_.action_TotalRatio, total_ratio_stats_mode_name_),
         qMakePair(ui_.action_TotalTransfer, total_transfer_stats_mode_name_),
         qMakePair(ui_.action_SessionRatio, session_ratio_stats_mode_name_),

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -232,8 +232,8 @@ void MakeDialog::onSourceChanged()
     }
     else
     {
-        QString files = tr("%Ln File(s)", nullptr, builder_->fileCount);
-        QString pieces = tr("%Ln Piece(s)", nullptr, builder_->pieceCount);
+        QString const files = tr("%Ln File(s)", nullptr, builder_->fileCount);
+        QString const pieces = tr("%Ln Piece(s)", nullptr, builder_->pieceCount);
         text = tr("%1 in %2; %3 @ %4")
                    .arg(Formatter::get().sizeToString(builder_->totalSize))
                    .arg(files)

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -38,7 +38,7 @@ namespace
 
 void ensureSoundCommandIsAList(tr_variant* dict)
 {
-    tr_quark key = TR_KEY_torrent_complete_sound_command;
+    tr_quark const key = TR_KEY_torrent_complete_sound_command;
 
     if (tr_variant* list = nullptr; tr_variantDictFindList(dict, key, &list))
     {

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -819,7 +819,7 @@ void PrefsDialog::refreshPref(int key)
         break;
     }
 
-    key2widget_t::iterator it(widgets_.find(key));
+    key2widget_t::iterator const it(widgets_.find(key));
 
     if (it != widgets_.end())
     {

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -104,7 +104,7 @@ RpcResponseFuture RpcClient::exec(tr_quark method, tr_variant* args)
 
 RpcResponseFuture RpcClient::exec(std::string_view method, tr_variant* args)
 {
-    TrVariantPtr json = createVariant();
+    TrVariantPtr const json = createVariant();
     tr_variantInitDict(json.get(), 3);
     dictAdd(json.get(), TR_KEY_method, method);
 
@@ -170,7 +170,7 @@ void RpcClient::sendLocalRequest(TrVariantPtr json, QFutureInterface<RpcResponse
 
 RpcResponseFuture RpcClient::sendRequest(TrVariantPtr json)
 {
-    int64_t tag = getNextTag();
+    int64_t const tag = getNextTag();
     dictAdd(json.get(), TR_KEY_tag, tag);
 
     QFutureInterface<RpcResponse> promise;
@@ -211,7 +211,7 @@ void RpcClient::localSessionCallback(tr_session* s, tr_variant* response, void* 
 
     auto* self = static_cast<RpcClient*>(vself);
 
-    TrVariantPtr json = createVariant();
+    TrVariantPtr const json = createVariant();
     *json = *response;
     variantInit(response, false);
 
@@ -266,7 +266,7 @@ void RpcClient::networkRequestFinished(QNetworkReply* reply)
         QByteArray const json_data = reply->readAll().trimmed();
         auto const json_sv = std::string_view{ std::data(json_data), size_t(std::size(json_data)) };
 
-        TrVariantPtr json = createVariant();
+        TrVariantPtr const json = createVariant();
         RpcResponse result;
         if (tr_variantFromBuf(json.get(), TR_VARIANT_PARSE_JSON, json_sv))
         {
@@ -280,8 +280,8 @@ void RpcClient::networkRequestFinished(QNetworkReply* reply)
 
 void RpcClient::localRequestFinished(TrVariantPtr response)
 {
-    int64_t tag = parseResponseTag(*response);
-    RpcResponse result = parseResponseData(*response);
+    int64_t const tag = parseResponseTag(*response);
+    RpcResponse const result = parseResponseData(*response);
     QFutureInterface<RpcResponse> promise = local_requests_.take(tag);
 
     promise.setProgressRange(0, 1);

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -24,7 +24,7 @@ void RpcQueue::stepFinished()
     if (future_watcher_.future().isResultReadyAt(0))
     {
         result = future_watcher_.result();
-        RpcResponseFuture future = future_watcher_.future();
+        RpcResponseFuture const future = future_watcher_.future();
 
         // we can't handle network errors, abort queue and pass the error upwards
         if (result.networkError != QNetworkReply::NoError)

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -63,7 +63,7 @@ void SqueezeLabel::paintEvent(QPaintEvent* paintEvent)
     }
 
     QPainter painter(this);
-    QFontMetrics fm = fontMetrics();
+    QFontMetrics const fm = fontMetrics();
     QStyleOption opt;
     opt.initFrom(this);
     auto const full_text = text();

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -164,7 +164,7 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
 
     for (size_t pos = 0; pos < n; ++pos)
     {
-        tr_quark key = keys[pos];
+        tr_quark const key = keys[pos];
         tr_variant const* child = values[pos];
         bool field_changed = false;
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -379,7 +379,7 @@ QString TorrentDelegate::statusString(Torrent const& tor)
 
     if (tor.isReadyToTransfer())
     {
-        QString s = shortTransferString(tor);
+        QString const s = shortTransferString(tor);
 
         if (!s.isEmpty())
         {

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -231,7 +231,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
 bool TorrentFilter::filterAcceptsRow(int source_row, QModelIndex const& source_parent) const
 {
-    QModelIndex child_index = sourceModel()->index(source_row, 0, source_parent);
+    QModelIndex const child_index = sourceModel()->index(source_row, 0, source_parent);
     auto const& tor = *child_index.model()->data(child_index, TorrentModel::TorrentRole).value<Torrent const*>();
     bool accepts = true;
 

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -119,7 +119,7 @@ void TrackerDelegate::drawTracker(QPainter* painter, QStyleOptionViewItem const&
     bool const is_item_enabled((option.state & QStyle::State_Enabled) != 0);
     bool const is_item_active((option.state & QStyle::State_Active) != 0);
 
-    QIcon tracker_icon(inf.st.getFavicon());
+    QIcon const tracker_icon(inf.st.getFavicon());
 
     QRect const content_rect(option.rect.adjusted(Margin.width(), Margin.height(), -Margin.width(), -Margin.height()));
     ItemLayout const layout(getText(inf), is_item_selected, option.direction, content_rect.topLeft(), content_rect.width());

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -99,7 +99,7 @@ void TrackerModel::refresh(TorrentModel const& torrent_model, torrent_ids_t cons
     }
 
     // sort 'em
-    CompareTrackers comp;
+    CompareTrackers const comp;
     std::sort(trackers.begin(), trackers.end(), comp);
 
     // merge 'em with the existing list

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -19,7 +19,7 @@ void TrackerModelFilter::setShowBackupTrackers(bool b)
 
 bool TrackerModelFilter::filterAcceptsRow(int source_row, QModelIndex const& source_parent) const
 {
-    QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
+    QModelIndex const index = sourceModel()->index(source_row, 0, source_parent);
     auto const tracker_info = index.data(TrackerModel::TrackerRole).value<TrackerInfo>();
     return show_backups_ || !tracker_info.st.is_backup;
 }

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -137,7 +137,7 @@ TEST(Bitfield, setRaw)
 
     // check that the spare bits t the end are zero
     bf = tr_bitfield{ 1 };
-    uint8_t by = std::numeric_limits<uint8_t>::max();
+    uint8_t const by = std::numeric_limits<uint8_t>::max();
     bf.setRaw(&by, 1);
     EXPECT_TRUE(bf.hasAll());
     EXPECT_FALSE(bf.hasNone());
@@ -149,7 +149,7 @@ TEST(Bitfield, setRaw)
 
 TEST(Bitfield, bitfields)
 {
-    unsigned int bitcount = 500;
+    unsigned int const bitcount = 500;
     tr_bitfield field(bitcount);
 
     // test tr_bitfield::set()

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -76,8 +76,8 @@ private:
     {
         bool identical = true;
 
-        tr_sys_file_t fd1 = tr_sys_file_open(fn1, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
-        tr_sys_file_t fd2 = tr_sys_file_open(fn2, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
+        tr_sys_file_t const fd1 = tr_sys_file_open(fn1, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
+        tr_sys_file_t const fd2 = tr_sys_file_open(fn2, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
         EXPECT_NE(fd1, TR_BAD_SYS_FILE);
         EXPECT_NE(fd2, TR_BAD_SYS_FILE);
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -286,7 +286,7 @@ TEST_F(FilePieceMapTest, wanted)
     // set the first file as not wanted.
     // since this begins and ends on a piece boundary,
     // this shouldn't affect any other files' pieces
-    bool wanted = false;
+    bool const wanted = false;
     files_wanted.set(0, wanted);
     expected_files_wanted.set(0, wanted);
     expected_pieces_wanted.setSpan(0, 5, wanted);

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -207,7 +207,7 @@ protected:
         char const* source)
     {
         // build random payloads
-        size_t payload_count = 1 + tr_rand_int_weak(max_file_count);
+        size_t const payload_count = 1 + tr_rand_int_weak(max_file_count);
         auto** payloads = tr_new0(void*, payload_count);
         auto* payload_sizes = tr_new0(size_t, payload_count);
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -258,7 +258,7 @@ TEST_F(UtilsTest, trStrlcpy)
     char const initial_char = '1';
     std::array<char, 100> destination = { initial_char };
 
-    std::vector<std::string> tests{
+    std::vector<std::string> const tests{
         "a",
         "",
         "12345678901234567890",


### PR DESCRIPTION
fix clang-tidy `misc-const-correctness` warnings.

