### PR TITLE
refactor: avoid unnecessary heap alloc when sending magnet link over RPC

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -626,9 +626,7 @@ static void initField(tr_torrent const* const tor, tr_stat const* const st, tr_v
         break;
 
     case TR_KEY_magnetLink:
-        str = tr_torrentGetMagnetLink(tor);
-        tr_variantInitStr(initme, str);
-        tr_free(str);
+        tr_variantInitStr(initme, tor->metainfo_.magnet());
         break;
 
     case TR_KEY_metadataPercentComplete:


### PR DESCRIPTION
tiny RPC refactor to avoid an unnecessary `tr_new()` / `tr_free()` when sending a magnet link over RPC