### PR TITLE
refactor: remove closure struct in tr-dht

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -109,11 +109,6 @@ void tr_free(void* p)
     }
 }
 
-void* tr_memdup(void const* src, size_t byteCount)
-{
-    return memcpy(tr_malloc(byteCount), src, byteCount);
-}
-
 /***
 ****
 ***/

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -169,14 +169,6 @@ void* tr_realloc(void* p, size_t size);
 /** @brief Portability wrapper around free() in which `nullptr' is a safe argument */
 void tr_free(void* p);
 
-/**
- * @brief make a newly-allocated copy of a chunk of memory
- * @param src the memory to copy
- * @param byteCount the number of bytes to copy
- * @return a newly-allocated copy of `src' that can be freed with tr_free()
- */
-[[nodiscard]] void* tr_memdup(void const* src, size_t byteCount);
-
 #define tr_new(struct_type, n_structs) (static_cast<struct_type*>(tr_malloc(sizeof(struct_type) * (size_t)(n_structs))))
 
 #define tr_new0(struct_type, n_structs) (static_cast<struct_type*>(tr_malloc0(sizeof(struct_type) * (size_t)(n_structs))))


### PR DESCRIPTION
This was the last use of tr_memdup(), so remove that too. :tada: 