### PR TITLE
fix: use correct variable for uploading speed

### DIFF
--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -137,7 +137,7 @@ std::string getShortTransferString(
 
     if (bool const have_up = have_meta && st->peersGettingFromUs > 0; have_up)
     {
-        return fmt::format(_("{upload_speed} ▲"), fmt::arg("upload_speed", tr_formatter_speed_KBps(downloadSpeed_KBps)));
+        return fmt::format(_("{upload_speed} ▲"), fmt::arg("upload_speed", tr_formatter_speed_KBps(uploadSpeed_KBps)));
     }
 
     if (st->isStalled)


### PR DESCRIPTION
Replaced wrong variable for uploading speed for active torrent seeding
Fixes #3448 and #3357