### PR TITLE
refactor: in sendPex(), reuse the temporary buffer

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2505,8 +2505,6 @@ static void sendPex(tr_peerMsgsImpl* msgs)
         return;
     }
 
-    uint8_t* tmp = nullptr;
-    uint8_t* walk = nullptr;
     evbuffer* const out = msgs->outMessages;
 
     // update msgs
@@ -2517,10 +2515,14 @@ static void sendPex(tr_peerMsgsImpl* msgs)
     auto val = tr_variant{};
     tr_variantInitDict(&val, 3); /* ipv6 support: left as 3: speed vs. likelihood? */
 
+    auto tmpbuf = std::vector<uint8_t>{};
+
     if (!std::empty(added))
     {
         // "added"
-        tmp = walk = tr_new(uint8_t, std::size(added) * 6U);
+        tmpbuf.resize(std::size(added) * 6U);
+        auto* begin = std::data(tmpbuf);
+        auto* walk = begin;
         for (auto const& p : added)
         {
             memcpy(walk, &p.addr.addr, 4U);
@@ -2529,27 +2531,29 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             walk += 2U;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(added) * 6U);
-        tr_variantDictAddRaw(&val, TR_KEY_added, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(added) * 6U);
+        tr_variantDictAddRaw(&val, TR_KEY_added, begin, walk - begin);
 
         // "added.f"
         // unset each holepunch flag because we don't support it.
-        tmp = walk = tr_new(uint8_t, std::size(added));
+        tmpbuf.resize(std::size(added));
+        begin = std::data(tmpbuf);
+        walk = begin;
         for (auto const& p : added)
         {
             *walk++ = p.flags & ~ADDED_F_HOLEPUNCH;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(added));
-        tr_variantDictAddRaw(&val, TR_KEY_added_f, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(added));
+        tr_variantDictAddRaw(&val, TR_KEY_added_f, begin, walk - begin);
     }
 
     if (!std::empty(dropped))
     {
         // "dropped"
-        tmp = walk = tr_new(uint8_t, std::size(dropped) * 6U);
+        tmpbuf.resize(std::size(dropped) * 6U);
+        auto* begin = std::data(tmpbuf);
+        auto* walk = begin;
         for (auto const& p : dropped)
         {
             memcpy(walk, &p.addr.addr, 4U);
@@ -2558,15 +2562,16 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             walk += 2U;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(dropped) * 6U);
-        tr_variantDictAddRaw(&val, TR_KEY_dropped, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(dropped) * 6U);
+        tr_variantDictAddRaw(&val, TR_KEY_dropped, begin, walk - begin);
     }
 
     if (!std::empty(added6))
     {
         // "added6"
-        tmp = walk = tr_new(uint8_t, std::size(added6) * 18U);
+        tmpbuf.resize(std::size(added6) * 18U);
+        auto* begin = std::data(tmpbuf);
+        auto* walk = begin;
         for (auto const& p : added6)
         {
             memcpy(walk, &p.addr.addr.addr6.s6_addr, 16U);
@@ -2575,27 +2580,29 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             walk += 2U;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(added6) * 18U);
-        tr_variantDictAddRaw(&val, TR_KEY_added6, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(added6) * 18U);
+        tr_variantDictAddRaw(&val, TR_KEY_added6, begin, walk - begin);
 
         // "added6.f"
         // unset each holepunch flag because we don't support it.
-        tmp = walk = tr_new(uint8_t, std::size(added6));
+        tmpbuf.resize(std::size(added6));
+        begin = std::data(tmpbuf);
+        walk = begin;
         for (auto const& p : added6)
         {
             *walk++ = p.flags & ~ADDED_F_HOLEPUNCH;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(added6));
-        tr_variantDictAddRaw(&val, TR_KEY_added6_f, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(added6));
+        tr_variantDictAddRaw(&val, TR_KEY_added6_f, begin, walk - begin);
     }
 
     if (!std::empty(dropped6))
     {
         // "dropped6"
-        tmp = walk = tr_new(uint8_t, std::size(dropped6) * 18U);
+        tmpbuf.resize(std::size(dropped6) * 18U);
+        auto* const begin = std::data(tmpbuf);
+        auto* walk = begin;
         for (auto const& p : dropped6)
         {
             memcpy(walk, &p.addr.addr.addr6.s6_addr, 16U);
@@ -2604,9 +2611,8 @@ static void sendPex(tr_peerMsgsImpl* msgs)
             walk += 2U;
         }
 
-        TR_ASSERT(static_cast<size_t>(walk - tmp) == std::size(dropped6) * 18U);
-        tr_variantDictAddRaw(&val, TR_KEY_dropped6, tmp, walk - tmp);
-        tr_free(tmp);
+        TR_ASSERT(static_cast<size_t>(walk - begin) == std::size(dropped6) * 18U);
+        tr_variantDictAddRaw(&val, TR_KEY_dropped6, begin, walk - begin);
     }
 
     /* write the pex message */


### PR DESCRIPTION
minor refactor to sendPex() to use `std::vector` instead of `tr_new() / tr_free()`