### PR TITLE
Fix broken tr_sessionSetPeerPortRandom() function.

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1291,10 +1291,10 @@ uint16_t tr_sessionGetPeerPort(tr_session const* session)
 
 uint16_t tr_sessionSetPeerPortRandom(tr_session* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    tr_port p = getRandomPort(session);
+    tr_sessionSetPeerPort(session, p.host());
 
-    session->setPeerPort(getRandomPort(session));
-    return session->private_peer_port.host();
+    return p.host();
 }
 
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random)


### PR DESCRIPTION
This PR fixes https://github.com/transmission/transmission/issues/2983

Testing: I've simulated this feature in GTK client and now it works as expected -- function returns new correct port number, the same open port I see in `netstat`.