### PR TITLE
fix: clang-tidy-15 warnings

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -133,7 +133,8 @@ size_t tr_bitfield::countFlags(size_t begin, size_t end) const noexcept
         for (size_t i = first_byte + 1; i < walk_end;)
         {
             tmp_accum += doPopcount(flags_[i]);
-            if ((i += 2) > walk_end)
+            i += 2;
+            if (i > walk_end)
             {
                 break;
             }

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -68,7 +68,7 @@ public:
     {
         if (!isInitialized())
         {
-            return {};
+            return { 0U, 0U };
         }
 
         return { pieceLoc(piece).block, pieceLastLoc(piece).block + 1 };
@@ -78,7 +78,7 @@ public:
     {
         if (!isInitialized())
         {
-            return {};
+            return { 0U, 0U };
         }
 
         auto const offset = pieceLoc(piece).byte;

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -177,9 +177,9 @@ void tr_completion::setHasAll() noexcept
 
 void tr_completion::addPiece(tr_piece_index_t piece)
 {
-    auto const [begin, end] = block_info_->blockSpanForPiece(piece);
+    auto const span = block_info_->blockSpanForPiece(piece);
 
-    for (tr_block_index_t block = begin; block < end; ++block)
+    for (tr_block_index_t block = span.begin; block < span.end; ++block)
     {
         addBlock(block);
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2257,13 +2257,13 @@ static void tr_torrentFileCompleted(tr_torrent* tor, tr_file_index_t i)
     }
 }
 
-static void tr_torrentPieceCompleted(tr_torrent* tor, tr_piece_index_t pieceIndex)
+static void tr_torrentPieceCompleted(tr_torrent* tor, tr_piece_index_t piece_index)
 {
-    tr_peerMgrPieceCompleted(tor, pieceIndex);
+    tr_peerMgrPieceCompleted(tor, piece_index);
 
     // if this piece completes any file, invoke the fileCompleted func for it
-    auto const [begin, end] = tor->fpm_.fileSpan(pieceIndex);
-    for (tr_file_index_t file = begin; file < end; ++file)
+    auto const span = tor->fpm_.fileSpan(piece_index);
+    for (auto file = span.begin; file < span.end; ++file)
     {
         if (tor->completion.hasBlocks(tr_torGetFileBlockSpan(tor, file)))
         {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2631,22 +2631,27 @@ static void torrentRenamePath(
     {
         error = EINVAL;
     }
-    else if ((error = renamePath(tor, oldpath, newname)) == 0)
+    else
     {
-        /* update tr_info.files */
-        for (auto const& file_index : file_indices)
-        {
-            renameTorrentFileString(tor, oldpath, newname, file_index);
-        }
+        error = renamePath(tor, oldpath, newname);
 
-        /* update tr_info.name if user changed the toplevel */
-        if (std::size(file_indices) == tor->fileCount() && !tr_strvContains(oldpath, '/'))
+        if (error == 0)
         {
-            tor->setName(newname);
-        }
+            /* update tr_info.files */
+            for (auto const& file_index : file_indices)
+            {
+                renameTorrentFileString(tor, oldpath, newname, file_index);
+            }
 
-        tor->markEdited();
-        tor->setDirty();
+            /* update tr_info.name if user changed the toplevel */
+            if (std::size(file_indices) == tor->fileCount() && !tr_strvContains(oldpath, '/'))
+            {
+                tor->setName(newname);
+            }
+
+            tor->markEdited();
+            tor->setDirty();
+        }
     }
 
     /***

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -240,7 +240,7 @@ enum
     UPNP_IGD_INVALID = 3
 };
 
-static auto* discoverThreadfunc(std::string bindaddr)
+static auto* discoverThreadfunc(std::string bindaddr) // NOLINT performance-unnecessary-value-param
 {
     return tr_upnpDiscover(2000, bindaddr.c_str());
 }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -822,26 +822,32 @@ void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkF
         if (!node.is_visited)
         {
             v = &node.v;
+
             node.is_visited = true;
         }
-        else if ((v = node.nextChild()) != nullptr)
+        else
         {
-            if (tr_variantIsDict(&node.v))
-            {
-                auto tmp = tr_variant{};
-                tr_variantInitQuark(&tmp, v->key);
-                walkFuncs->stringFunc(&tmp, user_data);
-            }
-        }
-        else // finished with this node
-        {
-            if (tr_variantIsContainer(&node.v))
-            {
-                walkFuncs->containerEndFunc(&node.v, user_data);
-            }
+            v = node.nextChild();
 
-            stack.pop();
-            continue;
+            if (v != nullptr)
+            {
+                if (tr_variantIsDict(&node.v))
+                {
+                    auto tmp = tr_variant{};
+                    tr_variantInitQuark(&tmp, v->key);
+                    walkFuncs->stringFunc(&tmp, user_data);
+                }
+            }
+            else // finished with this node
+            {
+                if (tr_variantIsContainer(&node.v))
+                {
+                    walkFuncs->containerEndFunc(&node.v, user_data);
+                }
+
+                stack.pop();
+                continue;
+            }
         }
 
         if (v != nullptr)

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -73,10 +73,8 @@ tr_watchdir_backend* tr_watchdir_generic_new(tr_watchdir_t handle)
 {
     auto* backend = new tr_watchdir_generic{};
     backend->base.free_func = &tr_watchdir_generic_free;
-
-    if ((backend
-             ->event = event_new(tr_watchdir_get_event_base(handle), -1, EV_PERSIST, &tr_watchdir_generic_on_event, handle)) ==
-        nullptr)
+    backend->event = event_new(tr_watchdir_get_event_base(handle), -1, EV_PERSIST, &tr_watchdir_generic_on_event, handle);
+    if (backend->event == nullptr)
     {
         auto const error_code = errno;
         tr_logAddError(fmt::format(

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -99,7 +99,8 @@ static void tr_watchdir_inotify_on_event(struct bufferevent* event, void* contex
         }
 
         /* Consume entire name into buffer */
-        if ((nread = bufferevent_read(event, name, ev.len)) == (size_t)-1)
+        nread = bufferevent_read(event, name, ev.len);
+        if (nread == static_cast<size_t>(-1))
         {
             auto const error_code = errno;
             tr_logAddError(fmt::format(

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -61,5 +61,5 @@ void AboutDialog::showCredits()
 
 void AboutDialog::showLicense()
 {
-    Utils::openDialog(license_dialog_, this);
+    Utils::openDialog(license_dialog_, this); // NOLINT clang-analyzer-cplusplus.NewDelete
 }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -815,28 +815,27 @@ RpcResponseFuture Session::exec(std::string_view method, tr_variant* args)
 
 void Session::updateStats(tr_variant* d, tr_session_stats* stats)
 {
-    auto value = dictFind<uint64_t>(d, TR_KEY_uploadedBytes);
-    if (value)
+    if (auto const value = dictFind<uint64_t>(d, TR_KEY_uploadedBytes); value)
     {
         stats->uploadedBytes = *value;
     }
 
-    if ((value = dictFind<uint64_t>(d, TR_KEY_downloadedBytes)))
+    if (auto const value = dictFind<uint64_t>(d, TR_KEY_downloadedBytes); value)
     {
         stats->downloadedBytes = *value;
     }
 
-    if ((value = dictFind<uint64_t>(d, TR_KEY_filesAdded)))
+    if (auto const value = dictFind<uint64_t>(d, TR_KEY_filesAdded); value)
     {
         stats->filesAdded = *value;
     }
 
-    if ((value = dictFind<uint64_t>(d, TR_KEY_sessionCount)))
+    if (auto const value = dictFind<uint64_t>(d, TR_KEY_sessionCount); value)
     {
         stats->sessionCount = *value;
     }
 
-    if ((value = dictFind<uint64_t>(d, TR_KEY_secondsActive)))
+    if (auto const value = dictFind<uint64_t>(d, TR_KEY_secondsActive); value)
     {
         stats->secondsActive = *value;
     }

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -174,7 +174,6 @@ QString timeToStringRounded(int seconds)
 
 QString TrackerDelegate::getText(TrackerInfo const& inf) const
 {
-    QString key;
     QString str;
     auto const err_markup_begin = QStringLiteral("<span style=\"color:red\">");
     auto const err_markup_end = QStringLiteral("</span>");
@@ -197,11 +196,6 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
     str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
     auto const url = QUrl(inf.st.announce);
     str += QStringLiteral("%1:%2").arg(url.host()).arg(url.port(80));
-
-    if (!key.isEmpty())
-    {
-        str += QStringLiteral(" - ") + key;
-    }
 
     str += inf.st.is_backup ? QStringLiteral("</i>") : QStringLiteral("</b>");
 

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -63,7 +63,7 @@ public:
     {
         if (dialog.isNull())
         {
-            dialog = new DialogT(std::forward<ArgsT>(args)...);
+            dialog = new DialogT(std::forward<ArgsT>(args)...); // NOLINT clang-analyzer-cplusplus.NewDelete
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
         }


### PR DESCRIPTION
Fix a handful of warnings that were uncovered by trying a devel build of clang-tidy-15.

No functional changes.