### PR TITLE
fix: readability-inconsistent-declaration-parameter-name warnings in libtransmission

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
   readability-*,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
-  -readability-inconsistent-declaration-parameter-name,
   -readability-magic-numbers,
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -104,7 +104,7 @@ public:
     }
 
     bool add(std::string_view announce_url_sv, tr_tracker_tier_t tier);
-    void add(tr_announce_list const& that);
+    void add(tr_announce_list const& src);
     bool remove(std::string_view announce_url);
     bool remove(tr_tracker_id_t id);
     bool replace(tr_tracker_id_t id, std::string_view announce_url_sv);

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -238,8 +238,8 @@ void tr_tracker_udp_announce(
 
 void tr_tracker_udp_start_shutdown(tr_session* session);
 
-void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view msg, char const* log_name);
+void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view benc, char const* log_name);
 
-void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view msg, char const* log_name);
+void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view benc, char const* log_name);
 
 tr_interned_string tr_announcerGetKey(tr_url_parsed_t const& parsed);

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -69,7 +69,7 @@ void tr_announcerClose(tr_session*);
 ***  For torrent customers
 **/
 
-struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback cb, void* cbdata);
+struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback callback, void* callback_data);
 
 void tr_announcerResetTorrent(struct tr_announcer*, tr_torrent*);
 
@@ -92,11 +92,11 @@ enum
     TR_ANN_CORRUPT
 };
 
-void tr_announcerAddBytes(tr_torrent*, int up_down_or_corrupt, uint32_t byteCount);
+void tr_announcerAddBytes(tr_torrent*, int type, uint32_t byteCount);
 
 time_t tr_announcerNextManualAnnounce(tr_torrent const*);
 
-tr_tracker_view tr_announcerTracker(tr_torrent const* torrent, size_t i);
+tr_tracker_view tr_announcerTracker(tr_torrent const* torrent, size_t nth);
 
 size_t tr_announcerTrackerCount(tr_torrent const* tor);
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -160,15 +160,15 @@ void tr_bandwidth::allocateBandwidth(
     }
 }
 
-void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir)
+void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peer_array, tr_direction dir)
 {
     /* First phase of IO. Tries to distribute bandwidth fairly to keep faster
      * peers from starving the others. Loop through the peers, giving each a
      * small chunk of bandwidth. Keep looping until we run out of bandwidth
      * and/or peers that can use it */
-    tr_logAddTrace(fmt::format("{} peers to go round-robin for {}", peerArray.size(), dir == TR_UP ? "upload" : "download"));
+    tr_logAddTrace(fmt::format("{} peers to go round-robin for {}", peer_array.size(), dir == TR_UP ? "upload" : "download"));
 
-    size_t n = peerArray.size();
+    auto n = peer_array.size();
     while (n > 0)
     {
         int const i = tr_rand_int_weak(n); /* pick a peer at random */
@@ -178,14 +178,14 @@ void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peerArray, tr_direction dir
          * out in a timely manner. */
         size_t const increment = 3000;
 
-        int const bytes_used = tr_peerIoFlush(peerArray[i], dir, increment);
+        int const bytes_used = tr_peerIoFlush(peer_array[i], dir, increment);
 
         tr_logAddTrace(fmt::format("peer #{} of {} used {} bytes in this pass", i, n, bytes_used));
 
         if (bytes_used != int(increment))
         {
             /* peer is done writing for now; move it to the end of the list */
-            std::swap(peerArray[i], peerArray[n - 1]);
+            std::swap(peer_array[i], peer_array[n - 1]);
             --n;
         }
     }

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -117,7 +117,7 @@ public:
      */
     void allocate(tr_direction dir, unsigned int period_msec);
 
-    void setParent(tr_bandwidth* newParent);
+    void setParent(tr_bandwidth* new_parent);
 
     [[nodiscard]] constexpr tr_priority_t getPriority() const noexcept
     {

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -43,7 +43,7 @@ public:
     void setHasNone() noexcept;
 
     // set one or more bits
-    void set(size_t bit, bool value = true);
+    void set(size_t nth, bool value = true);
     void setSpan(size_t begin, size_t end, bool value = true);
     void unset(size_t bit)
     {
@@ -53,12 +53,12 @@ public:
     {
         setSpan(begin, end, false);
     }
-    void setFromBools(bool const* bytes, size_t n);
+    void setFromBools(bool const* flags, size_t n);
 
     // "raw" here is in BEP0003 format: "The first byte of the bitfield
     // corresponds to indices 0 - 7 from high bit to low bit, respectively.
     // The next one 8-15, etc. Spare bits at the end are set to zero."
-    void setRaw(uint8_t const* bits, size_t byte_count);
+    void setRaw(uint8_t const* raw, size_t byte_count);
     [[nodiscard]] std::vector<uint8_t> raw() const;
 
     [[nodiscard]] constexpr bool hasAll() const noexcept

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -127,7 +127,7 @@ Cache::Cache(tr_torrents& torrents, int64_t max_bytes)
 ****
 ***/
 
-void Cache::writeBlock(tr_torrent_id_t tor_id, tr_block_index_t block, std::unique_ptr<std::vector<uint8_t>>& data)
+void Cache::writeBlock(tr_torrent_id_t tor_id, tr_block_index_t block, std::unique_ptr<std::vector<uint8_t>>& writeme)
 {
     auto const key = Key{ tor_id, block };
     auto iter = std::lower_bound(std::begin(blocks_), std::end(blocks_), key, CompareCacheBlockByKey{});
@@ -139,7 +139,7 @@ void Cache::writeBlock(tr_torrent_id_t tor_id, tr_block_index_t block, std::uniq
 
     iter->time_added = tr_time();
 
-    iter->buf = std::move(data);
+    iter->buf = std::move(writeme);
 
     ++cache_writes_;
     cache_write_bytes_ += std::size(*iter->buf);
@@ -205,11 +205,11 @@ int Cache::flushSpan(CIter const begin, CIter const end)
     return {};
 }
 
-int Cache::flushFile(tr_torrent* torrent, tr_file_index_t i)
+int Cache::flushFile(tr_torrent* torrent, tr_file_index_t file)
 {
     auto const compare = CompareCacheBlockByKey{};
     auto const tor_id = torrent->id();
-    auto const [block_begin, block_end] = tr_torGetFileBlockSpan(torrent, i);
+    auto const [block_begin, block_end] = tr_torGetFileBlockSpan(torrent, file);
 
     return flushSpan(
         std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_begin), compare),

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -105,9 +105,9 @@ struct tr_completion
 
     void amountDone(float* tab, size_t n_tabs) const;
 
-    void addBlock(tr_block_index_t i);
-    void addPiece(tr_piece_index_t i);
-    void removePiece(tr_piece_index_t i);
+    void addBlock(tr_block_index_t block);
+    void addPiece(tr_piece_index_t piece);
+    void removePiece(tr_piece_index_t piece);
 
     void setHasPiece(tr_piece_index_t i, bool has)
     {

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -78,7 +78,7 @@ bool tr_x509_store_add(tr_x509_store_t handle, tr_x509_cert_t cert);
 /**
  * @brief Allocate and initialize new X509 certificate from DER-encoded buffer.
  */
-tr_x509_cert_t tr_x509_cert_new(void const* der_data, size_t der_data_size);
+tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length);
 
 /**
  * @brief Free X509 certificate returned by @ref tr_x509_cert_new.
@@ -106,7 +106,7 @@ bool tr_rand_buffer(void* buffer, size_t length);
 /**
  * @brief Generate a SSHA password from its plaintext source.
  */
-std::string tr_ssha1(std::string_view plain_text);
+std::string tr_ssha1(std::string_view plaintext);
 
 /**
  * @brief Return true if this is salted text, false otherwise
@@ -116,7 +116,7 @@ bool tr_ssha1_test(std::string_view text);
 /**
  * @brief Validate a test password against the a ssha1 password.
  */
-bool tr_ssha1_matches(std::string_view ssha1, std::string_view plain_text);
+bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext);
 
 /**
  * @brief Translate null-terminated string into base64.

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -141,7 +141,7 @@ struct tr_handshake
     tr_peerIo* io = nullptr;
     DH dh = {};
     handshake_state_t state;
-    tr_encryption_mode encryptionMode;
+    tr_encryption_mode encryption_mode;
     uint16_t pad_c_len = {};
     uint16_t pad_d_len = {};
     uint16_t ia_len = {};
@@ -224,7 +224,7 @@ static bool buildHandshakeMessage(tr_handshake* handshake, uint8_t* buf)
     return true;
 }
 
-static ReadState tr_handshakeDone(tr_handshake* handshake, bool isConnected);
+static ReadState tr_handshakeDone(tr_handshake* handshake, bool is_connected);
 
 enum handshake_parse_err_t
 {
@@ -321,7 +321,7 @@ static uint32_t getCryptoProvide(tr_handshake const* handshake)
 {
     uint32_t provide = 0;
 
-    switch (handshake->encryptionMode)
+    switch (handshake->encryption_mode)
     {
     case TR_ENCRYPTION_REQUIRED:
     case TR_ENCRYPTION_PREFERRED:
@@ -341,7 +341,7 @@ static uint32_t getCryptoSelect(tr_handshake const* handshake, uint32_t crypto_p
     uint32_t choices[2];
     int nChoices = 0;
 
-    switch (handshake->encryptionMode)
+    switch (handshake->encryption_mode)
     {
     case TR_ENCRYPTION_REQUIRED:
         choices[nChoices++] = CRYPTO_PROVIDE_CRYPTO;
@@ -574,7 +574,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
 
     if (pstrlen == 19) /* unencrypted */
     {
-        if (handshake->encryptionMode == TR_ENCRYPTION_REQUIRED)
+        if (handshake->encryption_mode == TR_ENCRYPTION_REQUIRED)
         {
             tr_logAddTraceHand(handshake, "peer is unencrypted, and we're disallowing that");
             return tr_handshakeDone(handshake, false);
@@ -1054,12 +1054,12 @@ static bool fireDoneFunc(tr_handshake* handshake, bool isConnected)
     return success;
 }
 
-static ReadState tr_handshakeDone(tr_handshake* handshake, bool isOK)
+static ReadState tr_handshakeDone(tr_handshake* handshake, bool is_connected)
 {
-    tr_logAddTraceHand(handshake, isOK ? "handshakeDone: connected" : "handshakeDone: aborting");
+    tr_logAddTraceHand(handshake, is_connected ? "handshakeDone: connected" : "handshakeDone: aborting");
     tr_peerIoSetIOFuncs(handshake->io, nullptr, nullptr, nullptr, nullptr);
 
-    bool const success = fireDoneFunc(handshake, isOK);
+    bool const success = fireDoneFunc(handshake, is_connected);
     delete handshake;
     return success ? READ_LATER : READ_ERR;
 }
@@ -1104,7 +1104,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
      * have encountered a peer that doesn't do encryption... reconnect and
      * try a plaintext handshake */
     if ((handshake->state == AWAITING_YB || handshake->state == AWAITING_VC) &&
-        handshake->encryptionMode != TR_ENCRYPTION_REQUIRED && tr_peerIoReconnect(handshake->io) == 0)
+        handshake->encryption_mode != TR_ENCRYPTION_REQUIRED && tr_peerIoReconnect(handshake->io) == 0)
     {
         uint8_t msg[HANDSHAKE_SIZE];
 
@@ -1135,13 +1135,13 @@ static void handshakeTimeout(evutil_socket_t /*s*/, short /*type*/, void* handsh
 tr_handshake* tr_handshakeNew(
     std::shared_ptr<tr_handshake_mediator> mediator,
     tr_peerIo* io,
-    tr_encryption_mode encryptionMode,
+    tr_encryption_mode encryption_mode,
     tr_handshake_done_func done_func,
     void* done_func_user_data)
 {
     auto* const handshake = new tr_handshake{ std::move(mediator) };
     handshake->io = io;
-    handshake->encryptionMode = encryptionMode;
+    handshake->encryption_mode = encryption_mode;
     handshake->done_func = done_func;
     handshake->done_func_user_data = done_func_user_data;
     handshake->timeout_timer = evtimer_new(handshake->mediator->eventBase(), handshakeTimeout, handshake);
@@ -1154,7 +1154,7 @@ tr_handshake* tr_handshakeNew(
     {
         setReadState(handshake, AWAITING_HANDSHAKE);
     }
-    else if (encryptionMode != TR_CLEAR_PREFERRED)
+    else if (encryption_mode != TR_CLEAR_PREFERRED)
     {
         sendYa(handshake);
     }

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -76,8 +76,8 @@ tr_handshake* tr_handshakeNew(
     std::shared_ptr<tr_handshake_mediator> mediator,
     tr_peerIo* io,
     tr_encryption_mode encryption_mode,
-    tr_handshake_done_func when_done,
-    void* when_done_user_data);
+    tr_handshake_done_func done_func,
+    void* done_func_user_data);
 
 void tr_handshakeAbort(tr_handshake* handshake);
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -256,9 +256,9 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
 
 } // namespace
 
-int tr_ioRead(tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t* buf)
+int tr_ioRead(tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t* setme)
 {
-    return readOrWritePiece(tor, IoMode::Read, loc, buf, len);
+    return readOrWritePiece(tor, IoMode::Read, loc, setme, len);
 }
 
 int tr_ioPrefetch(tr_torrent* tor, tr_block_info::Location loc, uint32_t len)
@@ -266,9 +266,9 @@ int tr_ioPrefetch(tr_torrent* tor, tr_block_info::Location loc, uint32_t len)
     return readOrWritePiece(tor, IoMode::Prefetch, loc, nullptr, len);
 }
 
-int tr_ioWrite(tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t const* buf)
+int tr_ioWrite(tr_torrent* tor, tr_block_info::Location loc, uint32_t len, uint8_t const* writeme)
 {
-    return readOrWritePiece(tor, IoMode::Write, loc, (uint8_t*)buf, len);
+    return readOrWritePiece(tor, IoMode::Write, loc, const_cast<uint8_t*>(writeme), len);
 }
 
 bool tr_ioTestPiece(tr_torrent* tor, tr_piece_index_t piece)

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -218,15 +218,15 @@ tr_log_message* tr_logGetQueue()
     return ret;
 }
 
-void tr_logFreeQueue(tr_log_message* list)
+void tr_logFreeQueue(tr_log_message* freeme)
 {
-    while (list != nullptr)
+    while (freeme != nullptr)
     {
-        tr_log_message* next = list->next;
-        tr_free(list->message);
-        tr_free(list->name);
-        tr_free(list);
-        list = next;
+        auto* const next = freeme->next;
+        tr_free(freeme->message);
+        tr_free(freeme->name);
+        tr_free(freeme);
+        freeme = next;
     }
 }
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -92,7 +92,7 @@ void tr_logAddMessage(
     char const* source_file,
     int source_line,
     tr_log_level level,
-    std::string_view message,
+    std::string_view msg,
     std::string_view module_name = {});
 
 #define tr_logAddLevel(level, ...) \

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -137,50 +137,11 @@ tr_torrent_files findFiles(std::string_view const top, std::string_view const su
 
 } // namespace
 
-tr_metainfo_builder::tr_metainfo_builder(std::string_view filename)
-    : top_{ filename }
+tr_metainfo_builder::tr_metainfo_builder(std::string_view single_file_or_parent_directory)
+    : top_{ single_file_or_parent_directory }
 {
-    files_ = findFiles(tr_sys_path_dirname(filename), tr_sys_path_basename(filename));
+    files_ = findFiles(tr_sys_path_dirname(top_), tr_sys_path_basename(top_));
     block_info_ = tr_block_info{ files_.totalSize(), defaultPieceSize(files_.totalSize()) };
-}
-
-uint32_t tr_metainfo_builder::defaultPieceSize(uint64_t totalSize)
-{
-    uint32_t const KiB = 1024;
-    uint32_t const MiB = 1048576;
-    uint32_t const GiB = 1073741824;
-
-    if (totalSize >= 2 * GiB)
-    {
-        return 2 * MiB;
-    }
-
-    if (totalSize >= 1 * GiB)
-    {
-        return 1 * MiB;
-    }
-
-    if (totalSize >= 512 * MiB)
-    {
-        return 512 * KiB;
-    }
-
-    if (totalSize >= 350 * MiB)
-    {
-        return 256 * KiB;
-    }
-
-    if (totalSize >= 150 * MiB)
-    {
-        return 128 * KiB;
-    }
-
-    if (totalSize >= 50 * MiB)
-    {
-        return 64 * KiB;
-    }
-
-    return 32 * KiB; /* less than 50 meg */
 }
 
 bool tr_metainfo_builder::isLegalPieceSize(uint32_t x)

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -178,7 +178,44 @@ public:
 
     ///
 
-    [[nodiscard]] static uint32_t defaultPieceSize(uint64_t total_size);
+    [[nodiscard]] constexpr static uint32_t defaultPieceSize(uint64_t total_size) noexcept
+    {
+        uint32_t const KiB = 1024;
+        uint32_t const MiB = 1048576;
+        uint32_t const GiB = 1073741824;
+
+        if (total_size >= 2 * GiB)
+        {
+            return 2 * MiB;
+        }
+
+        if (total_size >= 1 * GiB)
+        {
+            return 1 * MiB;
+        }
+
+        if (total_size >= 512 * MiB)
+        {
+            return 512 * KiB;
+        }
+
+        if (total_size >= 350 * MiB)
+        {
+            return 256 * KiB;
+        }
+
+        if (total_size >= 150 * MiB)
+        {
+            return 128 * KiB;
+        }
+
+        if (total_size >= 50 * MiB)
+        {
+            return 64 * KiB;
+        }
+
+        return 32 * KiB; /* less than 50 meg */
+    }
 
     // must be a power of two and >= 16 KiB
     [[nodiscard]] static bool isLegalPieceSize(uint32_t x);

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -49,6 +49,6 @@ tr_natpmp* tr_natpmpInit(void);
 
 void tr_natpmpClose(tr_natpmp*);
 
-tr_port_forwarding tr_natpmpPulse(tr_natpmp*, tr_port port, bool isEnabled, tr_port* public_port, tr_port* real_private_port);
+tr_port_forwarding tr_natpmpPulse(tr_natpmp*, tr_port port, bool is_enabled, tr_port* public_port, tr_port* real_private_port);
 
 /* @} */

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -151,7 +151,7 @@ private:
 
 struct tr_address
 {
-    [[nodiscard]] static std::optional<tr_address> fromString(std::string_view str);
+    [[nodiscard]] static std::optional<tr_address> fromString(std::string_view address_sv);
     [[nodiscard]] static std::pair<tr_address, uint8_t const*> fromCompact4(uint8_t const* compact) noexcept;
     [[nodiscard]] static std::pair<tr_address, uint8_t const*> fromCompact6(uint8_t const* compact) noexcept;
 
@@ -201,7 +201,7 @@ struct tr_address
 extern tr_address const tr_inaddr_any;
 extern tr_address const tr_in6addr_any;
 
-bool tr_address_from_sockaddr_storage(tr_address* setme, tr_port* port, struct sockaddr_storage const* src);
+bool tr_address_from_sockaddr_storage(tr_address* setme, tr_port* port, struct sockaddr_storage const* from);
 
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);
 
@@ -218,7 +218,7 @@ struct tr_session;
 
 tr_socket_t tr_netBindTCP(tr_address const* addr, tr_port port, bool suppressMsgs);
 
-tr_socket_t tr_netAccept(tr_session* session, tr_socket_t bound, tr_address* setme_addr, tr_port* setme_port);
+tr_socket_t tr_netAccept(tr_session* session, tr_socket_t listening_sockfd, tr_address* setme_addr, tr_port* setme_port);
 
 void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm);
 

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -32,7 +32,7 @@ public:
         tr_file_index_t file_num,
         bool writable,
         std::string_view filename,
-        tr_preallocation_mode mode,
+        tr_preallocation_mode allocation,
         uint64_t file_size);
 
     void closeAll();

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -811,12 +811,12 @@ std::string tr_peerIo::addrStr() const
     return tr_isPeerIo(this) ? this->addr_.readable(this->port_) : "error";
 }
 
-void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* userData)
+void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* user_data)
 {
     io->canRead = readcb;
     io->didWrite = writecb;
     io->gotError = errcb;
-    io->userData = userData;
+    io->userData = user_data;
 }
 
 void tr_peerIoClear(tr_peerIo* io)
@@ -927,14 +927,14 @@ void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData)
     io->outbuf_info.emplace_back(byteCount, isPieceData);
 }
 
-void tr_peerIoWriteBytes(tr_peerIo* io, void const* bytes, size_t byteCount, bool isPieceData)
+void tr_peerIoWriteBytes(tr_peerIo* io, void const* writeme, size_t writeme_len, bool is_piece_data)
 {
     struct evbuffer_iovec iovec;
-    evbuffer_reserve_space(io->outbuf.get(), byteCount, &iovec, 1);
+    evbuffer_reserve_space(io->outbuf.get(), writeme_len, &iovec, 1);
 
-    iovec.iov_len = byteCount;
+    iovec.iov_len = writeme_len;
 
-    memcpy(iovec.iov_base, bytes, iovec.iov_len);
+    memcpy(iovec.iov_base, writeme, iovec.iov_len);
 
     if (io->isEncrypted())
     {
@@ -943,7 +943,7 @@ void tr_peerIoWriteBytes(tr_peerIo* io, void const* bytes, size_t byteCount, boo
 
     evbuffer_commit_space(io->outbuf.get(), &iovec, 1);
 
-    io->outbuf_info.emplace_back(byteCount, isPieceData);
+    io->outbuf_info.emplace_back(writeme_len, is_piece_data);
 }
 
 /***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -359,7 +359,7 @@ void tr_peerIoClear(tr_peerIo* io);
 ***
 **/
 
-void tr_peerIoWriteBytes(tr_peerIo* io, void const* writeme, size_t writemeLen, bool isPieceData);
+void tr_peerIoWriteBytes(tr_peerIo* io, void const* writeme, size_t writeme_len, bool is_piece_data);
 
 void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData);
 
@@ -367,7 +367,7 @@ void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData);
 ***
 **/
 
-void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t byte);
+void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t addme);
 void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t hs);
 void evbuffer_add_uint32(struct evbuffer* outbuf, uint32_t hl);
 void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t hll);

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -36,5 +36,5 @@ public:
     };
 
     // get a list of the next blocks that we should request from a peer
-    static std::vector<tr_block_span_t> next(Mediator const& peer_info, size_t n_wanted_blocks);
+    static std::vector<tr_block_span_t> next(Mediator const& mediator, size_t n_wanted_blocks);
 };

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1440,14 +1440,14 @@ struct CompareAtomsByUsefulness
 
 } // namespace get_peers_helpers
 
-std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t af, uint8_t list_mode, size_t max_count)
+std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t address_type, uint8_t list_mode, size_t max_peer_count)
 {
     using namespace get_peers_helpers;
 
     TR_ASSERT(tr_isTorrent(tor));
     auto const lock = tor->unique_lock();
 
-    TR_ASSERT(af == TR_AF_INET || af == TR_AF_INET6);
+    TR_ASSERT(address_type == TR_AF_INET || address_type == TR_AF_INET6);
     TR_ASSERT(list_mode == TR_PEERS_CONNECTED || list_mode == TR_PEERS_INTERESTING);
 
     tr_swarm const* s = tor->swarm;
@@ -1483,7 +1483,7 @@ std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t af, uint8_
     ***  add the first N of them into our return list
     **/
 
-    auto const n = std::min(std::size(atoms), max_count);
+    auto const n = std::min(std::size(atoms), max_peer_count);
     auto pex = std::vector<tr_pex>{};
     pex.reserve(n);
 
@@ -1491,7 +1491,7 @@ std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t af, uint8_
     {
         auto const* const atom = atoms[i];
 
-        if (atom->addr.type == af)
+        if (atom->addr.type == address_type)
         {
             TR_ASSERT(tr_address_is_valid(&atom->addr));
             pex.emplace_back(atom->addr, atom->port, atom->flags);

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -153,15 +153,15 @@ void tr_peerMgrRemoveTorrent(tr_torrent* tor);
 // return the number of connected peers that have `piece`, or -1 if we already have it
 int8_t tr_peerMgrPieceAvailability(tr_torrent const* tor, tr_piece_index_t piece);
 
-void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned int tabCount);
+void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned int n_tabs);
 
 uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor);
 
 void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor);
 
-void tr_peerMgrOnBlocklistChanged(tr_peerMgr* manager);
+void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr);
 
-struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setmeCount);
+struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, int* setme_count);
 
 tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);
 

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -76,9 +76,9 @@ class Filter
 {
 public:
     void decryptInit(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
-    void decrypt(size_t buflen, void* buf);
+    void decrypt(size_t buf_len, void* buf);
     void encryptInit(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
-    void encrypt(size_t buflen, void* buf);
+    void encrypt(size_t buf_len, void* buf);
 
 private:
     std::shared_ptr<struct arc4_context> dec_key_;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -864,9 +864,9 @@ private:
     mutable std::optional<float> percent_done_;
 };
 
-tr_peerMsgs* tr_peerMsgsNew(tr_torrent* torrent, peer_atom* atom, tr_peerIo* io, tr_peer_callback callback, void* callbackData)
+tr_peerMsgs* tr_peerMsgsNew(tr_torrent* torrent, peer_atom* atom, tr_peerIo* io, tr_peer_callback callback, void* callback_data)
 {
-    return new tr_peerMsgsImpl(torrent, atom, io, callback, callbackData);
+    return new tr_peerMsgsImpl(torrent, atom, io, callback, callback_data);
 }
 
 /**

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -37,8 +37,8 @@ struct tr_peer_socket tr_peer_socket_utp_create(struct UTPSocket* const handle);
 struct tr_session;
 struct tr_address;
 
-struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
+struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const* addr, tr_port port, bool client_is_seed);
 
-struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool clientIsSeed);
+struct tr_peer_socket tr_netOpenPeerUTPSocket(tr_session* session, tr_address const* addr, tr_port port, bool client_is_seed);
 
 void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket);

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -224,9 +224,9 @@ static void start_timer(tr_shared* s)
     set_evtimer_from_status(s);
 }
 
-void tr_sharedTraversalEnable(tr_shared* s, bool enable)
+void tr_sharedTraversalEnable(tr_shared* s, bool is_enable)
 {
-    if (enable)
+    if (is_enable)
     {
         s->isEnabled = true;
         start_timer(s);

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -21,7 +21,7 @@ void tr_sharedClose(tr_session*);
 
 void tr_sharedPortChanged(tr_session*);
 
-void tr_sharedTraversalEnable(tr_shared*, bool isEnabled);
+void tr_sharedTraversalEnable(tr_shared*, bool is_enabled);
 
 tr_port tr_sharedGetPeerPort(tr_shared const* s);
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -852,10 +852,10 @@ static auto parseWhitelist(std::string_view whitelist)
     return list;
 }
 
-void tr_rpc_server::setWhitelist(std::string_view sv)
+void tr_rpc_server::setWhitelist(std::string_view whitelist)
 {
-    this->whitelist_str_ = sv;
-    this->whitelist_ = parseWhitelist(sv);
+    this->whitelist_str_ = whitelist;
+    this->whitelist_ = parseWhitelist(whitelist);
 }
 
 /****

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -85,7 +85,7 @@ public:
         return salted_password_;
     }
 
-    void setPassword(std::string_view salted) noexcept;
+    void setPassword(std::string_view password) noexcept;
 
     [[nodiscard]] constexpr auto isAntiBruteForceEnabled() const noexcept
     {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -551,7 +551,7 @@ public:
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddress() const override;
         [[nodiscard]] std::optional<std::string_view> userAgent() const override;
-        [[nodiscard]] unsigned int clamp(int bandwidth_tag, unsigned int byte_count) const override;
+        [[nodiscard]] unsigned int clamp(int torrent_id, unsigned int byte_count) const override;
         void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
         // runs the tr_web::fetch response callback in the libtransmission thread
         void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const override;
@@ -679,6 +679,6 @@ unsigned int tr_sessionGetPieceSpeed_Bps(tr_session const*, tr_direction);
 
 bool tr_sessionGetActiveSpeedLimit_Bps(tr_session const* session, tr_direction dir, unsigned int* setme);
 
-std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction dir, size_t numwanted);
+std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction dir, size_t num_wanted);
 
 int tr_sessionCountQueueFreeSlots(tr_session* session, tr_direction);

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -110,14 +110,14 @@ public:
     }
 
     bool move(
-        std::string_view old_top_in,
-        std::string_view top_in,
+        std::string_view old_parent_in,
+        std::string_view parent_in,
         double volatile* setme_progress,
-        std::string_view log_name = "",
+        std::string_view parent_name = "",
         tr_error** error = nullptr) const;
 
     using FileFunc = std::function<void(char const* filename)>;
-    void remove(std::string_view top_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
+    void remove(std::string_view parent_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
 
     struct FoundFile : public tr_sys_path_info
     {

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -34,7 +34,7 @@ public:
     // If you're looping through several files, passing in a non-nullptr
     // `buffer` can reduce the number of memory allocations needed to
     // load multiple files.
-    bool parseTorrentFile(std::string_view benc_filename, std::vector<char>* buffer = nullptr, tr_error** error = nullptr);
+    bool parseTorrentFile(std::string_view benc_filename, std::vector<char>* contents = nullptr, tr_error** error = nullptr);
 
     // FILES
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1180,21 +1180,21 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 ****
 ***/
 
-tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t i)
+tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    auto const& subpath = tor->fileSubpath(i);
-    auto const priority = tor->file_priorities_.filePriority(i);
-    auto const wanted = tor->files_wanted_.fileWanted(i);
-    auto const length = tor->fileSize(i);
+    auto const& subpath = tor->fileSubpath(file);
+    auto const priority = tor->file_priorities_.filePriority(file);
+    auto const wanted = tor->files_wanted_.fileWanted(file);
+    auto const length = tor->fileSize(file);
 
     if (tor->completeness == TR_SEED || length == 0)
     {
         return { subpath.c_str(), length, length, 1.0, priority, wanted };
     }
 
-    auto const have = tor->completion.countHasBytesInSpan(tor->fpm_.byteSpan(i));
+    auto const have = tor->completion.countHasBytesInSpan(tor->fpm_.byteSpan(file));
     return { subpath.c_str(), have, length, have >= length ? 1.0 : have / double(length), priority, wanted };
 }
 
@@ -1205,9 +1205,9 @@ size_t tr_torrentFileCount(tr_torrent const* torrent)
     return torrent->fileCount();
 }
 
-tr_webseed_view tr_torrentWebseed(tr_torrent const* tor, size_t i)
+tr_webseed_view tr_torrentWebseed(tr_torrent const* tor, size_t nth)
 {
-    return tr_peerMgrWebseed(tor, i);
+    return tr_peerMgrWebseed(tor, nth);
 }
 
 size_t tr_torrentWebseedCount(tr_torrent const* tor)
@@ -1861,21 +1861,21 @@ void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
 ****
 ***/
 
-void tr_torrent::setBandwidthGroup(std::string_view bandwidth_group) noexcept
+void tr_torrent::setBandwidthGroup(std::string_view group_name) noexcept
 {
-    bandwidth_group = tr_strvStrip(bandwidth_group);
+    group_name = tr_strvStrip(group_name);
 
     auto const lock = this->unique_lock();
 
-    if (std::empty(bandwidth_group))
+    if (std::empty(group_name))
     {
         this->bandwidth_group_ = tr_interned_string{};
         this->bandwidth_.setParent(&this->session->top_bandwidth_);
     }
     else
     {
-        this->bandwidth_group_ = bandwidth_group;
-        this->bandwidth_.setParent(&this->session->getBandwidthGroup(bandwidth_group));
+        this->bandwidth_group_ = group_name;
+        this->bandwidth_.setParent(&this->session->getBandwidthGroup(group_name));
     }
 
     this->setDirty();
@@ -1968,9 +1968,9 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
 }
 
 // TODO(ckerr) migrate to fpm?
-tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t i)
+tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file)
 {
-    auto const [begin_byte, end_byte] = tor->fpm_.byteSpan(i);
+    auto const [begin_byte, end_byte] = tor->fpm_.byteSpan(file);
 
     auto const begin_block = tor->byteLoc(begin_byte).block;
     if (begin_byte >= end_byte) // 0-byte file
@@ -2154,7 +2154,7 @@ static void setLocationInEventThread(
 }
 
 void tr_torrent::setLocation(
-    std::string_view path,
+    std::string_view location,
     bool move_from_old_path,
     double volatile* setme_progress,
     int volatile* setme_state)
@@ -2168,7 +2168,7 @@ void tr_torrent::setLocation(
         this->session,
         setLocationInEventThread,
         this,
-        std::string{ path },
+        std::string{ location },
         move_from_old_path,
         setme_progress,
         setme_state);
@@ -2176,15 +2176,15 @@ void tr_torrent::setLocation(
 
 void tr_torrentSetLocation(
     tr_torrent* tor,
-    char const* path,
+    char const* location,
     bool move_from_old_path,
     double volatile* setme_progress,
     int volatile* setme_state)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(!tr_str_is_empty(path));
+    TR_ASSERT(!tr_str_is_empty(location));
 
-    tor->setLocation(path, move_from_old_path, setme_progress, setme_state);
+    tor->setLocation(location, move_from_old_path, setme_progress, setme_state);
 }
 
 ///
@@ -2391,27 +2391,27 @@ int tr_torrentGetQueuePosition(tr_torrent const* tor)
     return tor->queuePosition;
 }
 
-void tr_torrentSetQueuePosition(tr_torrent* tor, int pos)
+void tr_torrentSetQueuePosition(tr_torrent* tor, int queue_position)
 {
     int back = -1;
     int const old_pos = tor->queuePosition;
 
-    if (pos < 0)
+    if (queue_position < 0)
     {
-        pos = 0;
+        queue_position = 0;
     }
 
     tor->queuePosition = -1;
 
     for (auto* const walk : tor->session->torrents())
     {
-        if ((old_pos < pos) && (old_pos <= walk->queuePosition) && (walk->queuePosition <= pos))
+        if ((old_pos < queue_position) && (old_pos <= walk->queuePosition) && (walk->queuePosition <= queue_position))
         {
             walk->queuePosition--;
             walk->markChanged();
         }
 
-        if ((old_pos > pos) && (pos <= walk->queuePosition) && (walk->queuePosition < old_pos))
+        if ((old_pos > queue_position) && (queue_position <= walk->queuePosition) && (walk->queuePosition < old_pos))
         {
             walk->queuePosition++;
             walk->markChanged();
@@ -2423,7 +2423,7 @@ void tr_torrentSetQueuePosition(tr_torrent* tor, int pos)
         }
     }
 
-    tor->queuePosition = std::min(pos, back + 1);
+    tor->queuePosition = std::min(queue_position, back + 1);
     tor->markChanged();
 
     TR_ASSERT(queueIsSequenced(tor->session));
@@ -2437,9 +2437,9 @@ struct CompareTorrentByQueuePosition
     }
 };
 
-void tr_torrentsQueueMoveTop(tr_torrent* const* torrents_in, size_t n)
+void tr_torrentsQueueMoveTop(tr_torrent* const* torrents_in, size_t torrent_count)
 {
-    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + n);
+    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::rbegin(torrents), std::rend(torrents), CompareTorrentByQueuePosition{});
     for (auto* tor : torrents)
     {
@@ -2447,9 +2447,9 @@ void tr_torrentsQueueMoveTop(tr_torrent* const* torrents_in, size_t n)
     }
 }
 
-void tr_torrentsQueueMoveUp(tr_torrent* const* torrents_in, size_t n)
+void tr_torrentsQueueMoveUp(tr_torrent* const* torrents_in, size_t torrent_count)
 {
-    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + n);
+    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition{});
     for (auto* tor : torrents)
     {
@@ -2457,9 +2457,9 @@ void tr_torrentsQueueMoveUp(tr_torrent* const* torrents_in, size_t n)
     }
 }
 
-void tr_torrentsQueueMoveDown(tr_torrent* const* torrents_in, size_t n)
+void tr_torrentsQueueMoveDown(tr_torrent* const* torrents_in, size_t torrent_count)
 {
-    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + n);
+    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::rbegin(torrents), std::rend(torrents), CompareTorrentByQueuePosition{});
     for (auto* tor : torrents)
     {
@@ -2467,9 +2467,9 @@ void tr_torrentsQueueMoveDown(tr_torrent* const* torrents_in, size_t n)
     }
 }
 
-void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents_in, size_t n)
+void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents_in, size_t torrent_count)
 {
-    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + n);
+    auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition{});
     for (auto* tor : torrents)
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -60,7 +60,7 @@ bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDi
 ***
 **/
 
-void tr_torrentChangeMyPort(tr_torrent* session);
+void tr_torrentChangeMyPort(tr_torrent* tor);
 
 tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, tr_sha1_digest_t const& hash);
 
@@ -98,7 +98,7 @@ public:
 
     void setLocation(
         std::string_view location,
-        bool move_from_current_location,
+        bool move_from_old_path,
         double volatile* setme_progress,
         int volatile* setme_state);
 
@@ -770,7 +770,7 @@ tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error = nullptr);
-bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view filename, tr_error** error = nullptr);
+bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view magnet_link, tr_error** error = nullptr);
 void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels);
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);
 

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -85,7 +85,7 @@ tr_torrent_id_t tr_torrents::add(tr_torrent* tor)
     return id;
 }
 
-void tr_torrents::remove(tr_torrent const* tor, time_t timestamp)
+void tr_torrents::remove(tr_torrent const* tor, time_t current_time)
 {
     TR_ASSERT(tor != nullptr);
     TR_ASSERT(get(tor->id()) == tor);
@@ -93,7 +93,7 @@ void tr_torrents::remove(tr_torrent const* tor, time_t timestamp)
     by_id_[tor->id()] = nullptr;
     auto const [begin, end] = std::equal_range(std::begin(by_hash_), std::end(by_hash_), tor, CompareTorrentByHash{});
     by_hash_.erase(begin, end);
-    removed_.emplace_back(tor->id(), timestamp);
+    removed_.emplace_back(tor->id(), current_time);
 }
 
 std::vector<tr_torrent_id_t> tr_torrents::removedSince(time_t timestamp) const

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -54,7 +54,7 @@ static struct event* dht_timer = nullptr;
 static unsigned char myid[20];
 static tr_session* session_ = nullptr;
 
-static void timer_callback(evutil_socket_t s, short type, void* ignore);
+static void timer_callback(evutil_socket_t s, short type, void* session);
 
 static bool bootstrap_done(tr_session* session, int af)
 {
@@ -453,16 +453,16 @@ static void getstatus(getstatus_closure* const closure)
     }
 }
 
-int tr_dhtStatus(tr_session* session, int af, int* nodes_return)
+int tr_dhtStatus(tr_session* session, int af, int* setme_node_count)
 {
     auto closure = getstatus_closure{ af, -1, -1 };
 
     if (!tr_dhtEnabled(session) || (af == AF_INET && session->udp_socket == TR_BAD_SOCKET) ||
         (af == AF_INET6 && session->udp6_socket == TR_BAD_SOCKET))
     {
-        if (nodes_return != nullptr)
+        if (setme_node_count != nullptr)
         {
-            *nodes_return = 0;
+            *setme_node_count = 0;
         }
 
         return TR_DHT_STOPPED;
@@ -475,9 +475,9 @@ int tr_dhtStatus(tr_session* session, int af, int* nodes_return)
         tr_wait_msec(50 /*msec*/);
     }
 
-    if (nodes_return != nullptr)
+    if (setme_node_count != nullptr)
     {
-        *nodes_return = closure.count;
+        *setme_node_count = closure.count;
     }
 
     return closure.status;

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -25,7 +25,7 @@ int tr_dhtInit(tr_session*);
 void tr_dhtUninit(tr_session*);
 bool tr_dhtEnabled(tr_session const*);
 tr_port tr_dhtPort(tr_session*);
-int tr_dhtStatus(tr_session*, int af, int* setme_nodeCount);
+int tr_dhtStatus(tr_session*, int af, int* setme_node_count);
 char const* tr_dhtPrintableStatus(int status);
 bool tr_dhtAddNode(tr_session*, tr_address const*, tr_port, bool bootstrap);
 void tr_dhtUpkeep(tr_session*);

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -100,7 +100,7 @@ static void maxWidth(struct tr_option const* o, size_t& long_width, size_t& shor
     }
 }
 
-void tr_getopt_usage(char const* progName, char const* description, struct tr_option const opts[])
+void tr_getopt_usage(char const* appName, char const* description, struct tr_option const opts[])
 {
     auto long_width = size_t{ 0 };
     auto short_width = size_t{ 0 };
@@ -119,7 +119,7 @@ void tr_getopt_usage(char const* progName, char const* description, struct tr_op
         description = "Usage: %s [options]";
     }
 
-    printf(description, progName);
+    printf(description, appName);
     printf("\n\nOptions:\n");
     getopts_usage_line(&help, long_width, short_width, arg_width);
 

--- a/libtransmission/tr-getopt.h
+++ b/libtransmission/tr-getopt.h
@@ -38,7 +38,7 @@ enum
  * @brief similar to getopt()
  * @return TR_GETOPT_DONE, TR_GETOPT_ERR, TR_GETOPT_UNK, or the matching tr_option's `val' field
  */
-int tr_getopt(char const* summary, int argc, char const* const* argv, tr_option const* opts, char const** setme_optarg);
+int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option const* opts, char const** setme_optarg);
 
 /** @brief prints the `Usage' help section to stdout */
 void tr_getopt_usage(char const* appName, char const* description, tr_option const* opts);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -182,7 +182,7 @@ void tr_sessionGetSettings(tr_session const* session, struct tr_variant* setme_d
  * @see tr_sessionInit()
  * @see tr_sessionSaveSettings()
  */
-bool tr_sessionLoadSettings(struct tr_variant* dictionary, char const* configDir, char const* appName);
+bool tr_sessionLoadSettings(struct tr_variant* dictionary, char const* config_dir, char const* appName);
 
 /**
  * Add the session's configuration settings to the benc dictionary
@@ -195,7 +195,7 @@ bool tr_sessionLoadSettings(struct tr_variant* dictionary, char const* configDir
  * @param dictionary the dictionary to save
  * @see tr_sessionLoadSettings()
  */
-void tr_sessionSaveSettings(tr_session* session, char const* configDir, struct tr_variant const* dictionary);
+void tr_sessionSaveSettings(tr_session* session, char const* config_dir, struct tr_variant const* client_settings);
 
 /**
  * @brief Initialize a libtransmission session.
@@ -221,7 +221,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* configDir, struct t
  * @see tr_sessionLoadSettings()
  * @see tr_getDefaultConfigDir()
  */
-tr_session* tr_sessionInit(char const* configDir, bool messageQueueingEnabled, struct tr_variant* settings);
+tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, struct tr_variant* settings);
 
 /** @brief Update a session's settings from a benc dictionary
            like to the one used in tr_sessionInit() */
@@ -323,7 +323,7 @@ bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session);
  * This is intially set by tr_sessionInit() and can be
  * queried by tr_sessionIsRPCEnabled().
  */
-void tr_sessionSetRPCEnabled(tr_session* session, bool isEnabled);
+void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled);
 
 /** @brief Get whether or not RPC calls are allowed in this session.
     @see tr_sessionInit()
@@ -549,10 +549,10 @@ bool tr_sessionUsesAltSpeed(tr_session const*);
 void tr_sessionUseAltSpeedTime(tr_session*, bool);
 bool tr_sessionUsesAltSpeedTime(tr_session const*);
 
-void tr_sessionSetAltSpeedBegin(tr_session*, int minsSinceMidnight);
+void tr_sessionSetAltSpeedBegin(tr_session*, int minutes_since_midnight);
 int tr_sessionGetAltSpeedBegin(tr_session const*);
 
-void tr_sessionSetAltSpeedEnd(tr_session*, int minsSinceMidnight);
+void tr_sessionSetAltSpeedEnd(tr_session*, int minutes_since_midnight);
 int tr_sessionGetAltSpeedEnd(tr_session const*);
 
 enum tr_sched_day
@@ -596,10 +596,10 @@ bool tr_sessionIsIdleLimited(tr_session const*);
 void tr_sessionSetIdleLimit(tr_session*, uint16_t idleMinutes);
 uint16_t tr_sessionGetIdleLimit(tr_session const*);
 
-void tr_sessionSetPeerLimit(tr_session*, uint16_t maxGlobalPeers);
+void tr_sessionSetPeerLimit(tr_session*, uint16_t max_global_peers);
 uint16_t tr_sessionGetPeerLimit(tr_session const*);
 
-void tr_sessionSetPeerLimitPerTorrent(tr_session*, uint16_t maxPeers);
+void tr_sessionSetPeerLimitPerTorrent(tr_session*, uint16_t max_peers);
 uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const*);
 
 void tr_sessionSetPaused(tr_session*, bool isPaused);
@@ -611,7 +611,7 @@ bool tr_sessionGetDeleteSource(tr_session const*);
 tr_priority_t tr_torrentGetPriority(tr_torrent const*);
 void tr_torrentSetPriority(tr_torrent*, tr_priority_t);
 
-void tr_sessionSetAntiBruteForceThreshold(tr_session*, int bad_requests);
+void tr_sessionSetAntiBruteForceThreshold(tr_session*, int max_bad_requests);
 int tr_sessionGetAntiBruteForceThreshold(tr_session const*);
 
 void tr_sessionSetAntiBruteForceEnabled(tr_session*, bool enabled);
@@ -647,22 +647,22 @@ int tr_torrentGetQueuePosition(tr_torrent const*);
 
 /** @brief Set the queued torrent's position in the queue it's in.
  * Special cases: pos <= 0 moves to the front; pos >= queue length moves to the back */
-void tr_torrentSetQueuePosition(tr_torrent*, int queuePosition);
+void tr_torrentSetQueuePosition(tr_torrent*, int queue_position);
 
 /**
 **/
 
 /** @brief Convenience function for moving a batch of torrents to the front of their queue(s) */
-void tr_torrentsQueueMoveTop(tr_torrent* const* torrents, size_t torrentCount);
+void tr_torrentsQueueMoveTop(tr_torrent* const* torrents, size_t torrent_count);
 
 /** @brief Convenience function for moving a batch of torrents ahead one step in their queue(s) */
-void tr_torrentsQueueMoveUp(tr_torrent* const* torrents, size_t torrentCount);
+void tr_torrentsQueueMoveUp(tr_torrent* const* torrents, size_t torrent_count);
 
 /** @brief Convenience function for moving a batch of torrents back one step in their queue(s) */
-void tr_torrentsQueueMoveDown(tr_torrent* const* torrents, size_t torrentCount);
+void tr_torrentsQueueMoveDown(tr_torrent* const* torrents, size_t torrent_count);
 
 /** @brief Convenience function for moving a batch of torrents to the back of their queue(s) */
-void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents, size_t torrentCount);
+void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents, size_t torrent_count);
 
 /**
 **/
@@ -804,7 +804,7 @@ void tr_ctorFree(tr_ctor* ctor);
 
 /** @brief Set whether or not to delete the source torrent file
            when the torrent is added. (Default: False) */
-void tr_ctorSetDeleteSource(tr_ctor* ctor, bool doDelete);
+void tr_ctorSetDeleteSource(tr_ctor* ctor, bool delete_source);
 
 /** @brief Set the constructor's metainfo from a magnet link */
 bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, char const* magnet, tr_error** error);
@@ -843,7 +843,7 @@ void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool isPaused);
 void tr_ctorSetFilePriorities(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t fileCount, tr_priority_t priority);
 
 /** @brief Set the download flag for files in a torrent */
-void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* fileIndices, tr_file_index_t fileCount, bool wanted);
+void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t fileCount, bool wanted);
 
 /** @brief Get this peer constructor's peer limit */
 bool tr_ctorGetPeerLimit(tr_ctor const* ctor, tr_ctorMode mode, uint16_t* setmeCount);
@@ -893,7 +893,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
 using tr_fileFunc = bool (*)(char const* filename, struct tr_error** error);
 
 /** @brief Removes our torrent and .resume files for this torrent */
-void tr_torrentRemove(tr_torrent* torrent, bool removeLocalData, tr_fileFunc removeFunc);
+void tr_torrentRemove(tr_torrent* torrent, bool delete_flag, tr_fileFunc delete_func);
 
 /** @brief Start a torrent */
 void tr_torrentStart(tr_torrent* torrent);
@@ -955,7 +955,7 @@ void tr_torrentRenamePath(
     char const* oldpath,
     char const* newname,
     tr_torrent_rename_done_func callback,
-    void* callback_data);
+    void* callback_user_data);
 
 enum
 {
@@ -974,7 +974,7 @@ enum
 void tr_torrentSetLocation(
     tr_torrent* torrent,
     char const* location,
-    bool move_from_previous_location,
+    bool move_from_old_path,
     double volatile* setme_progress,
     int volatile* setme_state);
 
@@ -1085,7 +1085,7 @@ bool tr_torrentGetSeedIdle(tr_torrent const*, uint16_t* minutes);
 *****  Peer Limits
 ****/
 
-void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t peerLimit);
+void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers);
 
 uint16_t tr_torrentGetPeerLimit(tr_torrent const* tor);
 
@@ -1112,7 +1112,7 @@ void tr_torrentSetFilePriorities(
     tr_priority_t priority);
 
 /** @brief Set a batch of files to be downloaded or not. */
-void tr_torrentSetFileDLs(tr_torrent* torrent, tr_file_index_t const* files, tr_file_index_t fileCount, bool do_download);
+void tr_torrentSetFileDLs(tr_torrent* torrent, tr_file_index_t const* files, tr_file_index_t n_files, bool wanted);
 
 /* Raw function to change the torrent's downloadDir field.
    This should only be used by libtransmission or to bootstrap
@@ -1199,7 +1199,7 @@ using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent
  *
  * @see tr_completeness
  */
-void tr_sessionSetCompletenessCallback(tr_session* session, tr_torrent_completeness_func func, void* user_data);
+void tr_sessionSetCompletenessCallback(tr_session* session, tr_torrent_completeness_func callback, void* user_data);
 
 using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torrent, void* user_data);
 
@@ -1209,7 +1209,7 @@ using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torre
  * This happens when a magnet link finishes downloading
  * metadata from its peers.
  */
-void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func func, void* user_data);
+void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func callback, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's ratio limit
@@ -1218,7 +1218,7 @@ void tr_sessionSetMetadataCallback(tr_session* session, tr_session_metadata_func
  *
  * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
-void tr_sessionSetRatioLimitHitCallback(tr_session* torrent, tr_session_ratio_limit_hit_func func, void* user_data);
+void tr_sessionSetRatioLimitHitCallback(tr_session* session, tr_session_ratio_limit_hit_func callback, void* user_data);
 
 /**
  * Register to be notified whenever a torrent's idle limit
@@ -1227,7 +1227,7 @@ void tr_sessionSetRatioLimitHitCallback(tr_session* torrent, tr_session_ratio_li
  *
  * Has the same restrictions as tr_sessionSetCompletenessCallback
  */
-void tr_sessionSetIdleLimitHitCallback(tr_session* torrent, tr_session_idle_limit_hit_func func, void* user_data);
+void tr_sessionSetIdleLimitHitCallback(tr_session* session, tr_session_idle_limit_hit_func callback, void* user_data);
 
 /**
  * MANUAL ANNOUNCE
@@ -1451,7 +1451,7 @@ char* tr_torrentFilename(tr_torrent const* tor);
  **********************************************************************/
 void tr_torrentAvailability(tr_torrent const* torrent, int8_t* tab, int size);
 
-void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int size);
+void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int n_tabs);
 
 /**
  * Queue a torrent for verification.

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -126,10 +126,10 @@ void tr_timerAdd(struct event& timer, int seconds, int microseconds)
     evtimer_add(&timer, &tv);
 }
 
-void tr_timerAddMsec(struct event& timer, int msec)
+void tr_timerAddMsec(struct event& timer, int milliseconds)
 {
-    int const seconds = msec / 1000;
-    int const usec = (msec % 1000) * 1000;
+    int const seconds = milliseconds / 1000;
+    int const usec = (milliseconds % 1000) * 1000;
     tr_timerAdd(timer, seconds, usec);
 }
 
@@ -137,18 +137,18 @@ void tr_timerAddMsec(struct event& timer, int msec)
 ***
 **/
 
-bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** error)
+bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_error** error)
 {
-    auto const path = tr_pathbuf{ path_in };
+    auto const szfilename = tr_pathbuf{ filename };
 
     /* try to stat the file */
     tr_error* my_error = nullptr;
-    auto const info = tr_sys_path_get_info(path, 0, &my_error);
+    auto const info = tr_sys_path_get_info(szfilename, 0, &my_error);
     if (!info)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path),
+            fmt::arg("path", filename),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
@@ -157,30 +157,30 @@ bool tr_loadFile(std::string_view path_in, std::vector<char>& setme, tr_error** 
 
     if (!info->isFile())
     {
-        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", path)));
+        tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", filename)));
         tr_error_set(error, TR_ERROR_EISDIR, "Not a regular file"sv);
         return false;
     }
 
     /* Load the torrent file into our buffer */
-    auto const fd = tr_sys_file_open(path.c_str(), TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, &my_error);
+    auto const fd = tr_sys_file_open(szfilename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, &my_error);
     if (fd == TR_BAD_SYS_FILE)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path),
+            fmt::arg("path", filename),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_error_propagate(error, &my_error);
         return false;
     }
 
-    setme.resize(info->size);
-    if (!tr_sys_file_read(fd, std::data(setme), info->size, nullptr, &my_error))
+    contents.resize(info->size);
+    if (!tr_sys_file_read(fd, std::data(contents), info->size, nullptr, &my_error))
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", path),
+            fmt::arg("path", filename),
             fmt::arg("error", my_error->message),
             fmt::arg("error_code", my_error->code)));
         tr_sys_file_close(fd);
@@ -241,15 +241,15 @@ bool tr_saveFile(std::string_view filename_in, std::string_view contents, tr_err
     return true;
 }
 
-tr_disk_space tr_dirSpace(std::string_view dir)
+tr_disk_space tr_dirSpace(std::string_view directory)
 {
-    if (std::empty(dir))
+    if (std::empty(directory))
     {
         errno = EINVAL;
         return { -1, -1 };
     }
 
-    return tr_device_info_get_disk_space(tr_device_info_create(dir));
+    return tr_device_info_get_disk_space(tr_device_info_create(directory));
 }
 
 /****
@@ -283,16 +283,14 @@ bool tr_wildmat(std::string_view text, std::string_view pattern)
     return pattern == "*"sv || DoMatch(std::string{ text }.c_str(), std::string{ pattern }.c_str()) != 0;
 }
 
-char const* tr_strerror(int i)
+char const* tr_strerror(int errnum)
 {
-    char const* ret = strerror(i);
-
-    if (ret == nullptr)
+    if (char const* const ret = strerror(errnum); ret != nullptr)
     {
-        ret = "Unknown Error";
+        return ret;
     }
 
-    return ret;
+    return "Unknown Error";
 }
 
 /****
@@ -348,17 +346,17 @@ uint64_t tr_time_msec()
     return uint64_t(tv.tv_sec) * 1000 + (tv.tv_usec / 1000);
 }
 
-void tr_wait_msec(long int msec)
+void tr_wait_msec(long int delay_milliseconds)
 {
 #ifdef _WIN32
 
-    Sleep((DWORD)msec);
+    Sleep((DWORD)delay_milliseconds);
 
 #else
 
     struct timespec ts;
-    ts.tv_sec = msec / 1000;
-    ts.tv_nsec = (msec % 1000) * 1000000;
+    ts.tv_sec = delay_milliseconds / 1000;
+    ts.tv_nsec = (delay_milliseconds % 1000) * 1000000;
     nanosleep(&ts, nullptr);
 
 #endif
@@ -795,7 +793,7 @@ std::vector<int> tr_parseNumberRange(std::string_view str)
 ****
 ***/
 
-double tr_truncd(double x, int precision)
+double tr_truncd(double x, int decimal_places)
 {
     auto buf = std::array<char, 128>{};
     auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, "{:.{}f}", x, DBL_DIG);
@@ -803,7 +801,7 @@ double tr_truncd(double x, int precision)
 
     if (auto* const pt = strstr(std::data(buf), localeconv()->decimal_point); pt != nullptr)
     {
-        pt[precision != 0 ? precision + 1 : 0] = '\0';
+        pt[decimal_places != 0 ? decimal_places + 1 : 0] = '\0';
     }
 
     return atof(std::data(buf));

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -86,7 +86,7 @@ constexpr auto tr_saveFile(std::string_view filename, ContiguousRange const& x, 
  * @brief Get disk capacity and free disk space (in bytes) for the specified folder.
  * @return struct with free and total as zero or positive integer on success, -1 in case of error.
  */
-tr_disk_space tr_dirSpace(std::string_view path);
+tr_disk_space tr_dirSpace(std::string_view directory);
 
 /**
  * @brief Convenience wrapper around timer_add() to have a timer wake up in a number of seconds and microseconds
@@ -115,7 +115,7 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
 [[nodiscard]] std::optional<T> tr_parseNum(std::string_view& sv);
 
-bool tr_utf8_validate(std::string_view sv, char const** endptr);
+bool tr_utf8_validate(std::string_view sv, char const** good_end);
 
 #ifdef _WIN32
 
@@ -263,7 +263,7 @@ constexpr bool tr_strvSep(std::string_view* sv, std::string_view* token, char de
     return true;
 }
 
-[[nodiscard]] std::string_view tr_strvStrip(std::string_view sv);
+[[nodiscard]] std::string_view tr_strvStrip(std::string_view str);
 
 [[nodiscard]] char* tr_strvDup(std::string_view) TR_GNUC_MALLOC;
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -350,7 +350,7 @@ static void action_callback_POP(
     }
 }
 
-bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view benc, char const** setme_end, tr_error** error)
+bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view json, char const** setme_end, tr_error** error)
 {
     TR_ASSERT((parse_opts & TR_VARIANT_PARSE_JSON) != 0);
 
@@ -364,7 +364,7 @@ bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view ben
     jsonsl_enable_all_callbacks(jsn);
 
     data.error = nullptr;
-    data.size = std::size(benc);
+    data.size = std::size(json);
     data.has_content = false;
     data.key = ""sv;
     data.keybuf = evbuffer_new();
@@ -375,7 +375,7 @@ bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view ben
     data.top = &setme;
 
     /* parse it */
-    jsonsl_feed(jsn, static_cast<jsonsl_char_t const*>(std::data(benc)), std::size(benc));
+    jsonsl_feed(jsn, static_cast<jsonsl_char_t const*>(std::data(json)), std::size(json));
 
     /* EINVAL if there was no content */
     if (data.error == nullptr && !data.has_content)
@@ -386,7 +386,7 @@ bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view ben
     /* maybe set the end ptr */
     if (setme_end != nullptr)
     {
-        *setme_end = std::data(benc) + jsn->pos;
+        *setme_end = std::data(json) + jsn->pos;
     }
 
     /* cleanup */

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -184,31 +184,27 @@ size_t tr_variantListSize(tr_variant const* list)
     return tr_variantIsList(list) ? list->val.l.count : 0;
 }
 
-tr_variant* tr_variantListChild(tr_variant* v, size_t i)
+tr_variant* tr_variantListChild(tr_variant* list, size_t pos)
 {
-    tr_variant* ret = nullptr;
-
-    if (tr_variantIsList(v) && i < v->val.l.count)
+    if (tr_variantIsList(list) && pos < list->val.l.count)
     {
-        ret = v->val.l.vals + i;
+        return list->val.l.vals + pos;
     }
 
-    return ret;
+    return {};
 }
 
-bool tr_variantListRemove(tr_variant* list, size_t i)
+bool tr_variantListRemove(tr_variant* list, size_t pos)
 {
-    bool removed = false;
-
-    if (tr_variantIsList(list) && i < list->val.l.count)
+    if (tr_variantIsList(list) && pos < list->val.l.count)
     {
-        removed = true;
-        tr_variantFree(&list->val.l.vals[i]);
-        tr_removeElementFromArray(list->val.l.vals, i, sizeof(tr_variant), list->val.l.count);
+        tr_variantFree(&list->val.l.vals[pos]);
+        tr_removeElementFromArray(list->val.l.vals, pos, sizeof(tr_variant), list->val.l.count);
         --list->val.l.count;
+        return true;
     }
 
-    return removed;
+    return false;
 }
 
 bool tr_variantGetInt(tr_variant const* v, int64_t* setme)
@@ -371,52 +367,52 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const**
 ****
 ***/
 
-void tr_variantInitRaw(tr_variant* v, void const* src, size_t byteCount)
+void tr_variantInitRaw(tr_variant* initme, void const* raw, size_t raw_len)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string(&v->val.s, { static_cast<char const*>(src), byteCount });
+    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variant_string_set_string(&initme->val.s, { static_cast<char const*>(raw), raw_len });
 }
 
-void tr_variantInitQuark(tr_variant* v, tr_quark const q)
+void tr_variantInitQuark(tr_variant* initme, tr_quark const q)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_quark(&v->val.s, q);
+    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variant_string_set_quark(&initme->val.s, q);
 }
 
-void tr_variantInitStr(tr_variant* v, std::string_view str)
+void tr_variantInitStr(tr_variant* initme, std::string_view str)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string(&v->val.s, str);
+    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variant_string_set_string(&initme->val.s, str);
 }
 
-void tr_variantInitStrView(tr_variant* v, std::string_view str)
+void tr_variantInitStrView(tr_variant* initme, std::string_view str)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string_view(&v->val.s, str);
+    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variant_string_set_string_view(&initme->val.s, str);
 }
 
-void tr_variantInitBool(tr_variant* v, bool value)
+void tr_variantInitBool(tr_variant* initme, bool value)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_BOOL);
-    v->val.b = value;
+    tr_variantInit(initme, TR_VARIANT_TYPE_BOOL);
+    initme->val.b = value;
 }
 
-void tr_variantInitReal(tr_variant* v, double value)
+void tr_variantInitReal(tr_variant* initme, double value)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_REAL);
-    v->val.d = value;
+    tr_variantInit(initme, TR_VARIANT_TYPE_REAL);
+    initme->val.d = value;
 }
 
-void tr_variantInitInt(tr_variant* v, int64_t value)
+void tr_variantInitInt(tr_variant* initme, int64_t value)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_INT);
-    v->val.i = value;
+    tr_variantInit(initme, TR_VARIANT_TYPE_INT);
+    initme->val.i = value;
 }
 
-void tr_variantInitList(tr_variant* v, size_t reserve_count)
+void tr_variantInitList(tr_variant* initme, size_t reserve_count)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_LIST);
-    tr_variantListReserve(v, reserve_count);
+    tr_variantInit(initme, TR_VARIANT_TYPE_LIST);
+    tr_variantListReserve(initme, reserve_count);
 }
 
 static tr_variant* containerReserve(tr_variant* v, size_t count)
@@ -449,10 +445,10 @@ void tr_variantListReserve(tr_variant* list, size_t count)
     containerReserve(list, count);
 }
 
-void tr_variantInitDict(tr_variant* v, size_t reserve_count)
+void tr_variantInitDict(tr_variant* initme, size_t reserve_count)
 {
-    tr_variantInit(v, TR_VARIANT_TYPE_DICT);
-    tr_variantDictReserve(v, reserve_count);
+    tr_variantInit(initme, TR_VARIANT_TYPE_DICT);
+    tr_variantDictReserve(initme, reserve_count);
 }
 
 void tr_variantDictReserve(tr_variant* dict, size_t reserve_count)
@@ -474,52 +470,52 @@ tr_variant* tr_variantListAdd(tr_variant* list)
     return child;
 }
 
-tr_variant* tr_variantListAddInt(tr_variant* list, int64_t val)
+tr_variant* tr_variantListAddInt(tr_variant* list, int64_t value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitInt(child, val);
+    tr_variantInitInt(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddReal(tr_variant* list, double val)
+tr_variant* tr_variantListAddReal(tr_variant* list, double value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitReal(child, val);
+    tr_variantInitReal(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddBool(tr_variant* list, bool val)
+tr_variant* tr_variantListAddBool(tr_variant* list, bool value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitBool(child, val);
+    tr_variantInitBool(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view str)
+tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitStr(child, str);
+    tr_variantInitStr(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view str)
+tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitStrView(child, str);
+    tr_variantInitStrView(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const val)
+tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const value)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitQuark(child, val);
+    tr_variantInitQuark(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddRaw(tr_variant* list, void const* val, size_t len)
+tr_variant* tr_variantListAddRaw(tr_variant* list, void const* value, size_t value_len)
 {
     tr_variant* child = tr_variantListAdd(list);
-    tr_variantInitRaw(child, val, len);
+    tr_variantInitRaw(child, value, value_len);
     return child;
 }
 
@@ -617,10 +613,10 @@ tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark const key, std::
     return child;
 }
 
-tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark const key, void const* src, size_t len)
+tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark const key, void const* value, size_t len)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
-    tr_variantInitRaw(child, src, len);
+    tr_variantInitRaw(child, value, len);
     return child;
 }
 
@@ -809,10 +805,10 @@ private:
  * easier to read, but was vulnerable to a smash-stacking
  * attack via maliciously-crafted data. (#667)
  */
-void tr_variantWalk(tr_variant const* v_in, struct VariantWalkFuncs const* walkFuncs, void* user_data, bool sort_dicts)
+void tr_variantWalk(tr_variant const* top, struct VariantWalkFuncs const* walkFuncs, void* user_data, bool sort_dicts)
 {
     auto stack = VariantWalker{};
-    stack.emplace(v_in, sort_dicts);
+    stack.emplace(top, sort_dicts);
 
     while (!stack.empty())
     {
@@ -994,16 +990,16 @@ static size_t tr_variantDictSize(tr_variant const* dict)
     return tr_variantIsDict(dict) ? dict->val.l.count : 0;
 }
 
-bool tr_variantDictChild(tr_variant* dict, size_t n, tr_quark* key, tr_variant** val)
+bool tr_variantDictChild(tr_variant* dict, size_t pos, tr_quark* key, tr_variant** setme_value)
 {
     TR_ASSERT(tr_variantIsDict(dict));
 
     bool success = false;
 
-    if (tr_variantIsDict(dict) && n < dict->val.l.count)
+    if (tr_variantIsDict(dict) && pos < dict->val.l.count)
     {
-        *key = dict->val.l.vals[n].key;
-        *val = dict->val.l.vals + n;
+        *key = dict->val.l.vals[pos].key;
+        *setme_value = dict->val.l.vals + pos;
         success = true;
     }
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -151,7 +151,7 @@ void tr_variantInitStrView(tr_variant* initme, std::string_view);
 void tr_variantInitQuark(tr_variant* initme, tr_quark const quark);
 void tr_variantInitRaw(tr_variant* initme, void const* raw, size_t raw_len);
 
-bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** raw_setme, size_t* len_setme);
+bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size_t* setme_len);
 
 /***
 ****  Real Numbers
@@ -186,7 +186,7 @@ constexpr bool tr_variantIsInt(tr_variant const* v)
     return v != nullptr && v->type == TR_VARIANT_TYPE_INT;
 }
 
-void tr_variantInitInt(tr_variant* variant, int64_t value);
+void tr_variantInitInt(tr_variant* initme, int64_t value);
 bool tr_variantGetInt(tr_variant const* val, int64_t* setme);
 
 /***
@@ -198,17 +198,17 @@ constexpr bool tr_variantIsList(tr_variant const* v)
     return v != nullptr && v->type == TR_VARIANT_TYPE_LIST;
 }
 
-void tr_variantInitList(tr_variant* list, size_t reserve_count);
+void tr_variantInitList(tr_variant* initme, size_t reserve_count);
 void tr_variantListReserve(tr_variant* list, size_t reserve_count);
 
 tr_variant* tr_variantListAdd(tr_variant* list);
-tr_variant* tr_variantListAddBool(tr_variant* list, bool addme);
-tr_variant* tr_variantListAddInt(tr_variant* list, int64_t addme);
-tr_variant* tr_variantListAddReal(tr_variant* list, double addme);
-tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view);
-tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view);
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const addme);
-tr_variant* tr_variantListAddRaw(tr_variant* list, void const* addme_value, size_t addme_len);
+tr_variant* tr_variantListAddBool(tr_variant* list, bool value);
+tr_variant* tr_variantListAddInt(tr_variant* list, int64_t value);
+tr_variant* tr_variantListAddReal(tr_variant* list, double value);
+tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view value);
+tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value);
+tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const value);
+tr_variant* tr_variantListAddRaw(tr_variant* list, void const* value, size_t value_len);
 tr_variant* tr_variantListAddList(tr_variant* list, size_t reserve_count);
 tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count);
 tr_variant* tr_variantListChild(tr_variant* list, size_t pos);

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -19,7 +19,7 @@ struct tr_torrent;
 
 using tr_verify_done_func = void (*)(tr_torrent*, bool aborted, void* user_data);
 
-void tr_verifyAdd(tr_torrent* tor, tr_verify_done_func callback_func, void* callback_user_data);
+void tr_verifyAdd(tr_torrent* tor, tr_verify_done_func callback_func, void* callback_data);
 
 void tr_verifyRemove(tr_torrent* tor);
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -30,9 +30,9 @@ using namespace std::literals;
 ****
 ***/
 
-bool tr_addressIsIP(char const* str)
+bool tr_addressIsIP(char const* address)
 {
-    return str != nullptr && tr_address::fromString(str).has_value();
+    return address != nullptr && tr_address::fromString(address).has_value();
 }
 
 char const* tr_webGetResponseStr(long code)


### PR DESCRIPTION
does what it says on the tin: fix these warnings and enable the clang-tidy check in libtransmission