### PR TITLE
refactor: iwyu utils.h

### DIFF
--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -12,10 +12,6 @@
 #include <glibmm.h>
 #include <glibmm/i18n.h>
 
-#include <libtransmission/transmission.h>
-#include <libtransmission/utils.h>
-#include <libtransmission/web-utils.h>
-
 #include "FaviconCache.h" /* gtr_get_favicon() */
 #include "FilterBar.h"
 #include "HigWorkarea.h" /* GUI_PAD */

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -13,7 +13,6 @@
 #include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 #include <libtransmission/web-utils.h>
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -25,7 +25,7 @@
 #include <libtransmission/rpcimpl.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/tr-assert.h>
-#include <libtransmission/utils.h> /* tr_free */
+#include <libtransmission/utils.h> // tr_free(), tr_time()
 #include <libtransmission/variant.h>
 
 #include "Actions.h"
@@ -45,11 +45,11 @@ using TrVariantPtr = std::shared_ptr<tr_variant>;
 TrVariantPtr create_variant(tr_variant&& other)
 {
     auto result = TrVariantPtr(
-        tr_new0(tr_variant, 1),
+        new tr_variant{},
         [](tr_variant* ptr)
         {
             tr_variantFree(ptr);
-            tr_free(ptr);
+            delete ptr;
         });
     *result = std::move(other);
     tr_variantInitBool(&other, false);

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -33,6 +33,7 @@
 #include "tr-assert.h"
 #include "tr-udp.h"
 #include "utils.h"
+#include "web-utils.h"
 
 #define logwarn(interned, msg) tr_logAddWarn(msg, (interned).sv())
 #define logdbg(interned, msg) tr_logAddDebug(msg, (interned).sv())

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -22,6 +22,7 @@
 #include "torrents.h"
 #include "tr-assert.h"
 #include "trevent.h"
+#include "utils.h" // tr_time(), tr_formatter
 
 Cache::Key Cache::makeKey(tr_torrent const* torrent, tr_block_info::Location loc) noexcept
 {

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -539,7 +539,8 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
     /* Fallback to user-space copy. */
 
     static auto constexpr Buflen = size_t{ 1024U * 1024U }; /* 1024 KiB buffer */
-    auto* buf = static_cast<char*>(tr_malloc(Buflen));
+    auto buf = std::vector<char>{};
+    buf.resize(Buflen);
 
     while (file_size > 0U)
     {
@@ -547,12 +548,12 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         uint64_t bytes_read;
         uint64_t bytes_written;
 
-        if (!tr_sys_file_read(in, buf, chunk_size, &bytes_read, error))
+        if (!tr_sys_file_read(in, std::data(buf), chunk_size, &bytes_read, error))
         {
             break;
         }
 
-        if (!tr_sys_file_write(out, buf, bytes_read, &bytes_written, error))
+        if (!tr_sys_file_write(out, std::data(buf), bytes_read, &bytes_written, error))
         {
             break;
         }
@@ -561,9 +562,6 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         TR_ASSERT(bytes_written <= file_size);
         file_size -= bytes_written;
     }
-
-    /* cleanup */
-    tr_free(buf);
 
 #endif /* USE_COPY_FILE_RANGE || USE_SENDFILE64 */
 

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -249,10 +249,8 @@ char* tr_sys_path_resolve(char const* path, struct tr_error** error = nullptr);
  * @param[out] error Pointer to error object. Optional, pass `nullptr` if you
  *                   are not interested in error details.
  *
- * @return Pointer to newly allocated buffer containing base name (last path
- *         component; parent path removed) on success (use @ref tr_free to free
- *         it when no longer needed), `nullptr` otherwise (with `error` set
- *         accordingly).
+ * @return base name (last path component; parent path removed) on success,
+ *         or empty string otherwise (with `error` set accordingly).
  */
 std::string tr_sys_path_basename(std::string_view path, struct tr_error** error = nullptr);
 
@@ -261,10 +259,8 @@ std::string tr_sys_path_basename(std::string_view path, struct tr_error** error 
  *
  * @param[in]  path  Path to file or directory.
  *
- * @return Pointer to newly allocated buffer containing directory (parent path;
- *         last path component removed) on success (use @ref tr_free to free it
- *         when no longer needed), `nullptr` otherwise (with `error` set
- *         accordingly).
+ * @return parent path substring of `path` (last path component removed) on
+ *         success, or empty string otherwise with `error` set accordingly).
  */
 std::string_view tr_sys_path_dirname(std::string_view path);
 
@@ -640,9 +636,8 @@ bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, struc
  * @param[out] error Pointer to error object. Optional, pass `nullptr` if you are
  *                   not interested in error details.
  *
- * @return Pointer to newly allocated buffer containing path to current
- *         directory (use @ref tr_free to free it when no longer needed) on
- *         success, `nullptr` otherwise (with `error` set accordingly).
+ * @return current directory on success, or an empty string otherwise
+ *         (with `error` set accordingly).
  */
 std::string tr_sys_dir_get_current(struct tr_error** error = nullptr);
 
@@ -700,11 +695,11 @@ tr_sys_dir_t tr_sys_dir_open(char const* path, struct tr_error** error = nullptr
  * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
  *                    are not interested in error details.
  *
- * @return Pointer to next directory entry name (stored internally, DO NOT pass
- *         it to @ref tr_free) on success, `nullptr` otherwise (with `error` set
- *         accordingly). Note that `nullptr` will also be returned in case of end
- *         of directory; if you need to distinguish the two, check if `error`
- *         is `nullptr` afterwards.
+ * @return Pointer to next directory entry name (stored internally, DO NOT free
+ *         it) on success, `nullptr` otherwise (with `error` set accordingly).
+ *         Note that `nullptr` will also be returned in case of end of directory.
+ *         If you need to distinguish the two, check if `error` is `nullptr`
+ *         afterwards.
  */
 char const* tr_sys_dir_read_name(tr_sys_dir_t handle, struct tr_error** error = nullptr);
 

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -20,7 +20,6 @@
 #include "magnet-metainfo.h"
 #include "tr-assert.h"
 #include "utils.h"
-#include "variant.h"
 #include "web-utils.h"
 
 using namespace std::literals;

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -19,6 +19,7 @@
 #include "block-info.h"
 #include "file.h"
 #include "torrent-files.h"
+#include "utils.h" // tr_saveFile()
 
 class tr_metainfo_builder
 {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -46,7 +46,6 @@
 #include "trevent.h"
 #include "utils.h"
 #include "variant.h"
-#include "web-utils.h"
 #include "web.h"
 
 using namespace std::literals;

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -92,3 +92,15 @@ void tr_stats::clear()
     ret.ratio = tr_getRatio(ret.uploadedBytes, ret.downloadedBytes);
     return ret;
 }
+
+tr_session_stats tr_stats::add(tr_session_stats const& a, tr_session_stats const& b)
+{
+    auto ret = tr_session_stats{};
+    ret.uploadedBytes = a.uploadedBytes + b.uploadedBytes;
+    ret.downloadedBytes = a.downloadedBytes + b.downloadedBytes;
+    ret.filesAdded = a.filesAdded + b.filesAdded;
+    ret.sessionCount = a.sessionCount + b.sessionCount;
+    ret.secondsActive = a.secondsActive + b.secondsActive;
+    ret.ratio = tr_getRatio(ret.uploadedBytes, ret.downloadedBytes);
+    return ret;
+}

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -15,8 +15,6 @@
 
 #include "transmission.h" // for tr_session_stats
 
-#include "utils.h" // for tr_getRatio()
-
 // per-session data structure for bandwidth use statistics
 class tr_stats
 {
@@ -71,17 +69,7 @@ public:
     }
 
 private:
-    static tr_session_stats add(tr_session_stats const& a, tr_session_stats const& b)
-    {
-        auto ret = tr_session_stats{};
-        ret.uploadedBytes = a.uploadedBytes + b.uploadedBytes;
-        ret.downloadedBytes = a.downloadedBytes + b.downloadedBytes;
-        ret.filesAdded = a.filesAdded + b.filesAdded;
-        ret.sessionCount = a.sessionCount + b.sessionCount;
-        ret.secondsActive = a.secondsActive + b.secondsActive;
-        ret.ratio = tr_getRatio(ret.uploadedBytes, ret.downloadedBytes);
-        return ret;
-    }
+    static tr_session_stats add(tr_session_stats const& a, tr_session_stats const& b);
 
     void save() const;
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -19,7 +19,6 @@
 #include "torrent.h"
 #include "tr-assert.h"
 #include "utils.h"
-#include "variant.h"
 
 using namespace std::literals;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -49,7 +49,6 @@
 #include "tr-assert.h"
 #include "trevent.h" /* tr_runInEventThread() */
 #include "utils.h"
-#include "variant.h"
 #include "verify.h"
 #include "version.h"
 #include "web-utils.h"

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -47,6 +47,7 @@
 #include "tr-strbuf.h"
 #include "trevent.h"
 #include "variant.h"
+#include "utils.h" // tr_time(), _()
 
 using namespace std::literals;
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "torrent.h"
 #include "tr-assert.h"
+#include "utils.h" // tr_time(), tr_wait_msec()
 #include "verify.h"
 
 /***

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -13,7 +13,6 @@
 
 #include "tr-macros.h" // tr_sha1_digest_t
 #include "tr-strbuf.h" // tr_urlbuf
-#include "utils.h"
 
 struct evbuffer;
 
@@ -101,7 +100,8 @@ void tr_http_escape(OutputIt out, std::string_view in, bool escape_reserved)
 
     for (auto const& ch : in)
     {
-        if (tr_strvContains(UnescapedChars, ch) || (tr_strvContains(ReservedChars, ch) && !escape_reserved))
+        if (UnescapedChars.find(ch) != std::string_view::npos ||
+            (ReservedChars.find(ch) != std::string_view::npos && !escape_reserved))
         {
             out = ch;
         }

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -8,9 +8,10 @@
 
 #include <libtransmission/transmission.h>
 
+#include <libtransmission/error.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/utils.h>
-#include <libtransmission/error.h>
+#include <libtransmission/web-utils.h>
 
 #include "AddData.h"
 #include "Utils.h"

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -25,8 +25,9 @@
 #include <QDBusReply>
 #endif
 
-#include <libtransmission/tr-getopt.h>
 #include <libtransmission/transmission.h>
+
+#include <libtransmission/tr-getopt.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -11,10 +11,6 @@
 #include <QNetworkRequest>
 #include <QStandardPaths>
 
-#include <libtransmission/transmission.h>
-
-#include <libtransmission/web-utils.h> // tr_urlParse()
-
 #include "FaviconCache.h"
 
 /***

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -18,7 +18,6 @@
 #include <libtransmission/error.h>
 #include <libtransmission/makemeta.h>
 #include <libtransmission/transmission.h>
-#include <libtransmission/utils.h>
 
 #include "ColumnResizer.h"
 #include "Formatter.h"

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -9,7 +9,7 @@
 #include <QPushButton>
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/utils.h> /* mime64 */
+
 #include <libtransmission/variant.h>
 #include <libtransmission/torrent-metainfo.h>
 

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -22,7 +22,6 @@
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/quark.h>
-#include <libtransmission/utils.h>
 #include <libtransmission/variant.h>
 
 class QNetworkAccessManager;
@@ -97,5 +96,5 @@ private:
     QNetworkAccessManager* nam_ = {};
     QHash<int64_t, QFutureInterface<RpcResponse>> local_requests_;
     int64_t next_tag_ = {};
-    bool const verbose_ = tr_env_key_exists("TR_RPC_VERBOSE");
+    bool const verbose_ = qEnvironmentVariableIsSet("TR_RPC_VERBOSE");
 };

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -23,8 +23,9 @@
 #include <QTextStream>
 #include <QtDebug>
 
-#include <libtransmission/session-id.h>
 #include <libtransmission/transmission.h>
+
+#include <libtransmission/session-id.h>
 #include <libtransmission/utils.h> // tr_free
 #include <libtransmission/variant.h>
 

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -12,7 +12,6 @@
 #include <QUrl>
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/utils.h> /* tr_new0, tr_strdup */
 #include <libtransmission/variant.h>
 
 #include "Application.h"

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -17,6 +17,7 @@
 #include <QStyleOptionProgressBar>
 
 #include <libtransmission/transmission.h>
+
 #include <libtransmission/utils.h>
 
 #include "Torrent.h"

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -9,9 +9,6 @@
 #include <QPixmap>
 #include <QTextDocument>
 
-#include <libtransmission/transmission.h>
-#include <libtransmission/utils.h>
-
 #include "FaviconCache.h"
 #include "Formatter.h"
 #include "Torrent.h"

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -15,7 +15,6 @@
 #include "error.h"
 #include "torrent-metainfo.h"
 #include "tr-strbuf.h"
-#include "utils.h"
 #include "variant.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -12,7 +12,6 @@
 #include "transmission.h"
 
 #include "announcer-common.h"
-#include "crypto-utils.h"
 #include "net.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/benc-test.cc
+++ b/tests/libtransmission/benc-test.cc
@@ -8,7 +8,6 @@
 #include "transmission.h"
 
 #include "benc.h"
-#include "utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -11,7 +11,6 @@
 #include "transmission.h"
 #include "crypto-utils.h"
 #include "bitfield.h"
-#include "utils.h" /* tr_free */
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -14,7 +14,6 @@
 #include "peer-socket.h"
 #include "session.h" // tr_sessionIsAddressBlocked()
 #include "tr-strbuf.h"
-#include "utils.h"
 
 #include "test-fixtures.h"
 

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -8,8 +8,9 @@
 #include <string_view>
 
 #include "transmission.h"
+
+#include "crypto-utils.h" // tr_rand_buffer()
 #include "clients.h"
-#include "crypto-utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -11,8 +11,8 @@
 #include "transmission.h"
 
 #include "block-info.h"
+#include "crypto-utils.h" // tr_rand_buffer()
 #include "completion.h"
-#include "crypto-utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -9,6 +9,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <vector>
 
 #include "transmission.h"
 #include "error.h"
@@ -30,10 +31,10 @@ protected:
         auto const path1 = tr_pathbuf{ sandboxDir(), '/', filename1 };
 
         /* Create a file. */
-        auto* file_content = static_cast<char*>(tr_malloc(file_length));
-        tr_rand_buffer(file_content, file_length);
-        createFileWithContents(path1, file_content, file_length);
-        tr_free(file_content);
+        auto contents = std::vector<char>{};
+        contents.resize(file_length);
+        tr_rand_buffer(std::data(contents), std::size(contents));
+        createFileWithContents(path1, std::data(contents), std::size(contents));
 
         auto const path2 = tr_pathbuf{ sandboxDir(), '/', filename2 };
 
@@ -72,52 +73,11 @@ private:
         return bytes_remaining;
     }
 
-    static bool filesAreIdentical(char const* fn1, char const* fn2)
+    static bool filesAreIdentical(std::string_view filename1, std::string_view filename2)
     {
-        bool identical = true;
-
-        tr_sys_file_t const fd1 = tr_sys_file_open(fn1, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
-        tr_sys_file_t const fd2 = tr_sys_file_open(fn2, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
-        EXPECT_NE(fd1, TR_BAD_SYS_FILE);
-        EXPECT_NE(fd2, TR_BAD_SYS_FILE);
-
-        auto const info1 = tr_sys_file_get_info(fd1);
-        auto const info2 = tr_sys_file_get_info(fd2);
-        EXPECT_TRUE(info1);
-        EXPECT_TRUE(info2);
-        EXPECT_EQ(info1->size, info2->size);
-
-        auto bytes_left1 = info1->size;
-        auto bytes_left2 = info2->size;
-
-        size_t const buflen = 2 * 1024 * 1024; /* 2 MiB buffer */
-        auto* readbuf1 = static_cast<char*>(tr_malloc(buflen));
-        auto* readbuf2 = static_cast<char*>(tr_malloc(buflen));
-
-        while (bytes_left1 > 0 || bytes_left2 > 0)
-        {
-            bytes_left1 = fillBufferFromFd(fd1, bytes_left1, readbuf1, buflen);
-            bytes_left2 = fillBufferFromFd(fd2, bytes_left2, readbuf2, buflen);
-
-            if (bytes_left1 != bytes_left2)
-            {
-                identical = false;
-                break;
-            }
-
-            if (memcmp(readbuf1, readbuf2, buflen) != 0)
-            {
-                identical = false;
-                break;
-            }
-        }
-
-        tr_free(readbuf1);
-        tr_free(readbuf2);
-        tr_sys_file_close(fd1);
-        tr_sys_file_close(fd2);
-
-        return identical;
+        auto contents1 = std::vector<char>{};
+        auto contents2 = std::vector<char>{};
+        return tr_loadFile(filename1, contents1) && tr_loadFile(filename2, contents2) && contents1 == contents2;
     }
 };
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -11,7 +11,6 @@
 #include <string_view>
 
 #include "transmission.h"
-#include "utils.h" // tr_free()
 #include "variant.h"
 #include "variant-common.h"
 

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -10,9 +10,8 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h"
 #include "magnet-metainfo.h"
-#include "utils.h"
+#include "crypto-utils.h" // tr_rand_buffer()
 
 using namespace std::literals;
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -22,7 +22,6 @@
 #include "makemeta.h"
 #include "session.h" // TR_NAME
 #include "torrent-metainfo.h"
-#include "utils.h"
 
 #include "test-fixtures.h"
 

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -16,7 +16,6 @@
 #include "cache.h" // tr_cacheWriteBlock()
 #include "file.h" // tr_sys_path_*()
 #include "tr-strbuf.h"
-#include "utils.h"
 #include "variant.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/peer-msgs-test.cc
+++ b/tests/libtransmission/peer-msgs-test.cc
@@ -5,7 +5,6 @@
 
 #include "transmission.h"
 #include "peer-msgs.h"
-#include "utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -5,13 +5,11 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h"
 #include "file.h"
 #include "resume.h"
 #include "torrent.h" // tr_isTorrent()
 #include "tr-assert.h"
 #include "tr-strbuf.h"
-#include "utils.h"
 #include "variant.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -5,7 +5,6 @@
 
 #include "transmission.h"
 #include "rpcimpl.h"
-#include "utils.h"
 #include "variant.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -6,7 +6,6 @@
 #include "transmission.h"
 #include "session.h"
 #include "session-id.h"
-#include "utils.h"
 #include "version.h"
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -6,7 +6,7 @@
 #include "transmission.h"
 #include "file.h"
 #include "subprocess.h"
-#include "utils.h"
+#include "utils.h" // tr_env_get_string()
 
 #include <string>
 

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -8,14 +8,12 @@
 #include "file.h"
 #include "platform.h"
 #include "subprocess.h"
-#include "utils.h"
 
 #include "gtest/internal/gtest-port.h" // GetArgvs()
 
 #include "test-fixtures.h"
 
 #include <array>
-#include <cstdlib>
 #include <map>
 #include <string>
 #include <string_view>

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -11,7 +11,6 @@
 
 #include "torrent.h"
 #include "torrents.h"
-#include "utils.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -8,9 +8,8 @@
 #include "transmission.h"
 
 #include "benc.h"
-#include "crypto-utils.h"
+#include "crypto-utils.h" // tr_rand_buffer(), tr_rand_int()
 #include "error.h"
-#include "utils.h" /* tr_free */
 #include "variant-common.h"
 #include "variant.h"
 

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -10,7 +10,6 @@
 
 #include "file.h"
 #include "net.h"
-#include "utils.h"
 #include "watchdir.h"
 
 #include "test-fixtures.h"


### PR DESCRIPTION
Misc cleanup in trying to reduce the footprint of `tr_new()` / `tr_free()`

- reduce the number of files that include `utils.h`
- reduce use of `tr_new` / `tr_free` for temporary variables