### PR TITLE
New font format for StatsWindow.xib

### DIFF
--- a/macosx/StatsWindow.xib
+++ b/macosx/StatsWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -43,7 +43,7 @@
                         <rect key="frame" x="17" y="157" width="94" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Uploaded:" id="4">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="systemBold" size="11"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -52,7 +52,7 @@
                         <rect key="frame" x="17" y="125" width="94" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Downloaded:" id="6">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="systemBold" size="11"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -61,7 +61,7 @@
                         <rect key="frame" x="17" y="93" width="94" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Ratio:" id="12">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="systemBold" size="11"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -70,7 +70,7 @@
                         <rect key="frame" x="17" y="61" width="94" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Running Time:" id="14">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="systemBold" size="11"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -115,7 +115,7 @@
                         <rect key="frame" x="17" y="29" width="94" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Program Started:" id="38">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="systemBold" size="11"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>


### PR DESCRIPTION
I'm going to break down pr #3554 into more easily digestible chunks.

This pr adds bold font styling to more easily differentiate the information heading from the data.

Statistics
Original
![SCR-20220802-i09](https://user-images.githubusercontent.com/69029666/182269649-bc59ab42-ed0f-4e94-801a-01e0e5c24591.png)

This PR
![SCR-20220801-nek](https://user-images.githubusercontent.com/69029666/182074773-c1000bb1-7532-49a5-94e1-d7ab7a9f469e.png)