### PR TITLE
Bolding font changes to InfoOptionsView.xib

### DIFF
--- a/macosx/Base.lproj/InfoOptionsView.xib
+++ b/macosx/Base.lproj/InfoOptionsView.xib
@@ -75,7 +75,7 @@
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                                     <rect key="frame" x="-2" y="102" width="92" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Transfer Priority:" id="47">
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -84,7 +84,7 @@
                                     <rect key="frame" x="-1" y="11" width="223" height="16"/>
                                     <buttonCell key="cell" type="check" title="Stay within the global bandwidth limits" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" allowsMixedState="YES" inset="2" id="45">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="setUseGlobalSpeedLimit:" target="-2" id="60"/>
@@ -94,7 +94,7 @@
                                     <rect key="frame" x="-1" y="51" width="105" height="16"/>
                                     <buttonCell key="cell" type="check" title="Limit Download:" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" allowsMixedState="YES" inset="2" id="44">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="setUseSpeedLimit:" target="-2" id="58"/>
@@ -104,7 +104,7 @@
                                     <rect key="frame" x="-1" y="31" width="105" height="16"/>
                                     <buttonCell key="cell" type="check" title="Limit Upload:" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" allowsMixedState="YES" inset="2" id="43">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="setUseSpeedLimit:" target="-2" id="59"/>
@@ -164,7 +164,7 @@
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="5">
                                     <rect key="frame" x="-2" y="118" width="46" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Priority" id="46">
-                                        <font key="font" metaFont="smallSystemBold"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -172,7 +172,7 @@
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="20">
                                     <rect key="frame" x="-2" y="68" width="114" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Transfer Bandwidth" id="23">
-                                        <font key="font" metaFont="smallSystemBold"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -224,7 +224,7 @@
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="21">
                                     <rect key="frame" x="-2" y="120" width="87" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Seeding Limits" id="22">
-                                        <font key="font" metaFont="smallSystemBold"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -250,7 +250,7 @@
                                     <rect key="frame" x="-1" y="51" width="307" height="24"/>
                                     <buttonCell key="cell" type="check" title="Remove from the transfer list when seeding completes" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" allowsMixedState="YES" inset="2" id="114">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="setRemoveWhenSeedingCompletes:" target="-2" id="119"/>
@@ -259,7 +259,7 @@
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="13">
                                     <rect key="frame" x="-2" y="2" width="125" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Maximum connections:" id="32">
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -267,7 +267,7 @@
                                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="14">
                                     <rect key="frame" x="-2" y="18" width="60" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Advanced" id="31">
-                                        <font key="font" metaFont="smallSystemBold"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -361,7 +361,7 @@
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="15">
                                     <rect key="frame" x="-2" y="104" width="56" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Ratio:" id="30">
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -390,7 +390,7 @@
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="79">
                                     <rect key="frame" x="-2" y="82" width="56" height="14"/>
                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Inactivity:" id="89">
-                                        <font key="font" metaFont="smallSystem"/>
+                                        <font key="font" metaFont="systemBold" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>


### PR DESCRIPTION
Another in a series to break down pr https://github.com/transmission/transmission/pull/3554 into more easily digestible chunks.

This is another simple change to help differentiate information from data.

Options
Original
![SCR-20220802-hzv](https://user-images.githubusercontent.com/69029666/182269757-4c5a9d37-ad25-40e4-a91f-39756ef3d80f.png)

This PR
![SCR-20220803-lv](https://user-images.githubusercontent.com/69029666/182374399-1f3e8694-fa8e-48e6-83ae-73a4d207e173.png)
