### PR TITLE
Increase heading size of AddMagnetWindow.xib

### DIFF
--- a/macosx/Base.lproj/AddMagnetWindow.xib
+++ b/macosx/Base.lproj/AddMagnetWindow.xib
@@ -91,7 +91,7 @@ Gw
                     <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="100">
                         <rect key="frame" x="42" y="190" width="84" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Magnet Link" id="101">
-                            <font key="font" metaFont="systemBold"/>
+                            <font key="font" metaFont="systemBold" size="14"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>


### PR DESCRIPTION
Another in a series to break down pr https://github.com/transmission/transmission/pull/3554 into more easily digestible chunks.

This is another simple change to help differentiate information from data by increasing the header size. If anyone can direct me to the file, i'd also like to increase the font size of the torrent information below the title etc.

Original
![SCR-20220810-uno](https://user-images.githubusercontent.com/69029666/183875706-a67157cd-a1d7-4917-b9f3-a7ff1b49ed06.png)

This PR
Open torrent file
![SCR-20220731-ttd](https://user-images.githubusercontent.com/69029666/182021314-d569a653-92de-44b9-b69c-a9cc3e53359f.png)