### PR TITLE
refactor: timer pt 2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -181,7 +181,7 @@ jobs:
         run: brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3
+        run: brew install gtkmm3 libjpeg
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
         run: brew install qt@5

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -349,7 +349,7 @@ jobs:
         run: brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3
+        run: brew install gtkmm3 libjpeg
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
         run: brew install qt@5

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -114,7 +114,7 @@ static void natPulse(tr_shared* s, bool do_check)
     }
 }
 
-static void set_evtimer_from_status(tr_shared* s)
+static void restartTimer(tr_shared* s)
 {
     auto& timer = s->timer;
     if (!timer)
@@ -163,7 +163,7 @@ static void onTimer(void* vshared)
     s->doPortCheck = false;
 
     /* set up the timer for the next pulse */
-    set_evtimer_from_status(s);
+    restartTimer(s);
 }
 
 /***
@@ -209,7 +209,7 @@ void tr_sharedClose(tr_session* session)
 static void start_timer(tr_shared* s)
 {
     s->timer = s->session->timerMaker().create(onTimer, s);
-    set_evtimer_from_status(s);
+    restartTimer(s);
 }
 
 void tr_sharedTraversalEnable(tr_shared* s, bool is_enable)

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -4,10 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-
-#include <sys/types.h>
-
-#include <event2/event.h>
+#include <chrono>
 
 #include <fmt/core.h>
 
@@ -21,22 +18,30 @@
 #include "torrent.h"
 #include "tr-assert.h"
 #include "upnp.h"
-#include "utils.h"
+#include "utils.h" // for _()
+
+using namespace std::literals;
 
 struct tr_shared
 {
-    bool isEnabled;
-    bool isShuttingDown;
-    bool doPortCheck;
+    tr_shared(tr_session* session_in)
+        : session{ session_in }
+    {
+    }
 
-    tr_port_forwarding natpmpStatus;
-    tr_port_forwarding upnpStatus;
+    tr_session* const session = nullptr;
 
-    tr_upnp* upnp;
-    tr_natpmp* natpmp;
-    tr_session* session;
+    bool isEnabled = false;
+    bool isShuttingDown = false;
+    bool doPortCheck = false;
 
-    struct event* timer;
+    tr_port_forwarding natpmpStatus = TR_PORT_UNMAPPED;
+    tr_port_forwarding upnpStatus = TR_PORT_UNMAPPED;
+
+    tr_upnp* upnp = nullptr;
+    tr_natpmp* natpmp = nullptr;
+
+    std::unique_ptr<libtransmission::Timer> timer;
 };
 
 /***
@@ -111,42 +116,47 @@ static void natPulse(tr_shared* s, bool do_check)
 
 static void set_evtimer_from_status(tr_shared* s)
 {
-    int sec = 0;
-    int msec = 0;
+    auto& timer = s->timer;
+    if (!timer)
+    {
+        return;
+    }
 
-    /* when to wake up again */
+    // when to wake up again
     switch (tr_sharedTraversalStatus(s))
     {
     case TR_PORT_MAPPED:
-        /* if we're mapped, everything is fine... check back at renew_time
-         * to renew the port forwarding if it's expired */
+        // if we're mapped, everything is fine... check back at `renew_time`
+        // to renew the port forwarding if it's expired
         s->doPortCheck = true;
-        sec = std::max(0, int(s->natpmp->renew_time - tr_time()));
+        if (auto const now = tr_time(); s->natpmp->renew_time > now)
+        {
+            timer->startSingleShot(std::chrono::seconds{ s->natpmp->renew_time - now });
+        }
+        else // ???
+        {
+            timer->startSingleShot(1min);
+        }
         break;
 
     case TR_PORT_ERROR:
-        /* some kind of an error. wait 60 seconds and retry */
-        sec = 60;
+        // some kind of an error. wait a minute and retry
+        timer->startSingleShot(1min);
         break;
 
     default:
-        /* in progress. pulse frequently. */
-        msec = 333000;
+        // in progress. pulse frequently.
+        timer->startSingleShot(333ms);
         break;
-    }
-
-    if (s->timer != nullptr)
-    {
-        tr_timerAdd(*s->timer, sec, msec);
     }
 }
 
-static void onTimer(evutil_socket_t /*fd*/, short /*what*/, void* vshared)
+static void onTimer(void* vshared)
 {
     auto* s = static_cast<tr_shared*>(vshared);
 
     TR_ASSERT(s != nullptr);
-    TR_ASSERT(s->timer != nullptr);
+    TR_ASSERT(s->timer);
 
     /* do something */
     natPulse(s, s->doPortCheck);
@@ -162,34 +172,12 @@ static void onTimer(evutil_socket_t /*fd*/, short /*what*/, void* vshared)
 
 tr_shared* tr_sharedInit(tr_session* session)
 {
-    auto* const s = tr_new0(tr_shared, 1);
-
-    s->session = session;
-    s->isEnabled = false;
-    s->upnpStatus = TR_PORT_UNMAPPED;
-    s->natpmpStatus = TR_PORT_UNMAPPED;
-
-#if 0
-
-    if (isEnabled)
-    {
-        s->timer = tr_new0(struct event, 1);
-        evtimer_set(s->timer, onTimer, s);
-        tr_timerAdd(s->timer, 0, 333000);
-    }
-
-#endif
-
-    return s;
+    return new tr_shared{ session };
 }
 
 static void stop_timer(tr_shared* s)
 {
-    if (s->timer != nullptr)
-    {
-        event_free(s->timer);
-        s->timer = nullptr;
-    }
+    s->timer.reset();
 }
 
 static void stop_forwarding(tr_shared* s)
@@ -210,17 +198,17 @@ static void stop_forwarding(tr_shared* s)
 
 void tr_sharedClose(tr_session* session)
 {
-    tr_shared* s = session->shared;
+    tr_shared* shared = session->shared;
 
-    s->isShuttingDown = true;
-    stop_forwarding(s);
-    s->session->shared = nullptr;
-    tr_free(s);
+    shared->isShuttingDown = true;
+    stop_forwarding(shared);
+    shared->session->shared = nullptr;
+    delete shared;
 }
 
 static void start_timer(tr_shared* s)
 {
-    s->timer = evtimer_new(s->session->eventBase(), onTimer, s);
+    s->timer = s->session->timerMaker().create(onTimer, s);
     set_evtimer_from_status(s);
 }
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -17,6 +17,7 @@
 #include "transmission.h"
 
 #include "net.h"
+#include "timer.h"
 
 struct event;
 struct evhttp;
@@ -130,7 +131,7 @@ public:
 
     std::unique_ptr<struct tr_rpc_address> bindAddress;
 
-    struct event* start_retry_timer = nullptr;
+    std::unique_ptr<libtransmission::Timer> start_retry_timer;
     struct evhttp* httpd = nullptr;
     tr_session* const session;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -678,17 +678,15 @@ static void onNowTimer(void* vsession)
         }
     }
 
-    // set the timer to kick again right after the next second
-    auto const tv = tr_gettimeofday();
-    int constexpr Min = 100;
-    int constexpr Max = 999999;
-    auto const next_second_occurs_in_usec = std::chrono::microseconds{ std::clamp(int(1000000 - tv.tv_usec), Min, Max) };
-    auto next_second_occurs_in_msec = std::chrono::duration_cast<std::chrono::milliseconds>(next_second_occurs_in_usec);
-    if (next_second_occurs_in_msec < 100ms)
+    // set the timer to kick again right after (10ms after) the next second
+    auto const now = std::chrono::system_clock::now();
+    auto const target_time = std::chrono::time_point_cast<std::chrono::seconds>(now) + 1s + 10ms;
+    auto target_interval = target_time - now;
+    if (target_interval < 100ms)
     {
-        next_second_occurs_in_msec += 1s;
+        target_interval += 1s;
     }
-    session->now_timer_->setInterval(next_second_occurs_in_msec);
+    session->now_timer_->setInterval(std::chrono::duration_cast<std::chrono::milliseconds>(target_interval));
 }
 
 static void loadBlocklists(tr_session* session);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -518,7 +518,7 @@ public:
     struct event* udp6_event = nullptr;
 
     struct struct_utp_context* utp_context = nullptr;
-    struct event* utp_timer = nullptr;
+    std::unique_ptr<libtransmission::Timer> utp_timer;
 
     /* The open port on the local machine for incoming peer requests */
     tr_port private_peer_port;

--- a/libtransmission/timer.h
+++ b/libtransmission/timer.h
@@ -62,6 +62,20 @@ class TimerMaker
 public:
     virtual ~TimerMaker() = default;
     [[nodiscard]] virtual std::unique_ptr<Timer> create() = 0;
+
+    [[nodiscard]] virtual std::unique_ptr<Timer> create(std::function<void()> callback)
+    {
+        auto timer = create();
+        timer->setCallback(std::move(callback));
+        return timer;
+    }
+
+    [[nodiscard]] virtual std::unique_ptr<Timer> create(Timer::CStyleCallback callback, void* user_data)
+    {
+        auto timer = create();
+        timer->setCallback(callback, user_data);
+        return timer;
+    }
 };
 
 } // namespace libtransmission

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -755,10 +755,19 @@ int dht_sendto(int sockfd, void const* buf, int len, int flags, struct sockaddr 
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 
+/***
+****
+***/
+
 extern "C" int dht_gettimeofday(struct timeval* tv, [[maybe_unused]] timezone* tz)
 {
     TR_ASSERT(tz == nullptr);
-    *tv = tr_gettimeofday();
+
+    auto const d = std::chrono::system_clock::now().time_since_epoch();
+    auto const s = std::chrono::duration_cast<std::chrono::seconds>(d);
+    tv->tv_sec = s.count();
+    tv->tv_usec = std::chrono::duration_cast<std::chrono::microseconds>(d - s).count();
+
     return 0;
 }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -21,7 +21,7 @@
 #undef gai_strerror
 #define gai_strerror gai_strerrorA
 #else
-#include <sys/time.h>
+#include <sys/time.h> // for `struct timezone`
 #include <sys/types.h>
 #include <sys/socket.h> /* socket(), bind() */
 #include <netdb.h>
@@ -759,7 +759,7 @@ int dht_sendto(int sockfd, void const* buf, int len, int flags, struct sockaddr 
 ****
 ***/
 
-extern "C" int dht_gettimeofday(struct timeval* tv, [[maybe_unused]] timezone* tz)
+extern "C" int dht_gettimeofday(struct timeval* tv, [[maybe_unused]] struct timezone* tz)
 {
     TR_ASSERT(tz == nullptr);
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <csignal> /* sig_atomic_t */
 #include <cstring> /* strlen(), strncpy(), strstr(), memset() */
 #include <type_traits>
@@ -49,9 +50,9 @@ static auto constexpr SIZEOF_HASH_STRING = TR_SHA1_DIGEST_STRLEN;
 
 static void event_callback(evutil_socket_t, short /*type*/, void* /*unused*/);
 
-static auto constexpr UpkeepIntervalSecs = int{ 5 };
+static auto constexpr UpkeepInterval = 5s;
 
-static struct event* upkeep_timer = nullptr;
+static std::unique_ptr<libtransmission::Timer> upkeep_timer;
 
 static tr_socket_t lpd_socket; /**<separate multicast receive socket */
 static tr_socket_t lpd_socket2; /**<and multicast send socket */
@@ -229,7 +230,7 @@ static bool lpd_extractParam(char const* const str, char const* const name, int 
 /**
 * @} */
 
-static void on_upkeep_timer(evutil_socket_t, short /*unused*/, void* /*unused*/);
+static void on_upkeep_timer();
 
 /**
 * @brief Initializes Local Peer Discovery for this node
@@ -357,8 +358,8 @@ int tr_lpdInit(tr_session* ss, tr_address* /*tr_addr*/)
     lpd_event = event_new(ss->eventBase(), lpd_socket, EV_READ | EV_PERSIST, event_callback, nullptr);
     event_add(lpd_event, nullptr);
 
-    upkeep_timer = evtimer_new(ss->eventBase(), on_upkeep_timer, ss);
-    tr_timerAdd(*upkeep_timer, UpkeepIntervalSecs, 0);
+    upkeep_timer = ss->timerMaker().create([]() { on_upkeep_timer(); });
+    upkeep_timer->startRepeating(UpkeepInterval);
 
     tr_logAddDebug("Local Peer Discovery initialised");
 
@@ -393,8 +394,7 @@ void tr_lpdUninit(tr_session* ss)
     event_free(lpd_event);
     lpd_event = nullptr;
 
-    evtimer_del(upkeep_timer);
-    upkeep_timer = nullptr;
+    upkeep_timer.reset();
 
     /* just shut down, we won't remember any former nodes */
     evutil_closesocket(lpd_socket);
@@ -616,11 +616,11 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
     return announcesSent;
 }
 
-static void on_upkeep_timer(evutil_socket_t /*s*/, short /*type*/, void* /*user_data*/)
+static void on_upkeep_timer()
 {
     time_t const now = tr_time();
-    tr_lpdAnnounceMore(now, UpkeepIntervalSecs);
-    tr_timerAdd(*upkeep_timer, UpkeepIntervalSecs, 0);
+    auto const seconds = std::chrono::duration_cast<std::chrono::seconds>(UpkeepInterval).count();
+    tr_lpdAnnounceMore(now, seconds);
 }
 
 /**

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -204,8 +204,8 @@ static void libeventThreadFunc(tr_event_handle* events)
         evdns_base_free(dns_base, 0);
     }
     event_free(events->work_queue_event);
-    event_base_free(base);
-    events->session->clearEventBase();
+    // event_base_free(base);
+    // events->session->clearEventBase();
     events->session->evdns_base = nullptr;
     events->session->events = nullptr;
     delete events;

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -204,8 +204,8 @@ static void libeventThreadFunc(tr_event_handle* events)
         evdns_base_free(dns_base, 0);
     }
     event_free(events->work_queue_event);
-    // event_base_free(base);
-    // events->session->clearEventBase();
+    event_base_free(base);
+    events->session->clearEventBase();
     events->session->evdns_base = nullptr;
     events->session->events = nullptr;
     delete events;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -64,20 +64,6 @@ time_t __tr_current_time = 0;
 ****
 ***/
 
-struct timeval tr_gettimeofday()
-{
-    auto const d = std::chrono::system_clock::now().time_since_epoch();
-    auto const s = std::chrono::duration_cast<std::chrono::seconds>(d);
-    auto ret = timeval{};
-    ret.tv_sec = s.count();
-    ret.tv_usec = std::chrono::duration_cast<std::chrono::microseconds>(d - s).count();
-    return ret;
-}
-
-/***
-****
-***/
-
 void* tr_malloc(size_t size)
 {
     return size != 0 ? malloc(size) : nullptr;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -108,30 +108,6 @@ void tr_free(void* p)
     }
 }
 
-/***
-****
-***/
-
-void tr_timerAdd(struct event& timer, int seconds, int microseconds)
-{
-    auto tv = timeval{};
-    tv.tv_sec = seconds;
-    tv.tv_usec = microseconds;
-
-    TR_ASSERT(tv.tv_sec >= 0);
-    TR_ASSERT(tv.tv_usec >= 0);
-    TR_ASSERT(tv.tv_usec < 1000000);
-
-    evtimer_add(&timer, &tv);
-}
-
-void tr_timerAddMsec(struct event& timer, int milliseconds)
-{
-    int const seconds = milliseconds / 1000;
-    int const usec = (milliseconds % 1000) * 1000;
-    tr_timerAdd(timer, seconds, usec);
-}
-
 /**
 ***
 **/

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -36,8 +36,6 @@
 #define UTF_CPP_CPLUSPLUS 201703L
 #include <utf8.h>
 
-#include <event2/event.h>
-
 #include <fmt/format.h>
 
 #include <fast_float/fast_float.h>
@@ -273,8 +271,7 @@ std::string_view tr_strvStrip(std::string_view str)
 
 uint64_t tr_time_msec()
 {
-    auto const tv = tr_gettimeofday();
-    return uint64_t(tv.tv_sec) * 1000 + (tv.tv_usec / 1000);
+    return std::chrono::system_clock::now().time_since_epoch() / 1ms;
 }
 
 void tr_wait_msec(long int delay_milliseconds)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -285,9 +285,6 @@ std::string& tr_strvUtf8Clean(std::string_view cleanme, std::string& setme);
  */
 [[nodiscard]] std::string tr_strratio(double ratio, char const* infinity);
 
-/** @brief Portability wrapper for gettimeofday(), with tz argument dropped */
-struct timeval tr_gettimeofday();
-
 /**
  * @brief move a file
  * @return `True` on success, `false` otherwise (with `error` set accordingly).

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -88,21 +88,6 @@ constexpr auto tr_saveFile(std::string_view filename, ContiguousRange const& x, 
  */
 tr_disk_space tr_dirSpace(std::string_view directory);
 
-/**
- * @brief Convenience wrapper around timer_add() to have a timer wake up in a number of seconds and microseconds
- * @param timer         the timer to set
- * @param seconds       seconds to wait
- * @param microseconds  microseconds to wait
- */
-void tr_timerAdd(struct event& timer, int seconds, int microseconds);
-
-/**
- * @brief Convenience wrapper around timer_add() to have a timer wake up in a number of milliseconds
- * @param timer         the timer to set
- * @param milliseconds  milliseconds to wait
- */
-void tr_timerAddMsec(struct event& timer, int milliseconds);
-
 /** @brief return the current date in milliseconds */
 uint64_t tr_time_msec();
 


### PR DESCRIPTION
- Replace all remaining uses of `evtimer` with `libtransmission::Timer`.
- Remove unused `tr_timerAdd()`
- Remove unused `tr_timerAddMsec()`
- Remove unused `tr_gettimeofday()`