### PR TITLE
refactor: make tr_session fields private

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -82,7 +82,7 @@ static tr_urlbuf announce_url_new(tr_session const* session, tr_announce_request
         fmt::arg("numwant", req->numwant),
         fmt::arg("key", req->key));
 
-    if (session->encryptionMode == TR_ENCRYPTION_REQUIRED)
+    if (session->encryptionMode() == TR_ENCRYPTION_REQUIRED)
     {
         fmt::format_to(out, "&requirecrypto=1");
     }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -433,7 +433,7 @@ void tr_tracker_http_announce(
     auto do_make_request = [&](std::string_view const& protocol_name, tr_web::FetchOptions&& opt)
     {
         tr_logAddTrace(fmt::format("Sending {} announce to libcurl: '{}'", protocol_name, opt.url), request->log_name);
-        session->web->fetch(std::move(opt));
+        session->web().fetch(std::move(opt));
     };
 
     auto ipv6 = tr_globalIPv6(session);
@@ -692,5 +692,5 @@ void tr_tracker_http_scrape(
     options.timeout_secs = 30L;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
-    session->web->fetch(std::move(options));
+    session->web().fetch(std::move(options));
 }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -475,7 +475,7 @@ private:
     [[nodiscard]] static time_t getNextScrapeTime(tr_session const* session, tr_tier const* tier, int interval)
     {
         // Maybe don't scrape paused torrents
-        if (!tier->isRunning && !session->scrapePausedTorrents)
+        if (!tier->isRunning && !session->shouldScrapePausedTorrents())
         {
             return 0;
         }
@@ -1595,7 +1595,7 @@ void tr_announcer::upkeep()
 {
     auto const lock = session->unique_lock();
 
-    bool const is_closing = session->isClosed;
+    bool const is_closing = session->isClosed();
     time_t const now = tr_time();
 
     /* maybe send out some "stopped" messages for closed torrents */

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -198,7 +198,7 @@ static tr_scrape_info* tr_announcerGetScrapeInfo(tr_announcer* announcer, tr_int
 
 void tr_announcerInit(tr_session* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     auto* a = new tr_announcer{ session };
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -878,7 +878,7 @@ static tr_announce_request* announce_request_new(
     TR_ASSERT(current_tracker != nullptr);
 
     auto* const req = new tr_announce_request();
-    req->port = announcer->session->peerPort();
+    req->port = announcer->session->publicPeerPort();
     req->announce_url = current_tracker->announce_url;
     req->tracker_id = current_tracker->tracker_id;
     req->info_hash = tor->infoHash();

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -88,7 +88,7 @@ bool getFilename(tr_pathbuf& setme, tr_torrent const* tor, tr_file_index_t file_
     // We didn't find the file that we want to write to.
     // Let's figure out where it goes so that we can create it.
     auto const base = tor->currentDir();
-    auto const suffix = tor->session->isIncompleteFileNamingEnabled ? tr_torrent_files::PartialFileSuffix : ""sv;
+    auto const suffix = tor->session->isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
     setme.assign(base, '/', tor->fileSubpath(file_index), suffix);
     return true;
 }

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -130,7 +130,7 @@ int readOrWriteBytes(
     {
         // open (and maybe create) the file
         auto const prealloc = (!do_write || !tor->fileIsWanted(file_index)) ? TR_PREALLOCATE_NONE :
-                                                                              tor->session->preallocationMode;
+                                                                              tor->session->preallocationMode();
         fd = session->openFiles().get(tor->id(), file_index, do_write, filename, prealloc, file_size);
         if (fd && do_write)
         {

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -241,7 +241,7 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
     while (bytes_left != 0)
     {
         size_t const len = std::min(bytes_left, std::size(buffer));
-        if (auto const success = tor->session->cache->readBlock(tor, loc, len, std::data(buffer)) == 0; !success)
+        if (auto const success = tor->session->cache().readBlock(tor, loc, len, std::data(buffer)) == 0; !success)
         {
             return {};
         }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -66,7 +66,7 @@ void walkTree(std::string_view const top, std::string_view const subpath, std::s
     tr_sys_path_native_separators(std::data(path));
     tr_error* error = nullptr;
     auto const info = tr_sys_path_get_info(path, 0, &error);
-    if (!info)
+    if (error != nullptr)
     {
         tr_logAddWarn(fmt::format(
             _("Skipping '{path}': {error} ({error_code})"),
@@ -74,6 +74,10 @@ void walkTree(std::string_view const top, std::string_view const subpath, std::s
             fmt::arg("error", error->message),
             fmt::arg("error_code", error->code)));
         tr_error_free(error);
+        return;
+    }
+    if (!info)
+    {
         return;
     }
 

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -56,7 +56,7 @@ private:
 
     void setCommandTime();
 
-    natpmp_t natpmp_;
+    natpmp_t natpmp_ = {};
 
     tr_port public_port_ = {};
     tr_port private_port_ = {};

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -234,7 +234,7 @@ static socklen_t setup_sockaddr(tr_address const* addr, tr_port port, struct soc
 
 static tr_socket_t createSocket(tr_session* session, int domain, int type)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     auto const sockfd = socket(domain, type, 0);
     if (sockfd == TR_BAD_SOCKET)
@@ -537,7 +537,7 @@ bool tr_net_hasIPv6(tr_port port)
 
 tr_socket_t tr_netAccept(tr_session* session, tr_socket_t listening_sockfd, tr_address* addr, tr_port* port)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(addr != nullptr);
     TR_ASSERT(port != nullptr);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2220,7 +2220,7 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
 
     for (auto& item : choked)
     {
-        if (unchoked_interested >= session->upload_slots_per_torrent)
+        if (unchoked_interested >= session->uploadSlotsPerTorrent())
         {
             break;
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1258,7 +1258,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     {
         auto mediator = std::make_shared<tr_handshake_mediator_impl>(*session);
         tr_peerIo* const io = tr_peerIoNewIncoming(session, &session->topBandwidth(), addr, port, tr_time(), socket);
-        tr_handshake* const handshake = tr_handshakeNew(mediator, io, session->encryptionMode, on_handshake_done, manager);
+        tr_handshake* const handshake = tr_handshakeNew(mediator, io, session->encryptionMode(), on_handshake_done, manager);
 
         tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
 
@@ -2844,7 +2844,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     else
     {
         auto mediator = std::make_shared<tr_handshake_mediator_impl>(*mgr->session);
-        tr_handshake* handshake = tr_handshakeNew(mediator, io, mgr->session->encryptionMode, on_handshake_done, mgr);
+        tr_handshake* handshake = tr_handshakeNew(mediator, io, mgr->session->encryptionMode(), on_handshake_done, mgr);
 
         TR_ASSERT(io->torrentHash());
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1558,7 +1558,7 @@ static void prefetchPieces(tr_peerMsgsImpl* msgs)
     {
         if (auto& req = requests[i]; !req.prefetched)
         {
-            msgs->session->cache->prefetchBlock(msgs->torrent, msgs->torrent->pieceLoc(req.index, req.offset), req.length);
+            msgs->session->cache().prefetchBlock(msgs->torrent, msgs->torrent->pieceLoc(req.index, req.offset), req.length);
             req.prefetched = true;
         }
     }
@@ -2046,7 +2046,7 @@ static int clientGotBlock(
         return 0;
     }
 
-    msgs->session->cache->writeBlock(tor->id(), block, block_data);
+    msgs->session->cache().writeBlock(tor->id(), block, block_data);
     msgs->blame.set(loc.piece);
     msgs->publishGotBlock(block);
     return 0;
@@ -2299,7 +2299,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             evbuffer_add_uint32(out, req.offset);
 
             evbuffer_reserve_space(out, req.length, iovec, 1);
-            bool err = msgs->session->cache->readBlock(
+            bool err = msgs->session->cache().readBlock(
                            msgs->torrent,
                            msgs->torrent->pieceLoc(req.index, req.offset),
                            req.length,

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1178,7 +1178,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     // port number of the other side. Note that there is no need for the
     // receiving side of the connection to send this extension message,
     // since its port number is already known.
-    tr_variantDictAddInt(&val, TR_KEY_p, msgs->session->peerPort().host());
+    tr_variantDictAddInt(&val, TR_KEY_p, msgs->session->publicPeerPort().host());
 
     // http://bittorrent.org/beps/bep_0010.html
     // An integer, the number of outstanding request messages this

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1547,7 +1547,7 @@ static ReadState readBtId(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, size_t 
 
 static void prefetchPieces(tr_peerMsgsImpl* msgs)
 {
-    if (!msgs->session->isPrefetchEnabled)
+    if (!msgs->session->isPrefetchEnabled())
     {
         return;
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1156,7 +1156,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
     auto val = tr_variant{};
     tr_variantInitDict(&val, 8);
-    tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode != TR_CLEAR_PREFERRED);
+    tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
     if (ipv6 != nullptr)
     {

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -72,7 +72,7 @@ static char const* getNatStateStr(int state)
 static void natPulse(tr_shared* s, bool do_check)
 {
     auto& session = s->session;
-    tr_port const private_peer_port = session.private_peer_port;
+    auto const private_peer_port = session.privatePeerPort();
     bool const is_enabled = s->isEnabled && !s->isShuttingDown;
 
     if (!s->natpmp)
@@ -93,12 +93,11 @@ static void natPulse(tr_shared* s, bool do_check)
 
     if (s->natpmpStatus == TR_PORT_MAPPED)
     {
-        session.public_peer_port = public_peer_port;
-        session.private_peer_port = received_private_port;
+        session.setPeerPort(public_peer_port, received_private_port);
         tr_logAddInfo(fmt::format(
             _("Mapped private port {private_port} to public port {public_port}"),
-            fmt::arg("public_port", session.public_peer_port.host()),
-            fmt::arg("private_port", session.private_peer_port.host())));
+            fmt::arg("public_port", session.publicPeerPort().host()),
+            fmt::arg("private_port", session.privatePeerPort().host())));
     }
 
     s->upnpStatus = tr_upnpPulse(s->upnp, private_peer_port, is_enabled, do_check, session.bind_ipv4.readable());

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -532,7 +532,7 @@ static void handle_request(struct evhttp_request* req, void* arg)
                            "<p><code>{:s}: {:s}</code></p>"),
                 TR_RPC_SESSION_ID_HEADER,
                 session_id);
-            evhttp_add_header(req->output_headers, TR_RPC_SESSION_ID_HEADER, tr_strbuf<char, 64>{session_id});
+            evhttp_add_header(req->output_headers, TR_RPC_SESSION_ID_HEADER, tr_strbuf<char, 64>{ session_id });
             evhttp_add_header(req->output_headers, "Access-Control-Expose-Headers", TR_RPC_SESSION_ID_HEADER);
             send_simple_response(req, 409, tmp.c_str());
         }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1380,7 +1380,7 @@ static char const* portTest(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    auto const port = session->peerPort();
+    auto const port = session->publicPeerPort();
     auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port.host());
     session->web().fetch({ url, onPortTested, idle_data });
     return nullptr;
@@ -2218,7 +2218,7 @@ static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_peer_port:
-        tr_variantDictAddInt(d, key, s->peerPort().host());
+        tr_variantDictAddInt(d, key, s->publicPeerPort().host());
         break;
 
     case TR_KEY_peer_port_random_on_start:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1382,7 +1382,7 @@ static char const* portTest(
 {
     auto const port = session->peerPort();
     auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port.host());
-    session->web->fetch({ url, onPortTested, idle_data });
+    session->web().fetch({ url, onPortTested, idle_data });
     return nullptr;
 }
 
@@ -1466,7 +1466,7 @@ static char const* blocklistUpdate(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    session->web->fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
+    session->web().fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
     return nullptr;
 }
 
@@ -1675,7 +1675,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
 
         auto options = tr_web::FetchOptions{ filename, onMetadataFetched, d };
         options.cookies = cookies;
-        session->web->fetch(std::move(options));
+        session->web().fetch(std::move(options));
     }
     else
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1729,7 +1729,7 @@ static char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args
     }
 
     auto* const list = tr_variantDictAddList(args_out, TR_KEY_group, 1);
-    for (auto const& [name, group] : s->bandwidth_groups_)
+    for (auto const& [name, group] : s->bandwidthGroups())
     {
         if (names.empty() || names.count(name.sv()) > 0)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2346,7 +2346,7 @@ static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_session_id:
-        tr_variantDictAddStr(d, key, s->session_id.sv());
+        tr_variantDictAddStr(d, key, s->sessionId());
         break;
     }
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -417,8 +417,8 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary)
     tr_variantDictAddStr(d, TR_KEY_incomplete_dir, tr_sessionGetIncompleteDir(s));
     tr_variantDictAddBool(d, TR_KEY_incomplete_dir_enabled, tr_sessionIsIncompleteDirEnabled(s));
     tr_variantDictAddInt(d, TR_KEY_message_level, tr_logGetLevel());
-    tr_variantDictAddInt(d, TR_KEY_peer_limit_global, s->peerLimit);
-    tr_variantDictAddInt(d, TR_KEY_peer_limit_per_torrent, s->peerLimitPerTorrent);
+    tr_variantDictAddInt(d, TR_KEY_peer_limit_global, s->peerLimit());
+    tr_variantDictAddInt(d, TR_KEY_peer_limit_per_torrent, s->peerLimitPerTorrent());
     tr_variantDictAddInt(d, TR_KEY_peer_port, s->publicPeerPort().host());
     tr_variantDictAddBool(d, TR_KEY_peer_port_random_on_start, s->is_port_random_);
     tr_variantDictAddInt(d, TR_KEY_peer_port_random_low, s->random_port_low_.host());
@@ -458,7 +458,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary)
     tr_variantDictAddInt(d, TR_KEY_speed_limit_up, tr_sessionGetSpeedLimit_KBps(s, TR_UP));
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, tr_sessionIsSpeedLimited(s, TR_UP));
     tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:#o}", s->umask));
-    tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, s->upload_slots_per_torrent);
+    tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, s->uploadSlotsPerTorrent());
     tr_variantDictAddStr(d, TR_KEY_bind_address_ipv4, s->bind_ipv4.readable());
     tr_variantDictAddStr(d, TR_KEY_bind_address_ipv6, s->bind_ipv6.readable());
     tr_variantDictAddBool(d, TR_KEY_start_added_torrents, !tr_sessionGetPaused(s));
@@ -915,7 +915,7 @@ void tr_session::setImpl(struct init_data& data)
 
     if (tr_variantDictFindInt(settings, TR_KEY_peer_limit_global, &i))
     {
-        this->peerLimit = i;
+        this->peer_limit_ = i;
     }
 
     /**
@@ -1679,28 +1679,28 @@ void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers)
 {
     TR_ASSERT(session != nullptr);
 
-    session->peerLimit = max_global_peers;
+    session->peer_limit_ = max_global_peers;
 }
 
 uint16_t tr_sessionGetPeerLimit(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
-    return session->peerLimit;
+    return session->peerLimit();
 }
 
 void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers)
 {
     TR_ASSERT(session != nullptr);
 
-    session->peerLimitPerTorrent = max_peers;
+    session->peer_limit_per_torrent_ = max_peers;
 }
 
 uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
-    return session->peerLimitPerTorrent;
+    return session->peerLimitPerTorrent();
 }
 
 /***

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -181,7 +181,7 @@ void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchRes
 
 void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 {
-    session->web->fetch(std::move(options));
+    session->web_->fetch(std::move(options));
 }
 
 /***
@@ -659,7 +659,7 @@ void tr_session::initImpl(init_data& data)
 
     tr_udpInit(this);
 
-    this->web = tr_web::create(this->web_mediator);
+    this->web_ = tr_web::create(this->web_mediator_);
 
     if (this->isLPDEnabled())
     {
@@ -1835,7 +1835,7 @@ void tr_session::closeImplStart()
 
     /* and this goes *after* announcer close so that
        it won't be idle until the announce events are sent... */
-    this->web->closeSoon();
+    this->web_->closeSoon();
 
     this->cache.reset();
 
@@ -1904,7 +1904,7 @@ void tr_sessionClose(tr_session* session)
      * so we need to keep the transmission thread alive
      * for a bit while they tell the router & tracker
      * that we're closing now */
-    while ((session->shared != nullptr || !session->web->isClosed() || session->announcer != nullptr ||
+    while ((session->shared != nullptr || !session->web_->isClosed() || session->announcer != nullptr ||
             session->announcer_udp != nullptr) &&
            !deadlineReached(deadline))
     {
@@ -1917,7 +1917,7 @@ void tr_sessionClose(tr_session* session)
         tr_wait_msec(50);
     }
 
-    session->web.reset();
+    session->web_.reset();
 
     /* close the libtransmission thread */
     tr_eventClose(session);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1202,13 +1202,15 @@ void tr_session::setPeerPort(tr_port public_port, tr_port private_port)
     private_peer_port_ = public_port;
     public_peer_port_ = private_port;
 
-    tr_runInEventThread(this, [this]()
-    {
-        close_incoming_peer_port(this);
-        open_incoming_peer_port(this);
-        tr_sharedPortChanged(*this);
-        std::for_each(std::begin(torrents()), std::end(torrents()), [](auto* tor){ tr_torrentChangeMyPort(tor); });
-    });
+    tr_runInEventThread(
+        this,
+        [this]()
+        {
+            close_incoming_peer_port(this);
+            open_incoming_peer_port(this);
+            tr_sharedPortChanged(*this);
+            std::for_each(std::begin(torrents()), std::end(torrents()), [](auto* tor) { tr_torrentChangeMyPort(tor); });
+        });
 }
 
 void tr_sessionSetPeerPort(tr_session* session, uint16_t hport)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -432,7 +432,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary)
     tr_variantDictAddInt(d, TR_KEY_peer_id_ttl_hours, s->peer_id_ttl_hours);
     tr_variantDictAddBool(d, TR_KEY_queue_stalled_enabled, tr_sessionGetQueueStalledEnabled(s));
     tr_variantDictAddInt(d, TR_KEY_queue_stalled_minutes, tr_sessionGetQueueStalledMinutes(s));
-    tr_variantDictAddReal(d, TR_KEY_ratio_limit, s->desiredRatio);
+    tr_variantDictAddReal(d, TR_KEY_ratio_limit, s->desired_ratio_);
     tr_variantDictAddBool(d, TR_KEY_ratio_limit_enabled, s->is_ratio_limited_);
     tr_variantDictAddBool(d, TR_KEY_rename_partial_files, tr_sessionIsIncompleteFileNamingEnabled(s));
     tr_variantDictAddBool(d, TR_KEY_rpc_authentication_required, tr_sessionIsRPCPasswordEnabled(s));
@@ -1274,11 +1274,11 @@ void tr_sessionSetRatioLimited(tr_session* session, bool is_limited)
     session->is_ratio_limited_ = is_limited;
 }
 
-void tr_sessionSetRatioLimit(tr_session* session, double desiredRatio)
+void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio)
 {
     TR_ASSERT(tr_isSession(session));
 
-    session->desiredRatio = desiredRatio;
+    session->desired_ratio_ = desired_ratio;
 }
 
 bool tr_sessionIsRatioLimited(tr_session const* session)
@@ -1292,7 +1292,7 @@ double tr_sessionGetRatioLimit(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->desiredRatio;
+    return session->desired_ratio_;
 }
 
 /***
@@ -1306,11 +1306,11 @@ void tr_sessionSetIdleLimited(tr_session* session, bool is_limited)
     session->is_idle_limited_ = is_limited;
 }
 
-void tr_sessionSetIdleLimit(tr_session* session, uint16_t idleMinutes)
+void tr_sessionSetIdleLimit(tr_session* session, uint16_t idle_minutes)
 {
     TR_ASSERT(tr_isSession(session));
 
-    session->idleLimitMinutes = idleMinutes;
+    session->idle_limit_minutes_ = idle_minutes;
 }
 
 bool tr_sessionIsIdleLimited(tr_session const* session)
@@ -1324,7 +1324,7 @@ uint16_t tr_sessionGetIdleLimit(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->idleLimitMinutes;
+    return session->idle_limit_minutes_;
 }
 
 /***
@@ -2818,7 +2818,7 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 
 static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
 {
-    auto const& groups = session->bandwidth_groups_;
+    auto const& groups = session->bandwidthGroups();
 
     auto groups_dict = tr_variant{};
     tr_variantInitDict(&groups_dict, std::size(groups));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -649,8 +649,6 @@ void tr_session::initImpl(init_data& data)
     tr_sys_dir_create(tr_pathbuf{ this->configDir(), "/blocklists"sv }, TR_SYS_DIR_CREATE_PARENTS, 0777);
     loadBlocklists(this);
 
-    TR_ASSERT(tr_isSession(this));
-
     tr_announcerInit(this);
 
     tr_logAddInfo(fmt::format(_("Transmission version {version} starting"), fmt::arg("version", LONG_VERSION_STRING)));
@@ -1127,21 +1125,21 @@ void tr_session::onNowTimer()
 
 void tr_sessionSetDownloadDir(tr_session* session, char const* dir)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->setDownloadDir(dir != nullptr ? dir : "");
 }
 
 char const* tr_sessionGetDownloadDir(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->downloadDir().c_str();
 }
 
 char const* tr_sessionGetConfigDir(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->configDir().c_str();
 }
@@ -1152,14 +1150,14 @@ char const* tr_sessionGetConfigDir(tr_session const* session)
 
 void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool b)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->is_incomplete_file_naming_enabled_ = b;
 }
 
 bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_incomplete_file_naming_enabled_;
 }
@@ -1170,28 +1168,28 @@ bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session)
 
 void tr_sessionSetIncompleteDir(tr_session* session, char const* dir)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->setIncompleteDir(dir != nullptr ? dir : "");
 }
 
 char const* tr_sessionGetIncompleteDir(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->incompleteDir().c_str();
 }
 
 void tr_sessionSetIncompleteDirEnabled(tr_session* session, bool b)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->useIncompleteDir(b);
 }
 
 bool tr_sessionIsIncompleteDirEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->useIncompleteDir();
 }
@@ -1202,7 +1200,7 @@ bool tr_sessionIsIncompleteDirEnabled(tr_session const* session)
 
 static void peerPortChanged(tr_session* const session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     close_incoming_peer_port(session);
     open_incoming_peer_port(session);
@@ -1224,7 +1222,7 @@ static void setPeerPort(tr_session* session, tr_port port)
 
 void tr_sessionSetPeerPort(tr_session* session, uint16_t hport)
 {
-    if (auto const port = tr_port::fromHost(hport); tr_isSession(session) && session->private_peer_port != port)
+    if (auto const port = tr_port::fromHost(hport); session != nullptr && session->private_peer_port != port)
     {
         setPeerPort(session, port);
     }
@@ -1232,7 +1230,7 @@ void tr_sessionSetPeerPort(tr_session* session, uint16_t hport)
 
 uint16_t tr_sessionGetPeerPort(tr_session const* session)
 {
-    return tr_isSession(session) ? session->public_peer_port.host() : 0U;
+    return session != nullptr ? session->public_peer_port.host() : 0U;
 }
 
 uint16_t tr_sessionSetPeerPortRandom(tr_session* session)
@@ -1244,21 +1242,21 @@ uint16_t tr_sessionSetPeerPortRandom(tr_session* session)
 
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->is_port_random_ = random;
 }
 
 bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_port_random_;
 }
 
 tr_port_forwarding tr_sessionGetPortForwarding(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return tr_port_forwarding(tr_sharedTraversalStatus(session->shared));
 }
@@ -1269,28 +1267,28 @@ tr_port_forwarding tr_sessionGetPortForwarding(tr_session const* session)
 
 void tr_sessionSetRatioLimited(tr_session* session, bool is_limited)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->is_ratio_limited_ = is_limited;
 }
 
 void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->desired_ratio_ = desired_ratio;
 }
 
 bool tr_sessionIsRatioLimited(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_ratio_limited_;
 }
 
 double tr_sessionGetRatioLimit(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->desired_ratio_;
 }
@@ -1301,28 +1299,28 @@ double tr_sessionGetRatioLimit(tr_session const* session)
 
 void tr_sessionSetIdleLimited(tr_session* session, bool is_limited)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->is_idle_limited_ = is_limited;
 }
 
 void tr_sessionSetIdleLimit(tr_session* session, uint16_t idle_minutes)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->idle_limit_minutes_ = idle_minutes;
 }
 
 bool tr_sessionIsIdleLimited(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_idle_limited_;
 }
 
 uint16_t tr_sessionGetIdleLimit(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->idle_limit_minutes_;
 }
@@ -1339,7 +1337,7 @@ bool tr_sessionGetActiveSpeedLimit_Bps(tr_session const* session, tr_direction d
 {
     bool is_limited = true;
 
-    if (!tr_isSession(session))
+    if (session == nullptr)
     {
         return false;
     }
@@ -1374,8 +1372,8 @@ static void updateBandwidth(tr_session* session, tr_direction dir)
     bool const isLimited = tr_sessionGetActiveSpeedLimit_Bps(session, dir, &limit_Bps);
     bool const zeroCase = isLimited && limit_Bps == 0;
 
-    session->top_bandwidth_.setLimited(dir, isLimited && !zeroCase);
-    session->top_bandwidth_.setDesiredSpeedBytesPerSecond(dir, limit_Bps);
+    session->topBandwidth().setLimited(dir, isLimited && !zeroCase);
+    session->topBandwidth().setDesiredSpeedBytesPerSecond(dir, limit_Bps);
 }
 
 static auto constexpr MinutesPerHour = int{ 60 };
@@ -1408,7 +1406,7 @@ static void turtleUpdateTable(struct tr_turtle_info& turtle)
 
 static void altSpeedToggled(tr_session* const session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     updateBandwidth(session, TR_UP);
     updateBandwidth(session, TR_DOWN);
@@ -1423,7 +1421,7 @@ static void altSpeedToggled(tr_session* const session)
 
 static void useAltSpeed(tr_session* s, tr_turtle_info& turtle, bool enabled, bool byUser)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     if (turtle.isEnabled != enabled)
     {
@@ -1499,7 +1497,7 @@ static void turtleBootstrap(tr_session* session, tr_turtle_info& turtle)
 
 static void tr_sessionSetSpeedLimit_Bps(tr_session* s, tr_direction d, unsigned int Bps)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     s->speedLimit_Bps[d] = Bps;
@@ -1514,7 +1512,7 @@ void tr_sessionSetSpeedLimit_KBps(tr_session* s, tr_direction d, unsigned int KB
 
 unsigned int tr_sessionGetSpeedLimit_Bps(tr_session const* s, tr_direction d)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     return s->speedLimit_Bps[d];
@@ -1527,7 +1525,7 @@ unsigned int tr_sessionGetSpeedLimit_KBps(tr_session const* s, tr_direction d)
 
 void tr_sessionLimitSpeed(tr_session* s, tr_direction d, bool b)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     s->speedLimitEnabled[d] = b;
@@ -1537,7 +1535,7 @@ void tr_sessionLimitSpeed(tr_session* s, tr_direction d, bool b)
 
 bool tr_sessionIsSpeedLimited(tr_session const* s, tr_direction d)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     return s->speedLimitEnabled[d];
@@ -1549,7 +1547,7 @@ bool tr_sessionIsSpeedLimited(tr_session const* s, tr_direction d)
 
 static void tr_sessionSetAltSpeed_Bps(tr_session* s, tr_direction d, unsigned int Bps)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     s->turtle.speedLimit_Bps[d] = Bps;
@@ -1564,7 +1562,7 @@ void tr_sessionSetAltSpeed_KBps(tr_session* s, tr_direction d, unsigned int KBps
 
 static unsigned int tr_sessionGetAltSpeed_Bps(tr_session const* s, tr_direction d)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
     TR_ASSERT(tr_isDirection(d));
 
     return s->turtle.speedLimit_Bps[d];
@@ -1593,7 +1591,7 @@ static void userPokedTheClock(tr_session* session, tr_turtle_info& turtle)
 
 void tr_sessionUseAltSpeedTime(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (auto& turtle = session->turtle; turtle.isClockEnabled != enabled)
     {
@@ -1604,14 +1602,14 @@ void tr_sessionUseAltSpeedTime(tr_session* session, bool enabled)
 
 bool tr_sessionUsesAltSpeedTime(tr_session const* s)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     return s->turtle.isClockEnabled;
 }
 
 void tr_sessionSetAltSpeedBegin(tr_session* session, int minutes_since_midnight)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(minutes_since_midnight >= 0);
     TR_ASSERT(minutes_since_midnight < 60 * 24);
 
@@ -1624,14 +1622,14 @@ void tr_sessionSetAltSpeedBegin(tr_session* session, int minutes_since_midnight)
 
 int tr_sessionGetAltSpeedBegin(tr_session const* s)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     return s->turtle.beginMinute;
 }
 
 void tr_sessionSetAltSpeedEnd(tr_session* session, int minutes_since_midnight)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(minutes_since_midnight >= 0);
     TR_ASSERT(minutes_since_midnight < 60 * 24);
 
@@ -1644,14 +1642,14 @@ void tr_sessionSetAltSpeedEnd(tr_session* session, int minutes_since_midnight)
 
 int tr_sessionGetAltSpeedEnd(tr_session const* s)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     return s->turtle.endMinute;
 }
 
 void tr_sessionSetAltSpeedDay(tr_session* session, tr_sched_day days)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (auto& turtle = session->turtle; turtle.days != days)
     {
@@ -1662,7 +1660,7 @@ void tr_sessionSetAltSpeedDay(tr_session* session, tr_sched_day days)
 
 tr_sched_day tr_sessionGetAltSpeedDay(tr_session const* s)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     return s->turtle.days;
 }
@@ -1674,14 +1672,14 @@ void tr_sessionUseAltSpeed(tr_session* session, bool enabled)
 
 bool tr_sessionUsesAltSpeed(tr_session const* s)
 {
-    TR_ASSERT(tr_isSession(s));
+    TR_ASSERT(s != nullptr);
 
     return s->turtle.isEnabled;
 }
 
 void tr_sessionSetAltSpeedFunc(tr_session* session, tr_altSpeedFunc func, void* userData)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->turtle.callback = func;
     session->turtle.callbackUserData = userData;
@@ -1693,28 +1691,28 @@ void tr_sessionSetAltSpeedFunc(tr_session* session, tr_altSpeedFunc func, void* 
 
 void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->peerLimit = max_global_peers;
 }
 
 uint16_t tr_sessionGetPeerLimit(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->peerLimit;
 }
 
 void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->peerLimitPerTorrent = max_peers;
 }
 
 uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->peerLimitPerTorrent;
 }
@@ -1725,28 +1723,28 @@ uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const* session)
 
 void tr_sessionSetPaused(tr_session* session, bool is_paused)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->pause_added_torrent_ = is_paused;
 }
 
 bool tr_sessionGetPaused(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->pause_added_torrent_;
 }
 
 void tr_sessionSetDeleteSource(tr_session* session, bool delete_source)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->delete_source_torrent_ = delete_source;
 }
 
 bool tr_sessionGetDeleteSource(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->delete_source_torrent_;
 }
@@ -1757,12 +1755,12 @@ bool tr_sessionGetDeleteSource(tr_session const* session)
 
 unsigned int tr_sessionGetPieceSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->top_bandwidth_.getPieceSpeedBytesPerSecond(0, dir) : 0;
+    return session != nullptr ? session->topBandwidth().getPieceSpeedBytesPerSecond(0, dir) : 0;
 }
 
 static unsigned int tr_sessionGetRawSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return tr_isSession(session) ? session->top_bandwidth_.getRawSpeedBytesPerSecond(0, dir) : 0;
+    return session != nullptr ? session->topBandwidth().getRawSpeedBytesPerSecond(0, dir) : 0;
 }
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
@@ -1772,12 +1770,12 @@ double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
 
 int tr_sessionCountTorrents(tr_session const* session)
 {
-    return tr_isSession(session) ? std::size(session->torrents()) : 0;
+    return session != nullptr ? std::size(session->torrents()) : 0;
 }
 
 std::vector<tr_torrent*> tr_sessionGetTorrents(tr_session* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     auto const n = std::size(session->torrents());
     auto torrents = std::vector<tr_torrent*>{ n };
@@ -1837,7 +1835,7 @@ void tr_session::closeImplStart()
        it won't be idle until the announce events are sent... */
     this->web_->closeSoon();
 
-    this->cache.reset();
+    this->cache_.reset();
 
     /* saveTimer is not used at this point, reusing for UDP shutdown wait */
     TR_ASSERT(!save_timer_);
@@ -1884,7 +1882,7 @@ static auto constexpr ShutdownMaxSeconds = time_t{ 20 };
 
 void tr_sessionClose(tr_session* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     time_t const deadline = time(nullptr) + ShutdownMaxSeconds;
 
@@ -1960,7 +1958,7 @@ struct sessionLoadTorrentsData
 
 static void sessionLoadTorrents(struct sessionLoadTorrentsData* const data)
 {
-    TR_ASSERT(tr_isSession(data->session));
+    TR_ASSERT(data->session != nullptr);
 
     auto const& dirname = data->session->torrentDir();
     auto const info = tr_sys_path_get_info(dirname);
@@ -2040,14 +2038,14 @@ tr_torrent** tr_sessionLoadTorrents(tr_session* session, tr_ctor* ctor, int* set
 
 void tr_sessionSetPexEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->is_pex_enabled_ = enabled;
 }
 
 bool tr_sessionIsPexEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_pex_enabled_;
 }
@@ -2059,14 +2057,14 @@ bool tr_sessionAllowsDHT(tr_session const* session)
 
 bool tr_sessionIsDHTEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->is_dht_enabled_;
 }
 
 void tr_sessionSetDHTEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (enabled == session->isDHTEnabled())
     {
@@ -2089,7 +2087,7 @@ void tr_sessionSetDHTEnabled(tr_session* session, bool enabled)
 
 bool tr_sessionIsUTPEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
 #ifdef WITH_UTP
     return session->isUTPEnabled();
@@ -2100,7 +2098,7 @@ bool tr_sessionIsUTPEnabled(tr_session const* session)
 
 void tr_sessionSetUTPEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (enabled == session->isUTPEnabled())
     {
@@ -2125,7 +2123,7 @@ void tr_sessionSetUTPEnabled(tr_session* session, bool enabled)
 
 void tr_sessionSetLPDEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (enabled == session->isLPDEnabled())
     {
@@ -2150,7 +2148,7 @@ void tr_sessionSetLPDEnabled(tr_session* session, bool enabled)
 
 bool tr_sessionIsLPDEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->isLPDEnabled();
 }
@@ -2166,16 +2164,16 @@ bool tr_sessionAllowsLPD(tr_session const* session)
 
 void tr_sessionSetCacheLimit_MB(tr_session* session, int mb)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
-    session->cache->setLimit(tr_toMemBytes(mb));
+    session->cache().setLimit(tr_toMemBytes(mb));
 }
 
 int tr_sessionGetCacheLimit_MB(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
-    return tr_toMemMB(session->cache->getLimit());
+    return tr_toMemMB(session->cache().getLimit());
 }
 
 /***
@@ -2204,7 +2202,7 @@ void tr_session::setDefaultTrackers(std::string_view trackers)
 
 void tr_sessionSetDefaultTrackers(tr_session* session, char const* trackers)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->setDefaultTrackers(trackers != nullptr ? trackers : "");
 }
@@ -2240,7 +2238,7 @@ void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled)
 
 bool tr_sessionIsPortForwardingEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return tr_sharedTraversalIsEnabled(session->shared);
 }
@@ -2344,7 +2342,7 @@ void tr_sessionReloadBlocklists(tr_session* session)
 
 size_t tr_blocklistGetRuleCount(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     auto& src = session->blocklists;
     return std::accumulate(std::begin(src), std::end(src), 0, [](int sum, auto& cur) { return sum + cur->getRuleCount(); });
@@ -2352,7 +2350,7 @@ size_t tr_blocklistGetRuleCount(tr_session const* session)
 
 bool tr_blocklistIsEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->useBlocklist();
 }
@@ -2366,14 +2364,14 @@ void tr_session::useBlocklist(bool enabled)
 
 void tr_blocklistSetEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->useBlocklist(enabled);
 }
 
 bool tr_blocklistExists(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return !std::empty(session->blocklists);
 }
@@ -2444,21 +2442,21 @@ bool tr_session::useRpcWhitelist() const
 
 void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setEnabled(is_enabled);
 }
 
 bool tr_sessionIsRPCEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->isEnabled();
 }
 
 void tr_sessionSetRPCPort(tr_session* session, uint16_t hport)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     if (session->rpc_server_)
     {
@@ -2468,28 +2466,28 @@ void tr_sessionSetRPCPort(tr_session* session, uint16_t hport)
 
 uint16_t tr_sessionGetRPCPort(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_ ? session->rpc_server_->port().host() : uint16_t{};
 }
 
 void tr_sessionSetRPCUrl(tr_session* session, char const* url)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setUrl(url != nullptr ? url : "");
 }
 
 char const* tr_sessionGetRPCUrl(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->url().c_str();
 }
 
 void tr_sessionSetRPCCallback(tr_session* session, tr_rpc_func func, void* user_data)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_func = func;
     session->rpc_func_user_data = user_data;
@@ -2497,70 +2495,70 @@ void tr_sessionSetRPCCallback(tr_session* session, tr_rpc_func func, void* user_
 
 void tr_sessionSetRPCWhitelist(tr_session* session, char const* whitelist)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->setRpcWhitelist(whitelist != nullptr ? whitelist : "");
 }
 
 char const* tr_sessionGetRPCWhitelist(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->whitelist().c_str();
 }
 
 void tr_sessionSetRPCWhitelistEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->useRpcWhitelist(enabled);
 }
 
 bool tr_sessionGetRPCWhitelistEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->useRpcWhitelist();
 }
 
 void tr_sessionSetRPCPassword(tr_session* session, char const* password)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setPassword(password != nullptr ? password : "");
 }
 
 char const* tr_sessionGetRPCPassword(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->getSaltedPassword().c_str();
 }
 
 void tr_sessionSetRPCUsername(tr_session* session, char const* username)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setUsername(username != nullptr ? username : "");
 }
 
 char const* tr_sessionGetRPCUsername(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->username().c_str();
 }
 
 void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setPasswordEnabled(enabled);
 }
 
 bool tr_sessionIsRPCPasswordEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->isPasswordEnabled();
 }
@@ -2571,7 +2569,7 @@ bool tr_sessionIsRPCPasswordEnabled(tr_session const* session)
 
 void tr_sessionSetScriptEnabled(tr_session* session, TrScript type, bool enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
     session->useScript(type, enabled);
@@ -2579,7 +2577,7 @@ void tr_sessionSetScriptEnabled(tr_session* session, TrScript type, bool enabled
 
 bool tr_sessionIsScriptEnabled(tr_session const* session, TrScript type)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
     return session->useScript(type);
@@ -2587,7 +2585,7 @@ bool tr_sessionIsScriptEnabled(tr_session const* session, TrScript type)
 
 void tr_sessionSetScript(tr_session* session, TrScript type, char const* script)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
     session->setScript(type, script != nullptr ? script : "");
@@ -2595,7 +2593,7 @@ void tr_sessionSetScript(tr_session* session, TrScript type, char const* script)
 
 char const* tr_sessionGetScript(tr_session const* session, TrScript type)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(type < TR_SCRIPT_N_TYPES);
 
     return session->script(type).c_str();
@@ -2607,7 +2605,7 @@ char const* tr_sessionGetScript(tr_session const* session, TrScript type)
 
 void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, int max_simultaneous_seed_torrents)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_isDirection(dir));
 
     session->queueSize[dir] = max_simultaneous_seed_torrents;
@@ -2615,7 +2613,7 @@ void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, int max_simul
 
 int tr_sessionGetQueueSize(tr_session const* session, tr_direction dir)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_isDirection(dir));
 
     return session->queueSize[dir];
@@ -2623,7 +2621,7 @@ int tr_sessionGetQueueSize(tr_session const* session, tr_direction dir)
 
 void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_seed_torrents)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_isDirection(dir));
 
     session->queueEnabled[dir] = do_limit_simultaneous_seed_torrents;
@@ -2631,7 +2629,7 @@ void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_li
 
 bool tr_sessionGetQueueEnabled(tr_session const* session, tr_direction dir)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_isDirection(dir));
 
     return session->queueEnabled[dir];
@@ -2639,7 +2637,7 @@ bool tr_sessionGetQueueEnabled(tr_session const* session, tr_direction dir)
 
 void tr_sessionSetQueueStalledMinutes(tr_session* session, int minutes)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(minutes > 0);
 
     session->queueStalledMinutes = minutes;
@@ -2647,28 +2645,28 @@ void tr_sessionSetQueueStalledMinutes(tr_session* session, int minutes)
 
 void tr_sessionSetQueueStalledEnabled(tr_session* session, bool is_enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->stalledEnabled = is_enabled;
 }
 
 bool tr_sessionGetQueueStalledEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->stalledEnabled;
 }
 
 int tr_sessionGetQueueStalledMinutes(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->queueStalledMinutes;
 }
 
 void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int max_bad_requests)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(max_bad_requests > 0);
 
     session->rpc_server_->setAntiBruteForceLimit(max_bad_requests);
@@ -2676,28 +2674,28 @@ void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int max_bad_reque
 
 int tr_sessionGetAntiBruteForceThreshold(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->getAntiBruteForceLimit();
 }
 
 void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool is_enabled)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     session->rpc_server_->setAntiBruteForceEnabled(is_enabled);
 }
 
 bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     return session->rpc_server_->isAntiBruteForceEnabled();
 }
 
 std::vector<tr_torrent*> tr_sessionGetNextQueuedTorrents(tr_session* session, tr_direction direction, size_t num_wanted)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_isDirection(direction));
 
     // build an array of the candidates
@@ -2846,13 +2844,13 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
 
 void tr_session::closeTorrentFiles(tr_torrent* tor) noexcept
 {
-    this->cache->flushTorrent(tor);
+    this->cache().flushTorrent(tor);
     openFiles().closeTorrent(tor->id());
 }
 
 void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noexcept
 {
-    this->cache->flushFile(tor, file_num);
+    this->cache().flushFile(tor, file_num);
     openFiles().closeFile(tor->id(), file_num);
 }
 
@@ -2932,8 +2930,7 @@ auto makeEventBase()
 } // namespace
 
 tr_session::tr_session(std::string_view config_dir)
-    : magicNumber{ SESSION_MAGIC_NUMBER }
-    , cache{ std::make_unique<Cache>(torrents(), 1024 * 1024 * 2) }
+    : cache_{ std::make_unique<Cache>(torrents(), 1024 * 1024 * 2) }
     , session_id_{ tr_time }
     , event_base_{ makeEventBase() }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2934,7 +2934,7 @@ auto makeEventBase()
 tr_session::tr_session(std::string_view config_dir)
     : magicNumber{ SESSION_MAGIC_NUMBER }
     , cache{ std::make_unique<Cache>(torrents(), 1024 * 1024 * 2) }
-    , session_id{ tr_time }
+    , session_id_{ tr_time }
     , event_base_{ makeEventBase() }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
     , config_dir_{ config_dir }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -629,7 +629,6 @@ private:
     friend bool tr_sessionIsPexEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
-    friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
     friend bool tr_sessionIsRatioLimited(tr_session const* session);
     friend bool tr_sessionIsSpeedLimited(tr_session const* session, tr_direction dir);
     friend bool tr_sessionIsUTPEnabled(tr_session const* session);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -130,6 +130,51 @@ struct tr_session
 public:
     explicit tr_session(std::string_view config_dir);
 
+    [[nodiscard]] constexpr auto isClosing() const noexcept
+    {
+        return is_closing_;
+    }
+
+    [[nodiscard]] constexpr auto isClosed() const noexcept
+    {
+        return is_session_closed_;
+    }
+
+    [[nodiscard]] constexpr auto isDHTEnabled() const noexcept
+    {
+        return is_dht_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto isLPDEnabled() const noexcept
+    {
+        return is_lpd_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto isPexEnabled() const noexcept
+    {
+        return is_pex_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto isPrefetchEnabled() const noexcept
+    {
+        return is_prefetch_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto isUTPEnabled() const noexcept
+    {
+        return is_utp_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto isIncompleteFileNamingEnabled() const noexcept
+    {
+        return is_incomplete_file_naming_enabled_;
+    }
+
+    [[nodiscard]] constexpr auto shouldScrapePausedTorrents() const noexcept
+    {
+        return should_scrape_paused_torrents_;
+    }
+
     [[nodiscard]] event_base* eventBase() noexcept
     {
         return event_base_.get();
@@ -153,11 +198,6 @@ public:
     [[nodiscard]] auto unique_lock() const
     {
         return std::unique_lock(session_mutex_);
-    }
-
-    [[nodiscard]] constexpr auto isClosing() const noexcept
-    {
-        return is_closing_;
     }
 
     // paths
@@ -465,21 +505,6 @@ public:
             TR_SCRIPT_ON_TORRENT_DONE_SEEDING } }
     };
 
-    bool isPortRandom = false;
-    bool isPexEnabled = false;
-    bool isDHTEnabled = false;
-    bool isUTPEnabled = false;
-    bool isLPDEnabled = false;
-    bool isPrefetchEnabled = false;
-    bool is_closing_ = false;
-    bool isClosed = false;
-    bool isRatioLimited = false;
-    bool isIdleLimited = false;
-    bool isIncompleteFileNamingEnabled = false;
-    bool pauseAddedTorrent = false;
-    bool deleteSourceTorrent = false;
-    bool scrapePausedTorrents = false;
-
     uint8_t peer_id_ttl_hours = 0;
 
     bool stalledEnabled = false;
@@ -604,11 +629,46 @@ public:
     int peer_socket_tos_ = *tr_netTosFromName(TR_DEFAULT_PEER_SOCKET_TOS_STR);
 
 private:
+    friend bool tr_sessionGetDeleteSource(tr_session const* session);
+    friend bool tr_sessionGetPaused(tr_session const* session);
+    friend bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session);
+    friend bool tr_sessionIsDHTEnabled(tr_session const* session);
+    friend bool tr_sessionIsIdleLimited(tr_session const* session);
+    friend bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session);
+    friend bool tr_sessionIsPexEnabled(tr_session const* session);
+    friend bool tr_sessionIsRatioLimited(tr_session const* session);
+    friend bool tr_sessionIsUTPEnabled(tr_session const* session);
     friend void tr_sessionClose(tr_session* session);
+    friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
+    friend void tr_sessionSetDHTEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetDeleteSource(tr_session* session, bool delete_source);
+    friend void tr_sessionSetIdleLimited(tr_session* session, bool is_limited);
+    friend void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool b);
+    friend void tr_sessionSetLPDEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetPaused(tr_session* session, bool is_paused);
+    friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
+    friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
+    friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
 
     void closeImplStart();
     void closeImplWaitForIdleUdp();
     void closeImplFinish();
+
+    bool delete_source_torrent_ = false;
+    bool is_closing_ = false;
+    bool is_dht_enabled_ = false;
+    bool is_idle_limited_ = false;
+    bool is_incomplete_file_naming_enabled_ = false;
+    bool is_lpd_enabled_ = false;
+    bool is_pex_enabled_ = false;
+    bool is_port_random_ = false;
+    bool is_prefetch_enabled_ = false;
+    bool is_ratio_limited_ = false;
+    bool is_session_closed_ = false;
+    bool is_utp_enabled_ = false;
+    bool pause_added_torrent_ = false;
+    bool should_scrape_paused_torrents_ = false;
 
     static std::recursive_mutex session_mutex_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -578,29 +578,22 @@ public:
     struct struct_utp_context* utp_context = nullptr;
     std::unique_ptr<libtransmission::Timer> utp_timer;
 
-    /* The open port on the local machine for incoming peer requests */
-    tr_port private_peer_port;
+    void setPeerPort(tr_port public_port, tr_port private_port);
 
-    /**
-     * The open port on the public device for incoming peer requests.
-     * This is usually the same as private_peer_port but can differ
-     * if the public device is a router and it decides to use a different
-     * port than the one requested by Transmission.
-     */
-    tr_port public_peer_port;
-
-    [[nodiscard]] constexpr auto peerPort() const noexcept
+    void setPeerPort(tr_port port)
     {
-        return public_peer_port;
+        setPeerPort(port, port);
     }
 
-    constexpr auto setPeerPort(tr_port port) noexcept
+    [[nodiscard]] constexpr auto publicPeerPort() const noexcept
     {
-        public_peer_port = port;
+        return public_peer_port_;
     }
 
-    tr_port randomPortLow;
-    tr_port randomPortHigh;
+    [[nodiscard]] constexpr auto privatePeerPort() const noexcept
+    {
+        return private_peer_port_;
+    }
 
     std::vector<std::unique_ptr<BlocklistFile>> blocklists;
     struct tr_peerMgr* peerMgr = nullptr;
@@ -637,7 +630,9 @@ private:
     friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
     friend uint16_t tr_sessionGetIdleLimit(tr_session const* session);
+    friend uint16_t tr_sessionGetPeerPort(tr_session const* session);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
+    friend uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
     friend void tr_sessionClose(tr_session* session);
     friend void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options);
     friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
@@ -651,6 +646,7 @@ private:
     friend void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool b);
     friend void tr_sessionSetLPDEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetPaused(tr_session* session, bool is_paused);
+    friend void tr_sessionSetPeerPort(tr_session* session, uint16_t hport);
     friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled);
@@ -662,6 +658,21 @@ private:
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    [[nodiscard]] tr_port randomPort() const;
+    tr_port random_port_low_;
+    tr_port random_port_high_;
+
+    /* The open port on the local machine for incoming peer requests */
+    tr_port private_peer_port_;
+
+    /**
+     * The open port on the public device for incoming peer requests.
+     * This is usually the same as private_peer_port but can differ
+     * if the public device is a router and it decides to use a different
+     * port than the one requested by Transmission.
+     */
+    tr_port public_peer_port_;
 
     std::unique_ptr<Cache> cache_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -130,6 +130,16 @@ struct tr_session
 public:
     explicit tr_session(std::string_view config_dir);
 
+    [[nodiscard]] auto& topBandwidth() noexcept
+    {
+        return top_bandwidth_;
+    }
+
+    [[nodiscard]] auto const& topBandwidth() const noexcept
+    {
+        return top_bandwidth_;
+    }
+
     [[nodiscard]] std::string_view sessionId() const noexcept
     {
         return session_id_.sv();
@@ -138,6 +148,16 @@ public:
     [[nodiscard]] auto& web() noexcept
     {
         return *web_;
+    }
+
+    [[nodiscard]] auto const& cache() const noexcept
+    {
+        return *cache_;
+    }
+
+    [[nodiscard]] auto& cache() noexcept
+    {
+        return *cache_;
     }
 
     [[nodiscard]] constexpr auto isClosing() const noexcept
@@ -534,8 +554,6 @@ public:
 
     struct tr_turtle_info turtle;
 
-    int magicNumber = 0;
-
     tr_encryption_mode encryptionMode;
 
     tr_preallocation_mode preallocationMode;
@@ -588,16 +606,11 @@ public:
     struct tr_peerMgr* peerMgr = nullptr;
     struct tr_shared* shared = nullptr;
 
-    std::unique_ptr<Cache> cache;
-
     tr_rpc_func rpc_func = nullptr;
     void* rpc_func_user_data = nullptr;
 
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
-
-    // monitors the "global pool" speeds
-    tr_bandwidth top_bandwidth_;
 
     tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
     tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
@@ -649,6 +662,11 @@ private:
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    std::unique_ptr<Cache> cache_;
+
+    // monitors the "global pool" speeds
+    tr_bandwidth top_bandwidth_;
 
     tr_session_id session_id_;
 
@@ -780,16 +798,6 @@ struct tr_bindsockets* tr_sessionGetBindSockets(tr_session*);
 int tr_sessionCountTorrents(tr_session const* session);
 
 std::vector<tr_torrent*> tr_sessionGetTorrents(tr_session* session);
-
-enum
-{
-    SESSION_MAGIC_NUMBER = 3845,
-};
-
-constexpr bool tr_isSession(tr_session const* session)
-{
-    return session != nullptr && session->magicNumber == SESSION_MAGIC_NUMBER;
-}
 
 constexpr bool tr_isPriority(tr_priority_t p)
 {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -363,6 +363,11 @@ public:
 
     [[nodiscard]] tr_bandwidth& getBandwidthGroup(std::string_view name);
 
+    [[nodiscard]] constexpr auto& bandwidthGroups() const noexcept
+    {
+        return bandwidth_groups_;
+    }
+
     //
 
     [[nodiscard]] constexpr auto& openFiles() noexcept
@@ -610,12 +615,6 @@ public:
     // monitors the "global pool" speeds
     tr_bandwidth top_bandwidth_;
 
-    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
-
-    float desiredRatio;
-
-    uint16_t idleLimitMinutes;
-
     tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
     tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
 
@@ -637,8 +636,10 @@ private:
     friend char const* tr_sessionGetRPCUrl(tr_session const* session);
     friend char const* tr_sessionGetRPCUsername(tr_session const* session);
     friend char const* tr_sessionGetRPCWhitelist(tr_session const* session);
+    friend double tr_sessionGetRatioLimit(tr_session const* session);
     friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
+    friend uint16_t tr_sessionGetIdleLimit(tr_session const* session);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
     friend void tr_sessionClose(tr_session* session);
     friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
@@ -647,6 +648,7 @@ private:
     friend void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int max_bad_requests);
     friend void tr_sessionSetDHTEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetDeleteSource(tr_session* session, bool delete_source);
+    friend void tr_sessionSetIdleLimit(tr_session* session, uint16_t idle_minutes);
     friend void tr_sessionSetIdleLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool b);
     friend void tr_sessionSetLPDEnabled(tr_session* session, bool enabled);
@@ -659,8 +661,15 @@ private:
     friend void tr_sessionSetRPCPort(tr_session* session, uint16_t hport);
     friend void tr_sessionSetRPCUrl(tr_session* session, char const* url);
     friend void tr_sessionSetRPCUsername(tr_session* session, char const* username);
+    friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
+
+    float desired_ratio_;
+
+    uint16_t idle_limit_minutes_;
 
     std::unique_ptr<tr_rpc_server> rpc_server_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -619,16 +619,8 @@ public:
     tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
     tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
 
-    std::unique_ptr<tr_rpc_server> rpc_server_;
-
-    tr_announce_list default_trackers_;
-
-    // One of <netinet/ip.h>'s IPTOS_ values.
-    // See tr_netTos*() in libtransmission/net.h for more info
-    // Only session.cc should use this.
-    int peer_socket_tos_ = *tr_netTosFromName(TR_DEFAULT_PEER_SOCKET_TOS_STR);
-
 private:
+    friend bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session);
     friend bool tr_sessionGetDeleteSource(tr_session const* session);
     friend bool tr_sessionGetPaused(tr_session const* session);
     friend bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session);
@@ -636,12 +628,23 @@ private:
     friend bool tr_sessionIsIdleLimited(tr_session const* session);
     friend bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session);
     friend bool tr_sessionIsPexEnabled(tr_session const* session);
+    friend bool tr_sessionIsRPCEnabled(tr_session const* session);
+    friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
+    friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
     friend bool tr_sessionIsRatioLimited(tr_session const* session);
     friend bool tr_sessionIsUTPEnabled(tr_session const* session);
+    friend char const* tr_sessionGetRPCPassword(tr_session const* session);
+    friend char const* tr_sessionGetRPCUrl(tr_session const* session);
+    friend char const* tr_sessionGetRPCUsername(tr_session const* session);
+    friend char const* tr_sessionGetRPCWhitelist(tr_session const* session);
+    friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
+    friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
     friend void tr_sessionClose(tr_session* session);
     friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
     friend void tr_sessionSet(tr_session* session, tr_variant* settings);
+    friend void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool is_enabled);
+    friend void tr_sessionSetAntiBruteForceThreshold(tr_session* session, int max_bad_requests);
     friend void tr_sessionSetDHTEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetDeleteSource(tr_session* session, bool delete_source);
     friend void tr_sessionSetIdleLimited(tr_session* session, bool is_limited);
@@ -650,8 +653,23 @@ private:
     friend void tr_sessionSetPaused(tr_session* session, bool is_paused);
     friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetRPCEnabled(tr_session* session, bool is_enabled);
+    friend void tr_sessionSetRPCPassword(tr_session* session, char const* password);
+    friend void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetRPCPort(tr_session* session, uint16_t hport);
+    friend void tr_sessionSetRPCUrl(tr_session* session, char const* url);
+    friend void tr_sessionSetRPCUsername(tr_session* session, char const* username);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    std::unique_ptr<tr_rpc_server> rpc_server_;
+
+    tr_announce_list default_trackers_;
+
+    // One of <netinet/ip.h>'s IPTOS_ values.
+    // See tr_netTos*() in libtransmission/net.h for more info
+    // Only session.cc should use this.
+    int peer_socket_tos_ = *tr_netTosFromName(TR_DEFAULT_PEER_SOCKET_TOS_STR);
 
     struct init_data;
     void initImpl(struct init_data&);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -130,6 +130,11 @@ struct tr_session
 public:
     explicit tr_session(std::string_view config_dir);
 
+    [[nodiscard]] std::string_view sessionId() const noexcept
+    {
+        return session_id_.sv();
+    }
+
     [[nodiscard]] auto& web() noexcept
     {
         return *web_;
@@ -585,8 +590,6 @@ public:
 
     std::unique_ptr<Cache> cache;
 
-    tr_session_id session_id;
-
     tr_rpc_func rpc_func = nullptr;
     void* rpc_func_user_data = nullptr;
 
@@ -646,6 +649,8 @@ private:
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    tr_session_id session_id_;
 
     class WebMediator final : public tr_web::Mediator
     {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -638,8 +638,10 @@ private:
     friend bool tr_sessionIsPexEnabled(tr_session const* session);
     friend bool tr_sessionIsRatioLimited(tr_session const* session);
     friend bool tr_sessionIsUTPEnabled(tr_session const* session);
+    friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
     friend void tr_sessionClose(tr_session* session);
     friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
+    friend void tr_sessionSet(tr_session* session, tr_variant* settings);
     friend void tr_sessionSetDHTEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetDeleteSource(tr_session* session, bool delete_source);
     friend void tr_sessionSetIdleLimited(tr_session* session, bool is_limited);
@@ -650,6 +652,10 @@ private:
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+
+    struct init_data;
+    void initImpl(struct init_data&);
+    void setImpl(struct init_data&);
 
     void closeImplStart();
     void closeImplWaitForIdleUdp();

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -353,7 +353,7 @@ tr_ctor* tr_ctorNew(tr_session const* session)
 
     tr_ctorSetDeleteSource(ctor, tr_sessionGetDeleteSource(session));
     tr_ctorSetPaused(ctor, TR_FALLBACK, tr_sessionGetPaused(session));
-    tr_ctorSetPeerLimit(ctor, TR_FALLBACK, session->peerLimitPerTorrent);
+    tr_ctorSetPeerLimit(ctor, TR_FALLBACK, session->peerLimitPerTorrent());
     tr_ctorSetDownloadDir(ctor, TR_FALLBACK, tr_sessionGetDownloadDir(session));
 
     return ctor;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -707,7 +707,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     {
         tor->incomplete_dir = dir;
     }
-    tor->bandwidth_.setParent(&session->top_bandwidth_);
+    tor->bandwidth_.setParent(&session->topBandwidth());
     tor->bandwidth_.setPriority(tr_ctorGetBandwidthPriority(ctor));
     tor->error = TR_STAT_OK;
     tor->finishedSeedingByIdle = false;
@@ -864,7 +864,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)
 {
     TR_ASSERT(ctor != nullptr);
     auto* const session = tr_ctorGetSession(ctor);
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     // is the metainfo valid?
     auto metainfo = tr_ctorStealMetainfo(ctor);
@@ -1614,7 +1614,7 @@ void tr_torrentFree(tr_torrent* tor)
     {
         tr_session* session = tor->session;
 
-        TR_ASSERT(tr_isSession(session));
+        TR_ASSERT(session != nullptr);
 
         auto const lock = tor->unique_lock();
 
@@ -1869,7 +1869,7 @@ void tr_torrent::setBandwidthGroup(std::string_view group_name) noexcept
     if (std::empty(group_name))
     {
         this->bandwidth_group_ = tr_interned_string{};
-        this->bandwidth_.setParent(&this->session->top_bandwidth_);
+        this->bandwidth_.setParent(&this->session->topBandwidth());
     }
     else
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -170,7 +170,7 @@ static void tr_torrentUnsetPeerId(tr_torrent* tor)
 static int peerIdTTL(tr_torrent const* tor)
 {
     auto const ctime = tor->peer_id_creation_time_;
-    return ctime == 0 ? 0 : (int)difftime(ctime + tor->session->peer_id_ttl_hours * 3600, tr_time());
+    return ctime == 0 ? 0 : (int)difftime(ctime + tor->session->peerIdTtlHours() * 3600, tr_time());
 }
 
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -755,7 +755,7 @@ private:
 
 constexpr bool tr_isTorrent(tr_torrent const* tor)
 {
-    return tor != nullptr && tr_isSession(tor->session);
+    return tor != nullptr && tor->session != nullptr;
 }
 
 /**

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -518,7 +518,7 @@ public:
 
     [[nodiscard]] auto allowsPex() const noexcept
     {
-        return this->isPublic() && this->session->isPexEnabled;
+        return this->isPublic() && this->session->isPexEnabled();
     }
 
     [[nodiscard]] auto allowsDht() const

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -680,7 +680,7 @@ void tr_dhtUpkeep(tr_session* session)
 
 void tr_dhtCallback(unsigned char* buf, int buflen, struct sockaddr* from, socklen_t fromlen, void* sv)
 {
-    TR_ASSERT(tr_isSession(static_cast<tr_session*>(sv)));
+    TR_ASSERT(sv != nullptr);
 
     if (sv != session_)
     {

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -622,7 +622,7 @@ static AnnounceResult tr_dhtAnnounce(tr_torrent* tor, int af, bool announce)
     }
 
     auto const* dht_hash = reinterpret_cast<unsigned char const*>(std::data(tor->infoHash()));
-    auto const hport = announce ? session_->peerPort().host() : 0;
+    auto const hport = announce ? session_->publicPeerPort().host() : 0;
     int const rc = dht_search(dht_hash, hport, af, callback, nullptr);
     if (rc < 0)
     {

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -553,7 +553,7 @@ static int tr_lpdAnnounceMore(time_t const now, int const interval)
 {
     int announcesSent = 0;
 
-    if (!tr_isSession(session))
+    if (session == nullptr)
     {
         return -1;
     }
@@ -629,7 +629,7 @@ static void on_upkeep_timer()
 * @see DoS */
 static void event_callback(evutil_socket_t /*s*/, short type, void* /*user_data*/)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     /* do not allow announces to be processed if LPD is disabled */
     if (!tr_sessionAllowsLPD(session))

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -262,7 +262,7 @@ int tr_lpdInit(tr_session* ss, tr_address* /*tr_addr*/)
     TR_ASSERT(lpd_announceInterval > 0);
     TR_ASSERT(lpd_announceScope > 0);
 
-    lpd_port = ss->peerPort();
+    lpd_port = ss->publicPeerPort();
     if (std::empty(lpd_port))
     {
         return -1;

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -346,7 +346,7 @@ void tr_udpInit(tr_session* ss)
 
     tr_udpSetSocketTOS(ss);
 
-    if (ss->isDHTEnabled)
+    if (ss->isDHTEnabled())
     {
         tr_dhtInit(ss);
     }

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -276,7 +276,7 @@ void tr_udpInit(tr_session* ss)
     TR_ASSERT(ss->udp_socket == TR_BAD_SOCKET);
     TR_ASSERT(ss->udp6_socket == TR_BAD_SOCKET);
 
-    ss->udp_port = ss->peerPort();
+    ss->udp_port = ss->publicPeerPort();
     if (std::empty(ss->udp_port))
     {
         return;

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -224,7 +224,7 @@ FAIL:
 
 static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
 {
-    TR_ASSERT(tr_isSession(static_cast<tr_session*>(vsession)));
+    TR_ASSERT(vsession != nullptr);
     TR_ASSERT(type == EV_READ);
 
     unsigned char buf[4096];

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -231,7 +231,7 @@ void tr_utpInit(tr_session* session)
 
 bool tr_utpPacket(unsigned char const* buf, size_t buflen, struct sockaddr const* from, socklen_t fromlen, tr_session* ss)
 {
-    if (!ss->isClosed && !ss->utp_timer)
+    if (!ss->isClosed() && !ss->utp_timer)
     {
         ss->utp_timer = ss->timerMaker().create(timer_callback, ss);
         reset_timer(ss);

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -131,7 +131,7 @@ static uint64 utp_callback(utp_callback_arguments* args)
 {
     auto* const session = static_cast<tr_session*>(utp_context_get_userdata(args->context));
 
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(session->utp_context == args->context);
 
     switch (args->callback_type)

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -587,13 +587,13 @@ double tr_sessionGetRawSpeed_KBps(tr_session const*, tr_direction);
 void tr_sessionSetRatioLimited(tr_session*, bool is_limited);
 bool tr_sessionIsRatioLimited(tr_session const*);
 
-void tr_sessionSetRatioLimit(tr_session*, double desiredRatio);
+void tr_sessionSetRatioLimit(tr_session*, double desired_ratio);
 double tr_sessionGetRatioLimit(tr_session const*);
 
 void tr_sessionSetIdleLimited(tr_session*, bool is_limited);
 bool tr_sessionIsIdleLimited(tr_session const*);
 
-void tr_sessionSetIdleLimit(tr_session*, uint16_t idleMinutes);
+void tr_sessionSetIdleLimit(tr_session*, uint16_t idle_minutes);
 uint16_t tr_sessionGetIdleLimit(tr_session const*);
 
 void tr_sessionSetPeerLimit(tr_session*, uint16_t max_global_peers);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -584,13 +584,13 @@ bool tr_sessionGetActiveSpeedLimit_KBps(tr_session const* session, tr_direction 
 
 double tr_sessionGetRawSpeed_KBps(tr_session const*, tr_direction);
 
-void tr_sessionSetRatioLimited(tr_session*, bool isLimited);
+void tr_sessionSetRatioLimited(tr_session*, bool is_limited);
 bool tr_sessionIsRatioLimited(tr_session const*);
 
 void tr_sessionSetRatioLimit(tr_session*, double desiredRatio);
 double tr_sessionGetRatioLimit(tr_session const*);
 
-void tr_sessionSetIdleLimited(tr_session*, bool isLimited);
+void tr_sessionSetIdleLimited(tr_session*, bool is_limited);
 bool tr_sessionIsIdleLimited(tr_session const*);
 
 void tr_sessionSetIdleLimit(tr_session*, uint16_t idleMinutes);
@@ -602,10 +602,10 @@ uint16_t tr_sessionGetPeerLimit(tr_session const*);
 void tr_sessionSetPeerLimitPerTorrent(tr_session*, uint16_t max_peers);
 uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const*);
 
-void tr_sessionSetPaused(tr_session*, bool isPaused);
+void tr_sessionSetPaused(tr_session*, bool is_paused);
 bool tr_sessionGetPaused(tr_session const*);
 
-void tr_sessionSetDeleteSource(tr_session*, bool deleteSource);
+void tr_sessionSetDeleteSource(tr_session*, bool delete_source);
 bool tr_sessionGetDeleteSource(tr_session const*);
 
 tr_priority_t tr_torrentGetPriority(tr_torrent const*);

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -231,7 +231,7 @@ void tr_eventInit(tr_session* session)
 
 void tr_eventClose(tr_session* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
 
     auto* events = session->events;
     if (events == nullptr)
@@ -250,7 +250,7 @@ void tr_eventClose(tr_session* session)
 
 bool tr_amInEventThread(tr_session const* session)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     TR_ASSERT(session->events != nullptr);
 
     return std::this_thread::get_id() == session->events->thread_id;
@@ -262,7 +262,7 @@ bool tr_amInEventThread(tr_session const* session)
 
 void tr_runInEventThread(tr_session* session, std::function<void(void)>&& func)
 {
-    TR_ASSERT(tr_isSession(session));
+    TR_ASSERT(session != nullptr);
     auto* events = session->events;
     TR_ASSERT(events != nullptr);
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -113,8 +113,7 @@ bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_erro
         tr_error_propagate(error, &my_error);
         return false;
     }
-
-    if (!info->isFile())
+    if (!info || !info->isFile())
     {
         tr_logAddError(fmt::format(_("Couldn't read '{path}': Not a regular file"), fmt::arg("path", filename)));
         tr_error_set(error, TR_ERROR_EISDIR, "Not a regular file"sv);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -103,7 +103,7 @@ bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_erro
     /* try to stat the file */
     tr_error* my_error = nullptr;
     auto const info = tr_sys_path_get_info(szfilename, 0, &my_error);
-    if (!info)
+    if (my_error != nullptr)
     {
         tr_logAddError(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -549,7 +549,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     options.range = fmt::format(FMT_STRING("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->id();
     options.buffer = task->content();
-    tor->session->web->fetch(std::move(options));
+    tor->session->web().fetch(std::move(options));
 }
 
 } // namespace

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -371,7 +371,7 @@ public:
     {
         if (auto* const tor = tr_torrentFindFromId(session_, tor_id_); tor != nullptr)
         {
-            session_->cache->writeBlock(tor_id_, block_, data_);
+            session_->cache().writeBlock(tor_id_, block_, data_);
             webseed_->publishGotBlock(tor, block_);
         }
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -159,7 +159,7 @@ auto createIncomingIo(tr_session* session)
     auto const now = tr_time();
     auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
     auto* const
-        io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
+        io = tr_peerIoNewIncoming(session, &session->topBandwidth(), &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
     return std::make_pair(io, sockpair[1]);
 }
 
@@ -171,7 +171,7 @@ auto createOutgoingIo(tr_session* session, tr_sha1_digest_t const& info_hash)
     auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
     auto* const io = tr_peerIoNew(
         session,
-        &session->top_bandwidth_,
+        &session->topBandwidth(),
         &DefaultPeerAddr,
         DefaultPeerPort,
         now,

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -87,7 +87,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
 
     auto const test_incomplete_dir_threadfunc = [](TestIncompleteDirData* data) noexcept
     {
-        data->session->cache->writeBlock(data->tor->id(), data->block, data->buf);
+        data->session->cache().writeBlock(data->tor->id(), data->block, data->buf);
         tr_torrentGotBlock(data->tor, data->block);
         data->done = true;
     };

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -127,15 +127,13 @@ protected:
         }
 
         tr_error* error = nullptr;
-
-        if (auto path = tr_sys_dir_get_current(&error); !std::empty(path))
+        auto path = tr_sys_dir_get_current(&error);
+        if (error != nullptr)
         {
-            return path;
+            std::cerr << "tr_sys_dir_get_current error: '" << error->message << "'" << std::endl;
+            tr_error_free(error);
         }
-
-        std::cerr << "tr_sys_dir_get_current error: '" << error->message << "'" << std::endl;
-        tr_error_free(error);
-        return {};
+        return path;
     }
 
     static std::string create_sandbox(std::string const& parent_dir, std::string const& tmpl)

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -129,14 +129,13 @@ int parseCommandLine(app_options& options, int argc, char const* const* argv)
 std::string tr_getcwd()
 {
     tr_error* error = nullptr;
-    if (auto cur = tr_sys_dir_get_current(&error); !std::empty(cur))
+    auto cur = tr_sys_dir_get_current(&error);
+    if (error != nullptr)
     {
-        return cur;
+        fmt::print(stderr, "getcwd error: \"{}\"\n", error->message);
+        tr_error_free(error);
     }
-
-    fprintf(stderr, "getcwd error: \"%s\"", error->message);
-    tr_error_free(error);
-    return "";
+    return cur;
 }
 
 } // namespace


### PR DESCRIPTION
The recent regressions caused by Timer changes underscored how difficult it is to do any refactoring in `tr_session` -- it's too big and nearly all of it is public simply because the design of the code predates the C++ refactor and it _has_ to be public in order to compile.

This PR does partial cleanup work to make `tr_session` fields private. This PR is forward progress, but full remediation is beyond the scope of any single PR.