### PR TITLE
refactor: make tr_session.peer_count private

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2458,7 +2458,7 @@ void enforceSessionPeerLimit(tr_session* session)
         std::end(torrents),
         size_t{},
         [](size_t sum, tr_torrent const* tor) { return sum + tor->swarm->peerCount(); });
-    size_t const max = tr_sessionGetPeerLimit(session);
+    size_t const max = session->peerLimit();
     if (n_peers <= max)
     {
         return;
@@ -2738,7 +2738,7 @@ struct peer_candidate
     auto const now_msec = tr_time_msec();
 
     // leave 5% of connection slots for incoming connections -- ticket #2609
-    auto const max_candidates = static_cast<size_t>(tr_sessionGetPeerLimit(session) * 0.95);
+    auto const max_candidates = static_cast<size_t>(session->peerLimit() * 0.95);
 
     /* count how many peers and atoms we've got */
     auto atom_count = size_t{};

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2186,11 +2186,11 @@ static void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_peer_limit_global:
-        tr_variantDictAddInt(d, key, tr_sessionGetPeerLimit(s));
+        tr_variantDictAddInt(d, key, s->peerLimit());
         break;
 
     case TR_KEY_peer_limit_per_torrent:
-        tr_variantDictAddInt(d, key, tr_sessionGetPeerLimitPerTorrent(s));
+        tr_variantDictAddInt(d, key, s->peerLimitPerTorrent());
         break;
 
     case TR_KEY_incomplete_dir:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -417,8 +417,8 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary)
     tr_variantDictAddStr(d, TR_KEY_incomplete_dir, tr_sessionGetIncompleteDir(s));
     tr_variantDictAddBool(d, TR_KEY_incomplete_dir_enabled, tr_sessionIsIncompleteDirEnabled(s));
     tr_variantDictAddInt(d, TR_KEY_message_level, tr_logGetLevel());
-    tr_variantDictAddInt(d, TR_KEY_peer_limit_global, s->peerLimit);
-    tr_variantDictAddInt(d, TR_KEY_peer_limit_per_torrent, s->peerLimitPerTorrent);
+    tr_variantDictAddInt(d, TR_KEY_peer_limit_global, s->peerLimit());
+    tr_variantDictAddInt(d, TR_KEY_peer_limit_per_torrent, s->peerLimitPerTorrent());
     tr_variantDictAddInt(d, TR_KEY_peer_port, s->peerPort().host());
     tr_variantDictAddBool(d, TR_KEY_peer_port_random_on_start, s->isPortRandom);
     tr_variantDictAddInt(d, TR_KEY_peer_port_random_low, s->randomPortLow.host());
@@ -964,7 +964,7 @@ void tr_session::setImpl(init_data& data)
 
     if (tr_variantDictFindInt(settings, TR_KEY_peer_limit_global, &i))
     {
-        this->peerLimit = i;
+        this->peer_limit_ = i;
     }
 
     /**
@@ -1701,28 +1701,28 @@ void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers)
 {
     TR_ASSERT(tr_isSession(session));
 
-    session->peerLimit = max_global_peers;
+    session->peer_limit_ = max_global_peers;
 }
 
 uint16_t tr_sessionGetPeerLimit(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->peerLimit;
+    return session->peerLimit();
 }
 
 void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers)
 {
     TR_ASSERT(tr_isSession(session));
 
-    session->peerLimitPerTorrent = max_peers;
+    session->peer_limit_per_torrent_ = max_peers;
 }
 
 uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const* session)
 {
     TR_ASSERT(tr_isSession(session));
 
-    return session->peerLimitPerTorrent;
+    return session->peerLimitPerTorrent();
 }
 
 /***

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -302,20 +302,20 @@ public:
 
     [[nodiscard]] constexpr bool incPeerCount() noexcept
     {
-        if (this->peerCount >= this->peerLimit)
+        if (this->peer_count_ >= this->peer_limit_)
         {
             return false;
         }
 
-        ++this->peerCount;
+        ++this->peer_count_;
         return true;
     }
 
     constexpr void decPeerCount() noexcept
     {
-        if (this->peerCount > 0)
+        if (this->peer_count_ > 0)
         {
-            --this->peerCount;
+            --this->peer_count_;
         }
     }
 
@@ -498,10 +498,6 @@ public:
     struct evdns_base* evdns_base = nullptr;
     struct tr_event_handle* events = nullptr;
 
-    uint16_t peerCount = 0;
-    uint16_t peerLimit = 200;
-    uint16_t peerLimitPerTorrent = 50;
-
     uint16_t upload_slots_per_torrent = 0;
 
     /* The UDP sockets used for the DHT and uTP. */
@@ -617,10 +613,23 @@ public:
         return queue_stalled_minutes_;
     }
 
+    [[nodiscard]] auto constexpr peerLimit() const noexcept
+    {
+        return peer_limit_;
+    }
+
+    [[nodiscard]] auto constexpr peerLimitPerTorrent() const noexcept
+    {
+        return peer_limit_per_torrent_;
+    }
+
 private:
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
     friend void tr_sessionClose(tr_session* session);
+    friend void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary);
     friend void tr_sessionSet(tr_session* session, tr_variant* settings);
+    friend void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers);
+    friend void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers);
     friend void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, int max_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueStalledEnabled(tr_session* session, bool is_enabled);
@@ -632,6 +641,10 @@ private:
     void closeImplStart();
     void closeImplWaitForIdleUdp();
     void closeImplFinish();
+
+    uint16_t peer_count_ = 0;
+    uint16_t peer_limit_ = 200;
+    uint16_t peer_limit_per_torrent_ = 50;
 
     std::array<bool, 2> queue_enabled_ = { false, false };
     std::array<int, 2> queue_size_ = { 0, 0 };

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -353,7 +353,7 @@ tr_ctor* tr_ctorNew(tr_session const* session)
 
     tr_ctorSetDeleteSource(ctor, tr_sessionGetDeleteSource(session));
     tr_ctorSetPaused(ctor, TR_FALLBACK, tr_sessionGetPaused(session));
-    tr_ctorSetPeerLimit(ctor, TR_FALLBACK, session->peerLimitPerTorrent);
+    tr_ctorSetPeerLimit(ctor, TR_FALLBACK, session->peerLimitPerTorrent());
     tr_ctorSetDownloadDir(ctor, TR_FALLBACK, tr_sessionGetDownloadDir(session));
 
     return ctor;


### PR DESCRIPTION
No functional changes; just baby steps towards encapsulating pieces of tr_session.