### PR TITLE
refactor: reduce use of tr_malloc / tr_free

### DIFF
--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -95,7 +95,9 @@ enum
         return;
     }
 
-    if (std::empty(self.fPieces))
+    //determine if first time
+    BOOL const first = std::empty(self.fPieces);
+    if (first)
     {
         self.fPieces.resize(self.fNumPieces);
     }

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -3,6 +3,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <optional>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -1535,14 +1536,14 @@ bool trashDataFile(char const* filename, tr_error** error)
 - (void)setFilePriority:(tr_priority_t)priority forIndexes:(NSIndexSet*)indexSet
 {
     NSUInteger const count = indexSet.count;
-    tr_file_index_t* files = static_cast<tr_file_index_t*>(tr_malloc(count * sizeof(tr_file_index_t)));
+    auto files = std::vector<tr_file_index_t>{};
+    files.resize(count);
     for (NSUInteger index = indexSet.firstIndex, i = 0; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index], i++)
     {
         files[i] = index;
     }
 
-    tr_torrentSetFilePriorities(self.fHandle, files, count, priority);
-    tr_free(files);
+    tr_torrentSetFilePriorities(self.fHandle, std::data(files), std::size(files), priority);
 }
 
 - (BOOL)hasFilePriority:(tr_priority_t)priority forIndexes:(NSIndexSet*)indexSet

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -16,7 +16,6 @@
 
 #include <libtransmission/rpcimpl.h>
 #include <libtransmission/transmission.h>
-#include <libtransmission/utils.h> // tr_free
 #include <libtransmission/version.h> // LONG_VERSION_STRING
 
 #include "VariantHelpers.h"
@@ -31,15 +30,14 @@ namespace
 char const constexpr* const RequestDataPropertyKey{ "requestData" };
 char const constexpr* const RequestFutureinterfacePropertyKey{ "requestReplyFutureInterface" };
 
-void destroyVariant(tr_variant* json)
-{
-    tr_variantFree(json);
-    tr_free(json);
-}
-
 TrVariantPtr createVariant()
 {
-    return { tr_new0(tr_variant, 1), &destroyVariant };
+    return { new tr_variant{},
+             [](tr_variant* var)
+             {
+                 tr_variantFree(var);
+                 delete var;
+             } };
 }
 
 } // namespace


### PR DESCRIPTION
a small chore PR to continue reducing the instances of unmanaged heap-allocated memory, e.g. tr_malloc / tr_free