### PR TITLE
chore: iwyu headers

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -8,6 +8,7 @@
 #include <cstdio> /* printf */
 #include <cstdlib> /* atoi */
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -11,7 +11,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <utility>
 
 #ifdef HAVE_SYSLOG
 #include <syslog.h>

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdlib> // exit()
 #include <ctime>
+#include <iterator> // for std::back_inserter
 #include <map>
 #include <memory>
 #include <sstream>

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -6,6 +6,7 @@
 #include <cstdlib> // exit()
 #include <ctime>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <locale.h>

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <limits.h> /* INT_MAX */
+#include <memory>
 #include <numeric>
 #include <sstream>
 #include <stddef.h>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -7,6 +7,7 @@
 #include <climits> /* INT_MAX */
 #include <cstddef>
 #include <list>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>

--- a/gtk/IconCache.cc
+++ b/gtk/IconCache.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <glibmm.h>
 #include <giomm.h>

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -3,6 +3,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <memory>
 #include <string>
 
 #include <glibmm/i18n.h>

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <glibmm.h>
 #include <glibmm/i18n.h>

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <map>
+#include <memory>
 
 #include <glibmm.h>
 #include <glibmm/i18n.h>

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include <giomm.h>

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <memory>
+#include <utility>
 
 #include <glibmm.h>
 #include <glibmm/i18n.h>

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -3,7 +3,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <errno.h>
-#include <stdlib.h> /* strtol() */
 #include <string>
 #include <string_view>
 

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <climits> /* USHRT_MAX, INT_MAX */
+#include <memory>
 #include <sstream>
 #include <string>
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <glibmm/i18n.h>
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -8,6 +8,7 @@
 // We're using deprecated Gtk::StatusItem ourselves as well
 #undef GTKMM_DISABLE_DEPRECATED
 
+#include <memory>
 #include <string>
 
 #include <glibmm.h>

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <functional>
 #include <limits.h> /* INT_MAX */
+#include <memory>
 
 #include <giomm.h> /* g_file_trash() */
 #include <glibmm/i18n.h>

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -9,6 +9,7 @@
 #include <functional>
 #include <limits.h> /* INT_MAX */
 #include <memory>
+#include <utility>
 
 #include <giomm.h> /* g_file_trash() */
 #include <glibmm/i18n.h>

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -9,6 +9,7 @@
 #include <ctime>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sys/types.h>

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <set>
 #include <string>
 #include <string_view>
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <curl/curl.h>
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -12,6 +12,7 @@
 #include <deque>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <set>
 #include <string>

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib> // bsearch()
 #include <string_view>

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -9,6 +9,7 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <cstddef> // for size_t
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <cstddef> // for size_t
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -6,6 +6,7 @@
 #include <cstdlib> // std::lldiv()
 #include <iterator> // std::distance(), std::next(), std::prev()
 #include <limits> // std::numeric_limits<size_t>::max()
+#include <memory>
 #include <numeric> // std::accumulate()
 #include <utility> // std::make_pair()
 #include <vector>

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -9,10 +9,11 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <cstdint> // intX_t, uintX_t
+#include <cstdint> // for size_t
+#include <cstdint> // for intX_t, uintX_t
 #include <ctime>
-#include <memory> // std::unique_ptr
-#include <utility> // std::pair
+#include <memory> // for std::unique_ptr
+#include <utility> // for std::pair
 #include <vector>
 
 #include "transmission.h"

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "transmission.h"

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <memory>
 #include <mutex>
 
 #if defined(CYASSL_IS_WOLFSSL)

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -8,6 +8,8 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+#include <memory>
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <memory>
 #include <mutex>
 
 #if defined(POLARSSL_IS_MBEDTLS)

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef> // size_t
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype> // for isalpha()
+#include <iterator> // for std::back_inserter
 #include <string>
 #include <string_view>
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstring>
 #include <string_view>
+#include <utility>
 
 #include <event2/buffer.h>
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -9,6 +9,7 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <cstddef> // for size_t
 #include <optional>
 #include <memory>
 

--- a/libtransmission/history.h
+++ b/libtransmission/history.h
@@ -10,8 +10,9 @@
 #endif
 
 #include <array>
-#include <cstdint>
-#include <ctime> // time_t
+#include <cstddef> // for size_t
+#include <cstdint> // for uint32_t
+#include <ctime> // for time_t
 
 /**
  * A short-term memory object that remembers how many times something

--- a/libtransmission/lru-cache.h
+++ b/libtransmission/lru-cache.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <utility>
 
 // A fixed-size cache that erases least-recently-used items to make room for new ones.
 template<typename Key, typename Val, std::size_t N>

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <errno> // for ENOENT
 #include <optional>
 #include <set>
 #include <string>

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <errno> // for ENOENT
+#include <cerrno> // for ENOENT
 #include <optional>
 #include <set>
 #include <string>

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -7,6 +7,7 @@
 
 #include <algorithm> // std::move
 #include <cstddef> // std::byte
+#include <cstdint>
 #include <future>
 #include <string>
 #include <string_view>

--- a/libtransmission/natpmp_local.h
+++ b/libtransmission/natpmp_local.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <ctime> // time_t
+#include <cstdint>
 
 #include "transmission.h" // tr_port_forwarding
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -18,7 +18,7 @@
 #ifdef _WIN32
 #include <ws2tcpip.h>
 #else
-#include <errno.h>
+#include <cerrno>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #endif

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <cstdint> // uint8_t, uint64_t
 #include <string_view>
 #include <utility>

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstdint> // uint8_t, uint64_t
 #include <string_view>
+#include <utility>
 
 #include <fmt/core.h>
 

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -9,7 +9,8 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <cstdint>
+#include <cstddef> // for size_t
+#include <cstdint> // for uintX_t
 #include <optional>
 #include <string_view>
 #include <utility>

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iterator>
 #include <set>
 #include <utility>
 #include <vector>

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -12,6 +12,7 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t, uint64_t
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory> // std::unique_ptr
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include <event2/buffer.h>

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -12,6 +12,7 @@
 #include <cstdint> // int8_t
 #include <cstddef> // size_t
 #include <ctime> // time_t
+#include <utility>
 
 #include "bitfield.h"
 #include "peer-common.h"

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -8,6 +8,7 @@
 #include <list>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #ifdef __HAIKU__

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <iterator>
 #include <list>
 #include <string>
 #include <string_view>

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <memory>
 
 #include <fmt/core.h>
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstring> /* memcpy */
 #include <ctime>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <chrono>
 #include <cstring> /* memcpy */
 #include <ctime>

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <ctime>
 #include <iterator>
+#include <memory>
 #include <numeric>
 #include <set>
 #include <string_view>

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::partial_sort(), std::min(), std::max()
-#include <cerrno> /* ENOENT */
 #include <climits> /* INT_MAX */
 #include <condition_variable>
 #include <csignal>

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -9,6 +9,7 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 #include <string_view>

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <climits>
-#include <cstdlib>
 #include <cstring>
 #include <cwchar>
 #include <map>

--- a/libtransmission/timer-ev.cc
+++ b/libtransmission/timer-ev.cc
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <memory>
+#include <utility>
 
 #include <event2/event.h>
 

--- a/libtransmission/timer-ev.h
+++ b/libtransmission/timer-ev.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "timer.h"
 
 extern "C"

--- a/libtransmission/timer.h
+++ b/libtransmission/timer.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <utility>
 
 namespace libtransmission
 {

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "transmission.h"

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno> // for EINVAL
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "transmission.h"

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -11,6 +11,7 @@
 
 #include <ctime>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "transmission.h"

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -5,6 +5,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include <cstdlib> // for abort()
+
 #include <fmt/format.h>
 
 #include "tr-assert.h"

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -11,6 +11,7 @@
 #include <cstring> // for memcpy(), memset()
 #include <ctime>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -5,9 +5,10 @@
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
-#include <csignal> /* sig_atomic_t */
+#include <csignal> // for sig_atomic_t
+#include <cstdlib> // for abort()
 #include <cstdio>
-#include <cstring> /* memcpy(), memset() */
+#include <cstring> // for memcpy(), memset()
 #include <ctime>
 #include <fstream>
 #include <sstream>

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <csignal> /* sig_atomic_t */
 #include <cstring> /* strlen(), strncpy(), strstr(), memset() */
+#include <memory>
 #include <type_traits>
 
 #ifdef _WIN32

--- a/libtransmission/tr-popcount.h
+++ b/libtransmission/tr-popcount.h
@@ -3,10 +3,14 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
 #ifndef TR_POPCNT_H
 #define TR_POPCNT_H
 
-#include <stdint.h>
+#include <cstdint>
 
 /* Avoid defining irrelevant helpers that might interfere with other
  * preprocessor logic. */

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -2,6 +2,7 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#include <cerrno>
 #include <cstdint>
 #include <cstring> /* memcmp(), memcpy(), memset() */
 #include <cstdlib> /* malloc(), free() */

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <thread>
+#include <utility>
 
 #include <csignal>
 

--- a/libtransmission/upnp.cc
+++ b/libtransmission/upnp.cc
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <fmt/core.h>
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -13,6 +13,7 @@
 #include <cstdlib> // getenv()
 #include <cstring> /* strerror() */
 #include <ctime> // nanosleep()
+#include <iterator> // for std::back_inserter
 #include <set>
 #include <string>
 #include <string_view>

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::sort
-#include <cerrno>
 #include <cstring>
 #include <stack>
 #include <string>

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 
 #include "timer.h"
 #include "watchdir.h"

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "timer.h"
 #include "watchdir.h"

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef> // for size_t
 #include <map>
 #include <memory>
 #include <optional>

--- a/libtransmission/watchdir-generic.cc
+++ b/libtransmission/watchdir-generic.cc
@@ -5,6 +5,8 @@
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 
+#include <utility>
+
 #include "transmission.h"
 
 #include "watchdir-base.h"

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -5,8 +5,7 @@
 
 #include <cerrno>
 #include <climits> /* NAME_MAX */
-
-#include <iostream> // NOCOMMIT
+#include <memory>
 
 #include <unistd.h> /* close() */
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -6,6 +6,7 @@
 #include <cerrno>
 #include <climits> /* NAME_MAX */
 #include <memory>
+#include <utility>
 
 #include <unistd.h> /* close() */
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -6,7 +6,6 @@
 #include <cerrno> // for errno
 #include <memory>
 #include <string>
-#include <unordered_set>
 
 #include <fcntl.h> // for open()
 #include <unistd.h> // for close()

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -6,6 +6,7 @@
 #include <cerrno> // for errno
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <fcntl.h> // for open()
 #include <unistd.h> // for close()

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <cerrno> // for errno
+#include <memory>
 #include <string>
 #include <unordered_set>
 

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <cerrno>
 #include <cstddef> // for offsetof
+#include <memory>
 
 #include <process.h> // for _beginthreadex()
 

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <cstddef> // for offsetof
 #include <memory>
+#include <utility>
 
 #include <process.h> // for _beginthreadex()
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdlib> // for strtoul()
 #include <cstddef>
 #include <limits>
 #include <optional>

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -12,6 +12,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 struct evbuffer;
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -11,6 +11,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <event2/buffer.h>

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <future>
 #include <optional>
+#include <utility>
 
 #include <libtransmission/transmission.h>
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <ctime>
+#include <utility>
 
 #include <QDateTime>
 #include <QDesktopServices>

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <set>
+#include <utility>
 
 #include <QApplication>
 #include <QStyle>

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -8,6 +8,7 @@
 #include <cstdint> // uint64_t
 #include <map>
 #include <unordered_map>
+#include <utility>
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <future>
+#include <utility>
 #include <vector>
 
 #include <QDir>

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <utility>
 
 #include <QFileInfo>
 #include <QPushButton>

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cstdlib>
 #include <string_view>
 
 #include <QDateTime>

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <string_view>
+#include <utility>
 
 #include <QDateTime>
 #include <QDir>

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <utility>
+
 #include <QDir>
 
 #include "RelocateDialog.h"

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <iterator>
 #include <set>
 
 #include <QApplication>

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <utility>
+
 #include <QApplication>
 #include <QFont>
 #include <QFontMetrics>

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <utility>
 
 #include <QApplication>
 #include <QBrush>

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <set>
 #include <string_view>
 
 #include <libtransmission/transmission.h>

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <iterator> // for std::back_inserter
 #include <set>
 #include <string_view>
 

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include <QAbstractListModel>

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -3,10 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <set>
-#include <unordered_map>
-#include <unordered_set>
-
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QColor>

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstddef> // size_t
+#include <utility>
 
 #include <QHash>
 #include <QPointer>

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 #include "transmission.h"

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cstring>
 #include <string_view>
 
 #include <event2/util.h>

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -6,7 +6,6 @@
 #define LIBTRANSMISSION_VARIANT_MODULE
 
 #include <clocale> // setlocale()
-#include <cstring> // strlen()
 #include <string>
 #include <string_view>
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <cstdlib> // mktemp()
-#include <cstring> // strlen()
 #include <numeric>
 #include <string>
 #include <string_view>

--- a/tests/libtransmission/peer-msgs-test.cc
+++ b/tests/libtransmission/peer-msgs-test.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstring>
+
 #include "transmission.h"
 #include "peer-msgs.h"
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -17,7 +17,6 @@
 #include <array>
 #include <cerrno>
 #include <cstdio> // fopen()
-#include <cstring> // strcmp()
 #include <string>
 #include <string_view>
 

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstring>
 #include <string_view>
 
 #include "transmission.h"

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
-#include <cstring>
 #include <string_view>
 
 #include "transmission.h"

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -3,7 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <cstring>
 #include <set>
 #include <string_view>
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath> // sqrt()
 #include <cstdlib> // setenv(), unsetenv()
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -4,8 +4,9 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <cstdlib> // for strtoul()
 #include <chrono>
-#include <cstdint> // uint32_t
+#include <cstdint> // for uint32_t
 #include <future>
 #include <string>
 #include <string_view>

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -8,7 +8,6 @@
 #include <cinttypes> // PRIu64
 #include <cstdio>
 #include <ctime>
-#include <iterator>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
just some housekeeping: include headers when we use their declarations; don't include them when we don't.