### PR TITLE
refactor: avoid tr_new(), tr_free() in tr_variant

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -429,7 +430,7 @@ bool constexpr quarks_are_sorted()
 static_assert(quarks_are_sorted(), "Predefined quarks must be sorted by their string value");
 static_assert(std::size(my_static) == TR_N_KEYS);
 
-auto& my_runtime{ *new std::vector<std::string_view>{} };
+auto& my_runtime{ *new std::vector<std::string>{} };
 
 } // namespace
 
@@ -464,7 +465,7 @@ tr_quark tr_quark_new(std::string_view str)
     }
 
     auto const ret = TR_N_KEYS + std::size(my_runtime);
-    my_runtime.emplace_back(tr_strvDup(str), std::size(str));
+    my_runtime.emplace_back(std::string{ str });
     return ret;
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -73,18 +73,6 @@ void* tr_malloc0(size_t size)
     return size != 0 ? calloc(1, size) : nullptr;
 }
 
-void* tr_realloc(void* p, size_t size)
-{
-    void* result = size != 0 ? realloc(p, size) : nullptr;
-
-    if (result == nullptr)
-    {
-        tr_free(p);
-    }
-
-    return result;
-}
-
 void tr_free(void* p)
 {
     if (p != nullptr)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -138,9 +138,6 @@ void tr_free(void* p);
 
 #define tr_new0(struct_type, n_structs) (static_cast<struct_type*>(tr_malloc0(sizeof(struct_type) * (size_t)(n_structs))))
 
-#define tr_renew(struct_type, mem, n_structs) \
-    (static_cast<struct_type*>(tr_realloc((mem), sizeof(struct_type) * (size_t)(n_structs))))
-
 constexpr bool tr_str_is_empty(char const* value)
 {
     return value == nullptr || *value == '\0';

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -128,9 +128,6 @@ void* tr_malloc(size_t size);
 /** @brief Portability wrapper around calloc() in which `0' is a safe argument */
 void* tr_malloc0(size_t size);
 
-/** @brief Portability wrapper around reallocf() in which `0' is a safe argument */
-void* tr_realloc(void* p, size_t size);
-
 /** @brief Portability wrapper around free() in which `nullptr' is a safe argument */
 void tr_free(void* p);
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -68,7 +68,7 @@ static void tr_variant_string_clear(struct tr_variant_string* str)
 {
     if (str->type == TR_STRING_TYPE_HEAP)
     {
-        tr_free((char*)(str->str.str));
+        delete[]((char*)(str->str.str));
     }
 
     *str = STRING_INIT;
@@ -129,7 +129,7 @@ static void tr_variant_string_set_string(struct tr_variant_string* str, std::str
     }
     else
     {
-        auto* tmp = tr_new(char, len + 1);
+        auto* tmp = new char[len + 1];
         std::copy_n(bytes, len, tmp);
         tmp[len] = '\0';
         str->type = TR_STRING_TYPE_HEAP;
@@ -430,7 +430,10 @@ static tr_variant* containerReserve(tr_variant* v, size_t count)
             n *= 2U;
         }
 
-        v->val.l.vals = tr_renew(tr_variant, v->val.l.vals, n);
+        auto* vals = new tr_variant[n];
+        std::copy_n(v->val.l.vals, v->val.l.count, vals);
+        delete[] v->val.l.vals;
+        v->val.l.vals = vals;
         v->val.l.alloc = n;
     }
 
@@ -911,7 +914,7 @@ static void freeStringFunc(tr_variant const* v, void* /*user_data*/)
 
 static void freeContainerEndFunc(tr_variant const* v, void* /*user_data*/)
 {
-    tr_free(v->val.l.vals);
+    delete[] v->val.l.vals;
 }
 
 static struct VariantWalkFuncs const freeWalkFuncs = {


### PR DESCRIPTION
- use `new[]` and `delete[]` instead of `tr_new()` and `tr_free()`.
- but don't use std containers. Current plan is that `variant.h` needs to be safe for use by C code