### PR TITLE
refactor: avoid tr_new() in transmission-remote

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -350,7 +350,7 @@ int tr_main(int argc, char* argv[])
     tr_sessionSaveSettings(h, config_dir.c_str(), &settings);
 
     printf("\n");
-    tr_variantFree(&settings);
+    tr_variantReset(&settings);
     tr_sessionClose(h);
     return EXIT_SUCCESS;
 }

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -350,7 +350,7 @@ int tr_main(int argc, char* argv[])
     tr_sessionSaveSettings(h, config_dir.c_str(), &settings);
 
     printf("\n");
-    tr_variantReset(&settings);
+    tr_variantClear(&settings);
     tr_sessionClose(h);
     return EXIT_SUCCESS;
 }

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -692,7 +692,7 @@ static void daemon_reconfigure(void* /*arg*/)
         tr_variantDictAddBool(&settings, TR_KEY_rpc_enabled, true);
         tr_sessionLoadSettings(&settings, configDir, MyName);
         tr_sessionSet(mySession, &settings);
-        tr_variantFree(&settings);
+        tr_variantReset(&settings);
         tr_sessionReloadBlocklists(mySession);
     }
 }
@@ -954,7 +954,7 @@ static bool init_daemon_data(int argc, char* argv[], struct daemon_data* data, b
     return true;
 
 EXIT_EARLY:
-    tr_variantFree(&data->settings);
+    tr_variantReset(&data->settings);
     return false;
 }
 
@@ -985,6 +985,6 @@ int tr_main(int argc, char* argv[])
         tr_error_free(error);
     }
 
-    tr_variantFree(&data.settings);
+    tr_variantReset(&data.settings);
     return ret;
 }

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -692,7 +692,7 @@ static void daemon_reconfigure(void* /*arg*/)
         tr_variantDictAddBool(&settings, TR_KEY_rpc_enabled, true);
         tr_sessionLoadSettings(&settings, configDir, MyName);
         tr_sessionSet(mySession, &settings);
-        tr_variantReset(&settings);
+        tr_variantClear(&settings);
         tr_sessionReloadBlocklists(mySession);
     }
 }
@@ -954,7 +954,7 @@ static bool init_daemon_data(int argc, char* argv[], struct daemon_data* data, b
     return true;
 
 EXIT_EARLY:
-    tr_variantReset(&data->settings);
+    tr_variantClear(&data->settings);
     return false;
 }
 
@@ -985,6 +985,6 @@ int tr_main(int argc, char* argv[])
         tr_error_free(error);
     }
 
-    tr_variantReset(&data.settings);
+    tr_variantClear(&data.settings);
     return ret;
 }

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -459,7 +459,7 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torren
                 core_->signal_prefs_changed().emit(changed_key);
             }
 
-            tr_variantFree(&tmp);
+            tr_variantReset(&tmp);
             break;
         }
 
@@ -1328,7 +1328,7 @@ bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method
         invoked = true;
     }
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
     return invoked;
 }
 
@@ -1353,7 +1353,7 @@ void Application::Impl::start_all_torrents()
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-start"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantFree(&request);
+    tr_variantReset(&request);
 }
 
 void Application::Impl::pause_all_torrents()
@@ -1364,7 +1364,7 @@ void Application::Impl::pause_all_torrents()
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-stop"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantFree(&request);
+    tr_variantReset(&request);
 }
 
 tr_torrent* Application::Impl::get_first_selected_torrent() const

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -459,7 +459,7 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torren
                 core_->signal_prefs_changed().emit(changed_key);
             }
 
-            tr_variantReset(&tmp);
+            tr_variantClear(&tmp);
             break;
         }
 
@@ -1328,7 +1328,7 @@ bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method
         invoked = true;
     }
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
     return invoked;
 }
 
@@ -1353,7 +1353,7 @@ void Application::Impl::start_all_torrents()
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-start"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantReset(&request);
+    tr_variantClear(&request);
 }
 
 void Application::Impl::pause_all_torrents()
@@ -1364,7 +1364,7 @@ void Application::Impl::pause_all_torrents()
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-stop"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantReset(&request);
+    tr_variantClear(&request);
 }
 
 tr_torrent* Application::Impl::get_first_selected_torrent() const

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -416,7 +416,7 @@ void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
     }
 
     core_->exec(&top);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
@@ -435,7 +435,7 @@ void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
     }
 
     core_->exec(&top);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
@@ -454,7 +454,7 @@ void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
     }
 
     core_->exec(&top);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 Gtk::Widget* DetailsDialog::Impl::options_page_new()
@@ -2395,7 +2395,7 @@ void DetailsDialog::Impl::on_add_tracker_response(int response, std::shared_ptr<
                 core_->exec(&top);
                 refresh();
 
-                tr_variantFree(&top);
+                tr_variantReset(&top);
             }
             else
             {
@@ -2465,7 +2465,7 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
         core_->exec(&top);
         refresh();
 
-        tr_variantFree(&top);
+        tr_variantReset(&top);
     }
 }
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -416,7 +416,7 @@ void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
     }
 
     core_->exec(&top);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
@@ -435,7 +435,7 @@ void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
     }
 
     core_->exec(&top);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
@@ -454,7 +454,7 @@ void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
     }
 
     core_->exec(&top);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 Gtk::Widget* DetailsDialog::Impl::options_page_new()
@@ -2395,7 +2395,7 @@ void DetailsDialog::Impl::on_add_tracker_response(int response, std::shared_ptr<
                 core_->exec(&top);
                 refresh();
 
-                tr_variantReset(&top);
+                tr_variantClear(&top);
             }
             else
             {
@@ -2465,7 +2465,7 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
         core_->exec(&top);
         refresh();
 
-        tr_variantReset(&top);
+        tr_variantClear(&top);
     }
 }
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -50,7 +50,7 @@ TrVariantPtr create_variant(tr_variant&& other)
         new tr_variant{},
         [](tr_variant* ptr)
         {
-            tr_variantFree(ptr);
+            tr_variantReset(ptr);
             delete ptr;
         });
     *result = std::move(other);
@@ -1403,7 +1403,7 @@ void Session::start_now(tr_torrent_id_t id)
     auto ids = tr_variantDictAddList(args, TR_KEY_ids, 1);
     tr_variantListAddInt(ids, id);
     exec(&top);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 void Session::Impl::update()
@@ -1674,7 +1674,7 @@ void Session::port_test()
 
             impl_->signal_port_tested.emit(is_open);
         });
-    tr_variantFree(&request);
+    tr_variantReset(&request);
 }
 
 /***
@@ -1711,7 +1711,7 @@ void Session::blocklist_update()
 
             impl_->signal_blocklist_updated.emit(ruleCount);
         });
-    tr_variantFree(&request);
+    tr_variantReset(&request);
 }
 
 /***

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -50,7 +50,7 @@ TrVariantPtr create_variant(tr_variant&& other)
         new tr_variant{},
         [](tr_variant* ptr)
         {
-            tr_variantReset(ptr);
+            tr_variantClear(ptr);
             delete ptr;
         });
     *result = std::move(other);
@@ -1403,7 +1403,7 @@ void Session::start_now(tr_torrent_id_t id)
     auto ids = tr_variantDictAddList(args, TR_KEY_ids, 1);
     tr_variantListAddInt(ids, id);
     exec(&top);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 void Session::Impl::update()
@@ -1674,7 +1674,7 @@ void Session::port_test()
 
             impl_->signal_port_tested.emit(is_open);
         });
-    tr_variantReset(&request);
+    tr_variantClear(&request);
 }
 
 /***
@@ -1711,7 +1711,7 @@ void Session::blocklist_update()
 
             impl_->signal_blocklist_updated.emit(ruleCount);
         });
-    tr_variantReset(&request);
+    tr_variantClear(&request);
 }
 
 /***

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -268,7 +268,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
 
     // confirm that it's good by parsing it back again
     auto const contents = tr_variantToStr(&metainfo, TR_VARIANT_FMT_BENC);
-    tr_variantReset(&metainfo);
+    tr_variantClear(&metainfo);
     if (auto tm = tr_torrent_metainfo{}; !tm.parseBenc(contents, error))
     {
         return false;

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -268,7 +268,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
 
     // confirm that it's good by parsing it back again
     auto const contents = tr_variantToStr(&metainfo, TR_VARIANT_FMT_BENC);
-    tr_variantFree(&metainfo);
+    tr_variantReset(&metainfo);
     if (auto tm = tr_torrent_metainfo{}; !tm.parseBenc(contents, error))
     {
         return false;

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -10,7 +10,6 @@
 #include "error.h"
 #include "file.h"
 #include "tr-assert.h"
-#include "utils.h"
 
 using namespace std::literals;
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -392,6 +392,6 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
     tr_variantDictAddInt(info_dict, TR_KEY_piece_length, pieceSize());
     tr_variantDictAddRaw(info_dict, TR_KEY_pieces, std::data(piece_hashes_), std::size(piece_hashes_));
     auto ret = tr_variantToStr(&top, TR_VARIANT_FMT_BENC);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
     return ret;
 }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -392,6 +392,6 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
     tr_variantDictAddInt(info_dict, TR_KEY_piece_length, pieceSize());
     tr_variantDictAddRaw(info_dict, TR_KEY_pieces, std::data(piece_hashes_), std::size(piece_hashes_));
     auto ret = tr_variantToStr(&top, TR_VARIANT_FMT_BENC);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
     return ret;
 }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1227,7 +1227,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
     /* cleanup */
     evbuffer_free(payload);
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 }
 
 static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuffer* inbuf)
@@ -1333,7 +1333,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
         msgs->reqq = i;
     }
 
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 }
 
 static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* inbuf)
@@ -1354,7 +1354,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
         (void)tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
         (void)tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
         (void)tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
-        tr_variantFree(&dict);
+        tr_variantReset(&dict);
     }
 
     logtrace(
@@ -1401,7 +1401,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
 
             /* cleanup */
             evbuffer_free(payload);
-            tr_variantFree(&v);
+            tr_variantReset(&v);
         }
     }
 }
@@ -1452,7 +1452,7 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
             tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
         }
 
-        tr_variantFree(&val);
+        tr_variantReset(&val);
     }
 }
 
@@ -2158,7 +2158,7 @@ static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
 
         /* cleanup */
         evbuffer_free(payload);
-        tr_variantFree(&tmp);
+        tr_variantReset(&tmp);
     }
 }
 
@@ -2253,7 +2253,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             msgs->dbgOutMessageLen();
 
             evbuffer_free(payload);
-            tr_variantFree(&tmp);
+            tr_variantReset(&tmp);
 
             ok = true;
         }
@@ -2278,7 +2278,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             msgs->dbgOutMessageLen();
 
             evbuffer_free(payload);
-            tr_variantFree(&tmp);
+            tr_variantReset(&tmp);
         }
     }
 
@@ -2623,5 +2623,5 @@ void tr_peerMsgsImpl::sendPex()
     this->dbgOutMessageLen();
 
     evbuffer_free(payload);
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1227,7 +1227,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
     /* cleanup */
     evbuffer_free(payload);
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 }
 
 static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuffer* inbuf)
@@ -1333,7 +1333,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
         msgs->reqq = i;
     }
 
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 }
 
 static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* inbuf)
@@ -1354,7 +1354,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
         (void)tr_variantDictFindInt(&dict, TR_KEY_msg_type, &msg_type);
         (void)tr_variantDictFindInt(&dict, TR_KEY_piece, &piece);
         (void)tr_variantDictFindInt(&dict, TR_KEY_total_size, &total_size);
-        tr_variantReset(&dict);
+        tr_variantClear(&dict);
     }
 
     logtrace(
@@ -1401,7 +1401,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
 
             /* cleanup */
             evbuffer_free(payload);
-            tr_variantReset(&v);
+            tr_variantClear(&v);
         }
     }
 }
@@ -1452,7 +1452,7 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
             tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
         }
 
-        tr_variantReset(&val);
+        tr_variantClear(&val);
     }
 }
 
@@ -2158,7 +2158,7 @@ static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
 
         /* cleanup */
         evbuffer_free(payload);
-        tr_variantReset(&tmp);
+        tr_variantClear(&tmp);
     }
 }
 
@@ -2253,7 +2253,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             msgs->dbgOutMessageLen();
 
             evbuffer_free(payload);
-            tr_variantReset(&tmp);
+            tr_variantClear(&tmp);
 
             ok = true;
         }
@@ -2278,7 +2278,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             msgs->dbgOutMessageLen();
 
             evbuffer_free(payload);
-            tr_variantReset(&tmp);
+            tr_variantClear(&tmp);
         }
     }
 
@@ -2623,5 +2623,5 @@ void tr_peerMsgsImpl::sendPex()
     this->dbgOutMessageLen();
 
     evbuffer_free(payload);
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 }

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -12,7 +12,6 @@
 #include "transmission.h"
 
 #include "quark.h"
-#include "utils.h" // tr_strvDup()
 
 using namespace std::literals;
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -841,7 +841,7 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
      * same resume information... */
     tor->isDirty = wasDirty;
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
     return fields_loaded;
 }
 
@@ -955,7 +955,7 @@ void save(tr_torrent* tor)
         tor->setLocalError(fmt::format(FMT_STRING("Unable to save resume file: {:s}"), tr_strerror(err)));
     }
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 } // namespace tr_resume

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -841,7 +841,7 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fieldsToLoad, bool
      * same resume information... */
     tor->isDirty = wasDirty;
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
     return fields_loaded;
 }
 
@@ -955,7 +955,7 @@ void save(tr_torrent* tor)
         tor->setLocalError(fmt::format(FMT_STRING("Unable to save resume file: {:s}"), tr_strerror(err)));
     }
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 } // namespace tr_resume

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -307,7 +307,7 @@ static void handle_rpc_from_json(struct evhttp_request* req, tr_rpc_server* serv
 
     if (have_content)
     {
-        tr_variantReset(&top);
+        tr_variantClear(&top);
     }
 }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -307,7 +307,7 @@ static void handle_rpc_from_json(struct evhttp_request* req, tr_rpc_server* serv
 
     if (have_content)
     {
-        tr_variantFree(&top);
+        tr_variantReset(&top);
     }
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -79,7 +79,7 @@ static void tr_idle_function_done(struct tr_rpc_idle_data* data, std::string_vie
 
     (*data->callback)(data->session, &data->response, data->callback_user_data);
 
-    tr_variantFree(&data->response);
+    tr_variantReset(&data->response);
     delete data;
 }
 
@@ -2502,7 +2502,7 @@ void tr_rpc_request_exec_json(
 
         (*callback)(session, &response, callback_user_data);
 
-        tr_variantFree(&response);
+        tr_variantReset(&response);
     }
     else if (method->immediate)
     {
@@ -2525,7 +2525,7 @@ void tr_rpc_request_exec_json(
 
         (*callback)(session, &response, callback_user_data);
 
-        tr_variantFree(&response);
+        tr_variantReset(&response);
     }
     else
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -79,7 +79,7 @@ static void tr_idle_function_done(struct tr_rpc_idle_data* data, std::string_vie
 
     (*data->callback)(data->session, &data->response, data->callback_user_data);
 
-    tr_variantReset(&data->response);
+    tr_variantClear(&data->response);
     delete data;
 }
 
@@ -2502,7 +2502,7 @@ void tr_rpc_request_exec_json(
 
         (*callback)(session, &response, callback_user_data);
 
-        tr_variantReset(&response);
+        tr_variantClear(&response);
     }
     else if (method->immediate)
     {
@@ -2525,7 +2525,7 @@ void tr_rpc_request_exec_json(
 
         (*callback)(session, &response, callback_user_data);
 
-        tr_variantReset(&response);
+        tr_variantClear(&response);
     }
     else
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -481,7 +481,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
     tr_variantInitDict(dict, 0);
     tr_sessionGetDefaultSettings(dict);
     tr_variantMergeDicts(dict, &oldDict);
-    tr_variantReset(&oldDict);
+    tr_variantClear(&oldDict);
 
     /* file settings override the defaults */
     auto fileSettings = tr_variant{};
@@ -495,7 +495,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
     else if (tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename))
     {
         tr_variantMergeDicts(dict, &fileSettings);
-        tr_variantReset(&fileSettings);
+        tr_variantClear(&fileSettings);
         success = true;
     }
     else
@@ -520,7 +520,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     if (auto file_settings = tr_variant{}; tr_variantFromFile(&file_settings, TR_VARIANT_PARSE_JSON, filename))
     {
         tr_variantMergeDicts(&settings, &file_settings);
-        tr_variantReset(&file_settings);
+        tr_variantClear(&file_settings);
     }
 
     /* the client's settings override the file settings */
@@ -532,14 +532,14 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
         tr_variantInitDict(&sessionSettings, 0);
         tr_sessionGetSettings(session, &sessionSettings);
         tr_variantMergeDicts(&settings, &sessionSettings);
-        tr_variantReset(&sessionSettings);
+        tr_variantClear(&sessionSettings);
     }
 
     /* save the result */
     tr_variantToFile(&settings, TR_VARIANT_FMT_JSON, filename);
 
     /* cleanup */
-    tr_variantReset(&settings);
+    tr_variantClear(&settings);
 
     /* Write bandwidth groups limits to file  */
     bandwidthGroupWrite(session, config_dir);
@@ -695,7 +695,7 @@ void tr_session::initImpl(init_data& data)
     tr_utpInit(this);
 
     /* cleanup */
-    tr_variantReset(&settings);
+    tr_variantClear(&settings);
     data.done_cv.notify_one();
 }
 
@@ -2746,7 +2746,7 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
             group.honorParentLimits(TR_DOWN, honors);
         }
     }
-    tr_variantReset(&groups_dict);
+    tr_variantClear(&groups_dict);
 }
 
 static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
@@ -2771,7 +2771,7 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
 
     auto const filename = tr_pathbuf{ config_dir, '/', BandwidthGroupsFilename };
     auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
-    tr_variantReset(&groups_dict);
+    tr_variantClear(&groups_dict);
     return ret;
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -481,7 +481,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
     tr_variantInitDict(dict, 0);
     tr_sessionGetDefaultSettings(dict);
     tr_variantMergeDicts(dict, &oldDict);
-    tr_variantFree(&oldDict);
+    tr_variantReset(&oldDict);
 
     /* file settings override the defaults */
     auto fileSettings = tr_variant{};
@@ -495,7 +495,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
     else if (tr_variantFromFile(&fileSettings, TR_VARIANT_PARSE_JSON, filename))
     {
         tr_variantMergeDicts(dict, &fileSettings);
-        tr_variantFree(&fileSettings);
+        tr_variantReset(&fileSettings);
         success = true;
     }
     else
@@ -520,7 +520,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     if (auto file_settings = tr_variant{}; tr_variantFromFile(&file_settings, TR_VARIANT_PARSE_JSON, filename))
     {
         tr_variantMergeDicts(&settings, &file_settings);
-        tr_variantFree(&file_settings);
+        tr_variantReset(&file_settings);
     }
 
     /* the client's settings override the file settings */
@@ -532,14 +532,14 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
         tr_variantInitDict(&sessionSettings, 0);
         tr_sessionGetSettings(session, &sessionSettings);
         tr_variantMergeDicts(&settings, &sessionSettings);
-        tr_variantFree(&sessionSettings);
+        tr_variantReset(&sessionSettings);
     }
 
     /* save the result */
     tr_variantToFile(&settings, TR_VARIANT_FMT_JSON, filename);
 
     /* cleanup */
-    tr_variantFree(&settings);
+    tr_variantReset(&settings);
 
     /* Write bandwidth groups limits to file  */
     bandwidthGroupWrite(session, config_dir);
@@ -695,7 +695,7 @@ void tr_session::initImpl(init_data& data)
     tr_utpInit(this);
 
     /* cleanup */
-    tr_variantFree(&settings);
+    tr_variantReset(&settings);
     data.done_cv.notify_one();
 }
 
@@ -2746,7 +2746,7 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
             group.honorParentLimits(TR_DOWN, honors);
         }
     }
-    tr_variantFree(&groups_dict);
+    tr_variantReset(&groups_dict);
 }
 
 static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
@@ -2771,7 +2771,7 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
 
     auto const filename = tr_pathbuf{ config_dir, '/', BandwidthGroupsFilename };
     auto const ret = tr_variantToFile(&groups_dict, TR_VARIANT_FMT_JSON, filename);
-    tr_variantFree(&groups_dict);
+    tr_variantReset(&groups_dict);
     return ret;
 }
 

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -57,7 +57,7 @@ tr_session_stats tr_stats::loadOldStats(std::string_view config_dir)
             ret.uploadedBytes = (uint64_t)i;
         }
 
-        tr_variantReset(&top);
+        tr_variantClear(&top);
     }
 
     return ret;
@@ -75,7 +75,7 @@ void tr_stats::save() const
     tr_variantDictAddInt(&top, TR_KEY_session_count, saveme.sessionCount);
     tr_variantDictAddInt(&top, TR_KEY_uploaded_bytes, saveme.uploadedBytes);
     tr_variantToFile(&top, TR_VARIANT_FMT_JSON, filename);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 void tr_stats::clear()

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -57,7 +57,7 @@ tr_session_stats tr_stats::loadOldStats(std::string_view config_dir)
             ret.uploadedBytes = (uint64_t)i;
         }
 
-        tr_variantFree(&top);
+        tr_variantReset(&top);
     }
 
     return ret;
@@ -75,7 +75,7 @@ void tr_stats::save() const
     tr_variantDictAddInt(&top, TR_KEY_session_count, saveme.sessionCount);
     tr_variantDictAddInt(&top, TR_KEY_uploaded_bytes, saveme.uploadedBytes);
     tr_variantToFile(&top, TR_VARIANT_FMT_JSON, filename);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 void tr_stats::clear()

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -267,8 +267,8 @@ static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_
     tr_buildMetainfoExceptInfoDict(tor->metainfo_, &top_v);
     tr_variantMergeDicts(tr_variantDictAddDict(&top_v, TR_KEY_info, 0), &info_dict_v);
     auto const benc = tr_variantToStr(&top_v, TR_VARIANT_FMT_BENC);
-    tr_variantReset(&top_v);
-    tr_variantReset(&info_dict_v);
+    tr_variantClear(&top_v);
+    tr_variantClear(&info_dict_v);
 
     // does this synthetic torrent file parse?
     auto metainfo = tr_torrent_metainfo{};

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -267,8 +267,8 @@ static bool useNewMetainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_
     tr_buildMetainfoExceptInfoDict(tor->metainfo_, &top_v);
     tr_variantMergeDicts(tr_variantDictAddDict(&top_v, TR_KEY_info, 0), &info_dict_v);
     auto const benc = tr_variantToStr(&top_v, TR_VARIANT_FMT_BENC);
-    tr_variantFree(&top_v);
-    tr_variantFree(&info_dict_v);
+    tr_variantReset(&top_v);
+    tr_variantReset(&info_dict_v);
 
     // does this synthetic torrent file parse?
     auto metainfo = tr_torrent_metainfo{};

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -297,7 +297,7 @@ int tr_dhtInit(tr_session* ss)
             nodes6.assign(raw, raw + raw_len);
         }
 
-        tr_variantReset(&benc);
+        tr_variantClear(&benc);
     }
 
     if (have_id)
@@ -405,7 +405,7 @@ void tr_dhtUninit(tr_session* ss)
 
         auto const dat_file = tr_pathbuf{ ss->configDir(), "/dht.dat"sv };
         tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file.sv());
-        tr_variantReset(&benc);
+        tr_variantClear(&benc);
     }
 
     dht_uninit();

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -297,7 +297,7 @@ int tr_dhtInit(tr_session* ss)
             nodes6.assign(raw, raw + raw_len);
         }
 
-        tr_variantFree(&benc);
+        tr_variantReset(&benc);
     }
 
     if (have_id)
@@ -405,7 +405,7 @@ void tr_dhtUninit(tr_session* ss)
 
         auto const dat_file = tr_pathbuf{ ss->configDir(), "/dht.dat"sv };
         tr_variantToFile(&benc, TR_VARIANT_FMT_BENC, dat_file.sv());
-        tr_variantFree(&benc);
+        tr_variantReset(&benc);
     }
 
     dht_uninit();

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -154,7 +154,7 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
  *     tr_sessionGetDefaultSettings(&settings);
  *     if (tr_variantDictFindInt(&settings, TR_PREFS_KEY_PEER_PORT, &i))
  *         fprintf(stderr, "the default peer port is %d\n", (int)i);
- *     tr_variantFree(&settings);
+ *     tr_variantReset(&settings);
  * @endcode
  *
  * @param setme_dictionary pointer to a tr_variant dictionary
@@ -218,7 +218,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, struct 
  *     configDir = tr_getDefaultConfigDir("Transmission");
  *     session = tr_sessionInit(configDir, true, &settings);
  *
- *     tr_variantFree(&settings);
+ *     tr_variantReset(&settings);
  * @endcode
  *
  * @param configDir where Transmission will look for resume files, blocklists, etc.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -154,7 +154,7 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
  *     tr_sessionGetDefaultSettings(&settings);
  *     if (tr_variantDictFindInt(&settings, TR_PREFS_KEY_PEER_PORT, &i))
  *         fprintf(stderr, "the default peer port is %d\n", (int)i);
- *     tr_variantReset(&settings);
+ *     tr_variantClear(&settings);
  * @endcode
  *
  * @param setme_dictionary pointer to a tr_variant dictionary
@@ -218,7 +218,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, struct 
  *     configDir = tr_getDefaultConfigDir("Transmission");
  *     session = tr_sessionInit(configDir, true, &settings);
  *
- *     tr_variantReset(&settings);
+ *     tr_variantClear(&settings);
  * @endcode
  *
  * @param configDir where Transmission will look for resume files, blocklists, etc.

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -27,6 +27,7 @@
 #include "session.h"
 #include "tr-assert.h"
 #include "trevent.h"
+#include "utils.h"
 
 /***
 ****

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -27,7 +27,6 @@
 #include "session.h"
 #include "tr-assert.h"
 #include "trevent.h"
-#include "utils.h"
 
 /***
 ****

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -133,8 +133,6 @@ void tr_free(void* p);
 
 #define tr_new(struct_type, n_structs) (static_cast<struct_type*>(tr_malloc(sizeof(struct_type) * (size_t)(n_structs))))
 
-#define tr_new0(struct_type, n_structs) (static_cast<struct_type*>(tr_malloc0(sizeof(struct_type) * (size_t)(n_structs))))
-
 constexpr bool tr_str_is_empty(char const* value)
 {
     return value == nullptr || *value == '\0';

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -197,7 +197,7 @@ bool tr_variantListRemove(tr_variant* list, size_t pos)
 {
     if (tr_variantIsList(list) && pos < list->val.l.count)
     {
-        tr_variantFree(&list->val.l.vals[pos]);
+        tr_variantReset(&list->val.l.vals[pos]);
         tr_removeElementFromArray(list->val.l.vals, pos, sizeof(tr_variant), list->val.l.count);
         --list->val.l.count;
         return true;
@@ -653,7 +653,7 @@ bool tr_variantDictRemove(tr_variant* dict, tr_quark const key)
     {
         int const last = (int)dict->val.l.count - 1;
 
-        tr_variantFree(&dict->val.l.vals[i]);
+        tr_variantReset(&dict->val.l.vals[i]);
 
         if (i != last)
         {
@@ -927,7 +927,7 @@ static struct VariantWalkFuncs const freeWalkFuncs = {
     freeContainerEndFunc, //
 };
 
-void tr_variantFree(tr_variant* v)
+void tr_variantReset(tr_variant* v)
 {
     if (tr_variantIsSomething(v))
     {
@@ -1165,7 +1165,7 @@ bool tr_variantFromBuf(tr_variant* setme, int opts, std::string_view buf, char c
 
     if (!success)
     {
-        tr_variantFree(setme);
+        tr_variantReset(setme);
     }
 
     return success;

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -42,12 +42,6 @@ static bool tr_variantIsContainer(tr_variant const* v)
     return tr_variantIsList(v) || tr_variantIsDict(v);
 }
 
-static bool tr_variantIsSomething(tr_variant const* v)
-{
-    return tr_variantIsContainer(v) || tr_variantIsInt(v) || tr_variantIsString(v) || tr_variantIsReal(v) ||
-        tr_variantIsBool(v);
-}
-
 void tr_variantInit(tr_variant* v, char type)
 {
     v->type = type;
@@ -929,10 +923,12 @@ static struct VariantWalkFuncs const freeWalkFuncs = {
 
 void tr_variantReset(tr_variant* v)
 {
-    if (tr_variantIsSomething(v))
+    if (!tr_variantIsEmpty(v))
     {
         tr_variantWalk(v, &freeWalkFuncs, nullptr, false);
     }
+
+    *v = {};
 }
 
 /***

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -191,7 +191,7 @@ bool tr_variantListRemove(tr_variant* list, size_t pos)
 {
     if (tr_variantIsList(list) && pos < list->val.l.count)
     {
-        tr_variantReset(&list->val.l.vals[pos]);
+        tr_variantClear(&list->val.l.vals[pos]);
         tr_removeElementFromArray(list->val.l.vals, pos, sizeof(tr_variant), list->val.l.count);
         --list->val.l.count;
         return true;
@@ -647,7 +647,7 @@ bool tr_variantDictRemove(tr_variant* dict, tr_quark const key)
     {
         int const last = (int)dict->val.l.count - 1;
 
-        tr_variantReset(&dict->val.l.vals[i]);
+        tr_variantClear(&dict->val.l.vals[i]);
 
         if (i != last)
         {
@@ -921,7 +921,7 @@ static struct VariantWalkFuncs const freeWalkFuncs = {
     freeContainerEndFunc, //
 };
 
-void tr_variantReset(tr_variant* v)
+void tr_variantClear(tr_variant* v)
 {
     if (!tr_variantIsEmpty(v))
     {
@@ -1161,7 +1161,7 @@ bool tr_variantFromBuf(tr_variant* setme, int opts, std::string_view buf, char c
 
     if (!success)
     {
-        tr_variantReset(setme);
+        tr_variantClear(setme);
     }
 
     return success;

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -92,14 +92,14 @@ struct tr_variant
 };
 
 /**
- * @brief Reset the variant to an uninitialized state.
+ * @brief Clear the variant to an empty state.
  *
  * `tr_variantIsEmpty()` will return true after this is called.
  *
  * The variant itself is not freed, but any memory used by
  * its *value* -- e.g. a string or child variants -- is freed.
  */
-void tr_variantReset(tr_variant*);
+void tr_variantClear(tr_variant*);
 
 /***
 ****  Serialization / Deserialization

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -91,7 +91,15 @@ struct tr_variant
     } val = {};
 };
 
-void tr_variantFree(tr_variant*);
+/**
+ * @brief Reset the variant to an uninitialized state.
+ *
+ * `tr_variantIsEmpty()` will return true after this is called.
+ *
+ * The variant itself is not freed, but any memory used by
+ * its *value* -- e.g. a string or child variants -- is freed.
+ */
+void tr_variantReset(tr_variant*);
 
 /***
 ****  Serialization / Deserialization
@@ -149,6 +157,11 @@ bool tr_variantFromBuf(
 constexpr bool tr_variantIsType(tr_variant const* b, int type)
 {
     return b != nullptr && b->type == type;
+}
+
+constexpr bool tr_variantIsEmpty(tr_variant const* b)
+{
+    return b == nullptr || b->type == '\0';
 }
 
 /***

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -565,7 +565,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         auto const default_config_dir = tr_getDefaultConfigDir("Transmission");
         _fLib = tr_sessionInit(default_config_dir.c_str(), YES, &settings);
-        tr_variantReset(&settings);
+        tr_variantClear(&settings);
         _fConfigDirectory = @(default_config_dir.c_str());
 
         tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -565,7 +565,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         auto const default_config_dir = tr_getDefaultConfigDir("Transmission");
         _fLib = tr_sessionInit(default_config_dir.c_str(), YES, &settings);
-        tr_variantFree(&settings);
+        tr_variantReset(&settings);
         _fConfigDirectory = @(default_config_dir.c_str());
 
         tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -318,7 +318,7 @@ Prefs::Prefs(QString config_dir)
         }
     }
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 Prefs::~Prefs()
@@ -412,10 +412,10 @@ Prefs::~Prefs()
 
     tr_variantMergeDicts(&file_settings, &current_settings);
     tr_variantToFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toStdString());
-    tr_variantFree(&file_settings);
+    tr_variantReset(&file_settings);
 
     // cleanup
-    tr_variantFree(&current_settings);
+    tr_variantReset(&current_settings);
 }
 
 /**

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -318,7 +318,7 @@ Prefs::Prefs(QString config_dir)
         }
     }
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 Prefs::~Prefs()
@@ -412,10 +412,10 @@ Prefs::~Prefs()
 
     tr_variantMergeDicts(&file_settings, &current_settings);
     tr_variantToFile(&file_settings, TR_VARIANT_FMT_JSON, file.fileName().toStdString());
-    tr_variantReset(&file_settings);
+    tr_variantClear(&file_settings);
 
     // cleanup
-    tr_variantReset(&current_settings);
+    tr_variantClear(&current_settings);
 }
 
 /**

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -35,7 +35,7 @@ TrVariantPtr createVariant()
     return { new tr_variant{},
              [](tr_variant* var)
              {
-                 tr_variantFree(var);
+                 tr_variantReset(var);
                  delete var;
              } };
 }

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -35,7 +35,7 @@ TrVariantPtr createVariant()
     return { new tr_variant{},
              [](tr_variant* var)
              {
-                 tr_variantReset(var);
+                 tr_variantClear(var);
                  delete var;
              } };
 }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -352,7 +352,7 @@ void Session::start()
         tr_variantInitDict(&settings, 0);
         tr_sessionLoadSettings(&settings, config_dir_.toUtf8().constData(), "qt");
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings);
-        tr_variantReset(&settings);
+        tr_variantClear(&settings);
 
         rpc_.start(session_);
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -352,7 +352,7 @@ void Session::start()
         tr_variantInitDict(&settings, 0);
         tr_sessionLoadSettings(&settings, config_dir_.toUtf8().constData(), "qt");
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings);
-        tr_variantFree(&settings);
+        tr_variantReset(&settings);
 
         rpc_.start(session_);
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -72,7 +72,7 @@ TEST_P(JSONTest, testElements)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("null"sv), &sv));
     EXPECT_EQ(""sv, sv);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_P(JSONTest, testUtf8)
@@ -86,14 +86,14 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     in = R"({ "key": "\u005C" })"sv;
     EXPECT_TRUE(tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, in));
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("\\"sv, sv);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     /**
      * 1. Feed it JSON-escaped nonascii to the JSON decoder.
@@ -109,7 +109,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     EXPECT_FALSE(std::empty(json));
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
@@ -118,7 +118,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_P(JSONTest, test1)
@@ -167,7 +167,7 @@ TEST_P(JSONTest, test1)
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 1), &i));
     EXPECT_EQ(10, i);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_P(JSONTest, test2)
@@ -196,7 +196,7 @@ TEST_P(JSONTest, test3)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, TR_KEY_errorString, &sv));
     EXPECT_EQ("torrent not registered with this tracker 6UHsVW'*C"sv, sv);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_P(JSONTest, unescape)
@@ -209,7 +209,7 @@ TEST_P(JSONTest, unescape)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("string-1"sv), &sv));
     EXPECT_EQ("/usr/lib"sv, sv);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 INSTANTIATE_TEST_SUITE_P( //

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -72,7 +72,7 @@ TEST_P(JSONTest, testElements)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("null"sv), &sv));
     EXPECT_EQ(""sv, sv);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, testUtf8)
@@ -86,14 +86,14 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     in = R"({ "key": "\u005C" })"sv;
     EXPECT_TRUE(tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, in));
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("\\"sv, sv);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     /**
      * 1. Feed it JSON-escaped nonascii to the JSON decoder.
@@ -109,7 +109,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     EXPECT_FALSE(std::empty(json));
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
@@ -118,7 +118,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_TRUE(tr_variantIsDict(&top));
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, test1)
@@ -167,7 +167,7 @@ TEST_P(JSONTest, test1)
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 1), &i));
     EXPECT_EQ(10, i);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, test2)
@@ -196,7 +196,7 @@ TEST_P(JSONTest, test3)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, TR_KEY_errorString, &sv));
     EXPECT_EQ("torrent not registered with this tracker 6UHsVW'*C"sv, sv);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, unescape)
@@ -209,7 +209,7 @@ TEST_P(JSONTest, unescape)
     EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("string-1"sv), &sv));
     EXPECT_EQ("/usr/lib"sv, sv);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 INSTANTIATE_TEST_SUITE_P( //

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,7 +35,7 @@ TEST_F(RpcTest, list)
     EXPECT_TRUE(tr_variantIsInt(&top));
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
@@ -44,13 +44,13 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(6, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 1), &i));
     EXPECT_EQ(7, i);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
     EXPECT_TRUE(tr_variantIsString(&top));
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
@@ -63,7 +63,7 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(4, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 3), &i));
     EXPECT_EQ(5, i);
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 /***
@@ -86,7 +86,7 @@ TEST_F(RpcTest, sessionGet)
     tr_variantDictAddStrView(&request, TR_KEY_method, "session-get");
     tr_variant response;
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
-    tr_variantFree(&request);
+    tr_variantReset(&request);
 
     EXPECT_TRUE(tr_variantIsDict(&response));
     tr_variant* args;
@@ -183,7 +183,7 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_EQ(decltype(unexpected_keys){}, unexpected_keys);
 
     // cleanup
-    tr_variantFree(&response);
+    tr_variantReset(&response);
     tr_torrentRemove(tor, false, nullptr);
 }
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,7 +35,7 @@ TEST_F(RpcTest, list)
     EXPECT_TRUE(tr_variantIsInt(&top));
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
@@ -44,13 +44,13 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(6, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 1), &i));
     EXPECT_EQ(7, i);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
     EXPECT_TRUE(tr_variantIsString(&top));
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
     EXPECT_TRUE(tr_variantIsList(&top));
@@ -63,7 +63,7 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(4, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 3), &i));
     EXPECT_EQ(5, i);
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 /***
@@ -86,7 +86,7 @@ TEST_F(RpcTest, sessionGet)
     tr_variantDictAddStrView(&request, TR_KEY_method, "session-get");
     tr_variant response;
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
-    tr_variantReset(&request);
+    tr_variantClear(&request);
 
     EXPECT_TRUE(tr_variantIsDict(&response));
     tr_variant* args;
@@ -183,7 +183,7 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_EQ(decltype(unexpected_keys){}, unexpected_keys);
 
     // cleanup
-    tr_variantReset(&response);
+    tr_variantClear(&response);
     tr_torrentRemove(tor, false, nullptr);
 }
 

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -473,7 +473,7 @@ protected:
             tr_variantInitDict(settings, 10);
             auto constexpr deleter = [](tr_variant* v)
             {
-                tr_variantFree(v);
+                tr_variantReset(v);
                 delete v;
             };
             settings_.reset(settings, deleter);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -473,7 +473,7 @@ protected:
             tr_variantInitDict(settings, 10);
             auto constexpr deleter = [](tr_variant* v)
             {
-                tr_variantReset(v);
+                tr_variantClear(v);
                 delete v;
             };
             settings_.reset(settings, deleter);

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -218,7 +218,7 @@ TEST_F(VariantTest, parse)
     EXPECT_TRUE(tr_variantGetInt(&val, &i));
     EXPECT_EQ(int64_t(64), i);
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 
     benc = "li64ei32ei16ee"sv;
     ok = tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end);
@@ -233,7 +233,7 @@ TEST_F(VariantTest, parse)
     EXPECT_EQ(16, i);
     EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantReset(&val);
+    tr_variantClear(&val);
     end = nullptr;
 
     benc = "lllee"sv;
@@ -245,7 +245,7 @@ TEST_F(VariantTest, parse)
     EXPECT_TRUE(tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end));
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
     EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 
     benc = "d20:"sv;
     end = nullptr;
@@ -285,7 +285,7 @@ TEST_F(VariantTest, bencParseAndReencode)
         {
             EXPECT_EQ(test.benc.data() + test.benc.size(), end);
             EXPECT_EQ(test.benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
-            tr_variantReset(&val);
+            tr_variantClear(&val);
         }
     }
 }
@@ -302,7 +302,7 @@ TEST_F(VariantTest, bencSortWhenSerializing)
     EXPECT_EQ(std::data(In) + std::size(In), end);
     EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 }
 
 TEST_F(VariantTest, bencMalformedTooManyEndings)
@@ -317,7 +317,7 @@ TEST_F(VariantTest, bencMalformedTooManyEndings)
     EXPECT_EQ(std::data(In) + std::size(ExpectedOut), end);
     EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantReset(&val);
+    tr_variantClear(&val);
 }
 
 TEST_F(VariantTest, bencMalformedNoEnding)
@@ -358,7 +358,7 @@ TEST_F(VariantTest, bencToJson)
 
         auto const str = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
         EXPECT_EQ(test.expected, stripWhitespace(str));
-        tr_variantReset(&top);
+        tr_variantClear(&top);
     }
 }
 
@@ -414,8 +414,8 @@ TEST_F(VariantTest, merge)
     EXPECT_TRUE(tr_variantDictFindStrView(&dest, s8, &sv));
     EXPECT_EQ("ghi"sv, sv);
 
-    tr_variantReset(&dest);
-    tr_variantReset(&src);
+    tr_variantClear(&dest);
+    tr_variantClear(&src);
 }
 
 TEST_F(VariantTest, stackSmash)
@@ -472,7 +472,7 @@ TEST_F(VariantTest, boolAndIntRecast)
     EXPECT_TRUE(tr_variantDictFindInt(&top, key4, &i));
     EXPECT_NE(0, i);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_F(VariantTest, dictFindType)
@@ -534,7 +534,7 @@ TEST_F(VariantTest, dictFindType)
     EXPECT_TRUE(tr_variantDictFindInt(&top, key_int, &i));
     EXPECT_EQ(ExpectedInt, i);
 
-    tr_variantReset(&top);
+    tr_variantClear(&top);
 }
 
 TEST_F(VariantTest, variantFromBufFuzz)
@@ -550,13 +550,13 @@ TEST_F(VariantTest, variantFromBufFuzz)
         if (auto top = tr_variant{};
             tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, buf, nullptr, nullptr))
         {
-            tr_variantReset(&top);
+            tr_variantClear(&top);
         }
 
         if (auto top = tr_variant{};
             tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, buf, nullptr, nullptr))
         {
-            tr_variantReset(&top);
+            tr_variantClear(&top);
         }
     }
 }

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -218,7 +218,7 @@ TEST_F(VariantTest, parse)
     EXPECT_TRUE(tr_variantGetInt(&val, &i));
     EXPECT_EQ(int64_t(64), i);
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 
     benc = "li64ei32ei16ee"sv;
     ok = tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end);
@@ -233,7 +233,7 @@ TEST_F(VariantTest, parse)
     EXPECT_EQ(16, i);
     EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantFree(&val);
+    tr_variantReset(&val);
     end = nullptr;
 
     benc = "lllee"sv;
@@ -245,7 +245,7 @@ TEST_F(VariantTest, parse)
     EXPECT_TRUE(tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, benc, &end));
     EXPECT_EQ(std::data(benc) + std::size(benc), end);
     EXPECT_EQ(benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 
     benc = "d20:"sv;
     end = nullptr;
@@ -285,7 +285,7 @@ TEST_F(VariantTest, bencParseAndReencode)
         {
             EXPECT_EQ(test.benc.data() + test.benc.size(), end);
             EXPECT_EQ(test.benc, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
-            tr_variantFree(&val);
+            tr_variantReset(&val);
         }
     }
 }
@@ -302,7 +302,7 @@ TEST_F(VariantTest, bencSortWhenSerializing)
     EXPECT_EQ(std::data(In) + std::size(In), end);
     EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 }
 
 TEST_F(VariantTest, bencMalformedTooManyEndings)
@@ -317,7 +317,7 @@ TEST_F(VariantTest, bencMalformedTooManyEndings)
     EXPECT_EQ(std::data(In) + std::size(ExpectedOut), end);
     EXPECT_EQ(ExpectedOut, tr_variantToStr(&val, TR_VARIANT_FMT_BENC));
 
-    tr_variantFree(&val);
+    tr_variantReset(&val);
 }
 
 TEST_F(VariantTest, bencMalformedNoEnding)
@@ -358,7 +358,7 @@ TEST_F(VariantTest, bencToJson)
 
         auto const str = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
         EXPECT_EQ(test.expected, stripWhitespace(str));
-        tr_variantFree(&top);
+        tr_variantReset(&top);
     }
 }
 
@@ -414,8 +414,8 @@ TEST_F(VariantTest, merge)
     EXPECT_TRUE(tr_variantDictFindStrView(&dest, s8, &sv));
     EXPECT_EQ("ghi"sv, sv);
 
-    tr_variantFree(&dest);
-    tr_variantFree(&src);
+    tr_variantReset(&dest);
+    tr_variantReset(&src);
 }
 
 TEST_F(VariantTest, stackSmash)
@@ -472,7 +472,7 @@ TEST_F(VariantTest, boolAndIntRecast)
     EXPECT_TRUE(tr_variantDictFindInt(&top, key4, &i));
     EXPECT_NE(0, i);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_F(VariantTest, dictFindType)
@@ -534,7 +534,7 @@ TEST_F(VariantTest, dictFindType)
     EXPECT_TRUE(tr_variantDictFindInt(&top, key_int, &i));
     EXPECT_EQ(ExpectedInt, i);
 
-    tr_variantFree(&top);
+    tr_variantReset(&top);
 }
 
 TEST_F(VariantTest, variantFromBufFuzz)
@@ -550,13 +550,13 @@ TEST_F(VariantTest, variantFromBufFuzz)
         if (auto top = tr_variant{};
             tr_variantFromBuf(&top, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, buf, nullptr, nullptr))
         {
-            tr_variantFree(&top);
+            tr_variantReset(&top);
         }
 
         if (auto top = tr_variant{};
             tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, buf, nullptr, nullptr))
         {
-            tr_variantFree(&top);
+            tr_variantReset(&top);
         }
     }
 }

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -210,7 +210,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
                         tierCount + 1,
                         TR_PRIsv_ARG(sv),
                         newstr.c_str());
-                    tr_variantReset(node);
+                    tr_variantClear(node);
                     tr_variantInitStr(node, newstr);
                     changed = true;
                 }
@@ -366,7 +366,7 @@ int tr_main(int argc, char* argv[])
             tr_variantToFile(&top, TR_VARIANT_FMT_BENC, filename);
         }
 
-        tr_variantReset(&top);
+        tr_variantClear(&top);
     }
 
     printf("Changed %d files\n", changedCount);

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -210,7 +210,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
                         tierCount + 1,
                         TR_PRIsv_ARG(sv),
                         newstr.c_str());
-                    tr_variantFree(node);
+                    tr_variantReset(node);
                     tr_variantInitStr(node, newstr);
                     changed = true;
                 }
@@ -366,7 +366,7 @@ int tr_main(int argc, char* argv[])
             tr_variantToFile(&top, TR_VARIANT_FMT_BENC, filename);
         }
 
-        tr_variantFree(&top);
+        tr_variantReset(&top);
     }
 
     printf("Changed %d files\n", changedCount);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2221,7 +2221,7 @@ static int processResponse(char const* rpcurl, std::string_view response)
                     }
                 }
 
-                tr_variantReset(&top);
+                tr_variantClear(&top);
             }
         }
         else
@@ -2354,7 +2354,7 @@ static int flush(char const* rpcurl, tr_variant* benc)
         tr_curl_easy_cleanup(curl);
     }
 
-    tr_variantReset(benc);
+    tr_variantClear(benc);
 
     return status;
 }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2112,8 +2112,8 @@ static void filterIds(tr_variant* top)
 }
 static int processResponse(char const* rpcurl, std::string_view response)
 {
-    tr_variant top;
-    int status = EXIT_SUCCESS;
+    auto top = tr_variant{};
+    auto status = int{ EXIT_SUCCESS };
 
     if (debug)
     {
@@ -2236,30 +2236,36 @@ static int processResponse(char const* rpcurl, std::string_view response)
 static CURL* tr_curl_easy_init(struct evbuffer* writebuf)
 {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, fmt::format(FMT_STRING("{:s}/{:s}"), MyName, LONG_VERSION_STRING).c_str());
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFunc);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, writebuf);
-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, parseResponseHeader);
-    curl_easy_setopt(curl, CURLOPT_POST, 1);
-    curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
-    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, debug);
-    curl_easy_setopt(curl, CURLOPT_ENCODING, ""); /* "" tells curl to fill in the blanks with what it was compiled to support */
+    (void)curl_easy_setopt(curl, CURLOPT_USERAGENT, fmt::format(FMT_STRING("{:s}/{:s}"), MyName, LONG_VERSION_STRING).c_str());
+    (void)curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFunc);
+    (void)curl_easy_setopt(curl, CURLOPT_WRITEDATA, writebuf);
+    (void)curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, parseResponseHeader);
+    (void)curl_easy_setopt(curl, CURLOPT_POST, 1);
+    (void)curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+    (void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+    (void)curl_easy_setopt(curl, CURLOPT_VERBOSE, debug);
+    (void)curl_easy_setopt(
+        curl,
+        CURLOPT_ENCODING,
+        ""); /* "" tells curl to fill in the blanks with what it was compiled to support */
 
     if (netrc != nullptr)
     {
-        curl_easy_setopt(curl, CURLOPT_NETRC_FILE, netrc);
+        (void)curl_easy_setopt(curl, CURLOPT_NETRC_FILE, netrc);
     }
 
     if (auth != nullptr)
     {
-        curl_easy_setopt(curl, CURLOPT_USERPWD, auth);
+        (void)curl_easy_setopt(curl, CURLOPT_USERPWD, auth);
     }
 
     if (UseSSL)
     {
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0); /* do not verify subject/hostname */
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0); /* since most certs will be self-signed, do not verify against CA */
+        (void)curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0); /* do not verify subject/hostname */
+        (void)curl_easy_setopt(
+            curl,
+            CURLOPT_SSL_VERIFYPEER,
+            0); /* since most certs will be self-signed, do not verify against CA */
     }
 
     if (!tr_str_is_empty(session_id))
@@ -2267,8 +2273,8 @@ static CURL* tr_curl_easy_init(struct evbuffer* writebuf)
         auto const h = fmt::format(FMT_STRING("{:s}: {:s}"), TR_RPC_SESSION_ID_HEADER, session_id);
         auto* const custom_headers = curl_slist_append(nullptr, h.c_str());
 
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, custom_headers);
-        curl_easy_setopt(curl, CURLOPT_PRIVATE, custom_headers);
+        (void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, custom_headers);
+        (void)curl_easy_setopt(curl, CURLOPT_PRIVATE, custom_headers);
     }
 
     return curl;
@@ -2287,17 +2293,17 @@ static void tr_curl_easy_cleanup(CURL* curl)
     }
 }
 
-static int flush(char const* rpcurl, tr_variant** benc)
+static int flush(char const* rpcurl, tr_variant* benc)
 {
     int status = EXIT_SUCCESS;
-    auto const json = tr_variantToStr(*benc, TR_VARIANT_FMT_JSON_LEAN);
+    auto const json = tr_variantToStr(benc, TR_VARIANT_FMT_JSON_LEAN);
     auto const rpcurl_http = fmt::format(FMT_STRING("{:s}://{:s}"), UseSSL ? "https" : "http", rpcurl);
 
     auto* const buf = evbuffer_new();
     auto* curl = tr_curl_easy_init(buf);
-    curl_easy_setopt(curl, CURLOPT_URL, rpcurl_http.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json.c_str());
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, getTimeoutSecs(json));
+    (void)curl_easy_setopt(curl, CURLOPT_URL, rpcurl_http.c_str());
+    (void)curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json.c_str());
+    (void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, getTimeoutSecs(json));
 
     if (debug)
     {
@@ -2330,7 +2336,6 @@ static int flush(char const* rpcurl, tr_variant** benc)
             tr_curl_easy_cleanup(curl);
             curl = nullptr;
             status |= flush(rpcurl, benc);
-            benc = nullptr;
             break;
 
         default:
@@ -2349,97 +2354,81 @@ static int flush(char const* rpcurl, tr_variant** benc)
         tr_curl_easy_cleanup(curl);
     }
 
-    if (benc != nullptr)
-    {
-        tr_variantReset(*benc);
-        tr_free(*benc);
-        *benc = nullptr;
-    }
+    tr_variantReset(benc);
 
     return status;
 }
 
-static tr_variant* ensure_sset(tr_variant** sset)
+static tr_variant* ensure_sset(tr_variant* sset)
 {
-    tr_variant* args;
-
-    if (*sset != nullptr)
+    if (!tr_variantIsEmpty(sset))
     {
-        args = tr_variantDictFind(*sset, Arguments);
-    }
-    else
-    {
-        *sset = tr_new0(tr_variant, 1);
-        tr_variantInitDict(*sset, 3);
-        tr_variantDictAddStrView(*sset, TR_KEY_method, "session-set"sv);
-        args = tr_variantDictAddDict(*sset, Arguments, 0);
+        return tr_variantDictFind(sset, Arguments);
     }
 
-    return args;
+    tr_variantInitDict(sset, 3);
+    tr_variantDictAddStrView(sset, TR_KEY_method, "session-set"sv);
+    return tr_variantDictAddDict(sset, Arguments, 0);
 }
 
-static tr_variant* ensure_tset(tr_variant** tset)
+static tr_variant* ensure_tset(tr_variant* tset)
 {
-    tr_variant* args;
-
-    if (*tset != nullptr)
+    if (!tr_variantIsEmpty(tset))
     {
-        args = tr_variantDictFind(*tset, Arguments);
-    }
-    else
-    {
-        *tset = tr_new0(tr_variant, 1);
-        tr_variantInitDict(*tset, 3);
-        tr_variantDictAddStrView(*tset, TR_KEY_method, "torrent-set"sv);
-        args = tr_variantDictAddDict(*tset, Arguments, 1);
+        return tr_variantDictFind(tset, Arguments);
     }
 
-    return args;
+    tr_variantInitDict(tset, 3);
+    tr_variantDictAddStrView(tset, TR_KEY_method, "torrent-set"sv);
+    return tr_variantDictAddDict(tset, Arguments, 1);
 }
 
 static char rename_from[4096];
 
 static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 {
-    int c;
     int status = EXIT_SUCCESS;
     char const* optarg;
-    tr_variant* sset = nullptr;
-    tr_variant* tset = nullptr;
-    tr_variant* tadd = nullptr;
+    auto sset = tr_variant{};
+    auto tset = tr_variant{};
+    auto tadd = tr_variant{};
 
     *id = '\0';
 
-    while ((c = tr_getopt(Usage, argc, argv, std::data(Options), &optarg)) != TR_OPT_DONE)
+    for (;;)
     {
-        int const stepMode = getOptMode(c);
+        int const c = tr_getopt(Usage, argc, argv, std::data(Options), &optarg);
+        if (c == TR_OPT_DONE)
+        {
+            break;
+        }
 
+        int const stepMode = getOptMode(c);
         if (stepMode == 0) /* meta commands */
         {
             switch (c)
             {
             case 'a': /* add torrent */
-                if (sset != nullptr)
+                if (!tr_variantIsEmpty(&sset))
                 {
                     status |= flush(rpcurl, &sset);
                 }
 
-                if (tadd != nullptr)
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     status |= flush(rpcurl, &tadd);
                 }
 
-                if (tset != nullptr)
+                if (!tr_variantIsEmpty(&tset))
                 {
-                    addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+                    addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
                     status |= flush(rpcurl, &tset);
                 }
 
-                tadd = tr_new0(tr_variant, 1);
-                tr_variantInitDict(tadd, 3);
-                tr_variantDictAddStrView(tadd, TR_KEY_method, "torrent-add"sv);
-                tr_variantDictAddInt(tadd, TR_KEY_tag, TAG_TORRENT_ADD);
-                tr_variantDictAddDict(tadd, Arguments, 0);
+                tr_variantInitDict(&tadd, 3);
+                tr_variantDictAddStrView(&tadd, TR_KEY_method, "torrent-add"sv);
+                tr_variantDictAddInt(&tadd, TR_KEY_tag, TAG_TORRENT_ADD);
+                tr_variantDictAddDict(&tadd, Arguments, 0);
                 break;
 
             case 'b': /* debug */
@@ -2472,14 +2461,14 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 break;
 
             case 't': /* set current torrent */
-                if (tadd != nullptr)
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     status |= flush(rpcurl, &tadd);
                 }
 
-                if (tset != nullptr)
+                if (!tr_variantIsEmpty(&tset))
                 {
-                    addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+                    addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
                     status |= flush(rpcurl, &tset);
                 }
 
@@ -2501,9 +2490,9 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 break;
 
             case TR_OPT_UNK:
-                if (tadd != nullptr)
+                if (!tr_variantIsEmpty(&tadd))
                 {
-                    tr_variant* args = tr_variantDictFind(tadd, Arguments);
+                    tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                     auto const tmp = getEncodedMetainfo(optarg);
 
                     if (!std::empty(tmp))
@@ -2526,17 +2515,17 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
         }
         else if (stepMode == MODE_TORRENT_GET)
         {
-            auto* top = tr_new0(tr_variant, 1);
+            auto top = tr_variant{};
             tr_variant* args;
             tr_variant* fields;
-            tr_variantInitDict(top, 3);
-            tr_variantDictAddStrView(top, TR_KEY_method, "torrent-get"sv);
-            args = tr_variantDictAddDict(top, Arguments, 0);
+            tr_variantInitDict(&top, 3);
+            tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-get"sv);
+            args = tr_variantDictAddDict(&top, Arguments, 0);
             fields = tr_variantDictAddList(args, TR_KEY_fields, 0);
 
-            if (tset != nullptr)
+            if (!tr_variantIsEmpty(&tset))
             {
-                addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+                addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
                 status |= flush(rpcurl, &tset);
             }
 
@@ -2544,7 +2533,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
             {
             case 'F':
                 filter = tr_strvDup(optarg); /* Unnecessary dup? we will use it before optarg will be changed */
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_FILTER);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_FILTER);
 
                 for (size_t i = 0; i < TR_N_ELEMENTS(details_keys); ++i)
                 {
@@ -2554,7 +2543,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 addIdArg(args, id, "all");
                 break;
             case 'i':
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_DETAILS);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_DETAILS);
 
                 for (size_t i = 0; i < TR_N_ELEMENTS(details_keys); ++i)
                 {
@@ -2565,7 +2554,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 break;
 
             case 'l':
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_LIST);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_LIST);
 
                 for (size_t i = 0; i < TR_N_ELEMENTS(list_keys); ++i)
                 {
@@ -2576,7 +2565,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 break;
 
             case 940:
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_FILES);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_FILES);
 
                 for (size_t i = 0; i < TR_N_ELEMENTS(files_keys); ++i)
                 {
@@ -2587,20 +2576,20 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
                 break;
 
             case 941:
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_PEERS);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_PEERS);
                 tr_variantListAddStrView(fields, "peers"sv);
                 addIdArg(args, id, nullptr);
                 break;
 
             case 942:
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_PIECES);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_PIECES);
                 tr_variantListAddStrView(fields, "pieces"sv);
                 tr_variantListAddStrView(fields, "pieceCount"sv);
                 addIdArg(args, id, nullptr);
                 break;
 
             case 943:
-                tr_variantDictAddInt(top, TR_KEY_tag, TAG_TRACKERS);
+                tr_variantDictAddInt(&top, TR_KEY_tag, TAG_TRACKERS);
                 tr_variantListAddStrView(fields, "trackerStats"sv);
                 addIdArg(args, id, nullptr);
                 break;
@@ -2906,9 +2895,9 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
         {
             tr_variant* args;
 
-            if (tadd != nullptr)
+            if (!tr_variantIsEmpty(&tadd))
             {
-                args = tr_variantDictFind(tadd, Arguments);
+                args = tr_variantDictFind(&tadd, Arguments);
             }
             else
             {
@@ -2979,17 +2968,17 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
         }
         else if (c == 961) /* set location */
         {
-            if (tadd != nullptr)
+            if (!tr_variantIsEmpty(&tadd))
             {
-                tr_variant* args = tr_variantDictFind(tadd, Arguments);
+                tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                 tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
             }
             else
             {
-                auto* top = tr_new0(tr_variant, 1);
-                tr_variantInitDict(top, 2);
-                tr_variantDictAddStrView(top, TR_KEY_method, "torrent-set-location"sv);
-                tr_variant* args = tr_variantDictAddDict(top, Arguments, 3);
+                auto top = tr_variant{};
+                tr_variantInitDict(&top, 2);
+                tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set-location"sv);
+                tr_variant* args = tr_variantDictAddDict(&top, Arguments, 3);
                 tr_variantDictAddStr(args, TR_KEY_location, optarg);
                 tr_variantDictAddBool(args, TR_KEY_move, false);
                 addIdArg(args, id, nullptr);
@@ -3003,40 +2992,40 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
             {
             case 920: /* session-info */
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "session-get"sv);
-                    tr_variantDictAddInt(top, TR_KEY_tag, TAG_SESSION);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "session-get"sv);
+                    tr_variantDictAddInt(&top, TR_KEY_tag, TAG_SESSION);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 's': /* start */
-                if (tadd != nullptr)
+                if (!tr_variantIsEmpty(&tadd))
                 {
-                    tr_variantDictAddBool(tr_variantDictFind(tadd, TR_KEY_arguments), TR_KEY_paused, false);
+                    tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, false);
                 }
                 else
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-start"sv);
-                    addIdArg(tr_variantDictAddDict(top, Arguments, 1), id, nullptr);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-start"sv);
+                    addIdArg(tr_variantDictAddDict(&top, Arguments, 1), id, nullptr);
                     status |= flush(rpcurl, &top);
                 }
                 break;
 
             case 'S': /* stop */
-                if (tadd != nullptr)
+                if (!tr_variantIsEmpty(&tadd))
                 {
-                    tr_variantDictAddBool(tr_variantDictFind(tadd, TR_KEY_arguments), TR_KEY_paused, true);
+                    tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, true);
                 }
                 else
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-stop"sv);
-                    addIdArg(tr_variantDictAddDict(top, Arguments, 1), id, nullptr);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-stop"sv);
+                    addIdArg(tr_variantDictAddDict(&top, Arguments, 1), id, nullptr);
                     status |= flush(rpcurl, &top);
                 }
 
@@ -3044,77 +3033,77 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             case 'w':
                 {
-                    tr_variant* args = tadd != nullptr ? tr_variantDictFind(tadd, TR_KEY_arguments) : ensure_sset(&sset);
+                    auto* args = !tr_variantIsEmpty(&tadd) ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(&sset);
                     tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
                     break;
                 }
 
             case 850:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 1);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "session-close"sv);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 1);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "session-close"sv);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 963:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 1);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "blocklist-update"sv);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 1);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "blocklist-update"sv);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 921:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "session-stats"sv);
-                    tr_variantDictAddInt(top, TR_KEY_tag, TAG_STATS);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "session-stats"sv);
+                    tr_variantDictAddInt(&top, TR_KEY_tag, TAG_STATS);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 962:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "port-test"sv);
-                    tr_variantDictAddInt(top, TR_KEY_tag, TAG_PORTTEST);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "port-test"sv);
+                    tr_variantDictAddInt(&top, TR_KEY_tag, TAG_PORTTEST);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 600:
                 {
-                    if (tset != nullptr)
+                    if (!tr_variantIsEmpty(&tset))
                     {
-                        addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+                        addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
                         status |= flush(rpcurl, &tset);
                     }
 
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-reannounce"sv);
-                    addIdArg(tr_variantDictAddDict(top, Arguments, 1), id, nullptr);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-reannounce"sv);
+                    addIdArg(tr_variantDictAddDict(&top, Arguments, 1), id, nullptr);
                     status |= flush(rpcurl, &top);
                     break;
                 }
 
             case 'v':
                 {
-                    if (tset != nullptr)
+                    if (!tr_variantIsEmpty(&tset))
                     {
-                        addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+                        addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
                         status |= flush(rpcurl, &tset);
                     }
 
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-verify"sv);
-                    addIdArg(tr_variantDictAddDict(top, Arguments, 1), id, nullptr);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-verify"sv);
+                    addIdArg(tr_variantDictAddDict(&top, Arguments, 1), id, nullptr);
                     status |= flush(rpcurl, &top);
                     break;
                 }
@@ -3122,10 +3111,10 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
             case 'r':
             case 840:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-remove"sv);
-                    auto* args = tr_variantDictAddDict(top, Arguments, 2);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-remove"sv);
+                    auto* args = tr_variantDictAddDict(&top, Arguments, 2);
                     tr_variantDictAddBool(args, TR_KEY_delete_local_data, c == 840);
                     addIdArg(args, id, nullptr);
                     status |= flush(rpcurl, &top);
@@ -3134,10 +3123,10 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             case 960:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "torrent-set-location"sv);
-                    auto* args = tr_variantDictAddDict(top, Arguments, 3);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set-location"sv);
+                    auto* args = tr_variantDictAddDict(&top, Arguments, 3);
                     tr_variantDictAddStr(args, TR_KEY_location, optarg);
                     tr_variantDictAddBool(args, TR_KEY_move, true);
                     addIdArg(args, id, nullptr);
@@ -3147,10 +3136,10 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             case 964:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStr(top, TR_KEY_method, "rename");
-                    auto* args = tr_variantDictAddDict(top, Arguments, 3);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStr(&top, TR_KEY_method, "rename");
+                    auto* args = tr_variantDictAddDict(&top, Arguments, 3);
                     tr_variantDictAddStr(args, TR_KEY_path, rename_from);
                     tr_variantDictAddStr(args, TR_KEY_name, optarg);
                     addIdArg(args, id, NULL);
@@ -3166,10 +3155,10 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
 
             case 732:
                 {
-                    auto* top = tr_new0(tr_variant, 1);
-                    tr_variantInitDict(top, 2);
-                    tr_variantDictAddStrView(top, TR_KEY_method, "group-get"sv);
-                    tr_variantDictAddInt(top, TR_KEY_tag, TAG_GROUPS);
+                    auto top = tr_variant{};
+                    tr_variantInitDict(&top, 2);
+                    tr_variantDictAddStrView(&top, TR_KEY_method, "group-get"sv);
+                    tr_variantDictAddInt(&top, TR_KEY_tag, TAG_GROUPS);
                     status |= flush(rpcurl, &top);
                     break;
                 }
@@ -3182,18 +3171,18 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv)
         }
     }
 
-    if (tadd != nullptr)
+    if (!tr_variantIsEmpty(&tadd))
     {
         status |= flush(rpcurl, &tadd);
     }
 
-    if (tset != nullptr)
+    if (!tr_variantIsEmpty(&tset))
     {
-        addIdArg(tr_variantDictFind(tset, Arguments), id, nullptr);
+        addIdArg(tr_variantDictFind(&tset, Arguments), id, nullptr);
         status |= flush(rpcurl, &tset);
     }
 
-    if (sset != nullptr)
+    if (!tr_variantIsEmpty(&sset))
     {
         status |= flush(rpcurl, &sset);
     }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2221,7 +2221,7 @@ static int processResponse(char const* rpcurl, std::string_view response)
                     }
                 }
 
-                tr_variantFree(&top);
+                tr_variantReset(&top);
             }
         }
         else
@@ -2351,7 +2351,7 @@ static int flush(char const* rpcurl, tr_variant** benc)
 
     if (benc != nullptr)
     {
-        tr_variantFree(*benc);
+        tr_variantReset(*benc);
         tr_free(*benc);
         *benc = nullptr;
     }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -403,7 +403,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
             }
         }
 
-        tr_variantFree(&top);
+        tr_variantReset(&top);
 
         if (!matched)
         {

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -403,7 +403,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
             }
         }
 
-        tr_variantReset(&top);
+        tr_variantClear(&top);
 
         if (!matched)
         {


### PR DESCRIPTION
- Allocate variants on the stack instead of the heap. Since we block the thread waiting on curl, they'll stay in scope even on the stack. This eliminates a big pile of `tr_new0()` calls.

- remove now-unused `tr_new0` macro, just as predicted by @nevack 

- MInor API change to variant: rename `tr_variantFree()` to `tr_variantClear()` for clarity: the function clears the variant out and resets it to an unused state, freeing the variant's values _but not_ the variant itself. This is a minor naming change but since it's used in so many places this is a big part of the diff :dizzy_face: 