### PR TITLE
refactor: remove tr_utf8_validate() from public API

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -320,7 +320,12 @@ void tr_removeElementFromArray(void* array, size_t index_to_remove, size_t sizeo
 ****
 ***/
 
-bool tr_utf8_validate(std::string_view sv, char const** good_end)
+namespace
+{
+namespace tr_strvUtf8Clean_impl
+{
+
+bool validateUtf8(std::string_view sv, char const** good_end)
 {
     auto const* begin = std::data(sv);
     auto const* const end = begin + std::size(sv);
@@ -349,10 +354,6 @@ bool tr_utf8_validate(std::string_view sv, char const** good_end)
     return all_good;
 }
 
-namespace
-{
-namespace tr_strvUtf8Clean_impl
-{
 std::string strip_non_utf8(std::string_view sv)
 {
     auto out = std::string{};
@@ -404,7 +405,7 @@ std::string tr_strvUtf8Clean(std::string_view cleanme)
 {
     using namespace tr_strvUtf8Clean_impl;
 
-    if (tr_utf8_validate(cleanme, nullptr))
+    if (validateUtf8(cleanme, nullptr))
     {
         return std::string{ cleanme };
     }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -94,8 +94,6 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
 [[nodiscard]] std::optional<T> tr_parseNum(std::string_view& sv);
 
-bool tr_utf8_validate(std::string_view sv, char const** good_end);
-
 #ifdef _WIN32
 
 std::string tr_win32_format_message(uint32_t code);

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -127,13 +127,13 @@ TEST_F(UtilsTest, trStrvUtf8Clean)
     in = "\x92\xE0\xE3\xA4\xAD\xAE \xA1\xEB\xE2\xEC \x81\xAE\xA3\xAE\xAC"sv;
     out = tr_strvUtf8Clean(in);
     EXPECT_TRUE(std::size(out) == 17 || std::size(out) == 33);
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
+    EXPECT_EQ(out, tr_strvUtf8Clean(out));
 
     // same string, but utf-8 clean
     in = "Трудно быть Богом"sv;
     out = tr_strvUtf8Clean(in);
     EXPECT_NE(0U, std::size(out));
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
+    EXPECT_EQ(out, tr_strvUtf8Clean(out));
     EXPECT_EQ(in, out);
 
     // https://trac.transmissionbt.com/ticket/6064
@@ -142,13 +142,13 @@ TEST_F(UtilsTest, trStrvUtf8Clean)
     in = "\xF4\x00\x81\x82"sv;
     out = tr_strvUtf8Clean(in);
     EXPECT_NE(0U, std::size(out));
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
+    EXPECT_EQ(out, tr_strvUtf8Clean(out));
 
     in = "\xF4\x33\x81\x82"sv;
     out = tr_strvUtf8Clean(in);
     EXPECT_NE(nullptr, out.data());
     EXPECT_TRUE(out.size() == 4 || out.size() == 7);
-    EXPECT_TRUE(tr_utf8_validate(out, nullptr));
+    EXPECT_EQ(out, tr_strvUtf8Clean(out));
 }
 
 TEST_F(UtilsTest, trStrvUtf8CleanFuzz)
@@ -159,7 +159,7 @@ TEST_F(UtilsTest, trStrvUtf8CleanFuzz)
         buf.resize(tr_rand_int(4096));
         tr_rand_buffer(std::data(buf), std::size(buf));
         auto const out = tr_strvUtf8Clean({ std::data(buf), std::size(buf) });
-        EXPECT_TRUE(tr_utf8_validate(out, nullptr));
+        EXPECT_EQ(out, tr_strvUtf8Clean(out));
     }
 }
 


### PR DESCRIPTION
it was only used as an impl helper, so make it private.