### PR TITLE
refactor: use OutputIterator for url-escaped info hash strings

### DIFF
--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -172,29 +172,6 @@ char const* tr_webGetResponseStr(long code)
     }
 }
 
-static bool is_rfc2396_alnum(uint8_t ch)
-{
-    return ('0' <= ch && ch <= '9') || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ch == '.' || ch == '-' ||
-        ch == '_' || ch == '~';
-}
-
-void tr_http_escape_sha1(char* out, tr_sha1_digest_t const& digest)
-{
-    for (auto const b : digest)
-    {
-        if (is_rfc2396_alnum(uint8_t(b)))
-        {
-            *out++ = (char)b;
-        }
-        else
-        {
-            out = fmt::format_to(out, FMT_STRING("%{:02x}"), unsigned(b));
-        }
-    }
-
-    *out = '\0';
-}
-
 //// URLs
 
 namespace

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -111,7 +111,11 @@ void tr_http_escape(OutputIt out, std::string_view in, bool escape_reserved)
     }
 }
 
-void tr_http_escape_sha1(char* out, tr_sha1_digest_t const& digest);
+template<typename OutputIt>
+void tr_http_escape(OutputIt out, tr_sha1_digest_t const& digest)
+{
+    tr_http_escape(out, std::string_view{ reinterpret_cast<char const*>(digest.data()), std::size(digest) }, false);
+}
 
 char const* tr_webGetResponseStr(long response_code);
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -8,6 +8,7 @@
 #include <cinttypes> // PRIu64
 #include <cstdio>
 #include <ctime>
+#include <iterator>
 #include <string>
 #include <string_view>
 
@@ -339,14 +340,9 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         }
 
         // build the full scrape URL
-        auto escaped = std::array<char, TR_SHA1_DIGEST_LEN * 3 + 1>{};
-        tr_http_escape_sha1(std::data(escaped), metainfo.infoHash());
         auto const scrape = tracker.scrape.sv();
-        auto const url = tr_urlbuf{ scrape,
-                                    tr_strvContains(scrape, '?') ? '&' : '?',
-                                    "info_hash="sv,
-                                    std::string_view{ std::data(escaped) } };
-
+        auto url = tr_urlbuf{ scrape, tr_strvContains(scrape, '?') ? '&' : '?', "info_hash="sv };
+        tr_http_escape(std::back_inserter(url), metainfo.infoHash());
         printf("%" TR_PRIsv " ... ", TR_PRIsv_ARG(url));
         fflush(stdout);
 


### PR DESCRIPTION
We previously had two separate implementations for URL escaping, but only one is needed.