### PR TITLE
refactor: remove unused

### DIFF
--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -44,9 +44,6 @@ struct tr_sys_dir_win32
 static auto constexpr NativeLocalPathPrefix = L"\\\\?\\"sv;
 static auto constexpr NativeUncPathPrefix = L"\\\\?\\UNC\\"sv;
 
-static wchar_t const native_local_path_prefix[] = { '\\', '\\', '?', '\\' };
-static wchar_t const native_unc_path_prefix[] = { '\\', '\\', '?', '\\', 'U', 'N', 'C', '\\' };
-
 static void set_system_error(tr_error** error, DWORD code)
 {
     if (error == nullptr)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -71,6 +71,7 @@ std::recursive_mutex tr_session::session_mutex_;
 
 static auto constexpr DefaultBindAddressIpv4 = "0.0.0.0"sv;
 static auto constexpr DefaultBindAddressIpv6 = "::"sv;
+static auto constexpr DefaultRpcHostWhitelist = ""sv;
 #ifdef TR_LIGHTWEIGHT
 static auto constexpr DefaultCacheSizeMB = int{ 2 };
 static auto constexpr DefaultPrefetchEnabled = bool{ false };
@@ -345,7 +346,7 @@ void tr_sessionGetDefaultSettings(tr_variant* setme_dictionary)
     tr_variantDictAddStrView(d, TR_KEY_rpc_username, "");
     tr_variantDictAddStrView(d, TR_KEY_rpc_whitelist, TR_DEFAULT_RPC_WHITELIST);
     tr_variantDictAddBool(d, TR_KEY_rpc_whitelist_enabled, true);
-    tr_variantDictAddStrView(d, TR_KEY_rpc_host_whitelist, TR_DEFAULT_RPC_HOST_WHITELIST);
+    tr_variantDictAddStrView(d, TR_KEY_rpc_host_whitelist, DefaultRpcHostWhitelist);
     tr_variantDictAddBool(d, TR_KEY_rpc_host_whitelist_enabled, true);
     tr_variantDictAddInt(d, TR_KEY_rpc_port, TR_DEFAULT_RPC_PORT);
     tr_variantDictAddStrView(d, TR_KEY_rpc_url, TR_DEFAULT_RPC_URL_STR);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -69,6 +69,8 @@ using namespace std::literals;
 
 std::recursive_mutex tr_session::session_mutex_;
 
+static auto constexpr DefaultBindAddressIpv4 = "0.0.0.0"sv;
+static auto constexpr DefaultBindAddressIpv6 = "::"sv;
 #ifdef TR_LIGHTWEIGHT
 static auto constexpr DefaultCacheSizeMB = int{ 2 };
 static auto constexpr DefaultPrefetchEnabled = bool{ false };
@@ -273,10 +275,10 @@ tr_session::PublicAddressResult tr_session::publicAddress(tr_address_type type) 
     switch (type)
     {
     case TR_AF_INET:
-        return { bind_ipv4.addr_, bind_ipv4.addr_.readable() == TR_DEFAULT_BIND_ADDRESS_IPV4 };
+        return { bind_ipv4.addr_, bind_ipv4.addr_.readable() == DefaultBindAddressIpv4 };
 
     case TR_AF_INET6:
-        return { bind_ipv6.addr_, bind_ipv6.addr_.readable() == TR_DEFAULT_BIND_ADDRESS_IPV6 };
+        return { bind_ipv6.addr_, bind_ipv6.addr_.readable() == DefaultBindAddressIpv6 };
 
     default:
         TR_ASSERT_MSG(false, "invalid type");
@@ -368,8 +370,8 @@ void tr_sessionGetDefaultSettings(tr_variant* setme_dictionary)
     tr_variantDictAddBool(d, TR_KEY_speed_limit_up_enabled, false);
     tr_variantDictAddStr(d, TR_KEY_umask, fmt::format("{:03o}", DefaultUmask));
     tr_variantDictAddInt(d, TR_KEY_upload_slots_per_torrent, 8);
-    tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv4, TR_DEFAULT_BIND_ADDRESS_IPV4);
-    tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv6, TR_DEFAULT_BIND_ADDRESS_IPV6);
+    tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv4, DefaultBindAddressIpv4);
+    tr_variantDictAddStrView(d, TR_KEY_bind_address_ipv6, DefaultBindAddressIpv6);
     tr_variantDictAddBool(d, TR_KEY_start_added_torrents, true);
     tr_variantDictAddBool(d, TR_KEY_trash_original_torrent_files, false);
     tr_variantDictAddInt(d, TR_KEY_anti_brute_force_threshold, 100);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -429,7 +429,7 @@ void tr_sessionGetSettings(tr_session const* s, tr_variant* setme_dictionary)
     tr_variantDictAddStr(d, TR_KEY_rpc_password, tr_sessionGetRPCPassword(s));
     tr_variantDictAddInt(d, TR_KEY_rpc_port, tr_sessionGetRPCPort(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_socket_mode, fmt::format("{:#o}", s->rpc_server_->socket_mode_));
-    tr_variantDictAddStr(d, TR_KEY_rpc_url, tr_sessionGetRPCUrl(s));
+    tr_variantDictAddStr(d, TR_KEY_rpc_url, s->rpc_server_->url());
     tr_variantDictAddStr(d, TR_KEY_rpc_username, tr_sessionGetRPCUsername(s));
     tr_variantDictAddStr(d, TR_KEY_rpc_whitelist, tr_sessionGetRPCWhitelist(s));
     tr_variantDictAddBool(d, TR_KEY_rpc_whitelist_enabled, tr_sessionGetRPCWhitelistEnabled(s));
@@ -2406,20 +2406,6 @@ uint16_t tr_sessionGetRPCPort(tr_session const* session)
     TR_ASSERT(session != nullptr);
 
     return session->rpc_server_ ? session->rpc_server_->port().host() : uint16_t{};
-}
-
-void tr_sessionSetRPCUrl(tr_session* session, char const* url)
-{
-    TR_ASSERT(session != nullptr);
-
-    session->rpc_server_->setUrl(url != nullptr ? url : "");
-}
-
-char const* tr_sessionGetRPCUrl(tr_session const* session)
-{
-    TR_ASSERT(session != nullptr);
-
-    return session->rpc_server_->url().c_str();
 }
 
 void tr_sessionSetRPCCallback(tr_session* session, tr_rpc_func func, void* user_data)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -710,7 +710,6 @@ private:
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
     friend char const* tr_sessionGetRPCPassword(tr_session const* session);
-    friend char const* tr_sessionGetRPCUrl(tr_session const* session);
     friend char const* tr_sessionGetRPCUsername(tr_session const* session);
     friend char const* tr_sessionGetRPCWhitelist(tr_session const* session);
     friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
@@ -747,7 +746,6 @@ private:
     friend void tr_sessionSetRPCPassword(tr_session* session, char const* password);
     friend void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetRPCPort(tr_session* session, uint16_t hport);
-    friend void tr_sessionSetRPCUrl(tr_session* session, char const* url);
     friend void tr_sessionSetRPCUsername(tr_session* session, char const* username);
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -59,7 +59,6 @@
 ***/
 
 #define TR_PATH_DELIMITER '/'
-#define TR_PATH_DELIMITER_STR "/"
 
 /* Only use this macro to suppress false-positive alignment warnings */
 #define TR_DISCARD_ALIGN(ptr, type) ((type)(void*)(ptr))

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -130,7 +130,6 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
-#define TR_DEFAULT_RPC_HOST_WHITELIST ""
 #define TR_DEFAULT_RPC_PORT_STR "9091"
 #define TR_DEFAULT_RPC_PORT 9091
 #define TR_DEFAULT_RPC_URL_STR "/transmission/"

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -129,8 +129,6 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 /** @brief buffer variant of tr_getDefaultDownloadDir(). See tr_strvToBuf(). */
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
-#define TR_DEFAULT_BIND_ADDRESS_IPV4 "0.0.0.0"
-#define TR_DEFAULT_BIND_ADDRESS_IPV6 "::"
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
 #define TR_DEFAULT_RPC_HOST_WHITELIST ""
 #define TR_DEFAULT_RPC_PORT_STR "9091"

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -345,23 +345,6 @@ void tr_sessionSetRPCPort(tr_session* session, uint16_t port);
 uint16_t tr_sessionGetRPCPort(tr_session const* session);
 
 /**
- * @brief Specify which base URL to use.
- *
- * @param session the session to set
- * @param url     the base url to use. The RPC API is accessible under <url>/rpc, the web interface under * <url>/web.
- *
- *  @see tr_sessionGetRPCUrl
- */
-void tr_sessionSetRPCUrl(tr_session* session, char const* url);
-
-/**
- * @brief Get the base URL.
- * @see tr_sessionInit()
- * @see tr_sessionSetRPCUrl
- */
-char const* tr_sessionGetRPCUrl(tr_session const* session);
-
-/**
  * @brief Specify a whitelist for remote RPC access
  *
  * The whitelist is a comma-separated list of dotted-quad IP addresses

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -132,17 +132,6 @@ TEST_F(SessionTest, propertiesApi)
     EXPECT_EQ(""sv, session->blocklistUrl());
     EXPECT_EQ(""sv, tr_blocklistGetURL(session));
 
-    // rpc url
-
-    for (auto const& value : { "http://www.example.com/"sv, "http://www.example.org/transmission"sv, ""sv })
-    {
-        tr_sessionSetRPCUrl(session, std::string{ value }.c_str());
-        EXPECT_EQ(value, tr_sessionGetRPCUrl(session));
-    }
-
-    tr_sessionSetRPCUrl(session, nullptr);
-    EXPECT_EQ(""sv, tr_sessionGetRPCUrl(session));
-
     // rpc username
 
     for (auto const& value : { "foo"sv, "bar"sv, ""sv })


### PR DESCRIPTION
remove some unused code:

- remove tr_sessionSetRPCUrl()
- remove tr_sessionGetRPCUrl()
- remove TR_PATH_DELIMITER_STR
- remove native_local_path_prefix
- remove native_unc_path_prefix

and reduce the scope of some keys:

- make TR_DEFAULT_BIND_ADDRESS_IPV4 private
- make TR_DEFAULT_BIND_ADDRESS_IPV6 private
- make TR_DEFAULT_RPC_HOST_WHITELIST private