### PR TITLE
refactor: replace tr_http_escape() with tr_urlEscape()

### DIFF
--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -176,19 +176,19 @@ tr_urlbuf tr_magnet_metainfo::magnet() const
     if (!std::empty(name_))
     {
         s += "&dn="sv;
-        tr_http_escape(std::back_inserter(s), name_, true);
+        tr_urlEscape(std::back_inserter(s), name_);
     }
 
     for (auto const& tracker : this->announceList())
     {
         s += "&tr="sv;
-        tr_http_escape(std::back_inserter(s), tracker.announce.sv(), true);
+        tr_urlEscape(std::back_inserter(s), tracker.announce.sv());
     }
 
     for (auto const& webseed : webseed_urls_)
     {
         s += "&ws="sv;
-        tr_http_escape(std::back_inserter(s), webseed, true);
+        tr_urlEscape(std::back_inserter(s), webseed);
     }
 
     return s;

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -172,29 +172,6 @@ char const* tr_webGetResponseStr(long code)
     }
 }
 
-static bool is_rfc2396_alnum(uint8_t ch)
-{
-    return ('0' <= ch && ch <= '9') || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ch == '.' || ch == '-' ||
-        ch == '_' || ch == '~';
-}
-
-void tr_http_escape_sha1(char* out, tr_sha1_digest_t const& digest)
-{
-    for (auto const b : digest)
-    {
-        if (is_rfc2396_alnum(uint8_t(b)))
-        {
-            *out++ = (char)b;
-        }
-        else
-        {
-            out = fmt::format_to(out, FMT_STRING("%{:02x}"), unsigned(b));
-        }
-    }
-
-    *out = '\0';
-}
-
 //// URLs
 
 namespace

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -92,7 +92,7 @@ struct tr_url_query_view
 };
 
 template<typename OutputIt>
-void tr_http_escape(OutputIt out, std::string_view in, bool escape_reserved)
+void tr_urlEscape(OutputIt out, std::string_view in, bool escape_reserved = true)
 {
     auto constexpr ReservedChars = std::string_view{ "!*'();:@&=+$,/?%#[]" };
     auto constexpr UnescapedChars = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~" };
@@ -111,7 +111,11 @@ void tr_http_escape(OutputIt out, std::string_view in, bool escape_reserved)
     }
 }
 
-void tr_http_escape_sha1(char* out, tr_sha1_digest_t const& digest);
+template<typename OutputIt>
+void tr_urlEscape(OutputIt out, tr_sha1_digest_t const& digest)
+{
+    tr_urlEscape(out, std::string_view{ reinterpret_cast<char const*>(digest.data()), std::size(digest) });
+}
 
 char const* tr_webGetResponseStr(long response_code);
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -521,7 +521,7 @@ void makeUrl(tr_webseed* w, std::string_view name, OutputIt out)
 
     if (tr_strvEndsWith(url, "/"sv) && !std::empty(name))
     {
-        tr_http_escape(out, name, false);
+        tr_urlEscape(out, name, false);
     }
 }
 


### PR DESCRIPTION
Taking a second run at this; yesterday's PR had a regression in it.

This PR removes redundant code for escaping characters in a URI