### PR TITLE
fix: 3579 assertion when RPC client asks for torrent-id 0

### DIFF
--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -44,7 +44,6 @@ struct CompareTorrentByHash
 
 tr_torrent* tr_torrents::get(tr_torrent_id_t id)
 {
-    TR_ASSERT(0 < id);
     TR_ASSERT(static_cast<size_t>(id) < std::size(by_id_));
     if (static_cast<size_t>(id) >= std::size(by_id_))
     {


### PR DESCRIPTION
Fixes #3579.