### PR TITLE
perf: sonarcloud warnings about temp objects

### DIFF
--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -125,7 +125,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha1_digest_t final() override
+    [[nodiscard]] tr_sha1_digest_t finish() override
     {
         auto digest = tr_sha1_digest_t{};
         CC_SHA1_Final(reinterpret_cast<unsigned char*>(std::data(digest)), &handle_);
@@ -160,7 +160,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha256_digest_t final() override
+    [[nodiscard]] tr_sha256_digest_t finish() override
     {
         auto digest = tr_sha256_digest_t{};
         CC_SHA256_Final(reinterpret_cast<unsigned char*>(std::data(digest)), &handle_);

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -141,7 +141,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha1_digest_t final() override
+    [[nodiscard]] tr_sha1_digest_t finish() override
     {
         auto digest = tr_sha1_digest_t{};
         API(ShaFinal)(&handle_, reinterpret_cast<byte*>(std::data(digest)));
@@ -176,7 +176,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha256_digest_t final() override
+    [[nodiscard]] tr_sha256_digest_t finish() override
     {
         auto digest = tr_sha256_digest_t{};
         API(Sha256Final)(&handle_, reinterpret_cast<byte*>(std::data(digest)));

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -165,7 +165,7 @@ public:
         helper_.update(data, data_length);
     }
 
-    [[nodiscard]] tr_sha1_digest_t final() override
+    [[nodiscard]] tr_sha1_digest_t finish() override
     {
         return helper_.digest<tr_sha1_digest_t>();
     }
@@ -194,7 +194,7 @@ public:
         helper_.update(data, data_length);
     }
 
-    [[nodiscard]] tr_sha256_digest_t final() override
+    [[nodiscard]] tr_sha256_digest_t finish() override
     {
         return helper_.digest<tr_sha256_digest_t>();
     }

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -170,7 +170,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha1_digest_t final() override
+    [[nodiscard]] tr_sha1_digest_t finish() override
     {
         auto digest = tr_sha1_digest_t{};
         auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));
@@ -226,7 +226,7 @@ public:
         }
     }
 
-    [[nodiscard]] tr_sha256_digest_t final() override
+    [[nodiscard]] tr_sha256_digest_t finish() override
     {
         auto digest = tr_sha256_digest_t{};
         auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -29,14 +29,14 @@ public:
 
     virtual void clear() = 0;
     virtual void add(void const* data, size_t data_length) = 0;
-    [[nodiscard]] virtual tr_sha1_digest_t final() = 0;
+    [[nodiscard]] virtual tr_sha1_digest_t finish() = 0;
 
     template<typename... T>
     [[nodiscard]] static tr_sha1_digest_t digest(T... args)
     {
         auto context = tr_sha1::create();
         (context->add(std::data(args), std::size(args)), ...);
-        return context->final();
+        return context->finish();
     }
 };
 
@@ -48,14 +48,14 @@ public:
 
     virtual void clear() = 0;
     virtual void add(void const* data, size_t data_length) = 0;
-    [[nodiscard]] virtual tr_sha256_digest_t final() = 0;
+    [[nodiscard]] virtual tr_sha256_digest_t finish() = 0;
 
     template<typename... T>
     [[nodiscard]] static tr_sha256_digest_t digest(T... args)
     {
         auto context = tr_sha256::create();
         (context->add(std::data(args), std::size(args)), ...);
-        return context->final();
+        return context->finish();
     }
 };
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -251,7 +251,7 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
         bytes_left -= len;
     }
 
-    return sha->final();
+    return sha->finish();
 }
 
 } // namespace

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -247,7 +247,7 @@ bool tr_metainfo_builder::blockingMakeChecksums(tr_error** error)
         TR_ASSERT(bufptr - std::data(buf) == (int)piece_size);
         TR_ASSERT(left_in_piece == 0);
         sha->add(std::data(buf), std::size(buf));
-        auto const digest = sha->final();
+        auto const digest = sha->finish();
         walk = std::copy(std::begin(digest), std::end(digest), walk);
         sha->clear();
 

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -464,7 +464,7 @@ tr_quark tr_quark_new(std::string_view str)
     }
 
     auto const ret = TR_N_KEYS + std::size(my_runtime);
-    my_runtime.emplace_back(std::string{ str });
+    my_runtime.emplace_back(str);
     return ret;
 }
 

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -86,7 +86,7 @@ bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_err
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, char const* filename, tr_error** error)
 {
-    return tr_ctorSetMetainfoFromFile(ctor, std::string{ filename != nullptr ? filename : "" }, error);
+    return tr_ctorSetMetainfoFromFile(ctor, std::string_view{ filename != nullptr ? filename : "" }, error);
 }
 
 bool tr_ctorSetMetainfo(tr_ctor* ctor, char const* metainfo, size_t len, tr_error** error)

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -93,7 +93,7 @@ static bool verifyTorrent(tr_torrent* tor, bool const* stopFlag)
         /* if we're finishing a piece... */
         if (left_in_piece == 0)
         {
-            auto const has_piece = sha->final() == tor->pieceHash(piece);
+            auto const has_piece = sha->finish() == tor->pieceHash(piece);
 
             if (has_piece || had_piece)
             {

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -130,7 +130,7 @@ private:
             }
             else
             {
-                pending_.emplace(basename, info);
+                pending_.try_emplace(basename, info);
             }
         }
 

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -79,7 +79,7 @@ void BaseWatchdir::processFile(std::string_view basename)
     tr_logAddDebug(fmt::format("Callback decided to {:s} file '{:s}'", actionToString(action), basename));
     if (action == Action::Retry)
     {
-        auto const [iter, added] = pending_.try_emplace(std::string{ basename }, Pending{});
+        auto const [iter, added] = pending_.try_emplace(std::string{ basename });
 
         auto const now = std::chrono::steady_clock::now();
         auto& info = iter->second;
@@ -104,7 +104,7 @@ void BaseWatchdir::processFile(std::string_view basename)
     }
     else if (action == Action::Done)
     {
-        handled_.insert(std::string{ basename });
+        handled_.emplace(basename);
     }
 }
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -515,7 +515,7 @@ void onPartialDataFetched(tr_web::FetchResponse const& web_response)
 template<typename OutputIt>
 void makeUrl(tr_webseed* w, std::string_view name, OutputIt out)
 {
-    auto const url = w->base_url;
+    auto const& url = w->base_url;
 
     out = std::copy(std::begin(url), std::end(url), out);
 


### PR DESCRIPTION
- fix code smell warnings + minor perf by fixing warnings about unnecessary temporary objects

- rename `tr_sha1_digest_t::final()` as `finish()` since the former uses a C++ keyword