### PR TITLE
fix: lpd fixup

### DIFF
--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -96,9 +96,10 @@ auto makeAnnounceMsg(std::string_view cookie, tr_port port, std::string_view con
 
     if (!std::empty(cookie))
     {
-        ostr << "cookie: " << cookie << CrLf << CrLf << CrLf;
+        ostr << "cookie: " << cookie << CrLf;
     }
 
+    ostr << CrLf << CrLf;
     return ostr.str();
 }
 

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -19,8 +19,6 @@
 #include "net.h" // for tr_address, tr_port
 #include "timer.h"
 
-class tr_torrents;
-struct tr_session;
 struct event_base;
 
 class tr_lpd

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -1,5 +1,6 @@
-// This file Copyright © 2010 Johannes Lieder.
-// It may be used under the MIT (SPDX: MIT) license.
+// This file Copyright © 2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
 #pragma once


### PR DESCRIPTION
fix incorrect number of terminating \r\n characters at the end of an LSD announce message if no cookie is present.