### PR TITLE
fix: when renaming local data files fails, set torrent error and pause it

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -218,6 +218,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         {
             auto const path = tr_pathbuf{ tor->downloadDir(), '/', tor->fileSubpath(file_index) };
             tor->setLocalError(fmt::format(FMT_STRING("{:s} ({:s})"), tr_strerror(err), path));
+            tr_torrentStop(tor);
         }
 
         ++file_index;

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -827,6 +827,7 @@ void tr_peerIoClear(tr_peerIo* io)
     tr_peerIoSetIOFuncs(io, nullptr, nullptr, nullptr, nullptr);
     tr_peerIoSetEnabled(io, TR_UP, false);
     tr_peerIoSetEnabled(io, TR_DOWN, false);
+    io_close_socket(io);
 }
 
 int tr_peerIoReconnect(tr_peerIo* io)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2132,12 +2132,13 @@ static void setLocationInEventThread(
         ok = tor->metainfo_.files().move(tor->currentDir(), path, setme_progress, tor->name(), &error);
         if (error != nullptr)
         {
-            tr_logAddError(fmt::format(
+            tor->setLocalError(fmt::format(
                 _("Couldn't move '{old_path}' to '{path}': {error} ({error_code})"),
                 fmt::arg("old_path", tor->currentDir()),
                 fmt::arg("path", path),
                 fmt::arg("error", error->message),
                 fmt::arg("error_code", error->code)));
+            tr_torrentStop(tor);
             tr_error_clear(&error);
         }
     }


### PR DESCRIPTION
Fixes #3712.

For the "simple repro" testcase described in that issue, this change will set a torrent error and pause the torrent.