### PR TITLE
refactor: tr_peerIo read buffer

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -513,7 +513,7 @@ static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbu
     }
 
     uint32_t crypto_select = 0;
-    tr_peerIoReadUint32(handshake->io, inbuf, &crypto_select);
+    handshake->io->readUint32(&crypto_select);
     handshake->crypto_select = crypto_select;
     tr_logAddTraceHand(handshake, fmt::format("crypto select is {}", crypto_select));
 
@@ -804,7 +804,7 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     auto vc_in = vc_t{};
     handshake->io->readBytes(std::data(vc_in), std::size(vc_in));
 
-    tr_peerIoReadUint32(handshake->io, inbuf, &crypto_provide);
+    handshake->io->readUint32(&crypto_provide);
     handshake->crypto_provide = crypto_provide;
     tr_logAddTraceHand(handshake, fmt::format("crypto_provide is {}", crypto_provide));
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1061,7 +1061,7 @@ static bool fireDoneFunc(tr_handshake* handshake, bool isConnected)
 static ReadState tr_handshakeDone(tr_handshake* handshake, bool is_connected)
 {
     tr_logAddTraceHand(handshake, is_connected ? "handshakeDone: connected" : "handshakeDone: aborting");
-    tr_peerIoSetIOFuncs(handshake->io, nullptr, nullptr, nullptr, nullptr);
+    handshake->io->setCallbacks(nullptr, nullptr, nullptr, nullptr);
 
     bool const success = fireDoneFunc(handshake, is_connected);
     delete handshake;
@@ -1147,7 +1147,7 @@ tr_handshake* tr_handshakeNew(
     handshake->timeout_timer->startSingleShot(HandshakeTimeoutSec);
 
     tr_peerIoRef(io); /* balanced by the unref in ~tr_handshake() */
-    tr_peerIoSetIOFuncs(handshake->io, canRead, nullptr, gotError, handshake);
+    handshake->io->setCallbacks(canRead, nullptr, gotError, handshake);
 
     if (handshake->isIncoming())
     {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -1094,7 +1094,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
             handshake->mediator->setUTPFailed(*hash, io->address());
         }
 
-        if (handshake->mediator->allowsTCP() && tr_peerIoReconnect(handshake->io) == 0)
+        if (handshake->mediator->allowsTCP() && handshake->io->reconnect() == 0)
         {
             auto msg = std::array<uint8_t, HANDSHAKE_SIZE>{};
             buildHandshakeMessage(handshake, std::data(msg));
@@ -1109,7 +1109,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
      * try a plaintext handshake */
     if ((handshake->state == AWAITING_YB || handshake->state == AWAITING_VC) &&
         handshake->encryption_mode != TR_ENCRYPTION_REQUIRED && handshake->mediator->allowsTCP() &&
-        tr_peerIoReconnect(handshake->io) == 0)
+        handshake->io->reconnect() == 0)
     {
         auto msg = std::array<uint8_t, HANDSHAKE_SIZE>{};
         tr_logAddTraceHand(handshake, "handshake failed, trying plaintext...");

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -524,7 +524,7 @@ static ReadState readCryptoSelect(tr_handshake* handshake, struct evbuffer* inbu
     }
 
     uint16_t pad_d_len = 0;
-    tr_peerIoReadUint16(handshake->io, inbuf, &pad_d_len);
+    handshake->io->readUint16(&pad_d_len);
     tr_logAddTraceHand(handshake, fmt::format("pad_d_len is {}", pad_d_len));
 
     if (pad_d_len > 512)
@@ -808,7 +808,7 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
     handshake->crypto_provide = crypto_provide;
     tr_logAddTraceHand(handshake, fmt::format("crypto_provide is {}", crypto_provide));
 
-    tr_peerIoReadUint16(handshake->io, inbuf, &padc_len);
+    handshake->io->readUint16(&padc_len);
     tr_logAddTraceHand(handshake, fmt::format("padc is {}", padc_len));
     if (padc_len > PadC_MAXLEN)
     {
@@ -823,8 +823,6 @@ static ReadState readCryptoProvide(tr_handshake* handshake, struct evbuffer* inb
 
 static ReadState readPadC(tr_handshake* handshake, struct evbuffer* inbuf)
 {
-    uint16_t ia_len = 0;
-
     if (auto const needlen = handshake->pad_c_len + sizeof(uint16_t); evbuffer_get_length(inbuf) < needlen)
     {
         return READ_LATER;
@@ -835,7 +833,8 @@ static ReadState readPadC(tr_handshake* handshake, struct evbuffer* inbuf)
     handshake->io->readBytes(std::data(pad_c), handshake->pad_c_len);
 
     /* read ia_len */
-    tr_peerIoReadUint16(handshake->io, inbuf, &ia_len);
+    uint16_t ia_len = 0;
+    handshake->io->readUint16(&ia_len);
     tr_logAddTraceHand(handshake, fmt::format("ia_len is {}", ia_len));
     handshake->ia_len = ia_len;
     setState(handshake, AWAITING_IA);

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -550,7 +550,7 @@ static ReadState readPadD(tr_handshake* handshake, struct evbuffer* inbuf)
         return READ_LATER;
     }
 
-    tr_peerIoDrain(handshake->io, inbuf, needlen);
+    handshake->io->readBufferDrain(needlen);
 
     setState(handshake, AWAITING_HANDSHAKE);
     return READ_NOW;
@@ -954,7 +954,7 @@ static ReadState canRead(tr_peerIo* io, void* vhandshake, size_t* piece)
 
     auto* handshake = static_cast<tr_handshake*>(vhandshake);
 
-    evbuffer* const inbuf = io->getReadBuffer();
+    auto* const inbuf = io->readBuffer();
     bool readyForMore = true;
 
     /* no piece data in handshake */

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -976,6 +976,21 @@ void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t addme_hll)
     evbuffer_add(outbuf, &nll, sizeof(nll));
 }
 
+void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
+{
+    evbuffer_add_uint16(buf, val);
+}
+
+void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
+{
+    evbuffer_add_uint32(buf, val);
+}
+
+void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
+{
+    evbuffer_add_uint64(buf, val);
+}
+
 /***
 ****
 ***/

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1001,12 +1001,10 @@ void tr_peerIo::readUint16(uint16_t* setme)
     *setme = ntohs(tmp);
 }
 
-void tr_peerIoReadUint32(tr_peerIo* io, struct evbuffer* inbuf, uint32_t* setme)
+void tr_peerIo::readUint32(uint32_t* setme)
 {
-    TR_ASSERT(inbuf == io->readBuffer());
-
     auto tmp = uint32_t{};
-    io->readBytes(&tmp, sizeof(tmp));
+    readBytes(&tmp, sizeof(tmp));
     *setme = ntohl(tmp);
 }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -822,12 +822,12 @@ void tr_peerIo::setCallbacks(tr_can_read_cb readcb, tr_did_write_cb writecb, tr_
     this->userData = user_data;
 }
 
-void tr_peerIoClear(tr_peerIo* io)
+void tr_peerIo::clear()
 {
-    io->setCallbacks(nullptr, nullptr, nullptr, nullptr);
-    tr_peerIoSetEnabled(io, TR_UP, false);
-    tr_peerIoSetEnabled(io, TR_DOWN, false);
-    io_close_socket(io);
+    setCallbacks(nullptr, nullptr, nullptr, nullptr);
+    tr_peerIoSetEnabled(this, TR_UP, false);
+    tr_peerIoSetEnabled(this, TR_DOWN, false);
+    io_close_socket(this);
 }
 
 int tr_peerIo::reconnect()

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -994,12 +994,10 @@ void tr_peerIo::readBytes(void* bytes, size_t byte_count)
     }
 }
 
-void tr_peerIoReadUint16(tr_peerIo* io, struct evbuffer* inbuf, uint16_t* setme)
+void tr_peerIo::readUint16(uint16_t* setme)
 {
-    TR_ASSERT(inbuf == io->readBuffer());
-
     auto tmp = uint16_t{};
-    io->readBytes(&tmp, sizeof(tmp));
+    readBytes(&tmp, sizeof(tmp));
     *setme = ntohs(tmp);
 }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -814,17 +814,17 @@ std::string tr_peerIo::addrStr() const
     return tr_isPeerIo(this) ? this->addr_.readable(this->port_) : "error";
 }
 
-void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* user_data)
+void tr_peerIo::setCallbacks(tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* user_data)
 {
-    io->canRead = readcb;
-    io->didWrite = writecb;
-    io->gotError = errcb;
-    io->userData = user_data;
+    this->canRead = readcb;
+    this->didWrite = writecb;
+    this->gotError = errcb;
+    this->userData = user_data;
 }
 
 void tr_peerIoClear(tr_peerIo* io)
 {
-    tr_peerIoSetIOFuncs(io, nullptr, nullptr, nullptr, nullptr);
+    io->setCallbacks(nullptr, nullptr, nullptr, nullptr);
     tr_peerIoSetEnabled(io, TR_UP, false);
     tr_peerIoSetEnabled(io, TR_DOWN, false);
     io_close_socket(io);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -95,6 +95,8 @@ public:
         }
     }
 
+    void clear();
+
     void readBytes(void* bytes, size_t n_bytes);
 
     void readUint8(uint8_t* setme)
@@ -351,12 +353,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
     return io != nullptr && io->magic_number == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 &&
         tr_address_is_valid(&io->address());
 }
-
-/**
-***
-**/
-
-void tr_peerIoClear(tr_peerIo* io);
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -97,7 +97,7 @@ public:
 
     void clear();
 
-    void readBytes(void* bytes, size_t n_bytes);
+    void readBytes(void* bytes, size_t byte_count);
 
     void readUint8(uint8_t* setme)
     {
@@ -125,6 +125,8 @@ public:
     {
         return inbuf.get();
     }
+
+    void readBufferDrain(size_t byte_count);
 
     [[nodiscard]] auto readBufferSize() const noexcept
     {
@@ -385,8 +387,6 @@ constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
 }
-
-void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byte_count);
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -102,6 +102,8 @@ public:
         readBytes(setme, sizeof(uint8_t));
     }
 
+    void readUint16(uint16_t* setme);
+
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
         return addr_;
@@ -398,8 +400,6 @@ constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
 }
-
-void tr_peerIoReadUint16(tr_peerIo* io, struct evbuffer* inbuf, uint16_t* setme);
 
 void tr_peerIoReadUint32(tr_peerIo* io, struct evbuffer* inbuf, uint32_t* setme);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -95,6 +95,8 @@ public:
         }
     }
 
+    void readBytes(void* bytes, size_t n_bytes);
+
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
         return addr_;
@@ -107,9 +109,14 @@ public:
 
     std::string addrStr() const;
 
-    [[nodiscard]] auto getReadBuffer() noexcept
+    [[nodiscard]] auto readBuffer() noexcept
     {
         return inbuf.get();
+    }
+
+    [[nodiscard]] auto readBufferSize() const noexcept
+    {
+        return evbuffer_get_length(inbuf.get());
     }
 
     void readBufferAdd(void const* data, size_t n_bytes);
@@ -372,26 +379,26 @@ void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t hs);
 void evbuffer_add_uint32(struct evbuffer* outbuf, uint32_t hl);
 void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t hll);
 
-static inline void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
+constexpr void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
 {
     evbuffer_add_uint16(buf, val);
 }
 
-static inline void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
+constexpr void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
 {
     evbuffer_add_uint32(buf, val);
 }
 
-static inline void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
+constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
 }
 
-void tr_peerIoReadBytes(tr_peerIo* io, struct evbuffer* inbuf, void* bytes, size_t byteCount);
-
-static inline void tr_peerIoReadUint8(tr_peerIo* io, struct evbuffer* inbuf, uint8_t* setme)
+constexpr void tr_peerIoReadUint8(tr_peerIo* io, struct evbuffer* inbuf, uint8_t* setme)
 {
-    tr_peerIoReadBytes(io, inbuf, setme, sizeof(uint8_t));
+    TR_ASSERT(inbuf == io->readBuffer());
+
+    io->readBytes(setme, sizeof(uint8_t));
 }
 
 void tr_peerIoReadUint16(tr_peerIo* io, struct evbuffer* inbuf, uint16_t* setme);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -373,20 +373,9 @@ void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t hs);
 void evbuffer_add_uint32(struct evbuffer* outbuf, uint32_t hl);
 void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t hll);
 
-constexpr void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val)
-{
-    evbuffer_add_uint16(buf, val);
-}
-
-constexpr void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
-{
-    evbuffer_add_uint32(buf, val);
-}
-
-constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
-{
-    evbuffer_add_uint64(buf, val);
-}
+void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val);
+void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val);
+void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val);
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -97,6 +97,11 @@ public:
 
     void readBytes(void* bytes, size_t n_bytes);
 
+    void readUint8(uint8_t* setme)
+    {
+        readBytes(setme, sizeof(uint8_t));
+    }
+
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
         return addr_;
@@ -392,13 +397,6 @@ constexpr void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val)
 constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
-}
-
-constexpr void tr_peerIoReadUint8(tr_peerIo* io, struct evbuffer* inbuf, uint8_t* setme)
-{
-    TR_ASSERT(inbuf == io->readBuffer());
-
-    io->readBytes(setme, sizeof(uint8_t));
 }
 
 void tr_peerIoReadUint16(tr_peerIo* io, struct evbuffer* inbuf, uint16_t* setme);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -209,6 +209,8 @@ public:
         return torrent_hash_;
     }
 
+    void setCallbacks(tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* user_data);
+
     // TODO(ckerr): yikes, unlike other class' magic_numbers it looks
     // like this one isn't being used just for assertions, but also in
     // didWriteWrapper() to see if the tr_peerIo got freed during the
@@ -365,8 +367,6 @@ int tr_peerIoReconnect(tr_peerIo* io);
 /**
 ***
 **/
-
-void tr_peerIoSetIOFuncs(tr_peerIo* io, tr_can_read_cb readcb, tr_did_write_cb writecb, tr_net_error_cb errcb, void* user_data);
 
 void tr_peerIoClear(tr_peerIo* io);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -105,6 +105,8 @@ public:
     void readUint16(uint16_t* setme);
     void readUint32(uint32_t* setme);
 
+    int reconnect();
+
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
         return addr_;
@@ -349,20 +351,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
     return io != nullptr && io->magic_number == PEER_IO_MAGIC_NUMBER && io->refCount >= 0 &&
         tr_address_is_valid(&io->address());
 }
-
-/**
-***
-**/
-
-constexpr tr_session* tr_peerIoGetSession(tr_peerIo* io)
-{
-    TR_ASSERT(tr_isPeerIo(io));
-    TR_ASSERT(io->session != nullptr);
-
-    return io->session;
-}
-
-int tr_peerIoReconnect(tr_peerIo* io);
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -103,6 +103,7 @@ public:
     }
 
     void readUint16(uint16_t* setme);
+    void readUint32(uint32_t* setme);
 
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
@@ -400,8 +401,6 @@ constexpr void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val)
 {
     evbuffer_add_uint64(buf, val);
 }
-
-void tr_peerIoReadUint32(tr_peerIo* io, struct evbuffer* inbuf, uint32_t* setme);
 
 void tr_peerIoDrain(tr_peerIo* io, struct evbuffer* inbuf, size_t byte_count);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1893,7 +1893,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
             logtrace(msgs, "Got a BtPeerMsgs::Port");
 
             auto nport = uint16_t{};
-            tr_peerIoReadUint16(msgs->io, inbuf, &nport);
+            msgs->io->readUint16(&nport);
             if (auto const dht_port = tr_port::fromNetwork(nport); !std::empty(dht_port))
             {
                 msgs->dht_port = dht_port;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1459,7 +1459,7 @@ static void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* i
     TR_ASSERT(msglen > 0);
 
     auto ltep_msgid = uint8_t{};
-    tr_peerIoReadUint8(msgs->io, inbuf, &ltep_msgid);
+    msgs->io->readUint8(&ltep_msgid);
     msglen--;
 
     if (ltep_msgid == LtepMessages::Handshake)
@@ -1524,7 +1524,7 @@ static ReadState readBtId(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, size_t 
     }
 
     auto id = uint8_t{};
-    tr_peerIoReadUint8(msgs->io, inbuf, &id);
+    msgs->io->readUint8(&id);
     msgs->incoming.id = id;
     logtrace(
         msgs,

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1236,7 +1236,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len, struct evbuf
     // so try using a strbuf to handle it on the stack
     auto tmp = tr_strbuf<char, 512>{};
     tmp.resize(len);
-    tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
+    msgs->io->readBytes(std::data(tmp), std::size(tmp));
     auto const handshake_sv = tmp.sv();
 
     auto val = tr_variant{};
@@ -1342,7 +1342,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuf
 
     auto tmp = std::vector<char>{};
     tmp.resize(msglen);
-    tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
+    msgs->io->readBytes(std::data(tmp), std::size(tmp));
     char const* const msg_end = std::data(tmp) + std::size(tmp);
 
     auto dict = tr_variant{};
@@ -1414,7 +1414,7 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen, struct evbuffer* 
 
     auto tmp = std::vector<char>{};
     tmp.resize(msglen);
-    tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
+    msgs->io->readBytes(std::data(tmp), std::size(tmp));
 
     if (tr_variant val; tr_variantFromBuf(&val, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, tmp))
     {
@@ -1699,7 +1699,7 @@ static ReadState readBtPiece(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, size
     auto const n_to_read = std::min({ n_left_in_block, n_left_in_req, inlen });
     auto const old_length = std::size(*block_buf);
     block_buf->resize(old_length + n_to_read);
-    tr_peerIoReadBytes(msgs->io, inbuf, &((*block_buf)[old_length]), n_to_read);
+    msgs->io->readBuf(&((*block_buf)[old_length]), n_to_read);
 
     msgs->publishClientGotPieceData(n_to_read);
     *setme_piece_bytes_read += n_to_read;
@@ -1834,7 +1834,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, struct evbuffer* inbuf, si
         {
             logtrace(msgs, "got a bitfield");
             auto tmp = std::vector<uint8_t>(msglen);
-            tr_peerIoReadBytes(msgs->io, inbuf, std::data(tmp), std::size(tmp));
+            msgs->io->readBytes(std::data(tmp), std::size(tmp));
             msgs->have_ = tr_bitfield{ msgs->torrent->hasMetainfo() ? msgs->torrent->pieceCount() : std::size(tmp) * 8 };
             msgs->have_.setRaw(std::data(tmp), std::size(tmp));
             msgs->publishClientGotBitfield(&msgs->have_);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -286,7 +286,7 @@ public:
             }
         }
 
-        tr_peerIoSetIOFuncs(io, canRead, didWrite, gotError, this);
+        io->setCallbacks(canRead, didWrite, gotError, this);
         updateDesiredRequestCount(this);
     }
 


### PR DESCRIPTION
pt 1/n of tr_peerIo refactor.

The goal of the series is to remove the `tr_peerIoRef()` and `tr_peerIoUnref()` warts & use `std::shared_ptr<tr_peerIo>` instead.

This goal of this PR is to make `tr_peerIoFoo()` methods into `tr_peerIo::foo()` members. This means that followup PRs will be smaller because they won't have a hundred

```diff
- tr_peerIoReadFoo(msgs->io);
+ tr_peerIoReadFoo(msgs->io.get());
```