### PR TITLE
Refactor/tr peer io member funcs

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -182,7 +182,7 @@ void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peer_array, tr_direction di
          * out in a timely manner. */
         size_t const increment = 3000;
 
-        int const bytes_used = tr_peerIoFlush(peer_array[i], dir, increment);
+        int const bytes_used = peer_array[i]->flush(dir, increment);
 
         tr_logAddTrace(fmt::format("peer #{} of {} used {} bytes in this pass", i, n, bytes_used));
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -243,7 +243,7 @@ void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
      * or (2) the next tr_bandwidth::allocate () call, when we start over again. */
     for (auto* io : tmp)
     {
-        tr_peerIoSetEnabled(io, dir, io->hasBandwidthLeft(dir));
+        io->setEnabled(dir, io->hasBandwidthLeft(dir));
     }
 
     for (auto* io : tmp)

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -212,7 +212,7 @@ void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
     for (auto* io : tmp)
     {
         tr_peerIoRef(io);
-        tr_peerIoFlushOutgoingProtocolMsgs(io);
+        io->flushOutgoingProtocolMsgs();
 
         switch (io->priority)
         {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -439,7 +439,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
     /* ENCRYPT(VC, crypto_provide, len(PadC), PadC
      * PadC is reserved for future extensions to the handshake...
      * standard practice at this time is for it to be zero-length */
-    tr_peerIoWriteBuf(handshake->io, outbuf, false);
+    handshake->io->writeBuf(outbuf, false);
     handshake->io->encryptInit(handshake->io->isIncoming(), handshake->dh, *info_hash);
     evbuffer_add(outbuf, std::data(VC), std::size(VC));
     evbuffer_add_uint32(outbuf, getCryptoProvide(handshake));
@@ -460,7 +460,7 @@ static ReadState readYb(tr_handshake* handshake, struct evbuffer* inbuf)
     /* send it */
     handshake->io->decryptInit(handshake->io->isIncoming(), handshake->dh, *info_hash);
     setReadState(handshake, AWAITING_VC);
-    tr_peerIoWriteBuf(handshake->io, outbuf, false);
+    handshake->io->writeBuf(outbuf, false);
 
     /* cleanup */
     evbuffer_free(outbuf);
@@ -891,7 +891,7 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
     /* maybe de-encrypt our connection */
     if (crypto_select == CRYPTO_PROVIDE_PLAINTEXT)
     {
-        tr_peerIoWriteBuf(handshake->io, outbuf, false);
+        handshake->io->writeBuf(outbuf, false);
     }
 
     tr_logAddTraceHand(handshake, "sending handshake");
@@ -908,7 +908,7 @@ static ReadState readIA(tr_handshake* handshake, struct evbuffer const* inbuf)
     }
 
     /* send it out */
-    tr_peerIoWriteBuf(handshake->io, outbuf, false);
+    handshake->io->writeBuf(outbuf, false);
     evbuffer_free(outbuf);
 
     /* now await the handshake */

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -310,7 +310,7 @@ static void sendPublicKeyAndPad(tr_handshake* handshake)
     auto walk = data;
     walk = std::copy(std::begin(public_key), std::end(public_key), walk);
     walk += handshake->mediator->pad(walk, PadMax);
-    tr_peerIoWriteBytes(handshake->io, data, walk - data, false);
+    handshake->io->writeBytes(data, walk - data, false);
 }
 
 // 1 A->B: our public key (Ya) and some padding (PadA)
@@ -664,7 +664,7 @@ static ReadState readHandshake(tr_handshake* handshake, struct evbuffer* inbuf)
             return tr_handshakeDone(handshake, false);
         }
 
-        tr_peerIoWriteBytes(handshake->io, std::data(msg), std::size(msg), false);
+        handshake->io->writeBytes(std::data(msg), std::size(msg), false);
         handshake->haveSentBitTorrentHandshake = true;
     }
 
@@ -1100,7 +1100,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
             buildHandshakeMessage(handshake, std::data(msg));
             handshake->haveSentBitTorrentHandshake = true;
             setReadState(handshake, AWAITING_HANDSHAKE);
-            tr_peerIoWriteBytes(handshake->io, std::data(msg), std::size(msg), false);
+            handshake->io->writeBytes(std::data(msg), std::size(msg), false);
         }
     }
 
@@ -1116,7 +1116,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
         buildHandshakeMessage(handshake, std::data(msg));
         handshake->haveSentBitTorrentHandshake = true;
         setReadState(handshake, AWAITING_HANDSHAKE);
-        tr_peerIoWriteBytes(handshake->io, std::data(msg), std::size(msg), false);
+        handshake->io->writeBytes(std::data(msg), std::size(msg), false);
     }
     else
     {
@@ -1164,7 +1164,7 @@ tr_handshake* tr_handshakeNew(
 
         handshake->haveSentBitTorrentHandshake = true;
         setReadState(handshake, AWAITING_HANDSHAKE);
-        tr_peerIoWriteBytes(handshake->io, std::data(msg), std::size(msg), false);
+        handshake->io->writeBytes(std::data(msg), std::size(msg), false);
     }
 
     return handshake;

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -929,23 +929,22 @@ void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData)
     io->outbuf_info.emplace_back(byteCount, isPieceData);
 }
 
-void tr_peerIoWriteBytes(tr_peerIo* io, void const* writeme, size_t writeme_len, bool is_piece_data)
+void tr_peerIo::writeBytes(void const* writeme, size_t writeme_len, bool is_piece_data)
 {
     struct evbuffer_iovec iovec;
-    evbuffer_reserve_space(io->outbuf.get(), writeme_len, &iovec, 1);
 
+    evbuffer_reserve_space(outbuf.get(), writeme_len, &iovec, 1);
     iovec.iov_len = writeme_len;
-
     memcpy(iovec.iov_base, writeme, iovec.iov_len);
 
-    if (io->isEncrypted())
+    if (isEncrypted())
     {
-        io->encrypt(iovec.iov_len, iovec.iov_base);
+        encrypt(iovec.iov_len, iovec.iov_base);
     }
 
-    evbuffer_commit_space(io->outbuf.get(), &iovec, 1);
+    evbuffer_commit_space(outbuf.get(), &iovec, 1);
 
-    io->outbuf_info.emplace_back(writeme_len, is_piece_data);
+    outbuf_info.emplace_back(writeme_len, is_piece_data);
 }
 
 /***

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -563,7 +563,7 @@ void tr_peerIo::utpInit([[maybe_unused]] struct_utp_context* ctx)
 #endif
 }
 
-tr_peerIo* tr_peerIoNewIncoming(
+tr_peerIo* tr_peerIo::newIncoming(
     tr_session* session,
     tr_bandwidth* parent,
     tr_address const* addr,

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1154,13 +1154,12 @@ static int tr_peerIoTryWrite(tr_peerIo* io, size_t howmuch)
     return n;
 }
 
-int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t limit)
+int tr_peerIo::flush(tr_direction dir, size_t limit)
 {
-    TR_ASSERT(tr_isPeerIo(io));
     TR_ASSERT(tr_isDirection(dir));
 
-    int const bytes_used = dir == TR_DOWN ? tr_peerIoTryRead(io, limit) : tr_peerIoTryWrite(io, limit);
-    tr_logAddTraceIo(io, fmt::format("flushing peer-io, direction:{}, limit:{}, byte_used:{}", dir, limit, bytes_used));
+    int const bytes_used = dir == TR_DOWN ? tr_peerIoTryRead(this, limit) : tr_peerIoTryWrite(this, limit);
+    tr_logAddTraceIo(this, fmt::format("flushing peer-io, direction:{}, limit:{}, byte_used:{}", dir, limit, bytes_used));
     return bytes_used;
 }
 
@@ -1180,5 +1179,5 @@ int tr_peerIo::flushOutgoingProtocolMsgs()
         byte_count += n_bytes;
     }
 
-    return tr_peerIoFlush(this, TR_UP, byte_count);
+    return flush(TR_UP, byte_count);
 }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -491,7 +491,7 @@ static uint64 utp_callback(utp_callback_arguments* args)
 
 #endif /* #ifdef WITH_UTP */
 
-tr_peerIo* tr_peerIoNew(
+tr_peerIo* tr_peerIo::create(
     tr_session* session,
     tr_bandwidth* parent,
     tr_address const* addr,
@@ -574,7 +574,7 @@ tr_peerIo* tr_peerIoNewIncoming(
     TR_ASSERT(session != nullptr);
     TR_ASSERT(tr_address_is_valid(addr));
 
-    return tr_peerIoNew(session, parent, addr, port, current_time, nullptr, true, false, socket);
+    return tr_peerIo::create(session, parent, addr, port, current_time, nullptr, true, false, socket);
 }
 
 tr_peerIo* tr_peerIoNewOutgoing(
@@ -611,7 +611,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
         return nullptr;
     }
 
-    return tr_peerIoNew(session, parent, addr, port, current_time, &torrent_hash, false, is_seed, socket);
+    return tr_peerIo::create(session, parent, addr, port, current_time, &torrent_hash, false, is_seed, socket);
 }
 
 /***

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -916,17 +916,17 @@ static inline void processBuffer(tr_peerIo& io, evbuffer* buffer, size_t offset,
     TR_ASSERT(size == 0);
 }
 
-void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData)
+void tr_peerIo::writeBuf(struct evbuffer* buf, bool isPieceData)
 {
     size_t const byteCount = evbuffer_get_length(buf);
 
-    if (io->isEncrypted())
+    if (isEncrypted())
     {
-        processBuffer(*io, buf, 0, byteCount);
+        processBuffer(*this, buf, 0, byteCount);
     }
 
-    evbuffer_add_buffer(io->outbuf.get(), buf);
-    io->outbuf_info.emplace_back(byteCount, isPieceData);
+    evbuffer_add_buffer(outbuf.get(), buf);
+    outbuf_info.emplace_back(byteCount, isPieceData);
 }
 
 void tr_peerIo::writeBytes(void const* writeme, size_t writeme_len, bool is_piece_data)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -548,7 +548,7 @@ tr_peerIo* tr_peerIoNew(
     return io;
 }
 
-void tr_peerIoUtpInit([[maybe_unused]] struct_utp_context* ctx)
+void tr_peerIo::utpInit([[maybe_unused]] struct_utp_context* ctx)
 {
 #ifdef WITH_UTP
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -1164,21 +1164,21 @@ int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t limit)
     return bytes_used;
 }
 
-int tr_peerIoFlushOutgoingProtocolMsgs(tr_peerIo* io)
+int tr_peerIo::flushOutgoingProtocolMsgs()
 {
-    size_t byteCount = 0;
+    size_t byte_count = 0;
 
     /* count up how many bytes are used by non-piece-data messages
        at the front of our outbound queue */
-    for (auto const& [n_bytes, is_piece_data] : io->outbuf_info)
+    for (auto const& [n_bytes, is_piece_data] : outbuf_info)
     {
         if (is_piece_data)
         {
             break;
         }
 
-        byteCount += n_bytes;
+        byte_count += n_bytes;
     }
 
-    return tr_peerIoFlush(io, TR_UP, byteCount);
+    return tr_peerIoFlush(this, TR_UP, byte_count);
 }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -875,18 +875,11 @@ static unsigned int getDesiredOutputBufferSize(tr_peerIo const* io, uint64_t now
     return std::max(ceiling, currentSpeed_Bps * period);
 }
 
-size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now)
+size_t tr_peerIo::getWriteBufferSpace(uint64_t now) const
 {
-    size_t const desiredLen = getDesiredOutputBufferSize(io, now);
-    size_t const currentLen = evbuffer_get_length(io->outbuf.get());
-    size_t freeSpace = 0;
-
-    if (desiredLen > currentLen)
-    {
-        freeSpace = desiredLen - currentLen;
-    }
-
-    return freeSpace;
+    size_t const desired_len = getDesiredOutputBufferSize(this, now);
+    size_t const current_len = evbuffer_get_length(outbuf.get());
+    return desired_len > current_len ? desired_len - current_len : 0U;
 }
 
 /**

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -577,7 +577,7 @@ tr_peerIo* tr_peerIoNewIncoming(
     return tr_peerIo::create(session, parent, addr, port, current_time, nullptr, true, false, socket);
 }
 
-tr_peerIo* tr_peerIoNewOutgoing(
+tr_peerIo* tr_peerIo::newOutgoing(
     tr_session* session,
     tr_bandwidth* parent,
     tr_address const* addr,
@@ -611,7 +611,7 @@ tr_peerIo* tr_peerIoNewOutgoing(
         return nullptr;
     }
 
-    return tr_peerIo::create(session, parent, addr, port, current_time, &torrent_hash, false, is_seed, socket);
+    return create(session, parent, addr, port, current_time, &torrent_hash, false, is_seed, socket);
 }
 
 /***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -141,6 +141,7 @@ public:
     int flush(tr_direction dir, size_t byte_limit);
 
     void writeBytes(void const* writeme, size_t writeme_len, bool is_piece_data);
+    void writeBuf(struct evbuffer* buf, bool isPieceData);
 
     [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
     {
@@ -366,8 +367,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
 /**
 ***
 **/
-
-void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData);
 
 /**
 ***

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -138,6 +138,7 @@ public:
     void readBufferAdd(void const* data, size_t n_bytes);
 
     int flushOutgoingProtocolMsgs();
+    int flush(tr_direction dir, size_t byte_limit);
 
     [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
     {
@@ -388,11 +389,5 @@ void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val);
 size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now);
 
 void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
-
-/**
-***
-**/
-
-int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t byteLimit);
 
 /* @} */

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -109,6 +109,8 @@ public:
 
     int reconnect();
 
+    void setEnabled(tr_direction dir, bool is_enabled);
+
     [[nodiscard]] constexpr tr_address const& address() const noexcept
     {
         return addr_;
@@ -388,8 +390,6 @@ void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCo
 /**
 ***
 **/
-
-void tr_peerIoSetEnabled(tr_peerIo* io, tr_direction dir, bool isEnabled);
 
 int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t byteLimit);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -73,7 +73,7 @@ class tr_peerIo
 
 public:
     // TODO: 8 constructor args is too many; maybe a builder object?
-    tr_peerIo* newOutgoing(
+    static tr_peerIo* newOutgoing(
         tr_session* session,
         tr_bandwidth* parent,
         struct tr_address const* addr,
@@ -83,8 +83,16 @@ public:
         bool is_seed,
         bool utp);
 
+    static tr_peerIo* newIncoming(
+        tr_session* session,
+        tr_bandwidth* parent,
+        struct tr_address const* addr,
+        tr_port port,
+        time_t current_time,
+        struct tr_peer_socket const socket);
+
     // this is only public for testing purposes.
-    // production code should use tr_peerIo::newOutgoing() or tr_peerIoNewIncoming()
+    // production code should use newOutgoing() or newIncoming()
     static tr_peerIo* create(
         tr_session* session,
         tr_bandwidth* parent,
@@ -338,14 +346,6 @@ private:
     bool extended_protocol_supported_ = false;
     bool fast_extension_supported_ = false;
 };
-
-tr_peerIo* tr_peerIoNewIncoming(
-    tr_session* session,
-    tr_bandwidth* parent,
-    struct tr_address const* addr,
-    tr_port port,
-    time_t current_time,
-    struct tr_peer_socket const socket);
 
 void tr_peerIoRefImpl(char const* file, int line, tr_peerIo* io);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -140,6 +140,8 @@ public:
     int flushOutgoingProtocolMsgs();
     int flush(tr_direction dir, size_t byte_limit);
 
+    void writeBytes(void const* writeme, size_t writeme_len, bool is_piece_data);
+
     [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
     {
         return bandwidth_.clamp(dir, 1024) > 0;
@@ -364,8 +366,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
 /**
 ***
 **/
-
-void tr_peerIoWriteBytes(tr_peerIo* io, void const* writeme, size_t writeme_len, bool is_piece_data);
 
 void tr_peerIoWriteBuf(tr_peerIo* io, struct evbuffer* buf, bool isPieceData);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -369,10 +369,6 @@ constexpr bool tr_isPeerIo(tr_peerIo const* io)
 ***
 **/
 
-/**
-***
-**/
-
 void evbuffer_add_uint8(struct evbuffer* outbuf, uint8_t addme);
 void evbuffer_add_uint16(struct evbuffer* outbuf, uint16_t hs);
 void evbuffer_add_uint32(struct evbuffer* outbuf, uint32_t hl);
@@ -381,11 +377,5 @@ void evbuffer_add_uint64(struct evbuffer* outbuf, uint64_t hll);
 void evbuffer_add_hton_16(struct evbuffer* buf, uint16_t val);
 void evbuffer_add_hton_32(struct evbuffer* buf, uint32_t val);
 void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val);
-
-/**
-***
-**/
-
-void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
 
 /* @} */

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -72,8 +72,19 @@ class tr_peerIo
     using Filter = tr_message_stream_encryption::Filter;
 
 public:
+    // TODO: 8 constructor args is too many; maybe a builder object?
+    tr_peerIo* newOutgoing(
+        tr_session* session,
+        tr_bandwidth* parent,
+        struct tr_address const* addr,
+        tr_port port,
+        time_t current_time,
+        tr_sha1_digest_t const& torrent_hash,
+        bool is_seed,
+        bool utp);
+
     // this is only public for testing purposes.
-    // production code should use tr_peerIoNewOutgoing() or tr_peerIoNewIncoming()
+    // production code should use tr_peerIo::newOutgoing() or tr_peerIoNewIncoming()
     static tr_peerIo* create(
         tr_session* session,
         tr_bandwidth* parent,
@@ -327,17 +338,6 @@ private:
     bool extended_protocol_supported_ = false;
     bool fast_extension_supported_ = false;
 };
-
-// TODO: 8 constructor args is too many; maybe a builder object?
-tr_peerIo* tr_peerIoNewOutgoing(
-    tr_session* session,
-    tr_bandwidth* parent,
-    struct tr_address const* addr,
-    tr_port port,
-    time_t current_time,
-    tr_sha1_digest_t const& torrent_hash,
-    bool is_seed,
-    bool utp);
 
 tr_peerIo* tr_peerIoNewIncoming(
     tr_session* session,

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -285,6 +285,8 @@ public:
         return filter_.get() != nullptr;
     }
 
+    static void utpInit(struct_utp_context* ctx);
+
 private:
     tr_bandwidth bandwidth_;
 
@@ -312,12 +314,6 @@ private:
     bool extended_protocol_supported_ = false;
     bool fast_extension_supported_ = false;
 };
-
-/**
-***
-**/
-
-void tr_peerIoUtpInit(struct_utp_context* ctx);
 
 // TODO: 8 constructor args is too many; maybe a builder object?
 tr_peerIo* tr_peerIoNewOutgoing(

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -142,6 +142,7 @@ public:
 
     void writeBytes(void const* writeme, size_t writeme_len, bool is_piece_data);
     void writeBuf(struct evbuffer* buf, bool isPieceData);
+    size_t getWriteBufferSpace(uint64_t now) const;
 
     [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
     {
@@ -384,8 +385,6 @@ void evbuffer_add_hton_64(struct evbuffer* buf, uint64_t val);
 /**
 ***
 **/
-
-size_t tr_peerIoGetWriteBufferSpace(tr_peerIo const* io, uint64_t now);
 
 void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCount, int isPieceData);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -137,6 +137,8 @@ public:
 
     void readBufferAdd(void const* data, size_t n_bytes);
 
+    int flushOutgoingProtocolMsgs();
+
     [[nodiscard]] auto hasBandwidthLeft(tr_direction dir) noexcept
     {
         return bandwidth_.clamp(dir, 1024) > 0;
@@ -392,7 +394,5 @@ void tr_peerIoBandwidthUsed(tr_peerIo* io, tr_direction direction, size_t byteCo
 **/
 
 int tr_peerIoFlush(tr_peerIo* io, tr_direction dir, size_t byteLimit);
-
-int tr_peerIoFlushOutgoingProtocolMsgs(tr_peerIo* io);
 
 /* @} */

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -72,28 +72,18 @@ class tr_peerIo
     using Filter = tr_message_stream_encryption::Filter;
 
 public:
-    tr_peerIo(
-        tr_session* session_in,
+    // this is only public for testing purposes.
+    // production code should use tr_peerIoNewOutgoing() or tr_peerIoNewIncoming()
+    static tr_peerIo* create(
+        tr_session* session,
+        tr_bandwidth* parent,
+        tr_address const* addr,
+        tr_port port,
+        time_t current_time,
         tr_sha1_digest_t const* torrent_hash,
         bool is_incoming,
-        tr_address const& addr,
-        tr_port port,
         bool is_seed,
-        time_t current_time,
-        tr_bandwidth* parent_bandwidth)
-        : session{ session_in }
-        , time_created{ current_time }
-        , bandwidth_{ parent_bandwidth }
-        , addr_{ addr }
-        , port_{ port }
-        , is_seed_{ is_seed }
-        , is_incoming_{ is_incoming }
-    {
-        if (torrent_hash != nullptr)
-        {
-            torrent_hash_ = *torrent_hash;
-        }
-    }
+        struct tr_peer_socket const socket);
 
     void clear();
 
@@ -288,9 +278,28 @@ public:
     static void utpInit(struct_utp_context* ctx);
 
 private:
-    tr_bandwidth bandwidth_;
-
-    std::unique_ptr<tr_message_stream_encryption::Filter> filter_;
+    tr_peerIo(
+        tr_session* session_in,
+        tr_sha1_digest_t const* torrent_hash,
+        bool is_incoming,
+        tr_address const& addr,
+        tr_port port,
+        bool is_seed,
+        time_t current_time,
+        tr_bandwidth* parent_bandwidth)
+        : session{ session_in }
+        , time_created{ current_time }
+        , bandwidth_{ parent_bandwidth }
+        , addr_{ addr }
+        , port_{ port }
+        , is_seed_{ is_seed }
+        , is_incoming_{ is_incoming }
+    {
+        if (torrent_hash != nullptr)
+        {
+            torrent_hash_ = *torrent_hash;
+        }
+    }
 
     Filter& filter()
     {
@@ -301,6 +310,10 @@ private:
 
         return *filter_;
     }
+
+    tr_bandwidth bandwidth_;
+
+    std::unique_ptr<tr_message_stream_encryption::Filter> filter_;
 
     std::optional<tr_sha1_digest_t> torrent_hash_;
 
@@ -332,19 +345,6 @@ tr_peerIo* tr_peerIoNewIncoming(
     struct tr_address const* addr,
     tr_port port,
     time_t current_time,
-    struct tr_peer_socket const socket);
-
-// this is only public for testing purposes.
-// production code should use tr_peerIoNewOutgoing() or tr_peerIoNewIncoming()
-tr_peerIo* tr_peerIoNew(
-    tr_session* session,
-    tr_bandwidth* parent,
-    tr_address const* addr,
-    tr_port port,
-    time_t current_time,
-    tr_sha1_digest_t const* torrent_hash,
-    bool is_incoming,
-    bool is_seed,
     struct tr_peer_socket const socket);
 
 void tr_peerIoRefImpl(char const* file, int line, tr_peerIo* io);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1263,10 +1263,10 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     else /* we don't have a connection to them yet... */
     {
         auto mediator = std::make_shared<tr_handshake_mediator_impl>(*session);
-        tr_peerIo* const io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket);
+        tr_peerIo* const io = tr_peerIo::newIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket);
         tr_handshake* const handshake = tr_handshakeNew(mediator, io, session->encryptionMode(), on_handshake_done, manager);
 
-        tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIoNewIncoming() */
+        tr_peerIoUnref(io); /* balanced by the implicit ref in tr_peerIo::NewIncoming() */
 
         manager->incoming_handshakes.add(*addr, handshake);
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2836,7 +2836,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
 
     tr_logAddTraceSwarm(s, fmt::format("Starting an OUTGOING {} connection with {}", utp ? " µTP" : "TCP", atom.readable()));
 
-    tr_peerIo* const io = tr_peerIoNewOutgoing(
+    tr_peerIo* const io = tr_peerIo::newOutgoing(
         mgr->session,
         &mgr->session->top_bandwidth_,
         &atom.addr,
@@ -2859,7 +2859,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
 
         TR_ASSERT(io->torrentHash());
 
-        tr_peerIoUnref(io); /* balanced by the initial ref in tr_peerIoNewOutgoing() */
+        tr_peerIoUnref(io); /* balanced by the initial ref in tr_peerIo::newOutgoing() */
 
         s->outgoing_handshakes.add(atom.addr, handshake);
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2224,7 +2224,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
     **/
 
     auto piece = int{};
-    if (tr_peerIoGetWriteBufferSpace(msgs->io, now) >= METADATA_PIECE_SIZE && popNextMetadataRequest(msgs, &piece))
+    if (msgs->io->getWriteBufferSpace(now) >= METADATA_PIECE_SIZE && popNextMetadataRequest(msgs, &piece))
     {
         auto ok = bool{ false };
 
@@ -2283,7 +2283,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
     ***  Data Blocks
     **/
 
-    if (tr_peerIoGetWriteBufferSpace(msgs->io, now) >= tr_block_info::BlockSize && !std::empty(msgs->peer_requested_))
+    if (msgs->io->getWriteBufferSpace(now) >= tr_block_info::BlockSize && !std::empty(msgs->peer_requested_))
     {
         req = msgs->peer_requested_.front();
         msgs->peer_requested_.erase(std::begin(msgs->peer_requested_));

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2212,7 +2212,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
         size_t const len = evbuffer_get_length(msgs->outMessages);
         /* flush the protocol messages */
         logtrace(msgs, fmt::format(FMT_STRING("flushing outMessages... to {:p} (length is {:d})"), fmt::ptr(msgs->io), len));
-        tr_peerIoWriteBuf(msgs->io, msgs->outMessages, false);
+        msgs->io->writeBuf(msgs->outMessages, false);
         msgs->clientSentAnythingAt = now;
         msgs->outMessagesBatchedAt = 0;
         msgs->outMessagesBatchPeriod = LowPriorityIntervalSecs;
@@ -2333,7 +2333,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
                 size_t const n = evbuffer_get_length(out);
                 logtrace(msgs, fmt::format(FMT_STRING("sending block {:d}:{:d}->{:d}"), req.index, req.offset, req.length));
                 TR_ASSERT(n == msglen);
-                tr_peerIoWriteBuf(msgs->io, out, true);
+                msgs->io->writeBuf(out, true);
                 bytesWritten += n;
                 msgs->clientSentAnythingAt = now;
                 msgs->blocks_sent_to_peer.add(tr_time(), 1);

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -214,7 +214,7 @@ void tr_utpInit(tr_session* session)
     utp_set_callback(ctx, UTP_ON_ACCEPT, &utp_callback);
     utp_set_callback(ctx, UTP_SENDTO, &utp_callback);
 
-    tr_peerIoUtpInit(ctx);
+    tr_peerIo::utpInit(ctx);
 
 #ifdef TR_UTP_TRACE
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -163,7 +163,7 @@ auto createIncomingIo(tr_session* session)
     auto const now = tr_time();
     auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
     auto* const
-        io = tr_peerIoNewIncoming(session, &session->top_bandwidth_, &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
+        io = tr_peerIo::newIncoming(session, &session->top_bandwidth_, &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
     return std::make_pair(io, sockpair[1]);
 }
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -173,7 +173,7 @@ auto createOutgoingIo(tr_session* session, tr_sha1_digest_t const& info_hash)
     EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
     auto const now = tr_time();
     auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
-    auto* const io = tr_peerIoNew(
+    auto* const io = tr_peerIo::create(
         session,
         &session->top_bandwidth_,
         &DefaultPeerAddr,


### PR DESCRIPTION
pt 2/n of tr_peerIo refactor. Part 1 at #3732.

The goal of the series is to replace the `tr_peerIoRef()` and `tr_peerIoUnref()` functions with `std::shared_ptr<tr_peerIo>`.

This goal of this PR is to finish making all the other `tr_peerIoFoo()` methods into `tr_peerIo::foo()` members. This is a worthwhile cleanup on its own merits, and it's being done before the ref/unref cleanup to avoid hundreds of diffs like:

```diff
- tr_peerIoReadFoo(msgs->io);
+ tr_peerIoReadFoo(msgs->io.get());
```