### PR TITLE
Fix a progressBar direction for QT 5.15 for paused torrents

### DIFF
--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -528,14 +528,14 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     auto const color_role = is_item_selected ? QPalette::HighlightedText : QPalette::Text;
 
-    QStyle::State progress_bar_state(option.state | QStyle::State_Horizontal);
+    QStyle::State progress_bar_state(option.state);
 
     if (is_paused)
     {
         progress_bar_state = QStyle::State_None;
     }
 
-    progress_bar_state |= QStyle::State_Small;
+    progress_bar_state |= QStyle::State_Small | QStyle::State_Horizontal;
 
     QIcon::Mode const emblem_im = is_item_selected ? QIcon::Selected : QIcon::Normal;
     QIcon const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon();

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -217,14 +217,14 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
 
     auto const color_role = is_item_selected ? QPalette::HighlightedText : QPalette::Text;
 
-    QStyle::State progress_bar_state(option.state | QStyle::State_Horizontal);
+    QStyle::State progress_bar_state(option.state);
 
     if (is_paused)
     {
         progress_bar_state = QStyle::State_None;
     }
 
-    progress_bar_state |= QStyle::State_Small;
+    progress_bar_state |= QStyle::State_Small | QStyle::State_Horizontal;
 
     QIcon::Mode const emblem_im = is_item_selected ? QIcon::Selected : QIcon::Normal;
     QIcon const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon();


### PR DESCRIPTION
If torrent is paused progress_bar_state drops QStyle::State_Horizontal setting. This patch fixes this behaviour.