### PR TITLE
refactor: remove unnecessary default destructors

### DIFF
--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -37,8 +37,6 @@ public:
     {
     }
 
-    virtual ~tr_peerMsgs() override = default;
-
     [[nodiscard]] virtual bool is_peer_choked() const noexcept = 0;
     [[nodiscard]] virtual bool is_peer_interested() const noexcept = 0;
     [[nodiscard]] virtual bool is_client_choked() const noexcept = 0;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -831,7 +831,6 @@ private:
             : session_{ session }
         {
         }
-        ~WebMediator() override = default;
 
         [[nodiscard]] std::optional<std::string> cookieFile() const override;
         [[nodiscard]] std::optional<std::string> publicAddressV4() const override;
@@ -855,7 +854,6 @@ private:
             : session_{ session }
         {
         }
-        ~LpdMediator() override = default;
 
         [[nodiscard]] tr_port port() const override
         {

--- a/libtransmission/timer-ev.h
+++ b/libtransmission/timer-ev.h
@@ -25,8 +25,6 @@ public:
     {
     }
 
-    ~EvTimerMaker() override = default;
-
     [[nodiscard]] std::unique_ptr<Timer> create() override;
 
 private:

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -93,8 +93,6 @@ public:
     {
     }
 
-    ~tr_torrent() override = default;
-
     void setLocation(
         std::string_view location,
         bool move_from_old_path,

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -33,7 +33,6 @@ public:
         ensure_sz();
     }
 
-    ~tr_strbuf() = default;
     tr_strbuf(tr_strbuf const& other) = delete;
     tr_strbuf& operator=(tr_strbuf const& other) = delete;
 

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -33,7 +33,6 @@ public:
         retry_timer_->setCallback([this]() { onRetryTimer(); });
     }
 
-    ~BaseWatchdir() override = default;
     BaseWatchdir(BaseWatchdir&&) = delete;
     BaseWatchdir(BaseWatchdir const&) = delete;
     BaseWatchdir& operator=(BaseWatchdir&&) = delete;


### PR DESCRIPTION
Minor refactor / perf fix: remove unnecessary derived class default destructors.