### PR TITLE
refactor: prefer std::unique_ptr over std::shared_ptr

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -115,7 +115,7 @@ enum handshake_state_t
 struct tr_handshake
 {
     tr_handshake(
-        std::shared_ptr<tr_handshake_mediator> mediator_in,
+        std::unique_ptr<tr_handshake_mediator> mediator_in,
         std::shared_ptr<tr_peerIo> io_in,
         tr_encryption_mode encryption_mode_in)
         : mediator{ std::move(mediator_in) }
@@ -136,7 +136,7 @@ struct tr_handshake
         return io->isIncoming();
     }
 
-    std::shared_ptr<tr_handshake_mediator> const mediator;
+    std::unique_ptr<tr_handshake_mediator> const mediator;
 
     bool haveReadAnythingFromPeer = false;
     bool haveSentBitTorrentHandshake = false;
@@ -1129,7 +1129,7 @@ static void gotError(tr_peerIo* io, short what, void* vhandshake)
 **/
 
 tr_handshake* tr_handshakeNew(
-    std::shared_ptr<tr_handshake_mediator> mediator,
+    std::unique_ptr<tr_handshake_mediator> mediator,
     std::shared_ptr<tr_peerIo> io,
     tr_encryption_mode encryption_mode,
     tr_handshake_done_func done_func,

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -49,6 +49,8 @@ public:
         bool is_done;
     };
 
+    virtual ~tr_handshake_mediator() = default;
+
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfo(tr_sha1_digest_t const& info_hash) const = 0;
 
     [[nodiscard]] virtual std::optional<torrent_info> torrentInfoFromObfuscated(tr_sha1_digest_t const& info_hash) const = 0;
@@ -76,7 +78,7 @@ using tr_handshake_done_func = bool (*)(tr_handshake_result const& result);
 
 /** @brief create a new handshake */
 tr_handshake* tr_handshakeNew(
-    std::shared_ptr<tr_handshake_mediator> mediator,
+    std::unique_ptr<tr_handshake_mediator> mediator,
     std::shared_ptr<tr_peerIo> io,
     tr_encryption_mode encryption_mode,
     tr_handshake_done_func done_func,

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -104,7 +104,7 @@ public:
         anti_brute_force_limit_ = limit;
     }
 
-    std::shared_ptr<libdeflate_compressor> compressor;
+    std::unique_ptr<libdeflate_compressor, void (*)(libdeflate_compressor*)> compressor;
 
     [[nodiscard]] constexpr auto const& url() const noexcept
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1395,8 +1395,10 @@ static void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     content.resize(1024 * 128);
     for (;;)
     {
-        auto decompressor = std::shared_ptr<libdeflate_decompressor>{ libdeflate_alloc_decompressor(),
-                                                                      libdeflate_free_decompressor };
+        auto decompressor = std::unique_ptr<libdeflate_decompressor, void (*)(libdeflate_decompressor*)>{
+            libdeflate_alloc_decompressor(),
+            libdeflate_free_decompressor
+        };
         auto actual_size = size_t{};
         auto const decompress_result = libdeflate_gzip_decompress(
             decompressor.get(),

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2913,7 +2913,7 @@ auto makeTorrentDir(std::string_view config_dir)
 auto makeEventBase()
 {
     tr_evthread_init();
-    return std::shared_ptr<event_base>{ event_base_new(), event_base_free };
+    return std::unique_ptr<event_base, void (*)(event_base*)>{ event_base_new(), event_base_free };
 }
 
 } // namespace

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -877,8 +877,8 @@ private:
 
     LpdMediator lpd_mediator_{ *this };
 
-    std::shared_ptr<event_base> const event_base_;
-    std::shared_ptr<evdns_base> const evdns_base_;
+    std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
+    std::unique_ptr<evdns_base, void (*)(evdns_base*)> const evdns_base_;
     std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
 
     void onNowTimer();

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -28,6 +28,7 @@
 
 #include "crypto-utils.h"
 #include "log.h"
+#include "peer-io.h"
 #include "tr-assert.h"
 #include "utils.h"
 #include "web.h"
@@ -179,7 +180,7 @@ public:
     class Task
     {
     private:
-        std::shared_ptr<evbuffer> const privbuf{ evbuffer_new(), evbuffer_free };
+        tr_evbuffer_ptr const privbuf = tr_evbuffer_ptr{ evbuffer_new() };
         std::shared_ptr<CURL> const easy_handle{ curl_easy_init(), curl_easy_cleanup };
         tr_web::FetchOptions options;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -181,7 +181,7 @@ public:
     {
     private:
         tr_evbuffer_ptr const privbuf = tr_evbuffer_ptr{ evbuffer_new() };
-        std::shared_ptr<CURL> const easy_handle{ curl_easy_init(), curl_easy_cleanup };
+        std::unique_ptr<CURL, void (*)(CURL*)> const easy_handle{ curl_easy_init(), curl_easy_cleanup };
         tr_web::FetchOptions options;
 
     public:
@@ -466,7 +466,7 @@ public:
     // the thread started by Impl.curl_thread runs this function
     static void curlThreadFunc(Impl* impl)
     {
-        auto const multi = std::shared_ptr<CURLM>(curl_multi_init(), curl_multi_cleanup);
+        auto const multi = std::unique_ptr<CURLM, CURLMcode (*)(CURLM*)>(curl_multi_init(), curl_multi_cleanup);
 
         auto running_tasks = int{ 0 };
         auto repeats = unsigned{};
@@ -563,7 +563,7 @@ public:
         impl->is_closed_ = true;
     }
 
-    std::shared_ptr<CURLSH> const curlsh_{ curl_share_init(), curl_share_cleanup };
+    std::unique_ptr<CURLSH, CURLSHcode (*)(CURLSH*)> const curlsh_{ curl_share_init(), curl_share_cleanup };
 
     std::mutex queued_tasks_mutex;
     std::condition_variable queued_tasks_cv;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -22,6 +22,7 @@
 
 #include "bandwidth.h"
 #include "cache.h"
+#include "peer-io.h"
 #include "peer-mgr.h"
 #include "torrent.h"
 #include "trevent.h" /* tr_runInEventThread() */
@@ -42,7 +43,7 @@ void on_idle(tr_webseed* w);
 class tr_webseed_task
 {
 private:
-    std::shared_ptr<evbuffer> const content_{ evbuffer_new(), evbuffer_free };
+    tr_evbuffer_ptr const content_{ evbuffer_new() };
 
 public:
     tr_webseed_task(tr_torrent* tor, tr_webseed* webseed_in, tr_block_span_t blocks_in)
@@ -351,7 +352,7 @@ private:
 struct write_block_data
 {
 private:
-    std::shared_ptr<evbuffer> const content_{ evbuffer_new(), evbuffer_free };
+    tr_evbuffer_ptr const content_{ evbuffer_new() };
 
 public:
     write_block_data(


### PR DESCRIPTION
There were some instances in the code where `std::shared_ptr` was being used instead of `std::unique_ptr` not for semantic reasons, but rather as a quick-and-dirty way of passing in a random deleter. This PR cleans that up.