### PR TITLE
refactor: tr_peer_event

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -56,14 +56,14 @@ public:
 
     Type type = Type::Error;
 
-    uint32_t pieceIndex = 0; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
-    tr_bitfield* bitfield = nullptr; /* for GOT_BITFIELD */
-    uint32_t offset = 0; /* for GOT_BLOCK */
-    uint32_t length = 0; /* for GOT_BLOCK + GOT_PIECE_DATA */
-    int err = 0; /* errno for GOT_ERROR */
-    tr_port port = {}; /* for GOT_PORT */
+    tr_bitfield* bitfield = nullptr; // for GotBitfield
+    uint32_t pieceIndex = 0; // for GotBlock, GotHave, Cancel, Allowed, Suggest
+    uint32_t offset = 0; // for GotBlock
+    uint32_t length = 0; // for GotBlock, GotPieceData
+    int err = 0; // errno for GotError
+    tr_port port = {}; // for GotPort
 
-    [[nodiscard]] constexpr static tr_peer_event GotBlock(tr_block_info const& block_info, tr_block_index_t block) noexcept
+    [[nodiscard]] constexpr static auto GotBlock(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {
         auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
@@ -74,7 +74,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotAllowedFast(tr_piece_index_t piece) noexcept
+    [[nodiscard]] constexpr static auto GotAllowedFast(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotAllowedFast;
@@ -82,7 +82,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotBitfield(tr_bitfield* bitfield) noexcept
+    [[nodiscard]] constexpr static auto GotBitfield(tr_bitfield* bitfield) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotBitfield;
@@ -90,14 +90,14 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotChoke() noexcept
+    [[nodiscard]] constexpr static auto GotChoke() noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotChoke;
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotError(int err) noexcept
+    [[nodiscard]] constexpr static auto GotError(int err) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::Error;
@@ -105,7 +105,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotHave(tr_piece_index_t piece) noexcept
+    [[nodiscard]] constexpr static auto GotHave(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotHave;
@@ -113,21 +113,21 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotHaveAll() noexcept
+    [[nodiscard]] constexpr static auto GotHaveAll() noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotHaveAll;
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotHaveNone() noexcept
+    [[nodiscard]] constexpr static auto GotHaveNone() noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotHaveNone;
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
+    [[nodiscard]] constexpr static auto GotPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotPieceData;
@@ -135,7 +135,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotPort(tr_port port) noexcept
+    [[nodiscard]] constexpr static auto GotPort(tr_port port) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotPort;
@@ -143,7 +143,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotRejected(tr_block_info const& block_info, tr_block_index_t block) noexcept
+    [[nodiscard]] constexpr static auto GotRejected(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {
         auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
@@ -154,7 +154,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotSuggest(tr_piece_index_t piece) noexcept
+    [[nodiscard]] constexpr static auto GotSuggest(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientGotSuggest;
@@ -162,7 +162,7 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event ClientSentPieceData(uint32_t length) noexcept
+    [[nodiscard]] constexpr static auto SentPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
         event.type = Type::ClientSentPieceData;

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -15,6 +15,7 @@
 #include "transmission.h"
 
 #include "bitfield.h"
+#include "block-info.h"
 #include "history.h"
 #include "interned-string.h"
 #include "net.h" // tr_port
@@ -50,8 +51,9 @@ enum PeerEventType
     TR_PEER_ERROR
 };
 
-struct tr_peer_event
+class tr_peer_event
 {
+public:
     PeerEventType eventType;
 
     uint32_t pieceIndex; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
@@ -60,6 +62,16 @@ struct tr_peer_event
     uint32_t length; /* for GOT_BLOCK + GOT_PIECE_DATA */
     int err; /* errno for GOT_ERROR */
     tr_port port; /* for GOT_PORT */
+
+    [[nodiscard]] constexpr static tr_peer_event GotBlock(tr_block_info::Location loc, uint32_t length) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_BLOCK;
+        event.pieceIndex = loc.piece;
+        event.offset = loc.piece_offset;
+        event.length = length;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -130,7 +130,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
+        event.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
         event.length = length;
         return event;
     }
@@ -159,6 +159,14 @@ public:
         auto event = tr_peer_event{};
         event.eventType = TR_PEER_CLIENT_GOT_SUGGEST;
         event.pieceIndex = piece;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event PeerGotPieceData(uint32_t length) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
+        event.length = length;
         return event;
     }
 };

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -137,6 +137,14 @@ public:
         event.port = port;
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotBitfield(tr_bitfield* bitfield) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
+        event.bitfield = bitfield;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -100,6 +100,13 @@ public:
         event.length = block_info.blockSize(block);
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotHaveAll() noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_HAVE_ALL;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -56,12 +56,12 @@ class tr_peer_event
 public:
     PeerEventType eventType;
 
-    uint32_t pieceIndex; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
-    tr_bitfield* bitfield; /* for GOT_BITFIELD */
-    uint32_t offset; /* for GOT_BLOCK */
-    uint32_t length; /* for GOT_BLOCK + GOT_PIECE_DATA */
-    int err; /* errno for GOT_ERROR */
-    tr_port port; /* for GOT_PORT */
+    uint32_t pieceIndex = 0; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
+    tr_bitfield* bitfield = nullptr; /* for GOT_BITFIELD */
+    uint32_t offset = 0; /* for GOT_BLOCK */
+    uint32_t length = 0; /* for GOT_BLOCK + GOT_PIECE_DATA */
+    int err = 0; /* errno for GOT_ERROR */
+    tr_port port = {}; /* for GOT_PORT */
 
     [[nodiscard]] constexpr static tr_peer_event GotBlock(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {
@@ -105,6 +105,13 @@ public:
     {
         auto event = tr_peer_event{};
         event.eventType = TR_PEER_CLIENT_GOT_HAVE_ALL;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event GotHaveNone() noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_HAVE_NONE;
         return event;
     }
 };

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -114,6 +114,14 @@ public:
         event.eventType = TR_PEER_CLIENT_GOT_HAVE_NONE;
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotHave(tr_piece_index_t piece) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_HAVE;
+        event.pieceIndex = piece;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -171,7 +171,7 @@ public:
     }
 };
 
-using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);
+using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const& event, void* client_data);
 
 /**
  * State information about a connected peer.

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -63,13 +63,22 @@ public:
     int err; /* errno for GOT_ERROR */
     tr_port port; /* for GOT_PORT */
 
-    [[nodiscard]] constexpr static tr_peer_event GotBlock(tr_block_info::Location loc, uint32_t length) noexcept
+    [[nodiscard]] constexpr static tr_peer_event GotBlock(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {
+        auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
         event.eventType = TR_PEER_CLIENT_GOT_BLOCK;
         event.pieceIndex = loc.piece;
         event.offset = loc.piece_offset;
-        event.length = length;
+        event.length = block_info.blockSize(block);
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event GotError(int err) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_ERROR;
+        event.err = err;
         return event;
     }
 };

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -74,11 +74,30 @@ public:
         return event;
     }
 
+    [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
+        event.length = length;
+        return event;
+    }
+
     [[nodiscard]] constexpr static tr_peer_event GotError(int err) noexcept
     {
         auto event = tr_peer_event{};
         event.eventType = TR_PEER_ERROR;
         event.err = err;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event GotRejected(tr_block_info const& block_info, tr_block_index_t block) noexcept
+    {
+        auto const loc = block_info.blockLoc(block);
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_REJ;
+        event.pieceIndex = loc.piece;
+        event.offset = loc.piece_offset;
+        event.length = block_info.blockSize(block);
         return event;
     }
 };

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -129,6 +129,14 @@ public:
         event.pieceIndex = piece;
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotPort(tr_port port) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_PORT;
+        event.port = port;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -47,7 +47,7 @@ enum PeerEventType
     TR_PEER_CLIENT_GOT_HAVE,
     TR_PEER_CLIENT_GOT_HAVE_ALL,
     TR_PEER_CLIENT_GOT_HAVE_NONE,
-    TR_PEER_PEER_GOT_PIECE_DATA,
+    TR_PEER_CLIENT_SENT_PIECE_DATA,
     TR_PEER_ERROR
 };
 
@@ -162,10 +162,10 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event PeerGotPieceData(uint32_t length) noexcept
+    [[nodiscard]] constexpr static tr_peer_event ClientSentPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
+        event.eventType = TR_PEER_CLIENT_SENT_PIECE_DATA;
         event.length = length;
         return event;
     }

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -34,27 +34,27 @@ struct tr_bandwidth;
 ***  Peer Publish / Subscribe
 **/
 
-enum PeerEventType
-{
-    TR_PEER_CLIENT_GOT_BLOCK,
-    TR_PEER_CLIENT_GOT_CHOKE,
-    TR_PEER_CLIENT_GOT_PIECE_DATA,
-    TR_PEER_CLIENT_GOT_ALLOWED_FAST,
-    TR_PEER_CLIENT_GOT_SUGGEST,
-    TR_PEER_CLIENT_GOT_PORT,
-    TR_PEER_CLIENT_GOT_REJ,
-    TR_PEER_CLIENT_GOT_BITFIELD,
-    TR_PEER_CLIENT_GOT_HAVE,
-    TR_PEER_CLIENT_GOT_HAVE_ALL,
-    TR_PEER_CLIENT_GOT_HAVE_NONE,
-    TR_PEER_CLIENT_SENT_PIECE_DATA,
-    TR_PEER_ERROR
-};
-
 class tr_peer_event
 {
 public:
-    PeerEventType eventType;
+    enum class Type
+    {
+        ClientGotBlock,
+        ClientGotChoke,
+        ClientGotPieceData,
+        ClientGotAllowedFast,
+        ClientGotSuggest,
+        ClientGotPort,
+        ClientGotRej,
+        ClientGotBitfield,
+        ClientGotHave,
+        ClientGotHaveAll,
+        ClientGotHaveNone,
+        ClientSentPieceData,
+        Error
+    };
+
+    Type type = Type::Error;
 
     uint32_t pieceIndex = 0; /* for GOT_BLOCK, GOT_HAVE, CANCEL, ALLOWED, SUGGEST */
     tr_bitfield* bitfield = nullptr; /* for GOT_BITFIELD */
@@ -67,7 +67,7 @@ public:
     {
         auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_BLOCK;
+        event.type = Type::ClientGotBlock;
         event.pieceIndex = loc.piece;
         event.offset = loc.piece_offset;
         event.length = block_info.blockSize(block);
@@ -77,7 +77,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotAllowedFast(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_ALLOWED_FAST;
+        event.type = Type::ClientGotAllowedFast;
         event.pieceIndex = piece;
         return event;
     }
@@ -85,7 +85,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotBitfield(tr_bitfield* bitfield) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
+        event.type = Type::ClientGotBitfield;
         event.bitfield = bitfield;
         return event;
     }
@@ -93,14 +93,14 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotChoke() noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_CHOKE;
+        event.type = Type::ClientGotChoke;
         return event;
     }
 
     [[nodiscard]] constexpr static tr_peer_event GotError(int err) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_ERROR;
+        event.type = Type::Error;
         event.err = err;
         return event;
     }
@@ -108,7 +108,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotHave(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_HAVE;
+        event.type = Type::ClientGotHave;
         event.pieceIndex = piece;
         return event;
     }
@@ -116,21 +116,21 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotHaveAll() noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_HAVE_ALL;
+        event.type = Type::ClientGotHaveAll;
         return event;
     }
 
     [[nodiscard]] constexpr static tr_peer_event GotHaveNone() noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_HAVE_NONE;
+        event.type = Type::ClientGotHaveNone;
         return event;
     }
 
     [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
+        event.type = Type::ClientGotPieceData;
         event.length = length;
         return event;
     }
@@ -138,7 +138,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotPort(tr_port port) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_PORT;
+        event.type = Type::ClientGotPort;
         event.port = port;
         return event;
     }
@@ -147,7 +147,7 @@ public:
     {
         auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_REJ;
+        event.type = Type::ClientGotRej;
         event.pieceIndex = loc.piece;
         event.offset = loc.piece_offset;
         event.length = block_info.blockSize(block);
@@ -157,7 +157,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event GotSuggest(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_SUGGEST;
+        event.type = Type::ClientGotSuggest;
         event.pieceIndex = piece;
         return event;
     }
@@ -165,7 +165,7 @@ public:
     [[nodiscard]] constexpr static tr_peer_event ClientSentPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_SENT_PIECE_DATA;
+        event.type = Type::ClientSentPieceData;
         event.length = length;
         return event;
     }

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -101,6 +101,13 @@ public:
         return event;
     }
 
+    [[nodiscard]] constexpr static tr_peer_event GotChoke() noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_CHOKE;
+        return event;
+    }
+
     [[nodiscard]] constexpr static tr_peer_event GotHaveAll() noexcept
     {
         auto event = tr_peer_event{};

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -74,11 +74,26 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
+    [[nodiscard]] constexpr static tr_peer_event GotAllowedFast(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
-        event.length = length;
+        event.eventType = TR_PEER_CLIENT_GOT_ALLOWED_FAST;
+        event.pieceIndex = piece;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event GotBitfield(tr_bitfield* bitfield) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
+        event.bitfield = bitfield;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static tr_peer_event GotChoke() noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_CHOKE;
         return event;
     }
 
@@ -90,21 +105,11 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotRejected(tr_block_info const& block_info, tr_block_index_t block) noexcept
-    {
-        auto const loc = block_info.blockLoc(block);
-        auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_REJ;
-        event.pieceIndex = loc.piece;
-        event.offset = loc.piece_offset;
-        event.length = block_info.blockSize(block);
-        return event;
-    }
-
-    [[nodiscard]] constexpr static tr_peer_event GotChoke() noexcept
+    [[nodiscard]] constexpr static tr_peer_event GotHave(tr_piece_index_t piece) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_CHOKE;
+        event.eventType = TR_PEER_CLIENT_GOT_HAVE;
+        event.pieceIndex = piece;
         return event;
     }
 
@@ -122,11 +127,11 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotHave(tr_piece_index_t piece) noexcept
+    [[nodiscard]] constexpr static tr_peer_event GotPieceData(uint32_t length) noexcept
     {
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_HAVE;
-        event.pieceIndex = piece;
+        event.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
+        event.length = length;
         return event;
     }
 
@@ -138,19 +143,14 @@ public:
         return event;
     }
 
-    [[nodiscard]] constexpr static tr_peer_event GotBitfield(tr_bitfield* bitfield) noexcept
+    [[nodiscard]] constexpr static tr_peer_event GotRejected(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {
+        auto const loc = block_info.blockLoc(block);
         auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
-        event.bitfield = bitfield;
-        return event;
-    }
-
-    [[nodiscard]] constexpr static tr_peer_event GotAllowedFast(tr_piece_index_t piece) noexcept
-    {
-        auto event = tr_peer_event{};
-        event.eventType = TR_PEER_CLIENT_GOT_ALLOWED_FAST;
-        event.pieceIndex = piece;
+        event.eventType = TR_PEER_CLIENT_GOT_REJ;
+        event.pieceIndex = loc.piece;
+        event.offset = loc.piece_offset;
+        event.length = block_info.blockSize(block);
         return event;
     }
 

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -145,6 +145,14 @@ public:
         event.bitfield = bitfield;
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotAllowedFast(tr_piece_index_t piece) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_ALLOWED_FAST;
+        event.pieceIndex = piece;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -153,6 +153,14 @@ public:
         event.pieceIndex = piece;
         return event;
     }
+
+    [[nodiscard]] constexpr static tr_peer_event GotSuggest(tr_piece_index_t piece) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.eventType = TR_PEER_CLIENT_GOT_SUGGEST;
+        event.pieceIndex = piece;
+        return event;
+    }
 };
 
 using tr_peer_callback = void (*)(tr_peer* peer, tr_peer_event const* event, void* client_data);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -975,9 +975,9 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
     auto* s = static_cast<tr_swarm*>(vs);
     auto const lock = s->unique_lock();
 
-    switch (e->eventType)
+    switch (e->type)
     {
-    case TR_PEER_CLIENT_SENT_PIECE_DATA:
+    case tr_peer_event::Type::ClientSentPieceData:
         {
             auto const now = tr_time();
             auto* const tor = s->tor;
@@ -996,7 +996,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
             break;
         }
 
-    case TR_PEER_CLIENT_GOT_PIECE_DATA:
+    case tr_peer_event::Type::ClientGotPieceData:
         {
             auto const now = tr_time();
             auto* const tor = s->tor;
@@ -1014,23 +1014,23 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
             break;
         }
 
-    case TR_PEER_CLIENT_GOT_HAVE:
-    case TR_PEER_CLIENT_GOT_HAVE_ALL:
-    case TR_PEER_CLIENT_GOT_HAVE_NONE:
-    case TR_PEER_CLIENT_GOT_BITFIELD:
+    case tr_peer_event::Type::ClientGotHave:
+    case tr_peer_event::Type::ClientGotHaveAll:
+    case tr_peer_event::Type::ClientGotHaveNone:
+    case tr_peer_event::Type::ClientGotBitfield:
         /* TODO: if we don't need these, should these events be removed? */
         /* noop */
         break;
 
-    case TR_PEER_CLIENT_GOT_REJ:
+    case tr_peer_event::Type::ClientGotRej:
         s->active_requests.remove(s->tor->pieceLoc(e->pieceIndex, e->offset).block, peer);
         break;
 
-    case TR_PEER_CLIENT_GOT_CHOKE:
+    case tr_peer_event::Type::ClientGotChoke:
         s->active_requests.remove(peer);
         break;
 
-    case TR_PEER_CLIENT_GOT_PORT:
+    case tr_peer_event::Type::ClientGotPort:
         if (peer->atom != nullptr)
         {
             peer->atom->port = e->port;
@@ -1038,15 +1038,15 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
 
         break;
 
-    case TR_PEER_CLIENT_GOT_SUGGEST:
+    case tr_peer_event::Type::ClientGotSuggest:
         peerSuggestedPiece(s, peer, e->pieceIndex, false);
         break;
 
-    case TR_PEER_CLIENT_GOT_ALLOWED_FAST:
+    case tr_peer_event::Type::ClientGotAllowedFast:
         peerSuggestedPiece(s, peer, e->pieceIndex, true);
         break;
 
-    case TR_PEER_CLIENT_GOT_BLOCK:
+    case tr_peer_event::Type::ClientGotBlock:
         {
             auto* const tor = s->tor;
             auto const loc = tor->pieceLoc(e->pieceIndex, e->offset);
@@ -1056,7 +1056,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
             break;
         }
 
-    case TR_PEER_ERROR:
+    case tr_peer_event::Type::Error:
         if (e->err == ERANGE || e->err == EMSGSIZE || e->err == ENOTCONN)
         {
             /* some protocol error from the peer */
@@ -1073,9 +1073,6 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
         }
 
         break;
-
-    default:
-        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled peer event type {:d}"), e->eventType));
     }
 }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -977,7 +977,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const* e, void* vs)
 
     switch (e->eventType)
     {
-    case TR_PEER_PEER_GOT_PIECE_DATA:
+    case TR_PEER_CLIENT_SENT_PIECE_DATA:
         {
             auto const now = tr_time();
             auto* const tor = s->tor;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -533,9 +533,7 @@ public:
 
     void publishGotChoke()
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_CHOKE;
-        publish(e);
+        publish(tr_peer_event::GotChoke());
     }
 
     void publishClientGotHaveAll()

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -528,12 +528,7 @@ public:
 
     void publishGotRej(struct peer_request const* req)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_REJ;
-        e.pieceIndex = req->index;
-        e.offset = req->offset;
-        e.length = req->length;
-        publish(e);
+        publish(tr_peer_event::GotRejected(torrent->blockInfo(), torrent->pieceLoc(req->index, req->offset)));
     }
 
     void publishGotChoke()
@@ -559,18 +554,12 @@ public:
 
     void publishClientGotPieceData(uint32_t length)
     {
-        auto e = tr_peer_event{};
-        e.length = length;
-        e.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
-        publish(e);
+        publish(tr_peer_event::GotPieceData(length));
     }
 
     void publishPeerGotPieceData(uint32_t length)
     {
-        auto e = tr_peer_event{};
-        e.length = length;
-        e.eventType = TR_PEER_PEER_GOT_PIECE_DATA;
-        publish(e);
+        publish(tr_peer_event::GotPieceData(length));
     }
 
     void publishClientGotSuggest(tr_piece_index_t pieceIndex)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotHaveNone()
-    {
-        publish(tr_peer_event::GotHaveNone());
-    }
-
     void publishClientGotPieceData(uint32_t length)
     {
         publish(tr_peer_event::GotPieceData(length));
@@ -1900,7 +1895,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
         if (fext)
         {
             msgs->have_.setHasNone();
-            msgs->publishClientGotHaveNone();
+            msgs->publish(tr_peer_event::GotHaveNone());
             msgs->invalidatePercentDone();
         }
         else

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishPeerGotPieceData(uint32_t length)
-    {
-        publish(tr_peer_event::GotPieceData(length));
-    }
-
     void publishClientGotSuggest(tr_piece_index_t piece)
     {
         publish(tr_peer_event::GotSuggest(piece));
@@ -1992,7 +1987,7 @@ static void didWrite(tr_peerIo* io, size_t bytesWritten, bool wasPieceData, void
 
     if (wasPieceData)
     {
-        msgs->publishPeerGotPieceData(bytesWritten);
+        msgs->publish(tr_peer_event::PeerGotPieceData(bytesWritten));
     }
 
     if (tr_isPeerIo(io) && io->userData != nullptr)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -545,9 +545,7 @@ public:
 
     void publishClientGotHaveNone()
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_HAVE_NONE;
-        publish(e);
+        publish(tr_peer_event::GotHaveNone());
     }
 
     void publishClientGotPieceData(uint32_t length)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -518,10 +518,7 @@ public:
 
     void publishError(int err)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_ERROR;
-        e.err = err;
-        publish(e);
+        publish(tr_peer_event::GotError(err));
     }
 
     void publishGotBlock(tr_block_index_t block)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -569,12 +569,9 @@ public:
         publish(tr_peer_event::GotPort(port));
     }
 
-    void publishClientGotAllowedFast(tr_piece_index_t pieceIndex)
+    void publishClientGotAllowedFast(tr_piece_index_t piece)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_ALLOWED_FAST;
-        e.pieceIndex = pieceIndex;
-        publish(e);
+        publish(tr_peer_event::GotAllowedFast(piece));
     }
 
     void publishClientGotBitfield(tr_bitfield* bitfield)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotBitfield(tr_bitfield* bitfield)
-    {
-        publish(tr_peer_event::GotBitfield(bitfield));
-    }
-
     void publishClientGotHave(tr_piece_index_t index)
     {
         publish(tr_peer_event::GotHave(index));
@@ -1750,7 +1745,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
             msgs->io->readBytes(std::data(tmp), std::size(tmp));
             msgs->have_ = tr_bitfield{ msgs->torrent->hasMetainfo() ? msgs->torrent->pieceCount() : std::size(tmp) * 8 };
             msgs->have_.setRaw(std::data(tmp), std::size(tmp));
-            msgs->publishClientGotBitfield(&msgs->have_);
+            msgs->publish(tr_peer_event::GotBitfield(&msgs->have_));
             msgs->invalidatePercentDone();
             break;
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotSuggest(tr_piece_index_t piece)
-    {
-        publish(tr_peer_event::GotSuggest(piece));
-    }
-
     void publishClientGotPort(tr_port port)
     {
         publish(tr_peer_event::GotPort(port));
@@ -1836,7 +1831,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 
         if (fext)
         {
-            msgs->publishClientGotSuggest(ui32);
+            msgs->publish(tr_peer_event::GotSuggest(ui32));
         }
         else
         {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishGotBlock(tr_block_index_t block)
-    {
-        publish(tr_peer_event::GotBlock(torrent->blockInfo(), block));
-    }
-
     void publishGotRej(struct peer_request const* req)
     {
         publish(tr_peer_event::GotRejected(torrent->blockInfo(), torrent->pieceLoc(req->index, req->offset).block));
@@ -2011,7 +2006,7 @@ static int clientGotBlock(
 
     msgs->session->cache->writeBlock(tor->id(), block, block_data);
     msgs->blame.set(loc.piece);
-    msgs->publishGotBlock(block);
+    msgs->publish(tr_peer_event::GotBlock(tor->blockInfo(), block));
     return 0;
 }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishGotChoke()
-    {
-        publish(tr_peer_event::GotChoke());
-    }
-
     void publishClientGotHaveAll()
     {
         publish(tr_peer_event::GotHaveAll());
@@ -1738,7 +1733,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 
         if (!fext)
         {
-            msgs->publishGotChoke();
+            msgs->publish(tr_peer_event::GotChoke());
         }
 
         msgs->update_active(TR_PEER_TO_CLIENT);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -566,10 +566,7 @@ public:
 
     void publishClientGotPort(tr_port port)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_PORT;
-        e.port = port;
-        publish(e);
+        publish(tr_peer_event::GotPort(port));
     }
 
     void publishClientGotAllowedFast(tr_piece_index_t pieceIndex)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -561,11 +561,11 @@ public:
 
     void sendPex();
 
-    void publish(tr_peer_event const& e)
+    void publish(tr_peer_event const& peer_event)
     {
         if (callback_ != nullptr)
         {
-            (*callback_)(this, &e, callbackData_);
+            (*callback_)(this, peer_event, callbackData_);
         }
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotPieceData(uint32_t length)
-    {
-        publish(tr_peer_event::GotPieceData(length));
-    }
-
     void publishPeerGotPieceData(uint32_t length)
     {
         publish(tr_peer_event::GotPieceData(length));
@@ -1639,7 +1634,7 @@ static ReadState readBtPiece(tr_peerMsgsImpl* msgs, size_t inlen, size_t* setme_
     block_buf->resize(old_length + n_to_read);
     msgs->io->readBytes(&((*block_buf)[old_length]), n_to_read);
 
-    msgs->publishClientGotPieceData(n_to_read);
+    msgs->publish(tr_peer_event::GotPieceData(n_to_read));
     *setme_piece_bytes_read += n_to_read;
     logtrace(
         msgs,

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -514,12 +514,7 @@ public:
         // TODO -- might need to poke the mgr on startup
     }
 
-    // publishing events
-
-    void publishClientGotHave(tr_piece_index_t index)
-    {
-        publish(tr_peer_event::GotHave(index));
-    }
+    //
 
     [[nodiscard]] bool isValidRequest(peer_request const& req) const
     {
@@ -1732,7 +1727,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
         if (!msgs->have_.test(ui32))
         {
             msgs->have_.set(ui32);
-            msgs->publishClientGotHave(ui32);
+            msgs->publish(tr_peer_event::GotHave(ui32));
         }
 
         msgs->invalidatePercentDone();

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotPort(tr_port port)
-    {
-        publish(tr_peer_event::GotPort(port));
-    }
-
     void publishClientGotAllowedFast(tr_piece_index_t piece)
     {
         publish(tr_peer_event::GotAllowedFast(piece));
@@ -1228,7 +1223,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
     if (tr_variantDictFindInt(&val, TR_KEY_p, &i))
     {
         pex.port.setHost(i);
-        msgs->publishClientGotPort(pex.port);
+        msgs->publish(tr_peer_event::GotPort(pex.port));
         logtrace(msgs, fmt::format(FMT_STRING("peer's port is now {:d}"), i));
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishGotRej(struct peer_request const* req)
-    {
-        publish(tr_peer_event::GotRejected(torrent->blockInfo(), torrent->pieceLoc(req->index, req->offset).block));
-    }
-
     void publishGotChoke()
     {
         publish(tr_peer_event::GotChoke());
@@ -1936,7 +1931,8 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 
             if (fext)
             {
-                msgs->publishGotRej(&r);
+                msgs->publish(
+                    tr_peer_event::GotRejected(msgs->torrent->blockInfo(), msgs->torrent->pieceLoc(r.index, r.offset).block));
             }
             else
             {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotHaveAll()
-    {
-        publish(tr_peer_event::GotHaveAll());
-    }
-
     void publishClientGotHaveNone()
     {
         publish(tr_peer_event::GotHaveNone());
@@ -1888,7 +1883,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
         if (fext)
         {
             msgs->have_.setHasAll();
-            msgs->publishClientGotHaveAll();
+            msgs->publish(tr_peer_event::GotHaveAll());
             msgs->invalidatePercentDone();
         }
         else

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -526,13 +526,7 @@ public:
 
     void publishGotBlock(tr_block_index_t block)
     {
-        auto const loc = torrent->blockLoc(block);
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_BLOCK;
-        e.pieceIndex = loc.piece;
-        e.offset = loc.piece_offset;
-        e.length = torrent->blockSize(block);
-        publish(e);
+        publish(tr_peer_event::GotBlock(torrent->blockInfo(), block));
     }
 
     void publishGotRej(struct peer_request const* req)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -516,11 +516,6 @@ public:
 
     // publishing events
 
-    void publishClientGotAllowedFast(tr_piece_index_t piece)
-    {
-        publish(tr_peer_event::GotAllowedFast(piece));
-    }
-
     void publishClientGotBitfield(tr_bitfield* bitfield)
     {
         publish(tr_peer_event::GotBitfield(bitfield));
@@ -1842,7 +1837,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 
         if (fext)
         {
-            msgs->publishClientGotAllowedFast(ui32);
+            msgs->publish(tr_peer_event::GotAllowedFast(ui32));
         }
         else
         {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1962,7 +1962,7 @@ static void didWrite(tr_peerIo* io, size_t bytesWritten, bool wasPieceData, void
 
     if (wasPieceData)
     {
-        msgs->publish(tr_peer_event::ClientSentPieceData(bytesWritten));
+        msgs->publish(tr_peer_event::SentPieceData(bytesWritten));
     }
 
     if (tr_isPeerIo(io) && io->userData != nullptr)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1962,7 +1962,7 @@ static void didWrite(tr_peerIo* io, size_t bytesWritten, bool wasPieceData, void
 
     if (wasPieceData)
     {
-        msgs->publish(tr_peer_event::PeerGotPieceData(bytesWritten));
+        msgs->publish(tr_peer_event::ClientSentPieceData(bytesWritten));
     }
 
     if (tr_isPeerIo(io) && io->userData != nullptr)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -592,10 +592,7 @@ public:
 
     void publishClientGotHave(tr_piece_index_t index)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_HAVE;
-        e.pieceIndex = index;
-        publish(e);
+        publish(tr_peer_event::GotHave(index));
     }
 
     [[nodiscard]] bool isValidRequest(peer_request const& req) const

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -556,12 +556,9 @@ public:
         publish(tr_peer_event::GotPieceData(length));
     }
 
-    void publishClientGotSuggest(tr_piece_index_t pieceIndex)
+    void publishClientGotSuggest(tr_piece_index_t piece)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_SUGGEST;
-        e.pieceIndex = pieceIndex;
-        publish(e);
+        publish(tr_peer_event::GotSuggest(piece));
     }
 
     void publishClientGotPort(tr_port port)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -528,7 +528,7 @@ public:
 
     void publishGotRej(struct peer_request const* req)
     {
-        publish(tr_peer_event::GotRejected(torrent->blockInfo(), torrent->pieceLoc(req->index, req->offset)));
+        publish(tr_peer_event::GotRejected(torrent->blockInfo(), torrent->pieceLoc(req->index, req->offset).block));
     }
 
     void publishGotChoke()
@@ -540,9 +540,7 @@ public:
 
     void publishClientGotHaveAll()
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_HAVE_ALL;
-        publish(e);
+        publish(tr_peer_event::GotHaveAll());
     }
 
     void publishClientGotHaveNone()

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -579,10 +579,7 @@ public:
 
     void publishClientGotBitfield(tr_bitfield* bitfield)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_BITFIELD;
-        e.bitfield = bitfield;
-        publish(e);
+        publish(tr_peer_event::GotBitfield(bitfield));
     }
 
     void publishClientGotHave(tr_piece_index_t index)

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -297,11 +297,11 @@ public:
         return { n_slots, n_slots * PreferredBlocksPerTask };
     }
 
-    void publish(tr_peer_event event)
+    void publish(tr_peer_event const& peer_event)
     {
         if (callback != nullptr)
         {
-            (*callback)(this, &event, callback_data);
+            (*callback)(this, peer_event, callback_data);
         }
     }
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -251,15 +251,10 @@ public:
 
     void publishRejection(tr_block_span_t block_span)
     {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_REJ;
-
+        auto const* const tor = getTorrent();
         for (auto block = block_span.begin; block < block_span.end; ++block)
         {
-            auto const loc = getTorrent()->blockLoc(block);
-            e.pieceIndex = loc.piece;
-            e.offset = loc.piece_offset;
-            publish(e);
+            publish(tr_peer_event::GotRejected(tor->blockInfo(), block));
         }
     }
 
@@ -316,7 +311,7 @@ public:
     std::set<tr_webseed_task*> tasks;
 
 private:
-    void publish(tr_peer_event& event)
+    void publish(tr_peer_event event)
     {
         if (callback != nullptr)
         {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -259,21 +259,13 @@ public:
             auto const loc = getTorrent()->blockLoc(block);
             e.pieceIndex = loc.piece;
             e.offset = loc.piece_offset;
-            publish(&e);
+            publish(e);
         }
     }
 
     void publishGotBlock(tr_torrent const* tor, tr_block_index_t block)
     {
-        TR_ASSERT(block < tor->blockCount());
-
-        auto const loc = tor->blockLoc(block);
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_BLOCK;
-        e.pieceIndex = loc.piece;
-        e.offset = loc.piece_offset;
-        e.length = tor->blockSize(loc.block);
-        publish(&e);
+        publish(tr_peer_event::GotBlock(tor->blockInfo(), block));
     }
 
     void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) override
@@ -324,11 +316,11 @@ public:
     std::set<tr_webseed_task*> tasks;
 
 private:
-    void publish(tr_peer_event* event)
+    void publish(tr_peer_event& event)
     {
         if (callback != nullptr)
         {
-            (*callback)(this, event, callback_data);
+            (*callback)(this, &event, callback_data);
         }
     }
 
@@ -337,7 +329,7 @@ private:
         auto e = tr_peer_event{};
         e.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
         e.length = length;
-        publish(&e);
+        publish(e);
     }
 
     tr_bandwidth bandwidth_;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -245,7 +245,7 @@ public:
     void gotPieceData(uint32_t n_bytes)
     {
         bandwidth_.notifyBandwidthConsumed(TR_DOWN, n_bytes, true, tr_time_msec());
-        publishClientGotPieceData(n_bytes);
+        publish(tr_peer_event::GotPieceData(n_bytes));
         connection_limiter.gotData();
     }
 
@@ -317,14 +317,6 @@ private:
         {
             (*callback)(this, &event, callback_data);
         }
-    }
-
-    void publishClientGotPieceData(uint32_t length)
-    {
-        auto e = tr_peer_event{};
-        e.eventType = TR_PEER_CLIENT_GOT_PIECE_DATA;
-        e.length = length;
-        publish(e);
     }
 
     tr_bandwidth bandwidth_;


### PR DESCRIPTION
Minor cleanup; no functional changes.

- Add helper functions for creating `tr_peer_event` instances
- Use the helper functions in both peer-msgs and webseed
- Make the event enumeration an `enum class`