### PR TITLE
Add Advanced Download Manager & LibreTorrent client names

### DIFF
--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -599,7 +599,8 @@ struct Client
     format_func formatter;
 };
 
-auto constexpr Clients = std::array<Client, 127>{ {
+auto constexpr Clients = std::array<Client, 129>{ {
+    { "-AD", "Advanced Download Manager", three_digit_formatter },
     { "-AG", "Ares", four_digit_formatter },
     { "-AR", "Arctic", four_digit_formatter },
     { "-AT", "Artemis", four_digit_formatter },
@@ -650,6 +651,7 @@ auto constexpr Clients = std::array<Client, 127>{ {
     { "-LP", "Lphant", two_major_two_minor_formatter },
     { "-LT", "libtorrent (Rasterbar)", three_digit_formatter },
     { "-LW", "LimeWire", no_version_formatter },
+    { "-Lr", "LibreTorrent", three_digit_formatter },
     { "-MG", "MediaGet", mediaget_formatter },
     { "-MK", "Meerkat", four_digit_formatter },
     { "-ML", "MLDonkey", mldonkey_formatter },

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -24,8 +24,9 @@ TEST(Client, clientForId)
         std::string_view expected_client;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 38>{
-        { { "-AZ8421-"sv, "Azureus / Vuze 8.4.2.1"sv },
+    auto constexpr Tests = std::array<LocalTest, 40>{
+        { { "-ADB560-"sv, "Advanced Download Manager 11.5.6"sv },
+          { "-AZ8421-"sv, "Azureus / Vuze 8.4.2.1"sv },
           { "-BC0241-"sv, "BitComet 2.41"sv }, // two major, two minor
           { "-BI2300-"sv, "BiglyBT 2.3.0.0"sv },
           { "-BL246326"sv, "BitLord 2.4.6-326"sv }, // Style used after BitLord 0.59
@@ -42,6 +43,7 @@ TEST(Client, clientForId)
           { "-IIO\x10\x2D\x04-"sv, "-IIO%10-%04-"sv },
           { "-I\05O\x08\x03\x01-"sv, "-I%05O%08%03%01-"sv },
           { "-KT33D1-"sv, "KTorrent 3.3 Dev 1"sv },
+          { "-Lr10X0-"sv, "LibreTorrent 1.0.33"sv },
           { "-MR1100-"sv, "Miro 1.1.0.0"sv },
           { "-PI0091-"sv, "PicoTorrent 0.09.1"sv },
           { "-PI0120-"sv, "PicoTorrent 0.12.0"sv },


### PR DESCRIPTION
Add missing client names:
[Advanced Download Manager](https://play.google.com/store/apps/details?id=com.dv.adm&gl=US)
[LibreTorrent](https://gitlab.com/proninyaroslav/libretorrent)