### PR TITLE
Add fallback for copy_file_range EXDEV error

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -380,9 +380,10 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         if (copied == -1)
         {
             errno_cpy = errno; /* remember me for later */
-	    if (errno != EXDEV) { /* EXDEV is expected, don't log error */
+            if (errno != EXDEV) /* EXDEV is expected, don't log error */
+            {
                 set_system_error(error, errno);
-	    }
+            }
             if (file_size > 0U)
             {
                 file_size = info->size; /* restore file_size for next fallback */


### PR DESCRIPTION
Fixes #3654 

Add fallback to other copy routines in case of error in previous attempt.
I tried to keep it generic, but for now it targets `EXDEV` error in `copy_file_range` explicitly.

For efficiency sake, I kept the tiered approach to available kernel routines which was previously selected by compile flags.
To do the fallback in runtime I had to duplicate some code. The effort to refactor this went a bit above the scope of a bugfix. At least for now it keeps the change readily accessible for review.
Added some comments for the one trying to clean this up.

**Functional changes:**
Previously:
Try one of `copy_file_range` or `sendfile64` in this order selected during compile time, if it fails exit `tr_sys_path_copy`
Use user-space copy if neither was available during compile time

Now:
First try `copy_file_range` if available during compile time.
Try `sendfile64` if available in case of previous `EXDEV` or when `copy_file_range` wasn't available.
Then try user-space copy if neither kernel routine was available during compile time or previous `EXDEV` errno was set