### PR TITLE
transmission-edit: Allow changes to torrent source flag

### DIFF
--- a/utils/transmission-edit.1
+++ b/utils/transmission-edit.1
@@ -11,6 +11,7 @@
 .Op Fl a Ar url
 .Op Fl d Ar url
 .Op Fl r Ar search Ar replace
+.Op Fl s Ar source
 .Ar torrentfile(s)
 .Ek
 .Sh DESCRIPTION
@@ -26,6 +27,8 @@ Add an announce URL to the torrent's announce-list if it's not already in the li
 Remove an announce URL from the torrent's announce-list
 .It Fl r Fl -replace Ar search Ar replace
 Substring search-and-replace inside a torrent's announce URLs. This can be used to change an announce URL when the tracker moves or your passcode changes.
+.It Fl s Fl -source Ar source
+Set the source tag within a torrent
 .El
 .Sh EXAMPLES
 Update a tracker passcode in all your torrents:


### PR DESCRIPTION
This PR addresses #3724. I would probably have preferred to use the same argument for the source in both transmission-add and transmission-edit utils but as '-r' was already taken I just went with the obvious '-s' for setting the source flag/tag instead.