### PR TITLE
Qt: Allow piece size selection on torrent creation

### DIFF
--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -32,10 +32,11 @@ protected:
 private slots:
     void onSourceChanged();
     void makeTorrent();
+    void onPieceSizeUpdated(int);
 
 private:
     QString getSource() const;
-
+    void updatePiecesLabel();
     Session& session_;
 
     Ui::MakeDialog ui_ = {};

--- a/qt/MakeDialog.ui
+++ b/qt/MakeDialog.ui
@@ -79,6 +79,32 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="1">
+      <widget class="QSlider" name="pieceSizeSlider">
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>26</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="pieceSizeLabel">
+       <property name="text">
+        <string>Piece s&amp;ize:</string>
+       </property>
+       <property name="buddy">
+        <cstring>pieceSizeSlider</cstring>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
Qt has been behind the GTK build insofar as the ability to select piece size on torrent creation for a while. This PR should sort that.
~Also, as there was some discussion around the upper bound (#3402) of piece sizes I've set it to 64MB and also bumped the GTK limit to match.~