### PR TITLE
refactor: move the verify worker thread into a wrapper class

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1817,7 +1817,7 @@ void tr_session::closeImplStart()
     save_timer_.reset();
     now_timer_.reset();
 
-    tr_verifyClose(this);
+    verifier_.reset();
     tr_sharedClose(*this);
 
     close_incoming_peer_port(this);
@@ -2950,4 +2950,6 @@ tr_session::tr_session(std::string_view config_dir)
             stats().saveIfDirty();
         });
     save_timer_->startRepeating(SaveIntervalSecs);
+
+    verifier_->addCallback(tr_torrentOnVerifyDone);
 }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -39,6 +39,7 @@
 #include "torrents.h"
 #include "tr-lpd.h"
 #include "web.h"
+#include "verify.h"
 
 enum tr_auto_switch_state_t
 {
@@ -59,6 +60,13 @@ struct BlocklistFile;
 struct struct_utp_context;
 struct tr_announcer;
 struct tr_announcer_udp;
+
+namespace libtransmission::test
+{
+
+class SessionTest;
+
+} // namespace libtransmission::test
 
 struct tr_bindinfo
 {
@@ -698,6 +706,22 @@ public:
         return peer_id_ttl_hours_;
     }
 
+    void verifyRemove(tr_torrent* tor)
+    {
+        if (verifier_)
+        {
+            verifier_->remove(tor);
+        }
+    }
+
+    void verifyAdd(tr_torrent* tor)
+    {
+        if (verifier_)
+        {
+            verifier_->add(tor);
+        }
+    }
+
 private:
     [[nodiscard]] tr_port randomPort() const;
 
@@ -710,6 +734,7 @@ private:
     void closeImplWaitForIdleUdp();
     void closeImplFinish();
 
+    friend class libtransmission::test::SessionTest;
     friend bool tr_blocklistExists(tr_session const* session);
     friend bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
@@ -887,6 +912,8 @@ private:
     std::unique_ptr<libtransmission::Timer> save_timer_;
 
     tr_torrents torrents_;
+
+    std::unique_ptr<tr_verify_worker> verifier_ = std::make_unique<tr_verify_worker>();
 
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1500,7 +1500,6 @@ static void verifyTorrent(tr_torrent* const tor)
     }
 
     /* if the torrent's already being verified, stop it */
-    fmt::print(FMT_STRING("{:s}:{:d} calling verifyRemove()\n"), __FILE__, __LINE__);
     tor->session->verifyRemove(tor);
 
     bool const startAfter = (tor->isRunning || tor->startAfterVerify) && !tor->isStopping;
@@ -1517,7 +1516,6 @@ static void verifyTorrent(tr_torrent* const tor)
     else
     {
         tor->startAfterVerify = startAfter;
-        fmt::print(FMT_STRING("{:s}:{:d} calling verifyAdd()\n"), __FILE__, __LINE__);
         tor->session->verifyAdd(tor);
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1500,7 +1500,8 @@ static void verifyTorrent(tr_torrent* const tor)
     }
 
     /* if the torrent's already being verified, stop it */
-    tor->session->verifyAdd(tor);
+    fmt::print(FMT_STRING("{:s}:{:d} calling verifyRemove()\n"), __FILE__, __LINE__);
+    tor->session->verifyRemove(tor);
 
     bool const startAfter = (tor->isRunning || tor->startAfterVerify) && !tor->isStopping;
 
@@ -1516,6 +1517,7 @@ static void verifyTorrent(tr_torrent* const tor)
     else
     {
         tor->startAfterVerify = startAfter;
+        fmt::print(FMT_STRING("{:s}:{:d} calling verifyAdd()\n"), __FILE__, __LINE__);
         tor->session->verifyAdd(tor);
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -50,7 +50,6 @@
 #include "tr-assert.h"
 #include "trevent.h" /* tr_runInEventThread() */
 #include "utils.h"
-#include "verify.h"
 #include "version.h"
 #include "web-utils.h"
 
@@ -1480,7 +1479,7 @@ static void onVerifyDoneThreadFunc(tr_torrent* const tor)
     }
 }
 
-static void onVerifyDone(tr_torrent* tor, bool aborted, void* /*unused*/)
+void tr_torrentOnVerifyDone(tr_torrent* tor, bool aborted)
 {
     if (aborted || tor->isDeleting)
     {
@@ -1501,7 +1500,7 @@ static void verifyTorrent(tr_torrent* const tor)
     }
 
     /* if the torrent's already being verified, stop it */
-    tr_verifyRemove(tor);
+    tor->session->verifyAdd(tor);
 
     bool const startAfter = (tor->isRunning || tor->startAfterVerify) && !tor->isStopping;
 
@@ -1517,7 +1516,7 @@ static void verifyTorrent(tr_torrent* const tor)
     else
     {
         tor->startAfterVerify = startAfter;
-        tr_verifyAdd(tor, onVerifyDone, nullptr);
+        tor->session->verifyAdd(tor);
     }
 }
 
@@ -1548,7 +1547,8 @@ static void stopTorrent(tr_torrent* const tor)
         tr_logAddInfoTor(tor, _("Pausing torrent"));
     }
 
-    tr_verifyRemove(tor);
+    tor->session->verifyRemove(tor);
+
     tr_peerMgrStopTorrent(tor);
     tr_announcerTorrentStopped(tor);
 
@@ -1633,7 +1633,7 @@ static void removeTorrentInEventThread(tr_torrent* tor, bool delete_flag, tr_fil
     {
         // ensure the files are all closed and idle before moving
         tor->session->closeTorrentFiles(tor);
-        tr_verifyRemove(tor);
+        tor->session->verifyRemove(tor);
 
         if (delete_func == nullptr)
         {
@@ -2126,7 +2126,7 @@ static void setLocationInEventThread(
 
         // ensure the files are all closed and idle before moving
         tor->session->closeTorrentFiles(tor);
-        tr_verifyRemove(tor);
+        tor->session->verifyRemove(tor);
 
         tr_error* error = nullptr;
         ok = tor->metainfo_.files().move(tor->currentDir(), path, setme_progress, tor->name(), &error);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -781,6 +781,8 @@ void tr_ctorSetBandwidthPriority(tr_ctor* ctor, tr_priority_t priority);
 tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor);
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);
 
+void tr_torrentOnVerifyDone(tr_torrent* tor, bool aborted);
+
 #define tr_logAddCriticalTor(tor, msg) tr_logAddCritical(msg, (tor)->name())
 #define tr_logAddErrorTor(tor, msg) tr_logAddError(msg, (tor)->name())
 #define tr_logAddWarnTor(tor, msg) tr_logAddWarn(msg, (tor)->name())

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -258,7 +258,7 @@ void tr_verify_worker::add(tr_torrent* tor)
     node.torrent = tor;
     node.current_size = tor->hasTotal();
 
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    std::cerr << __FILE__ << ':' << __LINE__ << ' ' << tor->name() << std::endl;
     auto const lock = std::lock_guard(verify_mutex_);
     std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     tor->setVerifyState(TR_VERIFY_WAIT);

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -58,7 +58,6 @@ int tr_verify_worker::Node::compare(tr_verify_worker::Node const& that) const
 
 bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
 {
-    fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread {:s}\n"), __FILE__, __LINE__, tor->name());
     auto const begin = tr_time();
 
     tr_sys_file_t fd = TR_BAD_SYS_FILE;
@@ -75,45 +74,36 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
 
     tr_logAddDebugTor(tor, "verifying torrent...");
 
-    fmt::print(stderr, FMT_STRING("{:s}:{:d} starting the loop\n"), __FILE__, __LINE__);
     while (!*stop_flag && piece < tor->pieceCount())
     {
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         auto const file_length = tor->fileSize(file_index);
 
         /* if we're starting a new piece... */
         if (piece_pos == 0)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             had_piece = tor->hasPiece(piece);
         }
 
         /* if we're starting a new file... */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         if (file_pos == 0 && fd == TR_BAD_SYS_FILE && file_index != prev_file_index)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             auto const found = tor->findFile(file_index);
             fd = !found ? TR_BAD_SYS_FILE : tr_sys_file_open(found->filename(), TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0);
             prev_file_index = file_index;
         }
 
         /* figure out how much we can read this pass */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         uint64_t left_in_piece = tor->pieceSize(piece) - piece_pos;
         uint64_t left_in_file = file_length - file_pos;
         uint64_t bytes_this_pass = std::min(left_in_file, left_in_piece);
         bytes_this_pass = std::min(bytes_this_pass, uint64_t(std::size(buffer)));
 
         /* read a bit */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         if (fd != TR_BAD_SYS_FILE)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             auto num_read = uint64_t{};
             if (tr_sys_file_read_at(fd, std::data(buffer), bytes_this_pass, file_pos, &num_read) && num_read > 0)
             {
-                fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
                 bytes_this_pass = num_read;
                 sha->add(std::data(buffer), bytes_this_pass);
                 tr_sys_file_advise(fd, file_pos, bytes_this_pass, TR_SYS_FILE_ADVICE_DONT_NEED);
@@ -121,17 +111,14 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
         }
 
         /* move our offsets */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         left_in_piece -= bytes_this_pass;
         left_in_file -= bytes_this_pass;
         piece_pos += bytes_this_pass;
         file_pos += bytes_this_pass;
 
         /* if we're finishing a piece... */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         if (left_in_piece == 0)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             auto const has_piece = sha->finish() == tor->pieceHash(piece);
 
             if (has_piece || had_piece)
@@ -140,21 +127,17 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
                 changed |= has_piece != had_piece;
             }
 
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             tor->checked_pieces_.set(piece, true);
             tor->markChanged();
 
             /* sleeping even just a few msec per second goes a long
              * way towards reducing IO load... */
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             if (auto const now = tr_time(); last_slept_at != now)
             {
-                fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
                 last_slept_at = now;
                 tr_wait_msec(MsecToSleepPerSecondDuringVerify);
             }
 
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             sha->clear();
             ++piece;
             tor->setVerifyProgress(piece / float(tor->pieceCount()));
@@ -162,13 +145,10 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
         }
 
         /* if we're finishing a file... */
-        fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread done verifying {:s}\n"), __FILE__, __LINE__, tor->name());
         if (left_in_file == 0)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             if (fd != TR_BAD_SYS_FILE)
             {
-                fmt::print(stderr, FMT_STRING("{:s}:{:d} closing file\n"), __FILE__, __LINE__);
                 tr_sys_file_close(fd);
                 fd = TR_BAD_SYS_FILE;
             }
@@ -179,15 +159,12 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
     }
 
     /* cleanup */
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     if (fd != TR_BAD_SYS_FILE)
     {
-        fmt::print(stderr, FMT_STRING("{:s}:{:d} cleanup\n"), __FILE__, __LINE__);
         tr_sys_file_close(fd);
     }
 
     /* stopwatch */
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     time_t const end = tr_time();
     tr_logAddDebugTor(
         tor,
@@ -197,36 +174,29 @@ bool tr_verify_worker::verifyTorrent(tr_torrent* tor, bool const* stop_flag)
             tor->totalSize(),
             tor->totalSize() / (1 + (end - begin))));
 
-    fmt::print(stderr, FMT_STRING("{:s}:{:d} verify() exiting\n"), __FILE__, __LINE__);
     return changed;
 }
 
 void tr_verify_worker::verifyThreadFunc()
 {
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     for (;;)
     {
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread getting lock\n"), __FILE__, __LINE__);
             auto const lock = std::lock_guard(verify_mutex_);
-            fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread getting next todo\n"), __FILE__, __LINE__);
 
             stop_current_ = false;
             if (std::empty(todo_))
             {
-                fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread empty todo; exiting\n"), __FILE__, __LINE__);
                 current_node_.reset();
                 verify_thread_id_.reset();
                 return;
             }
 
-            fmt::print(stderr, FMT_STRING("{:s}:{:d} worker thread found a todo item\n"), __FILE__, __LINE__);
             auto const it = std::begin(todo_);
             current_node_ = *it;
             todo_.erase(it);
         }
 
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         auto* const tor = current_node_->torrent;
         tr_logAddTraceTor(tor, "Verifying torrent");
         tor->setVerifyState(TR_VERIFY_NOW);
@@ -234,16 +204,12 @@ void tr_verify_worker::verifyThreadFunc()
         tor->setVerifyState(TR_VERIFY_NONE);
         TR_ASSERT(tr_isTorrent(tor));
 
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         if (!stop_current_ && changed)
         {
-            fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
             tor->setDirty();
         }
 
-        fmt::print(stderr, FMT_STRING("{:s}:{:d} calling callbacks\n"), __FILE__, __LINE__);
         callCallback(tor, stop_current_);
-        fmt::print(stderr, FMT_STRING("{:s}:{:d} done calling callbacks\n"), __FILE__, __LINE__);
     }
 }
 
@@ -256,21 +222,14 @@ void tr_verify_worker::add(tr_torrent* tor)
     node.torrent = tor;
     node.current_size = tor->hasTotal();
 
-    fmt::print(stderr, FMT_STRING("{:s}:{:d} adding [{:s}]\n"), __FILE__, __LINE__, tor->name());
     auto const lock = std::lock_guard(verify_mutex_);
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     tor->setVerifyState(TR_VERIFY_WAIT);
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     todo_.insert(node);
-    fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     if (!verify_thread_id_)
     {
-        fmt::print(stderr, FMT_STRING("{:s}:{:d} starting worker thread\n"), __FILE__, __LINE__);
         auto thread = std::thread(&tr_verify_worker::verifyThreadFunc, this);
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         verify_thread_id_ = thread.get_id();
-        fmt::print(stderr, FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
         thread.detach();
     }
 }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1388,9 +1388,13 @@ TEST_F(FileTest, dirOpen)
     odir = tr_sys_dir_open(test_dir);
     EXPECT_NE(TR_BAD_SYS_DIR, odir);
     auto files = std::set<std::string>{};
-    char const* filename = nullptr;
-    while ((filename = tr_sys_dir_read_name(odir, &err)))
+    for (;;)
     {
+        char const* const filename = tr_sys_dir_read_name(odir, &err);
+        if (filename == nullptr)
+        {
+            break;
+        }
         files.insert(filename);
     }
     EXPECT_EQ(3U, files.size());

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -130,44 +130,29 @@ TEST_F(RenameTest, singleFilenameTorrent)
     static auto constexpr TotalSize = size_t{ 14 };
 
     // this is a single-file torrent whose file is hello-world.txt, holding the string "hello, world!"
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto* ctor = tr_ctorNew(session_);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto* tor = createTorrentFromBase64Metainfo(
         ctor,
         "ZDEwOmNyZWF0ZWQgYnkyNTpUcmFuc21pc3Npb24vMi42MSAoMTM0MDcpMTM6Y3JlYXRpb24gZGF0"
         "ZWkxMzU4NTQ5MDk4ZTg6ZW5jb2Rpbmc1OlVURi04NDppbmZvZDY6bGVuZ3RoaTE0ZTQ6bmFtZTE1"
         "OmhlbGxvLXdvcmxkLnR4dDEyOnBpZWNlIGxlbmd0aGkzMjc2OGU2OnBpZWNlczIwOukboJcrkFUY"
         "f6LvqLXBVvSHqCk6Nzpwcml2YXRlaTBlZWU=");
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_TRUE(tr_isTorrent(tor));
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the info
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(tr_file_index_t{ 1 }, tor->fileCount());
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the (empty) stats
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     blockingTorrentVerify(tor);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     expectHaveNone(tor, TotalSize);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     createSingleFileTorrentContents(tor->currentDir().sv());
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the stats again, now that we've added the file
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     blockingTorrentVerify(tor);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto const* st = tr_torrentStat(tor);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(TR_STATUS_STOPPED, st->activity);
-    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(TR_STAT_OK, st->error);
     EXPECT_EQ(0, st->leftUntilDone);
     EXPECT_EQ(0, st->haveUnchecked);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -66,7 +66,7 @@ protected:
         sync();
     }
 
-    static tr_torrent* createTorrentFromBase64Metainfo(tr_ctor* ctor, char const* benc_base64)
+    tr_torrent* createTorrentFromBase64Metainfo(tr_ctor* ctor, char const* benc_base64)
     {
         // create the torrent ctor
         auto const benc = tr_base64_decode(benc_base64);
@@ -77,10 +77,8 @@ protected:
         tr_ctorSetPaused(ctor, TR_FORCE, true);
 
         // create the torrent
-        auto* const tor = tr_torrentNew(ctor, nullptr);
+        auto* const tor = createTorrentAndWaitForVerifyDone(ctor);
         EXPECT_NE(nullptr, tor);
-
-        // cleanup
         return tor;
     }
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -132,29 +132,44 @@ TEST_F(RenameTest, singleFilenameTorrent)
     static auto constexpr TotalSize = size_t{ 14 };
 
     // this is a single-file torrent whose file is hello-world.txt, holding the string "hello, world!"
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     auto* ctor = tr_ctorNew(session_);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     auto* tor = createTorrentFromBase64Metainfo(
         ctor,
         "ZDEwOmNyZWF0ZWQgYnkyNTpUcmFuc21pc3Npb24vMi42MSAoMTM0MDcpMTM6Y3JlYXRpb24gZGF0"
         "ZWkxMzU4NTQ5MDk4ZTg6ZW5jb2Rpbmc1OlVURi04NDppbmZvZDY6bGVuZ3RoaTE0ZTQ6bmFtZTE1"
         "OmhlbGxvLXdvcmxkLnR4dDEyOnBpZWNlIGxlbmd0aGkzMjc2OGU2OnBpZWNlczIwOukboJcrkFUY"
         "f6LvqLXBVvSHqCk6Nzpwcml2YXRlaTBlZWU=");
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     EXPECT_TRUE(tr_isTorrent(tor));
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
 
     // sanity check the info
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     EXPECT_EQ(tr_file_index_t{ 1 }, tor->fileCount());
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
 
     // sanity check the (empty) stats
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     blockingTorrentVerify(tor);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     expectHaveNone(tor, TotalSize);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
 
     createSingleFileTorrentContents(tor->currentDir().sv());
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
 
     // sanity check the stats again, now that we've added the file
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     blockingTorrentVerify(tor);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     auto const* st = tr_torrentStat(tor);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     EXPECT_EQ(TR_STATUS_STOPPED, st->activity);
+    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
     EXPECT_EQ(TR_STAT_OK, st->error);
     EXPECT_EQ(0, st->leftUntilDone);
     EXPECT_EQ(0, st->haveUnchecked);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -132,44 +132,44 @@ TEST_F(RenameTest, singleFilenameTorrent)
     static auto constexpr TotalSize = size_t{ 14 };
 
     // this is a single-file torrent whose file is hello-world.txt, holding the string "hello, world!"
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto* ctor = tr_ctorNew(session_);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto* tor = createTorrentFromBase64Metainfo(
         ctor,
         "ZDEwOmNyZWF0ZWQgYnkyNTpUcmFuc21pc3Npb24vMi42MSAoMTM0MDcpMTM6Y3JlYXRpb24gZGF0"
         "ZWkxMzU4NTQ5MDk4ZTg6ZW5jb2Rpbmc1OlVURi04NDppbmZvZDY6bGVuZ3RoaTE0ZTQ6bmFtZTE1"
         "OmhlbGxvLXdvcmxkLnR4dDEyOnBpZWNlIGxlbmd0aGkzMjc2OGU2OnBpZWNlczIwOukboJcrkFUY"
         "f6LvqLXBVvSHqCk6Nzpwcml2YXRlaTBlZWU=");
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_TRUE(tr_isTorrent(tor));
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the info
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(tr_file_index_t{ 1 }, tor->fileCount());
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_STREQ("hello-world.txt", tr_torrentFile(tor, 0).name);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the (empty) stats
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     blockingTorrentVerify(tor);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     expectHaveNone(tor, TotalSize);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     createSingleFileTorrentContents(tor->currentDir().sv());
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
 
     // sanity check the stats again, now that we've added the file
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     blockingTorrentVerify(tor);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     auto const* st = tr_torrentStat(tor);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(TR_STATUS_STOPPED, st->activity);
-    std::cerr << __FILE__ << ':' << __LINE__ << std::endl;
+    fmt::print(FMT_STRING("{:s}:{:d}\n"), __FILE__, __LINE__);
     EXPECT_EQ(TR_STAT_OK, st->error);
     EXPECT_EQ(0, st->leftUntilDone);
     EXPECT_EQ(0, st->haveUnchecked);

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -468,7 +468,7 @@ protected:
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
-            5s);
+            20s);
     }
 
     tr_session* session_ = nullptr;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -449,14 +449,22 @@ protected:
         auto const n_previously_verified = std::size(verified_);
         auto* const tor = tr_torrentNew(ctor, nullptr);
         EXPECT_NE(nullptr, tor);
-        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify n_previously_verified " << n_previously_verified
-                  << std::endl;
+        fmt::print(
+            stderr,
+            FMT_STRING("{:s}:{:d} blockingTorrentVerify n_previously_verified {:d}\n"),
+            __FILE__,
+            __LINE__,
+            n_previously_verified);
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
             20s);
-        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify std::size(verified_) " << std::size(verified_)
-                  << std::endl;
+        fmt::print(
+            stderr,
+            FMT_STRING("{:s}:{:d} blockingTorrentVerify std::size(verified_) {:d}\n"),
+            __FILE__,
+            __LINE__,
+            std::size(verified_));
 
         // cleanup
         tr_ctorFree(ctor);
@@ -468,15 +476,23 @@ protected:
         EXPECT_NE(nullptr, tor->session);
         EXPECT_FALSE(tr_amInEventThread(tor->session));
         auto const n_previously_verified = std::size(verified_);
-        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify n_previously_verified " << n_previously_verified
-                  << std::endl;
+        fmt::print(
+            stderr,
+            FMT_STRING("{:s}:{:d} blockingTorrentVerify n_previously_verified {:d}\n"),
+            __FILE__,
+            __LINE__,
+            n_previously_verified);
         tr_torrentVerify(tor);
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
             20s);
-        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify std::size(verified_) " << std::size(verified_)
-                  << std::endl;
+        fmt::print(
+            stderr,
+            FMT_STRING("{:s}:{:d} blockingTorrentVerify std::size(verified_) {:d}\n"),
+            __FILE__,
+            __LINE__,
+            std::size(verified_));
     }
 
     tr_session* session_ = nullptr;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -449,10 +449,14 @@ protected:
         auto const n_previously_verified = std::size(verified_);
         auto* const tor = tr_torrentNew(ctor, nullptr);
         EXPECT_NE(nullptr, tor);
+        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify n_previously_verified " << n_previously_verified
+                  << std::endl;
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
-            5s);
+            20s);
+        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify std::size(verified_) " << std::size(verified_)
+                  << std::endl;
 
         // cleanup
         tr_ctorFree(ctor);
@@ -464,11 +468,15 @@ protected:
         EXPECT_NE(nullptr, tor->session);
         EXPECT_FALSE(tr_amInEventThread(tor->session));
         auto const n_previously_verified = std::size(verified_);
+        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify n_previously_verified " << n_previously_verified
+                  << std::endl;
         tr_torrentVerify(tor);
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
             20s);
+        std::cerr << __FILE__ << ':' << __LINE__ << " blockingTorrentVerify std::size(verified_) " << std::size(verified_)
+                  << std::endl;
     }
 
     tr_session* session_ = nullptr;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -385,22 +385,10 @@ protected:
         auto const n_previously_verified = std::size(verified_);
         auto* const tor = tr_torrentNew(ctor, nullptr);
         EXPECT_NE(nullptr, tor);
-        fmt::print(
-            stderr,
-            FMT_STRING("{:s}:{:d} blockingTorrentVerify n_previously_verified {:d}\n"),
-            __FILE__,
-            __LINE__,
-            n_previously_verified);
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
             20s);
-        fmt::print(
-            stderr,
-            FMT_STRING("{:s}:{:d} blockingTorrentVerify std::size(verified_) {:d}\n"),
-            __FILE__,
-            __LINE__,
-            std::size(verified_));
         return tor;
     }
 
@@ -479,23 +467,11 @@ protected:
         EXPECT_NE(nullptr, tor->session);
         EXPECT_FALSE(tr_amInEventThread(tor->session));
         auto const n_previously_verified = std::size(verified_);
-        fmt::print(
-            stderr,
-            FMT_STRING("{:s}:{:d} blockingTorrentVerify n_previously_verified {:d}\n"),
-            __FILE__,
-            __LINE__,
-            n_previously_verified);
         tr_torrentVerify(tor);
         waitFor(
             [this, tor, n_previously_verified]()
             { return std::size(verified_) > n_previously_verified && verified_.back() == tor; },
             20s);
-        fmt::print(
-            stderr,
-            FMT_STRING("{:s}:{:d} blockingTorrentVerify std::size(verified_) {:d}\n"),
-            __FILE__,
-            __LINE__,
-            std::size(verified_));
     }
 
     tr_session* session_ = nullptr;


### PR DESCRIPTION
This also adds a more reliable way for unit tests to know when a torrent is done being verified, which may ameliorate some of the CI flakes that deal with checking and/or moving local data.