### PR TITLE
daemon: use signalfd-based signal handling if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,7 @@ endif()
 include(LargeFileSupport)
 
 set(NEEDED_HEADERS
+    sys/signalfd.h
     sys/statvfs.h
     xfs/xfs.h
     xlocale.h)

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -171,7 +171,7 @@ static DWORD WINAPI handle_service_ctrl(DWORD control_code, DWORD /*event_type*/
 
 static unsigned int __stdcall service_thread_main(void* /*context*/)
 {
-    return callbacks->on_start(callback_arg, false);
+    return callbacks->on_start(callback_arg, nullptr, false);
 }
 
 static VOID WINAPI service_main(DWORD /*argc*/, LPWSTR* /*argv*/)
@@ -238,7 +238,7 @@ bool dtr_daemon(dtr_callbacks const* cb, void* cb_arg, bool foreground, int* exi
             return false;
         }
 
-        *exit_code = cb->on_start(cb_arg, true);
+        *exit_code = cb->on_start(cb_arg, nullptr, true);
     }
     else
     {

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -9,7 +9,7 @@ struct tr_error;
 
 typedef struct dtr_callbacks
 {
-    int (*on_start)(void* arg, bool foreground);
+    int (*on_start)(void* arg, bool (*setupsigfn)(void*), bool foreground);
     void (*on_stop)(void* arg);
     void (*on_reconfigure)(void* arg);
 } dtr_callbacks;


### PR DESCRIPTION
If `signalfd(2)` interface is available, prefer it over traditional signal
handlers. This is mostly intended to drop dedicated signal handling thread
and hook signal processing into `libevent` event loop in the most natural way.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>