### PR TITLE
Do not fsync descriptor referred to a tty

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -781,7 +781,7 @@ bool tr_sys_file_flush(tr_sys_file_t handle, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
 
-    bool const ret = fsync(handle) != -1;
+    bool const ret = (isatty(handle) ? true : (fsync(handle) != -1));
 
     if (!ret)
     {


### PR DESCRIPTION
When `transmission-daemon` is running with '--foreground' option, log messages are emitted to standard error, which may be referred to a tty. Since an attempt to `fsync()` tty is always an error, an extra `isatty()` precaution should be applied.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>