### PR TITLE
fixup new minor warnings

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -779,7 +779,7 @@ private:
     friend void tr_sessionSetRPCUsername(tr_session* session, char const* username);
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
-    friend void tr_sessionSetSpeedLimit_Bps(tr_session* session, tr_direction dir, unsigned int Bps);
+    friend void tr_sessionSetSpeedLimit_Bps(tr_session* session, tr_direction dir, unsigned int bytes_per_second);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
 
     static std::recursive_mutex session_mutex_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -518,7 +518,7 @@ bool tr_sessionIsSpeedLimited(tr_session const*, tr_direction);
 ****  Alternative speed limits that are used during scheduled times
 ***/
 
-void tr_sessionSetAltSpeed_KBps(tr_session*, tr_direction, unsigned int kilo_per_seond);
+void tr_sessionSetAltSpeed_KBps(tr_session*, tr_direction, unsigned int kilo_per_second);
 unsigned int tr_sessionGetAltSpeed_KBps(tr_session const*, tr_direction);
 
 void tr_sessionUseAltSpeed(tr_session*, bool);


### PR DESCRIPTION
fix minor clang-tidy warnings that came from #3756 and #3784.

No functional changes; just making clang-tidy happy.