### PR TITLE
fix: qt open magnet dialog munges magnet url

### DIFF
--- a/qt/AddData.h
+++ b/qt/AddData.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QByteArray>
 #include <QString>
 #include <QUrl>
@@ -34,9 +36,14 @@ public:
     QString readableName() const;
     QString readableShortName() const;
 
-    static bool isSupported(QString const& str)
+    static std::optional<AddData> create(QString const& str)
     {
-        return AddData(str).type != NONE;
+        if (auto ret = AddData{ str }; ret.type != NONE)
+        {
+            return ret;
+        }
+
+        return {};
     }
 
     int type = NONE;

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1273,19 +1273,19 @@ void MainWindow::openTorrent()
 
 void MainWindow::openURL()
 {
-    QString str = QApplication::clipboard()->text(QClipboard::Selection);
+    auto add = AddData::create(QApplication::clipboard()->text(QClipboard::Selection));
 
-    if (!AddData::isSupported(str))
+    if (!add)
     {
-        str = QApplication::clipboard()->text(QClipboard::Clipboard);
+        add = AddData::create(QApplication::clipboard()->text(QClipboard::Clipboard));
     }
 
-    if (!AddData::isSupported(str))
+    if (!add)
     {
-        str.clear();
+        add = AddData{};
     }
 
-    addTorrent(AddData(str), true);
+    addTorrent(std::move(*add), true);
 }
 
 void MainWindow::addTorrents(QStringList const& filenames)
@@ -1308,17 +1308,17 @@ void MainWindow::addTorrents(QStringList const& filenames)
     }
 }
 
-void MainWindow::addTorrent(AddData const& addMe, bool show_options)
+void MainWindow::addTorrent(AddData add_me, bool show_options)
 {
     if (show_options)
     {
-        auto* o = new OptionsDialog(session_, prefs_, addMe, this);
+        auto* o = new OptionsDialog(session_, prefs_, std::move(add_me), this);
         o->show();
         QApplication::alert(o);
     }
     else
     {
-        session_.addTorrent(addMe);
+        session_.addTorrent(std::move(add_me));
         QApplication::alert(this);
     }
 }

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -133,7 +133,7 @@ private:
     void initStatusBar();
 
     void clearSelection();
-    void addTorrent(AddData const& add_me, bool show_options);
+    void addTorrent(AddData add_me, bool show_options);
 
     // QWidget
     void hideEvent(QHideEvent* event) override;

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -39,18 +39,7 @@ OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme
 {
     ui_.setupUi(this);
 
-    QString title;
-
-    if (add_.type == AddData::FILENAME)
-    {
-        title = tr("Open Torrent from File");
-    }
-    else
-    {
-        title = tr("Open Torrent from URL or Magnet Link");
-    }
-
-    setWindowTitle(title);
+    setWindowTitle(add_.type == AddData::FILENAME ? tr("Open Torrent from File") : tr("Open Torrent from URL or Magnet Link"));
 
     edit_timer_.setInterval(2000);
     edit_timer_.setSingleShot(true);
@@ -319,9 +308,9 @@ void OptionsDialog::onSourceChanged()
     {
         add_.set(ui_.sourceButton->path());
     }
-    else
+    else if (auto const text = ui_.sourceEdit->text(); text != add_.readableName())
     {
-        add_.set(ui_.sourceEdit->text());
+        add_.set(text);
     }
 
     reload();

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -986,7 +986,7 @@ void Session::setBlocklistSize(int64_t i)
     emit blocklistUpdated(i);
 }
 
-void Session::addTorrent(AddData const& add_me, tr_variant* args, bool trash_original)
+void Session::addTorrent(AddData add_me, tr_variant* args, bool trash_original)
 {
     assert(tr_variantDictFind(args, TR_KEY_filename) == nullptr);
     assert(tr_variantDictFind(args, TR_KEY_metainfo) == nullptr);
@@ -1105,12 +1105,12 @@ void Session::onDuplicatesTimer()
     }
 }
 
-void Session::addTorrent(AddData const& add_me)
+void Session::addTorrent(AddData add_me)
 {
     tr_variant args;
     tr_variantInitDict(&args, 3);
 
-    addTorrent(add_me, &args, prefs_.getBool(Prefs::TRASH_ORIGINAL));
+    addTorrent(std::move(add_me), &args, prefs_.getBool(Prefs::TRASH_ORIGINAL));
 }
 
 void Session::addNewlyCreatedTorrent(QString const& filename, QString const& local_path)

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -93,7 +93,7 @@ public:
 
     void torrentSetLocation(torrent_ids_t const& ids, QString const& path, bool do_move);
     void torrentRenamePath(torrent_ids_t const& ids, QString const& oldpath, QString const& newname);
-    void addTorrent(AddData const& addme, tr_variant* top, bool trash_original);
+    void addTorrent(AddData addme, tr_variant* top, bool trash_original);
     void initTorrents(torrent_ids_t const& ids = {});
     void pauseTorrents(torrent_ids_t const& torrentIds = {});
     void startTorrents(torrent_ids_t const& torrentIds = {});
@@ -117,7 +117,7 @@ public:
     };
 
 public slots:
-    void addTorrent(AddData const& addme);
+    void addTorrent(AddData addme);
     void launchWebInterface() const;
     void queueMoveBottom(torrent_ids_t const& torrentIds = {});
     void queueMoveDown(torrent_ids_t const& torrentIds = {});


### PR DESCRIPTION
Fix a bug that made it difficult to add magnet links in transmission-qt when the Add dialog was enabled.