### PR TITLE
gtk: fix warnings recently reported by clang-16

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -2132,7 +2132,7 @@ public:
     static std::unique_ptr<EditTrackersDialog> create(DetailsDialog& parent, Glib::RefPtr<Session> core, tr_torrent const* tor);
 
 private:
-    void on_response(int response);
+    void on_response(int response) override;
 
 private:
     DetailsDialog& parent_;
@@ -2243,7 +2243,7 @@ public:
     static std::unique_ptr<AddTrackerDialog> create(DetailsDialog& parent, Glib::RefPtr<Session> core, tr_torrent const* tor);
 
 private:
-    void on_response(int response);
+    void on_response(int response) override;
 
 private:
     DetailsDialog& parent_;

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -203,7 +203,7 @@ class DownloadingPage : public Gtk::Box
 {
 public:
     DownloadingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
-    ~DownloadingPage();
+    ~DownloadingPage() override;
 
     TR_DISABLE_COPY_MOVE(DownloadingPage)
 
@@ -431,7 +431,7 @@ class PrivacyPage : public Gtk::Box
 {
 public:
     PrivacyPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
-    ~PrivacyPage();
+    ~PrivacyPage() override;
 
     TR_DISABLE_COPY_MOVE(PrivacyPage)
 
@@ -814,7 +814,7 @@ class SpeedPage : public Gtk::Box
 public:
     SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
 
-    TR_DISABLE_COPY_MOVE(SpeedPage);
+    TR_DISABLE_COPY_MOVE(SpeedPage)
 
 private:
     void refreshSchedSensitivity();
@@ -992,9 +992,9 @@ class NetworkPage : public Gtk::Box
 {
 public:
     NetworkPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
-    ~NetworkPage();
+    ~NetworkPage() override;
 
-    TR_DISABLE_COPY_MOVE(NetworkPage);
+    TR_DISABLE_COPY_MOVE(NetworkPage)
 
 private:
     void onCorePrefsChanged(tr_quark const key);


### PR DESCRIPTION
Fix the following warnings reported by `clang-16`:
```
----
gtk/DetailsDialog.cc:2135:10: warning: 'on_response' overrides a member function but is not marked 'override' [-Wsuggest-override]
    void on_response(int response);
         ^
/usr/include/gtkmm-3.0/gtkmm/dialog.h:303:16: note: overridden virtual function is here
  virtual void on_response(int response_id);
               ^
----
gtk/DetailsDialog.cc:2246:10: warning: 'on_response' overrides a member function but is not marked 'override' [-Wsuggest-override]
    void on_response(int response);
         ^
/usr/include/gtkmm-3.0/gtkmm/dialog.h:303:16: note: overridden virtual function is here
  virtual void on_response(int response_id);
               ^
----
gtk/PrefsDialog.cc:206:5: warning: '~DownloadingPage' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
    ~DownloadingPage();
    ^
/usr/include/gtkmm-3.0/gtkmm/box.h:114:3: note: overridden virtual function is here
  ~Box() noexcept override;
  ^
----
gtk/PrefsDialog.cc:434:5: warning: '~PrivacyPage' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
    ~PrivacyPage();
    ^
/usr/include/gtkmm-3.0/gtkmm/box.h:114:3: note: overridden virtual function is here
  ~Box() noexcept override;
  ^
----  
gtk/PrefsDialog.cc:817:36: warning: extra ';' after member function definition [-Wextra-semi]
    TR_DISABLE_COPY_MOVE(SpeedPage);
                                   ^
---
gtk/PrefsDialog.cc:997:38: warning: extra ';' after member function definition [-Wextra-semi]
    TR_DISABLE_COPY_MOVE(NetworkPage);
                                     ^
---
gtk/PrefsDialog.cc:995:5: warning: '~NetworkPage' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
    ~NetworkPage();
    ^
/usr/include/gtkmm-3.0/gtkmm/box.h:114:3: note: overridden virtual function is here
  ~Box() noexcept override;
  ^
---
```