### PR TITLE
refactor: add tr_peerIo::peek()

### DIFF
--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -140,6 +140,16 @@ public:
         return evbuffer_get_length(inbuf.get());
     }
 
+    [[nodiscard]] std::byte const* peek(size_t n_bytes) const noexcept
+    {
+        if (readBufferSize() < n_bytes)
+        {
+            return nullptr;
+        }
+
+        return reinterpret_cast<std::byte const*>(evbuffer_pullup(inbuf.get(), n_bytes));
+    }
+
     void readBufferAdd(void const* data, size_t n_bytes);
 
     int flushOutgoingProtocolMsgs();

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -140,6 +140,16 @@ public:
         return evbuffer_get_length(inbuf.get());
     }
 
+    [[nodiscard]] std::optional<std::string_view> peek(size_t n_bytes) const noexcept
+    {
+        if (readBufferSize() >= n_bytes)
+        {
+            return std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(inbuf.get(), n_bytes)), n_bytes };
+        }
+
+        return {};
+    }
+
     void readBufferAdd(void const* data, size_t n_bytes);
 
     int flushOutgoingProtocolMsgs();

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -140,16 +140,6 @@ public:
         return evbuffer_get_length(inbuf.get());
     }
 
-    [[nodiscard]] std::optional<std::string_view> peek(size_t n_bytes) const noexcept
-    {
-        if (readBufferSize() >= n_bytes)
-        {
-            return std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(inbuf.get(), n_bytes)), n_bytes };
-        }
-
-        return {};
-    }
-
     void readBufferAdd(void const* data, size_t n_bytes);
 
     int flushOutgoingProtocolMsgs();

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -331,13 +331,13 @@ TEST_F(FileTest, readFile)
 
     // read from closed file
     n_read = 0;
-    EXPECT_FALSE(tr_sys_file_read(fd, std::data(buf), std::size(buf), &n_read, &err)); // coverity USE_AFTER_FREE
+    EXPECT_FALSE(tr_sys_file_read(fd, std::data(buf), std::size(buf), &n_read, &err)); // coverity[USE_AFTER_FREE]
     EXPECT_EQ(0, n_read);
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 
     // read_at from closed file
-    EXPECT_FALSE(tr_sys_file_read_at(fd, std::data(buf), std::size(buf), offset, &n_read, &err)); // coverity USE_AFTER_FREE
+    EXPECT_FALSE(tr_sys_file_read_at(fd, std::data(buf), std::size(buf), offset, &n_read, &err)); // coverity[USE_AFTER_FREE]
     EXPECT_EQ(0, n_read);
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
@@ -1211,7 +1211,7 @@ TEST_F(FileTest, fileTruncate)
     EXPECT_EQ(25U, info->size);
 
     // try to truncate a closed file
-    EXPECT_FALSE(tr_sys_file_truncate(fd, 10, &err)); // coverity USE_AFTER_FREE
+    EXPECT_FALSE(tr_sys_file_truncate(fd, 10, &err)); // coverity[USE_AFTER_FREE]
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 


### PR DESCRIPTION
A minor refactor to help decouple handshake.cc from evbuffer.