### PR TITLE
Support change to enum definitions in gtkmm/glibmm/pangomm

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -348,7 +348,7 @@ void register_magnet_link_handler()
         auto const app = Gio::AppInfo::create_from_commandline(
             "transmission-gtk",
             "transmission-gtk",
-            Gio::APP_INFO_CREATE_SUPPORTS_URIS);
+            TR_GIO_APP_INFO_CREATE_FLAGS(SUPPORTS_URIS));
         app->set_as_default_for_type(content_type);
     }
     catch (Gio::Error const& e)
@@ -653,7 +653,7 @@ std::string get_application_id(std::string const& config_dir)
 } // namespace
 
 Application::Application(std::string const& config_dir, bool start_paused, bool is_iconified)
-    : Gtk::Application(get_application_id(config_dir), Gio::APPLICATION_HANDLES_OPEN)
+    : Gtk::Application(get_application_id(config_dir), TR_GIO_APPLICATION_FLAGS(HANDLES_OPEN))
     , impl_(std::make_unique<Impl>(*this, config_dir, start_paused, is_iconified))
 {
 }
@@ -724,14 +724,14 @@ void Application::Impl::app_setup()
             _("Transmission is a file sharing program. When you run a torrent, its data will be "
               "made available to others by means of upload. Any content you share is your sole responsibility."),
             false,
-            Gtk::MESSAGE_OTHER,
-            Gtk::BUTTONS_NONE,
+            TR_GTK_MESSAGE_TYPE(OTHER),
+            TR_GTK_BUTTONS_TYPE(NONE),
             true);
-        w.add_button(_("_Cancel"), Gtk::RESPONSE_REJECT);
-        w.add_button(_("I _Agree"), Gtk::RESPONSE_ACCEPT);
-        w.set_default_response(Gtk::RESPONSE_ACCEPT);
+        w.add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(REJECT));
+        w.add_button(_("I _Agree"), TR_GTK_RESPONSE_TYPE(ACCEPT));
+        w.set_default_response(TR_GTK_RESPONSE_TYPE(ACCEPT));
 
-        if (w.run() == Gtk::RESPONSE_ACCEPT)
+        if (w.run() == TR_GTK_RESPONSE_TYPE(ACCEPT))
         {
             // only show it once
             gtr_pref_flag_set(TR_KEY_user_has_given_informed_consent, true);
@@ -900,8 +900,8 @@ void Application::Impl::on_app_exit()
 
     auto* p = Gtk::make_managed<Gtk::Grid>();
     p->set_column_spacing(GUI_PAD_BIG);
-    p->set_halign(Gtk::ALIGN_CENTER);
-    p->set_valign(Gtk::ALIGN_CENTER);
+    p->set_halign(TR_GTK_ALIGN(CENTER));
+    p->set_valign(TR_GTK_ALIGN(CENTER));
     c->add(*p);
 
     auto* icon = Gtk::make_managed<Gtk::Image>("network-workgroup", Gtk::ICON_SIZE_DIALOG);
@@ -909,19 +909,19 @@ void Application::Impl::on_app_exit()
 
     auto* top_label = Gtk::make_managed<Gtk::Label>();
     top_label->set_markup(fmt::format(FMT_STRING("<b>{:s}</b>"), _("Closing Connections…")));
-    top_label->set_halign(Gtk::ALIGN_START);
-    top_label->set_valign(Gtk::ALIGN_CENTER);
+    top_label->set_halign(TR_GTK_ALIGN(START));
+    top_label->set_valign(TR_GTK_ALIGN(CENTER));
     p->attach(*top_label, 1, 0, 1, 1);
 
     auto* bottom_label = Gtk::make_managed<Gtk::Label>(_("Sending upload/download totals to tracker…"));
-    bottom_label->set_halign(Gtk::ALIGN_START);
-    bottom_label->set_valign(Gtk::ALIGN_CENTER);
+    bottom_label->set_halign(TR_GTK_ALIGN(START));
+    bottom_label->set_valign(TR_GTK_ALIGN(CENTER));
     p->attach(*bottom_label, 1, 1, 1, 1);
 
     auto* button = Gtk::make_managed<Gtk::Button>(_("_Quit Now"), true);
     button->set_margin_top(GUI_PAD);
-    button->set_halign(Gtk::ALIGN_START);
-    button->set_valign(Gtk::ALIGN_END);
+    button->set_halign(TR_GTK_ALIGN(START));
+    button->set_valign(TR_GTK_ALIGN(END));
     button->signal_clicked().connect([]() { ::exit(0); });
     p->attach(*button, 1, 2, 1, 1);
 
@@ -959,7 +959,7 @@ void Application::Impl::show_torrent_errors(Glib::ustring const& primary, std::v
         s << leader << ' ' << f << '\n';
     }
 
-    Gtk::MessageDialog w(*wind_, primary, false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE);
+    Gtk::MessageDialog w(*wind_, primary, false, TR_GTK_MESSAGE_TYPE(ERROR), TR_GTK_BUTTONS_TYPE(CLOSE));
     w.set_secondary_text(s.str());
     w.run();
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1588,7 +1588,7 @@ void setPeerViewColumns(Gtk::TreeView* peer_view)
             r->property_yalign() = 0.5F;
             c = Gtk::make_managed<Gtk::TreeViewColumn>(Glib::ustring(), *r);
             c->add_attribute(r->property_icon_name(), *col);
-            c->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+            c->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
             c->set_fixed_width(20);
         }
         else if (*col == peer_cols.download_request_count_string)
@@ -1702,7 +1702,7 @@ void DetailsDialog::Impl::peer_page_init(Glib::RefPtr<Gtk::Builder> const& build
 
     {
         auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-        r->property_ellipsize() = Pango::ELLIPSIZE_END;
+        r->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
         auto* c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Web Seeds"), *r);
         c->add_attribute(r->property_text(), webseed_cols.url);
         c->set_expand(true);
@@ -1722,7 +1722,7 @@ void DetailsDialog::Impl::peer_page_init(Glib::RefPtr<Gtk::Builder> const& build
 
     peer_store_ = Gtk::ListStore::create(peer_cols);
     auto m = Gtk::TreeModelSort::create(peer_store_);
-    m->set_sort_column(peer_cols.progress, Gtk::SORT_DESCENDING);
+    m->set_sort_column(peer_cols.progress, TR_GTK_SORT_TYPE(DESCENDING));
 
     peer_view_->set_model(m);
     peer_view_->set_has_tooltip(true);
@@ -2175,7 +2175,7 @@ void EditTrackersDialog::on_response(int response)
 {
     bool do_destroy = true;
 
-    if (response == Gtk::RESPONSE_ACCEPT)
+    if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         auto const text_buffer = urls_view_->get_buffer();
 
@@ -2187,8 +2187,13 @@ void EditTrackersDialog::on_response(int response)
             }
             else
             {
-                Gtk::MessageDialog
-                    w(*this, _("List contains invalid URLs"), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE, true);
+                Gtk::MessageDialog w(
+                    *this,
+                    _("List contains invalid URLs"),
+                    false,
+                    TR_GTK_MESSAGE_TYPE(ERROR),
+                    TR_GTK_BUTTONS_TYPE(CLOSE),
+                    true);
                 w.set_secondary_text(_("Please correct the errors and try again."));
                 w.run();
 
@@ -2286,7 +2291,7 @@ void AddTrackerDialog::on_response(int response)
 {
     bool destroy = true;
 
-    if (response == Gtk::RESPONSE_ACCEPT)
+    if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         auto const url = gtr_str_strip(url_entry_->get_text());
 
@@ -2397,7 +2402,7 @@ void DetailsDialog::Impl::tracker_page_init(Glib::RefPtr<Gtk::Builder> const& /*
 
     {
         auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-        r->property_ellipsize() = Pango::ELLIPSIZE_END;
+        r->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
         r->property_xpad() = GUI_PAD_SMALL;
         r->property_ypad() = pad;
         c->pack_start(*r, true);
@@ -2430,7 +2435,7 @@ void DetailsDialog::Impl::refresh()
 
     if (torrents.empty())
     {
-        dialog_.response(Gtk::RESPONSE_CLOSE);
+        dialog_.response(TR_GTK_RESPONSE_TYPE(CLOSE));
     }
 }
 

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -102,8 +102,8 @@ void gtr_confirm_remove(
         parent,
         gtr_sprintf("<big><b>%s</b></big>", primary_text),
         true /*use_markup*/,
-        Gtk::MESSAGE_QUESTION,
-        Gtk::BUTTONS_NONE,
+        TR_GTK_MESSAGE_TYPE(WARNING),
+        TR_GTK_BUTTONS_TYPE(NONE),
         true /*modal*/);
 
     if (!secondary_text.empty())
@@ -111,14 +111,14 @@ void gtr_confirm_remove(
         d->set_secondary_text(secondary_text, true);
     }
 
-    d->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
-    d->add_button(delete_files ? _("_Delete") : _("_Remove"), Gtk::RESPONSE_ACCEPT);
-    d->set_default_response(Gtk::RESPONSE_CANCEL);
+    d->add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
+    d->add_button(delete_files ? _("_Delete") : _("_Remove"), TR_GTK_RESPONSE_TYPE(ACCEPT));
+    d->set_default_response(TR_GTK_RESPONSE_TYPE(CANCEL));
 
     d->signal_response().connect(
         [d, core, torrent_ids, delete_files](int response) mutable
         {
-            if (response == Gtk::RESPONSE_ACCEPT)
+            if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
             {
                 for (auto const id : torrent_ids)
                 {

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -238,7 +238,7 @@ bool refreshFilesForeach(
         {
             refresh_data.resort_needed = true;
 
-            store->set_sort_column(GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, Gtk::SORT_ASCENDING);
+            store->set_sort_column(GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, TR_GTK_SORT_TYPE(ASCENDING));
         }
     }
 
@@ -472,7 +472,7 @@ void buildTree(FileRowNode& node, build_data& build)
     {
         build_data b = build;
         b.iter = child_iter;
-        node.foreach ([&b](auto& child_node) { buildTree(child_node, b); }, FileRowNode::TRAVERSE_ALL);
+        node.foreach ([&b](auto& child_node) { buildTree(child_node, b); }, TR_GLIB_NODE_TREE_TRAVERSE_FLAGS(FileRowNode, ALL));
     }
 }
 
@@ -546,7 +546,9 @@ void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
             build.w = &widget_;
             build.tor = tor;
             build.store = store_;
-            root.foreach ([&build](auto& child_node) { buildTree(child_node, build); }, FileRowNode::TRAVERSE_ALL);
+            root.foreach (
+                [&build](auto& child_node) { buildTree(child_node, build); },
+                TR_GLIB_NODE_TREE_TRAVERSE_FLAGS(FileRowNode, ALL));
         }
 
         refresh();
@@ -558,7 +560,7 @@ void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
     view_->set_model(store_);
 
     /* set default sort by label */
-    store_->set_sort_column(file_cols.label, Gtk::SORT_ASCENDING);
+    store_->set_sort_column(file_cols.label, TR_GTK_SORT_TYPE(ASCENDING));
 
     view_->expand_row(Gtk::TreeModel::Path("0"), false);
     // view_->expand_all();
@@ -632,12 +634,12 @@ void FileList::Impl::onRowActivated(Gtk::TreeModel::Path const& path, Gtk::TreeV
 
             /* if the file's not done, walk up the directory tree until we find
              * an ancestor that exists, and open that instead */
-            if (!filename.empty() && (prog < 100 || !Glib::file_test(filename, Glib::FILE_TEST_EXISTS)))
+            if (!filename.empty() && (prog < 100 || !Glib::file_test(filename, TR_GLIB_FILE_TEST(EXISTS))))
             {
                 do
                 {
                     filename = Glib::path_get_dirname(filename);
-                } while (!filename.empty() && !Glib::file_test(filename, Glib::FILE_TEST_EXISTS));
+                } while (!filename.empty() && !Glib::file_test(filename, TR_GLIB_FILE_TEST(EXISTS)));
             }
 
             if (handled = !filename.empty(); handled)
@@ -778,8 +780,8 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
                 fmt::arg("error", tr_strerror(error)),
                 fmt::arg("error_code", error)),
             false,
-            Gtk::MESSAGE_ERROR,
-            Gtk::BUTTONS_CLOSE,
+            TR_GTK_MESSAGE_TYPE(ERROR),
+            TR_GTK_BUTTONS_TYPE(CLOSE),
             true);
         w.set_secondary_text(_("Please correct the errors and try again."));
         w.run();
@@ -872,7 +874,7 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
 
     /* set up view */
     auto const sel = view_->get_selection();
-    sel->set_mode(Gtk::SELECTION_MULTIPLE);
+    sel->set_mode(TR_GTK_SELECTION_MODE(MULTIPLE));
     view_->expand_all();
     view_->set_search_column(file_cols.label);
 
@@ -888,7 +890,7 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
         /* add text renderer */
         auto* text_rend = Gtk::make_managed<Gtk::CellRendererText>();
         text_rend->property_editable() = true;
-        text_rend->property_ellipsize() = Pango::ELLIPSIZE_END;
+        text_rend->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
         text_rend->property_font_desc() = pango_font_description;
         text_rend->signal_edited().connect(sigc::mem_fun(*this, &Impl::cell_edited_callback));
         col->pack_start(*text_rend, true);
@@ -900,13 +902,13 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
     {
         /* add "size" column */
         auto* rend = Gtk::make_managed<Gtk::CellRendererText>();
-        rend->property_alignment() = Pango::ALIGN_RIGHT;
+        rend->property_alignment() = TR_PANGO_ALIGNMENT(RIGHT);
         rend->property_font_desc() = pango_font_description;
         rend->property_xpad() = GUI_PAD;
         rend->property_xalign() = 1.0F;
         rend->property_yalign() = 0.5F;
         auto* col = Gtk::make_managed<Gtk::TreeViewColumn>(_("Size"), *rend);
-        col->set_sizing(Gtk::TREE_VIEW_COLUMN_GROW_ONLY);
+        col->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(GROW_ONLY));
         col->set_sort_column(file_cols.size);
         col->add_attribute(rend->property_text(), file_cols.size_str);
         view_->append_column(*col);
@@ -924,7 +926,7 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
         col->add_attribute(rend->property_text(), file_cols.prog_str);
         col->add_attribute(rend->property_value(), file_cols.prog);
         col->set_fixed_width(width);
-        col->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+        col->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
         col->set_sort_column(file_cols.prog);
         view_->append_column(*col);
     }
@@ -940,7 +942,7 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
         auto* col = Gtk::make_managed<Gtk::TreeViewColumn>(title, *rend);
         col->set_data(ColumnIdKey, GINT_TO_POINTER(file_cols.enabled.index()));
         col->set_fixed_width(width);
-        col->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+        col->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
         col->set_cell_data_func(*rend, sigc::ptr_fun(&renderDownload));
         col->set_sort_column(file_cols.enabled);
         view_->append_column(*col);
@@ -959,7 +961,7 @@ FileList::Impl::Impl(FileList& widget, Gtk::TreeView* view, Glib::RefPtr<Session
         auto* col = Gtk::make_managed<Gtk::TreeViewColumn>(title, *rend);
         col->set_data(ColumnIdKey, GINT_TO_POINTER(file_cols.priority.index()));
         col->set_fixed_width(width);
-        col->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+        col->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
         col->set_sort_column(file_cols.priority);
         col->set_cell_data_func(*rend, sigc::ptr_fun(&renderPriority));
         view_->append_column(*col);
@@ -977,7 +979,7 @@ FileList::Impl::Impl(FileList& widget, Glib::RefPtr<Session> const& core, tr_tor
     view_->set_border_width(GUI_PAD_BIG);
 
     /* create the scrolled window and stick the view in it */
-    widget_.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
+    widget_.set_policy(TR_GTK_POLICY_TYPE(AUTOMATIC), TR_GTK_POLICY_TYPE(AUTOMATIC));
     widget_.set_shadow_type(Gtk::SHADOW_IN);
     widget_.add(*view_);
     widget_.set_size_request(-1, 200);

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -325,8 +325,8 @@ Gtk::CellRendererText* number_renderer_new()
 {
     auto* r = Gtk::make_managed<Gtk::CellRendererText>();
 
-    r->property_alignment() = Pango::ALIGN_RIGHT;
-    r->property_weight() = Pango::WEIGHT_ULTRALIGHT;
+    r->property_alignment() = TR_PANGO_ALIGNMENT(RIGHT);
+    r->property_weight() = TR_PANGO_WEIGHT(ULTRALIGHT);
     r->property_xalign() = 1.0;
     r->property_xpad() = GUI_PAD;
 

--- a/gtk/HigWorkarea.cc
+++ b/gtk/HigWorkarea.cc
@@ -33,8 +33,8 @@ void HigWorkarea::add_section_title_widget(guint& row, Gtk::Widget& w)
 void HigWorkarea::add_section_title(guint& row, Glib::ustring const& section_title)
 {
     auto* l = Gtk::make_managed<Gtk::Label>(gtr_sprintf("<b>%s</b>", section_title));
-    l->set_halign(Gtk::ALIGN_START);
-    l->set_valign(Gtk::ALIGN_CENTER);
+    l->set_halign(TR_GTK_ALIGN(START));
+    l->set_valign(TR_GTK_ALIGN(CENTER));
     l->set_use_markup(true);
     add_section_title_widget(row, *l);
 }
@@ -68,8 +68,8 @@ void HigWorkarea::add_label_w(guint row, Gtk::Widget& w)
 
     if (auto* label = dynamic_cast<Gtk::Label*>(&w); label != nullptr)
     {
-        label->set_halign(Gtk::ALIGN_START);
-        label->set_valign(Gtk::ALIGN_CENTER);
+        label->set_halign(TR_GTK_ALIGN(START));
+        label->set_valign(TR_GTK_ALIGN(CENTER));
         label->set_use_markup(true);
     }
 
@@ -80,8 +80,8 @@ void HigWorkarea::add_tall_control(guint row, Gtk::Widget& control)
 {
     if (auto* label = dynamic_cast<Gtk::Label*>(&control); label != nullptr)
     {
-        label->set_halign(Gtk::ALIGN_START);
-        label->set_valign(Gtk::ALIGN_CENTER);
+        label->set_halign(TR_GTK_ALIGN(START));
+        label->set_valign(TR_GTK_ALIGN(CENTER));
     }
 
     control.set_hexpand(true);
@@ -93,8 +93,8 @@ void HigWorkarea::add_control(guint row, Gtk::Widget& control)
 {
     if (auto* label = dynamic_cast<Gtk::Label*>(&control); label != nullptr)
     {
-        label->set_halign(Gtk::ALIGN_START);
-        label->set_valign(Gtk::ALIGN_CENTER);
+        label->set_halign(TR_GTK_ALIGN(START));
+        label->set_valign(TR_GTK_ALIGN(CENTER));
     }
 
     control.set_hexpand(true);
@@ -128,8 +128,8 @@ Gtk::Label* HigWorkarea::add_tall_row(
     Gtk::Widget* mnemonic)
 {
     auto* l = Gtk::make_managed<Gtk::Label>(mnemonic_string, true);
-    auto* h = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL, 0);
-    auto* v = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_VERTICAL, 0);
+    auto* h = Gtk::make_managed<Gtk::Box>(TR_GTK_ORIENTATION(HORIZONTAL), 0);
+    auto* v = Gtk::make_managed<Gtk::Box>(TR_GTK_ORIENTATION(VERTICAL), 0);
     h->pack_start(*l, false, false, 0);
     v->pack_start(*h, false, false, GUI_PAD_SMALL);
 

--- a/gtk/IconCache.cc
+++ b/gtk/IconCache.cc
@@ -40,7 +40,7 @@ std::array<std::unique_ptr<IconCache>, 7> icon_cache;
 
 Glib::RefPtr<Gdk::Pixbuf> create_void_pixbuf(int width, int height)
 {
-    auto const p = Gdk::Pixbuf::create(Gdk::COLORSPACE_RGB, true, 8, width, height);
+    auto const p = Gdk::Pixbuf::create(TR_GDK_COLORSPACE(RGB), true, 8, width, height);
     p->fill(0xFFFFFF00);
     return p;
 }

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -228,8 +228,8 @@ void MainWindow::Impl::syncAltSpeedButton()
     bool const b = gtr_pref_flag_get(TR_KEY_alt_speed_enabled);
     alt_speed_button_->set_active(b);
     alt_speed_image_->set_from_icon_name("turtle-symbolic", Gtk::BuiltinIconSize::ICON_SIZE_MENU);
-    alt_speed_button_->set_halign(Gtk::ALIGN_CENTER);
-    alt_speed_button_->set_valign(Gtk::ALIGN_CENTER);
+    alt_speed_button_->set_halign(TR_GTK_ALIGN(CENTER));
+    alt_speed_button_->set_valign(TR_GTK_ALIGN(CENTER));
     alt_speed_button_->set_tooltip_text(fmt::format(
         b ? _("Click to disable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)") :
             _("Click to enable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)"),

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -194,9 +194,9 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     progress_bar_->set_text(str);
 
     /* buttons */
-    set_response_sensitive(Gtk::RESPONSE_CANCEL, !is_done);
-    set_response_sensitive(Gtk::RESPONSE_CLOSE, is_done);
-    set_response_sensitive(Gtk::RESPONSE_ACCEPT, is_done && success);
+    set_response_sensitive(TR_GTK_RESPONSE_TYPE(CANCEL), !is_done);
+    set_response_sensitive(TR_GTK_RESPONSE_TYPE(CLOSE), is_done);
+    set_response_sensitive(TR_GTK_RESPONSE_TYPE(ACCEPT), is_done && success);
 
     success_ = success;
     return true;
@@ -219,16 +219,16 @@ void MakeProgressDialog::onProgressDialogResponse(int response)
 {
     switch (response)
     {
-    case Gtk::RESPONSE_CANCEL:
+    case TR_GTK_RESPONSE_TYPE(CANCEL):
         builder_.cancelChecksums();
         hide();
         break;
 
-    case Gtk::RESPONSE_ACCEPT:
+    case TR_GTK_RESPONSE_TYPE(ACCEPT):
         addTorrent();
         [[fallthrough]];
 
-    case Gtk::RESPONSE_CLOSE:
+    case TR_GTK_RESPONSE_TYPE(CLOSE):
         hide();
         break;
 
@@ -288,7 +288,7 @@ void MakeDialog::Impl::makeProgressDialog(std::string_view target, std::future<t
 
 void MakeDialog::Impl::onResponse(int response)
 {
-    if (response == Gtk::RESPONSE_ACCEPT)
+    if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         if (builder_)
         {
@@ -320,7 +320,7 @@ void MakeDialog::Impl::onResponse(int response)
             makeProgressDialog(target, builder_->makeChecksums());
         }
     }
-    else if (response == Gtk::RESPONSE_CLOSE)
+    else if (response == TR_GTK_RESPONSE_TYPE(CLOSE))
     {
         dialog_.hide();
     }
@@ -427,14 +427,14 @@ void MakeDialog::Impl::on_drag_data_received(
         auto const& uri = uris.front();
         auto const filename = Glib::filename_from_uri(uri);
 
-        if (Glib::file_test(filename, Glib::FILE_TEST_IS_DIR))
+        if (Glib::file_test(filename, TR_GLIB_FILE_TEST(IS_DIR)))
         {
             /* a directory was dragged onto the dialog... */
             folder_radio_->set_active(true);
             folder_chooser_->set_current_folder(filename);
             success = true;
         }
-        else if (Glib::file_test(filename, Glib::FILE_TEST_IS_REGULAR))
+        else if (Glib::file_test(filename, TR_GLIB_FILE_TEST(IS_REGULAR)))
         {
             /* a file was dragged on to the dialog... */
             file_radio_->set_active(true);
@@ -484,7 +484,7 @@ MakeDialog::Impl::Impl(MakeDialog& dialog, Glib::RefPtr<Gtk::Builder> const& bui
 {
     dialog_.signal_response().connect(sigc::mem_fun(*this, &Impl::onResponse));
 
-    destination_chooser_->set_current_folder(Glib::get_user_special_dir(Glib::USER_DIRECTORY_DESKTOP));
+    destination_chooser_->set_current_folder(Glib::get_user_special_dir(TR_GLIB_USER_DIRECTORY(DESKTOP)));
 
     folder_radio_->set_active(false);
     folder_radio_->signal_toggled().connect([this]() { onSourceToggled2(folder_radio_, folder_chooser_); });

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -191,8 +191,8 @@ void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& fi
                 fmt::arg("error", g_strerror(errcode)),
                 fmt::arg("error_code", errcode)),
             false,
-            Gtk::MESSAGE_ERROR,
-            Gtk::BUTTONS_CLOSE);
+            TR_GTK_MESSAGE_TYPE(ERROR),
+            TR_GTK_BUTTONS_TYPE(CLOSE));
         w->set_secondary_text(Glib::strerror(errno));
         w->signal_response().connect([w](int /*response*/) mutable { w.reset(); });
         w->show();
@@ -216,7 +216,7 @@ void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& fi
 
 void MessageLogWindow::Impl::onSaveDialogResponse(std::shared_ptr<Gtk::FileChooserDialog>& d, int response)
 {
-    if (response == Gtk::RESPONSE_ACCEPT)
+    if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         doSave(*d, d->get_filename());
     }
@@ -226,9 +226,9 @@ void MessageLogWindow::Impl::onSaveDialogResponse(std::shared_ptr<Gtk::FileChoos
 
 void MessageLogWindow::Impl::onSaveRequest()
 {
-    auto d = std::make_shared<Gtk::FileChooserDialog>(window_, _("Save Log"), Gtk::FILE_CHOOSER_ACTION_SAVE);
-    d->add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
-    d->add_button(_("_Save"), Gtk::RESPONSE_ACCEPT);
+    auto d = std::make_shared<Gtk::FileChooserDialog>(window_, _("Save Log"), TR_GTK_FILE_CHOOSER_ACTION(SAVE));
+    d->add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
+    d->add_button(_("_Save"), TR_GTK_RESPONSE_TYPE(ACCEPT));
 
     d->signal_response().connect([this, d](int response) mutable { onSaveDialogResponse(d, response); });
     d->show();
@@ -282,7 +282,7 @@ void renderText(
 {
     auto const* const node = iter->get_value(message_log_cols.tr_msg);
     renderer->property_text() = iter->get_value(col);
-    renderer->property_ellipsize() = Pango::ELLIPSIZE_END;
+    renderer->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
     setForegroundColor(renderer, node->level);
 }
 
@@ -302,7 +302,7 @@ void appendColumn(Gtk::TreeView* view, Gtk::TreeModelColumnBase const& col)
         auto* r = Gtk::make_managed<Gtk::CellRendererText>();
         c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Name"), *r);
         c->set_cell_data_func(*r, [r](auto* /*renderer*/, auto const& iter) { renderText(r, iter, message_log_cols.name); });
-        c->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+        c->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
         c->set_fixed_width(200);
         c->set_resizable(true);
     }
@@ -311,7 +311,7 @@ void appendColumn(Gtk::TreeView* view, Gtk::TreeModelColumnBase const& col)
         auto* r = Gtk::make_managed<Gtk::CellRendererText>();
         c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Message"), *r);
         c->set_cell_data_func(*r, [r](auto* /*renderer*/, auto const& iter) { renderText(r, iter, message_log_cols.message); });
-        c->set_sizing(Gtk::TREE_VIEW_COLUMN_FIXED);
+        c->set_sizing(TR_GTK_TREE_VIEW_COLUMN_SIZING(FIXED));
         c->set_fixed_width(500);
         c->set_resizable(true);
     }
@@ -488,7 +488,7 @@ MessageLogWindow::Impl::Impl(
 
     filter_ = Gtk::TreeModelFilter::create(store_);
     sort_ = Gtk::TreeModelSort::create(filter_);
-    sort_->set_sort_column(message_log_cols.sequence, Gtk::SORT_ASCENDING);
+    sort_->set_sort_column(message_log_cols.sequence, TR_GTK_SORT_TYPE(ASCENDING));
     maxLevel_ = static_cast<tr_log_level>(gtr_pref_int_get(TR_KEY_message_level));
     filter_->set_visible_func(sigc::mem_fun(*this, &Impl::isRowVisible));
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -136,13 +136,13 @@ void dbus_proxy_ready_callback(Glib::RefPtr<Gio::AsyncResult>& res)
 void gtr_notify_init()
 {
     Gio::DBus::Proxy::create_for_bus(
-        Gio::DBus::BUS_TYPE_SESSION,
+        TR_GIO_DBUS_BUS_TYPE(SESSION),
         NotificationsDbusName,
         NotificationsDbusCoreObject,
         NotificationsDbusCoreInterface,
         &dbus_proxy_ready_callback,
         {},
-        Gio::DBus::PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES);
+        TR_GIO_DBUS_PROXY_FLAGS(DO_NOT_LOAD_PROPERTIES));
 }
 
 namespace
@@ -172,7 +172,7 @@ void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, tr_torrent_
 
         try
         {
-            Glib::spawn_async({}, argv, Glib::SPAWN_SEARCH_PATH);
+            Glib::spawn_async({}, argv, TR_GLIB_SPAWN_FLAGS(SEARCH_PATH));
         }
         catch (Glib::SpawnError const&)
         {

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -105,7 +105,7 @@ void OptionsDialog::Impl::addResponseCB(int response)
 {
     if (tor_ != nullptr)
     {
-        if (response != Gtk::RESPONSE_ACCEPT)
+        if (response != TR_GTK_RESPONSE_TYPE(ACCEPT))
         {
             removeOldTorrent();
         }
@@ -268,7 +268,7 @@ OptionsDialog::Impl::Impl(
     , priority_combo_(gtr_get_widget<Gtk::ComboBox>(builder, "priority_combo"))
     , freespace_label_(gtr_get_widget_derived<FreeSpaceLabel>(builder, "free_space_label", core_, downloadDir_))
 {
-    dialog_.set_default_response(Gtk::RESPONSE_ACCEPT);
+    dialog_.set_default_response(TR_GTK_RESPONSE_TYPE(ACCEPT));
     dialog.signal_response().connect(sigc::mem_fun(*this, &Impl::addResponseCB));
 
     gtr_priority_combo_init(*priority_combo_);
@@ -320,7 +320,7 @@ OptionsDialog::Impl::Impl(
         sourceChanged(source_chooser);
     }
 
-    dialog_.get_widget_for_response(Gtk::RESPONSE_ACCEPT)->grab_focus();
+    dialog_.get_widget_for_response(TR_GTK_RESPONSE_TYPE(ACCEPT))->grab_focus();
 }
 
 /****
@@ -332,7 +332,7 @@ void TorrentFileChooserDialog::onOpenDialogResponse(int response, Glib::RefPtr<S
     /* remember this folder the next time we use this dialog */
     gtr_pref_string_set(TR_KEY_open_dialog_dir, get_current_folder());
 
-    if (response == Gtk::RESPONSE_ACCEPT)
+    if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         auto const* const tb = static_cast<Gtk::CheckButton*>(get_extra_widget());
         bool const do_start = gtr_pref_flag_get(TR_KEY_start_added_torrents);
@@ -354,12 +354,12 @@ std::unique_ptr<TorrentFileChooserDialog> TorrentFileChooserDialog::create(
 }
 
 TorrentFileChooserDialog::TorrentFileChooserDialog(Gtk::Window& parent, Glib::RefPtr<Session> const& core)
-    : Gtk::FileChooserDialog(parent, _("Open a Torrent"), Gtk::FILE_CHOOSER_ACTION_OPEN)
+    : Gtk::FileChooserDialog(parent, _("Open a Torrent"), TR_GTK_FILE_CHOOSER_ACTION(OPEN))
 {
     set_modal(true);
 
-    add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
-    add_button(_("_Open"), Gtk::RESPONSE_ACCEPT);
+    add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
+    add_button(_("_Open"), TR_GTK_RESPONSE_TYPE(ACCEPT));
 
     set_select_multiple(true);
     addTorrentFilters(this);
@@ -383,11 +383,11 @@ TorrentFileChooserDialog::TorrentFileChooserDialog(Gtk::Window& parent, Glib::Re
 void TorrentUrlChooserDialog::onOpenURLResponse(int response, Gtk::Entry const& entry, Glib::RefPtr<Session> const& core)
 {
 
-    if (response == Gtk::RESPONSE_CANCEL)
+    if (response == TR_GTK_RESPONSE_TYPE(CANCEL))
     {
         hide();
     }
-    else if (response == Gtk::RESPONSE_ACCEPT)
+    else if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
     {
         auto const url = gtr_str_strip(entry.get_text());
 
@@ -434,6 +434,6 @@ TorrentUrlChooserDialog::TorrentUrlChooserDialog(
     }
     else
     {
-        get_widget_for_response(Gtk::RESPONSE_ACCEPT)->grab_focus();
+        get_widget_for_response(TR_GTK_RESPONSE_TYPE(ACCEPT))->grab_focus();
     }
 }

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -39,11 +39,11 @@ void gtr_pref_init(std::string_view config_dir)
  */
 static void tr_prefs_init_defaults(tr_variant* d)
 {
-    auto dir = Glib::get_user_special_dir(Glib::USER_DIRECTORY_DOWNLOAD);
+    auto dir = Glib::get_user_special_dir(TR_GLIB_USER_DIRECTORY(DOWNLOAD));
 
     if (dir.empty())
     {
-        dir = Glib::get_user_special_dir(Glib::USER_DIRECTORY_DESKTOP);
+        dir = Glib::get_user_special_dir(TR_GLIB_USER_DIRECTORY(DESKTOP));
     }
 
     if (dir.empty())

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -48,12 +48,12 @@ private:
 
 void PrefsDialog::Impl::response_cb(int response)
 {
-    if (response == Gtk::RESPONSE_HELP)
+    if (response == TR_GTK_RESPONSE_TYPE(HELP))
     {
         gtr_open_uri(gtr_get_help_uri() + "/html/preferences.html");
     }
 
-    if (response == Gtk::RESPONSE_CLOSE)
+    if (response == TR_GTK_RESPONSE_TYPE(CLOSE))
     {
         dialog_.hide();
     }
@@ -503,8 +503,8 @@ void PrivacyPage::onBlocklistUpdate()
         *static_cast<Gtk::Window*>(get_toplevel()),
         _("Update Blocklist"),
         false,
-        Gtk::MESSAGE_INFO,
-        Gtk::BUTTONS_CLOSE);
+        TR_GTK_MESSAGE_TYPE(INFO),
+        TR_GTK_BUTTONS_TYPE(CLOSE));
     updateBlocklistButton_->set_sensitive(false);
     updateBlocklistDialog_->set_secondary_text(_("Getting new blocklist…"));
     updateBlocklistDialog_->signal_response().connect([this](int /*response*/) { onBlocklistUpdateResponse(); });
@@ -899,13 +899,13 @@ void SpeedPage::init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> cons
             { _("Every Day"), TR_SCHED_ALL },
             { _("Weekdays"), TR_SCHED_WEEKDAY },
             { _("Weekends"), TR_SCHED_WEEKEND },
-            { get_weekday_string(Glib::Date::MONDAY), TR_SCHED_MON },
-            { get_weekday_string(Glib::Date::TUESDAY), TR_SCHED_TUES },
-            { get_weekday_string(Glib::Date::WEDNESDAY), TR_SCHED_WED },
-            { get_weekday_string(Glib::Date::THURSDAY), TR_SCHED_THURS },
-            { get_weekday_string(Glib::Date::FRIDAY), TR_SCHED_FRI },
-            { get_weekday_string(Glib::Date::SATURDAY), TR_SCHED_SAT },
-            { get_weekday_string(Glib::Date::SUNDAY), TR_SCHED_SUN },
+            { get_weekday_string(Glib::Date::Weekday::MONDAY), TR_SCHED_MON },
+            { get_weekday_string(Glib::Date::Weekday::TUESDAY), TR_SCHED_TUES },
+            { get_weekday_string(Glib::Date::Weekday::WEDNESDAY), TR_SCHED_WED },
+            { get_weekday_string(Glib::Date::Weekday::THURSDAY), TR_SCHED_THURS },
+            { get_weekday_string(Glib::Date::Weekday::FRIDAY), TR_SCHED_FRI },
+            { get_weekday_string(Glib::Date::Weekday::SATURDAY), TR_SCHED_SAT },
+            { get_weekday_string(Glib::Date::Weekday::SUNDAY), TR_SCHED_SUN },
         });
     gtr_combo_box_set_active_enum(combo, gtr_pref_int_get(key));
     combo.signal_changed().connect([&combo, key, core]() { onIntComboChanged(&combo, key, core); });

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -87,7 +87,13 @@ bool RelocateDialog::Impl::onTimer()
 {
     if (done_ == TR_LOC_ERROR)
     {
-        Gtk::MessageDialog(*message_dialog_, _("Couldn't move torrent"), false, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_CLOSE, true)
+        Gtk::MessageDialog(
+            *message_dialog_,
+            _("Couldn't move torrent"),
+            false,
+            TR_GTK_MESSAGE_TYPE(ERROR),
+            TR_GTK_BUTTONS_TYPE(CLOSE),
+            true)
             .run();
         message_dialog_.reset();
     }
@@ -108,7 +114,7 @@ bool RelocateDialog::Impl::onTimer()
 
 void RelocateDialog::Impl::onResponse(int response)
 {
-    if (response == Gtk::RESPONSE_APPLY)
+    if (response == TR_GTK_RESPONSE_TYPE(APPLY))
     {
         auto const location = chooser_->get_filename();
 
@@ -119,11 +125,11 @@ void RelocateDialog::Impl::onResponse(int response)
             dialog_,
             Glib::ustring(),
             false,
-            Gtk::MESSAGE_INFO,
-            Gtk::BUTTONS_CLOSE,
+            TR_GTK_MESSAGE_TYPE(INFO),
+            TR_GTK_BUTTONS_TYPE(CLOSE),
             true);
         message_dialog_->set_secondary_text(_("This may take a moment…"));
-        message_dialog_->set_response_sensitive(Gtk::RESPONSE_CLOSE, false);
+        message_dialog_->set_response_sensitive(TR_GTK_RESPONSE_TYPE(CLOSE), false);
         message_dialog_->show();
 
         /* remember this location for the next torrent */
@@ -178,7 +184,7 @@ RelocateDialog::Impl::Impl(
     , chooser_(gtr_get_widget<Gtk::FileChooserButton>(builder, "new_location_button"))
     , move_tb_(gtr_get_widget<Gtk::RadioButton>(builder, "move_data_radio"))
 {
-    dialog_.set_default_response(Gtk::RESPONSE_CANCEL);
+    dialog_.set_default_response(TR_GTK_RESPONSE_TYPE(CANCEL));
     dialog_.signal_response().connect(sigc::mem_fun(*this, &Impl::onResponse));
 
     auto recent_dirs = gtr_get_recent_dirs("relocate");

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -65,7 +65,7 @@ public:
         : model_(model)
     {
         model_.get_sort_column_id(sort_column_id_, sort_type_);
-        model_.set_sort_column(Gtk::TreeSortable::DEFAULT_SORT_COLUMN_ID, Gtk::SORT_ASCENDING);
+        model_.set_sort_column(Gtk::TreeSortable::DEFAULT_SORT_COLUMN_ID, TR_GTK_SORT_TYPE(ASCENDING));
     }
 
     ~ScopedModelSortBlocker()
@@ -78,7 +78,7 @@ public:
 private:
     Gtk::TreeSortable& model_;
     int sort_column_id_ = -1;
-    Gtk::SortType sort_type_ = Gtk::SORT_ASCENDING;
+    Gtk::SortType sort_type_ = TR_GTK_SORT_TYPE(ASCENDING);
 };
 
 } // namespace
@@ -146,7 +146,7 @@ private:
     void on_file_changed_in_watchdir(
         Glib::RefPtr<Gio::File> const& file,
         Glib::RefPtr<Gio::File> const& other_type,
-        Gio::FileMonitorEvent event_type);
+        IF_GLIBMM2_68(Gio::FileMonitor::Event, Gio::FileMonitorEvent) event_type);
 
     void on_pref_changed(tr_quark key);
 
@@ -544,7 +544,7 @@ void Session::Impl::set_sort_mode(std::string_view mode, bool is_reversed)
 {
     auto const& col = torrent_cols.torrent;
     Gtk::TreeSortable::SlotCompare sort_func;
-    auto type = is_reversed ? Gtk::SORT_ASCENDING : Gtk::SORT_DESCENDING;
+    auto type = is_reversed ? TR_GTK_SORT_TYPE(ASCENDING) : TR_GTK_SORT_TYPE(DESCENDING);
     auto const sortable = get_model();
 
     if (mode == "sort-by-activity")
@@ -582,7 +582,7 @@ void Session::Impl::set_sort_mode(std::string_view mode, bool is_reversed)
     else
     {
         sort_func = &compare_by_name;
-        type = is_reversed ? Gtk::SORT_DESCENDING : Gtk::SORT_ASCENDING;
+        type = is_reversed ? TR_GTK_SORT_TYPE(DESCENDING) : TR_GTK_SORT_TYPE(ASCENDING);
     }
 
     sortable->set_sort_func(col, sort_func);
@@ -708,9 +708,9 @@ void Session::Impl::watchdir_monitor_file(Glib::RefPtr<Gio::File> const& file)
 void Session::Impl::on_file_changed_in_watchdir(
     Glib::RefPtr<Gio::File> const& file,
     Glib::RefPtr<Gio::File> const& /*other_type*/,
-    Gio::FileMonitorEvent event_type)
+    IF_GLIBMM2_68(Gio::FileMonitor::Event, Gio::FileMonitorEvent) event_type)
 {
-    if (event_type == Gio::FILE_MONITOR_EVENT_CREATED)
+    if (event_type == TR_GIO_FILE_MONITOR_EVENT(CREATED))
     {
         watchdir_monitor_file(file);
     }
@@ -1437,7 +1437,7 @@ bool gtr_inhibit_hibernation(guint32& cookie)
 
     try
     {
-        auto const connection = Gio::DBus::Connection::get_sync(Gio::DBus::BUS_TYPE_SESSION);
+        auto const connection = Gio::DBus::Connection::get_sync(TR_GIO_DBUS_BUS_TYPE(SESSION));
 
         auto response = connection->call_sync(
             SessionManagerObjectPath,
@@ -1471,7 +1471,7 @@ void gtr_uninhibit_hibernation(guint inhibit_cookie)
 {
     try
     {
-        auto const connection = Gio::DBus::Connection::get_sync(Gio::DBus::BUS_TYPE_SESSION);
+        auto const connection = Gio::DBus::Connection::get_sync(TR_GIO_DBUS_BUS_TYPE(SESSION));
 
         connection->call_sync(
             SessionManagerObjectPath,

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -95,8 +95,9 @@ void StatsDialog::Impl::dialogResponse(int response)
 {
     if (response == TR_RESPONSE_RESET)
     {
-        Gtk::MessageDialog w(dialog_, _("Reset your statistics?"), false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE, true);
-        w.add_button(_("_Cancel"), Gtk::RESPONSE_CANCEL);
+        Gtk::MessageDialog
+            w(dialog_, _("Reset your statistics?"), false, TR_GTK_MESSAGE_TYPE(QUESTION), TR_GTK_BUTTONS_TYPE(NONE), true);
+        w.add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
         w.add_button(_("_Reset"), TR_RESPONSE_RESET);
         w.set_secondary_text(
             _("These statistics are for your information only. "
@@ -109,7 +110,7 @@ void StatsDialog::Impl::dialogResponse(int response)
         }
     }
 
-    if (response == Gtk::RESPONSE_CLOSE)
+    if (response == TR_GTK_RESPONSE_TYPE(CLOSE))
     {
         dialog_.hide();
     }
@@ -147,7 +148,7 @@ StatsDialog::Impl::Impl(StatsDialog& dialog, Glib::RefPtr<Gtk::Builder> const& b
     , all_time_lb_(gtr_get_widget<Gtk::Label>(builder, "total_duration_value_label"))
     , all_sessions_lb_(gtr_get_widget<Gtk::Label>(builder, "start_count_label"))
 {
-    dialog_.set_default_response(Gtk::RESPONSE_CLOSE);
+    dialog_.set_default_response(TR_GTK_RESPONSE_TYPE(CLOSE));
     dialog_.signal_response().connect(sigc::mem_fun(*this, &Impl::dialogResponse));
 
     updateStats();

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -403,7 +403,7 @@ void TorrentCellRenderer::Impl::get_size_compact(Gtk::Widget& widget, int& width
     icon_renderer_->property_pixbuf() = icon;
     icon_renderer_->get_preferred_size(widget, min_size, icon_size);
     text_renderer_->property_text() = name;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_NONE;
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(NONE);
     text_renderer_->property_scale() = 1.0;
     text_renderer_->get_preferred_size(widget, min_size, name_size);
     text_renderer_->property_text() = gstr_stat;
@@ -442,12 +442,12 @@ void TorrentCellRenderer::Impl::get_size_full(Gtk::Widget& widget, int& width, i
     icon_renderer_->property_pixbuf() = icon;
     icon_renderer_->get_preferred_size(widget, min_size, icon_size);
     text_renderer_->property_text() = name;
-    text_renderer_->property_weight() = Pango::WEIGHT_BOLD;
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(BOLD);
     text_renderer_->property_scale() = 1.0;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_NONE;
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(NONE);
     text_renderer_->get_preferred_size(widget, min_size, name_size);
     text_renderer_->property_text() = gstr_prog;
-    text_renderer_->property_weight() = Pango::WEIGHT_NORMAL;
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(NORMAL);
     text_renderer_->property_scale() = SmallScale;
     text_renderer_->get_preferred_size(widget, min_size, prog_size);
     text_renderer_->property_text() = gstr_stat;
@@ -586,7 +586,7 @@ void TorrentCellRenderer::Impl::render_compact(
 
     auto stat_area = fill_area;
     text_renderer_->property_text() = gstr_stat;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_NONE;
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(NONE);
     text_renderer_->property_scale() = SmallScale;
     text_renderer_->get_preferred_width(widget, min_width, width);
     stat_area.set_width(width);
@@ -595,7 +595,7 @@ void TorrentCellRenderer::Impl::render_compact(
     name_area.set_width(
         fill_area.get_width() - icon_area.get_width() - stat_area.get_width() - prog_area.get_width() - GUI_PAD * 3);
 
-    if ((renderer_.get_state(widget, flags) & Gtk::StateFlags::STATE_FLAG_DIR_RTL) == 0)
+    if ((renderer_.get_state(widget, flags) & TR_GTK_STATE_FLAGS(DIR_RTL)) == Gtk::StateFlags{})
     {
         icon_area.set_x(fill_area.get_x());
         prog_area.set_x(fill_area.get_x() + fill_area.get_width() - prog_area.get_width());
@@ -626,7 +626,7 @@ void TorrentCellRenderer::Impl::render_compact(
 
     text_renderer_->property_text() = gstr_stat;
     text_renderer_->property_scale() = SmallScale;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_END;
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
     text_renderer_->property_foreground_rgba() = text_color;
     text_renderer_->render(cr, widget, stat_area, stat_area, flags);
 
@@ -672,15 +672,15 @@ void TorrentCellRenderer::Impl::render_full(
 
     Gdk::Rectangle name_area;
     text_renderer_->property_text() = name;
-    text_renderer_->property_weight() = Pango::WEIGHT_BOLD;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_NONE;
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(BOLD);
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(NONE);
     text_renderer_->property_scale() = 1.0;
     text_renderer_->get_preferred_size(widget, min_size, size);
     name_area.set_height(size.height);
 
     Gdk::Rectangle prog_area;
     text_renderer_->property_text() = gstr_prog;
-    text_renderer_->property_weight() = Pango::WEIGHT_NORMAL;
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(NORMAL);
     text_renderer_->property_scale() = SmallScale;
     text_renderer_->get_preferred_size(widget, min_size, size);
     prog_area.set_height(size.height);
@@ -709,7 +709,7 @@ void TorrentCellRenderer::Impl::render_full(
     name_area.set_y(fill_area.get_y());
     name_area.set_width(fill_area.get_width() - GUI_PAD - icon_area.get_width());
 
-    if ((renderer_.get_state(widget, flags) & Gtk::StateFlags::STATE_FLAG_DIR_RTL) == 0)
+    if ((renderer_.get_state(widget, flags) & TR_GTK_STATE_FLAGS(DIR_RTL)) == Gtk::StateFlags{})
     {
         icon_area.set_x(fill_area.get_x());
         name_area.set_x(fill_area.get_x() + fill_area.get_width() - name_area.get_width());
@@ -747,13 +747,13 @@ void TorrentCellRenderer::Impl::render_full(
     text_renderer_->property_text() = name;
     text_renderer_->property_scale() = 1.0;
     text_renderer_->property_foreground_rgba() = text_color;
-    text_renderer_->property_ellipsize() = Pango::ELLIPSIZE_END;
-    text_renderer_->property_weight() = Pango::WEIGHT_BOLD;
+    text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(END);
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(BOLD);
     text_renderer_->render(cr, widget, name_area, name_area, flags);
 
     text_renderer_->property_text() = gstr_prog;
     text_renderer_->property_scale() = SmallScale;
-    text_renderer_->property_weight() = Pango::WEIGHT_NORMAL;
+    text_renderer_->property_weight() = TR_PANGO_WEIGHT(NORMAL);
     text_renderer_->render(cr, widget, prog_area, prog_area, flags);
 
     progress_renderer_->property_value() = static_cast<int>(percentDone * 100.0);

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -261,8 +261,8 @@ void gtr_add_torrent_error_dialog(Gtk::Widget& child, tr_torrent* duplicate_torr
         *win,
         _("Couldn't open torrent"),
         false,
-        Gtk::MESSAGE_ERROR,
-        Gtk::BUTTONS_CLOSE);
+        TR_GTK_MESSAGE_TYPE(ERROR),
+        TR_GTK_BUTTONS_TYPE(CLOSE));
     w->set_secondary_text(secondary);
     w->signal_response().connect([w](int /*response*/) mutable { w.reset(); });
     w->show_all();
@@ -381,7 +381,7 @@ void gtr_open_uri(Glib::ustring const& uri)
         {
             try
             {
-                Glib::spawn_async({}, std::vector<std::string>{ "xdg-open", uri }, Glib::SPAWN_SEARCH_PATH);
+                Glib::spawn_async({}, std::vector<std::string>{ "xdg-open", uri }, TR_GLIB_SPAWN_FLAGS(SEARCH_PATH));
                 opened = true;
             }
             catch (Glib::SpawnError const&)
@@ -573,8 +573,8 @@ void gtr_unrecognized_url_dialog(Gtk::Widget& parent, Glib::ustring const& url)
         *window,
         fmt::format(_("Unsupported URL: '{url}'"), fmt::arg("url", url)),
         false /*use markup*/,
-        Gtk::MESSAGE_ERROR,
-        Gtk::BUTTONS_CLOSE,
+        TR_GTK_MESSAGE_TYPE(ERROR),
+        TR_GTK_BUTTONS_TYPE(CLOSE),
         true /*modal*/);
 
     gstr += fmt::format(_("Transmission doesn't know how to use '{url}'"), fmt::arg("url", url));

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -26,6 +26,80 @@
 
 #include "Session.h"
 
+/***
+****
+***/
+
+#ifndef GTKMM_CHECK_VERSION
+#define GTKMM_CHECK_VERSION(major, minor, micro) \
+    (GTKMM_MAJOR_VERSION > (major) || (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION > (minor)) || \
+     (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION == (minor) && GTKMM_MICRO_VERSION >= (micro)))
+#endif
+
+#ifndef GLIBMM_CHECK_VERSION
+#define GLIBMM_CHECK_VERSION(major, minor, micro) \
+    (GLIBMM_MAJOR_VERSION > (major) || (GLIBMM_MAJOR_VERSION == (major) && GLIBMM_MINOR_VERSION > (minor)) || \
+     (GLIBMM_MAJOR_VERSION == (major) && GLIBMM_MINOR_VERSION == (minor) && GLIBMM_MICRO_VERSION >= (micro)))
+#endif
+
+#ifndef PANGOMM_CHECK_VERSION
+#define PANGOMM_CHECK_VERSION(major, minor, micro) \
+    (PANGOMM_MAJOR_VERSION > (major) || (PANGOMM_MAJOR_VERSION == (major) && PANGOMM_MINOR_VERSION > (minor)) || \
+     (PANGOMM_MAJOR_VERSION == (major) && PANGOMM_MINOR_VERSION == (minor) && PANGOMM_MICRO_VERSION >= (micro)))
+#endif
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#define IF_GTKMM4(ThenValue, ElseValue) ThenValue
+#else
+#define IF_GTKMM4(ThenValue, ElseValue) ElseValue
+#endif
+
+#if GLIBMM_CHECK_VERSION(2, 68, 0)
+#define IF_GLIBMM2_68(ThenValue, ElseValue) ThenValue
+#else
+#define IF_GLIBMM2_68(ThenValue, ElseValue) ElseValue
+#endif
+
+#if PANGOMM_CHECK_VERSION(2, 48, 0)
+#define IF_PANGOMM2_48(ThenValue, ElseValue) ThenValue
+#else
+#define IF_PANGOMM2_48(ThenValue, ElseValue) ElseValue
+#endif
+
+#define TR_GTK_ALIGN(Code) IF_GTKMM4(Gtk::Align::Code, Gtk::ALIGN_##Code)
+#define TR_GTK_BUTTONS_TYPE(Code) IF_GTKMM4(Gtk::ButtonsType::Code, Gtk::BUTTONS_##Code)
+#define TR_GTK_FILE_CHOOSER_ACTION(Code) IF_GTKMM4(Gtk::FileChooser::Action::Code, Gtk::FILE_CHOOSER_ACTION_##Code)
+#define TR_GTK_MESSAGE_TYPE(Code) IF_GTKMM4(Gtk::MessageType::Code, Gtk::MESSAGE_##Code)
+#define TR_GTK_ORIENTATION(Code) IF_GTKMM4(Gtk::Orientation::Code, Gtk::ORIENTATION_##Code)
+#define TR_GTK_POLICY_TYPE(Code) IF_GTKMM4(Gtk::PolicyType::Code, Gtk::POLICY_##Code)
+#define TR_GTK_RESPONSE_TYPE(Code) IF_GTKMM4(Gtk::ResponseType::Code, Gtk::RESPONSE_##Code)
+#define TR_GTK_SELECTION_MODE(Code) IF_GTKMM4(Gtk::SelectionMode::Code, Gtk::SELECTION_##Code)
+#define TR_GTK_SORT_TYPE(Code) IF_GTKMM4(Gtk::SortType::Code, Gtk::SORT_##Code)
+#define TR_GTK_STATE_FLAGS(Code) IF_GTKMM4(Gtk::StateFlags::Code, Gtk::STATE_FLAG_##Code)
+#define TR_GTK_TREE_VIEW_COLUMN_SIZING(Code) IF_GTKMM4(Gtk::TreeViewColumn::Sizing::Code, Gtk::TREE_VIEW_COLUMN_##Code)
+
+#define TR_GDK_COLORSPACE(Code) IF_GTKMM4(Gdk::Colorspace::Code, Gdk::COLORSPACE_##Code)
+#define TR_GDK_DRAG_ACTION(Code) IF_GTKMM4(Gdk::DragAction::Code, Gdk::ACTION_##Code)
+
+#define TR_GLIB_FILE_TEST(Code) IF_GLIBMM2_68(Glib::FileTest::Code, Glib::FILE_TEST_##Code)
+#define TR_GLIB_NODE_TREE_TRAVERSE_FLAGS(Cls, Code) IF_GLIBMM2_68(Cls::TraverseFlags::Code, Cls::TRAVERSE_##Code)
+#define TR_GLIB_SPAWN_FLAGS(Code) IF_GLIBMM2_68(Glib::SpawnFlags::Code, Glib::SPAWN_##Code)
+#define TR_GLIB_USER_DIRECTORY(Code) IF_GLIBMM2_68(Glib::UserDirectory::Code, Glib::USER_DIRECTORY_##Code)
+
+#define TR_GIO_APP_INFO_CREATE_FLAGS(Code) IF_GLIBMM2_68(Gio::AppInfo::CreateFlags::Code, Gio::APP_INFO_CREATE_##Code)
+#define TR_GIO_APPLICATION_FLAGS(Code) IF_GLIBMM2_68(Gio::Application::Flags::Code, Gio::APPLICATION_##Code)
+#define TR_GIO_DBUS_BUS_TYPE(Code) IF_GLIBMM2_68(Gio::DBus::BusType::Code, Gio::DBus::BUS_TYPE_##Code)
+#define TR_GIO_DBUS_PROXY_FLAGS(Code) IF_GLIBMM2_68(Gio::DBus::ProxyFlags::Code, Gio::DBus::PROXY_FLAGS_##Code)
+#define TR_GIO_FILE_MONITOR_EVENT(Code) IF_GLIBMM2_68(Gio::FileMonitor::Event::Code, Gio::FILE_MONITOR_EVENT_##Code)
+
+#define TR_PANGO_ALIGNMENT(Code) IF_PANGOMM2_48(Pango::Alignment::Code, Pango::ALIGN_##Code)
+#define TR_PANGO_ELLIPSIZE_MODE(Code) IF_PANGOMM2_48(Pango::EllipsizeMode::Code, Pango::ELLIPSIZE_##Code)
+#define TR_PANGO_WEIGHT(Code) IF_PANGOMM2_48(Pango::Weight::Code, Pango::WEIGHT_##Code)
+
+/***
+****
+***/
+
 extern int const mem_K;
 extern char const* const mem_K_str;
 extern char const* const mem_M_str;


### PR DESCRIPTION
Newer versions (gtkmm 4 and its dependencies) of these libraries have switched from enums to enum classes. Wrap the names with macros to support both.