### PR TITLE
Run GTK dialogs in non-blocking fashion

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -2187,15 +2187,16 @@ void EditTrackersDialog::on_response(int response)
             }
             else
             {
-                Gtk::MessageDialog w(
+                auto w = std::make_shared<Gtk::MessageDialog>(
                     *this,
                     _("List contains invalid URLs"),
                     false,
                     TR_GTK_MESSAGE_TYPE(ERROR),
                     TR_GTK_BUTTONS_TYPE(CLOSE),
                     true);
-                w.set_secondary_text(_("Please correct the errors and try again."));
-                w.run();
+                w->set_secondary_text(_("Please correct the errors and try again."));
+                w->signal_response().connect([w](int /*response*/) mutable { w.reset(); });
+                w->show();
 
                 do_destroy = false;
             }

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -771,7 +771,7 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
     }
     else
     {
-        Gtk::MessageDialog w(
+        auto w = std::make_shared<Gtk::MessageDialog>(
             *static_cast<Gtk::Window*>(widget_.get_toplevel()),
             fmt::format(
                 _("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})"),
@@ -783,8 +783,9 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
             TR_GTK_MESSAGE_TYPE(ERROR),
             TR_GTK_BUTTONS_TYPE(CLOSE),
             true);
-        w.set_secondary_text(_("Please correct the errors and try again."));
-        w.run();
+        w->set_secondary_text(_("Please correct the errors and try again."));
+        w->signal_response().connect([w](int /*response*/) mutable { w.reset(); });
+        w->show();
     }
 
     return false;

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -87,15 +87,23 @@ bool RelocateDialog::Impl::onTimer()
 {
     if (done_ == TR_LOC_ERROR)
     {
-        Gtk::MessageDialog(
+        auto d = std::make_shared<Gtk::MessageDialog>(
             *message_dialog_,
             _("Couldn't move torrent"),
             false,
             TR_GTK_MESSAGE_TYPE(ERROR),
             TR_GTK_BUTTONS_TYPE(CLOSE),
-            true)
-            .run();
-        message_dialog_.reset();
+            true);
+
+        timer_.block();
+        d->signal_response().connect(
+            [this, d](int /*response*/) mutable
+            {
+                timer_.unblock();
+                d.reset();
+            });
+
+        d->show();
     }
     else if (done_ == TR_LOC_DONE)
     {

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -95,19 +95,29 @@ void StatsDialog::Impl::dialogResponse(int response)
 {
     if (response == TR_RESPONSE_RESET)
     {
-        Gtk::MessageDialog
-            w(dialog_, _("Reset your statistics?"), false, TR_GTK_MESSAGE_TYPE(QUESTION), TR_GTK_BUTTONS_TYPE(NONE), true);
-        w.add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
-        w.add_button(_("_Reset"), TR_RESPONSE_RESET);
-        w.set_secondary_text(
+        auto w = std::make_shared<Gtk::MessageDialog>(
+            dialog_,
+            _("Reset your statistics?"),
+            false,
+            TR_GTK_MESSAGE_TYPE(QUESTION),
+            TR_GTK_BUTTONS_TYPE(NONE),
+            true);
+        w->add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(CANCEL));
+        w->add_button(_("_Reset"), TR_RESPONSE_RESET);
+        w->set_secondary_text(
             _("These statistics are for your information only. "
               "Resetting them doesn't affect the statistics logged by your BitTorrent trackers."));
-
-        if (w.run() == TR_RESPONSE_RESET)
-        {
-            tr_sessionClearStats(core_->get_session());
-            updateStats();
-        }
+        w->signal_response().connect(
+            [this, w](int inner_response) mutable
+            {
+                if (inner_response == TR_RESPONSE_RESET)
+                {
+                    tr_sessionClearStats(core_->get_session());
+                    updateStats();
+                }
+                w.reset();
+            });
+        w->show();
     }
 
     if (response == TR_GTK_RESPONSE_TYPE(CLOSE))


### PR DESCRIPTION
GTK 4 drops blocking `run()` method for dialogs. Switch to non-blocking `show()` to support both GTK 3 and 4.