### PR TITLE
Corrected wrong url for donation

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1462,7 +1462,7 @@ void Application::Impl::actions_handler(Glib::ustring const& action_name)
     }
     else if (action_name == "donate")
     {
-        gtr_open_uri("https://transmissionbt.com/donate/");
+        gtr_open_uri("https://transmissionbt.com/donate");
     }
     else if (action_name == "pause-all-torrents")
     {


### PR DESCRIPTION
There is an option for donation in menu

![donate menu image](https://user-images.githubusercontent.com/31237074/189502736-d795d312-e6b9-4084-80d6-9978336fb676.png)

While clicking it opens this url `https://transmissionbt.com/donate.html/` and if you look carefully there is an extra `/` at the end and sometimes opening that link leads for 404 page like this:

![404 page](https://user-images.githubusercontent.com/31237074/189502922-ba3b55a8-2e3a-437a-93f7-ddb97ce57185.png)


So in this pull request I've removed that extra slash.