### PR TITLE
Qt: Correct 'Sort by Progress' for seeding torrents

### DIFF
--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -77,14 +77,19 @@ int Torrent::compareSeedProgress(Torrent const& that) const
         return a_ratio < *a_ratio_limit ? -1 : 1;
     }
 
-    if (*a_ratio_limit == 0 && *b_ratio_limit == 0)
+    if (!(*a_ratio_limit > 0) && !(*b_ratio_limit > 0))
     {
         return compareRatio(that);
     }
 
-    if (*a_ratio_limit == 0 || *b_ratio_limit == 0)
+    if (!(*a_ratio_limit > 0))
     {
-        return *a_ratio_limit ? -1 : 1;
+        return 1;
+    }
+
+    if (!(*b_ratio_limit > 0))
+    {
+        return -1;
     }
 
     double const a_progress = a_ratio / *a_ratio_limit;

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -54,27 +54,48 @@ bool Torrent::includesTracker(QString const& sitename) const
     return std::binary_search(std::begin(sitenames_), std::end(sitenames_), sitename);
 }
 
-int Torrent::compareSeedRatio(Torrent const& that) const
+int Torrent::compareSeedProgress(Torrent const& that) const
 {
-    auto const a = getSeedRatioLimit();
-    auto const b = that.getSeedRatioLimit();
+    auto const a_ratio = ratio();
+    auto const b_ratio = that.ratio();
 
-    if (!a && !b)
+    auto const a_ratio_limit = getSeedRatioLimit();
+    auto const b_ratio_limit = that.getSeedRatioLimit();
+
+    if (!a_ratio_limit && !b_ratio_limit)
     {
-        return 0;
+        return compareRatio(that);
     }
 
-    if (!a || !b)
+    if (!a_ratio_limit)
     {
-        return a ? -1 : 1;
+        return b_ratio < *b_ratio_limit ? 1 : -1;
     }
 
-    if (*a < *b)
+    if (!b_ratio_limit)
+    {
+        return a_ratio < *a_ratio_limit ? -1 : 1;
+    }
+
+    if (*a_ratio_limit == 0 && *b_ratio_limit == 0)
+    {
+        return compareRatio(that);
+    }
+
+    if (*a_ratio_limit == 0 || *b_ratio_limit == 0)
+    {
+        return *a_ratio_limit ? -1 : 1;
+    }
+
+    double const a_progress = a_ratio / *a_ratio_limit;
+    double const b_progress = b_ratio / *b_ratio_limit;
+
+    if (a_progress < b_progress)
     {
         return -1;
     }
 
-    if (*a > *b)
+    if (a_progress > b_progress)
     {
         return 1;
     }

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -56,9 +56,6 @@ bool Torrent::includesTracker(QString const& sitename) const
 
 int Torrent::compareSeedProgress(Torrent const& that) const
 {
-    auto const a_ratio = ratio();
-    auto const b_ratio = that.ratio();
-
     auto const a_ratio_limit = getSeedRatioLimit();
     auto const b_ratio_limit = that.getSeedRatioLimit();
 
@@ -66,6 +63,9 @@ int Torrent::compareSeedProgress(Torrent const& that) const
     {
         return compareRatio(that);
     }
+
+    auto const a_ratio = ratio();
+    auto const b_ratio = that.ratio();
 
     if (!a_ratio_limit)
     {

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -325,7 +325,7 @@ public:
         return failed_ever_;
     }
 
-    int compareSeedRatio(Torrent const&) const;
+    int compareSeedProgress(Torrent const&) const;
     int compareRatio(Torrent const&) const;
     int compareETA(Torrent const&) const;
 

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -182,7 +182,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
         if (val == 0)
         {
-            val = a->compareSeedRatio(*b);
+            val = a->compareSeedProgress(*b);
         }
 
         if (val == 0)


### PR DESCRIPTION
This is for issue #3796.

I don't like how complicated this turned out, but there are a lot of cases since each torrent can have either a normal limit, a limit of 0, or no limit at all.

The similar function `compareRatio` also accounts for the possibility that `ratio()` can be infinite, but I don't think this is actually possible because it could only result from a `downloadedBytes` of 0 which can't happen if you're seeding. Even seeding your own torrent the `downloadedBytes` is still positive. (If infinty is possible then we should probably also take care of `TR_RATIO_NA` in both functions.)

This commit also introduces some `-Wfloat-equal` warnings, but actually I think I'm right and the warning is stupid. If you really want to avoid the warning then I'll rearrange the code a bit to deal with it.