### PR TITLE
refactor: tr_globalIPv6() returns a std::optional<in6_addr>

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   cppcoreguidelines-avoid-const-or-ref-data-members,
   cppcoreguidelines-init-variables,
   cppcoreguidelines-interfaces-global-init,
+  cppcoreguidelines-no-malloc,
   cppcoreguidelines-prefer-member-initializer,
   cppcoreguidelines-slicing,
   cppcoreguidelines-special-member-functions,

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -113,10 +113,10 @@ static std::string format_ipv4_url_arg(tr_address const& ipv4_address)
     return "&ipv4="s + readable.data();
 }
 
-static std::string format_ipv6_url_arg(unsigned char const* ipv6_address)
+static std::string format_ipv6_url_arg(in6_addr const addr)
 {
     std::array<char, INET6_ADDRSTRLEN> readable;
-    evutil_inet_ntop(AF_INET6, ipv6_address, readable.data(), readable.size());
+    evutil_inet_ntop(AF_INET6, &addr, std::data(readable), std::size(readable));
 
     auto arg = "&ipv6="s;
     tr_urlPercentEncode(std::back_inserter(arg), readable.data());
@@ -436,7 +436,7 @@ void tr_tracker_http_announce(
         session->web->fetch(std::move(opt));
     };
 
-    auto ipv6 = tr_globalIPv6(session);
+    auto const ipv6 = tr_globalIPv6(session);
 
     /*
      * Before Curl 7.77.0, if we explicitly choose the IP version we want
@@ -451,13 +451,13 @@ void tr_tracker_http_announce(
         {
             options.url += format_ip_arg(session->announceIP());
         }
-        else if (ipv6 != nullptr)
+        else if (ipv6)
         {
             if (auto public_ipv4 = session->externalIP(); public_ipv4.has_value())
             {
                 options.url += format_ipv4_url_arg(*public_ipv4);
             }
-            options.url += format_ipv6_url_arg(ipv6);
+            options.url += format_ipv6_url_arg(*ipv6);
         }
 
         d->requests_sent_count = 1;
@@ -465,7 +465,7 @@ void tr_tracker_http_announce(
     }
     else
     {
-        if (session->useAnnounceIP() || ipv6 == nullptr)
+        if (session->useAnnounceIP() || !ipv6)
         {
             if (session->useAnnounceIP())
             {
@@ -481,7 +481,7 @@ void tr_tracker_http_announce(
             // First try to send the announce via IPv4:
             auto ipv4_options = options;
             // Set the "&ipv6=" argument
-            ipv4_options.url += format_ipv6_url_arg(ipv6);
+            ipv4_options.url += format_ipv6_url_arg(*ipv6);
             // Set protocol to IPv4
             ipv4_options.ip_proto = tr_web::FetchOptions::IPProtocol::V4;
             do_make_request("IPv4"sv, std::move(ipv4_options));

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -246,4 +246,4 @@ void tr_netSetTOS(tr_socket_t sock, int tos, tr_address_type type);
  */
 [[nodiscard]] std::string tr_net_strerror(int err);
 
-unsigned char const* tr_globalIPv6(tr_session const* session);
+[[nodiscard]] std::optional<in6_addr> tr_globalIPv6(tr_session const* session);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -284,7 +284,7 @@ public:
         if (tr_dhtEnabled(torrent->session) && io->supportsDHT())
         {
             /* Only send PORT over IPv6 when the IPv6 DHT is running (BEP-32). */
-            if (io->address().isIPv4() || tr_globalIPv6(nullptr) != nullptr)
+            if (io->address().isIPv4() || tr_globalIPv6(nullptr).has_value())
             {
                 protocolSendPort(this, tr_dhtPort(torrent->session));
             }
@@ -915,7 +915,7 @@ static void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
 static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 {
     evbuffer* const out = msgs->outMessages;
-    unsigned char const* ipv6 = tr_globalIPv6(msgs->io->session);
+    auto const ipv6 = tr_globalIPv6(msgs->io->session);
     static tr_quark version_quark = 0;
 
     if (msgs->clientSentLtepHandshake)
@@ -953,9 +953,9 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
-    if (ipv6 != nullptr)
+    if (ipv6.has_value())
     {
-        tr_variantDictAddRaw(&val, TR_KEY_ipv6, ipv6, 16);
+        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &*ipv6, sizeof(*ipv6));
     }
 
     // http://bittorrent.org/beps/bep_0009.html

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -516,7 +516,7 @@ public:
         tr_session& session_;
         struct event* udp_event_ = nullptr;
         struct event* udp6_event_ = nullptr;
-        unsigned char* udp6_bound_ = nullptr;
+        std::optional<in6_addr> udp6_bound_;
         tr_socket_t udp_socket_ = TR_BAD_SOCKET;
         tr_socket_t udp6_socket_ = TR_BAD_SOCKET;
 


### PR DESCRIPTION
This was also the last place in libtransmission's code where `malloc()` and `free()` were being used, so also add `cppcoreguidelines-no-malloc` to `libtransmission/.clang-tidy` :partying_face: 