### PR TITLE
add clientIDs for BitTorrent Web, Free Download Manager 6, Torch Browser

### DIFF
--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -505,7 +505,7 @@ struct Client
     format_func formatter;
 };
 
-auto constexpr Clients = std::array<Client, 129>{ {
+auto constexpr Clients = std::array<Client, 131>{ {
     { "-AD", "Advanced Download Manager", three_digit_formatter },
     { "-AG", "Ares", four_digit_formatter },
     { "-AR", "Arctic", four_digit_formatter },
@@ -529,7 +529,7 @@ auto constexpr Clients = std::array<Client, 129>{ {
     { "-BR", "BitRocket", bitrocket_formatter },
     { "-BS", "BTSlave", four_digit_formatter },
     { "-BT", "BitTorrent", utorrent_formatter },
-    { "-BW", "BitWombat", four_digit_formatter },
+    { "-BW", "BitTorrent Web", utorrent_formatter },
     { "-BX", "BittorrentX", four_digit_formatter },
     { "-CD", "Enhanced CTorrent", two_major_two_minor_formatter },
     { "-CT", "CTorrent", ctorrent_formatter },
@@ -584,6 +584,7 @@ auto constexpr Clients = std::array<Client, 129>{ {
     { "-ST", "SymTorrent", four_digit_formatter },
     { "-SZ", "Shareaza", four_digit_formatter },
     { "-S~", "Shareaza", four_digit_formatter },
+    { "-TB", "Torch Browser", no_version_formatter },
     { "-TN", "Torrent .NET", four_digit_formatter },
     { "-TR", "Transmission", transmission_formatter },
     { "-TS", "Torrentstorm", four_digit_formatter },
@@ -618,6 +619,7 @@ auto constexpr Clients = std::array<Client, 129>{ {
     { "AZ2500BT", "BitTyrant (Azureus Mod)", no_version_formatter },
     { "BLZ", "Blizzard Downloader", blizzard_formatter },
     { "DNA", "BitTorrent DNA", bittorrent_dna_formatter },
+    { "FD6", "Free Download Manager 6", no_version_formatter },
     { "LIME", "Limewire", no_version_formatter },
     { "M", "BitTorrent", mainline_formatter },
     { "Mbrst", "burst!", burst_formatter },

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -24,7 +24,7 @@ TEST(Client, clientForId)
         std::string_view expected_client;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 40>{
+    auto constexpr Tests = std::array<LocalTest, 44>{
         { { "-ADB560-"sv, "Advanced Download Manager 11.5.6"sv },
           { "-AZ8421-"sv, "Azureus / Vuze 8.4.2.1"sv },
           { "-BC0241-"sv, "BitComet 2.41"sv }, // two major, two minor
@@ -33,11 +33,13 @@ TEST(Client, clientForId)
           { "-BN0001-"sv, "Baidu Netdisk"sv }, // Baidu Netdisk Client v5.5.4
           { "-BT791B-"sv, "BitTorrent 7.9.1 (Beta)"sv },
           { "-BT791\0-"sv, "BitTorrent 7.9.1"sv },
+          { "-BW1293-"sv, "BitTorrent Web 1.2.9"sv }, // BitTorrent Web 1.2.9.4938 (9924)
           { "-FC1013-"sv, "FileCroc 1.0.1.3"sv },
           { "-FC1013-"sv, "FileCroc 1.0.1.3"sv },
           { "-FD51@\xFF-"sv, "Free Download Manager 5.1.x"sv }, // Negative test case
           { "-FD51R\xFF-"sv, "Free Download Manager 5.1.27"sv },
           { "-FD51W\xFF-"sv, "Free Download Manager 5.1.32"sv },
+          { "-FD51\x5D\xC7-"sv, "Free Download Manager 5.1.x"sv }, // Free Download Manager 5.1.38.7312 (79f26aa)
           { "-FL51FF-"sv, "Folx 5.x"sv }, // Folx v5.2.1.13690
           { "-FW6830-"sv, "FrostWire 6.8.3"sv },
           { "-IIO\x10\x2D\x04-"sv, "-IIO%10-%04-"sv },
@@ -47,6 +49,7 @@ TEST(Client, clientForId)
           { "-MR1100-"sv, "Miro 1.1.0.0"sv },
           { "-PI0091-"sv, "PicoTorrent 0.09.1"sv },
           { "-PI0120-"sv, "PicoTorrent 0.12.0"sv },
+          { "-TB2137-"sv, "Torch Browser"sv }, // Torch Browser 55.0.0.12137
           { "-TR0006-"sv, "Transmission 0.6"sv },
           { "-TR0072-"sv, "Transmission 0.72"sv },
           { "-TR111Z-"sv, "Transmission 1.11+"sv },
@@ -60,6 +63,7 @@ TEST(Client, clientForId)
           { "-XF9992-"sv, "Xfplay 9.9.92"sv }, // Xfplay 9.9.92 to 9.9.94 uses "-XF9992-"
           { "A2-1-18-8-"sv, "aria2 1.18.8"sv },
           { "A2-1-2-0-"sv, "aria2 1.2.0"sv },
+          { "FD6k4SYy9BOU4U4rk3-J"sv, "Free Download Manager 6"sv }, // Free Download Manager 6.17.0.4792 (9a17ce2)
           { "S58B-----"sv, "Shad0w 5.8.11"sv },
           { "Q1-23-4-"sv, "Queen Bee 1.23.4"sv },
           { "TIX0193-"sv, "Tixati 1.93"sv },


### PR DESCRIPTION
[BitTorrent Web](https://www.bittorrent.com/products/win/bittorrent-web-free/) "-BW" decades ago used by BitWombat, unlikely someone still uses it
[Free Download Manager 6](https://www.freedownloadmanager.org/) v6 uses "FD6<random>" as clientid, opposed to "-FD" used in v5
[Torch Browser](https://en.wikipedia.org/wiki/Torch_(browser))  uses "-TB" + last 4 digits of build number
