### PR TITLE
refactor: remove TR_PRIsv macros

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -125,10 +125,11 @@ void logAddImpl(
     }
 
 #ifdef NDEBUG
-    __android_log_print(prio, "transmission", "%" TR_PRIsv, TR_PRIsv_ARG(msg));
+    auto const szmsg = fmt::format("{:s}", msg);
 #else
-    __android_log_print(prio, "transmission", "[%s:%d] %" TR_PRIsv, file, line, TR_PRIsv_ARG(msg));
+    auto const szmsg = fmt::format("[{:s}:{:d}] {:s}", file, line, msg);
 #endif
+    __android_log_print(prio, "transmission", szmsg.c_str());
 
 #else
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -129,7 +129,7 @@ void logAddImpl(
 #else
     auto const szmsg = fmt::format("[{:s}:{:d}] {:s}", file, line, msg);
 #endif
-    __android_log_print(prio, "transmission", szmsg.c_str());
+    __android_log_write(prio, "transmission", szmsg.c_str());
 
 #else
 

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -70,9 +70,6 @@
 // Mostly to enforce better formatting
 #define TR_ARG_TUPLE(...) __VA_ARGS__
 
-#define TR_PRIsv "*.*s"
-#define TR_PRIsv_ARG(sv) TR_ARG_TUPLE(int(std::size(sv)), int(std::size(sv)), std::data(sv))
-
 // https://www.bittorrent.org/beps/bep_0003.html
 // A string of length 20 which this downloader uses as its id. Each
 // downloader generates its own id at random at the start of a new

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -9,6 +9,7 @@
 #include "transmission.h"
 
 #include "file.h"
+#include "platform.h"
 #include "tr-strbuf.h"
 
 #include "test-fixtures.h"

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -99,7 +99,7 @@ static bool removeURL(tr_variant* metainfo, std::string_view url)
 
     if (tr_variantDictFindStrView(metainfo, TR_KEY_announce, &sv) && url == sv)
     {
-        fmt::print(FMT_STRING("\tRemoved '{:s} from 'announce'\n"), sv);
+        fmt::print("\tRemoved '{:s}' from 'announce'\n", sv);
         tr_variantDictRemove(metainfo, TR_KEY_announce);
         changed = true;
     }
@@ -117,7 +117,7 @@ static bool removeURL(tr_variant* metainfo, std::string_view url)
             {
                 if (tr_variantGetStrView(node, &sv) && url == sv)
                 {
-                    fmt::print(FMT_STRING("\tRemoved '{:s} from 'announce-list' tier #{:d}\n"), sv, tierIndex + 1);
+                    fmt::print("\tRemoved '{:s}' from 'announce-list' tier #{:d}\n", sv, tierIndex + 1);
                     tr_variantListRemove(tier, nodeIndex);
                     changed = true;
                 }
@@ -129,7 +129,7 @@ static bool removeURL(tr_variant* metainfo, std::string_view url)
 
             if (tr_variantListSize(tier) == 0)
             {
-                fmt::print(FMT_STRING("\tNo URLs left in tier #{:d}... removing tier\n"), tierIndex + 1);
+                fmt::print("\tNo URLs left in tier #{:d}... removing tier\n", tierIndex + 1);
                 tr_variantListRemove(announce_list, tierIndex);
             }
             else
@@ -140,7 +140,7 @@ static bool removeURL(tr_variant* metainfo, std::string_view url)
 
         if (tr_variantListSize(announce_list) == 0)
         {
-            fmt::print(FMT_STRING("\tNo tiers left... removing announce-list\n"));
+            fmt::print("\tNo tiers left... removing announce-list\n");
             tr_variantDictRemove(metainfo, TR_KEY_announce_list);
         }
     }
@@ -156,7 +156,7 @@ static bool removeURL(tr_variant* metainfo, std::string_view url)
             if ((node != nullptr) && tr_variantGetStrView(node, &sv))
             {
                 tr_variantDictAddStr(metainfo, TR_KEY_announce, sv);
-                fmt::print(FMT_STRING("\tAdded '{:s}' to announce\n"), sv);
+                fmt::print("\tAdded '{:s}' to announce\n", sv);
             }
         }
     }
@@ -192,7 +192,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
     if (tr_variantDictFindStrView(metainfo, TR_KEY_announce, &sv) && tr_strvContains(sv, oldval))
     {
         auto const newstr = replaceSubstr(sv, oldval, newval);
-        fmt::print(FMT_STRING("\tReplaced in 'announce': '{:s}' --> '{:s}'\n"), sv, newstr);
+        fmt::print("\tReplaced in 'announce': '{:s}' --> '{:s}'\n", sv, newstr);
         tr_variantDictAddStr(metainfo, TR_KEY_announce, newstr);
         changed = true;
     }
@@ -212,11 +212,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
                 if (tr_variantGetStrView(node, &sv) && tr_strvContains(sv, oldval))
                 {
                     auto const newstr = replaceSubstr(sv, oldval, newval);
-                    fmt::print(
-                        FMT_STRING("\tReplaced in 'announce-list' tier #{:d}: '{:s}' --> '{:s}'\n"),
-                        tierCount + 1,
-                        sv,
-                        newstr);
+                    fmt::print("\tReplaced in 'announce-list' tier #{:d}: '{:s}' --> '{:s}'\n", tierCount + 1, sv, newstr);
                     tr_variantClear(node);
                     tr_variantInitStr(node, newstr);
                     changed = true;
@@ -270,7 +266,7 @@ static bool addURL(tr_variant* metainfo, char const* url)
     if (!had_announce && !had_announce_list)
     {
         /* this new tracker is the only one, so add it to "announce"... */
-        fmt::print(FMT_STRING("\tAdded '{:s}' in 'announce'\n"), url);
+        fmt::print("\tAdded '{:s}' in 'announce'\n", url);
         tr_variantDictAddStr(metainfo, TR_KEY_announce, url);
         changed = true;
     }
@@ -295,7 +291,7 @@ static bool addURL(tr_variant* metainfo, char const* url)
         {
             tr_variant* tier = tr_variantListAddList(announce_list, 1);
             tr_variantListAddStr(tier, url);
-            fmt::print(FMT_STRING("\tAdded '{:s}' to 'announce-list' tier #{:d}\n"), url, tr_variantListSize(announce_list));
+            fmt::print("\tAdded '{:s}' to 'announce-list' tier #{:d}\n", url, tr_variantListSize(announce_list));
             changed = true;
         }
     }
@@ -311,13 +307,13 @@ static bool setSource(tr_variant* metainfo, char const* source_value)
 
     if (!had_source)
     {
-        fmt::print(FMT_STRING("\tAdded '{:s}' as source\n"), source_value);
+        fmt::print("\tAdded '{:s}' as source\n", source_value);
         tr_variantDictAddStr(metainfo, TR_KEY_source, source_value);
         changed = true;
     }
     else if (current_source.compare(source_value) != 0)
     {
-        fmt::print(FMT_STRING("\tUpdated source: '{:s}' -> '{:s}'\n"), current_source.data(), source_value);
+        fmt::print("\tUpdated source: '{:s}' -> '{:s}'\n", current_source.data(), source_value);
         tr_variantDictAddStr(metainfo, TR_KEY_source, source_value);
         changed = true;
     }
@@ -339,13 +335,13 @@ int tr_main(int argc, char* argv[])
 
     if (options.show_version)
     {
-        fmt::print(stderr, FMT_STRING("{:s} {:s}\n"), MyName, LONG_VERSION_STRING);
+        fmt::print(stderr, "{:s} {:s}\n", MyName, LONG_VERSION_STRING);
         return EXIT_SUCCESS;
     }
 
     if (std::empty(options.files))
     {
-        fmt::print(stderr, FMT_STRING("ERROR: No torrent files specified.\n"));
+        fmt::print(stderr, "ERROR: No torrent files specified.\n");
         tr_getopt_usage(MyName, Usage, std::data(Options));
         fmt::print(stderr, "\n");
         return EXIT_FAILURE;
@@ -365,11 +361,11 @@ int tr_main(int argc, char* argv[])
         bool changed = false;
         tr_error* error = nullptr;
 
-        fmt::print(FMT_STRING("{:s}\n"), filename);
+        fmt::print("{:s}\n", filename);
 
         if (!tr_variantFromFile(&top, TR_VARIANT_PARSE_BENC, filename, &error))
         {
-            fmt::print(FMT_STRING("\tError reading file: {:s}\n"), error->message);
+            fmt::print("\tError reading file: {:s}\n", error->message);
             tr_error_free(error);
             continue;
         }
@@ -403,7 +399,7 @@ int tr_main(int argc, char* argv[])
         tr_variantClear(&top);
     }
 
-    fmt::print(FMT_STRING("Changed {:d} files\n"), changedCount);
+    fmt::print("Changed {:d} files\n", changedCount);
 
     return EXIT_SUCCESS;
 }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -379,7 +379,7 @@ static int numarg(char const* arg)
 
     if (*end != '\0')
     {
-        fprintf(stderr, "Not a number: \"%s\"\n", arg);
+        fmt::print(stderr, FMT_STRING("Not a number: '{:s}'\n"), arg);
         showUsage();
         exit(EXIT_FAILURE);
     }
@@ -553,7 +553,7 @@ static int getOptMode(int val)
         return MODE_GROUP_GET;
 
     default:
-        fprintf(stderr, "unrecognized argument %d\n", val);
+        fmt::print(stderr, FMT_STRING("unrecognized argument {:d}\n"), val);
         assert("unrecognized argument" && 0);
         return 0;
     }
@@ -578,7 +578,7 @@ static void addIdArg(tr_variant* args, std::string_view id_str, std::string_view
 
     if (std::empty(id_str))
     {
-        fprintf(stderr, "No torrent specified!  Please use the -t option first.\n");
+        fmt::print(stderr, "No torrent specified!  Please use the -t option first.\n");
         id_str = "-1"sv; /* no torrent will have this ID, so will act as a no-op */
     }
 
@@ -640,7 +640,7 @@ static void addTime(tr_variant* args, tr_quark const key, char const* arg)
     }
     else
     {
-        fprintf(stderr, "Please specify the time of day in 'hhmm' format.\n");
+        fmt::print(stderr, "Please specify the time of day in 'hhmm' format.\n");
     }
 }
 
@@ -672,7 +672,7 @@ static void addDays(tr_variant* args, tr_quark const key, char const* arg)
     }
     else
     {
-        fprintf(stderr, "Please specify the days of the week in '1-3,4,7' format.\n");
+        fmt::print(stderr, "Please specify the days of the week in '1-3,4,7' format.\n");
     }
 }
 
@@ -702,7 +702,7 @@ static void addFiles(tr_variant* args, tr_quark const key, char const* arg)
 
     if (tr_str_is_empty(arg))
     {
-        fprintf(stderr, "No files specified!\n");
+        fmt::print(stderr, "No files specified!\n");
         arg = "-1"; /* no file will have this index, so should be a no-op */
     }
 
@@ -939,31 +939,31 @@ static void printDetails(tr_variant* top)
             double d;
             auto sv = std::string_view{};
 
-            printf("NAME\n");
+            fmt::print("NAME\n");
 
             if (tr_variantDictFindInt(t, TR_KEY_id, &i))
             {
-                printf("  Id: %" PRId64 "\n", i);
+                fmt::print("  Id: {:d}\n", i);
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_name, &sv))
             {
-                printf("  Name: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Name: {:s}\n", sv);
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_hashString, &sv))
             {
-                printf("  Hash: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Hash: {:s}\n", sv);
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_magnetLink, &sv))
             {
-                printf("  Magnet: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Magnet: {:s}\n", sv);
             }
 
             if (tr_variantDictFindList(t, TR_KEY_labels, &l))
             {
-                printf("  Labels: ");
+                fmt::print("  Labels: ");
 
                 size_t child_pos = 0;
                 tr_variant const* child;
@@ -971,69 +971,69 @@ static void printDetails(tr_variant* top)
                 {
                     if (tr_variantGetStrView(child, &sv))
                     {
-                        printf(child_pos == 1 ? "%" TR_PRIsv : ", %" TR_PRIsv, TR_PRIsv_ARG(sv));
+                        fmt::print(child_pos == 1 ? "{:s}" : ", {:s}", sv);
                     }
                 }
 
-                printf("\n");
+                fmt::print("\n");
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_group, &sv) && !sv.empty())
             {
-                printf("  Bandwidth group: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Bandwidth group: {:s}\n", sv);
             }
 
-            printf("\n");
+            fmt::print("\n");
 
-            printf("TRANSFER\n");
-            printf("  State: %s\n", getStatusString(t).c_str());
+            fmt::print("TRANSFER\n");
+            fmt::print("  State: {:s}\n", getStatusString(t));
 
             if (tr_variantDictFindStrView(t, TR_KEY_downloadDir, &sv))
             {
-                printf("  Location: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Location: {:s}\n", sv);
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_sizeWhenDone, &i) && tr_variantDictFindInt(t, TR_KEY_leftUntilDone, &j))
             {
-                printf("  Percent Done: %s%%\n", strlpercent(100.0 * (i - j) / i).c_str());
+                fmt::print("  Percent Done: {:s}%\n", strlpercent(100.0 * (i - j) / i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_eta, &i))
             {
-                printf("  ETA: %s\n", tr_strltime(i).c_str());
+                fmt::print("  ETA: {:s}\n", tr_strltime(i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_rateDownload, &i))
             {
-                printf("  Download Speed: %s\n", tr_formatter_speed_KBps(i / (double)tr_speed_K).c_str());
+                fmt::print("  Download Speed: {:s}\n", tr_formatter_speed_KBps(i / (double)tr_speed_K));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_rateUpload, &i))
             {
-                printf("  Upload Speed: %s\n", tr_formatter_speed_KBps(i / (double)tr_speed_K).c_str());
+                fmt::print("  Upload Speed: {:s}\n", tr_formatter_speed_KBps(i / (double)tr_speed_K));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_haveUnchecked, &i) && tr_variantDictFindInt(t, TR_KEY_haveValid, &j))
             {
-                printf("  Have: %s (%s verified)\n", strlsize(i + j).c_str(), strlsize(j).c_str());
+                fmt::print("  Have: {:s} ({:s} verified)\n", strlsize(i + j), strlsize(j));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_sizeWhenDone, &i))
             {
                 if (i < 1)
                 {
-                    printf("  Availability: None\n");
+                    fmt::print("  Availability: None\n");
                 }
 
                 if (tr_variantDictFindInt(t, TR_KEY_desiredAvailable, &j) && tr_variantDictFindInt(t, TR_KEY_leftUntilDone, &k))
                 {
                     j += i - k;
-                    printf("  Availability: %s%%\n", strlpercent(100.0 * j / i).c_str());
+                    fmt::print("  Availability: {:s}%\n", strlpercent(100.0 * j / i));
                 }
 
                 if (tr_variantDictFindInt(t, TR_KEY_totalSize, &j))
                 {
-                    printf("  Total size: %s (%s wanted)\n", strlsize(j).c_str(), strlsize(i).c_str());
+                    fmt::print("  Total size: {:s} ({:s} wanted)\n", strlsize(j), strlsize(i));
                 }
             }
 
@@ -1041,24 +1041,21 @@ static void printDetails(tr_variant* top)
             {
                 if (auto corrupt = int64_t{}; tr_variantDictFindInt(t, TR_KEY_corruptEver, &corrupt) && corrupt != 0)
                 {
-                    printf(
-                        "  Downloaded: %s (+%s discarded after failed checksum)\n",
-                        strlsize(i).c_str(),
-                        strlsize(corrupt).c_str());
+                    fmt::print("  Downloaded: {:s} (+{:s} discarded after failed checksum)\n", strlsize(i), strlsize(corrupt));
                 }
                 else
                 {
-                    printf("  Downloaded: %s\n", strlsize(i).c_str());
+                    fmt::print("  Downloaded: {:s}\n", strlsize(i));
                 }
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_uploadedEver, &i))
             {
-                printf("  Uploaded: %s\n", strlsize(i).c_str());
+                fmt::print("  Uploaded: {:s}\n", strlsize(i));
 
                 if (tr_variantDictFindInt(t, TR_KEY_sizeWhenDone, &j))
                 {
-                    printf("  Ratio: %s\n", strlratio(i, j).c_str());
+                    fmt::print("  Ratio: {:s}\n", strlratio(i, j));
                 }
             }
 
@@ -1068,15 +1065,15 @@ static void printDetails(tr_variant* top)
                 switch (i)
                 {
                 case TR_STAT_TRACKER_WARNING:
-                    printf("  Tracker gave a warning: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                    fmt::print("  Tracker gave a warning: {:s}\n", sv);
                     break;
 
                 case TR_STAT_TRACKER_ERROR:
-                    printf("  Tracker gave an error: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                    fmt::print("  Tracker gave an error: {:s}\n", sv);
                     break;
 
                 case TR_STAT_LOCAL_ERROR:
-                    printf("  Error: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                    fmt::print("  Error: {:s}\n", sv);
                     break;
 
                 default:
@@ -1088,7 +1085,7 @@ static void printDetails(tr_variant* top)
                 tr_variantDictFindInt(t, TR_KEY_peersGettingFromUs, &j) &&
                 tr_variantDictFindInt(t, TR_KEY_peersSendingToUs, &k))
             {
-                printf("  Peers: connected to %" PRId64 ", uploading to %" PRId64 ", downloading from %" PRId64 "\n", i, j, k);
+                fmt::print("  Peers: connected to {:d}, uploading to {:d}, downloading from {:d}\n", i, j, k);
             }
 
             if (tr_variantDictFindList(t, TR_KEY_webseeds, &l) && tr_variantDictFindInt(t, TR_KEY_webseedsSendingToUs, &i))
@@ -1097,113 +1094,113 @@ static void printDetails(tr_variant* top)
 
                 if (n > 0)
                 {
-                    printf("  Web Seeds: downloading from %" PRId64 " of %" PRId64 " web seeds\n", i, n);
+                    fmt::print("  Web Seeds: downloading from {:d} of {:d} web seeds\n", i, n);
                 }
             }
 
-            printf("\n");
+            fmt::print("\n");
 
-            printf("HISTORY\n");
+            fmt::print("HISTORY\n");
 
             if (tr_variantDictFindInt(t, TR_KEY_addedDate, &i) && i != 0)
             {
-                printf("  Date added:       %s\n", format_date(buf, sizeof(buf), i));
+                fmt::print("  Date added:       {:s}\n", format_date(buf, sizeof(buf), i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_doneDate, &i) && i != 0)
             {
-                printf("  Date finished:    %s\n", format_date(buf, sizeof(buf), i));
+                fmt::print("  Date finished:    {:s}\n", format_date(buf, sizeof(buf), i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_startDate, &i) && i != 0)
             {
-                printf("  Date started:     %s\n", format_date(buf, sizeof(buf), i));
+                fmt::print("  Date started:     {:s}\n", format_date(buf, sizeof(buf), i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_activityDate, &i) && i != 0)
             {
-                printf("  Latest activity:  %s\n", format_date(buf, sizeof(buf), i));
+                fmt::print("  Latest activity:  {:s}\n", format_date(buf, sizeof(buf), i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_secondsDownloading, &i) && i > 0)
             {
-                printf("  Downloading Time: %s\n", tr_strltime(i).c_str());
+                fmt::print("  Downloading Time: {:s}\n", tr_strltime(i));
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_secondsSeeding, &i) && i > 0)
             {
-                printf("  Seeding Time:     %s\n", tr_strltime(i).c_str());
+                fmt::print("  Seeding Time:     {:s}\n", tr_strltime(i));
             }
 
-            printf("\n");
+            fmt::print("\n");
 
-            printf("ORIGINS\n");
+            fmt::print("ORIGINS\n");
 
             if (tr_variantDictFindInt(t, TR_KEY_dateCreated, &i) && i != 0)
             {
-                printf("  Date created: %s\n", format_date(buf, sizeof(buf), i));
+                fmt::print("  Date created: {:s}\n", format_date(buf, sizeof(buf), i));
             }
 
             if (tr_variantDictFindBool(t, TR_KEY_isPrivate, &boolVal))
             {
-                printf("  Public torrent: %s\n", (boolVal ? "No" : "Yes"));
+                fmt::print("  Public torrent: {:s}\n", (boolVal ? "No" : "Yes"));
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_comment, &sv) && !std::empty(sv))
             {
-                printf("  Comment: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Comment: {:s}\n", sv);
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_creator, &sv) && !std::empty(sv))
             {
-                printf("  Creator: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Creator: {:s}\n", sv);
             }
 
             if (tr_variantDictFindStrView(t, TR_KEY_source, &sv) && !std::empty(sv))
             {
-                printf("  Source: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("  Source: {:s}\n", sv);
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_pieceCount, &i))
             {
-                printf("  Piece Count: %" PRId64 "\n", i);
+                fmt::print("  Piece Count: {:d}\n", i);
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_pieceSize, &i))
             {
-                printf("  Piece Size: %s\n", strlmem(i).c_str());
+                fmt::print("  Piece Size: {:s}\n", strlmem(i));
             }
 
-            printf("\n");
+            fmt::print("\n");
 
-            printf("LIMITS & BANDWIDTH\n");
+            fmt::print("LIMITS & BANDWIDTH\n");
 
             if (tr_variantDictFindBool(t, TR_KEY_downloadLimited, &boolVal) &&
                 tr_variantDictFindInt(t, TR_KEY_downloadLimit, &i))
             {
-                printf("  Download Limit: ");
+                fmt::print("  Download Limit: ");
 
                 if (boolVal)
                 {
-                    printf("%s\n", tr_formatter_speed_KBps(i).c_str());
+                    fmt::print("{:s}\n", tr_formatter_speed_KBps(i));
                 }
                 else
                 {
-                    printf("Unlimited\n");
+                    fmt::print("Unlimited\n");
                 }
             }
 
             if (tr_variantDictFindBool(t, TR_KEY_uploadLimited, &boolVal) && tr_variantDictFindInt(t, TR_KEY_uploadLimit, &i))
             {
-                printf("  Upload Limit: ");
+                fmt::print("  Upload Limit: ");
 
                 if (boolVal)
                 {
-                    printf("%s\n", tr_formatter_speed_KBps(i).c_str());
+                    fmt::print("{:s}\n", tr_formatter_speed_KBps(i));
                 }
                 else
                 {
-                    printf("Unlimited\n");
+                    fmt::print("Unlimited\n");
                 }
             }
 
@@ -1212,19 +1209,19 @@ static void printDetails(tr_variant* top)
                 switch (i)
                 {
                 case TR_RATIOLIMIT_GLOBAL:
-                    printf("  Ratio Limit: Default\n");
+                    fmt::print("  Ratio Limit: Default\n");
                     break;
 
                 case TR_RATIOLIMIT_SINGLE:
                     if (tr_variantDictFindReal(t, TR_KEY_seedRatioLimit, &d))
                     {
-                        printf("  Ratio Limit: %s\n", strlratio2(d).c_str());
+                        fmt::print("  Ratio Limit: {:s}\n", strlratio2(d));
                     }
 
                     break;
 
                 case TR_RATIOLIMIT_UNLIMITED:
-                    printf("  Ratio Limit: Unlimited\n");
+                    fmt::print("  Ratio Limit: Unlimited\n");
                     break;
 
                 default:
@@ -1234,20 +1231,20 @@ static void printDetails(tr_variant* top)
 
             if (tr_variantDictFindBool(t, TR_KEY_honorsSessionLimits, &boolVal))
             {
-                printf("  Honors Session Limits: %s\n", (boolVal ? "Yes" : "No"));
+                fmt::print("  Honors Session Limits: {:s}\n", boolVal ? "Yes" : "No");
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_peer_limit, &i))
             {
-                printf("  Peer limit: %" PRId64 "\n", i);
+                fmt::print("  Peer limit: {:d}\n", i);
             }
 
             if (tr_variantDictFindInt(t, TR_KEY_bandwidthPriority, &i))
             {
-                printf("  Bandwidth Priority: %s\n", bandwidthPriorityNames[(i + 1) & 3]);
+                fmt::print("  Bandwidth Priority: {:s}\n", bandwidthPriorityNames[(i + 1) & 3]);
             }
 
-            printf("\n");
+            fmt::print("\n");
         }
     }
 }
@@ -1271,7 +1268,7 @@ static void printFileList(tr_variant* top)
                 tr_variantDictFindList(d, TR_KEY_priorities, &priorities) && tr_variantDictFindList(d, TR_KEY_wanted, &wanteds))
             {
                 int const jn = tr_variantListSize(files);
-                printf("%" TR_PRIsv " (%d files):\n", TR_PRIsv_ARG(name), jn);
+                fmt::print("{:s} ({:d} files):\n", name, jn);
                 printf("%3s  %4s %8s %3s %9s  %s\n", "#", "Done", "Priority", "Get", "Size", "Name");
 
                 for (int j = 0; j < jn; ++j)
@@ -1307,14 +1304,14 @@ static void printFileList(tr_variant* top)
                             break;
                         }
 
-                        printf(
-                            "%3d: %3.0f%% %-8s %-3s %9s  %" TR_PRIsv "\n",
+                        fmt::print(
+                            FMT_STRING("{:3d}: {:3.0f}% {:<8s} {:<3s} {:9s}  {:s}\n"),
                             j,
                             floor(100.0 * percent),
                             pristr,
                             wanted ? "Yes" : "No",
-                            strlsize(length).c_str(),
-                            TR_PRIsv_ARG(filename));
+                            strlsize(length),
+                            filename);
                     }
                 }
             }
@@ -1343,14 +1340,14 @@ static void printPeersImpl(tr_variant* peers)
             tr_variantDictFindInt(d, TR_KEY_rateToClient, &rateToClient) &&
             tr_variantDictFindInt(d, TR_KEY_rateToPeer, &rateToPeer))
         {
-            printf(
-                "%-40s  %-12s  %-5.1f %6.1f  %6.1f  %" TR_PRIsv "\n",
-                std::string{ address }.c_str(),
-                std::string{ flagstr }.c_str(),
-                (progress * 100.0),
-                rateToClient / (double)tr_speed_K,
-                rateToPeer / (double)tr_speed_K,
-                TR_PRIsv_ARG(client));
+            fmt::print(
+                FMT_STRING("{:<40s}  {:<12s}  {:<5.1f} {:6.1f}  {:6.1f}  {:s}\n"),
+                address,
+                flagstr,
+                progress * 100.0,
+                rateToClient / static_cast<double>(tr_speed_K),
+                rateToPeer / static_cast<double>(tr_speed_K),
+                client);
         }
     }
 }
@@ -1373,7 +1370,7 @@ static void printPeers(tr_variant* top)
 
                 if (i + 1 < n)
                 {
-                    printf("\n");
+                    fmt::print("\n");
                 }
             }
         }
@@ -1383,7 +1380,7 @@ static void printPeers(tr_variant* top)
 static void printPiecesImpl(std::string_view raw, size_t piece_count)
 {
     auto const str = tr_base64_decode(raw);
-    printf("  ");
+    fmt::print("  ");
 
     size_t piece = 0;
     size_t const col_width = 64;
@@ -1394,15 +1391,15 @@ static void printPiecesImpl(std::string_view raw, size_t piece_count)
             printf("%c", (ch & (1 << (7 - bit))) != 0 ? '1' : '0');
         }
 
-        printf(" ");
+        fmt::print(" ");
 
         if (piece % col_width == 0)
         {
-            printf("\n  ");
+            fmt::print("\n  ");
         }
     }
 
-    printf("\n");
+    fmt::print("\n");
 }
 
 static void printPieces(tr_variant* top)
@@ -1426,7 +1423,7 @@ static void printPieces(tr_variant* top)
 
                 if (i + 1 < n)
                 {
-                    printf("\n");
+                    fmt::print("\n");
                 }
             }
         }
@@ -1443,7 +1440,7 @@ static void printPortTest(tr_variant* top)
 
         if (tr_variantDictFindBool(args, TR_KEY_port_is_open, &boolVal))
         {
-            printf("Port is open: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("Port is open: {:s}\n", boolVal ? "Yes" : "No");
         }
     }
 }
@@ -1499,18 +1496,18 @@ static void printTorrentList(tr_variant* top)
                     fmt::format(FMT_STRING("{:.0f}%"), (100.0 * (sizeWhenDone - leftUntilDone) / sizeWhenDone)) :
                     std::string{ "n/a" };
 
-                printf(
-                    "%6d%c  %4s  %9s  %-8s  %6.1f  %6.1f  %5s  %-11s  %" TR_PRIsv "\n",
-                    (int)torId,
+                fmt::print(
+                    FMT_STRING("{:6d}{:c}  {:>4s}  {:>9s}  {:<8s}  {:6.1f}  {:6.1f}  {:>5s}  {:<11s}  {:s}\n"),
+                    torId,
                     error_mark,
-                    done_str.c_str(),
-                    strlsize(sizeWhenDone - leftUntilDone).c_str(),
-                    eta_str.c_str(),
-                    up / (double)tr_speed_K,
-                    down / (double)tr_speed_K,
-                    strlratio2(ratio).c_str(),
-                    getStatusString(d).c_str(),
-                    TR_PRIsv_ARG(name));
+                    done_str,
+                    strlsize(sizeWhenDone - leftUntilDone),
+                    eta_str,
+                    up / static_cast<double>(tr_speed_K),
+                    down / static_cast<double>(tr_speed_K),
+                    strlratio2(ratio),
+                    getStatusString(d),
+                    name);
 
                 total_up += up;
                 total_down += down;
@@ -1518,11 +1515,11 @@ static void printTorrentList(tr_variant* top)
             }
         }
 
-        printf(
-            "Sum:           %9s            %6.1f  %6.1f\n",
+        fmt::print(
+            FMT_STRING("Sum:           {:>9s}            {:6.1f}  {:6.1f}\n"),
             strlsize(total_size).c_str(),
-            total_up / (double)tr_speed_K,
-            total_down / (double)tr_speed_K);
+            total_up / static_cast<double>(tr_speed_K),
+            total_down / static_cast<double>(tr_speed_K));
     }
 }
 
@@ -1581,16 +1578,16 @@ static void printTrackersImpl(tr_variant* trackerStats)
         {
             time_t const now = time(nullptr);
 
-            printf("\n");
-            printf("  Tracker %d: %" TR_PRIsv "\n", (int)trackerId, TR_PRIsv_ARG(host));
+            fmt::print("\n");
+            fmt::print("  Tracker {:d}: {:s}\n", trackerId, host);
 
             if (isBackup)
             {
-                printf("  Backup on tier %d\n", (int)tier);
+                fmt::print("  Backup on tier {:d}\n", tier);
             }
             else
             {
-                printf("  Active in tier %d\n", (int)tier);
+                fmt::print("  Active in tier {:d}\n", tier);
             }
 
             if (!isBackup)
@@ -1601,34 +1598,34 @@ static void printTrackersImpl(tr_variant* trackerStats)
 
                     if (lastAnnounceSucceeded)
                     {
-                        printf("  Got a list of %d peers %s ago\n", (int)lastAnnouncePeerCount, timestr.c_str());
+                        fmt::print("  Got a list of {:d} peers {:s} ago\n", lastAnnouncePeerCount, timestr);
                     }
                     else if (lastAnnounceTimedOut)
                     {
-                        printf("  Peer list request timed out; will retry\n");
+                        fmt::print("  Peer list request timed out; will retry\n");
                     }
                     else
                     {
-                        printf("  Got an error \"%" TR_PRIsv "\" %s ago\n", TR_PRIsv_ARG(lastAnnounceResult), timestr.c_str());
+                        fmt::print("  Got an error '{:s}' {:s} ago\n", lastAnnounceResult, timestr);
                     }
                 }
 
                 switch (announceState)
                 {
                 case TR_TRACKER_INACTIVE:
-                    printf("  No updates scheduled\n");
+                    fmt::print("  No updates scheduled\n");
                     break;
 
                 case TR_TRACKER_WAITING:
-                    printf("  Asking for more peers in %s\n", tr_strltime(nextAnnounceTime - now).c_str());
+                    fmt::print("  Asking for more peers in {:s)\n", tr_strltime(nextAnnounceTime - now));
                     break;
 
                 case TR_TRACKER_QUEUED:
-                    printf("  Queued to ask for more peers\n");
+                    fmt::print("  Queued to ask for more peers\n");
                     break;
 
                 case TR_TRACKER_ACTIVE:
-                    printf("  Asking for more peers now... %s\n", tr_strltime(now - lastAnnounceStartTime).c_str());
+                    fmt::print("  Asking for more peers now... {:s}\n", tr_strltime(now - lastAnnounceStartTime));
                     break;
                 }
 
@@ -1638,22 +1635,19 @@ static void printTrackersImpl(tr_variant* trackerStats)
 
                     if (lastScrapeSucceeded)
                     {
-                        printf(
-                            "  Tracker had %d seeders and %d leechers %s ago\n",
-                            (int)seederCount,
-                            (int)leecherCount,
-                            timestr.c_str());
+                        fmt::print(
+                            "  Tracker had {:d} seeders and {:d} leechers {:s} ago\n",
+                            seederCount,
+                            leecherCount,
+                            timestr);
                     }
                     else if (lastScrapeTimedOut)
                     {
-                        printf("  Tracker scrape timed out; will retry\n");
+                        fmt::print("  Tracker scrape timed out; will retry\n");
                     }
                     else
                     {
-                        printf(
-                            "  Got a scrape error \"%" TR_PRIsv "\" %s ago\n",
-                            TR_PRIsv_ARG(lastScrapeResult),
-                            timestr.c_str());
+                        fmt::print("  Got a scrape error '{:s}' {:s} ago\n", lastScrapeResult, timestr);
                     }
                 }
 
@@ -1663,15 +1657,15 @@ static void printTrackersImpl(tr_variant* trackerStats)
                     break;
 
                 case TR_TRACKER_WAITING:
-                    printf("  Asking for peer counts in %s\n", tr_strltime(nextScrapeTime - now).c_str());
+                    fmt::print("  Asking for peer counts in {:s}\n", tr_strltime(nextScrapeTime - now));
                     break;
 
                 case TR_TRACKER_QUEUED:
-                    printf("  Queued to ask for peer counts\n");
+                    fmt::print("  Queued to ask for peer counts\n");
                     break;
 
                 case TR_TRACKER_ACTIVE:
-                    printf("  Asking for peer counts now... %s\n", tr_strltime(now - lastScrapeStartTime).c_str());
+                    fmt::print("  Asking for peer counts now... {:s}\n", tr_strltime(now - lastScrapeStartTime));
                     break;
                 }
             }
@@ -1697,7 +1691,7 @@ static void printTrackers(tr_variant* top)
 
                 if (i + 1 < n)
                 {
-                    printf("\n");
+                    fmt::print("\n");
                 }
             }
         }
@@ -1714,78 +1708,78 @@ static void printSession(tr_variant* top)
         bool boolVal;
         auto sv = std::string_view{};
 
-        printf("VERSION\n");
+        fmt::print("VERSION\n");
 
         if (tr_variantDictFindStrView(args, TR_KEY_version, &sv))
         {
-            printf("  Daemon version: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+            fmt::print("  Daemon version: {:s}\n", sv);
         }
 
         if (tr_variantDictFindInt(args, TR_KEY_rpc_version, &i))
         {
-            printf("  RPC version: %" PRId64 "\n", i);
+            fmt::print("  RPC version: {:d}\n", i);
         }
 
         if (tr_variantDictFindInt(args, TR_KEY_rpc_version_minimum, &i))
         {
-            printf("  RPC minimum version: %" PRId64 "\n", i);
+            fmt::print("  RPC minimum version: {:d}\n", i);
         }
 
-        printf("\n");
+        fmt::print("\n");
 
-        printf("CONFIG\n");
+        fmt::print("CONFIG\n");
 
         if (tr_variantDictFindStrView(args, TR_KEY_config_dir, &sv))
         {
-            printf("  Configuration directory: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+            fmt::print("  Configuration directory: {:s}\n", sv);
         }
 
         if (tr_variantDictFindStrView(args, TR_KEY_download_dir, &sv))
         {
-            printf("  Download directory: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+            fmt::print("  Download directory: {:s}\n", sv);
         }
 
         if (tr_variantDictFindInt(args, TR_KEY_peer_port, &i))
         {
-            printf("  Listenport: %" PRId64 "\n", i);
+            fmt::print("  Listenport: {:d}\n", i);
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_port_forwarding_enabled, &boolVal))
         {
-            printf("  Portforwarding enabled: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Portforwarding enabled: {:s}\n", boolVal ? "Yes" : "No");
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_utp_enabled, &boolVal))
         {
-            printf("  uTP enabled: %s\n", (boolVal ? "Yes" : "No"));
+            fmt::print("  uTP enabled: {:d}\n", (boolVal ? "Yes" : "No"));
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_dht_enabled, &boolVal))
         {
-            printf("  Distributed hash table enabled: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Distributed hash table enabled: {:s}\n", boolVal ? "Yes" : "No");
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_lpd_enabled, &boolVal))
         {
-            printf("  Local peer discovery enabled: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Local peer discovery enabled: {:s}\n", boolVal ? "Yes" : "No");
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_pex_enabled, &boolVal))
         {
-            printf("  Peer exchange allowed: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Peer exchange allowed: {:s}\n", boolVal ? "Yes" : "No");
         }
 
         if (tr_variantDictFindStrView(args, TR_KEY_encryption, &sv))
         {
-            printf("  Encryption: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+            fmt::print("  Encryption: {:s}\n", sv);
         }
 
         if (tr_variantDictFindInt(args, TR_KEY_cache_size_mb, &i))
         {
-            printf("  Maximum memory cache size: %s\n", tr_formatter_mem_MB(i).c_str());
+            fmt::print("  Maximum memory cache size: {:s}\n", tr_formatter_mem_MB(i));
         }
 
-        printf("\n");
+        fmt::print("\n");
 
         {
             bool altEnabled;
@@ -1818,10 +1812,10 @@ static void printSession(tr_variant* top)
                 tr_variantDictFindReal(args, TR_KEY_seedRatioLimit, &seedRatioLimit) &&
                 tr_variantDictFindBool(args, TR_KEY_seedRatioLimited, &seedRatioLimited))
             {
-                printf("LIMITS\n");
-                printf("  Peer limit: %" PRId64 "\n", peerLimit);
+                fmt::print("LIMITS\n");
+                fmt::print("  Peer limit: {:d}\n", peerLimit);
 
-                printf("  Default seed ratio limit: %s\n", seedRatioLimited ? strlratio2(seedRatioLimit).c_str() : "Unlimited");
+                fmt::print("  Default seed ratio limit: {:s}\n", seedRatioLimited ? strlratio2(seedRatioLimit) : "Unlimited");
 
                 std::string effective_up_limit;
 
@@ -1838,13 +1832,13 @@ static void printSession(tr_variant* top)
                     effective_up_limit = "Unlimited"s;
                 }
 
-                printf(
-                    "  Upload speed limit: %s (%s limit: %s; %s turtle limit: %s)\n",
-                    effective_up_limit.c_str(),
+                fmt::print(
+                    FMT_STRING("  Upload speed limit: {:s} ({:s} limit: {:s}; {:s} turtle limit: {:s})\n"),
+                    effective_up_limit,
                     upEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(upLimit).c_str(),
+                    tr_formatter_speed_KBps(upLimit),
                     altEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(altUp).c_str());
+                    tr_formatter_speed_KBps(altUp));
 
                 std::string effective_down_limit;
 
@@ -1861,13 +1855,13 @@ static void printSession(tr_variant* top)
                     effective_down_limit = "Unlimited"s;
                 }
 
-                printf(
-                    "  Download speed limit: %s (%s limit: %s; %s turtle limit: %s)\n",
-                    effective_down_limit.c_str(),
+                fmt::print(
+                    FMT_STRING("  Download speed limit: {:s} ({:s} limit: {:s}; {:s} turtle limit: {:s})\n"),
+                    effective_down_limit,
                     downEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(downLimit).c_str(),
+                    tr_formatter_speed_KBps(downLimit),
                     altEnabled ? "Enabled" : "Disabled",
-                    tr_formatter_speed_KBps(altDown).c_str());
+                    tr_formatter_speed_KBps(altDown));
 
                 if (altTimeEnabled)
                 {
@@ -1880,56 +1874,56 @@ static void printSession(tr_variant* top)
 
                     if ((altDay & TR_SCHED_SUN) != 0)
                     {
-                        printf("Sun ");
+                        fmt::print("Sun ");
                     }
 
                     if ((altDay & TR_SCHED_MON) != 0)
                     {
-                        printf("Mon ");
+                        fmt::print("Mon ");
                     }
 
                     if ((altDay & TR_SCHED_TUES) != 0)
                     {
-                        printf("Tue ");
+                        fmt::print("Tue ");
                     }
 
                     if ((altDay & TR_SCHED_WED) != 0)
                     {
-                        printf("Wed ");
+                        fmt::print("Wed ");
                     }
 
                     if ((altDay & TR_SCHED_THURS) != 0)
                     {
-                        printf("Thu ");
+                        fmt::print("Thu ");
                     }
 
                     if ((altDay & TR_SCHED_FRI) != 0)
                     {
-                        printf("Fri ");
+                        fmt::print("Fri ");
                     }
 
                     if ((altDay & TR_SCHED_SAT) != 0)
                     {
-                        printf("Sat ");
+                        fmt::print("Sat ");
                     }
 
-                    printf("\n");
+                    fmt::print("\n");
                 }
             }
         }
 
-        printf("\n");
+        fmt::print("\n");
 
-        printf("MISC\n");
+        fmt::print("MISC\n");
 
         if (tr_variantDictFindBool(args, TR_KEY_start_added_torrents, &boolVal))
         {
-            printf("  Autostart added torrents: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Autostart added torrents: {:s}\n", boolVal ? "Yes" : "No");
         }
 
         if (tr_variantDictFindBool(args, TR_KEY_trash_original_torrent_files, &boolVal))
         {
-            printf("  Delete automatically added torrents: %s\n", boolVal ? "Yes" : "No");
+            fmt::print("  Delete automatically added torrents: {:s}\n", boolVal ? "Yes" : "No");
         }
     }
 }
@@ -1949,23 +1943,23 @@ static void printSessionStats(tr_variant* top)
         if (tr_variantDictFindDict(args, TR_KEY_current_stats, &d) && tr_variantDictFindInt(d, TR_KEY_uploadedBytes, &up) &&
             tr_variantDictFindInt(d, TR_KEY_downloadedBytes, &down) && tr_variantDictFindInt(d, TR_KEY_secondsActive, &secs))
         {
-            printf("\nCURRENT SESSION\n");
-            printf("  Uploaded:   %s\n", strlsize(up).c_str());
-            printf("  Downloaded: %s\n", strlsize(down).c_str());
-            printf("  Ratio:      %s\n", strlratio(up, down).c_str());
-            printf("  Duration:   %s\n", tr_strltime(secs).c_str());
+            fmt::print("\nCURRENT SESSION\n");
+            fmt::print("  Uploaded:   {:s}\n", strlsize(up));
+            fmt::print("  Downloaded: {:s}\n", strlsize(down));
+            fmt::print("  Ratio:      {:s}\n", strlratio(up, down));
+            fmt::print("  Duration:   {:s}\n", tr_strltime(secs));
         }
 
         if (tr_variantDictFindDict(args, TR_KEY_cumulative_stats, &d) &&
             tr_variantDictFindInt(d, TR_KEY_sessionCount, &sessions) && tr_variantDictFindInt(d, TR_KEY_uploadedBytes, &up) &&
             tr_variantDictFindInt(d, TR_KEY_downloadedBytes, &down) && tr_variantDictFindInt(d, TR_KEY_secondsActive, &secs))
         {
-            printf("\nTOTAL\n");
-            printf("  Started %lu times\n", (unsigned long)sessions);
-            printf("  Uploaded:   %s\n", strlsize(up).c_str());
-            printf("  Downloaded: %s\n", strlsize(down).c_str());
-            printf("  Ratio:      %s\n", strlratio(up, down).c_str());
-            printf("  Duration:   %s\n", tr_strltime(secs).c_str());
+            fmt::print("\nTOTAL\n");
+            fmt::print("  Started %lu times\n", (unsigned long)sessions);
+            fmt::print("  Uploaded:   {:s}\n", strlsize(up));
+            fmt::print("  Downloaded: {:s}\n", strlsize(down));
+            fmt::print("  Ratio:      {:s}\n", strlratio(up, down));
+            fmt::print("  Duration:   {:s}\n", tr_strltime(secs));
         }
     }
 }
@@ -1993,9 +1987,9 @@ static void printGroups(tr_variant* top)
                 tr_variantDictFindBool(group, TR_KEY_uploadLimited, &upEnabled) &&
                 tr_variantDictFindBool(group, TR_KEY_honorsSessionLimits, &honors))
             {
-                printf("%" TR_PRIsv ": ", TR_PRIsv_ARG(name));
-                printf(
-                    "Upload speed limit: %s, Download speed limit: %s, %s session bandwidth limits\n",
+                fmt::print("{:s}: ", name);
+                fmt::print(
+                    FMT_STRING("Upload speed limit: {:s}, Download speed limit: {:s}, {:s} session bandwidth limits\n"),
                     upEnabled ? tr_formatter_speed_KBps(upLimit).c_str() : "unlimited",
                     downEnabled ? tr_formatter_speed_KBps(downLimit).c_str() : "unlimited",
                     honors ? "honors" : "does not honor");
@@ -2137,16 +2131,12 @@ static int processResponse(char const* rpcurl, std::string_view response, Config
 
     if (config.debug)
     {
-        fprintf(
-            stderr,
-            "got response (len %d):\n--------\n%" TR_PRIsv "\n--------\n",
-            int(std::size(response)),
-            TR_PRIsv_ARG(response));
+        fmt::print(stderr, "got response (len {:d}):\n--------\n{:s}\n--------\n", std::size(response), response);
     }
 
     if (config.json)
     {
-        printf("%" TR_PRIsv, TR_PRIsv_ARG(response));
+        fmt::print(response);
         return status;
     }
 
@@ -2164,7 +2154,7 @@ static int processResponse(char const* rpcurl, std::string_view response, Config
         {
             if (sv != "success"sv)
             {
-                printf("Error: %" TR_PRIsv "\n", TR_PRIsv_ARG(sv));
+                fmt::print("Error: {:s}\n", sv);
                 status |= EXIT_FAILURE;
             }
             else
@@ -2237,7 +2227,7 @@ static int processResponse(char const* rpcurl, std::string_view response, Config
                     }
                     else
                     {
-                        printf("%s responded: \"%" TR_PRIsv "\"\n", rpcurl, TR_PRIsv_ARG(sv));
+                        fmt::print("{:s} responded: {:s}\n", rpcurl, sv);
 
                         if (sv != "success"sv)
                         {
@@ -2339,7 +2329,7 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
 
     if (config.debug)
     {
-        fprintf(stderr, "posting:\n--------\n%s\n--------\n", json.c_str());
+        fmt::print(stderr, "posting:\n--------\n{:s}\n--------\n", json);
     }
 
     auto const res = curl_easy_perform(curl);
@@ -2373,7 +2363,7 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
 
         default:
             evbuffer_add(buf, "", 1);
-            fprintf(stderr, "Unexpected response: %s\n", evbuffer_pullup(buf, -1));
+            fmt::print(stderr, "Unexpected response: {:s}\n", reinterpret_cast<char const*>(evbuffer_pullup(buf, -1)));
             status |= EXIT_FAILURE;
             break;
         }
@@ -2485,7 +2475,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
                 else
                 {
-                    fprintf(stderr, "The TR_AUTH environment variable is not set\n");
+                    fmt::print(stderr, "The TR_AUTH environment variable is not set\n");
                     exit(0);
                 }
 
@@ -2515,15 +2505,15 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 'V': /* show version number */
-                fprintf(stderr, "%s %s\n", MyName, LONG_VERSION_STRING);
+                fmt::print(stderr, "{:s} {:s}\n", MyName, LONG_VERSION_STRING);
                 exit(0);
 
             case 944:
-                printf("%s\n", std::empty(config.torrent_ids) ? "all" : config.torrent_ids.c_str());
+                fmt::print("{:s}\n", std::empty(config.torrent_ids) ? "all" : config.torrent_ids.c_str());
                 break;
 
             case TR_OPT_ERR:
-                fprintf(stderr, "invalid option\n");
+                fmt::print(stderr, "invalid option\n");
                 showUsage();
                 status |= EXIT_FAILURE;
                 break;
@@ -2545,7 +2535,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
                 else
                 {
-                    fprintf(stderr, "Unknown option: %s\n", optarg);
+                    fmt::print(stderr, "Unknown option: {:s}\n", optarg);
                     status |= EXIT_FAILURE;
                 }
 
@@ -3203,7 +3193,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
 
             default:
-                fprintf(stderr, "got opt [%d]\n", c);
+                fmt::print(stderr, "got opt [{:d}]\n", c);
                 showUsage();
                 break;
             }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -5,8 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes> // PRIu64
-#include <cstdio>
 #include <ctime>
 #include <string>
 #include <string_view>
@@ -190,33 +188,33 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
     **/
     if (opts.print_info)
     {
-        printf("GENERAL\n\n");
-        printf("  Name: %s\n", metainfo.name().c_str());
+        fmt::print("GENERAL\n\n");
+        fmt::print("  Name: {:s}\n", metainfo.name());
         if (metainfo.hasV1Metadata())
         {
-            printf("  Hash v1: %" TR_PRIsv "\n", TR_PRIsv_ARG(metainfo.infoHashString()));
+            fmt::print("  Hash v1: {:s}\n", metainfo.infoHashString());
         }
         if (metainfo.hasV2Metadata())
         {
-            printf("  Hash v2: %" TR_PRIsv "\n", TR_PRIsv_ARG(metainfo.infoHash2String()));
+            fmt::print("  Hash v2: {:s}\n", metainfo.infoHash2String());
         }
-        printf("  Created by: %s\n", std::empty(metainfo.creator()) ? "Unknown" : metainfo.creator().c_str());
-        printf("  Created on: %s\n\n", toString(metainfo.dateCreated()).c_str());
+        fmt::print("  Created by: {:s}\n", std::empty(metainfo.creator()) ? "Unknown" : metainfo.creator());
+        fmt::print("  Created on: {:s}\n\n", toString(metainfo.dateCreated()));
 
         if (!std::empty(metainfo.comment()))
         {
-            printf("  Comment: %s\n", metainfo.comment().c_str());
+            fmt::print("  Comment: {:s}\n", metainfo.comment());
         }
 
         if (!std::empty(metainfo.source()))
         {
-            printf("  Source: %s\n", metainfo.source().c_str());
+            fmt::print("  Source: {:s}\n", metainfo.source());
         }
 
-        printf("  Piece Count: %" PRIu32 "\n", metainfo.pieceCount());
-        printf("  Piece Size: %s\n", tr_formatter_mem_B(metainfo.pieceSize()).c_str());
-        printf("  Total Size: %s\n", tr_formatter_size_B(metainfo.totalSize()).c_str());
-        printf("  Privacy: %s\n", metainfo.isPrivate() ? "Private torrent" : "Public torrent");
+        fmt::print("  Piece Count: {:d}\n", metainfo.pieceCount());
+        fmt::print("  Piece Size: {:s}\n", tr_formatter_mem_B(metainfo.pieceSize()));
+        fmt::print("  Total Size: {:s}\n", tr_formatter_size_B(metainfo.totalSize()));
+        fmt::print("  Privacy: {:s}\n", metainfo.isPrivate() ? "Private torrent" : "Public torrent");
     }
 
     /**
@@ -225,7 +223,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
 
     if (opts.print_trackers)
     {
-        printf("\nTRACKERS\n");
+        fmt::print("\nTRACKERS\n");
         auto current_tier = std::optional<tr_tracker_tier_t>{};
         auto print_tier = size_t{ 1 };
         for (auto const& tracker : metainfo.announceList())
@@ -233,24 +231,24 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
             if (!current_tier || current_tier != tracker.tier)
             {
                 current_tier = tracker.tier;
-                printf("\n  Tier #%zu\n", print_tier);
+                fmt::print("\n  Tier #{:d}\n", print_tier);
                 ++print_tier;
             }
 
-            printf("  %" TR_PRIsv "\n", TR_PRIsv_ARG(tracker.announce.sv()));
+            fmt::print("  {:s}\n", tracker.announce.sv());
         }
 
         /**
-    ***
-    **/
+        ***
+        **/
 
         if (auto const n_webseeds = metainfo.webseedCount(); n_webseeds > 0)
         {
-            printf("\nWEBSEEDS\n\n");
+            fmt::print("\nWEBSEEDS\n\n");
 
             for (size_t i = 0; i < n_webseeds; ++i)
             {
-                printf("  %s\n", metainfo.webseed(i).c_str());
+                fmt::print("  {:s}\n", metainfo.webseed(i));
             }
         }
     }
@@ -263,7 +261,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
     {
         if (!opts.show_bytesize)
         {
-            printf("\nFILES\n\n");
+            fmt::print("\nFILES\n\n");
         }
 
         auto filenames = std::vector<std::string>{};
@@ -301,7 +299,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
 
         for (auto const& filename : filenames)
         {
-            printf("%s\n", filename.c_str());
+            fmt::print("{:s}\n", filename);
         }
     }
 }
@@ -343,7 +341,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         auto delimiter = tr_strvContains(scrape_url, '?') ? '&' : '?';
         scrape_url.append(delimiter, "info_hash=");
         tr_urlPercentEncode(std::back_inserter(scrape_url), metainfo.infoHash());
-        printf("%" TR_PRIsv " ... ", TR_PRIsv_ARG(scrape_url));
+        fmt::print("{:s} ... ", scrape_url);
         fflush(stdout);
 
         // execute the http scrape
@@ -351,7 +349,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeoutSecs);
         if (auto const res = curl_easy_perform(curl); res != CURLE_OK)
         {
-            printf("error: %s\n", curl_easy_strerror(res));
+            fmt::print("error: {:s}\n", curl_easy_strerror(res));
             continue;
         }
 
@@ -360,7 +358,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
         if (response != 200 /*HTTP OK*/)
         {
-            printf("error: unexpected response %ld \"%s\"\n", response, tr_webGetResponseStr(response));
+            fmt::print("error: unexpected response {:d} '{:s}'\n", response, tr_webGetResponseStr(response));
             continue;
         }
 
@@ -370,7 +368,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         auto sv = std::string_view{ begin, evbuffer_get_length(buf) };
         if (!tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, sv))
         {
-            printf("error parsing scrape response\n");
+            fmt::print("error parsing scrape response\n");
             continue;
         }
 
@@ -391,7 +389,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
                     auto i = int64_t{};
                     auto const seeders = tr_variantDictFindInt(val, TR_KEY_complete, &i) ? int(i) : -1;
                     auto const leechers = tr_variantDictFindInt(val, TR_KEY_incomplete, &i) ? int(i) : -1;
-                    printf("%d seeders, %d leechers\n", seeders, leechers);
+                    fmt::print("{:d} seeders, {:d} leechers\n", seeders, leechers);
                     matched = true;
                 }
 
@@ -403,7 +401,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
         if (!matched)
         {
-            printf("no match\n");
+            fmt::print("no match\n");
         }
     }
 
@@ -428,16 +426,16 @@ int tr_main(int argc, char* argv[])
 
     if (opts.show_version)
     {
-        fprintf(stderr, "%s %s\n", MyName, LONG_VERSION_STRING);
+        fmt::print(stderr, "{:s} {:s}\n", MyName, LONG_VERSION_STRING);
         return EXIT_SUCCESS;
     }
 
     /* make sure the user specified a filename */
     if (std::empty(opts.filename))
     {
-        fprintf(stderr, "ERROR: No torrent file specified.\n");
+        fmt::print(stderr, "ERROR: No torrent file specified.\n");
         tr_getopt_usage(MyName, Usage, std::data(options));
-        fprintf(stderr, "\n");
+        fmt::print(stderr, "\n");
         return EXIT_FAILURE;
     }
 
@@ -447,12 +445,7 @@ int tr_main(int argc, char* argv[])
     auto const parsed = metainfo.parseTorrentFile(opts.filename, nullptr, &error);
     if (error != nullptr)
     {
-        fprintf(
-            stderr,
-            "Error parsing torrent file \"%" TR_PRIsv "\": %s (%d)\n",
-            TR_PRIsv_ARG(opts.filename),
-            error->message,
-            error->code);
+        fmt::print(stderr, "Error parsing torrent file '{:s}': {:s} ({:d})\n", opts.filename, error->message, error->code);
         tr_error_clear(&error);
     }
     if (!parsed)
@@ -462,15 +455,15 @@ int tr_main(int argc, char* argv[])
 
     if (opts.show_magnet)
     {
-        printf("%s", metainfo.magnet().c_str());
+        fmt::print("{:s}", metainfo.magnet());
     }
     else
     {
         if (opts.print_header)
         {
-            printf("Name: %s\n", metainfo.name().c_str());
-            printf("File: %" TR_PRIsv "\n", TR_PRIsv_ARG(opts.filename));
-            printf("\n");
+            fmt::print("Name: {:s}\n", metainfo.name());
+            fmt::print("File: {:s}\n", opts.filename);
+            fmt::print("\n");
             fflush(stdout);
         }
 


### PR DESCRIPTION
Use libfmt instead of print().