### PR TITLE
Blocklist/Session: move loadBlocklists function to BlockListfile struct

### DIFF
--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -11,6 +11,7 @@
 
 #include <cstddef> // for size_t
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -78,6 +79,8 @@ public:
 
     /// @brief Read the file of ranges, sort and merge, write to our own file, and reload from it
     size_t setContent(char const* filename);
+
+    static std::vector<std::unique_ptr<BlocklistFile>> loadBlocklists(std::string_view const config_dir, bool const is_enabled);
 
 private:
     struct AddressRange

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -738,7 +738,7 @@ void tr_session::initImpl(init_data& data)
     **/
 
     tr_sys_dir_create(tr_pathbuf{ configDir(), "/blocklists"sv }, TR_SYS_DIR_CREATE_PARENTS, 0777);
-    blocklists_.clear();
+    this->blocklists_.clear();
     this->blocklists_ = BlocklistFile::loadBlocklists(configDir(), useBlocklist());
 
     tr_announcerInit(this);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -768,8 +768,6 @@ public:
 private:
     [[nodiscard]] tr_port randomPort() const;
 
-    void loadBlocklists();
-
     struct init_data;
     void initImpl(init_data&);
     void setImpl(init_data&);


### PR DESCRIPTION
As mentioned in https://github.com/transmission/transmission/pull/3835#discussion_r982744627 
Move the tr_session::loadBlocklists() function to BlocklistFile::loadBlocklists() and have the tr_session::initImpl() call it from there.