### PR TITLE
refactor: add tr_address::toSockaddr()

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -209,27 +209,25 @@ bool tr_address_from_sockaddr_storage(tr_address* setme_addr, tr_port* setme_por
     return false;
 }
 
-static socklen_t setup_sockaddr(tr_address const* addr, tr_port port, struct sockaddr_storage* sockaddr)
+std::pair<sockaddr_storage, socklen_t> tr_address::toSockaddr(tr_port port) const noexcept
 {
-    TR_ASSERT(tr_address_is_valid(addr));
+    auto ss = sockaddr_storage{};
 
-    if (addr->isIPv4())
+    if (isIPv4())
     {
-        sockaddr_in sock4 = {};
-        sock4.sin_family = AF_INET;
-        sock4.sin_addr.s_addr = addr->addr.addr4.s_addr;
-        sock4.sin_port = port.network();
-        memcpy(sockaddr, &sock4, sizeof(sock4));
-        return sizeof(struct sockaddr_in);
+        auto* const ss4 = reinterpret_cast<sockaddr_in*>(&ss);
+        ss4->sin_addr.s_addr = addr.addr4.s_addr;
+        ss4->sin_family = AF_INET;
+        ss4->sin_port = port.network();
+        return { ss, sizeof(sockaddr_in) };
     }
 
-    sockaddr_in6 sock6 = {};
-    sock6.sin6_family = AF_INET6;
-    sock6.sin6_port = port.network();
-    sock6.sin6_flowinfo = 0;
-    sock6.sin6_addr = addr->addr.addr6;
-    memcpy(sockaddr, &sock6, sizeof(sock6));
-    return sizeof(struct sockaddr_in6);
+    auto* const ss6 = reinterpret_cast<sockaddr_in6*>(&ss);
+    ss6->sin6_addr = addr.addr6;
+    ss6->sin6_family = AF_INET6;
+    ss6->sin6_flowinfo = 0;
+    ss6->sin6_port = port.network();
+    return { ss, sizeof(sockaddr_in6) };
 }
 
 static tr_socket_t createSocket(tr_session* session, int domain, int type)
@@ -312,13 +310,11 @@ struct tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const
         }
     }
 
-    auto sock = sockaddr_storage{};
-    socklen_t const addrlen = setup_sockaddr(addr, port, &sock);
+    auto const [sock, addrlen] = addr->toSockaddr(port);
 
     // set source address
     auto const [source_addr, is_default_addr] = session->publicAddress(addr->type);
-    auto source_sock = sockaddr_storage{};
-    socklen_t const sourcelen = setup_sockaddr(&source_addr, {}, &source_sock);
+    auto const [source_sock, sourcelen] = source_addr.toSockaddr({});
 
     if (bind(s, (struct sockaddr*)&source_sock, sourcelen) == -1)
     {
@@ -372,13 +368,12 @@ struct tr_peer_socket tr_netOpenPeerUTPSocket(
 
     if (session->utp_context != nullptr && tr_address_is_valid_for_peers(addr, port))
     {
-        auto ss = sockaddr_storage{};
-        socklen_t const sslen = setup_sockaddr(addr, port, &ss);
+        auto const [ss, sslen] = addr->toSockaddr(port);
         auto* const socket = utp_create_socket(session->utp_context);
 
         if (socket != nullptr)
         {
-            if (utp_connect(socket, reinterpret_cast<sockaddr*>(&ss), sslen) != -1)
+            if (utp_connect(socket, reinterpret_cast<sockaddr const*>(&ss), sslen) != -1)
             {
                 ret = tr_peer_socket_utp_create(socket);
             }
@@ -420,7 +415,6 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
     TR_ASSERT(tr_address_is_valid(addr));
 
     static auto constexpr Domains = std::array<int, NUM_TR_AF_INET_TYPES>{ AF_INET, AF_INET6 };
-    auto sock = sockaddr_storage{};
 
     auto const fd = socket(Domains[addr->type], SOCK_STREAM, 0);
     if (fd == TR_BAD_SOCKET)
@@ -453,7 +447,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
 #endif
 
-    int const addrlen = setup_sockaddr(addr, port, &sock);
+    auto const [sock, addrlen] = addr->toSockaddr(port);
 
     if (bind(fd, (struct sockaddr*)&sock, addrlen) == -1)
     {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -191,6 +191,10 @@ struct tr_address
         return this->compare(that) > 0;
     }
 
+    //
+
+    [[nodiscard]] std::pair<sockaddr_storage, socklen_t> toSockaddr(tr_port port) const noexcept;
+
     tr_address_type type;
     union
     {


### PR DESCRIPTION
I was working on a fix for #8345 last night and hit a point where `tr-dht.cc` needed to be able to convert a `tr_address` + `tr_port` into a `sockaddr`.

That already exists as a private method in `net.cc`, so this side PR exposes it as a public method in `tr_address`.