### PR TITLE
chore: bump version to post-4.0.0-beta.1 dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set(TR_VERSION_MAJOR "4")
 set(TR_VERSION_MINOR "0")
 set(TR_VERSION_PATCH "0")
 set(TR_VERSION_BETA_NUMBER "1") # empty string for not beta
-set(TR_VERSION_DEV FALSE)
+set(TR_VERSION_DEV TRUE)
 
 # derived from above: release type
 if (TR_VERSION_DEV)


### PR DESCRIPTION
There should be only one commit with the name `4.0.0-beta.1`, so switch the `dev` setting back to true :smiley_cat: 