### PR TITLE
Fix "Capture of autoreleasing out parameter inside autorelease pool that may exit before method returns"

### DIFF
--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -671,7 +671,6 @@ NSMutableSet* creatorWindowControllerSet = nil;
     [self.fTimer invalidate];
     self.fTimer = nil;
 
-    auto success = false;
     tr_error* error = self.fFuture.get();
     if (error == nullptr)
     {

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -110,10 +110,10 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
         {
             FileListNode* parent = nil;
             NSUInteger previousIndex = !item.isFolder ?
-                [self.class findFileNode:item inList:self.fFileList
-                               atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(currentIndex, self.fFileList.count - currentIndex)]
-                           currentParent:nil
-                             finalParent:&parent] :
+                [self findFileNode:item inList:self.fFileList
+                         atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(currentIndex, self.fFileList.count - currentIndex)]
+                     currentParent:nil
+                       finalParent:&parent] :
                 NSNotFound;
 
             if (previousIndex == NSNotFound)
@@ -680,7 +680,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
     return menu;
 }
 
-+ (NSUInteger)findFileNode:(FileListNode*)node
+- (NSUInteger)findFileNode:(FileListNode*)node
                     inList:(NSArray<FileListNode*>*)list
                  atIndexes:(NSIndexSet*)indexes
              currentParent:(FileListNode*)currentParent

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1996,11 +1996,10 @@ bool trashDataFile(char const* filename, tr_error** error)
 
     if (success)
     {
-        using WeakUpdateNodeAndChildrenForRename = void (^__block __weak)(FileListNode*);
-        using UpdateNodeAndChildrenForRename = void (^)(FileListNode*);
-
         NSString* oldName = oldPath.lastPathComponent;
-        WeakUpdateNodeAndChildrenForRename weakUpdateNodeAndChildrenForRename;
+
+        using UpdateNodeAndChildrenForRename = void (^)(FileListNode*);
+        __weak __block UpdateNodeAndChildrenForRename weakUpdateNodeAndChildrenForRename;
         UpdateNodeAndChildrenForRename updateNodeAndChildrenForRename;
         weakUpdateNodeAndChildrenForRename = updateNodeAndChildrenForRename = ^(FileListNode* node) {
             [node updateFromOldName:oldName toNewName:newName inPath:path];


### PR DESCRIPTION
Problem: `__autoreleasing parent` is passed to a recursive concurrent method.
Solution: Adopt a recursive block and assign to `__autoreleasing parent` outside the block.
Testing: Create or open a torrent with directories inside; Open the torrent inspector; Open the files tab; Use the filter.