### PR TITLE
Workaround about dialog closure with GTK 3

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1331,6 +1331,7 @@ void Application::Impl::show_about_dialog()
     d->signal_close_request().connect_notify([d]() mutable { d.reset(); });
 #else
     d->signal_delete_event().connect_notify([d](void* /*event*/) mutable { d.reset(); });
+    d->signal_response().connect_notify([&dref = *d](int /*response*/) { dref.close(); });
 #endif
     d->show();
 }


### PR DESCRIPTION
GTK 4 doesn't have an action button and uses standard close button in header bar instead, which works fine.

Broken-by: #3805
Fixes: #3888