### PR TITLE
Add missing include in port-forwarding-upnp.cc

### DIFF
--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifdef SYSTEM_MINIUPNP
 #include <miniupnpc/miniupnpc.h>


### PR DESCRIPTION
Got error `FMT_STRING: identifier not found` due lack of include