### PR TITLE
macos: Hide Title (App Name) on BigSur and later.

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -623,6 +623,12 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     toolbar.displayMode = NSToolbarDisplayModeIconOnly;
     self.fWindow.toolbar = toolbar;
 
+    if (@available(macOS 11.0, *))
+    {
+        self.fWindow.toolbarStyle = NSWindowToolbarStyleUnified;
+        self.fWindow.titleVisibility = NSWindowTitleHidden;
+    }
+
     self.fWindow.delegate = self; //do manually to avoid placement issue
 
     [self.fWindow makeFirstResponder:self.fTableView];


### PR DESCRIPTION
Also specify Unified Toolbar Style explicitly, as hiding title triggers Unified Compact style.

Fixes #3891

Signed-off-by: Dzmitry Neviadomski <nevack.d@gmail.com>