### PR TITLE
Add build job based on Fedora 37

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -466,3 +466,75 @@ jobs:
         with:
           name: binaries-${{ github.job }}
           path: pfx/**/*
+
+  fedora-37-from-tarball:
+    needs: [ make-source-tarball, what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
+    runs-on: ubuntu-22.04
+    container:
+      image: fedora:37
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          cat /etc/os-release
+      - name: Get Dependencies
+        run: |
+          set -ex
+          dnf install -y \
+            ca-certificates \
+            cmake \
+            fmt-devel \
+            gcc-c++ \
+            gettext \
+            libcurl-devel \
+            libdeflate-devel \
+            libevent-devel \
+            libnatpmp-devel \
+            libpsl-devel \
+            miniupnpc-devel \
+            ninja-build \
+            openssl-devel \
+            pkgconf-pkg-config \
+            xz
+      - name: Get Dependencies (GTK)
+        if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
+        run: dnf install -y glibmm2.68-devel gtkmm4.0-devel
+      - name: Get Dependencies (Qt)
+        if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
+        run: dnf install -y qt6-qtbase-devel qt6-qttools-devel
+      - name: Get Source
+        uses: actions/download-artifact@v3
+        with:
+          name: source-tarball
+      - name: Extract Source
+        run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Configure
+        run: |
+          cmake \
+            -S src \
+            -B obj \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=pfx \
+            -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_MAC=OFF \
+            -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_WEB=OFF \
+            -DRUN_CLANG_TIDY=OFF
+      - name: Build
+        run: cmake --build obj --config RelWithDebInfo
+      - name: Test
+        if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
+        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+      - name: Install
+        run: cmake --build obj --config RelWithDebInfo --target install/strip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binaries-${{ github.job }}
+          path: pfx/**/*

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -162,6 +162,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}
 )
+
 include_directories(
     SYSTEM
     ${GTK${GTK_VERSION}_INCLUDE_DIRS}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -194,6 +194,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}
 )
+
 include_directories(
     SYSTEM
     ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
This allows to test against GTK 4 and Qt 6.

Changes to CMakeLists.txt files are non-functional and are meant to trigger the components rebuild, nothing more.