### PR TITLE
Adding ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -1,0 +1,27 @@
+name: Transmission issue report
+description: A bug, a suggestion, etc.
+body:
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is the issue?
+      description: |
+       For UI, attach a screenshot.
+       For crashes, attach a crash log.
+       For specific issues, attach a torrent or provide a magnet.
+  - type: dropdown
+    id: client
+    attributes:
+      label: Which application of Transmission?
+      options:
+        - macOS app
+        - GTK+ app on Linux, BSD, etc.
+        - Qt app on Linux, BSD, etc.
+        - Qt app on Windows
+        - Web client
+        - transmission-remote
+  - type: input
+    id: version
+    attributes:
+      label: Which version of Transmission?
+      description: Find it in "About Transmission" or specify which nightly build or specific commit

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -1,5 +1,5 @@
 name: Transmission issue report
-description: A bug, a suggestion, etc.
+description: Issues are used to track todos, bugs, feature requests, and more.
 body:
   - type: textarea
     id: issue
@@ -8,7 +8,7 @@ body:
       description: |
        For UI, attach a screenshot.
        For crashes, attach a crash log.
-       For specific issues, attach a torrent or provide a magnet.
+       For specific issues, attach a torrent or provide a magnet, with public domain content only.
   - type: dropdown
     id: client
     attributes:
@@ -19,9 +19,10 @@ body:
         - Qt app on Linux, BSD, etc.
         - Qt app on Windows
         - Web client
+        - transmission-daemon
         - transmission-remote
   - type: input
     id: version
     attributes:
       label: Which version of Transmission?
-      description: Find it in "About Transmission" or specify which nightly build or specific commit
+      description: Find it in "About Transmission" or specify which nightly build or specific commit.


### PR DESCRIPTION
Problem: Several GitHub issues are hard to triage without asking for minimal information regarding which version of Transmission is being used.
Solution: We add a minimal GitHub issue template with all fields optional (to be welcoming), guiding the contributors on what minimal information would be appreciated.

Here is a screenshot, and you may temporary test it on https://github.com/Coeur/transmission/issues, but I'll disable and delete all issues on my fork once this PR is merge.

---

![Capture d’écran 2022-10-10 à 03 33 17](https://user-images.githubusercontent.com/839992/194776071-188ef038-9152-452f-8255-a44dd1c25741.png)
