### PR TITLE
docs: git submodule on building should be recursive

### DIFF
--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -137,7 +137,7 @@ $ sudo make install
 $ cd Transmission/build
 $ make clean
 $ git pull --rebase --prune
-$ git submodule update
+$ git submodule update --recursive
 $ # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary.
 $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 $ make

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -123,7 +123,7 @@ $ ./configure -q && make -s
 ```console
 $ git clone https://github.com/transmission/transmission Transmission
 $ cd Transmission
-$ git submodule update --init
+$ git submodule update --init --recursive
 $ mkdir build
 $ cd build
 $ # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary.


### PR DESCRIPTION
I was reading how to build from the *docs* folder and there git submodule doesnt have the recursive flag.
