### PR TITLE
Docs: Remove trailing / to download link

### DIFF
--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -1,5 +1,5 @@
 ## Getting the Source ##
-The source code for both official and nightly releases can be found on our [download page](https://transmissionbt.com/download/).
+The source code for both official and nightly releases can be found on our [download page](https://transmissionbt.com/download).
 
 ## On macOS ##
 Transmission has an Xcode project file (Transmission.xcodeproj) for building in Xcode. Make sure you have this software:


### PR DESCRIPTION
The web server at https://transmissionbt.com seems unable to deal with trailing forward-slashes. https://transmissionbt.com/download/ results in 404 while the version without the trailing / succeeds.

Edit: Alternatively fix the web server to accept the original link ;)