### PR TITLE
Xcode 11.3.1 compatibility

### DIFF
--- a/macosx/CocoaCompatibility.h
+++ b/macosx/CocoaCompatibility.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSInteger, NSImageSymbolScale) {
 
 typedef NS_ENUM(NSInteger, NSWindowToolbarStyle) {
     NSWindowToolbarStylePreference = 2,
+    NSWindowToolbarStyleUnified = 3,
 } API_AVAILABLE(macos(11.0));
 
 @interface NSWindow ()


### PR DESCRIPTION
A recent build regression from #3919.
Just doing the minimal fix, as 4.0 will be the last Transmission version with support for Xcode 11.