### PR TITLE
refactor: tr_session field order

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -432,7 +432,7 @@ void tr_tracker_http_announce(
     auto do_make_request = [&](std::string_view const& protocol_name, tr_web::FetchOptions&& opt)
     {
         tr_logAddTrace(fmt::format("Sending {} announce to libcurl: '{}'", protocol_name, opt.url), request->log_name);
-        session->web->fetch(std::move(opt));
+        session->fetch(std::move(opt));
     };
 
     auto const ipv6 = tr_globalIPv6(session);
@@ -686,5 +686,5 @@ void tr_tracker_http_scrape(
     options.timeout_secs = 30L;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
-    session->web->fetch(std::move(options));
+    session->fetch(std::move(options));
 }

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -245,7 +245,7 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
     while (bytes_left != 0)
     {
         size_t const len = std::min(bytes_left, std::size(buffer));
-        if (auto const success = tor->session->cache->readBlock(tor, loc, len, std::data(buffer)) == 0; !success)
+        if (auto const success = tor->session->cache().readBlock(tor, loc, len, std::data(buffer)) == 0; !success)
         {
             return {};
         }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -472,7 +472,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::create(
     struct tr_peer_socket const socket)
 {
     TR_ASSERT(session != nullptr);
-    TR_ASSERT(session->events != nullptr);
+    TR_ASSERT(session->hasEventLoop());
     auto lock = session->unique_lock();
 
 #ifdef WITH_UTP
@@ -592,7 +592,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::newOutgoing(
 static void event_enable(tr_peerIo* io, short event)
 {
     TR_ASSERT(io->session != nullptr);
-    TR_ASSERT(io->session->events != nullptr);
+    TR_ASSERT(io->session->hasEventLoop());
 
     bool const need_events = io->socket.type == TR_PEER_SOCKET_TYPE_TCP;
 
@@ -629,7 +629,7 @@ static void event_enable(tr_peerIo* io, short event)
 
 static void event_disable(tr_peerIo* io, short event)
 {
-    TR_ASSERT(io->session->events != nullptr);
+    TR_ASSERT(io->session->hasEventLoop());
 
     bool const need_events = io->socket.type == TR_PEER_SOCKET_TYPE_TCP;
 
@@ -726,7 +726,7 @@ static void io_close_socket(tr_peerIo* io)
 tr_peerIo::~tr_peerIo()
 {
     auto const lock = session->unique_lock();
-    TR_ASSERT(session->events != nullptr);
+    TR_ASSERT(session->hasEventLoop());
 
     this->canRead = nullptr;
     this->didWrite = nullptr;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -704,14 +704,9 @@ static void swarmFree(tr_swarm* s)
     delete s;
 }
 
-tr_peerMgr* tr_peerMgrNew(tr_session* session)
+std::shared_ptr<tr_peerMgr> tr_peerMgrNew(tr_session* session)
 {
-    return new tr_peerMgr{ session };
-}
-
-void tr_peerMgrFree(tr_peerMgr* manager)
-{
-    delete manager;
+    return std::make_shared<tr_peerMgr>(session);
 }
 
 /***
@@ -1237,19 +1232,19 @@ static bool on_handshake_done(tr_handshake_result const& result)
     return success;
 }
 
-void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket)
+void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const& addr, tr_port port, struct tr_peer_socket const socket)
 {
     TR_ASSERT(manager->session != nullptr);
     auto const lock = manager->unique_lock();
 
     tr_session* session = manager->session;
 
-    if (session->addressIsBlocked(*addr))
+    if (session->addressIsBlocked(addr))
     {
-        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", addr->readable(port)));
+        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", addr.readable(port)));
         tr_netClosePeerSocket(session, socket);
     }
-    else if (manager->incoming_handshakes.contains(*addr))
+    else if (manager->incoming_handshakes.contains(addr))
     {
         tr_netClosePeerSocket(session, socket);
     }
@@ -1257,11 +1252,11 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     {
         auto* const handshake = tr_handshakeNew(
             std::make_unique<tr_handshake_mediator_impl>(*session),
-            tr_peerIo::newIncoming(session, &session->bandwidth(), addr, port, tr_time(), socket),
+            tr_peerIo::newIncoming(session, &session->bandwidth(), &addr, port, tr_time(), socket),
             session->encryptionMode(),
             on_handshake_done,
             manager);
-        manager->incoming_handshakes.add(*addr, handshake);
+        manager->incoming_handshakes.add(addr, handshake);
     }
 }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1257,7 +1257,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     {
         auto* const handshake = tr_handshakeNew(
             std::make_unique<tr_handshake_mediator_impl>(*session),
-            tr_peerIo::newIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket),
+            tr_peerIo::newIncoming(session, &session->bandwidth(), addr, port, tr_time(), socket),
             session->encryptionMode(),
             on_handshake_done,
             manager);
@@ -2569,8 +2569,8 @@ void tr_peerMgr::bandwidthPulse()
 
     /* allocate bandwidth to the peers */
     auto const msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
-    session->top_bandwidth_.allocate(TR_UP, msec);
-    session->top_bandwidth_.allocate(TR_DOWN, msec);
+    session->bandwidth().allocate(TR_UP, msec);
+    session->bandwidth().allocate(TR_DOWN, msec);
 
     /* torrent upkeep */
     for (auto* const tor : session->torrents())
@@ -2834,7 +2834,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
 
     auto io = tr_peerIo::newOutgoing(
         mgr->session,
-        &mgr->session->top_bandwidth_,
+        &mgr->session->bandwidth(),
         &atom.addr,
         atom.port,
         tr_time(),

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -11,6 +11,7 @@
 
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t, uint64_t
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -105,9 +106,7 @@ constexpr bool tr_isPex(tr_pex const* pex)
     return pex && tr_address_is_valid(&pex->addr);
 }
 
-[[nodiscard]] tr_peerMgr* tr_peerMgrNew(tr_session* session);
-
-void tr_peerMgrFree(tr_peerMgr* manager);
+[[nodiscard]] std::shared_ptr<tr_peerMgr> tr_peerMgrNew(tr_session* session);
 
 void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr);
 
@@ -121,7 +120,7 @@ void tr_peerMgrClientSentRequests(tr_torrent* torrent, tr_peer* peer, tr_block_s
 
 [[nodiscard]] size_t tr_peerMgrCountActiveRequestsToPeer(tr_torrent const* torrent, tr_peer const* peer);
 
-void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket);
+void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const& addr, tr_port port, struct tr_peer_socket const socket);
 
 [[nodiscard]] std::vector<tr_pex> tr_peerMgrCompactToPex(
     void const* compact,

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1354,7 +1354,7 @@ static void prefetchPieces(tr_peerMsgsImpl* msgs)
     {
         if (auto& req = requests[i]; !req.prefetched)
         {
-            msgs->session->cache->prefetchBlock(msgs->torrent, msgs->torrent->pieceLoc(req.index, req.offset), req.length);
+            msgs->session->cache().prefetchBlock(msgs->torrent, msgs->torrent->pieceLoc(req.index, req.offset), req.length);
             req.prefetched = true;
         }
     }
@@ -1843,7 +1843,7 @@ static int clientGotBlock(
         return 0;
     }
 
-    msgs->session->cache->writeBlock(tor->id(), block, block_data);
+    msgs->session->cache().writeBlock(tor->id(), block, block_data);
     msgs->blame.set(loc.piece);
     msgs->publish(tr_peer_event::GotBlock(tor->blockInfo(), block));
     return 0;
@@ -2099,7 +2099,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
             evbuffer_add_uint32(out, req.offset);
 
             evbuffer_reserve_space(out, req.length, &iov, 1);
-            bool err = msgs->session->cache->readBlock(
+            bool err = msgs->session->cache().readBlock(
                            msgs->torrent,
                            msgs->torrent->pieceLoc(req.index, req.offset),
                            req.length,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1708,7 +1708,7 @@ static char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args
     }
 
     auto* const list = tr_variantDictAddList(args_out, TR_KEY_group, 1);
-    for (auto const& [name, group] : s->bandwidth_groups_)
+    for (auto const& [name, group] : s->bandwidthGroups())
     {
         if (names.empty() || names.count(name.sv()) > 0)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1363,7 +1363,7 @@ static char const* portTest(
 {
     auto const port = session->peerPort();
     auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port.host());
-    session->web->fetch({ url, onPortTested, idle_data });
+    session->fetch({ url, onPortTested, idle_data });
     return nullptr;
 }
 
@@ -1449,7 +1449,7 @@ static char const* blocklistUpdate(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    session->web->fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
+    session->fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
     return nullptr;
 }
 
@@ -1654,7 +1654,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         auto* const d = new add_torrent_idle_data{ idle_data, ctor };
         auto options = tr_web::FetchOptions{ filename, onMetadataFetched, d };
         options.cookies = cookies;
-        session->web->fetch(std::move(options));
+        session->fetch(std::move(options));
     }
     else
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -630,7 +630,6 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
 
     /* initialize the bare skeleton of the session object */
     auto* const session = new tr_session{ config_dir };
-    session->cache = std::make_unique<Cache>(session->torrents(), 1024 * 1024 * 2);
     bandwidthGroupRead(session, config_dir);
 
     /* nice to start logging at the very beginning */
@@ -1841,7 +1840,7 @@ void tr_session::closeImplStart()
        it won't be idle until the announce events are sent... */
     this->web_->closeSoon();
 
-    this->cache.reset();
+    this->cache_.reset();
 
     /* saveTimer is not used at this point, reusing for UDP shutdown wait */
     TR_ASSERT(!save_timer_);
@@ -2145,14 +2144,14 @@ void tr_sessionSetCacheLimit_MB(tr_session* session, int mb)
 {
     TR_ASSERT(session != nullptr);
 
-    session->cache->setLimit(tr_toMemBytes(mb));
+    session->cache().setLimit(tr_toMemBytes(mb));
 }
 
 int tr_sessionGetCacheLimit_MB(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
-    return tr_toMemMB(session->cache->getLimit());
+    return tr_toMemMB(session->cache().getLimit());
 }
 
 /***
@@ -2728,13 +2727,13 @@ static int bandwidthGroupWrite(tr_session const* session, std::string_view confi
 
 void tr_session::closeTorrentFiles(tr_torrent* tor) noexcept
 {
-    this->cache->flushTorrent(tor);
+    this->cache().flushTorrent(tor);
     openFiles().closeTorrent(tor->id());
 }
 
 void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noexcept
 {
-    this->cache->flushFile(tor, file_num);
+    this->cache().flushFile(tor, file_num);
     openFiles().closeFile(tor->id(), file_num);
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1912,8 +1912,6 @@ void tr_sessionClose(tr_session* session)
         tr_wait_msec(50);
     }
 
-    session->web_.reset();
-
     /* close the libtransmission thread */
     tr_eventClose(session);
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -242,7 +242,7 @@ void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchRes
 
 void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 {
-    session->web->fetch(std::move(options));
+    session->fetch(std::move(options));
 }
 
 /***
@@ -748,8 +748,6 @@ void tr_session::initImpl(init_data& data)
     tr_sessionSet(this, &settings);
 
     this->udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this);
-
-    this->web = tr_web::create(this->web_mediator_);
 
     if (this->allowsLPD())
     {
@@ -1846,7 +1844,7 @@ void tr_session::closeImplStart()
 
     /* and this goes *after* announcer close so that
        it won't be idle until the announce events are sent... */
-    this->web->closeSoon();
+    this->web_->closeSoon();
 
     this->cache.reset();
 
@@ -1915,7 +1913,7 @@ void tr_sessionClose(tr_session* session)
      * so we need to keep the transmission thread alive
      * for a bit while they tell the router & tracker
      * that we're closing now */
-    while ((session->port_forwarding_ || !session->web->isClosed() || session->announcer != nullptr ||
+    while ((session->port_forwarding_ || !session->web_->isClosed() || session->announcer != nullptr ||
             session->announcer_udp != nullptr) &&
            !deadlineReached(deadline))
     {
@@ -1928,7 +1926,7 @@ void tr_sessionClose(tr_session* session)
         tr_wait_msec(50);
     }
 
-    session->web.reset();
+    session->web_.reset();
 
     /* close the libtransmission thread */
     tr_eventClose(session);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2826,7 +2826,6 @@ tr_session::tr_session(std::string_view config_dir)
                        evdns_base_free(dns, 0);
                    } }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
-    , session_stats_{ config_dir, time(nullptr) }
 {
     now_timer_ = timerMaker().create([this]() { onNowTimer(); });
     now_timer_->startRepeating(1s);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -714,7 +714,7 @@ void tr_session::initImpl(init_data& data)
     tr_variant const* const client_settings = data.client_settings;
     TR_ASSERT(tr_variantIsDict(client_settings));
 
-    tr_logAddTrace(fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&top_bandwidth_)));
+    tr_logAddTrace(fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&bandwidth())));
 
     auto settings = tr_variant{};
     tr_variantInitDict(&settings, 0);
@@ -1403,12 +1403,12 @@ static void updateBandwidth(tr_session* session, tr_direction dir)
 {
     if (auto const limit_bytes_per_second = session->activeSpeedLimitBps(dir); limit_bytes_per_second)
     {
-        session->top_bandwidth_.setLimited(dir, *limit_bytes_per_second > 0U);
-        session->top_bandwidth_.setDesiredSpeedBytesPerSecond(dir, *limit_bytes_per_second);
+        session->bandwidth().setLimited(dir, *limit_bytes_per_second > 0U);
+        session->bandwidth().setDesiredSpeedBytesPerSecond(dir, *limit_bytes_per_second);
     }
     else
     {
-        session->top_bandwidth_.setLimited(dir, false);
+        session->bandwidth().setLimited(dir, false);
     }
 }
 
@@ -1785,7 +1785,7 @@ bool tr_sessionGetDeleteSource(tr_session const* session)
 
 static unsigned int tr_sessionGetRawSpeed_Bps(tr_session const* session, tr_direction dir)
 {
-    return session != nullptr ? session->top_bandwidth_.getRawSpeedBytesPerSecond(0, dir) : 0;
+    return session != nullptr ? session->bandwidth().getRawSpeedBytesPerSecond(0, dir) : 0;
 }
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
@@ -2201,7 +2201,7 @@ tr_bandwidth& tr_session::getBandwidthGroup(std::string_view name)
         }
     }
 
-    auto& [group_name, group] = groups.emplace_back(name, std::make_unique<tr_bandwidth>(new tr_bandwidth(&top_bandwidth_)));
+    auto& [group_name, group] = groups.emplace_back(name, std::make_unique<tr_bandwidth>(new tr_bandwidth(&bandwidth())));
     return *group;
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -635,7 +635,7 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
     /* start the libtransmission thread */
     tr_net_init(); /* must go before tr_eventInit */
     tr_eventInit(session);
-    TR_ASSERT(session->events != nullptr);
+    TR_ASSERT(session->hasEventLoop());
 
     auto data = tr_session::init_data{};
     data.config_dir = config_dir;
@@ -1917,7 +1917,7 @@ void tr_sessionClose(tr_session* session)
     /* close the libtransmission thread */
     tr_eventClose(session);
 
-    while (session->events != nullptr)
+    while (session->hasEventLoop())
     {
         static bool forced = false;
         tr_logAddTrace(

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2814,7 +2814,10 @@ auto makeEventBase()
 } // namespace
 
 tr_session::tr_session(std::string_view config_dir)
-    : session_id_{ tr_time }
+    : config_dir_{ config_dir }
+    , resume_dir_{ makeResumeDir(config_dir) }
+    , torrent_dir_{ makeTorrentDir(config_dir) }
+    , session_id_{ tr_time }
     , event_base_{ makeEventBase() }
     , evdns_base_{ evdns_base_new(eventBase(), EVDNS_BASE_INITIALIZE_NAMESERVERS),
                    [](evdns_base* dns)
@@ -2823,9 +2826,6 @@ tr_session::tr_session(std::string_view config_dir)
                        evdns_base_free(dns, 0);
                    } }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
-    , config_dir_{ config_dir }
-    , resume_dir_{ makeResumeDir(config_dir) }
-    , torrent_dir_{ makeTorrentDir(config_dir) }
     , session_stats_{ config_dir, time(nullptr) }
 {
     now_timer_ = timerMaker().create([this]() { onNowTimer(); });

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2817,7 +2817,6 @@ tr_session::tr_session(std::string_view config_dir)
     : config_dir_{ config_dir }
     , resume_dir_{ makeResumeDir(config_dir) }
     , torrent_dir_{ makeTorrentDir(config_dir) }
-    , session_id_{ tr_time }
     , event_base_{ makeEventBase() }
     , evdns_base_{ evdns_base_new(eventBase(), EVDNS_BASE_INITIALIZE_NAMESERVERS),
                    [](evdns_base* dns)
@@ -2826,6 +2825,7 @@ tr_session::tr_session(std::string_view config_dir)
                        evdns_base_free(dns, 0);
                    } }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
+    , session_id_{ tr_time }
 {
     now_timer_ = timerMaker().create([this]() { onNowTimer(); });
     now_timer_->startRepeating(1s);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -171,6 +171,16 @@ public:
         return torrents_;
     }
 
+    [[nodiscard]] auto& cache()
+    {
+        return *cache_;
+    }
+
+    [[nodiscard]] auto const& cache() const
+    {
+        return *cache_;
+    }
+
     [[nodiscard]] auto unique_lock() const
     {
         return std::unique_lock(session_mutex_);
@@ -552,8 +562,6 @@ public:
     }
 
     struct tr_peerMgr* peerMgr = nullptr;
-
-    std::unique_ptr<Cache> cache;
 
     std::unique_ptr<tr_lpd> lpd_;
 
@@ -1012,6 +1020,8 @@ private:
     LpdMediator lpd_mediator_{ *this };
 
     tr_torrents torrents_;
+
+    std::unique_ptr<Cache> cache_ = std::make_unique<Cache>(torrents_, 1024 * 1024 * 2);
 
     std::unique_ptr<tr_verify_worker> verifier_ = std::make_unique<tr_verify_worker>();
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -181,6 +181,16 @@ public:
         return *cache_;
     }
 
+    [[nodiscard]] constexpr auto& bandwidth()
+    {
+        return top_bandwidth_;
+    }
+
+    [[nodiscard]] constexpr auto const& bandwidth() const
+    {
+        return top_bandwidth_;
+    }
+
     [[nodiscard]] auto unique_lock() const
     {
         return std::unique_lock(session_mutex_);
@@ -698,7 +708,7 @@ public:
 
     [[nodiscard]] auto pieceSpeedBps(tr_direction dir) const noexcept
     {
-        return top_bandwidth_.getPieceSpeedBytesPerSecond(0, dir);
+        return bandwidth().getPieceSpeedBytesPerSecond(0, dir);
     }
 
     [[nodiscard]] std::optional<unsigned int> activeSpeedLimitBps(tr_direction dir) const noexcept;
@@ -915,9 +925,6 @@ public:
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
 
-    // monitors the "global pool" speeds
-    tr_bandwidth top_bandwidth_;
-
     std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
 
     tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
@@ -1026,6 +1033,9 @@ private:
     tr_session_id session_id_;
 
     ///
+
+    // monitors the "global pool" speeds
+    tr_bandwidth top_bandwidth_;
 
     std::vector<std::unique_ptr<BlocklistFile>> blocklists_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -920,8 +920,6 @@ public:
 
     struct tr_peerMgr* peerMgr = nullptr;
 
-    std::unique_ptr<tr_lpd> lpd_;
-
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
 
@@ -1045,6 +1043,8 @@ private:
     std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);
 
     LpdMediator lpd_mediator_{ *this };
+
+    std::unique_ptr<tr_lpd> lpd_;
 
     std::unique_ptr<tr_rpc_server> rpc_server_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -769,6 +769,11 @@ public:
         return bandwidth_groups_;
     }
 
+    [[nodiscard]] auto hasEventLoop() const noexcept
+    {
+        return events != nullptr;
+    }
+
 private:
     class PortForwardingMediator final : public tr_port_forwarding::Mediator
     {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -561,7 +561,6 @@ public:
 
     std::unique_ptr<Cache> cache;
 
-    std::unique_ptr<tr_web> web;
     std::unique_ptr<tr_lpd> lpd_;
 
     struct tr_announcer* announcer = nullptr;
@@ -769,6 +768,11 @@ public:
         {
             verifier_->add(tor);
         }
+    }
+
+    void fetch(tr_web::FetchOptions options) const
+    {
+        web_->fetch(std::move(options));
     }
 
 private:
@@ -986,6 +990,7 @@ private:
     PortForwardingMediator port_forwarding_mediator_{ *this };
 
     WebMediator web_mediator_{ this };
+    std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);
 
     LpdMediator lpd_mediator_{ *this };
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1097,7 +1097,7 @@ private:
     std::unique_ptr<tr_port_forwarding> port_forwarding_ = tr_port_forwarding::create(port_forwarding_mediator_);
 
     WebMediator web_mediator_{ this };
-    std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);
+    std::unique_ptr<tr_web> const web_ = tr_web::create(web_mediator_);
 
     LpdMediator lpd_mediator_{ *this };
     std::unique_ptr<tr_lpd> lpd_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -866,6 +866,8 @@ private:
     void closeImplWaitForIdleUdp();
     void closeImplFinish();
 
+    void onNowTimer();
+
     void onPeerPortChanged();
     void setPeerPort(tr_port port);
 
@@ -925,6 +927,14 @@ private:
     std::string const config_dir_;
     std::string const resume_dir_;
     std::string const torrent_dir_;
+
+    std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
+    std::unique_ptr<evdns_base, void (*)(evdns_base*)> const evdns_base_;
+    std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
+
+    std::unique_ptr<libtransmission::Timer> now_timer_;
+
+    std::unique_ptr<libtransmission::Timer> save_timer_;
 
     static std::recursive_mutex session_mutex_;
 
@@ -1000,15 +1010,6 @@ private:
     std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);
 
     LpdMediator lpd_mediator_{ *this };
-
-    std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
-    std::unique_ptr<evdns_base, void (*)(evdns_base*)> const evdns_base_;
-    std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
-
-    void onNowTimer();
-    std::unique_ptr<libtransmission::Timer> now_timer_;
-
-    std::unique_ptr<libtransmission::Timer> save_timer_;
 
     tr_torrents torrents_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -922,6 +922,10 @@ private:
     friend void tr_sessionSetSpeedLimit_Bps(tr_session* session, tr_direction dir, unsigned int bytes_per_second);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
 
+    std::string const config_dir_;
+    std::string const resume_dir_;
+    std::string const torrent_dir_;
+
     static std::recursive_mutex session_mutex_;
 
     std::vector<std::unique_ptr<BlocklistFile>> blocklists_;
@@ -1012,9 +1016,6 @@ private:
 
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
 
-    std::string const config_dir_;
-    std::string const resume_dir_;
-    std::string const torrent_dir_;
     std::string download_dir_;
     std::string incomplete_dir_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1023,7 +1023,7 @@ private:
     std::string default_trackers_str_;
     std::string peer_congestion_algorithm_;
 
-    tr_stats session_stats_;
+    tr_stats session_stats_{ config_dir_, time(nullptr) };
 
     std::optional<tr_address> external_ip_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -931,8 +931,6 @@ public:
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
 
-    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
-
 private:
     /// const fields
 
@@ -945,6 +943,21 @@ private:
     std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
 
     /// trivial fields
+
+    queue_start_callback_t queue_start_callback_ = nullptr;
+    void* queue_start_user_data_ = nullptr;
+
+    tr_session_idle_limit_hit_func idle_limit_hit_callback_ = nullptr;
+    void* idle_limit_hit_user_data_ = nullptr;
+
+    tr_session_ratio_limit_hit_func ratio_limit_hit_cb_ = nullptr;
+    void* ratio_limit_hit_user_data_ = nullptr;
+
+    tr_session_metadata_func got_metadata_cb_ = nullptr;
+    void* got_metadata_user_data_ = nullptr;
+
+    tr_torrent_completeness_func completeness_func_ = nullptr;
+    void* completeness_func_user_data_ = nullptr;
 
     std::array<unsigned int, 2> speed_limit_Bps_ = { 0U, 0U };
     std::array<bool, 2> speed_limit_enabled_ = { false, false };
@@ -1012,11 +1025,15 @@ private:
     bool should_scrape_paused_torrents_ = false;
     bool is_incomplete_file_naming_enabled_ = false;
 
+    std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_ = {};
+    bool blocklist_enabled_ = false;
+    bool incomplete_dir_enabled_ = false;
+
+    bool announce_ip_enabled_ = false;
+
     /// fields that are nontrivial but don't have dependencies
 
-    std::unique_ptr<libtransmission::Timer> now_timer_;
-
-    std::unique_ptr<libtransmission::Timer> save_timer_;
+    std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
 
     std::string download_dir_;
     std::string incomplete_dir_;
@@ -1024,6 +1041,8 @@ private:
     std::string blocklist_url_;
     std::string default_trackers_str_;
     std::string peer_congestion_algorithm_;
+
+    std::string announce_ip_;
 
     static std::recursive_mutex session_mutex_;
 
@@ -1033,15 +1052,21 @@ private:
 
     std::optional<tr_address> external_ip_;
 
+    ///
+
+    std::unique_ptr<libtransmission::Timer> now_timer_;
+
+    std::unique_ptr<libtransmission::Timer> save_timer_;
+
     tr_session_id session_id_;
 
     tr_bindinfo bind_ipv4_ = tr_bindinfo{ tr_inaddr_any };
     tr_bindinfo bind_ipv6_ = tr_bindinfo{ tr_in6addr_any };
 
-    ///
-
     // monitors the "global pool" speeds
     tr_bandwidth top_bandwidth_;
+
+    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
 
     std::vector<std::unique_ptr<BlocklistFile>> blocklists_;
 
@@ -1060,34 +1085,9 @@ private:
     std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);
 
     LpdMediator lpd_mediator_{ *this };
-
     std::unique_ptr<tr_lpd> lpd_;
 
     std::unique_ptr<tr_rpc_server> rpc_server_;
-
-    std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
-
-    queue_start_callback_t queue_start_callback_ = nullptr;
-    void* queue_start_user_data_ = nullptr;
-
-    tr_session_idle_limit_hit_func idle_limit_hit_callback_ = nullptr;
-    void* idle_limit_hit_user_data_ = nullptr;
-
-    tr_session_ratio_limit_hit_func ratio_limit_hit_cb_ = nullptr;
-    void* ratio_limit_hit_user_data_ = nullptr;
-
-    tr_session_metadata_func got_metadata_cb_ = nullptr;
-    void* got_metadata_user_data_ = nullptr;
-
-    tr_torrent_completeness_func completeness_func_ = nullptr;
-    void* completeness_func_user_data_ = nullptr;
-
-    std::array<bool, TR_SCRIPT_N_TYPES> scripts_enabled_ = {};
-    bool blocklist_enabled_ = false;
-    bool incomplete_dir_enabled_ = false;
-
-    std::string announce_ip_;
-    bool announce_ip_enabled_ = false;
 
 public:
     struct struct_utp_context* utp_context = nullptr;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -551,13 +551,7 @@ public:
         return public_peer_port;
     }
 
-    constexpr auto setPeerPort(tr_port port) noexcept
-    {
-        public_peer_port = port;
-    }
-
     struct tr_peerMgr* peerMgr = nullptr;
-    std::unique_ptr<tr_port_forwarding> port_forwarding_;
 
     std::unique_ptr<Cache> cache;
 
@@ -872,9 +866,14 @@ private:
     void closeImplWaitForIdleUdp();
     void closeImplFinish();
 
+    void onPeerPortChanged();
+    void setPeerPort(tr_port port);
+
     friend class libtransmission::test::SessionTest;
+
     friend bool tr_blocklistExists(tr_session const* session);
     friend bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session);
+    friend bool tr_sessionIsPortForwardingEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
     friend char const* tr_sessionGetRPCPassword(tr_session const* session);
@@ -883,6 +882,7 @@ private:
     friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
     friend size_t tr_blocklistGetRuleCount(tr_session const* session);
     friend size_t tr_blocklistSetContent(tr_session* session, char const* content_filename);
+    friend tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
     friend uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
@@ -903,8 +903,10 @@ private:
     friend void tr_sessionSetPaused(tr_session* session, bool is_paused);
     friend void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers);
     friend void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers);
+    friend void tr_sessionSetPeerPort(tr_session* session, uint16_t hport);
     friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, int max_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueStalledEnabled(tr_session* session, bool is_enabled);
@@ -988,6 +990,7 @@ private:
     bool is_incomplete_file_naming_enabled_ = false;
 
     PortForwardingMediator port_forwarding_mediator_{ *this };
+    std::unique_ptr<tr_port_forwarding> port_forwarding_ = tr_port_forwarding::create(port_forwarding_mediator_);
 
     WebMediator web_mediator_{ this };
     std::unique_ptr<tr_web> web_ = tr_web::create(web_mediator_);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -770,7 +770,7 @@ private:
 
         [[nodiscard]] tr_address incomingPeerAddress() const override
         {
-            return session_.bind_ipv4.addr_;
+            return session_.bind_ipv4_.addr_;
         }
 
         [[nodiscard]] tr_port privatePeerPort() const override
@@ -862,6 +862,12 @@ private:
     void onPeerPortChanged();
     void setPeerPort(tr_port port);
 
+    void closePeerPort()
+    {
+        bind_ipv4_.close();
+        bind_ipv6_.close();
+    }
+
     friend class libtransmission::test::SessionTest;
     friend struct tr_bindinfo;
 
@@ -926,9 +932,6 @@ public:
     struct tr_announcer_udp* announcer_udp = nullptr;
 
     std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
-
-    tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
-    tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
 
 private:
     /// const fields
@@ -1031,6 +1034,9 @@ private:
     std::optional<tr_address> external_ip_;
 
     tr_session_id session_id_;
+
+    tr_bindinfo bind_ipv4_ = tr_bindinfo{ tr_inaddr_any };
+    tr_bindinfo bind_ipv6_ = tr_bindinfo{ tr_in6addr_any };
 
     ///
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -53,14 +53,15 @@ tr_peer_id_t tr_peerIdInit();
 struct event_base;
 struct evdns_base;
 
-class tr_rpc_server;
-class tr_web;
 class tr_lpd;
 class tr_port_forwarding;
+class tr_rpc_server;
+class tr_web;
 struct BlocklistFile;
 struct struct_utp_context;
 struct tr_announcer;
 struct tr_announcer_udp;
+struct tr_peerMgr;
 
 namespace libtransmission
 {
@@ -759,6 +760,15 @@ public:
         web_->fetch(std::move(options));
     }
 
+    void addIncoming(tr_address const& addr, tr_port port, struct tr_peer_socket const socket);
+
+    void addTorrent(tr_torrent* tor);
+
+    [[nodiscard]] auto const& bandwidthGroups() const noexcept
+    {
+        return bandwidth_groups_;
+    }
+
 private:
     class PortForwardingMediator final : public tr_port_forwarding::Mediator
     {
@@ -926,8 +936,6 @@ private:
 public:
     std::unique_ptr<tr_udp_core> udp_core_;
 
-    struct tr_peerMgr* peerMgr = nullptr;
-
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
 
@@ -1077,6 +1085,8 @@ private:
     std::unique_ptr<Cache> cache_ = std::make_unique<Cache>(torrents_, 1024 * 1024 * 2);
 
     std::unique_ptr<tr_verify_worker> verifier_ = std::make_unique<tr_verify_worker>();
+
+    std::shared_ptr<tr_peerMgr> peer_mgr_;
 
     PortForwardingMediator port_forwarding_mediator_{ *this };
     std::unique_ptr<tr_port_forwarding> port_forwarding_ = tr_port_forwarding::create(port_forwarding_mediator_);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -712,9 +712,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     auto const& labels = tr_ctorGetLabels(ctor);
     tor->setLabels(labels);
 
-    tor->unique_id_ = session->torrents().add(tor);
-
-    tr_peerMgrAddTorrent(session->peerMgr, tor);
+    session->addTorrent(tor);
 
     TR_ASSERT(tor->downloadedCur == 0);
     TR_ASSERT(tor->uploadedCur == 0);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -704,7 +704,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     {
         tor->incomplete_dir = dir;
     }
-    tor->bandwidth_.setParent(&session->top_bandwidth_);
+    tor->bandwidth_.setParent(&session->bandwidth());
     tor->bandwidth_.setPriority(tr_ctorGetBandwidthPriority(ctor));
     tor->error = TR_STAT_OK;
     tor->finishedSeedingByIdle = false;
@@ -1872,7 +1872,7 @@ void tr_torrent::setBandwidthGroup(std::string_view group_name) noexcept
     if (std::empty(group_name))
     {
         this->bandwidth_group_ = tr_interned_string{};
-        this->bandwidth_.setParent(&this->session->top_bandwidth_);
+        this->bandwidth_.setParent(&this->session->bandwidth());
     }
     else
     {

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -99,7 +99,7 @@ static void utp_on_accept(tr_session* const session, UTPSocket* const s)
         return;
     }
 
-    tr_peerMgrAddIncoming(session->peerMgr, &addr, port, tr_peer_socket_utp_create(s));
+    session->addIncoming(addr, port, tr_peer_socket_utp_create(s));
 }
 
 static void utp_send_to(

--- a/libtransmission/trevent.cc
+++ b/libtransmission/trevent.cc
@@ -220,7 +220,7 @@ void tr_eventInit(tr_session* session)
     events->thread_id = thread.get_id();
     thread.detach();
     // wait until the libevent thread is running
-    events->work_queue_cv.wait(lock, [session] { return session->events != nullptr; });
+    events->work_queue_cv.wait(lock, [session] { return session->hasEventLoop(); });
 }
 
 void tr_eventClose(tr_session* session)
@@ -245,7 +245,7 @@ void tr_eventClose(tr_session* session)
 bool tr_amInEventThread(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
-    TR_ASSERT(session->events != nullptr);
+    TR_ASSERT(session->hasEventLoop());
 
     return std::this_thread::get_id() == session->events->thread_id;
 }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -525,7 +525,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     options.range = fmt::format(FMT_STRING("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->id();
     options.buffer = task->content();
-    tor->session->web->fetch(std::move(options));
+    tor->session->fetch(std::move(options));
 }
 
 } // namespace

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -347,7 +347,7 @@ public:
     {
         if (auto* const tor = tr_torrentFindFromId(session_, tor_id_); tor != nullptr)
         {
-            session_->cache->writeBlock(tor_id_, block_, data_);
+            session_->cache().writeBlock(tor_id_, block_, data_);
             webseed_->publish(tr_peer_event::GotBlock(tor->blockInfo(), block_));
         }
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -162,8 +162,7 @@ public:
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         auto const now = tr_time();
         auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
-        auto
-            io = tr_peerIo::newIncoming(session, &session->top_bandwidth_, &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
+        auto io = tr_peerIo::newIncoming(session, &session->bandwidth(), &DefaultPeerAddr, DefaultPeerPort, now, peer_socket);
         return std::make_pair(io, sockpair[1]);
     }
 
@@ -175,7 +174,7 @@ public:
         auto const peer_socket = tr_peer_socket_tcp_create(sockpair[0]);
         auto io = tr_peerIo::create(
             session,
-            &session->top_bandwidth_,
+            &session->bandwidth(),
             &DefaultPeerAddr,
             DefaultPeerPort,
             now,

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -87,7 +87,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
 
     auto const test_incomplete_dir_threadfunc = [](TestIncompleteDirData* data) noexcept
     {
-        data->session->cache->writeBlock(data->tor->id(), data->block, data->buf);
+        data->session->cache().writeBlock(data->tor->id(), data->block, data->buf);
         tr_torrentGotBlock(data->tor, data->block);
         data->done = true;
     };


### PR DESCRIPTION
# THIS IS A WIP; MIGHT BE UNSTABLE; NEEDS TESTING

first step in fixing the tr_session-crashes-on-shutdown: start re-ordering the class fields into the order they should be destroyed