### PR TITLE
Fix 'modalDelegate:' is deprecated to avoid contextInfo leaks.

### DIFF
--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -81,7 +81,7 @@ AboutWindowController* fAboutBoxInstance = nil;
 - (IBAction)hideLicense:(id)sender
 {
     [self.fLicenseSheet orderOut:nil];
-    [NSApp endSheet:self.fLicenseSheet];
+    [self.window endSheet:self.fLicenseSheet];
 }
 
 @end

--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -80,7 +80,6 @@ AboutWindowController* fAboutBoxInstance = nil;
 
 - (IBAction)hideLicense:(id)sender
 {
-    [self.fLicenseSheet orderOut:nil];
     [self.window endSheet:self.fLicenseSheet];
 }
 

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -91,7 +91,6 @@ BlocklistDownloaderViewController* fBLViewController = nil;
 - (void)setFinished
 {
     [self.fPrefsController.window endSheet:self.fStatusWindow];
-    [self.fStatusWindow orderOut:self];
 
     fBLViewController = nil;
 }
@@ -99,7 +98,6 @@ BlocklistDownloaderViewController* fBLViewController = nil;
 - (void)setFailed:(NSString*)error
 {
     [self.fPrefsController.window endSheet:self.fStatusWindow];
-    [self.fStatusWindow orderOut:self];
 
     NSAlert* alert = [[NSAlert alloc] init];
     [alert addButtonWithTitle:NSLocalizedString(@"OK", "Blocklist -> button")];

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -90,7 +90,7 @@ BlocklistDownloaderViewController* fBLViewController = nil;
 
 - (void)setFinished
 {
-    [NSApp endSheet:self.fStatusWindow];
+    [self.fPrefsController.window endSheet:self.fStatusWindow];
     [self.fStatusWindow orderOut:self];
 
     fBLViewController = nil;
@@ -98,7 +98,7 @@ BlocklistDownloaderViewController* fBLViewController = nil;
 
 - (void)setFailed:(NSString*)error
 {
-    [NSApp endSheet:self.fStatusWindow];
+    [self.fPrefsController.window endSheet:self.fStatusWindow];
     [self.fStatusWindow orderOut:self];
 
     NSAlert* alert = [[NSAlert alloc] init];
@@ -109,8 +109,6 @@ BlocklistDownloaderViewController* fBLViewController = nil;
     alert.informativeText = error;
 
     [alert beginSheetModalForWindow:self.fPrefsController.window completionHandler:^(NSModalResponse returnCode) {
-        [alert.window orderOut:self];
-
         fBLViewController = nil;
     }];
 }

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -687,7 +687,6 @@ NSMutableSet* creatorWindowControllerSet = nil;
 
         alert.informativeText = [NSString stringWithFormat:@"%s (%d)", error->message, error->code];
         [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
-            [alert.window orderOut:nil];
             [self.window close];
         }];
         tr_error_free(error);

--- a/macosx/FileRenameSheetController.mm
+++ b/macosx/FileRenameSheetController.mm
@@ -58,10 +58,11 @@ typedef void (^CompletionBlock)(BOOL);
                 modalForWindow:(NSWindow*)window
              completionHandler:(void (^)(BOOL))completionHandler
 {
+    // we capture renamer strongly to avoid it being deallocated before completionHandler
+    __block FileRenameSheetController* strongRenamer = renamer;
     [window beginSheet:renamer.window completionHandler:^(NSModalResponse returnCode) {
         completionHandler(returnCode == NSModalResponseOK);
-
-        [renamer.window orderOut:self];
+        strongRenamer = nil;
     }];
 }
 

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -295,7 +295,6 @@
 
 - (IBAction)cancelRules:(id)sender
 {
-    [self.groupRulesSheetWindow orderOut:nil];
     [self.fTableView.window endSheet:self.groupRulesSheetWindow];
 
     NSInteger index = [GroupsController.groups indexForRow:self.fTableView.selectedRow];
@@ -309,7 +308,6 @@
 
 - (IBAction)saveRules:(id)sender
 {
-    [self.groupRulesSheetWindow orderOut:nil];
     [self.fTableView.window endSheet:self.groupRulesSheetWindow];
 
     NSInteger index = [GroupsController.groups indexForRow:self.fTableView.selectedRow];

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -296,7 +296,7 @@
 - (IBAction)cancelRules:(id)sender
 {
     [self.groupRulesSheetWindow orderOut:nil];
-    [NSApp endSheet:self.groupRulesSheetWindow];
+    [self.fTableView.window endSheet:self.groupRulesSheetWindow];
 
     NSInteger index = [GroupsController.groups indexForRow:self.fTableView.selectedRow];
     if (![GroupsController.groups autoAssignRulesForIndex:index])
@@ -310,7 +310,7 @@
 - (IBAction)saveRules:(id)sender
 {
     [self.groupRulesSheetWindow orderOut:nil];
-    [NSApp endSheet:self.groupRulesSheetWindow];
+    [self.fTableView.window endSheet:self.groupRulesSheetWindow];
 
     NSInteger index = [GroupsController.groups indexForRow:self.fTableView.selectedRow];
     [GroupsController.groups setUsesAutoAssignRules:YES forIndex:index];

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -159,8 +159,6 @@ tr_session* fLib = NULL;
     alert.showsSuppressionButton = YES;
 
     [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
-        [alert.window orderOut:nil];
-
         if (alert.suppressionButton.state == NSControlStateValueOn)
         {
             [NSUserDefaults.standardUserDefaults setBool:NO forKey:@"WarningResetStats"];

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -68,13 +68,11 @@ NSString* urlString = nil;
 
 - (void)openURLEndSheet:(id)sender
 {
-    [self.window orderOut:sender];
     [NSApp endSheet:self.window returnCode:1];
 }
 
 - (void)openURLCancelEndSheet:(id)sender
 {
-    [self.window orderOut:sender];
     [NSApp endSheet:self.window returnCode:0];
 }
 


### PR DESCRIPTION
The commit date is "3 February 2019" and it't not an error... I started this long time ago. ^_^
In some sort, this is the continuation of #1579 which did part of what I was originally attempting to address in #827.

Fix 1: `NSApp endSheet:` is deprecated:
>NSWindow's -beginSheet:completionHandler: and -endSheet:returnCode: should be used instead.  NSApplication's -beginSheet:modalForWindow:modalDelegate:didEndSelector:contextInfo: will continue to work as it previously did, leaking contextInfo and failing when there is already an existing sheet.

Fix 2: `orderOut:` is not needed when using `beginSheet:`.

Testing:
I tested all those changes on both macOS Ventura 13.0 and macOS Mojave 10.14.6.
- Closing the License sheet
- Closing the Blocklist sheet
- Closing the GroupRules sheet
- Closing the OpenURL sheet
- Closing the FileRename sheet