### PR TITLE
refactor: tr_session declaration cleanup

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2821,7 +2821,9 @@ auto makeEventBase()
 } // namespace
 
 tr_session::tr_session(std::string_view config_dir)
-    : session_id_{ tr_time }
+    : config_dir_{ config_dir }
+    , resume_dir_{ makeResumeDir(config_dir) }
+    , torrent_dir_{ makeTorrentDir(config_dir) }
     , event_base_{ makeEventBase() }
     , evdns_base_{ evdns_base_new(eventBase(), EVDNS_BASE_INITIALIZE_NAMESERVERS),
                    [](evdns_base* dns)
@@ -2830,9 +2832,7 @@ tr_session::tr_session(std::string_view config_dir)
                        evdns_base_free(dns, 0);
                    } }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
-    , config_dir_{ config_dir }
-    , resume_dir_{ makeResumeDir(config_dir) }
-    , torrent_dir_{ makeTorrentDir(config_dir) }
+    , session_id_{ tr_time }
     , session_stats_{ config_dir, time(nullptr) }
 {
     now_timer_ = timerMaker().create([this]() { onNowTimer(); });

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -630,7 +630,6 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
 
     /* initialize the bare skeleton of the session object */
     auto* const session = new tr_session{ config_dir };
-    session->cache = std::make_unique<Cache>(session->torrents(), 1024 * 1024 * 2);
     bandwidthGroupRead(session, config_dir);
 
     /* nice to start logging at the very beginning */
@@ -2833,7 +2832,6 @@ tr_session::tr_session(std::string_view config_dir)
                    } }
     , timer_maker_{ std::make_unique<libtransmission::EvTimerMaker>(eventBase()) }
     , session_id_{ tr_time }
-    , session_stats_{ config_dir, time(nullptr) }
 {
     now_timer_ = timerMaker().create([this]() { onNowTimer(); });
     now_timer_->startRepeating(1s);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -608,32 +608,6 @@ public:
         session_stats_.addFileCreated();
     }
 
-public:
-    static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
-        { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
-          { TR_KEY_script_torrent_done_enabled, TR_KEY_script_torrent_done_filename, TR_SCRIPT_ON_TORRENT_DONE },
-          { TR_KEY_script_torrent_done_seeding_enabled,
-            TR_KEY_script_torrent_done_seeding_filename,
-            TR_SCRIPT_ON_TORRENT_DONE_SEEDING } }
-    };
-
-    struct tr_turtle_info turtle;
-
-    struct tr_event_handle* events = nullptr;
-
-    std::unique_ptr<tr_udp_core> udp_core_;
-
-    /* The open port on the local machine for incoming peer requests */
-    tr_port private_peer_port;
-
-    /**
-     * The open port on the public device for incoming peer requests.
-     * This is usually the same as private_peer_port but can differ
-     * if the public device is a router and it decides to use a different
-     * port than the one requested by Transmission.
-     */
-    tr_port public_peer_port;
-
     [[nodiscard]] constexpr tr_port peerPort() const noexcept
     {
         return public_peer_port;
@@ -643,25 +617,6 @@ public:
     {
         public_peer_port = port;
     }
-
-    struct tr_peerMgr* peerMgr = nullptr;
-    std::unique_ptr<tr_port_forwarding> port_forwarding_;
-
-    std::unique_ptr<Cache> cache;
-
-    std::unique_ptr<tr_web> web;
-    std::unique_ptr<tr_lpd> lpd_;
-
-    struct tr_announcer* announcer = nullptr;
-    struct tr_announcer_udp* announcer_udp = nullptr;
-
-    // monitors the "global pool" speeds
-    tr_bandwidth top_bandwidth_;
-
-    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
-
-    tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
-    tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
 
     [[nodiscard]] constexpr auto queueEnabled(tr_direction dir) const noexcept
     {
@@ -917,6 +872,52 @@ private:
     friend void tr_sessionSetSpeedLimit_Bps(tr_session* session, tr_direction dir, unsigned int bytes_per_second);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
 
+public:
+    static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
+        { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
+          { TR_KEY_script_torrent_done_enabled, TR_KEY_script_torrent_done_filename, TR_SCRIPT_ON_TORRENT_DONE },
+          { TR_KEY_script_torrent_done_seeding_enabled,
+            TR_KEY_script_torrent_done_seeding_filename,
+            TR_SCRIPT_ON_TORRENT_DONE_SEEDING } }
+    };
+
+    struct tr_turtle_info turtle;
+
+    struct tr_event_handle* events = nullptr;
+
+    std::unique_ptr<tr_udp_core> udp_core_;
+
+    /* The open port on the local machine for incoming peer requests */
+    tr_port private_peer_port;
+
+    /**
+     * The open port on the public device for incoming peer requests.
+     * This is usually the same as private_peer_port but can differ
+     * if the public device is a router and it decides to use a different
+     * port than the one requested by Transmission.
+     */
+    tr_port public_peer_port;
+
+    struct tr_peerMgr* peerMgr = nullptr;
+    std::unique_ptr<tr_port_forwarding> port_forwarding_;
+
+    std::unique_ptr<Cache> cache;
+
+    std::unique_ptr<tr_web> web;
+    std::unique_ptr<tr_lpd> lpd_;
+
+    struct tr_announcer* announcer = nullptr;
+    struct tr_announcer_udp* announcer_udp = nullptr;
+
+    // monitors the "global pool" speeds
+    tr_bandwidth top_bandwidth_;
+
+    std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
+
+    tr_bindinfo bind_ipv4 = tr_bindinfo{ tr_inaddr_any };
+    tr_bindinfo bind_ipv6 = tr_bindinfo{ tr_in6addr_any };
+
+private:
     static std::recursive_mutex session_mutex_;
 
     std::vector<std::unique_ptr<BlocklistFile>> blocklists_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -873,6 +873,8 @@ private:
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
 
 public:
+    /// constexpr fields
+
     static constexpr std::array<std::tuple<tr_quark, tr_quark, TrScript>, 3> Scripts{
         { { TR_KEY_script_torrent_added_enabled, TR_KEY_script_torrent_added_filename, TR_SCRIPT_ON_TORRENT_ADDED },
           { TR_KEY_script_torrent_done_enabled, TR_KEY_script_torrent_done_filename, TR_SCRIPT_ON_TORRENT_DONE },
@@ -881,6 +883,20 @@ public:
             TR_SCRIPT_ON_TORRENT_DONE_SEEDING } }
     };
 
+private:
+    /// const fields
+
+    std::string const config_dir_;
+    std::string const resume_dir_;
+    std::string const torrent_dir_;
+
+    std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
+    std::unique_ptr<evdns_base, void (*)(evdns_base*)> const evdns_base_;
+    std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
+
+    /// other fields
+
+public:
     struct tr_turtle_info turtle;
 
     struct tr_event_handle* events = nullptr;
@@ -991,10 +1007,6 @@ private:
 
     LpdMediator lpd_mediator_{ *this };
 
-    std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
-    std::unique_ptr<evdns_base, void (*)(evdns_base*)> const evdns_base_;
-    std::unique_ptr<libtransmission::TimerMaker> const timer_maker_;
-
     void onNowTimer();
     std::unique_ptr<libtransmission::Timer> now_timer_;
 
@@ -1006,9 +1018,6 @@ private:
 
     std::array<std::string, TR_SCRIPT_N_TYPES> scripts_;
 
-    std::string const config_dir_;
-    std::string const resume_dir_;
-    std::string const torrent_dir_;
     std::string download_dir_;
     std::string incomplete_dir_;
 


### PR DESCRIPTION
supersedes https://github.com/transmission/transmission/tree/refactor/session-field-order.

This is a more incremental version of that PR and should be ready for merging. No behavioral changes and  does not fix the crash-on-shutdown problem.

Ultimately the crash-on-shutdown problem will be solved by reducing coupling between tr_session's fields and destroying them in the correct sequence when the `tr_session` is destroyed. To make that future work easier, this housekeeping PR reorganizes the `tr_session` class declaration into this order:

- classes and types
- constructor
- methods
- constexpr fields
- const fields
- trivial fields
- loosely-coupled fields
- other fields

