### PR TITLE
refactor: session private fields

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -432,7 +432,7 @@ void tr_tracker_http_announce(
     auto do_make_request = [&](std::string_view const& protocol_name, tr_web::FetchOptions&& opt)
     {
         tr_logAddTrace(fmt::format("Sending {} announce to libcurl: '{}'", protocol_name, opt.url), request->log_name);
-        session->web->fetch(std::move(opt));
+        session->fetch(std::move(opt));
     };
 
     auto const ipv6 = tr_globalIPv6(session);
@@ -686,5 +686,5 @@ void tr_tracker_http_scrape(
     options.timeout_secs = 30L;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
-    session->web->fetch(std::move(options));
+    session->fetch(std::move(options));
 }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1237,19 +1237,19 @@ static bool on_handshake_done(tr_handshake_result const& result)
     return success;
 }
 
-void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket)
+void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const& addr, tr_port port, struct tr_peer_socket const socket)
 {
     TR_ASSERT(manager->session != nullptr);
     auto const lock = manager->unique_lock();
 
     tr_session* session = manager->session;
 
-    if (session->addressIsBlocked(*addr))
+    if (session->addressIsBlocked(addr))
     {
-        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", addr->readable(port)));
+        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", addr.readable(port)));
         tr_netClosePeerSocket(session, socket);
     }
-    else if (manager->incoming_handshakes.contains(*addr))
+    else if (manager->incoming_handshakes.contains(addr))
     {
         tr_netClosePeerSocket(session, socket);
     }
@@ -1257,11 +1257,11 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port 
     {
         auto* const handshake = tr_handshakeNew(
             std::make_unique<tr_handshake_mediator_impl>(*session),
-            tr_peerIo::newIncoming(session, &session->top_bandwidth_, addr, port, tr_time(), socket),
+            tr_peerIo::newIncoming(session, &session->top_bandwidth_, &addr, port, tr_time(), socket),
             session->encryptionMode(),
             on_handshake_done,
             manager);
-        manager->incoming_handshakes.add(*addr, handshake);
+        manager->incoming_handshakes.add(addr, handshake);
     }
 }
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -121,7 +121,7 @@ void tr_peerMgrClientSentRequests(tr_torrent* torrent, tr_peer* peer, tr_block_s
 
 [[nodiscard]] size_t tr_peerMgrCountActiveRequestsToPeer(tr_torrent const* torrent, tr_peer const* peer);
 
-void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const* addr, tr_port port, struct tr_peer_socket const socket);
+void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_address const& addr, tr_port port, struct tr_peer_socket const socket);
 
 [[nodiscard]] std::vector<tr_pex> tr_peerMgrCompactToPex(
     void const* compact,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1708,7 +1708,7 @@ static char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args
     }
 
     auto* const list = tr_variantDictAddList(args_out, TR_KEY_group, 1);
-    for (auto const& [name, group] : s->bandwidth_groups_)
+    for (auto const& [name, group] : s->bandwidthGroups())
     {
         if (names.empty() || names.count(name.sv()) > 0)
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1363,7 +1363,7 @@ static char const* portTest(
 {
     auto const port = session->peerPort();
     auto const url = fmt::format(FMT_STRING("https://portcheck.transmissionbt.com/{:d}"), port.host());
-    session->web->fetch({ url, onPortTested, idle_data });
+    session->fetch({ url, onPortTested, idle_data });
     return nullptr;
 }
 
@@ -1449,7 +1449,7 @@ static char const* blocklistUpdate(
     tr_variant* /*args_out*/,
     struct tr_rpc_idle_data* idle_data)
 {
-    session->web->fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
+    session->fetch({ session->blocklistUrl(), onBlocklistFetched, idle_data });
     return nullptr;
 }
 
@@ -1654,7 +1654,7 @@ static char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_varia
         auto* const d = new add_torrent_idle_data{ idle_data, ctor };
         auto options = tr_web::FetchOptions{ filename, onMetadataFetched, d };
         options.cookies = cookies;
-        session->web->fetch(std::move(options));
+        session->fetch(std::move(options));
     }
     else
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2689,7 +2689,7 @@ static void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 
 static int bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
 {
-    auto const& groups = session->bandwidth_groups_;
+    auto const& groups = session->bandwidthGroups();
 
     auto groups_dict = tr_variant{};
     tr_variantInitDict(&groups_dict, std::size(groups));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -710,7 +710,7 @@ void tr_session::initImpl(init_data& data)
 
     tr_logSetQueueEnabled(data.message_queuing_enabled);
 
-    this->peerMgr = tr_peerMgrNew(this);
+    this->peer_mgr_ = tr_peerMgrNew(this);
 
     this->port_forwarding_ = tr_port_forwarding::create(port_forwarding_mediator_);
 
@@ -1861,7 +1861,7 @@ void tr_session::closeImplFinish()
     this->udp_core_.reset();
 
     stats().saveIfDirty();
-    tr_peerMgrFree(peerMgr);
+    tr_peerMgrFree(peer_mgr_);
     tr_utpClose(this);
     blocklists_.clear();
     openFiles().closeAll();
@@ -2238,7 +2238,7 @@ void tr_sessionReloadBlocklists(tr_session* session)
     session->blocklists_.clear();
     session->blocklists_ = BlocklistFile::loadBlocklists(session->configDir(), session->useBlocklist());
 
-    tr_peerMgrOnBlocklistChanged(session->peerMgr);
+    tr_peerMgrOnBlocklistChanged(session->peer_mgr_);
 }
 
 size_t tr_blocklistGetRuleCount(tr_session const* session)
@@ -2839,12 +2839,12 @@ tr_session::tr_session(std::string_view config_dir)
 
 void tr_session::addIncoming(tr_address const& addr, tr_port port, struct tr_peer_socket const socket)
 {
-    tr_peerMgrAddIncoming(peerMgr, addr, port, socket);
+    tr_peerMgrAddIncoming(peer_mgr_, addr, port, socket);
 }
 
 void tr_session::addTorrent(tr_torrent* tor)
 {
     tor->unique_id_ = torrents().add(tor);
 
-    tr_peerMgrAddTorrent(peerMgr, tor);
+    tr_peerMgrAddTorrent(peer_mgr_, tor);
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -295,7 +295,7 @@ static void acceptIncomingPeer(evutil_socket_t fd, short /*what*/, void* vsessio
     {
         tr_logAddTrace(fmt::format("new incoming connection {} ({})", client_socket, client_addr.readable(client_port)));
 
-        tr_peerMgrAddIncoming(session->peerMgr, &client_addr, client_port, tr_peer_socket_tcp_create(client_socket));
+        session->addIncoming(client_addr, client_port, tr_peer_socket_tcp_create(client_socket));
     }
 }
 
@@ -2835,4 +2835,9 @@ tr_session::tr_session(std::string_view config_dir)
     save_timer_->startRepeating(SaveIntervalSecs);
 
     verifier_->addCallback(tr_torrentOnVerifyDone);
+}
+
+void tr_session::addIncoming(tr_address const& addr, tr_port port, struct tr_peer_socket const socket)
+{
+    tr_peerMgrAddIncoming(peerMgr, addr, port, socket);
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2841,3 +2841,10 @@ void tr_session::addIncoming(tr_address const& addr, tr_port port, struct tr_pee
 {
     tr_peerMgrAddIncoming(peerMgr, addr, port, socket);
 }
+
+void tr_session::addTorrent(tr_torrent* tor)
+{
+    tor->unique_id_ = torrents().add(tor);
+
+    tr_peerMgrAddTorrent(peerMgr, tor);
+}

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -242,7 +242,7 @@ void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchRes
 
 void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 {
-    session->web->fetch(std::move(options));
+    session->fetch(std::move(options));
 }
 
 /***
@@ -736,7 +736,7 @@ void tr_session::initImpl(init_data& data)
 
     this->udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this);
 
-    this->web = tr_web::create(this->web_mediator_);
+    this->web_ = tr_web::create(this->web_mediator_);
 
     if (this->allowsLPD())
     {
@@ -1834,7 +1834,7 @@ void tr_session::closeImplStart()
 
     /* and this goes *after* announcer close so that
        it won't be idle until the announce events are sent... */
-    this->web->closeSoon();
+    this->web_->closeSoon();
 
     this->cache.reset();
 
@@ -1903,7 +1903,7 @@ void tr_sessionClose(tr_session* session)
      * so we need to keep the transmission thread alive
      * for a bit while they tell the router & tracker
      * that we're closing now */
-    while ((session->port_forwarding_ || !session->web->isClosed() || session->announcer != nullptr ||
+    while ((session->port_forwarding_ || !session->web_->isClosed() || session->announcer != nullptr ||
             session->announcer_udp != nullptr) &&
            !deadlineReached(deadline))
     {
@@ -1916,7 +1916,7 @@ void tr_sessionClose(tr_session* session)
         tr_wait_msec(50);
     }
 
-    session->web.reset();
+    session->web_.reset();
 
     /* close the libtransmission thread */
     tr_eventClose(session);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -811,6 +811,11 @@ public:
         }
     }
 
+    void fetch(tr_web::FetchOptions options) const
+    {
+        web_->fetch(std::move(options));
+    }
+
 private:
     [[nodiscard]] tr_port randomPort() const;
 
@@ -1036,8 +1041,10 @@ private:
 public:
     std::unique_ptr<Cache> cache = std::make_unique<Cache>(torrents_, 1024 * 1024 * 2);
 
-    std::unique_ptr<tr_web> web;
+private:
+    std::unique_ptr<tr_web> web_;
 
+public:
     std::unique_ptr<tr_lpd> lpd_;
 
     struct tr_announcer* announcer = nullptr;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1047,9 +1047,9 @@ public:
 
     std::unique_ptr<tr_udp_core> udp_core_;
 
-    struct tr_peerMgr* peerMgr = nullptr;
-
 private:
+    struct tr_peerMgr* peer_mgr_ = nullptr;
+
     std::unique_ptr<tr_port_forwarding> port_forwarding_;
 
     tr_torrents torrents_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1044,9 +1044,9 @@ public:
 private:
     std::unique_ptr<tr_web> web_;
 
-public:
     std::unique_ptr<tr_lpd> lpd_;
 
+public:
     struct tr_announcer* announcer = nullptr;
     struct tr_announcer_udp* announcer_udp = nullptr;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -844,6 +844,7 @@ private:
 
     friend bool tr_blocklistExists(tr_session const* session);
     friend bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session);
+    friend bool tr_sessionIsPortForwardingEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCPasswordEnabled(tr_session const* session);
     friend char const* tr_sessionGetRPCPassword(tr_session const* session);
@@ -852,6 +853,7 @@ private:
     friend int tr_sessionGetAntiBruteForceThreshold(tr_session const* session);
     friend size_t tr_blocklistGetRuleCount(tr_session const* session);
     friend size_t tr_blocklistSetContent(tr_session* session, char const* content_filename);
+    friend tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
     friend uint16_t tr_sessionGetPeerPort(tr_session const* session);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
@@ -876,6 +878,7 @@ private:
     friend void tr_sessionSetPeerPort(tr_session* session, uint16_t hport);
     friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetPortForwardingEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, int max_simultaneous_seed_torrents);
     friend void tr_sessionSetQueueStalledEnabled(tr_session* session, bool is_enabled);
@@ -1042,9 +1045,9 @@ public:
 
     struct tr_peerMgr* peerMgr = nullptr;
 
+private:
     std::unique_ptr<tr_port_forwarding> port_forwarding_;
 
-private:
     tr_torrents torrents_;
 
     tr_open_files open_files_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -823,6 +823,8 @@ public:
 
     void addIncoming(tr_address const& addr, tr_port port, struct tr_peer_socket const socket);
 
+    void addTorrent(tr_torrent* tor);
+
 private:
     [[nodiscard]] tr_port randomPort() const;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -816,6 +816,11 @@ public:
         web_->fetch(std::move(options));
     }
 
+    [[nodiscard]] auto const& bandwidthGroups() const noexcept
+    {
+        return bandwidth_groups_;
+    }
+
 private:
     [[nodiscard]] tr_port randomPort() const;
 
@@ -1059,9 +1064,9 @@ public:
     // monitors the "global pool" speeds
     tr_bandwidth top_bandwidth_;
 
+private:
     std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
 
-private:
     std::vector<std::unique_ptr<BlocklistFile>> blocklists_;
 
     std::unique_ptr<tr_rpc_server> rpc_server_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -821,6 +821,8 @@ public:
         return bandwidth_groups_;
     }
 
+    void addIncoming(tr_address const& addr, tr_port port, struct tr_peer_socket const socket);
+
 private:
     [[nodiscard]] tr_port randomPort() const;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -154,7 +154,7 @@ private:
 
         [[nodiscard]] tr_port privatePeerPort() const override
         {
-            return session_.private_peer_port;
+            return session_.private_peer_port_;
         }
 
         [[nodiscard]] libtransmission::TimerMaker& timerMaker() override
@@ -164,8 +164,8 @@ private:
 
         void onPortForwarded(tr_port public_port, tr_port private_port) override
         {
-            session_.public_peer_port = public_port;
-            session_.private_peer_port = private_port;
+            session_.public_peer_port_ = public_port;
+            session_.private_peer_port_ = private_port;
         }
 
     private:
@@ -610,13 +610,10 @@ public:
 
     [[nodiscard]] constexpr tr_port peerPort() const noexcept
     {
-        return public_peer_port;
+        return public_peer_port_;
     }
 
-    constexpr auto setPeerPort(tr_port port) noexcept
-    {
-        public_peer_port = port;
-    }
+    void setPeerPort(tr_port port);
 
     [[nodiscard]] constexpr auto queueEnabled(tr_direction dir) const noexcept
     {
@@ -827,6 +824,8 @@ private:
     void onNowTimer();
 
     friend class libtransmission::test::SessionTest;
+    friend struct tr_bindinfo;
+
     friend bool tr_blocklistExists(tr_session const* session);
     friend bool tr_sessionGetAntiBruteForceEnabled(tr_session const* session);
     friend bool tr_sessionIsRPCEnabled(tr_session const* session);
@@ -838,6 +837,7 @@ private:
     friend size_t tr_blocklistGetRuleCount(tr_session const* session);
     friend size_t tr_blocklistSetContent(tr_session* session, char const* content_filename);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant* client_settings);
+    friend uint16_t tr_sessionGetPeerPort(tr_session const* session);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
     friend uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
     friend void tr_sessionClose(tr_session* session);
@@ -857,6 +857,7 @@ private:
     friend void tr_sessionSetPaused(tr_session* session, bool is_paused);
     friend void tr_sessionSetPeerLimit(tr_session* session, uint16_t max_global_peers);
     friend void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers);
+    friend void tr_sessionSetPeerPort(tr_session* session, uint16_t hport);
     friend void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
     friend void tr_sessionSetPexEnabled(tr_session* session, bool enabled);
     friend void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_seed_torrents);
@@ -938,17 +939,15 @@ private:
 
     tr_preallocation_mode preallocation_mode_ = TR_PREALLOCATE_SPARSE;
 
-public:
     // The open port on the local machine for incoming peer requests
-    tr_port private_peer_port;
+    tr_port private_peer_port_;
 
     // The open port on the public device for incoming peer requests.
     // This is usually the same as private_peer_port but can differ
     // if the public device is a router and it decides to use a different
     // port than the one requested by Transmission.
-    tr_port public_peer_port;
+    tr_port public_peer_port_;
 
-private:
     tr_port random_port_low_;
     tr_port random_port_high_;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -613,8 +613,6 @@ public:
         return public_peer_port_;
     }
 
-    void setPeerPort(tr_port port);
-
     [[nodiscard]] constexpr auto queueEnabled(tr_direction dir) const noexcept
     {
         return queue_enabled_[dir];
@@ -827,6 +825,8 @@ public:
 
 private:
     [[nodiscard]] tr_port randomPort() const;
+
+    void setPeerPort(tr_port port);
 
     void closePeerPort()
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -712,9 +712,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     auto const& labels = tr_ctorGetLabels(ctor);
     tor->setLabels(labels);
 
-    tor->unique_id_ = session->torrents().add(tor);
-
-    tr_peerMgrAddTorrent(session->peerMgr, tor);
+    session->addTorrent(tor);
 
     TR_ASSERT(tor->downloadedCur == 0);
     TR_ASSERT(tor->uploadedCur == 0);

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -99,7 +99,7 @@ static void utp_on_accept(tr_session* const session, UTPSocket* const s)
         return;
     }
 
-    tr_peerMgrAddIncoming(session->peerMgr, &addr, port, tr_peer_socket_utp_create(s));
+    session->addIncoming(addr, port, tr_peer_socket_utp_create(s));
 }
 
 static void utp_send_to(

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -525,7 +525,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     options.range = fmt::format(FMT_STRING("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->id();
     options.buffer = task->content();
-    tor->session->web->fetch(std::move(options));
+    tor->session->fetch(std::move(options));
 }
 
 } // namespace


### PR DESCRIPTION
A followup to #3958.

No functional changes; doesn't fix the crash-on-shutdown problem.

This is an incremental janitorial PR that makes more `tr_session` fields private to reduce coupling.