### PR TITLE
Update to the message log window on macOS

### DIFF
--- a/macosx/MessageWindow.xib
+++ b/macosx/MessageWindow.xib
@@ -85,7 +85,7 @@
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="imageCell:63:image" id="63"/>
+                                            <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" animates="YES" imageAlignment="top" imageScaling="proportionallyDown" image="imageCell:63:image" id="63"/>
                                             <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="Level"/>
                                         </tableColumn>
                                         <tableColumn identifier="Date" editable="NO" width="92" minWidth="40" maxWidth="1000" id="32">
@@ -115,7 +115,7 @@
                                             <sortDescriptor key="sortDescriptorPrototype" selector="localizedStandardCompare:" sortKey="Name"/>
                                             <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                         </tableColumn>
-                                        <tableColumn identifier="Message" editable="NO" width="355" minWidth="10" maxWidth="3.4028229999999999e+38" id="68">
+                                        <tableColumn identifier="Message" editable="NO" width="355" minWidth="200" maxWidth="3.4028229999999999e+38" id="68">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Message">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Fix: #3627 

This commit:
- Set the minimum size of the Message column of the message log window to 200 (previously was 10) to fix #3627
- Align the log level indicator to the top
![image](https://user-images.githubusercontent.com/20237141/195748766-7d5fd28f-3483-41b9-9936-71439bbda0a8.png)
Previously:
![image](https://user-images.githubusercontent.com/20237141/195748897-bbaa8f9f-00bb-42b4-ab76-ac304a19240e.png)
