### PR TITLE
Fix session use after free (GTK client)

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -198,7 +198,7 @@ TorrentModelColumns const torrent_cols;
 Glib::RefPtr<Session> Session::Impl::get_core_ptr() const
 {
     core_.reference();
-    return Glib::RefPtr<Session>(&core_);
+    return Glib::make_refptr_for_instance(&core_);
 }
 
 /***


### PR DESCRIPTION
In GLIB 2.68+ `Glib::RefPtr<>` is an alias for `std::shared_ptr<>` which has no idea about GLIB's reference counting, thus destroying the object instead of unreferencing it. Use `Glib::make_refptr_for_instance()` to construct the smart pointer which passes in a custom reference-aware deleter for us.

Fixes: #3954