### PR TITLE
Remove preprocessor defines from macOS client

### DIFF
--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -9,9 +9,11 @@
 #import "NSStringAdditions.h"
 #import "Torrent.h"
 
-#define POPUP_PRIORITY_HIGH 0
-#define POPUP_PRIORITY_NORMAL 1
-#define POPUP_PRIORITY_LOW 2
+typedef NS_ENUM(NSUInteger, PopupPriority) {
+    PopupPriorityHigh = 0,
+    PopupPriorityNormal = 1,
+    PopupPriorityLow = 2,
+};
 
 @interface AddMagnetWindowController ()
 
@@ -80,21 +82,21 @@
     [self setGroupsMenu];
     [self.fGroupPopUp selectItemWithTag:self.fGroupValue];
 
-    NSInteger priorityIndex;
+    PopupPriority priorityIndex;
     switch (self.torrent.priority)
     {
     case TR_PRI_HIGH:
-        priorityIndex = POPUP_PRIORITY_HIGH;
+        priorityIndex = PopupPriorityHigh;
         break;
     case TR_PRI_NORMAL:
-        priorityIndex = POPUP_PRIORITY_NORMAL;
+        priorityIndex = PopupPriorityNormal;
         break;
     case TR_PRI_LOW:
-        priorityIndex = POPUP_PRIORITY_LOW;
+        priorityIndex = PopupPriorityLow;
         break;
     default:
         NSAssert1(NO, @"Unknown priority for adding torrent: %d", self.torrent.priority);
-        priorityIndex = POPUP_PRIORITY_NORMAL;
+        priorityIndex = PopupPriorityNormal;
     }
     [self.fPriorityPopUp selectItemAtIndex:priorityIndex];
 
@@ -263,13 +265,13 @@
     tr_priority_t priority;
     switch ([sender indexOfSelectedItem])
     {
-    case POPUP_PRIORITY_HIGH:
+    case PopupPriorityHigh:
         priority = TR_PRI_HIGH;
         break;
-    case POPUP_PRIORITY_NORMAL:
+    case PopupPriorityNormal:
         priority = TR_PRI_NORMAL;
         break;
-    case POPUP_PRIORITY_LOW:
+    case PopupPriorityLow:
         priority = TR_PRI_LOW;
         break;
     default:

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -10,11 +10,13 @@
 #import "NSStringAdditions.h"
 #import "Torrent.h"
 
-#define UPDATE_SECONDS 1.0
+static NSTimeInterval const kUpdateSeconds = 1.0;
 
-#define POPUP_PRIORITY_HIGH 0
-#define POPUP_PRIORITY_NORMAL 1
-#define POPUP_PRIORITY_LOW 2
+typedef NS_ENUM(NSUInteger, PopupPriority) {
+    PopupPriorityHigh = 0,
+    PopupPriorityNormal = 1,
+    PopupPriorityLow = 2,
+};
 
 @interface AddWindowController ()
 
@@ -131,21 +133,21 @@
     [self setGroupsMenu];
     [self.fGroupPopUp selectItemWithTag:self.fGroupValue];
 
-    NSInteger priorityIndex;
+    PopupPriority priorityIndex;
     switch (self.torrent.priority)
     {
     case TR_PRI_HIGH:
-        priorityIndex = POPUP_PRIORITY_HIGH;
+        priorityIndex = PopupPriorityHigh;
         break;
     case TR_PRI_NORMAL:
-        priorityIndex = POPUP_PRIORITY_NORMAL;
+        priorityIndex = PopupPriorityNormal;
         break;
     case TR_PRI_LOW:
-        priorityIndex = POPUP_PRIORITY_LOW;
+        priorityIndex = PopupPriorityLow;
         break;
     default:
         NSAssert1(NO, @"Unknown priority for adding torrent: %d", self.torrent.priority);
-        priorityIndex = POPUP_PRIORITY_NORMAL;
+        priorityIndex = PopupPriorityNormal;
     }
     [self.fPriorityPopUp selectItemAtIndex:priorityIndex];
 
@@ -166,7 +168,7 @@
         self.fLocationImageView.image = nil;
     }
 
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_SECONDS target:self selector:@selector(updateFiles)
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateFiles)
                                                  userInfo:nil
                                                   repeats:YES];
     [self updateFiles];
@@ -294,13 +296,13 @@
     tr_priority_t priority;
     switch ([sender indexOfSelectedItem])
     {
-    case POPUP_PRIORITY_HIGH:
+    case PopupPriorityHigh:
         priority = TR_PRI_HIGH;
         break;
-    case POPUP_PRIORITY_NORMAL:
+    case PopupPriorityNormal:
         priority = TR_PRI_NORMAL;
         break;
-    case POPUP_PRIORITY_LOW:
+    case PopupPriorityLow:
         priority = TR_PRI_LOW;
         break;
     default:

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -5,7 +5,7 @@
 #import "BadgeView.h"
 #import "NSStringAdditions.h"
 
-#define BETWEEN_PADDING 2.0
+static CGFloat const kBetweenPadding = 2.0;
 
 @interface BadgeView ()
 
@@ -61,7 +61,7 @@
 
         if (download)
         {
-            bottom += uploadBadge.size.height + BETWEEN_PADDING; //download rate above upload rate
+            bottom += uploadBadge.size.height + kBetweenPadding; //download rate above upload rate
         }
     }
     if (download)

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -6,10 +6,10 @@
 #import "BlocklistDownloader.h"
 
 //thirty second delay before running after option is changed
-#define SMALL_DELAY 30
+static NSTimeInterval const kSmallDelay = 30;
 
 //update one week after previous update
-#define FULL_WAIT (60 * 60 * 24 * 7)
+static NSTimeInterval const kFullWait = 60 * 60 * 24 * 7;
 
 @interface BlocklistScheduler ()
 
@@ -51,9 +51,9 @@ BlocklistScheduler* fScheduler = nil;
     NSDate* lastUpdateDate = [NSUserDefaults.standardUserDefaults objectForKey:@"BlocklistNewLastUpdate"];
     if (lastUpdateDate)
     {
-        lastUpdateDate = [lastUpdateDate dateByAddingTimeInterval:FULL_WAIT];
+        lastUpdateDate = [lastUpdateDate dateByAddingTimeInterval:kFullWait];
     }
-    NSDate* closeDate = [NSDate dateWithTimeIntervalSinceNow:SMALL_DELAY];
+    NSDate* closeDate = [NSDate dateWithTimeIntervalSinceNow:kSmallDelay];
 
     NSDate* useDate = lastUpdateDate ? [lastUpdateDate laterDate:closeDate] : closeDate;
 

--- a/macosx/BonjourController.mm
+++ b/macosx/BonjourController.mm
@@ -4,7 +4,7 @@
 
 #import "BonjourController.h"
 
-#define BONJOUR_SERVICE_NAME_MAX_LENGTH 63
+static NSUInteger const kBonjourServiceNameMaxLength = 63;
 
 @interface BonjourController ()
 
@@ -37,9 +37,9 @@ BonjourController* fDefaultController = nil;
 
     NSMutableString* serviceName = [NSMutableString
         stringWithFormat:@"Transmission (%@ - %@)", NSUserName(), [NSHost currentHost].localizedName];
-    if (serviceName.length > BONJOUR_SERVICE_NAME_MAX_LENGTH)
+    if (serviceName.length > kBonjourServiceNameMaxLength)
     {
-        [serviceName deleteCharactersInRange:NSMakeRange(BONJOUR_SERVICE_NAME_MAX_LENGTH, serviceName.length - BONJOUR_SERVICE_NAME_MAX_LENGTH)];
+        [serviceName deleteCharactersInRange:NSMakeRange(kBonjourServiceNameMaxLength, serviceName.length - kBonjourServiceNameMaxLength)];
     }
 
     self.fService = [[NSNetService alloc] initWithDomain:@"" type:@"_http._tcp." name:serviceName port:port];

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -55,34 +55,38 @@
 #import "ExpandedPathToPathTransformer.h"
 #import "ExpandedPathToIconTransformer.h"
 
-#define TOOLBAR_CREATE @"Toolbar Create"
-#define TOOLBAR_OPEN_FILE @"Toolbar Open"
-#define TOOLBAR_OPEN_WEB @"Toolbar Open Web"
-#define TOOLBAR_REMOVE @"Toolbar Remove"
-#define TOOLBAR_INFO @"Toolbar Info"
-#define TOOLBAR_PAUSE_ALL @"Toolbar Pause All"
-#define TOOLBAR_RESUME_ALL @"Toolbar Resume All"
-#define TOOLBAR_PAUSE_RESUME_ALL @"Toolbar Pause / Resume All"
-#define TOOLBAR_PAUSE_SELECTED @"Toolbar Pause Selected"
-#define TOOLBAR_RESUME_SELECTED @"Toolbar Resume Selected"
-#define TOOLBAR_PAUSE_RESUME_SELECTED @"Toolbar Pause / Resume Selected"
-#define TOOLBAR_FILTER @"Toolbar Toggle Filter"
-#define TOOLBAR_QUICKLOOK @"Toolbar QuickLook"
-#define TOOLBAR_SHARE @"Toolbar Share"
+typedef NSString* ToolbarItemIdentifier NS_TYPED_EXTENSIBLE_ENUM;
+
+static ToolbarItemIdentifier const ToolbarItemIdentifierCreate = @"Toolbar Create";
+static ToolbarItemIdentifier const ToolbarItemIdentifierOpenFile = @"Toolbar Open";
+static ToolbarItemIdentifier const ToolbarItemIdentifierOpenWeb = @"Toolbar Open Web";
+static ToolbarItemIdentifier const ToolbarItemIdentifierRemove = @"Toolbar Remove";
+static ToolbarItemIdentifier const ToolbarItemIdentifierInfo = @"Toolbar Info";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseAll = @"Toolbar Pause All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierResumeAll = @"Toolbar Resume All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeAll = @"Toolbar Pause / Resume All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseSelected = @"Toolbar Pause Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierResumeSelected = @"Toolbar Resume Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeSelected = @"Toolbar Pause / Resume Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierFilter = @"Toolbar Toggle Filter";
+static ToolbarItemIdentifier const ToolbarItemIdentifierQuickLook = @"Toolbar QuickLook";
+static ToolbarItemIdentifier const ToolbarItemIdentifierShare = @"Toolbar Share";
 
 typedef NS_ENUM(unsigned int, toolbarGroupTag) { //
     TOOLBAR_PAUSE_TAG = 0,
     TOOLBAR_RESUME_TAG = 1
 };
 
-#define SORT_DATE @"Date"
-#define SORT_NAME @"Name"
-#define SORT_STATE @"State"
-#define SORT_PROGRESS @"Progress"
-#define SORT_TRACKER @"Tracker"
-#define SORT_ORDER @"Order"
-#define SORT_ACTIVITY @"Activity"
-#define SORT_SIZE @"Size"
+typedef NSString* SortType NS_TYPED_EXTENSIBLE_ENUM;
+
+static SortType const SortTypeDate = @"Date";
+static SortType const SortTypeName = @"Name";
+static SortType const SortTypeState = @"State";
+static SortType const SortTypeProgress = @"Progress";
+static SortType const SortTypeTracker = @"Tracker";
+static SortType const SortTypeOrder = @"Order";
+static SortType const SortTypeActivity = @"Activity";
+static SortType const SortTypeSize = @"Size";
 
 typedef NS_ENUM(unsigned int, sortTag) {
     SORT_ORDER_TAG = 0,
@@ -100,25 +104,25 @@ typedef NS_ENUM(unsigned int, sortOrderTag) { //
     SORT_DESC_TAG = 1
 };
 
-#define TORRENT_TABLE_VIEW_DATA_TYPE @"TorrentTableViewDataType"
+static NSString* const kTorrentTableViewDataType = @"TorrentTableViewDataType";
 
-#define ROW_HEIGHT_REGULAR 62.0
-#define ROW_HEIGHT_SMALL 22.0
+static CGFloat const kRowHeightRegular = 62.0;
+static CGFloat const kRowHeightSmall = 22.0;
 
-#define STATUS_BAR_HEIGHT 21.0
-#define FILTER_BAR_HEIGHT 23.0
-#define BOTTOM_BAR_HEIGHT 24.0
+static CGFloat const kStatusBarHeight = 21.0;
+static CGFloat const kFilterBarHeight = 23.0;
+static CGFloat const kBottomBarHeight = 24.0;
 
-#define UPDATE_UI_SECONDS 1.0
+static NSTimeInterval const kUpdateUISeconds = 1.0;
 
-#define TRANSFER_PLIST @"Transfers.plist"
+static NSString* const kTransferPlist = @"Transfers.plist";
 
-#define WEBSITE_URL @"https://transmissionbt.com/"
-#define FORUM_URL @"https://forum.transmissionbt.com/"
-#define GITHUB_URL @"https://github.com/transmission/transmission"
-#define DONATE_URL @"https://transmissionbt.com/donate/"
+static NSString* const kWebsiteURL = @"https://transmissionbt.com/";
+static NSString* const kForumURL = @"https://forum.transmissionbt.com/";
+static NSString* const kGithubURL = @"https://github.com/transmission/transmission";
+static NSString* const kDonateURL = @"https://transmissionbt.com/donate/";
 
-#define DONATE_NAG_TIME (60 * 60 * 24 * 7)
+static NSTimeInterval const kDonateNagTime = 60 * 60 * 24 * 7;
 
 static void altSpeedToggledCallback([[maybe_unused]] tr_session* handle, bool active, bool byUser, void* controller)
 {
@@ -641,7 +645,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     BOOL const small = [self.fDefaults boolForKey:@"SmallView"];
     if (small)
     {
-        self.fTableView.rowHeight = ROW_HEIGHT_SMALL;
+        self.fTableView.rowHeight = kRowHeightSmall;
     }
     self.fTableView.usesAlternatingRowBackgroundColors = !small;
 
@@ -659,7 +663,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         @"Remove all transfers that have completed seeding.",
         "Main window -> 3rd bottom left button (remove all) tooltip");
 
-    [self.fTableView registerForDraggedTypes:@[ TORRENT_TABLE_VIEW_DATA_TYPE ]];
+    [self.fTableView registerForDraggedTypes:@[ kTorrentTableViewDataType ]];
     [self.fWindow registerForDraggedTypes:@[ NSFilenamesPboardType, NSURLPboardType ]];
 
     //sort the sort menu items (localization is from strings file)
@@ -735,7 +739,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
     //update previous transfers state by recreating a torrent from history
     //and comparing to torrents already loaded via tr_sessionLoadTorrents
-    NSString* historyFile = [self.fConfigDirectory stringByAppendingPathComponent:TRANSFER_PLIST];
+    NSString* historyFile = [self.fConfigDirectory stringByAppendingPathComponent:kTransferPlist];
     NSArray* history = [NSArray arrayWithContentsOfFile:historyFile];
     if (!history)
     {
@@ -825,8 +829,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
     //timer to update the interface every second
     [self updateUI];
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_UI_SECONDS target:self selector:@selector(updateUI)
-                                                 userInfo:nil
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds target:self selector:@selector(updateUI) userInfo:nil
                                                   repeats:YES];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSEventTrackingRunLoopMode];
@@ -873,7 +876,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         BOOL const firstLaunch = tr_sessionGetCumulativeStats(self.fLib).sessionCount <= 1;
 
         NSDate* lastDonateDate = [self.fDefaults objectForKey:@"DonateAskDate"];
-        BOOL const timePassed = !lastDonateDate || (-1 * lastDonateDate.timeIntervalSinceNow) >= DONATE_NAG_TIME;
+        BOOL const timePassed = !lastDonateDate || (-1 * lastDonateDate.timeIntervalSinceNow) >= kDonateNagTime;
 
         if (!firstLaunch && timePassed)
         {
@@ -2560,40 +2563,40 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         self.fTorrentHashes[torrent.hashString] = torrent;
     }
 
-    NSString* historyFile = [self.fConfigDirectory stringByAppendingPathComponent:TRANSFER_PLIST];
+    NSString* historyFile = [self.fConfigDirectory stringByAppendingPathComponent:kTransferPlist];
     [history writeToFile:historyFile atomically:YES];
 }
 
 - (void)setSort:(id)sender
 {
-    NSString* sortType;
+    SortType sortType;
     NSMenuItem* senderMenuItem = sender;
     switch (senderMenuItem.tag)
     {
     case SORT_ORDER_TAG:
-        sortType = SORT_ORDER;
+        sortType = SortTypeOrder;
         [self.fDefaults setBool:NO forKey:@"SortReverse"];
         break;
     case SORT_DATE_TAG:
-        sortType = SORT_DATE;
+        sortType = SortTypeDate;
         break;
     case SORT_NAME_TAG:
-        sortType = SORT_NAME;
+        sortType = SortTypeName;
         break;
     case SORT_PROGRESS_TAG:
-        sortType = SORT_PROGRESS;
+        sortType = SortTypeProgress;
         break;
     case SORT_STATE_TAG:
-        sortType = SORT_STATE;
+        sortType = SortTypeState;
         break;
     case SORT_TRACKER_TAG:
-        sortType = SORT_TRACKER;
+        sortType = SortTypeTracker;
         break;
     case SORT_ACTIVITY_TAG:
-        sortType = SORT_ACTIVITY;
+        sortType = SortTypeActivity;
         break;
     case SORT_SIZE_TAG:
-        sortType = SORT_SIZE;
+        sortType = SortTypeSize;
         break;
     default:
         NSAssert1(NO, @"Unknown sort tag received: %ld", senderMenuItem.tag);
@@ -2639,7 +2642,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                                                                       selector:@selector(localizedStandardCompare:)];
 
     NSString* sortType = [self.fDefaults stringForKey:@"Sort"];
-    if ([sortType isEqualToString:SORT_STATE])
+    if ([sortType isEqualToString:SortTypeState])
     {
         NSSortDescriptor* stateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"stateSortKey" ascending:!asc];
         NSSortDescriptor* progressDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"progress" ascending:!asc];
@@ -2647,7 +2650,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         descriptors = @[ stateDescriptor, progressDescriptor, ratioDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_PROGRESS])
+    else if ([sortType isEqualToString:SortTypeProgress])
     {
         NSSortDescriptor* progressDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"progress" ascending:asc];
         NSSortDescriptor* ratioProgressDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"progressStopRatio" ascending:asc];
@@ -2655,39 +2658,39 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         descriptors = @[ progressDescriptor, ratioProgressDescriptor, ratioDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_TRACKER])
+    else if ([sortType isEqualToString:SortTypeTracker])
     {
         NSSortDescriptor* trackerDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"trackerSortKey" ascending:asc
                                                                              selector:@selector(localizedCaseInsensitiveCompare:)];
 
         descriptors = @[ trackerDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_ACTIVITY])
+    else if ([sortType isEqualToString:SortTypeActivity])
     {
         NSSortDescriptor* rateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"totalRate" ascending:asc];
         NSSortDescriptor* activityDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateActivityOrAdd" ascending:asc];
 
         descriptors = @[ rateDescriptor, activityDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_DATE])
+    else if ([sortType isEqualToString:SortTypeDate])
     {
         NSSortDescriptor* dateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateAdded" ascending:asc];
 
         descriptors = @[ dateDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_SIZE])
+    else if ([sortType isEqualToString:SortTypeSize])
     {
         NSSortDescriptor* sizeDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"size" ascending:asc];
 
         descriptors = @[ sizeDescriptor, nameDescriptor ];
     }
-    else if ([sortType isEqualToString:SORT_NAME])
+    else if ([sortType isEqualToString:SortTypeName])
     {
         descriptors = @[ nameDescriptor ];
     }
     else
     {
-        NSAssert1([sortType isEqualToString:SORT_ORDER], @"Unknown sort type received: %@", sortType);
+        NSAssert1([sortType isEqualToString:SortTypeOrder], @"Unknown sort type received: %@", sortType);
 
         if (!includeQueueOrder)
         {
@@ -2772,23 +2775,23 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 {
     NSString* filterType = [self.fDefaults stringForKey:@"Filter"];
     BOOL filterActive = NO, filterDownload = NO, filterSeed = NO, filterPause = NO, filterError = NO, filterStatus = YES;
-    if ([filterType isEqualToString:FILTER_ACTIVE])
+    if ([filterType isEqualToString:FilterTypeActive])
     {
         filterActive = YES;
     }
-    else if ([filterType isEqualToString:FILTER_DOWNLOAD])
+    else if ([filterType isEqualToString:FilterTypeDownload])
     {
         filterDownload = YES;
     }
-    else if ([filterType isEqualToString:FILTER_SEED])
+    else if ([filterType isEqualToString:FilterTypeSeed])
     {
         filterSeed = YES;
     }
-    else if ([filterType isEqualToString:FILTER_PAUSE])
+    else if ([filterType isEqualToString:FilterTypePause])
     {
         filterPause = YES;
     }
-    else if ([filterType isEqualToString:FILTER_ERROR])
+    else if ([filterType isEqualToString:FilterTypeError])
     {
         filterError = YES;
     }
@@ -2798,14 +2801,14 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 
     NSInteger const groupFilterValue = [self.fDefaults integerForKey:@"FilterGroup"];
-    BOOL const filterGroup = groupFilterValue != GROUP_FILTER_ALL_TAG;
+    BOOL const filterGroup = groupFilterValue != kGroupFilterAllTag;
 
     NSArray* searchStrings = self.fFilterBar.searchStrings;
     if (searchStrings && searchStrings.count == 0)
     {
         searchStrings = nil;
     }
-    BOOL const filterTracker = searchStrings && [[self.fDefaults stringForKey:@"FilterSearchType"] isEqualToString:FILTER_TYPE_TRACKER];
+    BOOL const filterTracker = searchStrings && [[self.fDefaults stringForKey:@"FilterSearchType"] isEqualToString:FilterSearchTypeTracker];
 
     std::atomic<int32_t> active{ 0 }, downloading{ 0 }, seeding{ 0 }, paused{ 0 }, error{ 0 };
     // Pointers to be captured by Obj-C Block as const*
@@ -3570,7 +3573,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 - (BOOL)outlineView:(NSOutlineView*)outlineView writeItems:(NSArray*)items toPasteboard:(NSPasteboard*)pasteboard
 {
     //only allow reordering of rows if sorting by order
-    if ([self.fDefaults boolForKey:@"SortByGroup"] || [[self.fDefaults stringForKey:@"Sort"] isEqualToString:SORT_ORDER])
+    if ([self.fDefaults boolForKey:@"SortByGroup"] || [[self.fDefaults stringForKey:@"Sort"] isEqualToString:SortTypeOrder])
     {
         NSMutableIndexSet* indexSet = [NSMutableIndexSet indexSet];
         for (id torrent in items)
@@ -3583,8 +3586,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             [indexSet addIndex:[self.fTableView rowForItem:torrent]];
         }
 
-        [pasteboard declareTypes:@[ TORRENT_TABLE_VIEW_DATA_TYPE ] owner:self];
-        [pasteboard setData:[NSKeyedArchiver archivedDataWithRootObject:indexSet] forType:TORRENT_TABLE_VIEW_DATA_TYPE];
+        [pasteboard declareTypes:@[ kTorrentTableViewDataType ] owner:self];
+        [pasteboard setData:[NSKeyedArchiver archivedDataWithRootObject:indexSet] forType:kTorrentTableViewDataType];
         return YES;
     }
     return NO;
@@ -3596,7 +3599,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             proposedChildIndex:(NSInteger)index
 {
     NSPasteboard* pasteboard = info.draggingPasteboard;
-    if ([pasteboard.types containsObject:TORRENT_TABLE_VIEW_DATA_TYPE])
+    if ([pasteboard.types containsObject:kTorrentTableViewDataType])
     {
         if ([self.fDefaults boolForKey:@"SortByGroup"])
         {
@@ -3605,7 +3608,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                 return NSDragOperationNone;
             }
 
-            if ([[self.fDefaults stringForKey:@"Sort"] isEqualToString:SORT_ORDER])
+            if ([[self.fDefaults stringForKey:@"Sort"] isEqualToString:SortTypeOrder])
             {
                 if ([item isKindOfClass:[Torrent class]])
                 {
@@ -3647,9 +3650,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 - (BOOL)outlineView:(NSOutlineView*)outlineView acceptDrop:(id<NSDraggingInfo>)info item:(id)item childIndex:(NSInteger)newRow
 {
     NSPasteboard* pasteboard = info.draggingPasteboard;
-    if ([pasteboard.types containsObject:TORRENT_TABLE_VIEW_DATA_TYPE])
+    if ([pasteboard.types containsObject:kTorrentTableViewDataType])
     {
-        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:TORRENT_TABLE_VIEW_DATA_TYPE]
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:kTorrentTableViewDataType]
                                                                    error:nil];
 
         //get the torrents to move
@@ -3882,7 +3885,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
     self.fTableView.usesAlternatingRowBackgroundColors = !makeSmall;
 
-    self.fTableView.rowHeight = makeSmall ? ROW_HEIGHT_SMALL : ROW_HEIGHT_REGULAR;
+    self.fTableView.rowHeight = makeSmall ? kRowHeightSmall : kRowHeightRegular;
 
     [self.fTableView beginUpdates];
     [self.fTableView
@@ -4093,7 +4096,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (NSToolbarItem*)toolbar:(NSToolbar*)toolbar itemForItemIdentifier:(NSString*)ident willBeInsertedIntoToolbar:(BOOL)flag
 {
-    if ([ident isEqualToString:TOOLBAR_CREATE])
+    if ([ident isEqualToString:ToolbarItemIdentifierCreate])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
 
@@ -4107,7 +4110,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_OPEN_FILE])
+    else if ([ident isEqualToString:ToolbarItemIdentifierOpenFile])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
 
@@ -4121,7 +4124,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_OPEN_WEB])
+    else if ([ident isEqualToString:ToolbarItemIdentifierOpenWeb])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
 
@@ -4135,7 +4138,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_REMOVE])
+    else if ([ident isEqualToString:ToolbarItemIdentifierRemove])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
 
@@ -4149,7 +4152,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_INFO])
+    else if ([ident isEqualToString:ToolbarItemIdentifierInfo])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
         ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
@@ -4163,12 +4166,12 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_PAUSE_RESUME_ALL])
+    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeAll])
     {
         GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
 
-        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:TOOLBAR_PAUSE_ALL];
-        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:TOOLBAR_RESUME_ALL];
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseAll];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeAll];
 
         NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
         segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
@@ -4213,12 +4216,12 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return groupItem;
     }
-    else if ([ident isEqualToString:TOOLBAR_PAUSE_RESUME_SELECTED])
+    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeSelected])
     {
         GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
 
-        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:TOOLBAR_PAUSE_SELECTED];
-        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:TOOLBAR_RESUME_SELECTED];
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseSelected];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeSelected];
 
         NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
         segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
@@ -4264,7 +4267,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return groupItem;
     }
-    else if ([ident isEqualToString:TOOLBAR_FILTER])
+    else if ([ident isEqualToString:ToolbarItemIdentifierFilter])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
         ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
@@ -4278,7 +4281,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_QUICKLOOK])
+    else if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
     {
         ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
         ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
@@ -4293,7 +4296,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         return item;
     }
-    else if ([ident isEqualToString:TOOLBAR_SHARE])
+    else if ([ident isEqualToString:ToolbarItemIdentifierShare])
     {
         ShareToolbarItem* item = [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ShareToolbarItem class]];
 
@@ -4349,16 +4352,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 - (NSArray*)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
 {
     return @[
-        TOOLBAR_CREATE,
-        TOOLBAR_OPEN_FILE,
-        TOOLBAR_OPEN_WEB,
-        TOOLBAR_REMOVE,
-        TOOLBAR_PAUSE_RESUME_SELECTED,
-        TOOLBAR_PAUSE_RESUME_ALL,
-        TOOLBAR_SHARE,
-        TOOLBAR_QUICKLOOK,
-        TOOLBAR_FILTER,
-        TOOLBAR_INFO,
+        ToolbarItemIdentifierCreate,
+        ToolbarItemIdentifierOpenFile,
+        ToolbarItemIdentifierOpenWeb,
+        ToolbarItemIdentifierRemove,
+        ToolbarItemIdentifierPauseResumeSelected,
+        ToolbarItemIdentifierResumeAll,
+        ToolbarItemIdentifierShare,
+        ToolbarItemIdentifierQuickLook,
+        ToolbarItemIdentifierFilter,
+        ToolbarItemIdentifierInfo,
         NSToolbarSpaceItemIdentifier,
         NSToolbarFlexibleSpaceItemIdentifier
     ];
@@ -4367,16 +4370,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 - (NSArray*)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar
 {
     return @[
-        TOOLBAR_CREATE,
-        TOOLBAR_OPEN_FILE,
-        TOOLBAR_REMOVE,
+        ToolbarItemIdentifierCreate,
+        ToolbarItemIdentifierOpenFile,
+        ToolbarItemIdentifierRemove,
         NSToolbarSpaceItemIdentifier,
-        TOOLBAR_PAUSE_RESUME_ALL,
+        ToolbarItemIdentifierPauseResumeAll,
         NSToolbarFlexibleSpaceItemIdentifier,
-        TOOLBAR_SHARE,
-        TOOLBAR_QUICKLOOK,
-        TOOLBAR_FILTER,
-        TOOLBAR_INFO
+        ToolbarItemIdentifierShare,
+        ToolbarItemIdentifierQuickLook,
+        ToolbarItemIdentifierFilter,
+        ToolbarItemIdentifierInfo,
     ];
 }
 
@@ -4385,13 +4388,13 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     NSString* ident = toolbarItem.itemIdentifier;
 
     //enable remove item
-    if ([ident isEqualToString:TOOLBAR_REMOVE])
+    if ([ident isEqualToString:ToolbarItemIdentifierRemove])
     {
         return self.fTableView.numberOfSelectedRows > 0;
     }
 
     //enable pause all item
-    if ([ident isEqualToString:TOOLBAR_PAUSE_ALL])
+    if ([ident isEqualToString:ToolbarItemIdentifierPauseAll])
     {
         for (Torrent* torrent in self.fTorrents)
         {
@@ -4404,7 +4407,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 
     //enable resume all item
-    if ([ident isEqualToString:TOOLBAR_RESUME_ALL])
+    if ([ident isEqualToString:ToolbarItemIdentifierResumeAll])
     {
         for (Torrent* torrent in self.fTorrents)
         {
@@ -4417,7 +4420,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 
     //enable pause item
-    if ([ident isEqualToString:TOOLBAR_PAUSE_SELECTED])
+    if ([ident isEqualToString:ToolbarItemIdentifierPauseSelected])
     {
         for (Torrent* torrent in self.fTableView.selectedTorrents)
         {
@@ -4430,7 +4433,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 
     //enable resume item
-    if ([ident isEqualToString:TOOLBAR_RESUME_SELECTED])
+    if ([ident isEqualToString:ToolbarItemIdentifierResumeSelected])
     {
         for (Torrent* torrent in self.fTableView.selectedTorrents)
         {
@@ -4443,28 +4446,28 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 
     //set info item
-    if ([ident isEqualToString:TOOLBAR_INFO])
+    if ([ident isEqualToString:ToolbarItemIdentifierInfo])
     {
         ((NSButton*)toolbarItem.view).state = self.fInfoController.window.visible;
         return YES;
     }
 
     //set filter item
-    if ([ident isEqualToString:TOOLBAR_FILTER])
+    if ([ident isEqualToString:ToolbarItemIdentifierFilter])
     {
         ((NSButton*)toolbarItem.view).state = self.fFilterBar != nil;
         return YES;
     }
 
     //set quick look item
-    if ([ident isEqualToString:TOOLBAR_QUICKLOOK])
+    if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
     {
         ((NSButton*)toolbarItem.view).state = self.fPreviewPanel != nil;
         return self.fTableView.numberOfSelectedRows > 0;
     }
 
     //enable share item
-    if ([ident isEqualToString:TOOLBAR_SHARE])
+    if ([ident isEqualToString:ToolbarItemIdentifierShare])
     {
         return self.fTableView.numberOfSelectedRows > 0;
     }
@@ -4494,36 +4497,36 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     //enable sort options
     if (action == @selector(setSort:))
     {
-        NSString* sortType;
+        SortType sortType;
         switch (menuItem.tag)
         {
         case SORT_ORDER_TAG:
-            sortType = SORT_ORDER;
+            sortType = SortTypeOrder;
             break;
         case SORT_DATE_TAG:
-            sortType = SORT_DATE;
+            sortType = SortTypeDate;
             break;
         case SORT_NAME_TAG:
-            sortType = SORT_NAME;
+            sortType = SortTypeName;
             break;
         case SORT_PROGRESS_TAG:
-            sortType = SORT_PROGRESS;
+            sortType = SortTypeProgress;
             break;
         case SORT_STATE_TAG:
-            sortType = SORT_STATE;
+            sortType = SortTypeState;
             break;
         case SORT_TRACKER_TAG:
-            sortType = SORT_TRACKER;
+            sortType = SortTypeTracker;
             break;
         case SORT_ACTIVITY_TAG:
-            sortType = SORT_ACTIVITY;
+            sortType = SortTypeActivity;
             break;
         case SORT_SIZE_TAG:
-            sortType = SORT_SIZE;
+            sortType = SortTypeSize;
             break;
         default:
             NSAssert1(NO, @"Unknown sort tag received: %ld", [menuItem tag]);
-            sortType = SORT_ORDER;
+            sortType = SortTypeOrder;
         }
 
         menuItem.state = [sortType isEqualToString:[self.fDefaults stringForKey:@"Sort"]] ? NSControlStateValueOn : NSControlStateValueOff;
@@ -4856,7 +4859,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         BOOL const isReverse = menuItem.tag == SORT_DESC_TAG;
         menuItem.state = (isReverse == [self.fDefaults boolForKey:@"SortReverse"]) ? NSControlStateValueOn : NSControlStateValueOff;
-        return ![[self.fDefaults stringForKey:@"Sort"] isEqualToString:SORT_ORDER];
+        return ![[self.fDefaults stringForKey:@"Sort"] isEqualToString:SortTypeOrder];
     }
 
     //enable group sort item
@@ -5157,15 +5160,15 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (CGFloat)mainWindowComponentHeight
 {
-    CGFloat height = BOTTOM_BAR_HEIGHT;
+    CGFloat height = kBottomBarHeight;
     if (self.fStatusBar)
     {
-        height += STATUS_BAR_HEIGHT;
+        height += kStatusBarHeight;
     }
 
     if (self.fFilterBar)
     {
-        height += FILTER_BAR_HEIGHT;
+        height += kFilterBarHeight;
     }
 
     return height;
@@ -5182,7 +5185,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             self.fDisplayedTorrents.count :
             0;
 
-        height = (GROUP_SEPARATOR_HEIGHT + self.fTableView.intercellSpacing.height) * groups +
+        height = (kGroupSeparatorHeight + self.fTableView.intercellSpacing.height) * groups +
             (self.fTableView.rowHeight + self.fTableView.intercellSpacing.height) * (self.fTableView.numberOfRows - groups);
     }
     else
@@ -5267,22 +5270,22 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)linkHomepage:(id)sender
 {
-    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:WEBSITE_URL]];
+    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:kWebsiteURL]];
 }
 
 - (void)linkForums:(id)sender
 {
-    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:FORUM_URL]];
+    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:kForumURL]];
 }
 
 - (void)linkGitHub:(id)sender
 {
-    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:GITHUB_URL]];
+    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:kGithubURL]];
 }
 
 - (void)linkDonate:(id)sender
 {
-    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:DONATE_URL]];
+    [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:kDonateURL]];
 }
 
 - (void)updaterWillRelaunchApplication:(SUUpdater*)updater

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -19,8 +19,10 @@
 #import "Controller.h"
 #import "NSStringAdditions.h"
 
-#define TRACKER_ADD_TAG 0
-#define TRACKER_REMOVE_TAG 1
+typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
+    TrackerSegmentTagAdd = 0,
+    TrackerSegmentTagRemove = 1,
+};
 
 @interface CreatorWindowController ()
 
@@ -390,7 +392,7 @@ NSMutableSet* creatorWindowControllerSet = nil;
         return;
     }
 
-    if ([[sender cell] tagForSegment:[sender selectedSegment]] == TRACKER_REMOVE_TAG)
+    if ([[sender cell] tagForSegment:[sender selectedSegment]] == TrackerSegmentTagRemove)
     {
         [self.fTrackers removeObjectsAtIndexes:self.fTrackerTable.selectedRowIndexes];
 
@@ -438,7 +440,7 @@ NSMutableSet* creatorWindowControllerSet = nil;
 
 - (void)tableViewSelectionDidChange:(NSNotification*)notification
 {
-    [self.fTrackerAddRemoveControl setEnabled:self.fTrackerTable.numberOfSelectedRows > 0 forSegment:TRACKER_REMOVE_TAG];
+    [self.fTrackerAddRemoveControl setEnabled:self.fTrackerTable.numberOfSelectedRows > 0 forSegment:TrackerSegmentTagRemove];
 }
 
 - (void)copy:(id)sender

--- a/macosx/DragOverlayView.mm
+++ b/macosx/DragOverlayView.mm
@@ -4,8 +4,8 @@
 
 #import "DragOverlayView.h"
 
-#define PADDING 10.0
-#define ICON_WIDTH 64.0
+static CGFloat const kPadding = 10.0;
+static CGFloat const kIconWidth = 64.0;
 
 @interface DragOverlayView ()
 
@@ -62,7 +62,7 @@
     [bp fill];
 
     //place icon
-    [icon drawInRect:NSMakeRect(PADDING, (NSHeight(badgeRect) - ICON_WIDTH) * 0.5, ICON_WIDTH, ICON_WIDTH) fromRect:NSZeroRect
+    [icon drawInRect:NSMakeRect(kPadding, (NSHeight(badgeRect) - kIconWidth) * 0.5, kIconWidth, kIconWidth) fromRect:NSZeroRect
            operation:NSCompositingOperationSourceOver
             fraction:1.0];
 
@@ -71,9 +71,9 @@
     NSSize const subLineSize = [subLine sizeWithAttributes:self.fSubLineAttributes];
 
     NSRect lineRect = NSMakeRect(
-        PADDING + ICON_WIDTH + 5.0,
+        kPadding + kIconWidth + 5.0,
         (NSHeight(badgeRect) + (subLineSize.height + 2.0 - mainLineSize.height)) * 0.5,
-        NSWidth(badgeRect) - (PADDING + ICON_WIDTH + 2.0) - PADDING,
+        NSWidth(badgeRect) - (kPadding + kIconWidth + 2.0) - kPadding,
         mainLineSize.height);
     [mainLine drawInRect:lineRect withAttributes:self.fMainLineAttributes];
 

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -11,14 +11,14 @@
 #import "FileListNode.h"
 #import "NSStringAdditions.h"
 
-#define PADDING_HORIZONTAL 2.0
-#define IMAGE_FOLDER_SIZE 16.0
-#define IMAGE_ICON_SIZE 32.0
-#define PADDING_BETWEEN_IMAGE_AND_TITLE 4.0
-#define PADDING_ABOVE_TITLE_FILE 2.0
-#define PADDING_BELOW_STATUS_FILE 2.0
-#define PADDING_BETWEEN_NAME_AND_FOLDER_STATUS 4.0
-#define PADDING_EXPANSION_FRAME 2.0
+static CGFloat const kPaddingHorizontal = 2.0;
+static CGFloat const kImageFolderSize = 16.0;
+static CGFloat const kImageIconSize = 32.0;
+static CGFloat const kPaddingBetweenImageAndTitle = 4.0;
+static CGFloat const kPaddingAboveTitleFile = 2.0;
+static CGFloat const kPaddingBelowStatusFile = 2.0;
+static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
+static CGFloat const kPaddingExpansionFrame = 2.0;
 
 @interface FileNameCell ()
 
@@ -73,9 +73,9 @@
 {
     NSRect result = bounds;
 
-    result.origin.x += PADDING_HORIZONTAL;
+    result.origin.x += kPaddingHorizontal;
 
-    CGFloat const IMAGE_SIZE = ((FileListNode*)self.objectValue).isFolder ? IMAGE_FOLDER_SIZE : IMAGE_ICON_SIZE;
+    CGFloat const IMAGE_SIZE = ((FileListNode*)self.objectValue).isFolder ? kImageFolderSize : kImageIconSize;
     result.origin.y += (result.size.height - IMAGE_SIZE) * 0.5;
     result.size = NSMakeSize(IMAGE_SIZE, IMAGE_SIZE);
 
@@ -129,7 +129,7 @@
         NSMouseInRect([view convertPoint:view.window.mouseLocationOutsideOfEventStream fromView:nil], realRect, view.flipped))
     {
         realRect.size.width = [titleString size].width;
-        return NSInsetRect(realRect, -PADDING_EXPANSION_FRAME, -PADDING_EXPANSION_FRAME);
+        return NSInsetRect(realRect, -kPaddingExpansionFrame, -kPaddingExpansionFrame);
     }
 
     return NSZeroRect;
@@ -137,8 +137,8 @@
 
 - (void)drawWithExpansionFrame:(NSRect)cellFrame inView:(NSView*)view
 {
-    cellFrame.origin.x += PADDING_EXPANSION_FRAME;
-    cellFrame.origin.y += PADDING_EXPANSION_FRAME;
+    cellFrame.origin.x += kPaddingExpansionFrame;
+    cellFrame.origin.y += kPaddingExpansionFrame;
 
     self.fTitleAttributes[NSForegroundColorAttributeName] = NSColor.controlTextColor;
     NSAttributedString* titleString = self.attributedTitle;
@@ -155,13 +155,13 @@
     NSRect result;
     if (!((FileListNode*)self.objectValue).isFolder)
     {
-        result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + IMAGE_ICON_SIZE + PADDING_BETWEEN_IMAGE_AND_TITLE;
-        result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE_FILE;
+        result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kImageIconSize + kPaddingBetweenImageAndTitle;
+        result.origin.y = NSMinY(bounds) + kPaddingAboveTitleFile;
         result.size.width = NSMaxX(bounds) - NSMinX(result);
     }
     else
     {
-        result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + IMAGE_FOLDER_SIZE + PADDING_BETWEEN_IMAGE_AND_TITLE;
+        result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kImageFolderSize + kPaddingBetweenImageAndTitle;
         result.origin.y = NSMidY(bounds) - titleSize.height * 0.5;
         result.size.width = MIN(titleSize.width, NSMaxX(bounds) - NSMinX(result));
     }
@@ -178,12 +178,12 @@
     if (!((FileListNode*)self.objectValue).isFolder)
     {
         result.origin.x = NSMinX(titleRect);
-        result.origin.y = NSMaxY(bounds) - PADDING_BELOW_STATUS_FILE - statusSize.height;
+        result.origin.y = NSMaxY(bounds) - kPaddingBelowStatusFile - statusSize.height;
         result.size.width = NSWidth(titleRect);
     }
     else
     {
-        result.origin.x = NSMaxX(titleRect) + PADDING_BETWEEN_NAME_AND_FOLDER_STATUS;
+        result.origin.x = NSMaxX(titleRect) + kPaddingBetweenNameAndFolderStatus;
         result.origin.y = NSMaxY(titleRect) - statusSize.height - 1.0;
         result.size.width = NSMaxX(bounds) - NSMaxX(titleRect);
     }

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -11,7 +11,7 @@
 #import "NSMutableArrayAdditions.h"
 #import "NSStringAdditions.h"
 
-#define ROW_SMALL_HEIGHT 18.0
+static CGFloat const kRowSmallHeight = 18.0;
 
 typedef NS_ENUM(unsigned int, fileCheckMenuTag) { //
     FILE_CHECK_TAG,
@@ -346,7 +346,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
 {
     if (((FileListNode*)item).isFolder)
     {
-        return ROW_SMALL_HEIGHT;
+        return kRowSmallHeight;
     }
     else
     {

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -8,7 +8,7 @@
 #import "NSImageAdditions.h"
 #import "Torrent.h"
 
-#define IMAGE_OVERLAP 1.0
+static CGFloat const kImageOverlap = 1.0;
 
 @implementation FilePriorityCell
 
@@ -145,7 +145,7 @@
 
         if (count > 1)
         {
-            totalWidth -= IMAGE_OVERLAP * (count - 1);
+            totalWidth -= kImageOverlap * (count - 1);
         }
 
         CGFloat currentWidth = floor(NSMidX(cellFrame) - totalWidth * 0.5);
@@ -163,7 +163,7 @@
                 respectFlipped:YES
                          hints:nil];
 
-            currentWidth += imageSize.width - IMAGE_OVERLAP;
+            currentWidth += imageSize.width - kImageOverlap;
         }
     }
 }

--- a/macosx/FilterBarController.h
+++ b/macosx/FilterBarController.h
@@ -4,17 +4,21 @@
 
 #import <AppKit/AppKit.h>
 
-#define FILTER_NONE @"None"
-#define FILTER_ACTIVE @"Active"
-#define FILTER_DOWNLOAD @"Download"
-#define FILTER_SEED @"Seed"
-#define FILTER_PAUSE @"Pause"
-#define FILTER_ERROR @"Error"
+typedef NSString* FilterType NS_TYPED_EXTENSIBLE_ENUM;
 
-#define FILTER_TYPE_NAME @"Name"
-#define FILTER_TYPE_TRACKER @"Tracker"
+extern FilterType const FilterTypeNone;
+extern FilterType const FilterTypeActive;
+extern FilterType const FilterTypeDownload;
+extern FilterType const FilterTypeSeed;
+extern FilterType const FilterTypePause;
+extern FilterType const FilterTypeError;
 
-#define GROUP_FILTER_ALL_TAG -2
+typedef NSString* FilterSearchType NS_TYPED_EXTENSIBLE_ENUM;
+
+extern FilterSearchType const FilterSearchTypeName;
+extern FilterSearchType const FilterSearchTypeTracker;
+
+extern const NSInteger kGroupFilterAllTag;
 
 @interface FilterBarController : NSViewController
 

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -7,8 +7,22 @@
 #import "GroupsController.h"
 #import "NSStringAdditions.h"
 
-#define FILTER_TYPE_TAG_NAME 401
-#define FILTER_TYPE_TAG_TRACKER 402
+FilterType const FilterTypeNone = @"None";
+FilterType const FilterTypeActive = @"Active";
+FilterType const FilterTypeDownload = @"Download";
+FilterType const FilterTypeSeed = @"Seed";
+FilterType const FilterTypePause = @"Pause";
+FilterType const FilterTypeError = @"Error";
+
+FilterSearchType const FilterSearchTypeName = @"Name";
+FilterSearchType const FilterSearchTypeTracker = @"Tracker";
+
+NSInteger const kGroupFilterAllTag = -2;
+
+typedef NS_ENUM(NSInteger, FilterTypeTag) {
+    FilterTypeTagName = 401,
+    FilterTypeTagTracker = 402,
+};
 
 @interface FilterBarController ()
 
@@ -53,41 +67,41 @@
     self.fPauseFilterButton.cell.backgroundStyle = NSBackgroundStyleRaised;
     self.fErrorFilterButton.cell.backgroundStyle = NSBackgroundStyleRaised;
 
-    [self.fSearchField.searchMenuTemplate itemWithTag:FILTER_TYPE_TAG_NAME].title = NSLocalizedString(@"Name", "Filter Bar -> filter menu");
-    [self.fSearchField.searchMenuTemplate itemWithTag:FILTER_TYPE_TAG_TRACKER].title = NSLocalizedString(@"Tracker", "Filter Bar -> filter menu");
+    [self.fSearchField.searchMenuTemplate itemWithTag:FilterTypeTagName].title = NSLocalizedString(@"Name", "Filter Bar -> filter menu");
+    [self.fSearchField.searchMenuTemplate itemWithTag:FilterTypeTagTracker].title = NSLocalizedString(@"Tracker", "Filter Bar -> filter menu");
 
-    [self.fGroupsButton.menu itemWithTag:GROUP_FILTER_ALL_TAG].title = NSLocalizedString(@"All Groups", "Filter Bar -> group filter menu");
+    [self.fGroupsButton.menu itemWithTag:kGroupFilterAllTag].title = NSLocalizedString(@"All Groups", "Filter Bar -> group filter menu");
 
     //set current filter
     NSString* filterType = [NSUserDefaults.standardUserDefaults stringForKey:@"Filter"];
 
     NSButton* currentFilterButton;
-    if ([filterType isEqualToString:FILTER_ACTIVE])
+    if ([filterType isEqualToString:FilterTypeActive])
     {
         currentFilterButton = self.fActiveFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_PAUSE])
+    else if ([filterType isEqualToString:FilterTypePause])
     {
         currentFilterButton = self.fPauseFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_SEED])
+    else if ([filterType isEqualToString:FilterTypeSeed])
     {
         currentFilterButton = self.fSeedFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_DOWNLOAD])
+    else if ([filterType isEqualToString:FilterTypeDownload])
     {
         currentFilterButton = self.fDownloadFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_ERROR])
+    else if ([filterType isEqualToString:FilterTypeError])
     {
         currentFilterButton = self.fErrorFilterButton;
     }
     else
     {
         //safety
-        if (![filterType isEqualToString:FILTER_NONE])
+        if (![filterType isEqualToString:FilterTypeNone])
         {
-            [NSUserDefaults.standardUserDefaults setObject:FILTER_NONE forKey:@"Filter"];
+            [NSUserDefaults.standardUserDefaults setObject:FilterTypeNone forKey:@"Filter"];
         }
         currentFilterButton = self.fNoFilterButton;
     }
@@ -98,18 +112,18 @@
 
     NSMenu* filterSearchMenu = self.fSearchField.searchMenuTemplate;
     NSString* filterSearchTypeTitle;
-    if ([filterSearchType isEqualToString:FILTER_TYPE_TRACKER])
+    if ([filterSearchType isEqualToString:FilterSearchTypeTracker])
     {
-        filterSearchTypeTitle = [filterSearchMenu itemWithTag:FILTER_TYPE_TAG_TRACKER].title;
+        filterSearchTypeTitle = [filterSearchMenu itemWithTag:FilterTypeTagTracker].title;
     }
     else
     {
         //safety
-        if (![filterType isEqualToString:FILTER_TYPE_NAME])
+        if (![filterType isEqualToString:FilterSearchTypeName])
         {
-            [NSUserDefaults.standardUserDefaults setObject:FILTER_TYPE_NAME forKey:@"FilterSearchType"];
+            [NSUserDefaults.standardUserDefaults setObject:FilterSearchTypeName forKey:@"FilterSearchType"];
         }
-        filterSearchTypeTitle = [filterSearchMenu itemWithTag:FILTER_TYPE_TAG_NAME].title;
+        filterSearchTypeTitle = [filterSearchMenu itemWithTag:FilterTypeTagName].title;
     }
     self.fSearchField.placeholderString = filterSearchTypeTitle;
 
@@ -135,23 +149,23 @@
     NSString* oldFilterType = [NSUserDefaults.standardUserDefaults stringForKey:@"Filter"];
 
     NSButton* prevFilterButton;
-    if ([oldFilterType isEqualToString:FILTER_PAUSE])
+    if ([oldFilterType isEqualToString:FilterTypePause])
     {
         prevFilterButton = self.fPauseFilterButton;
     }
-    else if ([oldFilterType isEqualToString:FILTER_ACTIVE])
+    else if ([oldFilterType isEqualToString:FilterTypeActive])
     {
         prevFilterButton = self.fActiveFilterButton;
     }
-    else if ([oldFilterType isEqualToString:FILTER_SEED])
+    else if ([oldFilterType isEqualToString:FilterTypeSeed])
     {
         prevFilterButton = self.fSeedFilterButton;
     }
-    else if ([oldFilterType isEqualToString:FILTER_DOWNLOAD])
+    else if ([oldFilterType isEqualToString:FilterTypeDownload])
     {
         prevFilterButton = self.fDownloadFilterButton;
     }
-    else if ([oldFilterType isEqualToString:FILTER_ERROR])
+    else if ([oldFilterType isEqualToString:FilterTypeError])
     {
         prevFilterButton = self.fErrorFilterButton;
     }
@@ -165,30 +179,30 @@
         prevFilterButton.state = NSControlStateValueOff;
         [sender setState:NSControlStateValueOn];
 
-        NSString* filterType;
+        FilterType filterType;
         if (sender == self.fActiveFilterButton)
         {
-            filterType = FILTER_ACTIVE;
+            filterType = FilterTypeActive;
         }
         else if (sender == self.fDownloadFilterButton)
         {
-            filterType = FILTER_DOWNLOAD;
+            filterType = FilterTypeDownload;
         }
         else if (sender == self.fPauseFilterButton)
         {
-            filterType = FILTER_PAUSE;
+            filterType = FilterTypePause;
         }
         else if (sender == self.fSeedFilterButton)
         {
-            filterType = FILTER_SEED;
+            filterType = FilterTypeSeed;
         }
         else if (sender == self.fErrorFilterButton)
         {
-            filterType = FILTER_ERROR;
+            filterType = FilterTypeError;
         }
         else
         {
-            filterType = FILTER_NONE;
+            filterType = FilterTypeNone;
         }
 
         [NSUserDefaults.standardUserDefaults setObject:filterType forKey:@"Filter"];
@@ -206,27 +220,27 @@
     NSString* filterType = [NSUserDefaults.standardUserDefaults stringForKey:@"Filter"];
 
     NSButton* button;
-    if ([filterType isEqualToString:FILTER_NONE])
+    if ([filterType isEqualToString:FilterTypeNone])
     {
         button = right ? self.fActiveFilterButton : self.fErrorFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_ACTIVE])
+    else if ([filterType isEqualToString:FilterTypeActive])
     {
         button = right ? self.fDownloadFilterButton : self.fNoFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_DOWNLOAD])
+    else if ([filterType isEqualToString:FilterTypeDownload])
     {
         button = right ? self.fSeedFilterButton : self.fActiveFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_SEED])
+    else if ([filterType isEqualToString:FilterTypeSeed])
     {
         button = right ? self.fPauseFilterButton : self.fDownloadFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_PAUSE])
+    else if ([filterType isEqualToString:FilterTypePause])
     {
         button = right ? self.fErrorFilterButton : self.fSeedFilterButton;
     }
-    else if ([filterType isEqualToString:FILTER_ERROR])
+    else if ([filterType isEqualToString:FilterTypeError])
     {
         button = right ? self.fNoFilterButton : self.fPauseFilterButton;
     }
@@ -254,25 +268,25 @@
     NSString* oldFilterType = [NSUserDefaults.standardUserDefaults stringForKey:@"FilterSearchType"];
 
     NSInteger prevTag, currentTag = [sender tag];
-    if ([oldFilterType isEqualToString:FILTER_TYPE_TRACKER])
+    if ([oldFilterType isEqualToString:FilterSearchTypeTracker])
     {
-        prevTag = FILTER_TYPE_TAG_TRACKER;
+        prevTag = FilterTypeTagTracker;
     }
     else
     {
-        prevTag = FILTER_TYPE_TAG_NAME;
+        prevTag = FilterTypeTagName;
     }
 
     if (currentTag != prevTag)
     {
-        NSString* filterType;
-        if (currentTag == FILTER_TYPE_TAG_TRACKER)
+        FilterSearchType filterType;
+        if (currentTag == FilterTypeTagTracker)
         {
-            filterType = FILTER_TYPE_TRACKER;
+            filterType = FilterSearchTypeTracker;
         }
         else
         {
-            filterType = FILTER_TYPE_NAME;
+            filterType = FilterSearchTypeName;
         }
 
         [NSUserDefaults.standardUserDefaults setObject:filterType forKey:@"FilterSearchType"];
@@ -293,7 +307,7 @@
 
 - (void)reset:(BOOL)updateUI
 {
-    [NSUserDefaults.standardUserDefaults setInteger:GROUP_FILTER_ALL_TAG forKey:@"FilterGroup"];
+    [NSUserDefaults.standardUserDefaults setInteger:kGroupFilterAllTag forKey:@"FilterGroup"];
 
     if (updateUI)
     {
@@ -306,7 +320,7 @@
     }
     else
     {
-        [NSUserDefaults.standardUserDefaults setObject:FILTER_NONE forKey:@"Filter"];
+        [NSUserDefaults.standardUserDefaults setObject:FilterTypeNone forKey:@"Filter"];
         [NSUserDefaults.standardUserDefaults removeObjectForKey:@"FilterSearchString"];
     }
 }
@@ -362,13 +376,13 @@
         NSString* filterType = [NSUserDefaults.standardUserDefaults stringForKey:@"FilterSearchType"];
 
         BOOL state;
-        if (menuItem.tag == FILTER_TYPE_TAG_TRACKER)
+        if (menuItem.tag == FilterTypeTagTracker)
         {
-            state = [filterType isEqualToString:FILTER_TYPE_TRACKER];
+            state = [filterType isEqualToString:FilterSearchTypeTracker];
         }
         else
         {
-            state = [filterType isEqualToString:FILTER_TYPE_NAME];
+            state = [filterType isEqualToString:FilterSearchTypeName];
         }
 
         menuItem.state = state ? NSControlStateValueOn : NSControlStateValueOff;
@@ -393,7 +407,7 @@
 
     NSImage* icon;
     NSString* toolTip;
-    if (groupIndex == GROUP_FILTER_ALL_TAG)
+    if (groupIndex == kGroupFilterAllTag)
     {
         icon = [NSImage imageNamed:@"PinTemplate"];
         toolTip = NSLocalizedString(@"All Groups", "Groups -> Button");

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -4,14 +4,14 @@
 
 #import "GroupPopUpButtonCell.h"
 
-#define FRAME_INSET 2.0
+static CGFloat const kFrameInset = 2.0;
 
 @implementation GroupPopUpButtonCell
 
 - (void)drawImageWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect imageFrame = cellFrame;
-    imageFrame.origin.x -= FRAME_INSET;
+    imageFrame.origin.x -= kFrameInset;
 
     [super drawImageWithFrame:imageFrame inView:controlView];
 }
@@ -19,7 +19,7 @@
 - (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect textFrame = cellFrame;
-    textFrame.origin.y += FRAME_INSET / 2;
+    textFrame.origin.y += kFrameInset / 2;
 
     [super drawTitleWithFrame:textFrame inView:controlView];
 }

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -6,9 +6,9 @@
 #import "NSImageAdditions.h"
 #import "NSMutableArrayAdditions.h"
 
-#define ICON_WIDTH 16.0
-#define BORDER_WIDTH 1.25
-#define ICON_WIDTH_SMALL 12.0
+static CGFloat const kIconWidth = 16.0;
+static CGFloat const kBorderWidth = 1.25;
+static CGFloat const kIconWidthSmall = 12.0;
 
 @interface GroupsController ()
 
@@ -298,7 +298,7 @@ GroupsController* fGroupsInstance = nil;
     if (small)
     {
         icon = [icon copy];
-        icon.size = NSMakeSize(ICON_WIDTH_SMALL, ICON_WIDTH_SMALL);
+        icon.size = NSMakeSize(kIconWidthSmall, kIconWidthSmall);
 
         item.image = icon;
     }
@@ -320,7 +320,7 @@ GroupsController* fGroupsInstance = nil;
         if (small)
         {
             icon = [icon copy];
-            icon.size = NSMakeSize(ICON_WIDTH_SMALL, ICON_WIDTH_SMALL);
+            icon.size = NSMakeSize(kIconWidthSmall, kIconWidthSmall);
 
             item.image = icon;
         }
@@ -372,11 +372,11 @@ GroupsController* fGroupsInstance = nil;
         return icon;
     }
 
-    icon = [NSImage imageWithSize:NSMakeSize(ICON_WIDTH, ICON_WIDTH) flipped:NO drawingHandler:^BOOL(NSRect rect) {
+    icon = [NSImage imageWithSize:NSMakeSize(kIconWidth, kIconWidth) flipped:NO drawingHandler:^BOOL(NSRect rect) {
         //shape
-        rect = NSInsetRect(rect, BORDER_WIDTH / 2, BORDER_WIDTH / 2);
+        rect = NSInsetRect(rect, kBorderWidth / 2, kBorderWidth / 2);
         NSBezierPath* bp = [NSBezierPath bezierPathWithOvalInRect:rect];
-        bp.lineWidth = BORDER_WIDTH;
+        bp.lineWidth = kBorderWidth;
 
         //border
         // code reference for dashed style

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -7,10 +7,12 @@
 #import "ExpandedPathToPathTransformer.h"
 #import "ExpandedPathToIconTransformer.h"
 
-#define GROUP_TABLE_VIEW_DATA_TYPE @"GroupTableViewDataType"
+static NSString* const kGroupTableViewDataType = @"GroupTableViewDataType";
 
-#define ADD_TAG 0
-#define REMOVE_TAG 1
+typedef NS_ENUM(NSInteger, SegmentTag) {
+    SegmentTagAdd = 0,
+    SegmentTagRemove = 1,
+};
 
 @interface GroupsPrefsController ()
 
@@ -38,7 +40,7 @@
 
 - (void)awakeFromNib
 {
-    [self.fTableView registerForDraggedTypes:@[ GROUP_TABLE_VIEW_DATA_TYPE ]];
+    [self.fTableView registerForDraggedTypes:@[ kGroupTableViewDataType ]];
 
     [self.fSelectedColorView addObserver:self forKeyPath:@"color" options:0 context:NULL];
 
@@ -93,8 +95,8 @@
 
 - (BOOL)tableView:(NSTableView*)tableView writeRowsWithIndexes:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard*)pboard
 {
-    [pboard declareTypes:@[ GROUP_TABLE_VIEW_DATA_TYPE ] owner:self];
-    [pboard setData:[NSKeyedArchiver archivedDataWithRootObject:rowIndexes] forType:GROUP_TABLE_VIEW_DATA_TYPE];
+    [pboard declareTypes:@[ kGroupTableViewDataType ] owner:self];
+    [pboard setData:[NSKeyedArchiver archivedDataWithRootObject:rowIndexes] forType:kGroupTableViewDataType];
     return YES;
 }
 
@@ -104,7 +106,7 @@
        proposedDropOperation:(NSTableViewDropOperation)operation
 {
     NSPasteboard* pasteboard = info.draggingPasteboard;
-    if ([pasteboard.types containsObject:GROUP_TABLE_VIEW_DATA_TYPE])
+    if ([pasteboard.types containsObject:kGroupTableViewDataType])
     {
         [self.fTableView setDropRow:row dropOperation:NSTableViewDropAbove];
         return NSDragOperationGeneric;
@@ -119,9 +121,9 @@
     dropOperation:(NSTableViewDropOperation)operation
 {
     NSPasteboard* pasteboard = info.draggingPasteboard;
-    if ([pasteboard.types containsObject:GROUP_TABLE_VIEW_DATA_TYPE])
+    if ([pasteboard.types containsObject:kGroupTableViewDataType])
     {
-        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:GROUP_TABLE_VIEW_DATA_TYPE]
+        NSIndexSet* indexes = [NSKeyedUnarchiver unarchivedObjectOfClass:NSIndexSet.class fromData:[pasteboard dataForType:kGroupTableViewDataType]
                                                                    error:nil];
         NSInteger oldRow = indexes.firstIndex;
 
@@ -152,7 +154,7 @@
 
     switch ([[sender cell] tagForSegment:[sender selectedSegment]])
     {
-    case ADD_TAG:
+    case SegmentTagAdd:
         [self.fTableView beginUpdates];
 
         [GroupsController.groups addNewGroup];
@@ -169,7 +171,7 @@
 
         break;
 
-    case REMOVE_TAG:
+    case SegmentTagRemove:
         row = self.fTableView.selectedRow;
 
         [self.fTableView beginUpdates];
@@ -338,7 +340,7 @@
 
 - (void)updateSelectedGroup
 {
-    [self.fAddRemoveControl setEnabled:self.fTableView.numberOfSelectedRows > 0 forSegment:REMOVE_TAG];
+    [self.fAddRemoveControl setEnabled:self.fTableView.numberOfSelectedRows > 0 forSegment:SegmentTagRemove];
     if (self.fTableView.numberOfSelectedRows == 1)
     {
         NSInteger const index = [GroupsController.groups indexForRow:self.fTableView.selectedRow];

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -10,12 +10,14 @@
 #import "PiecesView.h"
 #import "Torrent.h"
 
-#define PIECES_CONTROL_PROGRESS 0
-#define PIECES_CONTROL_AVAILABLE 1
+typedef NS_ENUM(NSUInteger, PiecesControlSegment) {
+    PiecesControlSegmentProgress = 0,
+    PiecesControlSegmentAvailable = 1,
+};
 
-#define STACKVIEW_INSET 12.0
-#define STACKVIEW_HORIZONTAL_SPACING 20.0
-#define STACKVIEW_VERTICAL_SPACING 8.0
+static CGFloat const kStackViewInset = 12.0;
+static CGFloat const kStackViewHorizontalSpacing = 20.0;
+static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 @interface InfoActivityViewController ()
 
@@ -172,17 +174,17 @@
 
 - (CGFloat)horizLayoutHeight
 {
-    return NSHeight(self.fTransferView.frame) + 2 * STACKVIEW_INSET;
+    return NSHeight(self.fTransferView.frame) + 2 * kStackViewInset;
 }
 
 - (CGFloat)horizLayoutWidth
 {
-    return NSWidth(self.fTransferView.frame) + NSWidth(self.fDatesView.frame) + (2 * STACKVIEW_INSET) + STACKVIEW_HORIZONTAL_SPACING;
+    return NSWidth(self.fTransferView.frame) + NSWidth(self.fDatesView.frame) + (2 * kStackViewInset) + kStackViewHorizontalSpacing;
 }
 
 - (CGFloat)vertLayoutHeight
 {
-    return NSHeight(self.fTransferView.frame) + NSHeight(self.fDatesView.frame) + (2 * STACKVIEW_INSET) + STACKVIEW_VERTICAL_SPACING;
+    return NSHeight(self.fTransferView.frame) + NSHeight(self.fDatesView.frame) + (2 * kStackViewInset) + kStackViewVerticalSpacing;
 }
 
 - (CGFloat)changeInWindowHeight
@@ -194,14 +196,14 @@
         self.fActivityStackView.orientation = NSUserInterfaceLayoutOrientationHorizontal;
 
         //add some padding between views in horizontal layout
-        self.fActivityStackView.spacing = STACKVIEW_HORIZONTAL_SPACING;
+        self.fActivityStackView.spacing = kStackViewHorizontalSpacing;
 
         difference = NSHeight(self.view.frame) - self.horizLayoutHeight;
     }
     else
     {
         self.fActivityStackView.orientation = NSUserInterfaceLayoutOrientationVertical;
-        self.fActivityStackView.spacing = STACKVIEW_VERTICAL_SPACING;
+        self.fActivityStackView.spacing = kStackViewVerticalSpacing;
 
         difference = NSHeight(self.view.frame) - self.vertLayoutHeight;
     }
@@ -352,7 +354,7 @@
 
 - (void)setPiecesView:(id)sender
 {
-    BOOL const availability = [sender selectedSegment] == PIECES_CONTROL_AVAILABLE;
+    BOOL const availability = [sender selectedSegment] == PiecesControlSegmentAvailable;
     [NSUserDefaults.standardUserDefaults setBool:availability forKey:@"PiecesViewShowAvailability"];
     [self updatePiecesView:nil];
 }
@@ -361,8 +363,8 @@
 {
     BOOL const piecesAvailableSegment = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
 
-    [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PIECES_CONTROL_AVAILABLE];
-    [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PIECES_CONTROL_PROGRESS];
+    [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
+    [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
 
     [self.fPiecesView updateView];
 }
@@ -401,8 +403,8 @@
         self.fDownloadTimeField.stringValue = @"";
         self.fSeedTimeField.stringValue = @"";
 
-        [self.fPiecesControl setSelected:NO forSegment:PIECES_CONTROL_AVAILABLE];
-        [self.fPiecesControl setSelected:NO forSegment:PIECES_CONTROL_PROGRESS];
+        [self.fPiecesControl setSelected:NO forSegment:PiecesControlSegmentAvailable];
+        [self.fPiecesControl setSelected:NO forSegment:PiecesControlSegmentProgress];
         self.fPiecesControl.enabled = NO;
         self.fPiecesView.torrent = nil;
     }
@@ -411,8 +413,8 @@
         Torrent* torrent = self.fTorrents[0];
 
         BOOL const piecesAvailableSegment = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
-        [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PIECES_CONTROL_AVAILABLE];
-        [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PIECES_CONTROL_PROGRESS];
+        [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
+        [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
         self.fPiecesControl.enabled = YES;
 
         self.fPiecesView.torrent = torrent;

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -6,18 +6,22 @@
 #import "NSStringAdditions.h"
 #import "Torrent.h"
 
-#define OPTION_POPUP_GLOBAL 0
-#define OPTION_POPUP_NO_LIMIT 1
-#define OPTION_POPUP_LIMIT 2
+typedef NS_ENUM(NSInteger, OptionPopupType) {
+    OptionPopupTypeGlobal = 0,
+    OptionPopupTypeNoLimit = 1,
+    OptionPopupTypeLimit = 2,
+};
 
-#define OPTION_POPUP_PRIORITY_HIGH 0
-#define OPTION_POPUP_PRIORITY_NORMAL 1
-#define OPTION_POPUP_PRIORITY_LOW 2
+typedef NS_ENUM(NSUInteger, OptionPopupPriority) {
+    OptionPopupPriorityHigh = 0,
+    OptionPopupPriorityNormal = 1,
+    OptionPopupPriorityLow = 2,
+};
 
-#define INVALID -99
+static NSInteger const kInvalidValue = -99;
 
-#define STACKVIEW_INSET 12.0
-#define STACKVIEW_SPACING 8.0
+static CGFloat const kStackViewInset = 12.0;
+static CGFloat const kStackViewSpacing = 8.0;
 
 @interface InfoOptionsViewController ()
 
@@ -103,17 +107,17 @@
 
 - (CGFloat)horizLayoutHeight
 {
-    return NSHeight(self.fPriorityView.frame) + 2 * STACKVIEW_INSET;
+    return NSHeight(self.fPriorityView.frame) + 2 * kStackViewInset;
 }
 
 - (CGFloat)horizLayoutWidth
 {
-    return NSWidth(self.fPriorityView.frame) + NSWidth(self.fSeedingView.frame) + (2 * STACKVIEW_INSET) + STACKVIEW_SPACING;
+    return NSWidth(self.fPriorityView.frame) + NSWidth(self.fSeedingView.frame) + (2 * kStackViewInset) + kStackViewSpacing;
 }
 
 - (CGFloat)vertLayoutHeight
 {
-    return NSHeight(self.fPriorityView.frame) + NSHeight(self.fSeedingView.frame) + (2 * STACKVIEW_INSET) + STACKVIEW_SPACING;
+    return NSHeight(self.fPriorityView.frame) + NSHeight(self.fSeedingView.frame) + (2 * kStackViewInset) + kStackViewSpacing;
 }
 
 - (CGFloat)changeInWindowHeight
@@ -202,8 +206,8 @@
     NSInteger globalUseSpeedLimit = torrent.usesGlobalSpeedLimit ? NSControlStateValueOn : NSControlStateValueOff;
 
     while ((torrent = [enumerator nextObject]) &&
-           (uploadUseSpeedLimit != NSControlStateValueMixed || uploadSpeedLimit != INVALID || downloadUseSpeedLimit != NSControlStateValueMixed ||
-            downloadSpeedLimit != INVALID || globalUseSpeedLimit != NSControlStateValueMixed))
+           (uploadUseSpeedLimit != NSControlStateValueMixed || uploadSpeedLimit != kInvalidValue || downloadUseSpeedLimit != NSControlStateValueMixed ||
+            downloadSpeedLimit != kInvalidValue || globalUseSpeedLimit != NSControlStateValueMixed))
     {
         if (uploadUseSpeedLimit != NSControlStateValueMixed &&
             uploadUseSpeedLimit != ([torrent usesSpeedLimit:YES] ? NSControlStateValueOn : NSControlStateValueOff))
@@ -211,9 +215,9 @@
             uploadUseSpeedLimit = NSControlStateValueMixed;
         }
 
-        if (uploadSpeedLimit != INVALID && uploadSpeedLimit != [torrent speedLimit:YES])
+        if (uploadSpeedLimit != kInvalidValue && uploadSpeedLimit != [torrent speedLimit:YES])
         {
-            uploadSpeedLimit = INVALID;
+            uploadSpeedLimit = kInvalidValue;
         }
 
         if (downloadUseSpeedLimit != NSControlStateValueMixed &&
@@ -222,9 +226,9 @@
             downloadUseSpeedLimit = NSControlStateValueMixed;
         }
 
-        if (downloadSpeedLimit != INVALID && downloadSpeedLimit != [torrent speedLimit:NO])
+        if (downloadSpeedLimit != kInvalidValue && downloadSpeedLimit != [torrent speedLimit:NO])
         {
-            downloadSpeedLimit = INVALID;
+            downloadSpeedLimit = kInvalidValue;
         }
 
         if (globalUseSpeedLimit != NSControlStateValueMixed &&
@@ -240,7 +244,7 @@
 
     self.fUploadLimitLabel.enabled = uploadUseSpeedLimit == NSControlStateValueOn;
     self.fUploadLimitField.enabled = uploadUseSpeedLimit == NSControlStateValueOn;
-    if (uploadSpeedLimit != INVALID)
+    if (uploadSpeedLimit != kInvalidValue)
     {
         self.fUploadLimitField.intValue = uploadSpeedLimit;
     }
@@ -255,7 +259,7 @@
 
     self.fDownloadLimitLabel.enabled = downloadUseSpeedLimit == NSControlStateValueOn;
     self.fDownloadLimitField.enabled = downloadUseSpeedLimit == NSControlStateValueOn;
-    if (downloadSpeedLimit != INVALID)
+    if (downloadSpeedLimit != kInvalidValue)
     {
         self.fDownloadLimitField.intValue = downloadSpeedLimit;
     }
@@ -279,26 +283,26 @@
     NSUInteger idleLimit = torrent.idleLimitMinutes;
 
     while ((torrent = [enumerator nextObject]) &&
-           (checkRatio != INVALID || ratioLimit != INVALID || checkIdle != INVALID || idleLimit != INVALID))
+           (checkRatio != kInvalidValue || ratioLimit != kInvalidValue || checkIdle != kInvalidValue || idleLimit != kInvalidValue))
     {
-        if (checkRatio != INVALID && checkRatio != torrent.ratioSetting)
+        if (checkRatio != kInvalidValue && checkRatio != torrent.ratioSetting)
         {
-            checkRatio = INVALID;
+            checkRatio = kInvalidValue;
         }
 
-        if (ratioLimit != INVALID && ratioLimit != torrent.ratioLimit)
+        if (ratioLimit != kInvalidValue && ratioLimit != torrent.ratioLimit)
         {
-            ratioLimit = INVALID;
+            ratioLimit = kInvalidValue;
         }
 
-        if (checkIdle != INVALID && checkIdle != torrent.idleSetting)
+        if (checkIdle != kInvalidValue && checkIdle != torrent.idleSetting)
         {
-            checkIdle = INVALID;
+            checkIdle = kInvalidValue;
         }
 
-        if (idleLimit != INVALID && idleLimit != torrent.idleLimitMinutes)
+        if (idleLimit != kInvalidValue && idleLimit != torrent.idleLimitMinutes)
         {
-            idleLimit = INVALID;
+            idleLimit = kInvalidValue;
         }
 
         if (removeWhenFinishSeeding != NSControlStateValueMixed &&
@@ -312,15 +316,15 @@
     NSInteger index;
     if (checkRatio == TR_RATIOLIMIT_SINGLE)
     {
-        index = OPTION_POPUP_LIMIT;
+        index = OptionPopupTypeLimit;
     }
     else if (checkRatio == TR_RATIOLIMIT_UNLIMITED)
     {
-        index = OPTION_POPUP_NO_LIMIT;
+        index = OptionPopupTypeNoLimit;
     }
     else if (checkRatio == TR_RATIOLIMIT_GLOBAL)
     {
-        index = OPTION_POPUP_GLOBAL;
+        index = OptionPopupTypeGlobal;
     }
     else
     {
@@ -330,7 +334,7 @@
     self.fRatioPopUp.enabled = YES;
 
     self.fRatioLimitField.hidden = checkRatio != TR_RATIOLIMIT_SINGLE;
-    if (ratioLimit != INVALID)
+    if (ratioLimit != kInvalidValue)
     {
         self.fRatioLimitField.floatValue = ratioLimit;
     }
@@ -344,15 +348,15 @@
     //set idle view
     if (checkIdle == TR_IDLELIMIT_SINGLE)
     {
-        index = OPTION_POPUP_LIMIT;
+        index = OptionPopupTypeLimit;
     }
     else if (checkIdle == TR_IDLELIMIT_UNLIMITED)
     {
-        index = OPTION_POPUP_NO_LIMIT;
+        index = OptionPopupTypeNoLimit;
     }
     else if (checkIdle == TR_IDLELIMIT_GLOBAL)
     {
-        index = OPTION_POPUP_GLOBAL;
+        index = OptionPopupTypeGlobal;
     }
     else
     {
@@ -362,7 +366,7 @@
     self.fIdlePopUp.enabled = YES;
 
     self.fIdleLimitField.hidden = checkIdle != TR_IDLELIMIT_SINGLE;
-    if (idleLimit != INVALID)
+    if (idleLimit != kInvalidValue)
     {
         self.fIdleLimitField.integerValue = idleLimit;
     }
@@ -384,26 +388,26 @@
 
     NSInteger priority = torrent.priority;
 
-    while ((torrent = [enumerator nextObject]) && priority != INVALID)
+    while ((torrent = [enumerator nextObject]) && priority != kInvalidValue)
     {
         if (priority != torrent.priority)
         {
-            priority = INVALID;
+            priority = kInvalidValue;
         }
     }
 
     //set priority view
     if (priority == TR_PRI_HIGH)
     {
-        index = OPTION_POPUP_PRIORITY_HIGH;
+        index = OptionPopupPriorityHigh;
     }
     else if (priority == TR_PRI_NORMAL)
     {
-        index = OPTION_POPUP_PRIORITY_NORMAL;
+        index = OptionPopupPriorityNormal;
     }
     else if (priority == TR_PRI_LOW)
     {
-        index = OPTION_POPUP_PRIORITY_LOW;
+        index = OptionPopupPriorityLow;
     }
     else
     {
@@ -422,7 +426,7 @@
     {
         if (maxPeers != torrent.maxPeerConnect)
         {
-            maxPeers = INVALID;
+            maxPeers = kInvalidValue;
             break;
         }
     }
@@ -430,7 +434,7 @@
     //set peer view
     self.fPeersConnectField.enabled = YES;
     self.fPeersConnectLabel.enabled = YES;
-    if (maxPeers != INVALID)
+    if (maxPeers != kInvalidValue)
     {
         self.fPeersConnectField.intValue = maxPeers;
     }
@@ -504,14 +508,14 @@
     BOOL single = NO;
     switch ([sender indexOfSelectedItem])
     {
-    case OPTION_POPUP_LIMIT:
+    case OptionPopupTypeLimit:
         setting = TR_RATIOLIMIT_SINGLE;
         single = YES;
         break;
-    case OPTION_POPUP_NO_LIMIT:
+    case OptionPopupTypeNoLimit:
         setting = TR_RATIOLIMIT_UNLIMITED;
         break;
-    case OPTION_POPUP_GLOBAL:
+    case OptionPopupTypeGlobal:
         setting = TR_RATIOLIMIT_GLOBAL;
         break;
     default:
@@ -554,14 +558,14 @@
     BOOL single = NO;
     switch ([sender indexOfSelectedItem])
     {
-    case OPTION_POPUP_LIMIT:
+    case OptionPopupTypeLimit:
         setting = TR_IDLELIMIT_SINGLE;
         single = YES;
         break;
-    case OPTION_POPUP_NO_LIMIT:
+    case OptionPopupTypeNoLimit:
         setting = TR_IDLELIMIT_UNLIMITED;
         break;
-    case OPTION_POPUP_GLOBAL:
+    case OptionPopupTypeGlobal:
         setting = TR_IDLELIMIT_GLOBAL;
         break;
     default:
@@ -620,13 +624,13 @@
     tr_priority_t priority;
     switch ([sender indexOfSelectedItem])
     {
-    case OPTION_POPUP_PRIORITY_HIGH:
+    case OptionPopupPriorityHigh:
         priority = TR_PRI_HIGH;
         break;
-    case OPTION_POPUP_PRIORITY_NORMAL:
+    case OptionPopupPriorityNormal:
         priority = TR_PRI_NORMAL;
         break;
-    case OPTION_POPUP_PRIORITY_LOW:
+    case OptionPopupPriorityLow:
         priority = TR_PRI_LOW;
         break;
     default:

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -12,8 +12,8 @@
 #import "WebSeedTableView.h"
 #import "NSImageAdditions.h"
 
-#define ANIMATION_ID_KEY @"animationId"
-#define WEB_SEED_ANIMATION_ID @"webSeed"
+static NSString* const kAnimationIdKey = @"animationId";
+static NSString* const kWebSeedAnimationId = @"webSeed";
 
 @interface InfoPeersViewController ()<CAAnimationDelegate>
 
@@ -89,7 +89,7 @@
     webSeedTableAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
     webSeedTableAnimation.duration = 0.125;
     webSeedTableAnimation.delegate = self;
-    [webSeedTableAnimation setValue:WEB_SEED_ANIMATION_ID forKey:ANIMATION_ID_KEY];
+    [webSeedTableAnimation setValue:kWebSeedAnimationId forKey:kAnimationIdKey];
     self.fWebSeedTableTopConstraint.animations = @{ @"constant" : webSeedTableAnimation };
 
     [self setWebSeedTableHidden:YES animate:NO];
@@ -515,7 +515,7 @@
 
 - (void)animationDidStart:(CAAnimation*)animation
 {
-    if (![[animation valueForKey:ANIMATION_ID_KEY] isEqualToString:WEB_SEED_ANIMATION_ID])
+    if (![[animation valueForKey:kAnimationIdKey] isEqualToString:kWebSeedAnimationId])
     {
         return;
     }
@@ -525,7 +525,7 @@
 
 - (void)animationDidStop:(CAAnimation*)animation finished:(BOOL)finished
 {
-    if (![[animation valueForKey:ANIMATION_ID_KEY] isEqualToString:WEB_SEED_ANIMATION_ID])
+    if (![[animation valueForKey:kAnimationIdKey] isEqualToString:kWebSeedAnimationId])
     {
         return;
     }

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -8,10 +8,12 @@
 #import "TrackerNode.h"
 #import "TrackerTableView.h"
 
-#define TRACKER_GROUP_SEPARATOR_HEIGHT 14.0
+static CGFloat const kTrackerGroupSeparatorHeight = 14.0;
 
-#define TRACKER_ADD_TAG 0
-#define TRACKER_REMOVE_TAG 1
+typedef NS_ENUM(NSInteger, TrackerSegmentTag) {
+    TrackerSegmentTagAdd = 0,
+    TrackerSegmentTagRemove = 1,
+};
 
 @interface InfoTrackersViewController ()
 
@@ -50,9 +52,9 @@
 - (void)awakeFromNib
 {
     [self.fTrackerAddRemoveControl.cell setToolTip:NSLocalizedString(@"Add a tracker", "Inspector view -> tracker buttons")
-                                        forSegment:TRACKER_ADD_TAG];
+                                        forSegment:TrackerSegmentTagAdd];
     [self.fTrackerAddRemoveControl.cell setToolTip:NSLocalizedString(@"Remove selected trackers", "Inspector view -> tracker buttons")
-                                        forSegment:TRACKER_REMOVE_TAG];
+                                        forSegment:TrackerSegmentTagRemove];
 
     CGFloat const height = [NSUserDefaults.standardUserDefaults floatForKey:@"InspectorContentHeightTracker"];
     if (height != 0.0)
@@ -179,7 +181,7 @@
     //check for NSDictionary instead of TrackerNode because of display issue when adding a row
     if ([self.fTrackers[row] isKindOfClass:[NSDictionary class]])
     {
-        return TRACKER_GROUP_SEPARATOR_HEIGHT;
+        return kTrackerGroupSeparatorHeight;
     }
     else
     {
@@ -195,7 +197,7 @@
 
 - (void)tableViewSelectionDidChange:(NSNotification*)notification
 {
-    [self.fTrackerAddRemoveControl setEnabled:self.fTrackerTable.numberOfSelectedRows > 0 forSegment:TRACKER_REMOVE_TAG];
+    [self.fTrackerAddRemoveControl setEnabled:self.fTrackerTable.numberOfSelectedRows > 0 forSegment:TrackerSegmentTagRemove];
 }
 
 - (BOOL)tableView:(NSTableView*)tableView isGroupRow:(NSInteger)row
@@ -272,7 +274,7 @@
 
     [self updateInfo];
 
-    if ([[sender cell] tagForSegment:[sender selectedSegment]] == TRACKER_REMOVE_TAG)
+    if ([[sender cell] tagForSegment:[sender selectedSegment]] == TrackerSegmentTagRemove)
     {
         [self removeTrackers];
     }
@@ -299,15 +301,15 @@
 
         self.fTrackerTable.torrent = nil;
 
-        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TRACKER_ADD_TAG];
-        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TRACKER_REMOVE_TAG];
+        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TrackerSegmentTagAdd];
+        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TrackerSegmentTagRemove];
     }
     else
     {
         self.fTrackerTable.torrent = self.fTorrents[0];
 
-        [self.fTrackerAddRemoveControl setEnabled:YES forSegment:TRACKER_ADD_TAG];
-        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TRACKER_REMOVE_TAG];
+        [self.fTrackerAddRemoveControl setEnabled:YES forSegment:TrackerSegmentTagAdd];
+        [self.fTrackerAddRemoveControl setEnabled:NO forSegment:TrackerSegmentTagRemove];
     }
 
     [self.fTrackerTable deselectAll:self];

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -14,16 +14,18 @@
 #import "NSStringAdditions.h"
 #import "Torrent.h"
 
-#define TAB_INFO_IDENT @"Info"
-#define TAB_ACTIVITY_IDENT @"Activity"
-#define TAB_TRACKER_IDENT @"Tracker"
-#define TAB_PEERS_IDENT @"Peers"
-#define TAB_FILES_IDENT @"Files"
-#define TAB_OPTIONS_IDENT @"Options"
+typedef NSString* TabIdentifier NS_TYPED_EXTENSIBLE_ENUM;
 
-#define TAB_MIN_HEIGHT 250
+static TabIdentifier const TabIdentifierInfo = @"Info";
+static TabIdentifier const TabIdentifierActivity = @"Activity";
+static TabIdentifier const TabIdentifierTracker = @"Tracker";
+static TabIdentifier const TabIdentifierPeers = @"Peers";
+static TabIdentifier const TabIdentifierFiles = @"Files";
+static TabIdentifier const TabIdentifierOptions = @"Options";
 
-#define INVALID -99
+static CGFloat const kTabMinHeight = 250;
+
+static NSInteger const kInvalidTag = -99;
 
 typedef NS_ENUM(unsigned int, tabTag) {
     TAB_GENERAL_TAG = 0,
@@ -112,36 +114,36 @@ typedef NS_ENUM(unsigned int, tabTag) {
     [self.fTabs setImage:[NSImage systemSymbol:@"gearshape" withFallback:@"InfoOptions"] forSegment:TAB_OPTIONS_TAG];
 
     //set selected tab
-    self.fCurrentTabTag = INVALID;
+    self.fCurrentTabTag = kInvalidTag;
     NSString* identifier = [NSUserDefaults.standardUserDefaults stringForKey:@"InspectorSelected"];
     NSInteger tag;
-    if ([identifier isEqualToString:TAB_INFO_IDENT])
+    if ([identifier isEqualToString:TabIdentifierInfo])
     {
         tag = TAB_GENERAL_TAG;
     }
-    else if ([identifier isEqualToString:TAB_ACTIVITY_IDENT])
+    else if ([identifier isEqualToString:TabIdentifierActivity])
     {
         tag = TAB_ACTIVITY_TAG;
     }
-    else if ([identifier isEqualToString:TAB_TRACKER_IDENT])
+    else if ([identifier isEqualToString:TabIdentifierTracker])
     {
         tag = TAB_TRACKERS_TAG;
     }
-    else if ([identifier isEqualToString:TAB_PEERS_IDENT])
+    else if ([identifier isEqualToString:TabIdentifierPeers])
     {
         tag = TAB_PEERS_TAG;
     }
-    else if ([identifier isEqualToString:TAB_FILES_IDENT])
+    else if ([identifier isEqualToString:TabIdentifierFiles])
     {
         tag = TAB_FILE_TAG;
     }
-    else if ([identifier isEqualToString:TAB_OPTIONS_IDENT])
+    else if ([identifier isEqualToString:TabIdentifierOptions])
     {
         tag = TAB_OPTIONS_TAG;
     }
     else //safety
     {
-        [NSUserDefaults.standardUserDefaults setObject:TAB_INFO_IDENT forKey:@"InspectorSelected"];
+        [NSUserDefaults.standardUserDefaults setObject:TabIdentifierInfo forKey:@"InspectorSelected"];
         tag = TAB_GENERAL_TAG;
     }
 
@@ -227,7 +229,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
 
     //take care of old view
     CGFloat oldHeight = 0;
-    if (oldTabTag != INVALID)
+    if (oldTabTag != kInvalidTag)
     {
         if ([self.fViewController respondsToSelector:@selector(saveViewSize)])
         {
@@ -247,7 +249,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
     }
 
     //set new tab item
-    NSString* identifier;
+    TabIdentifier identifier;
     switch (self.fCurrentTabTag)
     {
     case TAB_GENERAL_TAG:
@@ -258,7 +260,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fGeneralViewController;
-        identifier = TAB_INFO_IDENT;
+        identifier = TabIdentifierInfo;
         break;
     case TAB_ACTIVITY_TAG:
         if (!self.fActivityViewController)
@@ -268,7 +270,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fActivityViewController;
-        identifier = TAB_ACTIVITY_IDENT;
+        identifier = TabIdentifierActivity;
         break;
     case TAB_TRACKERS_TAG:
         if (!self.fTrackersViewController)
@@ -278,7 +280,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fTrackersViewController;
-        identifier = TAB_TRACKER_IDENT;
+        identifier = TabIdentifierTracker;
         break;
     case TAB_PEERS_TAG:
         if (!self.fPeersViewController)
@@ -288,7 +290,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fPeersViewController;
-        identifier = TAB_PEERS_IDENT;
+        identifier = TabIdentifierPeers;
         break;
     case TAB_FILE_TAG:
         if (!self.fFileViewController)
@@ -298,7 +300,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fFileViewController;
-        identifier = TAB_FILES_IDENT;
+        identifier = TabIdentifierFiles;
         break;
     case TAB_OPTIONS_TAG:
         if (!self.fOptionsViewController)
@@ -308,7 +310,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         }
 
         self.fViewController = self.fOptionsViewController;
-        identifier = TAB_OPTIONS_IDENT;
+        identifier = TabIdentifierOptions;
         break;
     default:
         NSAssert1(NO, @"Unknown info tab selected: %ld", self.fCurrentTabTag);
@@ -361,7 +363,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
             }
         }
 
-        window.minSize = NSMakeSize(minWindowWidth, NSHeight(windowRect) - NSHeight(viewRect) + TAB_MIN_HEIGHT);
+        window.minSize = NSMakeSize(minWindowWidth, NSHeight(windowRect) - NSHeight(viewRect) + kTabMinHeight);
         window.maxSize = NSMakeSize(FLT_MAX, FLT_MAX);
     }
     else
@@ -393,7 +395,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
     }
     else
     {
-        [window setFrame:windowRect display:YES animate:oldTabTag != INVALID];
+        [window setFrame:windowRect display:YES animate:oldTabTag != kInvalidTag];
     }
 
     [window.contentView addSubview:view];

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -11,13 +11,15 @@
 #import "NSMutableArrayAdditions.h"
 #import "NSStringAdditions.h"
 
-#define LEVEL_ERROR 0
-#define LEVEL_WARN 1
-#define LEVEL_INFO 2
-#define LEVEL_DEBUG 3
-#define LEVEL_TRACE 4
+typedef NS_ENUM(NSUInteger, LevelButtonLevel) {
+    LevelButtonLevelError = 0,
+    LevelButtonLevelWarn = 1,
+    LevelButtonLevelInfo = 2,
+    LevelButtonLevelDebug = 3,
+    LevelButtonLevelTrace = 4,
+};
 
-#define UPDATE_SECONDS 0.75
+static NSTimeInterval const kUpdateSeconds = 0.75;
 
 @interface MessageWindowController ()
 
@@ -70,16 +72,16 @@
     window.collectionBehavior = NSWindowCollectionBehaviorFullScreenNone;
 
     //set images and text for popup button items
-    [self.fLevelButton itemAtIndex:LEVEL_ERROR].title = NSLocalizedString(@"Error", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_WARN].title = NSLocalizedString(@"Warning", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_INFO].title = NSLocalizedString(@"Info", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_DEBUG].title = NSLocalizedString(@"Debug", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_TRACE].title = NSLocalizedString(@"Trace", "Message window -> level string");
-    [self.fLevelButton itemAtIndex:LEVEL_ERROR].image = [self.class iconForLevel:TR_LOG_ERROR];
-    [self.fLevelButton itemAtIndex:LEVEL_WARN].image = [self.class iconForLevel:TR_LOG_WARN];
-    [self.fLevelButton itemAtIndex:LEVEL_INFO].image = [self.class iconForLevel:TR_LOG_INFO];
-    [self.fLevelButton itemAtIndex:LEVEL_DEBUG].image = [self.class iconForLevel:TR_LOG_DEBUG];
-    [self.fLevelButton itemAtIndex:LEVEL_TRACE].image = [self.class iconForLevel:TR_LOG_TRACE];
+    [self.fLevelButton itemAtIndex:LevelButtonLevelError].title = NSLocalizedString(@"Error", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LevelButtonLevelWarn].title = NSLocalizedString(@"Warning", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LevelButtonLevelInfo].title = NSLocalizedString(@"Info", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LevelButtonLevelDebug].title = NSLocalizedString(@"Debug", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LevelButtonLevelTrace].title = NSLocalizedString(@"Trace", "Message window -> level string");
+    [self.fLevelButton itemAtIndex:LevelButtonLevelError].image = [self.class iconForLevel:TR_LOG_ERROR];
+    [self.fLevelButton itemAtIndex:LevelButtonLevelWarn].image = [self.class iconForLevel:TR_LOG_WARN];
+    [self.fLevelButton itemAtIndex:LevelButtonLevelInfo].image = [self.class iconForLevel:TR_LOG_INFO];
+    [self.fLevelButton itemAtIndex:LevelButtonLevelDebug].image = [self.class iconForLevel:TR_LOG_DEBUG];
+    [self.fLevelButton itemAtIndex:LevelButtonLevelTrace].image = [self.class iconForLevel:TR_LOG_TRACE];
 
     CGFloat const levelButtonOldWidth = NSWidth(self.fLevelButton.frame);
     [self.fLevelButton sizeToFit];
@@ -121,23 +123,23 @@
     switch ([NSUserDefaults.standardUserDefaults integerForKey:@"MessageLevel"])
     {
     case TR_LOG_ERROR:
-        [self.fLevelButton selectItemAtIndex:LEVEL_ERROR];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelError];
         break;
     case TR_LOG_WARN:
-        [self.fLevelButton selectItemAtIndex:LEVEL_WARN];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelWarn];
         break;
     case TR_LOG_INFO:
-        [self.fLevelButton selectItemAtIndex:LEVEL_INFO];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelInfo];
         break;
     case TR_LOG_DEBUG:
-        [self.fLevelButton selectItemAtIndex:LEVEL_DEBUG];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelDebug];
         break;
     case TR_LOG_TRACE:
-        [self.fLevelButton selectItemAtIndex:LEVEL_TRACE];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelTrace];
         break;
     default: //safety
         [NSUserDefaults.standardUserDefaults setInteger:TR_LOG_ERROR forKey:@"MessageLevel"];
-        [self.fLevelButton selectItemAtIndex:LEVEL_ERROR];
+        [self.fLevelButton selectItemAtIndex:LevelButtonLevelError];
     }
 
     self.fMessages = [[NSMutableArray alloc] init];
@@ -156,7 +158,7 @@
 {
     if (!self.fTimer)
     {
-        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_SECONDS target:self selector:@selector(updateLog:)
+        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateLog:)
                                                      userInfo:nil
                                                       repeats:YES];
         [self updateLog:nil];
@@ -182,7 +184,7 @@
 - (void)window:(NSWindow*)window didDecodeRestorableState:(NSCoder*)coder
 {
     [self.fTimer invalidate];
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_SECONDS target:self selector:@selector(updateLog:) userInfo:nil
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateLog:) userInfo:nil
                                                   repeats:YES];
     [self updateLog:nil];
 }
@@ -392,19 +394,19 @@
     NSInteger level;
     switch (self.fLevelButton.indexOfSelectedItem)
     {
-    case LEVEL_ERROR:
+    case LevelButtonLevelError:
         level = TR_LOG_ERROR;
         break;
-    case LEVEL_WARN:
+    case LevelButtonLevelWarn:
         level = TR_LOG_WARN;
         break;
-    case LEVEL_INFO:
+    case LevelButtonLevelInfo:
         level = TR_LOG_INFO;
         break;
-    case LEVEL_DEBUG:
+    case LevelButtonLevelDebug:
         level = TR_LOG_DEBUG;
         break;
-    case LEVEL_TRACE:
+    case LevelButtonLevelTrace:
         level = TR_LOG_TRACE;
         break;
     default:

--- a/macosx/NSImageAdditions.mm
+++ b/macosx/NSImageAdditions.mm
@@ -9,16 +9,16 @@
 
 @implementation NSImage (NSImageAdditions)
 
-#define ICON_WIDTH 16.0
-#define BORDER_WIDTH 1.25
+static CGFloat const kIconSize = 16.0;
+static CGFloat const kBorderWidth = 1.25;
 
 + (NSImage*)discIconWithColor:(NSColor*)color insetFactor:(CGFloat)insetFactor
 {
-    return [NSImage imageWithSize:NSMakeSize(ICON_WIDTH, ICON_WIDTH) flipped:NO drawingHandler:^BOOL(NSRect rect) {
+    return [NSImage imageWithSize:NSMakeSize(kIconSize, kIconSize) flipped:NO drawingHandler:^BOOL(NSRect rect) {
         //shape
-        rect = NSInsetRect(rect, BORDER_WIDTH / 2 + rect.size.width * insetFactor / 2, BORDER_WIDTH / 2 + rect.size.height * insetFactor / 2);
+        rect = NSInsetRect(rect, kBorderWidth / 2 + rect.size.width * insetFactor / 2, kBorderWidth / 2 + rect.size.height * insetFactor / 2);
         NSBezierPath* bp = [NSBezierPath bezierPathWithOvalInRect:rect];
-        bp.lineWidth = BORDER_WIDTH;
+        bp.lineWidth = kBorderWidth;
 
         //border
         CGFloat fractionOfBlendedColor = NSApp.darkMode ? 0.15 : 0.3;

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -12,10 +12,10 @@
 #import "InfoWindowController.h"
 #import "NSApplicationAdditions.h"
 
-#define MAX_ACROSS 18
-#define BETWEEN 1.0
+static NSInteger const kMaxAcross = 18;
+static CGFloat const kBetweenPadding = 1.0;
 
-#define HIGH_PEERS 30
+static int8_t const kHighPeers = 10;
 
 enum
 {
@@ -69,12 +69,12 @@ enum
     if (_torrent)
     {
         //determine relevant values
-        _fNumPieces = MIN(_torrent.pieceCount, MAX_ACROSS * MAX_ACROSS);
+        _fNumPieces = MIN(_torrent.pieceCount, kMaxAcross * kMaxAcross);
         _fAcross = ceil(sqrt(_fNumPieces));
 
         CGFloat const width = self.bounds.size.width;
-        _fWidth = (width - (_fAcross + 1) * BETWEEN) / _fAcross;
-        _fExtraBorder = (width - ((_fWidth + BETWEEN) * _fAcross + BETWEEN)) / 2;
+        _fWidth = (width - (_fAcross + 1) * kBetweenPadding) / _fAcross;
+        _fExtraBorder = (width - ((_fWidth + kBetweenPadding) * _fAcross + kBetweenPadding)) / 2;
     }
 
     NSImage* back = [[NSImage alloc] initWithSize:self.bounds.size];
@@ -154,7 +154,7 @@ enum
                 self.fPieces[index] = PIECE_NONE;
             }
         }
-        else if (showAvailability && pieces[index] >= HIGH_PEERS)
+        else if (showAvailability && pieces[index] >= kHighPeers)
         {
             if (first || self.fPieces[index] != PIECE_HIGH_PEERS)
             {
@@ -165,7 +165,7 @@ enum
         else
         {
             //always redraw "mixed"
-            CGFloat percent = showAvailability ? (CGFloat)pieces[index] / HIGH_PEERS : piecesPercent[index];
+            CGFloat percent = showAvailability ? (CGFloat)pieces[index] / kHighPeers : piecesPercent[index];
             NSColor* fullColor = showAvailability ? NSColor.systemGreenColor : NSColor.systemBlueColor;
             pieceColor = [defaultColor blendedColorWithFraction:percent ofColor:fullColor];
             self.fPieces[index] = PIECE_SOME;
@@ -176,8 +176,8 @@ enum
             NSInteger const across = index % self.fAcross;
             NSInteger const down = index / self.fAcross;
             fillRects[usedCount] = NSMakeRect(
-                across * (self.fWidth + BETWEEN) + BETWEEN + self.fExtraBorder,
-                image.size.width - (down + 1) * (self.fWidth + BETWEEN) - self.fExtraBorder,
+                across * (self.fWidth + kBetweenPadding) + kBetweenPadding + self.fExtraBorder,
+                image.size.width - (down + 1) * (self.fWidth + kBetweenPadding) - self.fExtraBorder,
                 self.fWidth,
                 self.fWidth);
             fillColors[usedCount] = pieceColor;

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -4,8 +4,7 @@
 
 #import "PortChecker.h"
 
-#define CHECKER_URL(port) [NSString stringWithFormat:@"https://portcheck.transmissionbt.com/%ld", port]
-#define CHECK_FIRE 3.0
+static NSTimeInterval const kCheckFireInterval = 3.0;
 
 @interface PortChecker ()
 
@@ -33,7 +32,7 @@
 
         _fStatus = PORT_STATUS_CHECKING;
 
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:CHECK_FIRE target:self selector:@selector(startProbe:)
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval target:self selector:@selector(startProbe:)
                                                  userInfo:@(portNumber)
                                                   repeats:NO];
         if (!delay)
@@ -113,7 +112,8 @@
 {
     self.fTimer = nil;
 
-    NSURLRequest* portProbeRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:CHECKER_URL([[timer userInfo] integerValue])]
+    NSString* urlString = [NSString stringWithFormat:@"https://portcheck.transmissionbt.com/%ld", [timer.userInfo integerValue]];
+    NSURLRequest* portProbeRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]
                                                       cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData
                                                   timeoutInterval:15.0];
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -16,24 +16,30 @@
 #import "NSImageAdditions.h"
 #import "NSStringAdditions.h"
 
-#define DOWNLOAD_FOLDER 0
-#define DOWNLOAD_TORRENT 2
+typedef NS_ENUM(NSUInteger, DownloadPopupIndex) {
+    DownloadPopupIndexFolder = 0,
+    DownloadPopupIndexTorrent = 2,
+};
 
-#define RPC_IP_ADD_TAG 0
-#define RPC_IP_REMOVE_TAG 1
+typedef NS_ENUM(NSUInteger, RPCIPTag) {
+    RPCIPTagAdd = 0,
+    RPCIPTagRemove = 1,
+};
 
-#define TOOLBAR_GENERAL @"TOOLBAR_GENERAL"
-#define TOOLBAR_TRANSFERS @"TOOLBAR_TRANSFERS"
-#define TOOLBAR_GROUPS @"TOOLBAR_GROUPS"
-#define TOOLBAR_BANDWIDTH @"TOOLBAR_BANDWIDTH"
-#define TOOLBAR_PEERS @"TOOLBAR_PEERS"
-#define TOOLBAR_NETWORK @"TOOLBAR_NETWORK"
-#define TOOLBAR_REMOTE @"TOOLBAR_REMOTE"
+typedef NSString* ToolbarTab NS_TYPED_EXTENSIBLE_ENUM;
 
-#define RPC_KEYCHAIN_SERVICE "Transmission:Remote"
-#define RPC_KEYCHAIN_NAME "Remote"
+static ToolbarTab const ToolbarTabGeneral = @"TOOLBAR_GENERAL";
+static ToolbarTab const ToolbarTabTransfers = @"TOOLBAR_TRANSFERS";
+static ToolbarTab const ToolbarTabGroups = @"TOOLBAR_GROUPS";
+static ToolbarTab const ToolbarTabBandwidth = @"TOOLBAR_BANDWIDTH";
+static ToolbarTab const ToolbarTabPeers = @"TOOLBAR_PEERS";
+static ToolbarTab const ToolbarTabNetwork = @"TOOLBAR_NETWORK";
+static ToolbarTab const ToolbarTabRemote = @"TOOLBAR_REMOTE";
 
-#define WEBUI_URL @"http://localhost:%ld/"
+static char* const kRPCKeychainService = "Transmission:Remote";
+static char* const kRPCKeychainName = "Remote";
+
+static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
 @interface PrefsController ()
 
@@ -206,7 +212,7 @@
     toolbar.allowsUserCustomization = NO;
     toolbar.displayMode = NSToolbarDisplayModeIconAndLabel;
     toolbar.sizeMode = NSToolbarSizeModeRegular;
-    toolbar.selectedItemIdentifier = TOOLBAR_GENERAL;
+    toolbar.selectedItemIdentifier = ToolbarTabGeneral;
     self.window.toolbar = toolbar;
 
     [self setWindowSize];
@@ -216,7 +222,8 @@
     [self updateShowAddMagnetWindowField];
 
     //set download folder
-    [self.fFolderPopUp selectItemAtIndex:[self.fDefaults boolForKey:@"DownloadLocationConstant"] ? DOWNLOAD_FOLDER : DOWNLOAD_TORRENT];
+    [self.fFolderPopUp selectItemAtIndex:[self.fDefaults boolForKey:@"DownloadLocationConstant"] ? DownloadPopupIndexFolder :
+                                                                                                   DownloadPopupIndexTorrent];
 
     //set stop ratio
     self.fRatioStopField.floatValue = [self.fDefaults floatForKey:@"RatioLimit"];
@@ -295,7 +302,7 @@
 {
     NSToolbarItem* item = [[NSToolbarItem alloc] initWithItemIdentifier:ident];
 
-    if ([ident isEqualToString:TOOLBAR_GENERAL])
+    if ([ident isEqualToString:ToolbarTabGeneral])
     {
         item.label = NSLocalizedString(@"General", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"gearshape" withFallback:NSImageNamePreferencesGeneral];
@@ -303,7 +310,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_TRANSFERS])
+    else if ([ident isEqualToString:ToolbarTabTransfers])
     {
         item.label = NSLocalizedString(@"Transfers", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"arrow.up.arrow.down" withFallback:@"Transfers"];
@@ -311,7 +318,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_GROUPS])
+    else if ([ident isEqualToString:ToolbarTabGroups])
     {
         item.label = NSLocalizedString(@"Groups", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"pin" withFallback:@"Groups"];
@@ -319,7 +326,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_BANDWIDTH])
+    else if ([ident isEqualToString:ToolbarTabBandwidth])
     {
         item.label = NSLocalizedString(@"Bandwidth", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"speedometer" withFallback:@"Bandwidth"];
@@ -327,7 +334,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_PEERS])
+    else if ([ident isEqualToString:ToolbarTabPeers])
     {
         item.label = NSLocalizedString(@"Peers", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"person.2" withFallback:NSImageNameUserGroup];
@@ -335,7 +342,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_NETWORK])
+    else if ([ident isEqualToString:ToolbarTabNetwork])
     {
         item.label = NSLocalizedString(@"Network", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"network" withFallback:NSImageNameNetwork];
@@ -343,7 +350,7 @@
         item.action = @selector(setPrefView:);
         item.autovalidates = NO;
     }
-    else if ([ident isEqualToString:TOOLBAR_REMOTE])
+    else if ([ident isEqualToString:ToolbarTabRemote])
     {
         item.label = NSLocalizedString(@"Remote", "Preferences -> toolbar item title");
         item.image = [NSImage systemSymbol:@"antenna.radiowaves.left.and.right" withFallback:@"Remote"];
@@ -362,13 +369,13 @@
 - (NSArray*)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
 {
     return @[
-        TOOLBAR_GENERAL,
-        TOOLBAR_TRANSFERS,
-        TOOLBAR_GROUPS,
-        TOOLBAR_BANDWIDTH,
-        TOOLBAR_PEERS,
-        TOOLBAR_NETWORK,
-        TOOLBAR_REMOTE
+        ToolbarTabGeneral,
+        ToolbarTabTransfers,
+        ToolbarTabGroups,
+        ToolbarTabBandwidth,
+        ToolbarTabPeers,
+        ToolbarTabNetwork,
+        ToolbarTabRemote
     ];
 }
 
@@ -887,7 +894,7 @@
 
 - (void)setDownloadLocation:(id)sender
 {
-    [self.fDefaults setBool:self.fFolderPopUp.indexOfSelectedItem == DOWNLOAD_FOLDER forKey:@"DownloadLocationConstant"];
+    [self.fDefaults setBool:self.fFolderPopUp.indexOfSelectedItem == DownloadPopupIndexFolder forKey:@"DownloadLocationConstant"];
     [self updateShowAddMagnetWindowField];
 }
 
@@ -904,7 +911,7 @@
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK)
         {
-            [self.fFolderPopUp selectItemAtIndex:DOWNLOAD_FOLDER];
+            [self.fFolderPopUp selectItemAtIndex:DownloadPopupIndexFolder];
 
             NSString* folder = panel.URLs[0].path;
             [self.fDefaults setObject:folder forKey:@"DownloadFolder"];
@@ -917,7 +924,8 @@
         else
         {
             //reset if cancelled
-            [self.fFolderPopUp selectItemAtIndex:[self.fDefaults boolForKey:@"DownloadLocationConstant"] ? DOWNLOAD_FOLDER : DOWNLOAD_TORRENT];
+            [self.fFolderPopUp selectItemAtIndex:[self.fDefaults boolForKey:@"DownloadLocationConstant"] ? DownloadPopupIndexFolder :
+                                                                                                           DownloadPopupIndexTorrent];
         }
     }];
 }
@@ -1086,7 +1094,7 @@
 
 - (void)linkWebUI:(id)sender
 {
-    NSString* urlString = [NSString stringWithFormat:WEBUI_URL, [self.fDefaults integerForKey:@"RPCPort"]];
+    NSString* urlString = [NSString stringWithFormat:kWebUIURLFormat, [self.fDefaults integerForKey:@"RPCPort"]];
     [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:urlString]];
 }
 
@@ -1105,7 +1113,7 @@
     self.fRPCPassword = [sender stringValue];
 
     char const* password = [sender stringValue].UTF8String;
-    [self setKeychainPassword:password forService:RPC_KEYCHAIN_SERVICE username:RPC_KEYCHAIN_NAME];
+    [self setKeychainPassword:password forService:kRPCKeychainService username:kRPCKeychainName];
 
     tr_sessionSetRPCPassword(self.fHandle, password);
 }
@@ -1116,10 +1124,10 @@
     char const* password = nil;
     SecKeychainFindGenericPassword(
         NULL,
-        strlen(RPC_KEYCHAIN_SERVICE),
-        RPC_KEYCHAIN_SERVICE,
-        strlen(RPC_KEYCHAIN_NAME),
-        RPC_KEYCHAIN_NAME,
+        strlen(kRPCKeychainService),
+        kRPCKeychainService,
+        strlen(kRPCKeychainName),
+        kRPCKeychainName,
         &passwordLength,
         (void**)&password,
         NULL);
@@ -1185,7 +1193,7 @@
         return;
     }
 
-    if ([[sender cell] tagForSegment:[sender selectedSegment]] == RPC_IP_REMOVE_TAG)
+    if ([[sender cell] tagForSegment:[sender selectedSegment]] == RPCIPTagRemove)
     {
         [self.fRPCWhitelistArray removeObjectsAtIndexes:self.fRPCWhitelistTable.selectedRowIndexes];
         [self.fRPCWhitelistTable deselectAll:self];
@@ -1285,7 +1293,7 @@
 
 - (void)tableViewSelectionDidChange:(NSNotification*)notification
 {
-    [self.fRPCAddRemoveControl setEnabled:self.fRPCWhitelistTable.numberOfSelectedRows > 0 forSegment:RPC_IP_REMOVE_TAG];
+    [self.fRPCAddRemoveControl setEnabled:self.fRPCWhitelistTable.numberOfSelectedRows > 0 forSegment:RPCIPTagRemove];
 }
 
 - (void)helpForScript:(id)sender
@@ -1535,33 +1543,33 @@
     }
 
     NSView* view;
-    if ([identifier isEqualToString:TOOLBAR_TRANSFERS])
+    if ([identifier isEqualToString:ToolbarTabTransfers])
     {
         view = self.fTransfersView;
     }
-    else if ([identifier isEqualToString:TOOLBAR_GROUPS])
+    else if ([identifier isEqualToString:ToolbarTabGroups])
     {
         view = self.fGroupsView;
     }
-    else if ([identifier isEqualToString:TOOLBAR_BANDWIDTH])
+    else if ([identifier isEqualToString:ToolbarTabBandwidth])
     {
         view = self.fBandwidthView;
     }
-    else if ([identifier isEqualToString:TOOLBAR_PEERS])
+    else if ([identifier isEqualToString:ToolbarTabPeers])
     {
         view = self.fPeersView;
     }
-    else if ([identifier isEqualToString:TOOLBAR_NETWORK])
+    else if ([identifier isEqualToString:ToolbarTabNetwork])
     {
         view = self.fNetworkView;
     }
-    else if ([identifier isEqualToString:TOOLBAR_REMOTE])
+    else if ([identifier isEqualToString:ToolbarTabRemote])
     {
         view = self.fRemoteView;
     }
     else
     {
-        identifier = TOOLBAR_GENERAL; //general view is the default selected
+        identifier = ToolbarTabGeneral; //general view is the default selected
         view = self.fGeneralView;
     }
 

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -4,14 +4,14 @@
 
 #import "PriorityPopUpButtonCell.h"
 
-#define FRAME_INSET 2.0
+static CGFloat const kFrameInset = 2.0;
 
 @implementation PriorityPopUpButtonCell
 
 - (void)drawTitleWithFrame:(NSRect)cellFrame inView:(NSView*)controlView
 {
     NSRect textFrame = cellFrame;
-    textFrame.origin.x += 2 * FRAME_INSET;
+    textFrame.origin.x += 2 * kFrameInset;
 
     [super drawTitleWithFrame:textFrame inView:controlView];
 }

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -6,7 +6,7 @@
 #import "Controller.h"
 #import "NSStringAdditions.h"
 
-#define UPDATE_SECONDS 1.0
+static NSTimeInterval const kUpdateSeconds = 1.0;
 
 @interface StatsWindowController ()
 
@@ -59,7 +59,7 @@ tr_session* fLib = NULL;
 {
     [self updateStats];
 
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_SECONDS target:self selector:@selector(updateStats)
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateStats)
                                                  userInfo:nil
                                                   repeats:YES];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -5,10 +5,15 @@
 #import "StatusBarController.h"
 #import "NSStringAdditions.h"
 
-#define STATUS_RATIO_TOTAL @"RatioTotal"
-#define STATUS_RATIO_SESSION @"RatioSession"
-#define STATUS_TRANSFER_TOTAL @"TransferTotal"
-#define STATUS_TRANSFER_SESSION @"TransferSession"
+typedef NSString* StatusRatioType NS_TYPED_EXTENSIBLE_ENUM;
+
+static StatusRatioType const StatusRatioTypeTotal = @"RatioTotal";
+static StatusRatioType const StatusRatioTypeSession = @"RatioSession";
+
+typedef NSString* StatusTransferType NS_TYPED_EXTENSIBLE_ENUM;
+
+static StatusTransferType const StatusTransferTypeTotal = @"TransferTotal";
+static StatusTransferType const StatusTransferTypeSession = @"TransferSession";
 
 typedef NS_ENUM(unsigned int, statusTag) {
     STATUS_RATIO_TOTAL_TAG = 0,
@@ -91,16 +96,16 @@ typedef NS_ENUM(unsigned int, statusTag) {
     //set status button text
     NSString *statusLabel = [NSUserDefaults.standardUserDefaults stringForKey:@"StatusLabel"], *statusString;
     BOOL total;
-    if ((total = [statusLabel isEqualToString:STATUS_RATIO_TOTAL]) || [statusLabel isEqualToString:STATUS_RATIO_SESSION])
+    if ((total = [statusLabel isEqualToString:StatusRatioTypeTotal]) || [statusLabel isEqualToString:StatusRatioTypeSession])
     {
         auto const stats = total ? tr_sessionGetCumulativeStats(self.fLib) : tr_sessionGetStats(self.fLib);
 
         statusString = [NSLocalizedString(@"Ratio", "status bar -> status label")
             stringByAppendingFormat:@": %@", [NSString stringForRatio:stats.ratio]];
     }
-    else //STATUS_TRANSFER_TOTAL or STATUS_TRANSFER_SESSION
+    else //StatusTransferTypeTotal or StatusTransferTypeSession
     {
-        total = [statusLabel isEqualToString:STATUS_TRANSFER_TOTAL];
+        total = [statusLabel isEqualToString:StatusTransferTypeTotal];
 
         auto const stats = total ? tr_sessionGetCumulativeStats(self.fLib) : tr_sessionGetStats(self.fLib);
 
@@ -123,16 +128,16 @@ typedef NS_ENUM(unsigned int, statusTag) {
     switch ([sender tag])
     {
     case STATUS_RATIO_TOTAL_TAG:
-        statusLabel = STATUS_RATIO_TOTAL;
+        statusLabel = StatusRatioTypeTotal;
         break;
     case STATUS_RATIO_SESSION_TAG:
-        statusLabel = STATUS_RATIO_SESSION;
+        statusLabel = StatusRatioTypeSession;
         break;
     case STATUS_TRANSFER_TOTAL_TAG:
-        statusLabel = STATUS_TRANSFER_TOTAL;
+        statusLabel = StatusTransferTypeTotal;
         break;
     case STATUS_TRANSFER_SESSION_TAG:
-        statusLabel = STATUS_TRANSFER_SESSION;
+        statusLabel = StatusTransferTypeSession;
         break;
     default:
         NSAssert1(NO, @"Unknown status label tag received: %ld", [sender tag]);
@@ -198,20 +203,20 @@ typedef NS_ENUM(unsigned int, statusTag) {
         switch (menuItem.tag)
         {
         case STATUS_RATIO_TOTAL_TAG:
-            statusLabel = STATUS_RATIO_TOTAL;
+            statusLabel = StatusRatioTypeTotal;
             break;
         case STATUS_RATIO_SESSION_TAG:
-            statusLabel = STATUS_RATIO_SESSION;
+            statusLabel = StatusRatioTypeSession;
             break;
         case STATUS_TRANSFER_TOTAL_TAG:
-            statusLabel = STATUS_TRANSFER_TOTAL;
+            statusLabel = StatusTransferTypeTotal;
             break;
         case STATUS_TRANSFER_SESSION_TAG:
-            statusLabel = STATUS_TRANSFER_SESSION;
+            statusLabel = StatusTransferTypeSession;
             break;
         default:
             NSAssert1(NO, @"Unknown status label tag received: %ld", menuItem.tag);
-            statusLabel = STATUS_RATIO_TOTAL;
+            statusLabel = StatusRatioTypeTotal;
         }
 
         menuItem.state = [statusLabel isEqualToString:[NSUserDefaults.standardUserDefaults stringForKey:@"StatusLabel"]] ?

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
     TorrentDeterminationUserSpecified
 };
 
-#define kTorrentDidChangeGroupNotification @"TorrentDidChangeGroup"
+extern NSString* const kTorrentDidChangeGroupNotification;
 
 @interface Torrent : NSObject<NSCopying, QLPreviewItem>
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -19,7 +19,9 @@
 #import "NSStringAdditions.h"
 #import "TrackerNode.h"
 
-#define ETA_IDLE_DISPLAY_SEC (2 * 60)
+NSString* const kTorrentDidChangeGroupNotification = @"TorrentDidChangeGroup";
+
+static int const kETAIdleDisplaySec = 2 * 60;
 
 @interface Torrent ()
 
@@ -2055,7 +2057,7 @@ bool trashDataFile(char const* filename, tr_error** error)
         }
 
         //idle: show only if remaining time is less than cap
-        if (self.fStat->etaIdle != TR_ETA_NOT_AVAIL && self.fStat->etaIdle < ETA_IDLE_DISPLAY_SEC)
+        if (self.fStat->etaIdle != TR_ETA_NOT_AVAIL && self.fStat->etaIdle < kETAIdleDisplaySec)
         {
             return YES;
         }
@@ -2074,7 +2076,7 @@ bool trashDataFile(char const* filename, tr_error** error)
         eta = self.fStat->eta;
         fromIdle = NO;
     }
-    else if (self.fStat->etaIdle != TR_ETA_NOT_AVAIL && self.fStat->etaIdle < ETA_IDLE_DISPLAY_SEC)
+    else if (self.fStat->etaIdle != TR_ETA_NOT_AVAIL && self.fStat->etaIdle < kETAIdleDisplaySec)
     {
         eta = self.fStat->etaIdle;
         fromIdle = YES;

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -10,43 +10,42 @@
 #import "Torrent.h"
 #import "TorrentTableView.h"
 
-#define BAR_HEIGHT 12.0
+static CGFloat const kBarHeight = 12.0;
 
-#define IMAGE_SIZE_REG 32.0
-#define IMAGE_SIZE_MIN 16.0
-#define ERROR_IMAGE_SIZE 20.0
+static CGFloat const kImageSizeRegular = 32.0;
+static CGFloat const kImageSizeMin = 16.0;
+static CGFloat const kErrorImageSize = 20.0;
 
-#define GROUP_IMAGE_SIZE_REG 10.0
-#define GROUP_IMAGE_SIZE_MIN 6.0
-#define GROUP_PADDING_REG 22.0
-#define GROUP_PADDING_MIN 14.0
+static CGFloat const kGroupImageSizeRegular = 10.0;
+static CGFloat const kGroupImageSizeMin = 6.0;
+static CGFloat const kGroupPaddingRegular = 22.0;
+static CGFloat const kGroupPaddingMin = 14.0;
 
-#define NORMAL_BUTTON_WIDTH 14.0
-#define ACTION_BUTTON_WIDTH 16.0
+static CGFloat const kNormalButtonWidth = 14.0;
+static CGFloat const kActionButtonWidth = 16.0;
 
-#define PRIORITY_ICON_WIDTH 12.0
-#define PRIORITY_ICON_HEIGHT 12.0
+static CGFloat const kPriorityIconSize = 12.0;
 
 //ends up being larger than font height
-#define HEIGHT_TITLE 16.0
-#define HEIGHT_STATUS 12.0
+static CGFloat const kHeightTitle = 16.0;
+static CGFloat const kHeightStatus = 12.0;
 
-#define PADDING_HORIZONTAL 5.0
-#define PADDING_BETWEEN_BUTTONS 3.0
-#define PADDING_BETWEEN_IMAGE_AND_TITLE (PADDING_HORIZONTAL + 1.0)
-#define PADDING_BETWEEN_IMAGE_AND_BAR PADDING_HORIZONTAL
-#define PADDING_BETWEEN_TITLE_AND_PRIORITY 6.0
-#define PADDING_ABOVE_TITLE 4.0
-#define PADDING_BETWEEN_TITLE_AND_MIN_STATUS 3.0
-#define PADDING_BETWEEN_TITLE_AND_PROGRESS 1.0
-#define PADDING_BETWEEN_PROGRESS_AND_BAR 2.0
-#define PADDING_BETWEEN_BAR_AND_STATUS 2.0
-#define PADDING_BETWEEN_BAR_AND_EDGE_MIN 3.0
-#define PADDING_EXPANSION_FRAME 2.0
+static CGFloat const kPaddingHorizontal = 5.0;
+static CGFloat const kPaddingBetweenButtons = 3.0;
+static CGFloat const kPaddingBetweenImageAndTitle = kPaddingHorizontal + 1.0;
+static CGFloat const kPaddingBetweenImageAndBar = kPaddingHorizontal;
+static CGFloat const kPaddingBetweenTitleAndPriority = 6.0;
+static CGFloat const kPaddingAboveTitle = 4.0;
+static CGFloat const kPaddingBetweenTitleAndMinStatus = 3.0;
+static CGFloat const kPaddingBetweenTitleAndProgress = 1.0;
+static CGFloat const kPaddingBetweenProgressAndBar = 2.0;
+static CGFloat const kPaddingBetweenBarAndStatus = 2.0;
+static CGFloat const kPaddingBetweenBarAndEdgeMin = 3.0;
+static CGFloat const kPaddingExpansionFrame = 2.0;
 
-#define PIECES_TOTAL_PERCENT 0.6
+static CGFloat const kPiecesTotalPercent = 0.6;
 
-#define MAX_PIECES (18 * 18)
+static NSInteger const kMaxPieces = 18 * 18;
 
 @interface TorrentCell ()
 
@@ -127,10 +126,10 @@
 - (NSRect)iconRectForBounds:(NSRect)bounds
 {
     BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
-    CGFloat const imageSize = minimal ? IMAGE_SIZE_MIN : IMAGE_SIZE_REG;
-    CGFloat const padding = minimal ? GROUP_PADDING_MIN : GROUP_PADDING_REG;
+    CGFloat const imageSize = minimal ? kImageSizeMin : kImageSizeRegular;
+    CGFloat const padding = minimal ? kGroupPaddingMin : kGroupPaddingRegular;
 
-    return NSMakeRect(NSMinX(bounds) + (padding * 0.5) + PADDING_HORIZONTAL, ceil(NSMidY(bounds) - imageSize * 0.5), imageSize, imageSize);
+    return NSMakeRect(NSMinX(bounds) + (padding * 0.5) + kPaddingHorizontal, ceil(NSMidY(bounds) - imageSize * 0.5), imageSize, imageSize);
 }
 
 - (NSRect)actionRectForBounds:(NSRect)bounds
@@ -337,7 +336,7 @@
     if (error && !minimal)
     {
         NSImage* errorImage = [NSImage imageNamed:NSImageNameCaution];
-        NSRect const errorRect = NSMakeRect(NSMaxX(iconRect) - ERROR_IMAGE_SIZE, NSMaxY(iconRect) - ERROR_IMAGE_SIZE, ERROR_IMAGE_SIZE, ERROR_IMAGE_SIZE);
+        NSRect const errorRect = NSMakeRect(NSMaxX(iconRect) - kErrorImageSize, NSMaxY(iconRect) - kErrorImageSize, kErrorImageSize, kErrorImageSize);
         [errorImage drawInRect:errorRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0
                 respectFlipped:YES
                          hints:nil];
@@ -473,10 +472,10 @@
     if (torrent.priority != TR_PRI_NORMAL)
     {
         NSRect const priorityRect = NSMakeRect(
-            NSMaxX(titleRect) + PADDING_BETWEEN_TITLE_AND_PRIORITY,
-            NSMidY(titleRect) - PRIORITY_ICON_HEIGHT * 0.5,
-            PRIORITY_ICON_WIDTH,
-            PRIORITY_ICON_HEIGHT);
+            NSMaxX(titleRect) + kPaddingBetweenTitleAndPriority,
+            NSMidY(titleRect) - kPriorityIconSize * 0.5,
+            kPriorityIconSize,
+            kPriorityIconSize);
 
         NSColor* priorityColor = self.backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.labelColor;
 
@@ -528,7 +527,7 @@
         NSMouseInRect([view convertPoint:view.window.mouseLocationOutsideOfEventStream fromView:nil], realRect, view.flipped))
     {
         realRect.size.width = [titleString size].width;
-        return NSInsetRect(realRect, -PADDING_EXPANSION_FRAME, -PADDING_EXPANSION_FRAME);
+        return NSInsetRect(realRect, -kPaddingExpansionFrame, -kPaddingExpansionFrame);
     }
 
     return NSZeroRect;
@@ -536,8 +535,8 @@
 
 - (void)drawWithExpansionFrame:(NSRect)cellFrame inView:(NSView*)view
 {
-    cellFrame.origin.x += PADDING_EXPANSION_FRAME;
-    cellFrame.origin.y += PADDING_EXPANSION_FRAME;
+    cellFrame.origin.x += kPaddingExpansionFrame;
+    cellFrame.origin.y += kPaddingExpansionFrame;
 
     self.fTitleAttributes[NSForegroundColorAttributeName] = NSColor.labelColor;
     NSAttributedString* titleString = self.attributedTitle;
@@ -554,7 +553,7 @@
     if (piecesBarPercent > 0.0)
     {
         NSRect piecesBarRect, regularBarRect;
-        NSDivideRect(barRect, &piecesBarRect, &regularBarRect, floor(NSHeight(barRect) * PIECES_TOTAL_PERCENT * piecesBarPercent), NSMaxYEdge);
+        NSDivideRect(barRect, &piecesBarRect, &regularBarRect, floor(NSHeight(barRect) * kPiecesTotalPercent * piecesBarPercent), NSMaxYEdge);
 
         [self drawRegularBar:regularBarRect];
         [self drawPiecesBar:piecesBarRect];
@@ -665,7 +664,7 @@
         return;
     }
 
-    NSInteger pieceCount = MIN(torrent.pieceCount, MAX_PIECES);
+    NSInteger pieceCount = MIN(torrent.pieceCount, kMaxPieces);
     float* piecesPercent = static_cast<float*>(malloc(pieceCount * sizeof(float)));
     [torrent getAmountFinished:piecesPercent size:pieceCount];
 
@@ -720,7 +719,7 @@
     NSRect result;
     result.size = [string size];
 
-    result.origin.x = NSMaxX(bounds) - (PADDING_HORIZONTAL + NSWidth(result));
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + NSWidth(result));
     result.origin.y = ceil(NSMidY(bounds) - NSHeight(result) * 0.5);
 
     return result;
@@ -732,25 +731,25 @@
                          minimal:(BOOL)minimal
 {
     NSRect result;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + (minimal ? IMAGE_SIZE_MIN : IMAGE_SIZE_REG) + PADDING_BETWEEN_IMAGE_AND_TITLE;
-    result.size.height = HEIGHT_TITLE;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + (minimal ? kImageSizeMin : kImageSizeRegular) + kPaddingBetweenImageAndTitle;
+    result.size.height = kHeightTitle;
 
     if (minimal)
     {
-        result.origin.x += GROUP_PADDING_MIN;
+        result.origin.x += kGroupPaddingMin;
         result.origin.y = ceil(NSMidY(bounds) - NSHeight(result) * 0.5);
-        result.size.width = rightBound - NSMinX(result) - PADDING_BETWEEN_TITLE_AND_MIN_STATUS;
+        result.size.width = rightBound - NSMinX(result) - kPaddingBetweenTitleAndMinStatus;
     }
     else
     {
-        result.origin.x += GROUP_PADDING_REG;
-        result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE;
-        result.size.width = rightBound - NSMinX(result) - PADDING_HORIZONTAL;
+        result.origin.x += kGroupPaddingRegular;
+        result.origin.y = NSMinY(bounds) + kPaddingAboveTitle;
+        result.size.width = rightBound - NSMinX(result) - kPaddingHorizontal;
     }
 
     if (((Torrent*)self.representedObject).priority != TR_PRI_NORMAL)
     {
-        result.size.width -= PRIORITY_ICON_WIDTH + PADDING_BETWEEN_TITLE_AND_PRIORITY;
+        result.size.width -= kPriorityIconSize + kPaddingBetweenTitleAndPriority;
     }
     result.size.width = MIN(NSWidth(result), [string size].width);
 
@@ -760,11 +759,11 @@
 - (NSRect)rectForProgressWithStringInBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE + HEIGHT_TITLE + PADDING_BETWEEN_TITLE_AND_PROGRESS;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + GROUP_PADDING_REG + IMAGE_SIZE_REG + PADDING_BETWEEN_IMAGE_AND_TITLE;
+    result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle + kPaddingBetweenTitleAndProgress;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kGroupPaddingRegular + kImageSizeRegular + kPaddingBetweenImageAndTitle;
 
-    result.size.height = HEIGHT_STATUS;
-    result.size.width = NSMaxX(bounds) - NSMinX(result) - PADDING_HORIZONTAL;
+    result.size.height = kHeightStatus;
+    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal;
 
     return result;
 }
@@ -772,12 +771,12 @@
 - (NSRect)rectForStatusWithStringInBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE + HEIGHT_TITLE + PADDING_BETWEEN_TITLE_AND_PROGRESS + HEIGHT_STATUS +
-        PADDING_BETWEEN_PROGRESS_AND_BAR + BAR_HEIGHT + PADDING_BETWEEN_BAR_AND_STATUS;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + GROUP_PADDING_REG + IMAGE_SIZE_REG + PADDING_BETWEEN_IMAGE_AND_TITLE;
+    result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle + kPaddingBetweenTitleAndProgress + kHeightStatus +
+        kPaddingBetweenProgressAndBar + kBarHeight + kPaddingBetweenBarAndStatus;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kGroupPaddingRegular + kImageSizeRegular + kPaddingBetweenImageAndTitle;
 
-    result.size.height = HEIGHT_STATUS;
-    result.size.width = NSMaxX(bounds) - NSMinX(result) - PADDING_HORIZONTAL;
+    result.size.height = kHeightStatus;
+    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal;
 
     return result;
 }
@@ -785,12 +784,12 @@
 - (NSRect)barRectRegForBounds:(NSRect)bounds
 {
     NSRect result;
-    result.size.height = BAR_HEIGHT;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + GROUP_PADDING_REG + IMAGE_SIZE_REG + PADDING_BETWEEN_IMAGE_AND_BAR;
-    result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE + HEIGHT_TITLE + PADDING_BETWEEN_TITLE_AND_PROGRESS + HEIGHT_STATUS +
-        PADDING_BETWEEN_PROGRESS_AND_BAR;
+    result.size.height = kBarHeight;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kGroupPaddingRegular + kImageSizeRegular + kPaddingBetweenImageAndBar;
+    result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle + kPaddingBetweenTitleAndProgress + kHeightStatus +
+        kPaddingBetweenProgressAndBar;
 
-    result.size.width = floor(NSMaxX(bounds) - NSMinX(result) - PADDING_HORIZONTAL - 2.0 * (PADDING_BETWEEN_BUTTONS + NORMAL_BUTTON_WIDTH));
+    result.size.width = floor(NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal - 2.0 * (kPaddingBetweenButtons + kNormalButtonWidth));
 
     return result;
 }
@@ -798,10 +797,10 @@
 - (NSRect)barRectMinForBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + IMAGE_SIZE_MIN + GROUP_PADDING_MIN + PADDING_BETWEEN_IMAGE_AND_BAR;
-    result.origin.y = NSMinY(bounds) + PADDING_BETWEEN_BAR_AND_EDGE_MIN;
-    result.size.height = NSHeight(bounds) - 2.0 * PADDING_BETWEEN_BAR_AND_EDGE_MIN;
-    result.size.width = NSMaxX(bounds) - NSMinX(result) - PADDING_BETWEEN_BAR_AND_EDGE_MIN;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kImageSizeMin + kGroupPaddingMin + kPaddingBetweenImageAndBar;
+    result.origin.y = NSMinY(bounds) + kPaddingBetweenBarAndEdgeMin;
+    result.size.height = NSHeight(bounds) - 2.0 * kPaddingBetweenBarAndEdgeMin;
+    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingBetweenBarAndEdgeMin;
 
     return result;
 }
@@ -809,14 +808,14 @@
 - (NSRect)controlButtonRectForBounds:(NSRect)bounds
 {
     NSRect result;
-    result.size.height = NORMAL_BUTTON_WIDTH;
-    result.size.width = NORMAL_BUTTON_WIDTH;
-    result.origin.x = NSMaxX(bounds) - (PADDING_HORIZONTAL + NORMAL_BUTTON_WIDTH + PADDING_BETWEEN_BUTTONS + NORMAL_BUTTON_WIDTH);
+    result.size.height = kNormalButtonWidth;
+    result.size.width = kNormalButtonWidth;
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth + kPaddingBetweenButtons + kNormalButtonWidth);
 
     if (![self.fDefaults boolForKey:@"SmallView"])
     {
-        result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE + HEIGHT_TITLE - (NORMAL_BUTTON_WIDTH - BAR_HEIGHT) * 0.5 +
-            PADDING_BETWEEN_TITLE_AND_PROGRESS + HEIGHT_STATUS + PADDING_BETWEEN_PROGRESS_AND_BAR;
+        result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle - (kNormalButtonWidth - kBarHeight) * 0.5 +
+            kPaddingBetweenTitleAndProgress + kHeightStatus + kPaddingBetweenProgressAndBar;
     }
     else
     {
@@ -829,14 +828,14 @@
 - (NSRect)revealButtonRectForBounds:(NSRect)bounds
 {
     NSRect result;
-    result.size.height = NORMAL_BUTTON_WIDTH;
-    result.size.width = NORMAL_BUTTON_WIDTH;
-    result.origin.x = NSMaxX(bounds) - (PADDING_HORIZONTAL + NORMAL_BUTTON_WIDTH);
+    result.size.height = kNormalButtonWidth;
+    result.size.width = kNormalButtonWidth;
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth);
 
     if (![self.fDefaults boolForKey:@"SmallView"])
     {
-        result.origin.y = NSMinY(bounds) + PADDING_ABOVE_TITLE + HEIGHT_TITLE - (NORMAL_BUTTON_WIDTH - BAR_HEIGHT) * 0.5 +
-            PADDING_BETWEEN_TITLE_AND_PROGRESS + HEIGHT_STATUS + PADDING_BETWEEN_PROGRESS_AND_BAR;
+        result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle - (kNormalButtonWidth - kBarHeight) * 0.5 +
+            kPaddingBetweenTitleAndProgress + kHeightStatus + kPaddingBetweenProgressAndBar;
     }
     else
     {
@@ -848,14 +847,14 @@
 
 - (NSRect)actionButtonRectForBounds:(NSRect)bounds
 {
-    return NSMakeRect(NSMidX(bounds) - ACTION_BUTTON_WIDTH * 0.5, NSMidY(bounds) - ACTION_BUTTON_WIDTH * 0.5, ACTION_BUTTON_WIDTH, ACTION_BUTTON_WIDTH);
+    return NSMakeRect(NSMidX(bounds) - kActionButtonWidth * 0.5, NSMidY(bounds) - kActionButtonWidth * 0.5, kActionButtonWidth, kActionButtonWidth);
 }
 
 - (NSRect)groupIconRectForBounds:(NSRect)bounds
 {
     BOOL const minimal = [self.fDefaults boolForKey:@"SmallView"];
-    CGFloat const imageSize = minimal ? GROUP_IMAGE_SIZE_MIN : GROUP_IMAGE_SIZE_REG;
-    CGFloat const padding = minimal ? GROUP_PADDING_MIN + 2 : GROUP_PADDING_REG + 1.5;
+    CGFloat const imageSize = minimal ? kGroupImageSizeMin : kGroupImageSizeRegular;
+    CGFloat const padding = minimal ? kGroupPaddingMin + 2 : kGroupPaddingRegular + 1.5;
 
     return NSMakeRect(NSMinX(bounds) - padding * 0.5, NSMidY(bounds) - imageSize * 0.5, imageSize, imageSize);
 }

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -8,7 +8,7 @@
 
 @class Torrent;
 
-#define GROUP_SEPARATOR_HEIGHT 18.0
+extern const CGFloat kGroupSeparatorHeight;
 
 @interface TorrentTableView : NSOutlineView<NSOutlineViewDelegate, NSAnimationDelegate, NSPopoverDelegate>
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -13,18 +13,24 @@
 #import "TorrentCell.h"
 #import "TorrentGroup.h"
 
-#define MAX_GROUP 999999
+CGFloat const kGroupSeparatorHeight = 18.0;
+
+static NSInteger const kMaxGroup = 999999;
 
 //eliminate when Lion-only
-#define ACTION_MENU_GLOBAL_TAG 101
-#define ACTION_MENU_UNLIMITED_TAG 102
-#define ACTION_MENU_LIMIT_TAG 103
+typedef NS_ENUM(NSUInteger, ActionMenuTag) {
+    ActionMenuTagGlobal = 101,
+    ActionMenuTagUnlimited = 102,
+    ActionMenuTagLimit = 103,
+};
 
-#define ACTION_MENU_PRIORITY_HIGH_TAG 101
-#define ACTION_MENU_PRIORITY_NORMAL_TAG 102
-#define ACTION_MENU_PRIORITY_LOW_TAG 103
+typedef NS_ENUM(NSUInteger, ActionMenuPriorityTag) {
+    ActionMenuPriorityTagHigh = 101,
+    ActionMenuPriorityTagNormal = 102,
+    ActionMenuPriorityTagLow = 103,
+};
 
-#define TOGGLE_PROGRESS_SECONDS 0.175
+static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 @interface TorrentTableView ()
 
@@ -124,7 +130,7 @@
 {
     if (value == -1)
     {
-        value = MAX_GROUP;
+        value = kMaxGroup;
     }
 
     return [self.fCollapsedGroups containsIndex:value];
@@ -134,7 +140,7 @@
 {
     if (value == -1)
     {
-        value = MAX_GROUP;
+        value = kMaxGroup;
     }
 
     [self.fCollapsedGroups removeIndex:value];
@@ -157,7 +163,7 @@
 
 - (CGFloat)outlineView:(NSOutlineView*)outlineView heightOfRowByItem:(id)item
 {
-    return [item isKindOfClass:[Torrent class]] ? self.rowHeight : GROUP_SEPARATOR_HEIGHT;
+    return [item isKindOfClass:[Torrent class]] ? self.rowHeight : kGroupSeparatorHeight;
 }
 
 - (NSCell*)outlineView:(NSOutlineView*)outlineView dataCellForTableColumn:(NSTableColumn*)tableColumn item:(id)item
@@ -425,7 +431,7 @@
     NSInteger value = group.groupIndex;
     if (value < 0)
     {
-        value = MAX_GROUP;
+        value = kMaxGroup;
     }
 
     if ([self.fCollapsedGroups containsIndex:value])
@@ -441,7 +447,7 @@
     NSInteger value = group.groupIndex;
     if (value < 0)
     {
-        value = MAX_GROUP;
+        value = kMaxGroup;
     }
 
     [self.fCollapsedGroups addIndex:value];
@@ -832,12 +838,12 @@
         BOOL const upload = menu == self.fUploadMenu;
         BOOL const limit = [self.fMenuTorrent usesSpeedLimit:upload];
 
-        item = [menu itemWithTag:ACTION_MENU_LIMIT_TAG];
+        item = [menu itemWithTag:ActionMenuTagLimit];
         item.state = limit ? NSControlStateValueOn : NSControlStateValueOff;
         item.title = [NSString stringWithFormat:NSLocalizedString(@"Limit (%ld KB/s)", "torrent action menu -> upload/download limit"),
                                                 [self.fMenuTorrent speedLimit:upload]];
 
-        item = [menu itemWithTag:ACTION_MENU_UNLIMITED_TAG];
+        item = [menu itemWithTag:ActionMenuTagUnlimited];
         item.state = !limit ? NSControlStateValueOn : NSControlStateValueOff;
     }
     else if (menu == self.fRatioMenu)
@@ -860,28 +866,28 @@
 
         tr_ratiolimit const mode = self.fMenuTorrent.ratioSetting;
 
-        item = [menu itemWithTag:ACTION_MENU_LIMIT_TAG];
+        item = [menu itemWithTag:ActionMenuTagLimit];
         item.state = mode == TR_RATIOLIMIT_SINGLE ? NSControlStateValueOn : NSControlStateValueOff;
         item.title = [NSString localizedStringWithFormat:NSLocalizedString(@"Stop at Ratio (%.2f)", "torrent action menu -> ratio stop"),
                                                          self.fMenuTorrent.ratioLimit];
 
-        item = [menu itemWithTag:ACTION_MENU_UNLIMITED_TAG];
+        item = [menu itemWithTag:ActionMenuTagUnlimited];
         item.state = mode == TR_RATIOLIMIT_UNLIMITED ? NSControlStateValueOn : NSControlStateValueOff;
 
-        item = [menu itemWithTag:ACTION_MENU_GLOBAL_TAG];
+        item = [menu itemWithTag:ActionMenuTagGlobal];
         item.state = mode == TR_RATIOLIMIT_GLOBAL ? NSControlStateValueOn : NSControlStateValueOff;
     }
     else if (menu == self.fPriorityMenu)
     {
         tr_priority_t const priority = self.fMenuTorrent.priority;
 
-        NSMenuItem* item = [menu itemWithTag:ACTION_MENU_PRIORITY_HIGH_TAG];
+        NSMenuItem* item = [menu itemWithTag:ActionMenuPriorityTagHigh];
         item.state = priority == TR_PRI_HIGH ? NSControlStateValueOn : NSControlStateValueOff;
 
-        item = [menu itemWithTag:ACTION_MENU_PRIORITY_NORMAL_TAG];
+        item = [menu itemWithTag:ActionMenuPriorityTagNormal];
         item.state = priority == TR_PRI_NORMAL ? NSControlStateValueOn : NSControlStateValueOff;
 
-        item = [menu itemWithTag:ACTION_MENU_PRIORITY_LOW_TAG];
+        item = [menu itemWithTag:ActionMenuPriorityTagLow];
         item.state = priority == TR_PRI_LOW ? NSControlStateValueOn : NSControlStateValueOff;
     }
 }
@@ -889,7 +895,7 @@
 //the following methods might not be needed when Lion-only
 - (void)setQuickLimitMode:(id)sender
 {
-    BOOL const limit = [sender tag] == ACTION_MENU_LIMIT_TAG;
+    BOOL const limit = [sender tag] == ActionMenuTagLimit;
     [self.fMenuTorrent setUseSpeedLimit:limit upload:[sender menu] == self.fUploadMenu];
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateOptions" object:nil];
@@ -916,13 +922,13 @@
     tr_ratiolimit mode;
     switch ([sender tag])
     {
-    case ACTION_MENU_UNLIMITED_TAG:
+    case ActionMenuTagUnlimited:
         mode = TR_RATIOLIMIT_UNLIMITED;
         break;
-    case ACTION_MENU_LIMIT_TAG:
+    case ActionMenuTagLimit:
         mode = TR_RATIOLIMIT_SINGLE;
         break;
-    case ACTION_MENU_GLOBAL_TAG:
+    case ActionMenuTagGlobal:
         mode = TR_RATIOLIMIT_GLOBAL;
         break;
     default:
@@ -947,13 +953,13 @@
     tr_priority_t priority;
     switch ([sender tag])
     {
-    case ACTION_MENU_PRIORITY_HIGH_TAG:
+    case ActionMenuPriorityTagHigh:
         priority = TR_PRI_HIGH;
         break;
-    case ACTION_MENU_PRIORITY_NORMAL_TAG:
+    case ActionMenuPriorityTagNormal:
         priority = TR_PRI_NORMAL;
         break;
-    case ACTION_MENU_PRIORITY_LOW_TAG:
+    case ActionMenuPriorityTagLow:
         priority = TR_PRI_LOW;
         break;
     default:
@@ -975,7 +981,7 @@
     }
 
     //this stops a previous animation
-    self.fPiecesBarAnimation = [[NSAnimation alloc] initWithDuration:TOGGLE_PROGRESS_SECONDS animationCurve:NSAnimationEaseIn];
+    self.fPiecesBarAnimation = [[NSAnimation alloc] initWithDuration:kToggleProgressSeconds animationCurve:NSAnimationEaseIn];
     self.fPiecesBarAnimation.animationBlockingMode = NSAnimationNonblocking;
     self.fPiecesBarAnimation.progressMarks = progressMarks;
     self.fPiecesBarAnimation.delegate = self;

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -10,15 +10,15 @@
 #import "TrackerCell.h"
 #import "TrackerNode.h"
 
-#define PADDING_HORIZONTAL 3.0
-#define PADDING_STATUS_HORIZONTAL 3.0
-#define ICON_SIZE 16.0
-#define PADDING_BETWEEN_ICON_AND_NAME 4.0
-#define PADDING_ABOVE_ICON 1.0
-#define PADDING_ABOVE_NAME 1.0
-#define PADDING_BETWEEN_LINES 1.0
-#define PADDING_BETWEEN_LINES_ON_SAME_LINE 4.0
-#define COUNT_WIDTH 60.0
+static CGFloat const kPaddingHorizontal = 3.0;
+static CGFloat const kPaddingStatusHorizontal = 3.0;
+static CGFloat const kIconSize = 16.0;
+static CGFloat const kPaddingBetweenIconAndName = 4.0;
+static CGFloat const kPaddingAboveIcon = 1.0;
+static CGFloat const kPaddingAboveName = 1.0;
+static CGFloat const kPaddingBetweenLines = 1.0;
+static CGFloat const kPaddingBetweenLinesOnSameLine = 4.0;
+static CGFloat const kCountWidth = 60.0;
 
 @interface TrackerCell ()
 
@@ -250,17 +250,17 @@ NSMutableSet* fTrackerIconLoading;
 
 - (NSRect)imageRectForBounds:(NSRect)bounds
 {
-    return NSMakeRect(NSMinX(bounds) + PADDING_HORIZONTAL, NSMinY(bounds) + PADDING_ABOVE_ICON, ICON_SIZE, ICON_SIZE);
+    return NSMakeRect(NSMinX(bounds) + kPaddingHorizontal, NSMinY(bounds) + kPaddingAboveIcon, kIconSize, kIconSize);
 }
 
 - (NSRect)rectForNameWithString:(NSAttributedString*)string inBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.x = NSMinX(bounds) + PADDING_HORIZONTAL + ICON_SIZE + PADDING_BETWEEN_ICON_AND_NAME;
-    result.origin.y = NSMinY(bounds) + PADDING_ABOVE_NAME;
+    result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kIconSize + kPaddingBetweenIconAndName;
+    result.origin.y = NSMinY(bounds) + kPaddingAboveName;
 
     result.size.height = [string size].height;
-    result.size.width = NSMaxX(bounds) - NSMinX(result) - PADDING_HORIZONTAL;
+    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal;
 
     return result;
 }
@@ -268,9 +268,9 @@ NSMutableSet* fTrackerIconLoading;
 - (NSRect)rectForCountWithString:(NSAttributedString*)string withAboveRect:(NSRect)aboveRect inBounds:(NSRect)bounds
 {
     return NSMakeRect(
-        NSMaxX(bounds) - PADDING_HORIZONTAL - COUNT_WIDTH,
-        NSMaxY(aboveRect) + PADDING_BETWEEN_LINES,
-        COUNT_WIDTH,
+        NSMaxX(bounds) - kPaddingHorizontal - kCountWidth,
+        NSMaxY(aboveRect) + kPaddingBetweenLines,
+        kCountWidth,
         [string size].height);
 }
 
@@ -289,11 +289,11 @@ NSMutableSet* fTrackerIconLoading;
                          inBounds:(NSRect)bounds
 {
     NSRect result;
-    result.origin.x = NSMinX(bounds) + PADDING_STATUS_HORIZONTAL;
-    result.origin.y = NSMaxY(aboveRect) + PADDING_BETWEEN_LINES;
+    result.origin.x = NSMinX(bounds) + kPaddingStatusHorizontal;
+    result.origin.y = NSMaxY(aboveRect) + kPaddingBetweenLines;
 
     result.size.height = [string size].height;
-    result.size.width = NSMinX(rightRect) - PADDING_BETWEEN_LINES_ON_SAME_LINE - NSMinX(result);
+    result.size.width = NSMinX(rightRect) - kPaddingBetweenLinesOnSameLine - NSMinX(result);
 
     return result;
 }


### PR DESCRIPTION
Preprocessor defines used to be the way to define Objective-C object constants back when Transmission was first implemented (before 2009). GCC did not support inline static/global Objective-C object references, so preprocessor defines were the only way to define constants.
Nowadays it is no longer true, as Clang supports NSStrings, NSDictionaries, NSArrays and NSNumbers to be static constant variables. It is also safer due to type checking that is not employed when using preprocessor defines.

This PR replaces the old preprocessor defines with either static const variables or NS_ENUM/NS_TYPED_EXTENSIBLE_ENUMs, which are better suited to define constants in objc projects.