### PR TITLE
feat: add libtransmission::Dns.cached()

### DIFF
--- a/libtransmission/dns.h
+++ b/libtransmission/dns.h
@@ -20,7 +20,7 @@ class Dns
 public:
     virtual ~Dns() = default;
 
-    using Callback = std::function<void(struct sockaddr const*, socklen_t salen)>;
+    using Callback = std::function<void(struct sockaddr const*, socklen_t salen, time_t expires_at)>;
     using Tag = unsigned int;
 
     class Hints

--- a/libtransmission/dns.h
+++ b/libtransmission/dns.h
@@ -60,6 +60,10 @@ public:
         }
     };
 
+    [[nodiscard]] virtual std::optional<std::pair<struct sockaddr const*, socklen_t>> cached(
+        std::string_view address,
+        Hints hints = {}) const = 0;
+
     virtual Tag lookup(std::string_view address, Callback&& callback, Hints hints = {}) = 0;
 
     virtual void cancel(Tag) = 0;

--- a/tests/libtransmission/dns-test.cc
+++ b/tests/libtransmission/dns-test.cc
@@ -147,11 +147,12 @@ TEST_F(EvDnsTest, canCancel)
 TEST_F(EvDnsTest, doesCacheEntries)
 {
     auto dns = EvDns{ event_base_, tr_time };
+    static auto constexpr Name = "example.com"sv;
 
     struct sockaddr const* ai_addr = nullptr;
 
     dns.lookup(
-        "example.com",
+        Name,
         [&ai_addr](struct sockaddr const* ai, socklen_t ailen)
         {
             EXPECT_NE(nullptr, ai);
@@ -165,7 +166,7 @@ TEST_F(EvDnsTest, doesCacheEntries)
 
     auto second_callback_called = false;
     dns.lookup(
-        "example.com",
+        Name,
         [&ai_addr, &second_callback_called](struct sockaddr const* ai, socklen_t ailen)
         {
             EXPECT_NE(nullptr, ai);
@@ -176,6 +177,12 @@ TEST_F(EvDnsTest, doesCacheEntries)
     // since it's cached, the callback should have been invoked
     // without waiting for the event loop
     EXPECT_TRUE(second_callback_called);
+
+    // confirm that `cached()` returns the cached value immediately
+    auto res = dns.cached(Name);
+    EXPECT_TRUE(res);
+    EXPECT_EQ(ai_addr, res->first);
+    EXPECT_GT(res->second, 0);
 }
 
 } // namespace libtransmission::test

--- a/tests/libtransmission/dns-test.cc
+++ b/tests/libtransmission/dns-test.cc
@@ -41,7 +41,10 @@ protected:
         ::testing::Test::TearDown();
     }
 
-    bool waitFor(struct event_base* evb, std::function<bool()> const& test, std::chrono::milliseconds msec = DefaultTimeout)
+    static bool waitFor(
+        struct event_base* evb,
+        std::function<bool()> const& test,
+        std::chrono::milliseconds msec = DefaultTimeout)
     {
         auto const deadline = std::chrono::steady_clock::now() + msec;
 

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -14,19 +14,19 @@ using namespace std::literals;
 
 TEST_F(NetTest, conversionsIPv4)
 {
-    auto constexpr port = tr_port::fromHost(80);
-    auto constexpr addrstr = "127.0.0.1"sv;
+    auto constexpr Port = tr_port::fromHost(80);
+    auto constexpr AddrStr = "127.0.0.1"sv;
 
-    auto addr = tr_address::fromString(addrstr);
+    auto addr = tr_address::fromString(AddrStr);
     EXPECT_TRUE(addr);
-    EXPECT_EQ(addrstr, addr->readable());
+    EXPECT_EQ(AddrStr, addr->readable());
 
-    auto [ss, sslen] = addr->toSockaddr(port);
+    auto [ss, sslen] = addr->toSockaddr(Port);
     EXPECT_EQ(AF_INET, ss.ss_family);
-    EXPECT_EQ(port.network(), reinterpret_cast<sockaddr_in const*>(&ss)->sin_port);
+    EXPECT_EQ(Port.network(), reinterpret_cast<sockaddr_in const*>(&ss)->sin_port);
 
     auto addrport = tr_address::fromSockaddr(reinterpret_cast<sockaddr const*>(&ss));
     EXPECT_TRUE(addrport);
     EXPECT_EQ(addr, addrport->first);
-    EXPECT_EQ(port, addrport->second);
+    EXPECT_EQ(Port, addrport->second);
 }


### PR DESCRIPTION
A followup to #3977 for caching addresses

- add `dns.cached()` which only queries the cache, returning immediately & not running an async lookup
- the `lookup()` callback now also has a TTL argument