### PR TITLE
fixup! refactor: remove TR_PRIsv macros (#3842)

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2136,7 +2136,7 @@ static int processResponse(char const* rpcurl, std::string_view response, Config
 
     if (config.json)
     {
-        fmt::print(response);
+        fmt::print("{:s}\n", response);
         return status;
     }
 


### PR DESCRIPTION
fix: invalid format string passed to fmt::print. This bug first appeared in 4.0.0-beta.1