### PR TITLE
macOS fix a potential hang when updating the blocklist

### DIFF
--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -284,7 +284,7 @@ BlocklistDownloader* fBLDownloader = nil;
     NSTask* gunzip = [[NSTask alloc] init];
     gunzip.launchPath = @"/usr/bin/gunzip";
     gunzip.currentDirectoryPath = destinationDir.path;
-    gunzip.arguments = @[ @"--keep", file.path ];
+    gunzip.arguments = @[ @"--keep", @"--force", file.path ];
 
     @try
     {


### PR DESCRIPTION
fixes a potential hang when updating the blocklist on macOS via gunzip

see here for more details:
https://github.com/transmission/transmission/issues/3969

* Added the `--force` flag to NSTask to overwrite any previously interrupted downloads