### PR TITLE
Fix "User-facing text should use localized string macro"

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3305,10 +3305,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 {
     if (menu == self.fGroupsSetMenu || menu == self.fGroupsSetContextMenu)
     {
-        for (NSInteger i = menu.numberOfItems - 1; i >= 0; i--)
-        {
-            [menu removeItemAtIndex:i];
-        }
+        [menu removeAllItems];
 
         NSMenu* groupMenu = [GroupsController.groups groupMenuWithTarget:self action:@selector(setGroup:) isSmall:NO];
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -603,7 +603,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
 
 - (NSMenu*)menu
 {
-    NSMenu* menu = [[NSMenu alloc] initWithTitle:@"File Outline Menu"];
+    NSMenu* menu = [[NSMenu alloc] initWithTitle:@""];
 
     //check and uncheck
     NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Check Selected", "File Outline -> Menu")
@@ -631,7 +631,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
 
     //priority
     item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Priority", "File Outline -> Menu") action:NULL keyEquivalent:@""];
-    NSMenu* priorityMenu = [[NSMenu alloc] initWithTitle:@"File Priority Menu"];
+    NSMenu* priorityMenu = [[NSMenu alloc] initWithTitle:@""];
     item.submenu = priorityMenu;
     [menu addItem:item];
 

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -349,6 +349,7 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
 {
     if (menu == self.fGroupsButton.menu)
     {
+        //remove all items except first three
         for (NSInteger i = menu.numberOfItems - 1; i >= 3; i--)
         {
             [menu removeItemAtIndex:i];

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -287,7 +287,7 @@ GroupsController* fGroupsInstance = nil;
 
 - (NSMenu*)groupMenuWithTarget:(id)target action:(SEL)action isSmall:(BOOL)small
 {
-    NSMenu* menu = [[NSMenu alloc] initWithTitle:@"Groups"];
+    NSMenu* menu = [[NSMenu alloc] initWithTitle:@""];
 
     NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"None", "Groups -> Menu") action:action
                                            keyEquivalent:@""];

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -27,3 +27,8 @@
 - (NSArray<NSString*>*)nonEmptyComponentsSeparatedByCharactersInSet:(NSCharacterSet*)separators;
 
 @end
+
+__attribute__((annotate("returns_localized_nsstring"))) static inline NSString* LocalizationNotNeeded(NSString* s)
+{
+    return s;
+}

--- a/macosx/SparkleProxy.mm
+++ b/macosx/SparkleProxy.mm
@@ -4,12 +4,14 @@
 
 @import ObjectiveC;
 @import AppKit;
+#import "NSStringAdditions.h"
 
+// Development-only proxy when app is not signed for running Sparkle
 void SUUpdater_checkForUpdates(id self, SEL _cmd, ...)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSAlert* alert = [[NSAlert alloc] init];
-        alert.messageText = @"Sparkle not configured";
+        alert.messageText = LocalizationNotNeeded(@"Sparkle not configured");
         alert.informativeText = [NSString
             stringWithFormat:@"App needs to be codesigned for Development to support Sparkle with Hardened Runtime. Alternatively, re-codesign without the Hardened Runtime option: `sudo codesign -s - %@`",
                              NSBundle.mainBundle.bundleURL.lastPathComponent];


### PR DESCRIPTION
This fixes the localization warnings that were recommended by #3940.
The documentation of NSMenu says that the title is being ignored for our usage, so no need to localize it.
Alternatively, for debugging purposes, we could keep that non-displayed string and proxy it through `LocalizationNotNeeded`.