### PR TITLE
macOS: Change BadgeView.mm so that up is up and down is down

### DIFF
--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -54,19 +54,19 @@ static CGFloat const kBetweenPadding = 2.0;
     BOOL const upload = self.fUploadRate >= 0.1;
     BOOL const download = self.fDownloadRate >= 0.1;
     CGFloat bottom = 0.0;
-    if (upload)
-    {
-        NSImage* uploadBadge = [NSImage imageNamed:@"UploadBadge"];
-        [self badge:uploadBadge string:[NSString stringForSpeedAbbrev:self.fUploadRate] atHeight:bottom];
-
-        if (download)
-        {
-            bottom += uploadBadge.size.height + kBetweenPadding; //download rate above upload rate
-        }
-    }
     if (download)
     {
-        [self badge:[NSImage imageNamed:@"DownloadBadge"] string:[NSString stringForSpeedAbbrev:self.fDownloadRate] atHeight:bottom];
+        NSImage* downloadBadge = [NSImage imageNamed:@"DownloadBadge"];
+        [self badge:downloadBadge string:[NSString stringForSpeedAbbrev:self.fDownloadRate] atHeight:bottom];
+
+        if (upload)
+        {
+            bottom += downloadBadge.size.height + kBetweenPadding; //upload rate above download rate
+        }
+    }
+    if (upload)
+    {
+        [self badge:[NSImage imageNamed:@"UploadBadge"] string:[NSString stringForSpeedAbbrev:self.fUploadRate] atHeight:bottom];
     }
 }
 


### PR DESCRIPTION
For all that is holy, upload should be above download when these two actions happen simultaneously.

![SCR-20221031-nt8](https://user-images.githubusercontent.com/69029666/198929162-3e46ff0b-85f4-4c78-a439-f1df2d65c6f2.png)
