### PR TITLE
fix: chrome needs vendor prefix(-webkit-) for mask

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -369,13 +369,19 @@ $video-image: '../img/film.svg';
 @mixin mime-icon($mime-icon) {
   // background-image: url($mime-icon);
   background-color: var(--color-fg-primary);
+  -webkit-mask-image: url($mime-icon);
   mask-image: url($mime-icon);
+  -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
 
   &[data-icon-multifile='true'] {
+    -webkit-mask-image: url($mime-icon), url($folder-image);
     mask-image: url($mime-icon), url($folder-image);
+    -webkit-mask-position: top left, bottom right;
     mask-position: top left, bottom right;
+    -webkit-mask-repeat: no-repeat, no-repeat;
     mask-repeat: no-repeat, no-repeat;
+    -webkit-mask-size: 16px, 16px;
     mask-size: 16px, 16px;
   }
 }
@@ -437,6 +443,7 @@ $video-image: '../img/film.svg';
       .icon {
         flex-shrink: 0;
         height: $icon-size;
+        -webkit-mask-size: $icon-size, $icon-size-num * 0.5px;
         mask-size: $icon-size, $icon-size-num * 0.5px;
         width: $icon-size;
 

--- a/web/stylelint.config.js
+++ b/web/stylelint.config.js
@@ -27,6 +27,7 @@ module.exports = {
     "primer/no-undefined-vars": true,
     "primer/no-unused-vars": true,
     "property-no-unknown": true,
+    "property-no-vendor-prefix": null,
     "scss/at-rule-no-unknown": true,
     "selector-attribute-quotes": null,
     "selector-max-compound-selectors": null,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6468924/199022361-26c35dc7-7c61-40b3-8718-6a8e894ac4e3.png)

Currently mime icons are not shown properly in Chrome. To fix this, vendor prefix(-webkit-) should be added to style.
(https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image#browser_compatibility)

And I'm not sure if I'm allowed to change stylelint config, but I added "property-no-vendor-prefix": null in it.