### PR TITLE
chore: get rid of webpack error while creating source map

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -40,7 +40,7 @@ const config = {
   output: {
     filename: 'transmission-app.js',
     path: path.resolve(__dirname, 'public_html'),
-    sourceMapFilename: 'transmission-app.js.map'
+    sourceMapFilename: '[file].map',
   },
   plugins: [
     new MiniCssExtractPlugin({
@@ -52,7 +52,7 @@ const config = {
     }),
   ],
   resolve: {
-    extensions: ['.js', '.scss']
+    extensions: ['.js', '.scss'],
   },
 };
 
@@ -60,18 +60,15 @@ if (mode === 'development') {
   config.devServer = {
     compress: true,
     historyApiFallback: {
-      rewrites: [
-        { from: '/transmission/web', to: '/' },
-      ]
+      rewrites: [{ from: '/transmission/web', to: '/' }],
     },
     hot: true,
     port: devPort,
     proxy: {
-      '/rpc': rpcUrl
+      '/rpc': rpcUrl,
     },
-    static: './public_html'
+    static: './public_html',
   };
 }
 
 module.exports = config;
-


### PR DESCRIPTION
I found 'ERROR in Conflict: Multiple assets emit different content to the same filename transmission-app.js.map'  msg occurs everytime code changes during dev mode.
This commit resolves the error message.