### PR TITLE
fix: open torrent dialog layout adjusted

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1571,6 +1571,17 @@ dialog {
   padding-left: 10px;
 }
 
+/// OPEN TORRENT DIALOG
+.open-torrent {
+  input {
+    margin-bottom: 15px;
+  }
+
+  #auto-start-label {
+    margin-left: 5px;
+  }
+}
+
 /// HOTKEYS DIALOG
 
 .shortcuts-dialog {

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -160,7 +160,7 @@ export class OpenDialog extends EventTarget {
     label = document.createElement('label');
     label.id = 'add-dialog-folder-label';
     label.for = input_id;
-    label.textContent = 'Destination folder:';
+    label.textContent = 'Destination folder: ';
     workarea.append(label);
 
     const freespace = document.createElement('span');


### PR DESCRIPTION
Comparing with 3.0 web interface, open torrent dialog layout has no margin between items.

3.0
![image](https://user-images.githubusercontent.com/6468924/199174352-130d07bb-e892-40ff-a796-714dae750433.png)

Current 4.0
![image](https://user-images.githubusercontent.com/6468924/199174537-d73e2652-fc56-42b7-be7e-4f2bbfe3366d.png)

Adjusted
![image](https://user-images.githubusercontent.com/6468924/199176537-5e43cbf2-274b-4cb6-8b3d-ddcaccc398bf.png)

