### PR TITLE
Auto enlarge search field when editing

### DIFF
--- a/macosx/FilterBar.xib
+++ b/macosx/FilterBar.xib
@@ -15,6 +15,7 @@
                 <outlet property="fNoFilterButton" destination="9" id="27"/>
                 <outlet property="fPauseFilterButton" destination="6" id="28"/>
                 <outlet property="fSearchField" destination="10" id="31"/>
+                <outlet property="fSearchFieldMinWidthConstraint" destination="Ven-bt-DjP" id="X9R-JZ-TVl"/>
                 <outlet property="fSeedFilterButton" destination="7" id="32"/>
                 <outlet property="view" destination="2" id="33"/>
             </connections>

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
     FilterTypeTagTracker = 402,
 };
 
-@interface FilterBarController ()
+@interface FilterBarController ()<NSSearchFieldDelegate>
 
 @property(nonatomic) IBOutlet FilterButton* fNoFilterButton;
 @property(nonatomic) IBOutlet FilterButton* fActiveFilterButton;
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
 @property(nonatomic) IBOutlet FilterButton* fErrorFilterButton;
 
 @property(nonatomic) IBOutlet NSSearchField* fSearchField;
+@property(nonatomic) IBOutlet NSLayoutConstraint* fSearchFieldMinWidthConstraint;
 
 @property(nonatomic) IBOutlet NSPopUpButton* fGroupsButton;
 
@@ -135,8 +136,11 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
 
     [self updateGroupsButton];
 
-    //update when groups change
+    // update when groups change
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(updateGroups:) name:@"UpdateGroups" object:nil];
+
+    // update when filter change
+    self.fSearchField.delegate = self;
 }
 
 - (void)dealloc
@@ -261,6 +265,16 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
 - (void)focusSearchField
 {
     [self.view.window makeFirstResponder:self.fSearchField];
+}
+
+- (void)searchFieldDidStartSearching:(NSSearchField*)sender
+{
+    [self.fSearchFieldMinWidthConstraint animator].constant = 95;
+}
+
+- (void)searchFieldDidEndSearching:(NSSearchField*)sender
+{
+    [self.fSearchFieldMinWidthConstraint animator].constant = 48;
 }
 
 - (void)setSearchType:(id)sender


### PR DESCRIPTION
Basic implementation.
It may not be the most reactive design, but it solves the issue that previously the search string was always hidden for users on a narrow window.

https://user-images.githubusercontent.com/839992/199260091-8e7035b9-e687-474f-810d-559b5e0de51f.mov

