### PR TITLE
Downgrade Fedora image used in GitHub Actions CI to 36

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -467,12 +467,12 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  fedora-37-from-tarball:
+  fedora-36-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: ubuntu-22.04
     container:
-      image: fedora:37
+      image: fedora:36
     steps:
       - name: Show Configuration
         run: |


### PR DESCRIPTION
37 is still "rawhide" and it starts to pull in packages from 38 making things weird.