### PR TITLE
Fix: values above INT_MAX (68 years) are interpreted as negative values

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -2072,9 +2072,9 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     time_t eta = self.fStat->eta;
     // if there's a regular ETA, the torrent isn't idle
     BOOL fromIdle = NO;
+    // Foundation undocumented behavior: values above INT_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451)
     if (eta > INT_MAX)
     {
-        // Foundation bug (not fixed in macOS 13.0): values above INT_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451).
         unknown = YES;
     }
     else if (eta == TR_ETA_NOT_AVAIL || eta == TR_ETA_UNKNOWN)
@@ -2100,6 +2100,8 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
         formatter.collapsesLargestUnit = YES;
         formatter.includesTimeRemainingPhrase = YES;
     });
+    // the duration of months being variable, setting the reference date to now (instead of 00:00:00 UTC on 1 January 2001)
+    formatter.referenceDate = NSDate.date;
     NSString* idleString = [formatter stringFromTimeInterval:eta];
 
     if (fromIdle)

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -2068,25 +2068,16 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
 
 - (NSString*)etaString
 {
-    BOOL unknown = NO;
     time_t eta = self.fStat->eta;
     // if there's a regular ETA, the torrent isn't idle
     BOOL fromIdle = NO;
-    // Foundation undocumented behavior: values above INT_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451)
-    if (eta > INT_MAX)
-    {
-        unknown = YES;
-    }
-    else if (eta == TR_ETA_NOT_AVAIL || eta == TR_ETA_UNKNOWN)
+    if (eta == TR_ETA_NOT_AVAIL || eta == TR_ETA_UNKNOWN)
     {
         eta = self.fStat->etaIdle;
         fromIdle = YES;
-        if (eta == TR_ETA_NOT_AVAIL || eta >= kETAIdleDisplaySec)
-        {
-            unknown = YES;
-        }
     }
-    if (unknown)
+    // Foundation undocumented behavior: values above INT_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451)
+    if (eta < 0 || eta > INT_MAX || (fromIdle && eta >= kETAIdleDisplaySec))
     {
         return NSLocalizedString(@"remaining time unknown", "Torrent -> eta string");
     }


### PR DESCRIPTION
Fix #3451