### PR TITLE
refactor: simplify blocklist code

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cstdio>
 #include <fstream>
 #include <string_view>
 #include <vector>
@@ -27,6 +26,298 @@ using namespace std::literals;
 
 namespace libtransmission
 {
+namespace
+{
+using address_pair_t = std::pair<tr_address, tr_address>;
+
+auto constexpr FileFormatVersion = std::array<char, 4>{ 'v', '0', '0', '3' };
+auto constexpr BinSuffix = std::string_view{ ".bin" };
+
+void save(std::string_view filename, std::pair<tr_address, tr_address> const* ranges, size_t n_ranges)
+{
+    auto out = std::ofstream{ tr_pathbuf{ filename }, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
+    if (!out.is_open())
+    {
+        tr_logAddWarn(fmt::format(
+            _("Couldn't read '{path}': {error} ({error_code})"),
+            fmt::arg("path", filename),
+            fmt::arg("error", tr_strerror(errno)),
+            fmt::arg("error_code", errno)));
+        return;
+    }
+
+    if (!out.write(std::data(FileFormatVersion), std::size(FileFormatVersion)) ||
+        !out.write(reinterpret_cast<char const*>(ranges), n_ranges * sizeof(*ranges)))
+    {
+        tr_logAddWarn(fmt::format(
+            _("Couldn't save '{path}': {error} ({error_code})"),
+            fmt::arg("path", filename),
+            fmt::arg("error", tr_strerror(errno)),
+            fmt::arg("error_code", errno)));
+    }
+    else
+    {
+        tr_logAddInfo(fmt::format(
+            ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", n_ranges),
+            fmt::arg("path", tr_sys_path_basename(filename)),
+            fmt::arg("count", n_ranges)));
+    }
+
+    out.close();
+}
+
+/*
+ * P2P plaintext format: "comment:x.x.x.x-y.y.y.y" / "comment:x:x:x:x:x:x:x:x-x:x:x:x:x:x:x:x"
+ * https://web.archive.org/web/20100328075307/http://wiki.phoenixlabs.org/wiki/P2P_Format
+ * https://en.wikipedia.org/wiki/PeerGuardian#P2P_plaintext_format
+ */
+std::optional<address_pair_t> parseLine1(std::string_view line)
+{
+    // remove leading "comment:"
+    auto pos = line.find(':');
+    if (pos == std::string_view::npos)
+    {
+        return {};
+    }
+    line = line.substr(pos + 1);
+
+    // parse the leading 'x.x.x.x'
+    pos = line.find('-');
+    if (pos == std::string_view::npos)
+    {
+        return {};
+    }
+
+    auto addrpair = address_pair_t{};
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
+    {
+        addrpair.first = *addr;
+    }
+    else
+    {
+        return {};
+    }
+
+    line = line.substr(pos + 1);
+
+    // parse the trailing 'y.y.y.y'
+    if (auto const addr = tr_address::fromString(line); addr)
+    {
+        addrpair.second = *addr;
+    }
+    else
+    {
+        return {};
+    }
+
+    return addrpair;
+}
+/*
+ * DAT / eMule format: "000.000.000.000 - 000.255.255.255 , 000 , invalid ip"a
+ * https://sourceforge.net/p/peerguardian/wiki/dev-blocklist-format-dat/
+ */
+std::optional<address_pair_t> parseLine2(std::string_view line)
+{
+    static auto constexpr Delim1 = std::string_view{ " - " };
+    static auto constexpr Delim2 = std::string_view{ " , " };
+
+    auto pos = line.find(Delim1);
+    if (pos == std::string_view::npos)
+    {
+        return {};
+    }
+
+    auto addrpair = address_pair_t{};
+
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
+    {
+        addrpair.first = *addr;
+    }
+    else
+    {
+        return {};
+    }
+
+    line = line.substr(pos + std::size(Delim1));
+    pos = line.find(Delim2);
+    if (pos == std::string_view::npos)
+    {
+        return {};
+    }
+
+    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
+    {
+        addrpair.second = *addr;
+    }
+    else
+    {
+        return {};
+    }
+
+    return addrpair;
+}
+
+/*
+ * CIDR notation: "0.0.0.0/8", "::/64"
+ * https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
+ */
+std::optional<address_pair_t> parseLine3(char const* line)
+{
+    auto ip = std::array<unsigned int, 4>{};
+    unsigned int pflen = 0;
+    uint32_t ip_u = 0;
+    uint32_t mask = 0xffffffff;
+
+    // NOLINTNEXTLINE readability-container-data-pointer
+    if (sscanf(line, "%u.%u.%u.%u/%u", TR_ARG_TUPLE(&ip[0], &ip[1], &ip[2], &ip[3]), &pflen) != 5)
+    {
+        return {};
+    }
+
+    if (pflen > 32 || ip[0] > 0xff || ip[1] > 0xff || ip[2] > 0xff || ip[3] > 0xff)
+    {
+        return {};
+    }
+
+    // this is host order
+    mask <<= 32 - pflen;
+    ip_u = ip[0] << 24 | ip[1] << 16 | ip[2] << 8 | ip[3];
+
+    // fill the non-prefix bits the way we need it
+    auto addrpair = address_pair_t{};
+    addrpair.first.addr.addr4.s_addr = ntohl(ip_u & mask);
+    addrpair.second.addr.addr4.s_addr = ntohl(ip_u | (~mask));
+    return addrpair;
+}
+
+std::optional<address_pair_t> parseLine(char const* line)
+{
+    if (auto range = parseLine1(line); range)
+    {
+        return range;
+    }
+
+    if (auto range = parseLine2(line); range)
+    {
+        return range;
+    }
+
+    if (auto range = parseLine3(line); range)
+    {
+        return range;
+    }
+
+    return {};
+}
+
+auto parseFile(std::string_view filename)
+{
+    auto ranges = std::vector<address_pair_t>{};
+
+    auto in = std::ifstream{ tr_pathbuf{ filename } };
+    if (!in.is_open())
+    {
+        tr_logAddWarn(fmt::format(
+            _("Couldn't read '{path}': {error} ({error_code})"),
+            fmt::arg("path", filename),
+            fmt::arg("error", tr_strerror(errno)),
+            fmt::arg("error_code", errno)));
+        return ranges;
+    }
+
+    auto line = std::string{};
+    auto line_number = size_t{ 0U };
+    while (std::getline(in, line))
+    {
+        ++line_number;
+        if (auto range = parseLine(line.c_str()); range)
+        {
+            ranges.push_back(*range);
+        }
+        else
+        {
+            // don't try to display the actual lines - it causes issues
+            tr_logAddWarn(fmt::format(_("Couldn't parse line: '{line}'"), fmt::arg("line", line_number)));
+        }
+    }
+    in.close();
+
+    if (std::empty(ranges))
+    {
+        return ranges;
+    }
+
+    // safeguard against some joker swapping the begin & end ranges
+    for (auto& range : ranges)
+    {
+        if (range.first > range.second)
+        {
+            std::swap(range.first, range.second);
+        }
+    }
+
+    // sort ranges by start address
+    std::sort(std::begin(ranges), std::end(ranges), [](auto const& a, auto const& b) { return a.first < b.first; });
+
+    // merge overlapping ranges
+    auto keep = size_t{ 0U };
+    for (auto const& range : ranges)
+    {
+        if (ranges[keep].second < range.first)
+        {
+            ranges[++keep] = range;
+        }
+        else if (ranges[keep].second < range.second)
+        {
+            ranges[keep].second = range.second;
+        }
+    }
+
+    TR_ASSERT_MSG(keep + 1 <= std::size(ranges), "Can shrink `ranges` or leave intact, but not grow");
+    ranges.resize(keep + 1);
+
+#ifdef TR_ENABLE_ASSERTS
+    for (auto const& range : ranges)
+    {
+        TR_ASSERT(range.first <= range.second);
+    }
+    for (size_t i = 1, n = std::size(ranges); i < n; ++i)
+    {
+        TR_ASSERT(ranges[i - 1].second < ranges[i].first);
+    }
+#endif
+
+    return ranges;
+}
+
+auto getFilenamesInDir(std::string_view folder)
+{
+    auto files = std::vector<std::string>{};
+
+    auto const odir = tr_sys_dir_open(tr_pathbuf{ folder });
+
+    if (odir == TR_BAD_SYS_DIR)
+    {
+        return files;
+    }
+
+    char const* name = nullptr;
+    auto prefix = std::string{ folder } + '/';
+    while ((name = tr_sys_dir_read_name(odir)) != nullptr)
+    {
+        if (name[0] == '.') // ignore dotfiles
+        {
+            continue;
+        }
+
+        files.emplace_back(prefix + name);
+    }
+
+    tr_sys_dir_close(odir);
+    return files;
+}
+
+} // namespace
 
 void Blocklist::ensureLoaded() const
 {
@@ -96,38 +387,6 @@ void Blocklist::ensureLoaded() const
         fmt::arg("path", tr_sys_path_basename(bin_file_)),
         fmt::arg("count", std::size(rules_))));
 }
-
-namespace
-{
-
-auto getFilenamesInDir(std::string_view folder)
-{
-    auto files = std::vector<std::string>{};
-
-    auto const odir = tr_sys_dir_open(tr_pathbuf{ folder });
-
-    if (odir == TR_BAD_SYS_DIR)
-    {
-        return files;
-    }
-
-    char const* name = nullptr;
-    auto prefix = std::string{ folder } + '/';
-    while ((name = tr_sys_dir_read_name(odir)) != nullptr)
-    {
-        if (name[0] == '.') // ignore dotfiles
-        {
-            continue;
-        }
-
-        files.emplace_back(prefix + name);
-    }
-
-    tr_sys_dir_close(odir);
-    return files;
-}
-
-} // namespace
 
 std::vector<Blocklist> Blocklist::loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled)
 {
@@ -209,267 +468,10 @@ bool Blocklist::hasAddress(tr_address const& addr) const
     return std::binary_search(std::begin(rules_), std::end(rules_), addr, Compare{});
 }
 
-/*
- * P2P plaintext format: "comment:x.x.x.x-y.y.y.y" / "comment:x:x:x:x:x:x:x:x-x:x:x:x:x:x:x:x"
- * https://web.archive.org/web/20100328075307/http://wiki.phoenixlabs.org/wiki/P2P_Format
- * https://en.wikipedia.org/wiki/PeerGuardian#P2P_plaintext_format
- */
-std::optional<Blocklist::AddressPair> Blocklist::parseLine1(std::string_view line)
-{
-    // remove leading "comment:"
-    auto pos = line.find(':');
-    if (pos == std::string_view::npos)
-    {
-        return {};
-    }
-    line = line.substr(pos + 1);
-
-    // parse the leading 'x.x.x.x'
-    pos = line.find('-');
-    if (pos == std::string_view::npos)
-    {
-        return {};
-    }
-
-    auto addrpair = AddressPair{};
-    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
-    {
-        addrpair.first = *addr;
-    }
-    else
-    {
-        return {};
-    }
-
-    line = line.substr(pos + 1);
-
-    // parse the trailing 'y.y.y.y'
-    if (auto const addr = tr_address::fromString(line); addr)
-    {
-        addrpair.second = *addr;
-    }
-    else
-    {
-        return {};
-    }
-
-    return addrpair;
-}
-
-/*
- * DAT / eMule format: "000.000.000.000 - 000.255.255.255 , 000 , invalid ip"a
- * https://sourceforge.net/p/peerguardian/wiki/dev-blocklist-format-dat/
- */
-std::optional<Blocklist::AddressPair> Blocklist::parseLine2(std::string_view line)
-{
-    static auto constexpr Delim1 = std::string_view{ " - " };
-    static auto constexpr Delim2 = std::string_view{ " , " };
-
-    auto pos = line.find(Delim1);
-    if (pos == std::string_view::npos)
-    {
-        return {};
-    }
-
-    auto addrpair = AddressPair{};
-
-    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
-    {
-        addrpair.first = *addr;
-    }
-    else
-    {
-        return {};
-    }
-
-    line = line.substr(pos + std::size(Delim1));
-    pos = line.find(Delim2);
-    if (pos == std::string_view::npos)
-    {
-        return {};
-    }
-
-    if (auto const addr = tr_address::fromString(line.substr(0, pos)); addr)
-    {
-        addrpair.second = *addr;
-    }
-    else
-    {
-        return {};
-    }
-
-    return addrpair;
-}
-
-/*
- * CIDR notation: "0.0.0.0/8", "::/64"
- * https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
- */
-std::optional<Blocklist::AddressPair> Blocklist::parseLine3(char const* line)
-{
-    auto ip = std::array<unsigned int, 4>{};
-    unsigned int pflen = 0;
-    uint32_t ip_u = 0;
-    uint32_t mask = 0xffffffff;
-
-    // NOLINTNEXTLINE readability-container-data-pointer
-    if (sscanf(line, "%u.%u.%u.%u/%u", TR_ARG_TUPLE(&ip[0], &ip[1], &ip[2], &ip[3]), &pflen) != 5)
-    {
-        return {};
-    }
-
-    if (pflen > 32 || ip[0] > 0xff || ip[1] > 0xff || ip[2] > 0xff || ip[3] > 0xff)
-    {
-        return {};
-    }
-
-    // this is host order
-    mask <<= 32 - pflen;
-    ip_u = ip[0] << 24 | ip[1] << 16 | ip[2] << 8 | ip[3];
-
-    // fill the non-prefix bits the way we need it
-    auto addrpair = AddressPair{};
-    addrpair.first.addr.addr4.s_addr = ntohl(ip_u & mask);
-    addrpair.second.addr.addr4.s_addr = ntohl(ip_u | (~mask));
-    return addrpair;
-}
-
-std::optional<Blocklist::AddressPair> Blocklist::parseLine(char const* line)
-{
-    if (auto range = parseLine1(line); range)
-    {
-        return range;
-    }
-
-    if (auto range = parseLine2(line); range)
-    {
-        return range;
-    }
-
-    if (auto range = parseLine3(line); range)
-    {
-        return range;
-    }
-
-    return {};
-}
-
-std::vector<Blocklist::AddressPair> Blocklist::parseFile(std::string_view filename)
-{
-    auto in = std::ifstream{ tr_pathbuf{ filename } };
-    if (!in.is_open())
-    {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
-        return {};
-    }
-
-    auto line = std::string{};
-    auto line_number = size_t{ 0U };
-    auto ranges = std::vector<AddressPair>{};
-    while (std::getline(in, line))
-    {
-        ++line_number;
-        if (auto range = parseLine(line.c_str()); range)
-        {
-            ranges.push_back(*range);
-        }
-        else
-        {
-            // don't try to display the actual lines - it causes issues
-            tr_logAddWarn(fmt::format(_("Couldn't parse line: '{line}'"), fmt::arg("line", line_number)));
-        }
-    }
-    in.close();
-
-    if (std::empty(ranges))
-    {
-        return {};
-    }
-
-    // safeguard against some joker swapping the begin & end ranges
-    for (auto& range : ranges)
-    {
-        if (range.first > range.second)
-        {
-            std::swap(range.first, range.second);
-        }
-    }
-
-    // sort ranges by start address
-    std::sort(std::begin(ranges), std::end(ranges), [](auto const& a, auto const& b) { return a.first < b.first; });
-
-    // merge overlapping ranges
-    size_t keep = 0; // index in ranges
-    for (auto const& range : ranges)
-    {
-        if (ranges[keep].second < range.first)
-        {
-            ranges[++keep] = range;
-        }
-        else if (ranges[keep].second < range.second)
-        {
-            ranges[keep].second = range.second;
-        }
-    }
-
-    TR_ASSERT_MSG(keep + 1 <= std::size(ranges), "Can shrink `ranges` or leave intact, but not grow");
-    ranges.resize(keep + 1);
-
-#ifdef TR_ENABLE_ASSERTS
-    for (auto const& range : ranges)
-    {
-        TR_ASSERT(range.first <= range.second);
-    }
-    for (size_t i = 1, n = std::size(ranges); i < n; ++i)
-    {
-        TR_ASSERT(ranges[i - 1].second < ranges[i].first);
-    }
-#endif
-
-    return ranges;
-}
-
-void Blocklist::save(std::string_view filename, AddressPair const* ranges, size_t n_ranges)
-{
-    auto out = std::ofstream{ tr_pathbuf{ filename }, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
-    if (!out.is_open())
-    {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
-        return;
-    }
-
-    if (!out.write(std::data(FileFormatVersion), std::size(FileFormatVersion)) ||
-        !out.write(reinterpret_cast<char const*>(ranges), n_ranges * sizeof(AddressPair)))
-    {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't save '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
-    }
-    else
-    {
-        tr_logAddInfo(fmt::format(
-            ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", n_ranges),
-            fmt::arg("path", tr_sys_path_basename(filename)),
-            fmt::arg("count", n_ranges)));
-    }
-
-    out.close();
-}
-
 std::optional<Blocklist> Blocklist::saveNew(std::string_view external_file, std::string_view bin_file, bool is_enabled)
 {
     // if we can't parse the file, do nothing
-    auto const rules = Blocklist::parseFile(external_file);
+    auto const rules = parseFile(external_file);
     if (std::empty(rules))
     {
         return {};

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -31,45 +31,23 @@ using namespace std::literals;
 ****  PRIVATE
 ***/
 
-BlocklistFile::AddressRange BlocklistFile::addressPairToRange(AddressPair const& pair)
-{
-    auto ret = AddressRange{};
-
-    if (auto const& addr = pair.first; addr.isIPv4())
-    {
-        ret.begin_ = ntohl(addr.addr.addr4.s_addr);
-        fmt::print("ipv4 begin {:s} -> {:d}\n", addr.readable(), ret.begin_);
-    }
-    else // IPv6
-    {
-        ret.begin6_ = addr.addr.addr6;
-        fmt::print("ipv6 begin {:s} -> {:d}\n", addr.readable(), ret.begin_);
-    }
-
-    if (auto const& addr = pair.second; addr.isIPv4())
-    {
-        ret.end_ = ntohl(addr.addr.addr4.s_addr);
-        fmt::print("ipv4 end {:s} -> {:d}\n", addr.readable(), ret.end_);
-    }
-    else // IPv6
-    {
-        ret.end6_ = addr.addr.addr6;
-        fmt::print("ipv6 end {:s} -> {:d}\n", addr.readable(), ret.end_);
-    }
-
-    return ret;
-}
-
-
-void BlocklistFile::close()
-{
-    rules_.clear();
-}
-
 void BlocklistFile::ensureLoaded() const
 {
     if (!std::empty(rules_))
     {
+        return;
+    }
+
+    tr_error* error = nullptr;
+    auto const file_info = tr_sys_path_get_info(filename_, 0, &error);
+    if (error)
+    {
+        tr_logAddWarn(fmt::format(
+            _("Couldn't read '{path}': {error} ({error_code})"),
+            fmt::arg("path", filename_),
+            fmt::arg("error", error->message),
+            fmt::arg("error_code", error->code)));
+        tr_error_clear(&error);
         return;
     }
 
@@ -84,63 +62,36 @@ void BlocklistFile::ensureLoaded() const
         return;
     }
 
-    auto file_info = tr_sys_path_get_info(filename_);
-    auto zeroes_count = 0;
-    auto max_zeroes = 0;
-
-    static auto constexpr RangeSize = sizeof(AddressRange);
-    if (file_info->size >= RangeSize)
+    bool unsupported_file = false;
+    if (file_info->size < std::size(FileFormatVersion))
     {
-        std::array<char, 40> first_struct = {};
-
-        in.read(reinterpret_cast<char*>(&first_struct), std::size(first_struct));
-        in.clear();
-        in.seekg(0, std::ios::beg);
-
-        for (auto const struct_byte : first_struct)
-        {
-            if (struct_byte != 0)
-            {
-                zeroes_count = 0;
-            }
-            else
-            {
-                ++zeroes_count;
-
-                if (zeroes_count > max_zeroes)
-                {
-                    max_zeroes = zeroes_count;
-                }
-            }
-        }
+        unsupported_file = true;
     }
-
-    // Check for old blocklist file format
-    // Old struct size was 8 bytes (2 IPv4), new struct size is 40 bytes (2 IPv4, 2 IPv6)
-    //
-    // If we encounter less than 4 continuous bytes containing 0 we are using old file format
-    // (as the new format guarantees at least 2 empty IPv4 OR 2 empty IPv6)
-    // If we confirm using old style convert to new style and rewrite blocklist file
-    if ((file_info->size >= 40 && max_zeroes < 4) || (file_info->size % 8 == 0 && file_info->size % 40 != 0))
+    else if (((file_info->size - std::size(FileFormatVersion)) % sizeof(AddressPair)) != 0)
     {
-        auto range = AddressRange{};
-        while (in.read(reinterpret_cast<char*>(&range), 8))
-        {
-            rules_.emplace_back(range);
-        }
-
-        tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
-
-        RewriteBlocklistFile();
+        unsupported_file = true;
     }
-
     else
     {
-        auto range = AddressRange{};
-        while (in.read(reinterpret_cast<char*>(&range), sizeof(range)))
-        {
-            rules_.emplace_back(range);
-        }
+        auto version_string = std::array<char, std::size(FileFormatVersion)>{};
+        in.read(std::data(version_string), std::size(version_string));
+        unsupported_file = version_string != FileFormatVersion;
+    }
+    if (unsupported_file)
+    {
+        tr_sys_path_remove(filename_);
+        auto source_file = std::string_view{ filename_ };
+        source_file.remove_suffix(std::size(BinSuffix));
+        tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
+        rules_ = parseFile(source_file);
+        save(filename_, std::data(rules_), std::size(rules_));
+        return;
+    }
+
+    auto range = AddressPair{};
+    while (in.read(reinterpret_cast<char*>(&range), sizeof(range)))
+    {
+        rules_.emplace_back(range);
     }
 
     tr_logAddInfo(fmt::format(
@@ -179,13 +130,13 @@ std::vector<std::unique_ptr<BlocklistFile>> BlocklistFile::loadBlocklists(
             continue;
         }
 
-        if (auto const path = tr_pathbuf{ blocklist_dir, '/', name }; tr_strvEndsWith(path, ".bin"sv))
+        if (auto const path = tr_pathbuf{ blocklist_dir, '/', name }; tr_strvEndsWith(path, BinSuffix))
         {
             load = path;
         }
         else
         {
-            auto const binname = tr_pathbuf{ blocklist_dir, '/', name, ".bin"sv };
+            auto const binname = tr_pathbuf{ blocklist_dir, '/', name, BinSuffix };
 
             if (auto const bininfo = tr_sys_path_get_info(binname); !bininfo)
             {
@@ -247,42 +198,38 @@ bool BlocklistFile::hasAddress(tr_address const& addr)
 
     ensureLoaded();
 
-    if (std::empty(rules_))
+    struct Compare
     {
-        return false;
-    }
+        [[nodiscard]] auto compare(tr_address const& a, AddressPair const& b) const noexcept // <=>
+        {
+            if (a < b.first)
+            {
+                return -1;
+            }
+            if (b.second < a)
+            {
+                return 1;
+            }
+            return 0;
+        }
 
-    if (addr.isIPv4())
-    {
-        auto const needle = ntohl(addr.addr.addr4.s_addr);
+        [[nodiscard]] auto compare(AddressPair const& a, tr_address const& b) const noexcept // <=>
+        {
+            return -compare(b, a);
+        }
 
-        // std::binary_search works differently and requires a less-than comparison
-        // and two arguments of the same type. std::bsearch is the right choice.
-        auto const* range = static_cast<AddressRange const*>(std::bsearch(
-            &needle,
-            std::data(rules_),
-            std::size(rules_),
-            sizeof(AddressRange),
-            AddressRange::compareIPv4AddressToRange));
+        [[nodiscard]] auto operator()(AddressPair const& a, tr_address const& b) const noexcept // <
+        {
+            return compare(a, b) < 0;
+        }
 
-        return range != nullptr;
-    }
+        [[nodiscard]] auto operator()(tr_address const& a, AddressPair const& b) const noexcept // <
+        {
+            return compare(a, b) < 0;
+        }
+    };
 
-    if (addr.isIPv6())
-    {
-        auto const needle = addr.addr.addr6;
-
-        auto const* range = static_cast<AddressRange const*>(std::bsearch(
-            &needle,
-            std::data(rules_),
-            std::size(rules_),
-            sizeof(AddressRange),
-            AddressRange::compareIPv6AddressToRange));
-
-        return range != nullptr;
-    }
-
-    return false;
+    return std::binary_search(std::begin(rules_), std::end(rules_), addr, Compare{});
 }
 
 /*
@@ -410,49 +357,29 @@ std::optional<BlocklistFile::AddressPair> BlocklistFile::parseLine3(char const* 
     return addrpair;
 }
 
-std::optional<BlocklistFile::AddressRange> BlocklistFile::parseLine(char const* line)
+std::optional<BlocklistFile::AddressPair> BlocklistFile::parseLine(char const* line)
 {
-    fmt::print("parseLine {:s}\n", line);
-    if (auto const addrpair = parseLine1(line); addrpair)
+    if (auto range = parseLine1(line); range)
     {
-        fmt::print("parseLine1 succeeded: {:s} -> {:s}\n", addrpair->first.readable(), addrpair->second.readable());
-        return addressPairToRange(*addrpair);
+        return range;
     }
 
-    if (auto const addrpair = parseLine2(line); addrpair)
+    if (auto range = parseLine2(line); range)
     {
-        fmt::print("parseLine2 succeeded: {:s} -> {:s}\n", addrpair->first.readable(), addrpair->second.readable());
-        return addressPairToRange(*addrpair);
+        return range;
     }
 
-    if (auto const addrpair = parseLine3(line); addrpair)
+    if (auto range = parseLine3(line); range)
     {
-        fmt::print("parseLine3 succeeded: {:s} -> {:s}\n", addrpair->first.readable(), addrpair->second.readable());
-        return addressPairToRange(*addrpair);
+        return range;
     }
 
     return {};
 }
 
-bool BlocklistFile::compareAddressRangesByFirstAddress(AddressRange const& a, AddressRange const& b)
+std::vector<BlocklistFile::AddressPair> BlocklistFile::parseFile(std::string_view filename)
 {
-    if (a.begin_ == 0 && a.end_ == 0)
-    {
-        // IPv6
-        return (memcmp(a.begin6_.s6_addr, b.begin6_.s6_addr, sizeof(a.begin6_.s6_addr)) < 0);
-    }
-
-    return a.begin_ < b.begin_;
-}
-
-size_t BlocklistFile::setContent(char const* filename)
-{
-    if (filename == nullptr)
-    {
-        return {};
-    }
-
-    auto in = std::ifstream{ filename };
+    auto in = std::ifstream{ tr_pathbuf{ filename } };
     if (!in.is_open())
     {
         tr_logAddWarn(fmt::format(
@@ -465,23 +392,20 @@ size_t BlocklistFile::setContent(char const* filename)
 
     auto line = std::string{};
     auto line_number = size_t{ 0U };
-    auto ranges = std::vector<AddressRange>{};
+    auto ranges = std::vector<AddressPair>{};
     while (std::getline(in, line))
     {
         ++line_number;
-        if (auto const range = parseLine(line.c_str()); range)
+        if (auto range = parseLine(line.c_str()); range)
         {
-            fmt::print("pushing range back\n");
             ranges.push_back(*range);
         }
         else
         {
             // don't try to display the actual lines - it causes issues
-            fmt::print(_("Couldn't parse line: '{line}'\n"), fmt::arg("line", line_number));
             tr_logAddWarn(fmt::format(_("Couldn't parse line: '{line}'"), fmt::arg("line", line_number)));
         }
     }
-    fmt::print("ranges size {:d}\n", std::size(ranges));
     in.close();
 
     if (std::empty(ranges))
@@ -489,164 +413,92 @@ size_t BlocklistFile::setContent(char const* filename)
         return {};
     }
 
-    //separate before sorting
-    auto ipv4_ranges = std::vector<AddressRange>{};
-    auto ipv6_ranges = std::vector<AddressRange>{};
-
-    for (auto const& range : ranges)
+    // safeguard against some joker swapping the begin & end ranges
+    for (auto& range : ranges)
     {
-        if (range.begin_ == 0 && range.end_ == 0)
+        if (range.first > range.second)
         {
-            // IPv6
-            ipv6_ranges.emplace_back(range);
-        }
-        else
-        {
-            ipv4_ranges.emplace_back(range);
+            std::swap(range.first, range.second);
         }
     }
 
-    std::sort(std::begin(ipv4_ranges), std::end(ipv4_ranges), BlocklistFile::compareAddressRangesByFirstAddress);
-    std::sort(std::begin(ipv6_ranges), std::end(ipv6_ranges), BlocklistFile::compareAddressRangesByFirstAddress);
-    fmt::print("I think we have {:d} ipv4 and {:d} ipv6\n", std::size(ipv4_ranges), std::size(ipv6_ranges));
+    std::sort(std::begin(ranges), std::end(ranges), [](auto const& a, auto const& b) { return a.first < b.first; });
 
-    // combine sorted
-    ranges.clear();
-    ranges.insert(ranges.end(), ipv4_ranges.begin(), ipv4_ranges.end());
-    ranges.insert(ranges.end(), ipv6_ranges.begin(), ipv6_ranges.end());
-    fmt::print("ranges size after sorting {:d}\n", std::size(ranges));
-
+    // merge overlapping ranges
     size_t keep = 0; // index in ranges
-
-    // merge
     for (auto const& range : ranges)
     {
-        if (range.begin_ == 0 && range.end_ == 0)
+        if (ranges[keep].second < range.first)
         {
-            fmt::print("ipv6\n");
-            // IPv6
-            if (memcmp(ranges[keep].end6_.s6_addr, range.begin6_.s6_addr, sizeof(range.begin6_.s6_addr)) < 0)
-            {
-                ranges[++keep] = range;
-            }
-            else if (memcmp(ranges[keep].end6_.s6_addr, range.end6_.s6_addr, sizeof(range.begin6_.s6_addr)) < 0)
-            {
-                ranges[keep].end6_ = range.end6_;
-            }
+            ranges[++keep] = range;
         }
-        else
+        else if (ranges[keep].second < range.second)
         {
-            fmt::print("ipv4 {:d} {:d}\n", range.begin_, range.end_);
-            if (ranges[keep].end_ < range.begin_)
-            {
-                ranges[++keep] = range;
-            }
-            else if (ranges[keep].end_ < range.end_)
-            {
-                ranges[keep].end_ = range.end_;
-            }
+            ranges[keep].second = range.second;
         }
     }
 
     TR_ASSERT_MSG(keep + 1 <= std::size(ranges), "Can shrink `ranges` or leave intact, but not grow");
     ranges.resize(keep + 1);
-    fmt::print("ranges size after merging {:d}\n", std::size(ranges));
 
 #ifdef TR_ENABLE_ASSERTS
-    assertValidRules(ranges);
+    for (auto const& r : ranges)
+    {
+        TR_ASSERT(r.first <= r.second);
+    }
+    for (size_t i = 1, n = std::size(ranges); i < n; ++i)
+    {
+        TR_ASSERT(ranges[i - 1].second < ranges[i].first);
+    }
 #endif
 
-    auto out = std::ofstream{ filename_, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
+    return ranges;
+}
+
+size_t BlocklistFile::setContent(char const* filename)
+{
+    auto const ranges = parseFile(filename);
+    auto const n_ranges = std::size(ranges);
+
+    if (n_ranges != 0U)
+    {
+        save(filename_, std::data(ranges), std::size(ranges));
+        rules_ = ranges;
+        ensureLoaded();
+    }
+
+    return n_ranges;
+}
+
+void BlocklistFile::save(std::string_view filename, AddressPair const* ranges, size_t n_ranges)
+{
+    auto out = std::ofstream{ tr_pathbuf{ filename }, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
     if (!out.is_open())
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename_),
+            fmt::arg("path", filename),
             fmt::arg("error", tr_strerror(errno)),
             fmt::arg("error_code", errno)));
-        return {};
+        return;
     }
 
-    if (!out.write(reinterpret_cast<char const*>(ranges.data()), std::size(ranges) * sizeof(AddressRange)))
+    if (!out.write(std::data(FileFormatVersion), std::size(FileFormatVersion)) ||
+        !out.write(reinterpret_cast<char const*>(ranges), n_ranges * sizeof(AddressPair)))
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't save '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename_),
+            fmt::arg("path", filename),
             fmt::arg("error", tr_strerror(errno)),
             fmt::arg("error_code", errno)));
     }
     else
     {
         tr_logAddInfo(fmt::format(
-            ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", std::size(rules_)),
-            fmt::arg("path", tr_sys_path_basename(filename_)),
-            fmt::arg("count", std::size(rules_))));
+            ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", n_ranges),
+            fmt::arg("path", tr_sys_path_basename(filename)),
+            fmt::arg("count", n_ranges)));
     }
 
     out.close();
-
-    close();
-    ensureLoaded();
-    return std::size(rules_);
 }
-
-void BlocklistFile::RewriteBlocklistFile() const
-{
-    auto out = std::ofstream{ filename_, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
-    if (!out.is_open())
-    {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename_),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
-        return;
-    }
-
-    if (!out.write(reinterpret_cast<char const*>(rules_.data()), std::size(rules_) * sizeof(AddressRange)))
-    {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't save '{path}': {error} ({error_code})"),
-            fmt::arg("path", filename_),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
-    }
-
-    out.close();
-    ensureLoaded();
-}
-
-#ifdef TR_ENABLE_ASSERTS
-void BlocklistFile::assertValidRules(std::vector<AddressRange> const& ranges)
-{
-    for (auto const& r : ranges)
-    {
-        if (r.begin_ == 0 && r.end_ == 0)
-        {
-            TR_ASSERT(memcmp(r.begin6_.s6_addr, r.end6_.s6_addr, sizeof(r.begin6_.s6_addr)) <= 0);
-        }
-        else
-        {
-            TR_ASSERT(r.begin_ <= r.end_);
-        }
-    }
-
-    auto ranges_ipv4 = std::vector<AddressRange>{};
-    auto ranges_ipv6 = std::vector<AddressRange>{};
-
-    for (size_t i = 0; i < std::size(ranges); i++)
-    {
-        if (ranges[i].begin_ == 0 && ranges[i].end_ == 0)
-        {
-            ranges_ipv6.emplace_back(ranges[i]);
-        }
-        else
-        {
-            ranges_ipv4.emplace_back(ranges[i]);
-        }
-    }
-
-    TR_ASSERT(is_sorted(std::begin(ranges_ipv4), std::end(ranges_ipv4), BlocklistFile::compareAddressRangesByFirstAddress));
-    TR_ASSERT(is_sorted(std::begin(ranges_ipv6), std::end(ranges_ipv6), BlocklistFile::compareAddressRangesByFirstAddress));
-}
-#endif

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -457,6 +457,7 @@ bool Blocklist::contains(tr_address const& addr) const
             }
             return 0;
         }
+
         [[nodiscard]] static auto compare(address_range_t const& a, tr_address const& b) noexcept // <=>
         {
             return -compare(b, a);
@@ -503,9 +504,9 @@ std::optional<Blocklist> Blocklist::saveNew(std::string_view external_file, std:
         return {};
     }
 
-    // save the bin file
     save(bin_file, std::data(rules), std::size(rules));
 
+    // return a new Blocklist with these rules
     auto ret = Blocklist{ bin_file, is_enabled };
     ret.rules_ = std::move(rules);
     return ret;

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -328,7 +328,7 @@ void Blocklist::ensureLoaded() const
     // get the file's size
     tr_error* error = nullptr;
     auto const file_info = tr_sys_path_get_info(bin_file_, 0, &error);
-    if (error)
+    if (error != nullptr)
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
@@ -445,7 +445,7 @@ bool Blocklist::contains(tr_address const& addr) const
 
     struct Compare
     {
-        [[nodiscard]] auto compare(tr_address const& a, address_range_t const& b) const noexcept // <=>
+        [[nodiscard]] static auto compare(tr_address const& a, address_range_t const& b) noexcept // <=>
         {
             if (a < b.first)
             {
@@ -457,7 +457,7 @@ bool Blocklist::contains(tr_address const& addr) const
             }
             return 0;
         }
-        [[nodiscard]] auto compare(address_range_t const& a, tr_address const& b) const noexcept // <=>
+        [[nodiscard]] static auto compare(address_range_t const& a, tr_address const& b) noexcept // <=>
         {
             return -compare(b, a);
         }
@@ -479,7 +479,7 @@ bool Blocklist::contains(tr_address const& addr) const
 std::optional<Blocklist> Blocklist::saveNew(std::string_view external_file, std::string_view bin_file, bool is_enabled)
 {
     // if we can't parse the file, do nothing
-    auto const rules = parseFile(external_file);
+    auto rules = parseFile(external_file);
     if (std::empty(rules))
     {
         return {};

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -232,7 +232,7 @@ auto parseFile(std::string_view filename)
     while (std::getline(in, line))
     {
         ++line_number;
-        if (auto range = parseLine(line); range)
+        if (auto range = parseLine(line); range && (range->first.type == range->second.type))
         {
             ranges.push_back(*range);
         }

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -372,9 +372,9 @@ void Blocklist::ensureLoaded() const
     {
         // bad binary file; try to rebuild it
         in.close();
-        auto source_file = std::string_view{ bin_file_ };
-        source_file.remove_suffix(std::size(BinFileSuffix));
-        rules_ = parseFile(source_file);
+        auto src_file = std::string_view{ bin_file_ };
+        src_file.remove_suffix(std::size(BinFileSuffix));
+        rules_ = parseFile(src_file);
         if (!std::empty(rules_))
         {
             tr_logAddInfo(_("Rewriting old blocklist file format to new format"));

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -124,15 +124,15 @@ void BlocklistFile::ensureLoaded() const
 ***/
 
 std::vector<std::unique_ptr<BlocklistFile>> BlocklistFile::loadBlocklists(
-    std::string_view const config_dir,
+    std::string_view const blocklist_dir,
     bool const is_enabled)
 {
     auto loadme = std::unordered_set<std::string>{};
     auto working_set = std::vector<std::unique_ptr<BlocklistFile>>{};
 
-    /* walk the blocklist directory... */
-    auto const dirname = tr_pathbuf{ config_dir, "/blocklists"sv };
-    auto const odir = tr_sys_dir_open(dirname);
+    // walk the blocklist directory
+
+    auto const odir = tr_sys_dir_open(tr_pathbuf{ blocklist_dir });
 
     if (odir == TR_BAD_SYS_DIR)
     {
@@ -149,13 +149,13 @@ std::vector<std::unique_ptr<BlocklistFile>> BlocklistFile::loadBlocklists(
             continue;
         }
 
-        if (auto const path = tr_pathbuf{ dirname, '/', name }; tr_strvEndsWith(path, ".bin"sv))
+        if (auto const path = tr_pathbuf{ blocklist_dir, '/', name }; tr_strvEndsWith(path, ".bin"sv))
         {
             load = path;
         }
         else
         {
-            auto const binname = tr_pathbuf{ dirname, '/', name, ".bin"sv };
+            auto const binname = tr_pathbuf{ blocklist_dir, '/', name, ".bin"sv };
 
             if (auto const bininfo = tr_sys_path_get_info(binname); !bininfo)
             {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -155,14 +155,11 @@ std::vector<BlocklistFile> BlocklistFile::loadBlocklists(std::string_view const 
     }
 
     auto ret = std::vector<BlocklistFile>{};
-    for (auto const& filename : getFilenamesInDir(blocklist_dir))
+    for (auto const& bin_file : getFilenamesInDir(blocklist_dir))
     {
-        if (tr_strvEndsWith(filename, BinSuffix))
+        if (tr_strvEndsWith(bin_file, BinSuffix))
         {
-            auto const bin_file = filename;
-            auto src_file = std::string_view{ bin_file };
-            src_file.remove_suffix(std::size(BinSuffix));
-            ret.emplace_back(src_file, bin_file, is_enabled);
+            ret.emplace_back(bin_file, is_enabled);
         }
     }
     return ret;
@@ -499,7 +496,7 @@ std::optional<BlocklistFile> BlocklistFile::saveNew(std::string_view external_fi
 
     save(bin_file, std::data(rules), std::size(rules));
 
-    auto ret = BlocklistFile(src_file, bin_file, is_enabled);
+    auto ret = BlocklistFile{ bin_file, is_enabled };
     ret.rules_ = std::move(rules);
     return ret;
 }

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -21,22 +21,32 @@
 
 struct tr_address;
 
-struct BlocklistFile
+namespace libtransmission
+{
+
+class Blocklist
 {
 public:
-    BlocklistFile() = default;
+    static std::vector<Blocklist> loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled);
 
-    BlocklistFile(std::string_view bin_file, bool is_enabled)
+    static std::optional<Blocklist> saveNew(std::string_view external_file, std::string_view bin_file, bool is_enabled);
+
+    Blocklist() = default;
+
+    Blocklist(std::string_view bin_file, bool is_enabled)
         : bin_file_{ bin_file }
         , is_enabled_{ is_enabled }
     {
     }
 
-    static std::vector<BlocklistFile> loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled);
-
     [[nodiscard]] constexpr auto const& binFile() const noexcept
     {
         return bin_file_;
+    }
+
+    [[nodiscard]] constexpr bool enabled() const noexcept
+    {
+        return is_enabled_;
     }
 
     [[nodiscard]] size_t size() const
@@ -46,19 +56,12 @@ public:
         return std::size(rules_);
     }
 
-    [[nodiscard]] constexpr bool enabled() const noexcept
-    {
-        return is_enabled_;
-    }
-
     void setEnabled(bool is_enabled) noexcept
     {
         is_enabled_ = is_enabled;
     }
 
     bool hasAddress(tr_address const& addr) const;
-
-    static std::optional<BlocklistFile> saveNew(std::string_view external_file, std::string_view bin_file, bool is_enabled);
 
 private:
     using AddressPair = std::pair<tr_address, tr_address>;
@@ -80,3 +83,5 @@ private:
     std::string bin_file_;
     bool is_enabled_ = false;
 };
+
+} // namespace libtransmission

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -151,7 +151,7 @@ private:
 
     static std::optional<AddressPair> parseLine1(std::string_view line);
     static std::optional<AddressPair> parseLine2(std::string_view line);
-    static bool parseLine3(char const* line, AddressRange* range);
+    static std::optional<AddressPair> parseLine3(char const* line);
 
 #ifdef TR_ENABLE_ASSERTS
     /// @brief Sanity checks: make sure the rules are sorted in ascending order and don't overlap

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -66,16 +66,6 @@ public:
 private:
     using AddressPair = std::pair<tr_address, tr_address>;
 
-    static auto constexpr FileFormatVersion = std::array<char, 4>{ 'v', '0', '0', '3' };
-    static auto constexpr BinSuffix = std::string_view{ ".bin" };
-
-    static void save(std::string_view filename, AddressPair const* pairs, size_t n_pairs);
-    static std::vector<AddressPair> parseFile(std::string_view filename);
-    static std::optional<AddressPair> parseLine(char const* line);
-    static std::optional<AddressPair> parseLine1(std::string_view line);
-    static std::optional<AddressPair> parseLine2(std::string_view line);
-    static std::optional<AddressPair> parseLine3(char const* line);
-
     void ensureLoaded() const;
 
     mutable std::vector<AddressPair> rules_;

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -9,8 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <array>
-#include <cstddef> // for size_t
 #include <optional>
 #include <string>
 #include <string_view>
@@ -39,9 +37,13 @@ public:
     {
     }
 
-    [[nodiscard]] constexpr auto const& binFile() const noexcept
+    [[nodiscard]] bool contains(tr_address const& addr) const;
+
+    [[nodiscard]] auto size() const
     {
-        return bin_file_;
+        ensureLoaded();
+
+        return std::size(rules_);
     }
 
     [[nodiscard]] constexpr bool enabled() const noexcept
@@ -49,26 +51,20 @@ public:
         return is_enabled_;
     }
 
-    [[nodiscard]] size_t size() const
-    {
-        ensureLoaded();
-
-        return std::size(rules_);
-    }
-
     void setEnabled(bool is_enabled) noexcept
     {
         is_enabled_ = is_enabled;
     }
 
-    bool hasAddress(tr_address const& addr) const;
+    [[nodiscard]] constexpr auto const& binFile() const noexcept
+    {
+        return bin_file_;
+    }
 
 private:
-    using AddressPair = std::pair<tr_address, tr_address>;
-
     void ensureLoaded() const;
 
-    mutable std::vector<AddressPair> rules_;
+    mutable std::vector<std::pair<tr_address, tr_address>> rules_;
 
     std::string bin_file_;
     bool is_enabled_ = false;

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -26,19 +26,13 @@ struct BlocklistFile
 public:
     BlocklistFile() = default;
 
-    BlocklistFile(std::string_view src_file, std::string_view bin_file, bool is_enabled)
-        : src_file_{ src_file }
-        , bin_file_{ bin_file }
+    BlocklistFile(std::string_view bin_file, bool is_enabled)
+        : bin_file_{ bin_file }
         , is_enabled_{ is_enabled }
     {
     }
 
     static std::vector<BlocklistFile> loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled);
-
-    [[nodiscard]] constexpr auto const& srcFile() const noexcept
-    {
-        return src_file_;
-    }
 
     [[nodiscard]] constexpr auto const& binFile() const noexcept
     {
@@ -83,7 +77,6 @@ private:
 
     mutable std::vector<AddressPair> rules_;
 
-    std::string src_file_;
     std::string bin_file_;
     bool is_enabled_ = false;
 };

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -25,7 +25,7 @@ namespace libtransmission
 class Blocklist
 {
 public:
-    static std::vector<Blocklist> loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled);
+    [[nodiscard]] static std::vector<Blocklist> loadBlocklists(std::string_view const blocklist_dir, bool const is_enabled);
 
     static std::optional<Blocklist> saveNew(std::string_view external_file, std::string_view bin_file, bool is_enabled);
 

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -150,7 +150,7 @@ private:
     static bool compareAddressRangesByFirstAddress(AddressRange const& a, AddressRange const& b);
 
     static std::optional<AddressPair> parseLine1(std::string_view line);
-    static bool parseLine2(std::string_view line, struct AddressRange* range);
+    static std::optional<AddressPair> parseLine2(std::string_view line);
     static bool parseLine3(char const* line, AddressRange* range);
 
 #ifdef TR_ENABLE_ASSERTS

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -81,7 +81,9 @@ public:
     /// @brief Read the file of ranges, sort and merge, write to our own file, and reload from it
     size_t setContent(char const* filename);
 
-    static std::vector<std::unique_ptr<BlocklistFile>> loadBlocklists(std::string_view const config_dir, bool const is_enabled);
+    static std::vector<std::unique_ptr<BlocklistFile>> loadBlocklists(
+        std::string_view const blocklist_dir,
+        bool const is_enabled);
 
 private:
     struct AddressRange

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -13,8 +13,10 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility> // for std::pair
 #include <vector>
 
 #ifdef _WIN32
@@ -23,7 +25,10 @@
 #include <netinet/in.h>
 #endif
 
+#include "transmission.h"
+
 #include "file.h" // for tr_sys_file_t
+#include "net.h" // for tr_address
 #include "tr-assert.h"
 #include "tr-macros.h"
 
@@ -132,15 +137,19 @@ private:
         }
     };
 
+    using AddressPair = std::pair<tr_address, tr_address>;
+
+    static AddressRange addressPairToRange(AddressPair const& pair);
+
     void RewriteBlocklistFile() const;
     void ensureLoaded() const;
     void load();
     void close();
 
-    static bool parseLine(char const* line, AddressRange* range);
+    static std::optional<AddressRange> parseLine(char const* line);
     static bool compareAddressRangesByFirstAddress(AddressRange const& a, AddressRange const& b);
 
-    static bool parseLine1(std::string_view line, struct AddressRange* range);
+    static std::optional<AddressPair> parseLine1(std::string_view line);
     static bool parseLine2(std::string_view line, struct AddressRange* range);
     static bool parseLine3(char const* line, AddressRange* range);
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -243,6 +243,11 @@ struct tr_address
         return this->compare(that) < 0;
     }
 
+    [[nodiscard]] bool operator<=(tr_address const& that) const noexcept
+    {
+        return this->compare(that) <= 0;
+    }
+
     [[nodiscard]] bool operator>(tr_address const& that) const noexcept
     {
         return this->compare(that) > 0;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -536,7 +536,7 @@ void tr_session::initImpl(init_data& data)
 
     tr_logSetQueueEnabled(data.message_queuing_enabled);
 
-    this->blocklists_ = BlocklistFile::loadBlocklists(blocklist_dir_, useBlocklist());
+    this->blocklists_ = libtransmission::Blocklist::loadBlocklists(blocklist_dir_, useBlocklist());
 
     tr_announcerInit(this);
 
@@ -1634,7 +1634,7 @@ bool tr_session::addressIsBlocked(tr_address const& addr) const noexcept
 
 void tr_sessionReloadBlocklists(tr_session* session)
 {
-    session->blocklists_ = BlocklistFile::loadBlocklists(session->blocklist_dir_, session->useBlocklist());
+    session->blocklists_ = libtransmission::Blocklist::loadBlocklists(session->blocklist_dir_, session->useBlocklist());
 
     if (session->peer_mgr_)
     {
@@ -1680,7 +1680,7 @@ size_t tr_blocklistSetContent(tr_session* session, char const* content_filename)
     auto const bin_file = tr_pathbuf{ session->blocklist_dir_, '/', DEFAULT_BLOCKLIST_FILENAME };
 
     // Try to save it
-    auto added = BlocklistFile::saveNew(content_filename, bin_file, session->useBlocklist());
+    auto added = libtransmission::Blocklist::saveNew(content_filename, bin_file, session->useBlocklist());
     if (!added)
     {
         return 0U;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1621,7 +1621,7 @@ void tr_session::useBlocklist(bool enabled)
     std::for_each(
         std::begin(blocklists_),
         std::end(blocklists_),
-        [enabled](auto& blocklist) { blocklist->setEnabled(enabled); });
+        [enabled](auto& blocklist) { blocklist.setEnabled(enabled); });
 }
 
 bool tr_session::addressIsBlocked(tr_address const& addr) const noexcept
@@ -1629,12 +1629,11 @@ bool tr_session::addressIsBlocked(tr_address const& addr) const noexcept
     return std::any_of(
         std::begin(blocklists_),
         std::end(blocklists_),
-        [&addr](auto& blocklist) { return blocklist->hasAddress(addr); });
+        [&addr](auto& blocklist) { return blocklist.hasAddress(addr); });
 }
 
 void tr_sessionReloadBlocklists(tr_session* session)
 {
-    session->blocklists_.clear();
     session->blocklists_ = BlocklistFile::loadBlocklists(session->blocklist_dir_, session->useBlocklist());
 
     if (session->peer_mgr_)
@@ -1648,7 +1647,7 @@ size_t tr_blocklistGetRuleCount(tr_session const* session)
     TR_ASSERT(session != nullptr);
 
     auto& src = session->blocklists_;
-    return std::accumulate(std::begin(src), std::end(src), 0, [](int sum, auto& cur) { return sum + cur->getRuleCount(); });
+    return std::accumulate(std::begin(src), std::end(src), 0, [](int sum, auto& cur) { return sum + std::size(cur); });
 }
 
 bool tr_blocklistIsEnabled(tr_session const* session)
@@ -1676,28 +1675,35 @@ size_t tr_blocklistSetContent(tr_session* session, char const* content_filename)
 {
     auto const lock = session->unique_lock();
 
-    // find (or add) the default blocklist
-    auto& src = session->blocklists_;
-    char const* const name = DEFAULT_BLOCKLIST_FILENAME;
-    auto const it = std::find_if(
-        std::begin(src),
-        std::end(src),
-        [&name](auto const& blocklist) { return tr_strvEndsWith(blocklist->filename(), name); });
+    // These rules will replace the default blocklist.
+    // Build the path of the default blocklist .bin file where we'll save these rules.
+    auto const bin_file = tr_pathbuf{ session->blocklist_dir_, '/', DEFAULT_BLOCKLIST_FILENAME };
 
-    BlocklistFile* b = nullptr;
-    if (it == std::end(src))
+    // Try to save it
+    auto added = BlocklistFile::saveNew(content_filename, bin_file, session->useBlocklist());
+    if (!added)
     {
-        src.push_back(std::make_unique<BlocklistFile>(session->blocklist_dir_.c_str(), session->useBlocklist()));
-        b = std::rbegin(src)->get();
+        return 0U;
+    }
+
+    auto const n_rules = std::size(*added);
+
+    // Add (or replace) it in our blocklists_ vector
+    auto& src = session->blocklists_;
+    if (auto iter = std::find_if(
+            std::begin(src),
+            std::end(src),
+            [&bin_file](auto const& candidate) { return bin_file == candidate.binFile(); });
+        iter != std::end(src))
+    {
+        *iter = std::move(*added);
     }
     else
     {
-        b = it->get();
+        src.emplace_back(std::move(*added));
     }
 
-    // set the default blocklist's content
-    auto const rule_count = b->setContent(content_filename);
-    return rule_count;
+    return n_rules;
 }
 
 void tr_blocklistSetURL(tr_session* session, char const* url)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1629,7 +1629,7 @@ bool tr_session::addressIsBlocked(tr_address const& addr) const noexcept
     return std::any_of(
         std::begin(blocklists_),
         std::end(blocklists_),
-        [&addr](auto& blocklist) { return blocklist.hasAddress(addr); });
+        [&addr](auto& blocklist) { return blocklist.contains(addr); });
 }
 
 void tr_sessionReloadBlocklists(tr_session* session)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -53,13 +53,13 @@ class tr_lpd;
 class tr_port_forwarding;
 class tr_rpc_server;
 class tr_web;
-struct BlocklistFile;
 struct struct_utp_context;
 struct tr_announcer;
 struct tr_variant;
 
 namespace libtransmission
 {
+class Blocklist;
 class Dns;
 class Timer;
 class TimerMaker;
@@ -1046,7 +1046,7 @@ private:
     /// other fields
 
 public:
-    std::vector<BlocklistFile> blocklists_;
+    std::vector<libtransmission::Blocklist> blocklists_;
 
     struct tr_event_handle* events = nullptr;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1045,9 +1045,9 @@ private:
 
     /// other fields
 
-public:
     std::vector<libtransmission::Blocklist> blocklists_;
 
+public:
     struct tr_event_handle* events = nullptr;
 
     // depends-on: announcer_udp_

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1046,7 +1046,7 @@ private:
     /// other fields
 
 public:
-    std::vector<std::unique_ptr<BlocklistFile>> blocklists_;
+    std::vector<BlocklistFile> blocklists_;
 
     struct tr_event_handle* events = nullptr;
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -43,21 +43,6 @@ protected:
         "IPv6 example:2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"
         "Evilcorp:216.88.88.0-216.88.88.255\n";
 
-#if 0
-    void createFileWithContents(char const* path, char const* contents)
-    {
-        auto const dir = tr_sys_path_dirname(path);
-        tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0700);
-
-        auto const fd = tr_sys_file_open(path, TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE, 0600);
-        blockingFileWrite(fd, contents, strlen(contents));
-        tr_sys_file_close(fd);
-
-        sync();
-    }
-
-#endif
-
     bool addressIsBlocked(char const* address_str)
     {
         auto const addr = tr_address::fromString(address_str);


### PR DESCRIPTION
* Replace the `AddressRange` struct with a `std::pair<tr_address, tr_address>`: The `AddressRange` searching / sorting code is complicated and hard-to-read. The pre-existing `tr_address` class already handles comparisons and has test coverage. The blocklist ascii file parsers even generate `tr_address` temporary objects before converting them into `AddressRange. So a lot of complex, redundant code goes away if we remove `AddressRange`.

* Embed a format version string at the front of each `.bin` file. This makes it simpler to sniff out incompatible binary files without rules that sniff around address data.

* Make blocklists std::movable. This was disabled once upon a time because each object held an fd to a memory-mapped file, but not anymore. This also means we can use `std::vector<Blocklist>` directly; previously we needed to use `std::vector<std::unique_ptr<Blocklist>>`

* Hide more implementation details by moving code out of `blocklist.h` into an anonymous namespace in `blocklist.cc`.