### PR TITLE
fix: inspector icon should be disabled as default

### DIFF
--- a/web/src/action-manager.js
+++ b/web/src/action-manager.js
@@ -41,7 +41,7 @@ export class ActionManager extends EventTarget {
       'select-all': { enabled: false, shortcut: 'Alt+A', text: 'Select all' },
       'show-about-dialog': { enabled: true, text: 'About' },
       'show-inspector': {
-        enabled: true,
+        enabled: false,
         shortcut: 'Alt+I',
         text: 'Torrent Inspector',
       },


### PR DESCRIPTION
I think 'show-inspector' icon should be set to disabled as default like other default disabled icons like trash, resume, and pause.
Currently the icon is enabled when load web interface or refresh it, then it switches to disabled soon. Even it stays enabled when there is no torrent in the list.