### PR TITLE
refactor: replace tr_boundinfo with tr_session::BoundSocket

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -372,14 +372,16 @@ void Blocklist::ensureLoaded() const
     {
         // bad binary file; try to rebuild it
         in.close();
-        auto src_file = std::string_view{ bin_file_ };
-        src_file.remove_suffix(std::size(BinFileSuffix));
-        rules_ = parseFile(src_file);
-        if (!std::empty(rules_))
+        auto const sz_src_file = std::string{ std::data(bin_file_), std::size(bin_file_) - std::size(BinFileSuffix) };
+        if (tr_sys_path_exists(sz_src_file))
         {
-            tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
-            tr_sys_path_remove(bin_file_);
-            save(bin_file_, std::data(rules_), std::size(rules_));
+            rules_ = parseFile(sz_src_file);
+            if (!std::empty(rules_))
+            {
+                tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
+                tr_sys_path_remove(bin_file_);
+                save(bin_file_, std::data(rules_), std::size(rules_));
+            }
         }
         return;
     }

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -479,10 +479,10 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
     return fd;
 }
 
-tr_socket_t tr_netBindTCP(tr_address const* addr, tr_port port, bool suppress_msgs)
+tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_msgs)
 {
     int unused = 0;
-    return tr_netBindTCPImpl(*addr, port, suppress_msgs, &unused);
+    return tr_netBindTCPImpl(addr, port, suppress_msgs, &unused);
 }
 
 bool tr_net_hasIPv6(tr_port port)

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -43,10 +43,6 @@
 #define IN_MULTICAST(a) (((a)&0xf0000000) == 0xe0000000)
 #endif
 
-tr_address const tr_in6addr_any = { TR_AF_INET6, { IN6ADDR_ANY_INIT } };
-
-tr_address const tr_inaddr_any = { TR_AF_INET, { { { { INADDR_ANY } } } } };
-
 std::string tr_net_strerror(int err)
 {
 #ifdef _WIN32
@@ -392,13 +388,13 @@ void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket)
     }
 }
 
-static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool suppress_msgs, int* err_out)
+static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool suppress_msgs, int* err_out)
 {
-    TR_ASSERT(tr_address_is_valid(addr));
+    TR_ASSERT(tr_address_is_valid(&addr));
 
     static auto constexpr Domains = std::array<int, NUM_TR_AF_INET_TYPES>{ AF_INET, AF_INET6 };
 
-    auto const fd = socket(Domains[addr->type], SOCK_STREAM, 0);
+    auto const fd = socket(Domains[addr.type], SOCK_STREAM, 0);
     if (fd == TR_BAD_SOCKET)
     {
         *err_out = sockerrno;
@@ -418,7 +414,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
 #ifdef IPV6_V6ONLY
 
-    if (addr->isIPv6() &&
+    if (addr.isIPv6() &&
         (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char const*>(&optval), sizeof(optval)) == -1) &&
         (sockerrno != ENOPROTOOPT)) // if the kernel doesn't support it, ignore it
     {
@@ -429,7 +425,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
 #endif
 
-    auto const [sock, addrlen] = addr->toSockaddr(port);
+    auto const [sock, addrlen] = addr.toSockaddr(port);
 
     if (bind(fd, (struct sockaddr*)&sock, addrlen) == -1)
     {
@@ -441,7 +437,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
                 err == EADDRINUSE ?
                     _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
                     _("Couldn't bind port {port} on {address}: {error} ({error_code})"),
-                fmt::arg("address", addr->readable()),
+                fmt::arg("address", addr.readable()),
                 fmt::arg("port", port.host()),
                 fmt::arg("error", tr_net_strerror(err)),
                 fmt::arg("error_code", err)));
@@ -454,7 +450,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 
     if (!suppress_msgs)
     {
-        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr->readable()));
+        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.readable()));
     }
 
 #ifdef TCP_FASTOPEN
@@ -486,7 +482,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const* addr, tr_port port, bool 
 tr_socket_t tr_netBindTCP(tr_address const* addr, tr_port port, bool suppress_msgs)
 {
     int unused = 0;
-    return tr_netBindTCPImpl(addr, port, suppress_msgs, &unused);
+    return tr_netBindTCPImpl(*addr, port, suppress_msgs, &unused);
 }
 
 bool tr_net_hasIPv6(tr_port port)
@@ -497,7 +493,7 @@ bool tr_net_hasIPv6(tr_port port)
     if (!already_done)
     {
         int err = 0;
-        auto const fd = tr_netBindTCPImpl(&tr_in6addr_any, port, true, &err);
+        auto const fd = tr_netBindTCPImpl(tr_address::AnyIPv4(), port, true, &err);
 
         if (fd != TR_BAD_SOCKET || err != EAFNOSUPPORT) /* we support ipv6 */
         {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -263,10 +263,17 @@ struct tr_address
         struct in6_addr addr6;
         struct in_addr addr4;
     } addr;
-};
 
-extern tr_address const tr_inaddr_any;
-extern tr_address const tr_in6addr_any;
+    [[nodiscard]] static auto constexpr AnyIPv4() noexcept
+    {
+        return tr_address{ TR_AF_INET, { { { { INADDR_ANY } } } } };
+    }
+
+    [[nodiscard]] static auto constexpr AnyIPv6() noexcept
+    {
+        return tr_address{ TR_AF_INET6, { IN6ADDR_ANY_INIT } };
+    }
+};
 
 bool tr_address_is_valid_for_peers(tr_address const* addr, tr_port port);
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -288,7 +288,7 @@ constexpr bool tr_address_is_valid(tr_address const* a)
 
 struct tr_session;
 
-tr_socket_t tr_netBindTCP(tr_address const* addr, tr_port port, bool suppress_msgs);
+tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_msgs);
 
 [[nodiscard]] std::optional<std::tuple<tr_address, tr_port, tr_socket_t>> tr_netAccept(
     tr_session* session,

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -44,7 +44,7 @@ public:
     tr_port_forwarding_impl& operator=(tr_port_forwarding_impl&&) = delete;
     tr_port_forwarding_impl& operator=(tr_port_forwarding_impl const&) = delete;
 
-    void portChanged() override
+    void localPortChanged() override
     {
         if (!is_enabled_)
         {

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -40,6 +40,6 @@ public:
     [[nodiscard]] virtual bool isEnabled() const = 0;
     [[nodiscard]] virtual tr_port_forwarding_state state() const = 0;
 
-    virtual void portChanged() = 0;
+    virtual void localPortChanged() = 0;
     virtual void setEnabled(bool enabled) = 0;
 };

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -267,10 +267,15 @@ void tr_session::onIncomingPeerConnection(tr_socket_t fd, void* vsession)
     }
 }
 
-tr_session::BoundSocket::BoundSocket(event_base* evbase, tr_address addr, tr_port port, IncomingCallback cb, void* cb_data)
+tr_session::BoundSocket::BoundSocket(
+    event_base* evbase,
+    tr_address const& addr,
+    tr_port port,
+    IncomingCallback cb,
+    void* cb_data)
     : cb_{ cb }
     , cb_data_{ cb_data }
-    , socket_{ tr_netBindTCP(&addr, port, false) }
+    , socket_{ tr_netBindTCP(addr, port, false) }
 {
     if (socket_ == TR_BAD_SOCKET)
     {
@@ -557,9 +562,7 @@ static void updateBandwidth(tr_session* session, tr_direction dir);
 void tr_session::setSettings(tr_variant* settings_dict, bool force)
 {
     TR_ASSERT(amInSessionThread());
-
-    auto* const settings = settings_dict;
-    TR_ASSERT(tr_variantIsDict(settings));
+    TR_ASSERT(tr_variantIsDict(settings_dict));
 
     // load the session settings
     auto new_settings = tr_session_settings{};
@@ -567,8 +570,8 @@ void tr_session::setSettings(tr_variant* settings_dict, bool force)
     setSettings(std::move(new_settings), force);
 
     // delegate loading out the other settings
-    alt_speeds_.load(settings);
-    rpc_server_->load(settings);
+    alt_speeds_.load(settings_dict);
+    rpc_server_->load(settings_dict);
 }
 
 void tr_session::setSettings(tr_session_settings settings_in, bool force)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -625,13 +625,13 @@ void tr_session::setSettings(tr_session_settings settings_in, bool force)
         if (auto const& val = new_settings.bind_address_ipv4; force || port_changed || val != old_settings.bind_address_ipv4)
         {
             auto const [addr, is_default] = publicAddress(TR_AF_INET);
-            bound_ipv4_ = BoundSocket{ eventBase(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this };
+            bound_ipv4_.emplace(eventBase(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this);
         }
 
         if (auto const& val = new_settings.bind_address_ipv6; force || port_changed || val != old_settings.bind_address_ipv6)
         {
             auto const [addr, is_default] = publicAddress(TR_AF_INET6);
-            bound_ipv6_ = BoundSocket{ eventBase(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this };
+            bound_ipv6_.emplace(eventBase(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this);
         }
     }
     else

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -301,11 +301,6 @@ tr_session::BoundSocket::BoundSocket(
 
 tr_session::BoundSocket::~BoundSocket()
 {
-    close();
-}
-
-void tr_session::BoundSocket::close()
-{
     if (ev_ != nullptr)
     {
         event_free(ev_);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -273,10 +273,9 @@ tr_session::BoundSocket::BoundSocket(
     tr_port port,
     IncomingCallback on_incoming,
     void* on_incoming_user_data)
-    : addr_{ addr }
-    , on_incoming_{ on_incoming }
+    : on_incoming_{ on_incoming }
     , on_incoming_user_data_{ on_incoming_user_data }
-    , socket_{ tr_netBindTCP(&addr_, port, false) }
+    , socket_{ tr_netBindTCP(&addr, port, false) }
 {
     if (socket_ == TR_BAD_SOCKET)
     {
@@ -284,7 +283,7 @@ tr_session::BoundSocket::BoundSocket(
     }
 
     tr_logAddInfo(
-        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr_.readable(port))));
+        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr.readable(port))));
 
     ev_ = event_new(
         evbase,

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -82,6 +82,10 @@ private:
     public:
         using IncomingCallback = void (*)(tr_socket_t, void*);
         BoundSocket(struct event_base*, tr_address addr, tr_port port, IncomingCallback cb, void* cb_data);
+        BoundSocket(BoundSocket&&) = delete;
+        BoundSocket(BoundSocket const&) = delete;
+        BoundSocket operator=(BoundSocket&&) = delete;
+        BoundSocket operator=(BoundSocket const&) = delete;
         ~BoundSocket();
 
     private:

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1095,7 +1095,7 @@ private:
     // depends-on: timer_maker_, top_bandwidth_, torrents_, web_
     std::unique_ptr<struct tr_peerMgr, void (*)(struct tr_peerMgr*)> peer_mgr_;
 
-    // depends-on: peer_mgr_, torrents_
+    // depends-on: peer_mgr_, advertised_peer_port_, torrents_
     LpdMediator lpd_mediator_{ *this };
 
     // depends-on: lpd_mediator_

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -81,7 +81,7 @@ private:
     {
     public:
         using IncomingCallback = void (*)(tr_socket_t, void*);
-        BoundSocket(struct event_base*, tr_address addr, tr_port port, IncomingCallback cb, void* cb_data);
+        BoundSocket(struct event_base*, tr_address const& addr, tr_port port, IncomingCallback cb, void* cb_data);
         BoundSocket(BoundSocket&&) = delete;
         BoundSocket(BoundSocket const&) = delete;
         BoundSocket operator=(BoundSocket&&) = delete;
@@ -1048,6 +1048,8 @@ private:
 
     tr_session_id session_id_;
 
+    tr_open_files open_files_;
+
     std::vector<libtransmission::Blocklist> blocklists_;
 
     /// other fields
@@ -1070,15 +1072,13 @@ private:
     // depends-on: top_bandwidth_
     std::vector<std::pair<tr_interned_string, std::unique_ptr<tr_bandwidth>>> bandwidth_groups_;
 
-    // depends-on: settings_, timer_maker_
+    // depends-on: timer_maker_, settings_, local_peer_port_
     PortForwardingMediator port_forwarding_mediator_{ *this };
     std::unique_ptr<tr_port_forwarding> port_forwarding_ = tr_port_forwarding::create(port_forwarding_mediator_);
 
     // depends-on: session_thread_, top_bandwidth_
     AltSpeedMediator alt_speed_mediator_{ *this };
     tr_session_alt_speeds alt_speeds_{ alt_speed_mediator_ };
-
-    tr_open_files open_files_;
 
     // depends-on: open_files_
     tr_torrents torrents_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -14,7 +14,6 @@
 #include <array>
 #include <cstddef> // size_t
 #include <cstdint> // uintX_t
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -82,17 +81,12 @@ private:
     {
     public:
         using IncomingCallback = void (*)(tr_socket_t, void*);
-        BoundSocket(
-            struct event_base*,
-            tr_address const& addr,
-            tr_port port,
-            IncomingCallback on_incoming,
-            void* on_incoming_user_data);
+        BoundSocket(struct event_base*, tr_address addr, tr_port port, IncomingCallback cb, void* cb_data);
         ~BoundSocket();
 
     private:
-        IncomingCallback on_incoming_;
-        void* on_incoming_user_data_;
+        IncomingCallback cb_;
+        void* cb_data_;
         tr_socket_t socket_ = TR_BAD_SOCKET;
         struct event* ev_ = nullptr;
     };
@@ -154,8 +148,7 @@ private:
 
         [[nodiscard]] tr_address incomingPeerAddress() const override
         {
-            auto [address, is_default] = session_.publicAddress(TR_AF_INET);
-            return address;
+            return session_.publicAddress(TR_AF_INET).address;
         }
 
         [[nodiscard]] tr_port localPeerPort() const override
@@ -1055,10 +1048,10 @@ private:
 
     /// other fields
 
-    // depends-on: session_thread_, old_settings.bind_address_ipv4, local_peer_port_
+    // depends-on: session_thread_, settings_.bind_address_ipv4, local_peer_port_
     std::optional<BoundSocket> bound_ipv4_;
 
-    // depends-on: session_thread_, old_settings.bind_address_ipv6, local_peer_port_
+    // depends-on: session_thread_, settings_.bind_address_ipv6, local_peer_port_
     std::optional<BoundSocket> bound_ipv6_;
 
 public:

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -91,7 +91,6 @@ private:
         ~BoundSocket();
 
     private:
-        tr_address addr_;
         IncomingCallback on_incoming_;
         void* on_incoming_user_data_;
         tr_socket_t socket_ = TR_BAD_SOCKET;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -88,22 +88,7 @@ private:
             tr_port port,
             IncomingCallback on_incoming,
             void* on_incoming_user_data);
-
         ~BoundSocket();
-
-        void bindAndListenForIncomingPeers(tr_session* session);
-
-        void close();
-
-        [[nodiscard]] auto const& address() const noexcept
-        {
-            return addr_;
-        }
-
-        [[nodiscard]] auto readable() const
-        {
-            return addr_.readable();
-        }
 
     private:
         tr_address addr_;

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -32,6 +32,12 @@ TEST_F(NetTest, conversionsIPv4)
     EXPECT_EQ(Port, addrport->second);
 }
 
+TEST_F(NetTest, trAddress)
+{
+    EXPECT_EQ("0.0.0.0", tr_address::AnyIPv4().readable());
+    EXPECT_EQ("::", tr_address::AnyIPv6().readable());
+}
+
 TEST_F(NetTest, compact4)
 {
     static auto constexpr ExpectedReadable = "10.10.10.5"sv;


### PR DESCRIPTION
A smaller PR in the tr_session Lifecycle PR Arc.

- Add `BoundSocket` whose constructor binds a socket & uses libevent to monitor it for incoming connections. The destructor cleans it all up and closes the socket. Unlike the `tr_bindinfo` class that it replaces, does not rely on / does not know about tr_session internals

- `tr_session::publicAddress()` no longer requires the bound sockets. This fixes a minor regression when TCP is disabled.

- Add helper function `tr_session::setSettings(tr_session_settings)` that can be used to make settings changes in a single batch. This is useful because some changes can have side-effects that need to be applied in a specific order. `setSettings()` handles knowing this sequencing so simplify callers' responsibilities.

- Minor perf: replace `tr_inaddr_any` with `tr_address::AnyAddr4()` to make it constexpr

Next up: making DHT nonblocking