### PR TITLE
Removing superfluous interface declarations

### DIFF
--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -41,13 +41,6 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
 @property(nonatomic) NSInteger fGroupValue;
 @property(nonatomic) TorrentDeterminationType fGroupDeterminationType;
 
-- (void)confirmAdd;
-
-- (void)setDestinationPath:(NSString*)destination determinationType:(TorrentDeterminationType)determinationType;
-
-- (void)setGroupsMenu;
-- (void)changeGroupValue:(id)sender;
-
 @end
 
 @implementation AddMagnetWindowController

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -52,15 +52,6 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
 
 @property(nonatomic) TorrentDeterminationType fGroupValueDetermination;
 
-- (void)updateFiles;
-
-- (void)confirmAdd;
-
-- (void)setDestinationPath:(NSString*)destination determinationType:(TorrentDeterminationType)determinationType;
-
-- (void)setGroupsMenu;
-- (void)changeGroupValue:(id)sender;
-
 @end
 
 @implementation AddWindowController

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -16,8 +16,6 @@ static CGFloat const kBetweenPadding = 2.0;
 @property(nonatomic) CGFloat fDownloadRate;
 @property(nonatomic) CGFloat fUploadRate;
 
-- (void)badge:(NSImage*)badge string:(NSString*)string atHeight:(CGFloat)height;
-
 @end
 
 @implementation BadgeView

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -14,9 +14,6 @@
 @property(nonatomic) long long fExpectedSize;
 @property(nonatomic) blocklistDownloadState fState;
 
-- (void)startDownload;
-- (BOOL)decompressFrom:(NSURL*)file to:(NSURL*)destination error:(NSError**)error;
-
 @end
 
 @implementation BlocklistDownloader

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -16,9 +16,6 @@
 
 @property(nonatomic, readonly) PrefsController* fPrefsController;
 
-- (instancetype)initWithPrefsController:(PrefsController*)prefsController;
-- (void)startDownload;
-
 @end
 
 @implementation BlocklistDownloaderViewController

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -15,8 +15,6 @@ static NSTimeInterval const kFullWait = 60 * 60 * 24 * 7;
 
 @property(nonatomic) NSTimer* fTimer;
 
-- (void)runUpdater;
-
 @end
 
 @implementation BlocklistScheduler

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -54,12 +54,6 @@ typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
 
 @property(nonatomic, readonly) NSUserDefaults* fDefaults;
 
-+ (NSURL*)chooseFile;
-
-- (void)updateLocationField;
-- (void)createReal;
-- (void)checkProgress;
-
 @end
 
 NSMutableSet* creatorWindowControllerSet = nil;

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -11,8 +11,6 @@
 @property(nonatomic, readonly) NSMutableIndexSet* indexesInternal;
 @property(nonatomic) NSImage* iconInternal;
 
-- (instancetype)initWithFolder:(BOOL)isFolder name:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
-
 @end
 
 @implementation FileListNode

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -27,9 +27,6 @@ static CGFloat const kPaddingExpansionFrame = 2.0;
 @property(nonatomic, readonly) NSMutableDictionary* fTitleAttributes;
 @property(nonatomic, readonly) NSMutableDictionary* fStatusAttributes;
 
-- (NSRect)rectForTitleWithString:(NSAttributedString*)string inBounds:(NSRect)bounds;
-- (NSRect)rectForStatusWithString:(NSAttributedString*)string withTitleRect:(NSRect)titleRect inBounds:(NSRect)bounds;
-
 @end
 
 @implementation FileNameCell

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -38,9 +38,6 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
 
 @property(nonatomic) IBOutlet NSPopUpButton* fGroupsButton;
 
-- (void)updateGroupsButton;
-- (void)updateGroups:(NSNotification*)notification;
-
 @end
 
 @implementation FilterBarController

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -14,12 +14,6 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 @property(nonatomic, readonly) NSMutableArray<NSMutableDictionary*>* fGroups;
 
-- (void)saveGroups;
-
-- (NSImage*)imageForGroup:(NSMutableDictionary*)dict;
-
-- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroupAtIndex:(NSInteger)index;
-
 @end
 
 @implementation GroupsController

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -31,9 +31,6 @@ typedef NS_ENUM(NSInteger, SegmentTag) {
 @property(nonatomic, weak) IBOutlet NSPredicateEditor* ruleEditor;
 @property(nonatomic, weak) IBOutlet NSLayoutConstraint* ruleEditorHeightConstraint;
 
-- (void)updateSelectedGroup;
-- (void)refreshCustomLocationWithSingleGroup;
-
 @end
 
 @implementation GroupsPrefsController

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -68,8 +68,6 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 @property(nonatomic, readonly) CGFloat horizLayoutWidth;
 @property(nonatomic, readonly) CGFloat vertLayoutHeight;
 
-- (void)setupInfo;
-
 @end
 
 @implementation InfoActivityViewController

--- a/macosx/InfoFileViewController.mm
+++ b/macosx/InfoFileViewController.mm
@@ -20,10 +20,6 @@
 @property(nonatomic) IBOutlet NSButton* fCheckAllButton;
 @property(nonatomic) IBOutlet NSButton* fUncheckAllButton;
 
-- (void)setupInfo;
-
-- (BOOL)canQuickLookFile:(FileListNode*)item;
-
 @end
 
 @implementation InfoFileViewController

--- a/macosx/InfoGeneralViewController.mm
+++ b/macosx/InfoGeneralViewController.mm
@@ -35,8 +35,6 @@
 @property(nonatomic) IBOutlet NSTextField* fWhereSectionLabel;
 @property(nonatomic) IBOutlet NSScrollView* fCommentScrollView;
 
-- (void)setupInfo;
-
 @end
 
 @implementation InfoGeneralViewController

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -67,10 +67,6 @@ static CGFloat const kStackViewSpacing = 8.0;
 @property(nonatomic, readonly) CGFloat horizLayoutWidth;
 @property(nonatomic, readonly) CGFloat vertLayoutHeight;
 
-- (void)setupInfo;
-- (void)setGlobalLabels;
-- (void)updateOptionsNotification:(NSNotification*)notification;
-
 @end
 
 @implementation InfoOptionsViewController

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -33,10 +33,6 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
 @property(nonatomic) IBOutlet NSLayoutConstraint* fWebSeedTableTopConstraint;
 @property(nonatomic, readonly) NSArray<NSSortDescriptor*>* peerSortDescriptors;
 
-- (void)setupInfo;
-
-- (void)setWebSeedTableHidden:(BOOL)hide animate:(BOOL)animate;
-
 @end
 
 @implementation InfoPeersViewController

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -28,11 +28,6 @@ typedef NS_ENUM(NSInteger, TrackerSegmentTag) {
 
 @property(nonatomic) IBOutlet NSSegmentedControl* fTrackerAddRemoveControl;
 
-- (void)setupInfo;
-
-- (void)addTrackers;
-- (void)removeTrackers;
-
 @end
 
 @implementation InfoTrackersViewController

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -58,9 +58,6 @@ typedef NS_ENUM(unsigned int, tabTag) {
 @property(nonatomic) IBOutlet NSTextField* fBasicInfoField;
 @property(nonatomic) IBOutlet NSTextField* fNoneSelectedField;
 
-- (void)resetInfo;
-- (void)resetInfoForTorrent:(NSNotification*)notification;
-
 @end
 
 @implementation InfoWindowController

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -39,11 +39,6 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 
 @property(nonatomic) NSLock* fLock;
 
-- (void)resizeColumn;
-- (BOOL)shouldIncludeMessageForFilter:(NSString*)filterString message:(NSDictionary*)message;
-- (void)updateListForFilter;
-- (NSString*)stringForMessage:(NSDictionary*)message;
-
 @end
 
 @implementation MessageWindowController

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -16,10 +16,6 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 
 @property(nonatomic) NSTimer* fTimer;
 
-- (void)startProbe:(NSTimer*)timer;
-
-- (void)callBackWithStatus:(port_status_t)status;
-
 @end
 
 @implementation PortChecker

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -102,10 +102,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 @property(nonatomic) IBOutlet NSSegmentedControl* fRPCAddRemoveControl;
 @property(nonatomic, copy) NSString* fRPCPassword;
 
-- (void)setPrefView:(id)sender;
-
-- (void)setKeychainPassword:(char const*)password forService:(char const*)service username:(char const*)username;
-
 @end
 
 @implementation PrefsController

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -27,10 +27,6 @@ static NSTimeInterval const kUpdateSeconds = 1.0;
 @property(nonatomic) IBOutlet NSButton* fResetButton;
 @property(nonatomic) NSTimer* fTimer;
 
-- (void)updateStats;
-
-- (void)performResetStats;
-
 @end
 
 @implementation StatsWindowController

--- a/macosx/StatusBarView.mm
+++ b/macosx/StatusBarView.mm
@@ -4,12 +4,6 @@
 
 #import "StatusBarView.h"
 
-@interface StatusBarView ()
-
-- (void)reload;
-
-@end
-
 @implementation StatusBarView
 
 - (BOOL)mouseDownCanMoveWindow

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -47,29 +47,6 @@ static int const kETAIdleDisplaySec = 2 * 60;
 
 @property(nonatomic) BOOL fTimeMachineExcludeInitialized;
 
-- (instancetype)initWithPath:(NSString*)path
-                        hash:(NSString*)hashString
-               torrentStruct:(tr_torrent*)torrentStruct
-               magnetAddress:(NSString*)magnetAddress
-                         lib:(tr_session*)lib
-                  groupValue:(NSNumber*)groupValue
-     removeWhenFinishSeeding:(NSNumber*)removeWhenFinishSeeding
-              downloadFolder:(NSString*)downloadFolder
-      legacyIncompleteFolder:(NSString*)incompleteFolder;
-
-- (void)createFileList;
-- (void)insertPathForComponents:(NSArray*)components
-             withComponentIndex:(NSUInteger)componentIndex
-                      forParent:(FileListNode*)parent
-                       fileSize:(uint64_t)size
-                          index:(NSInteger)index
-                       flatList:(NSMutableArray<FileListNode*>*)flatFileList;
-- (void)sortFileList:(NSMutableArray<FileListNode*>*)fileNodes;
-
-- (void)startQueue;
-- (void)ratioLimitHit;
-- (void)idleLimitHit;
-- (void)metadataRetrieved;
 - (void)renameFinished:(BOOL)success
                  nodes:(NSArray<FileListNode*>*)nodes
      completionHandler:(void (^)(BOOL))completionHandler
@@ -78,8 +55,6 @@ static int const kETAIdleDisplaySec = 2 * 60;
 
 @property(nonatomic, readonly) BOOL shouldShowEta;
 @property(nonatomic, readonly) NSString* etaString;
-
-- (void)setTimeMachineExclude:(BOOL)exclude;
 
 @end
 

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -49,24 +49,6 @@ static NSInteger const kMaxPieces = 18 * 18;
 
 @interface TorrentCell ()
 
-- (void)drawBar:(NSRect)barRect;
-- (void)drawRegularBar:(NSRect)barRect;
-- (void)drawPiecesBar:(NSRect)barRect;
-
-- (NSRect)rectForMinimalStatusWithString:(NSAttributedString*)string inBounds:(NSRect)bounds;
-- (NSRect)rectForTitleWithString:(NSAttributedString*)string
-                  withRightBound:(CGFloat)rightBound
-                        inBounds:(NSRect)bounds
-                         minimal:(BOOL)minimal;
-- (NSRect)rectForProgressWithStringInBounds:(NSRect)bounds;
-- (NSRect)rectForStatusWithStringInBounds:(NSRect)bounds;
-- (NSRect)barRectRegForBounds:(NSRect)bounds;
-- (NSRect)barRectMinForBounds:(NSRect)bounds;
-
-- (NSRect)controlButtonRectForBounds:(NSRect)bounds;
-- (NSRect)revealButtonRectForBounds:(NSRect)bounds;
-- (NSRect)actionButtonRectForBounds:(NSRect)bounds;
-
 @property(nonatomic, readonly) NSUserDefaults* fDefaults;
 
 @property(nonatomic, readonly) NSMutableDictionary* fTitleAttributes;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -61,10 +61,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 @property(nonatomic) BOOL fActionPopoverShown;
 @property(nonatomic) NSView* fPositioningView;
 
-- (BOOL)pointInGroupStatusRect:(NSPoint)point;
-
-- (void)setGroupStatusColumns;
-
 @end
 
 @implementation TorrentTableView

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -27,20 +27,6 @@ static CGFloat const kCountWidth = 60.0;
 @property(nonatomic, readonly) NSMutableDictionary* fNameAttributes;
 @property(nonatomic, readonly) NSMutableDictionary* fStatusAttributes;
 
-- (void)loadTrackerIcon:(NSString*)baseAddress;
-
-- (NSRect)imageRectForBounds:(NSRect)bounds;
-- (NSRect)rectForNameWithString:(NSAttributedString*)string inBounds:(NSRect)bounds;
-- (NSRect)rectForCountWithString:(NSAttributedString*)string withAboveRect:(NSRect)aboveRect inBounds:(NSRect)bounds;
-- (NSRect)rectForCountLabelWithString:(NSAttributedString*)string withRightRect:(NSRect)rightRect inBounds:(NSRect)bounds;
-- (NSRect)rectForStatusWithString:(NSAttributedString*)string
-                    withAboveRect:(NSRect)aboveRect
-                    withRightRect:(NSRect)rightRect
-                         inBounds:(NSRect)bounds;
-
-- (NSAttributedString*)attributedStatusWithString:(NSString*)statusString;
-- (NSAttributedString*)attributedCount:(NSInteger)count;
-
 @end
 
 @implementation TrackerCell

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -12,8 +12,6 @@
 @property(nonatomic) IBOutlet NSButton* fOpenButton;
 @property(nonatomic) IBOutlet NSButton* fCancelButton;
 
-- (void)updateOpenButtonForURL:(NSString*)string;
-
 @end
 
 @implementation URLSheetWindowController


### PR DESCRIPTION
In Objective-C, declaring methods in the private interface is superfluous at least since Xcode 5.0. We only support Xcode 11.3.1 or newer.