### PR TITLE
Fix issues reported by clang-tidy `readability` checks (GTK client)

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: >
+  -*,
+  readability-*,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-redundant-access-specifiers

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -177,14 +177,14 @@ void gtr_action_activate(Glib::ustring const& name)
     get_action(name)->activate();
 }
 
-void gtr_action_set_sensitive(Glib::ustring const& name, bool b)
+void gtr_action_set_sensitive(Glib::ustring const& name, bool is_sensitive)
 {
-    get_action(name)->set_enabled(b);
+    get_action(name)->set_enabled(is_sensitive);
 }
 
-void gtr_action_set_toggled(Glib::ustring const& name, bool b)
+void gtr_action_set_toggled(Glib::ustring const& name, bool is_toggled)
 {
-    get_action(name)->set_state(Glib::Variant<bool>::create(b));
+    get_action(name)->change_state(is_toggled);
 }
 
 Glib::RefPtr<Glib::Object> gtr_action_get_object(Glib::ustring const& name)

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -396,7 +396,7 @@ void Application::Impl::on_main_window_size_allocated()
     bool const is_maximized = gdk_window != nullptr && (gdk_window->get_state() & Gdk::WINDOW_STATE_MAXIMIZED) != 0;
 #endif
 
-    gtr_pref_int_set(TR_KEY_main_window_is_maximized, is_maximized);
+    gtr_pref_flag_set(TR_KEY_main_window_is_maximized, is_maximized);
 
     if (!is_maximized)
     {

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -870,7 +870,8 @@ bool Application::Impl::on_drag_data_received(Glib::ValueBase const& value, doub
         open_files(FileListHandler::slist_to_vector(files_value.get(), Glib::OwnershipType::OWNERSHIP_NONE));
         return true;
     }
-    else if (G_VALUE_HOLDS(value.gobj(), StringValue::value_type()))
+
+    if (G_VALUE_HOLDS(value.gobj(), StringValue::value_type()))
     {
         StringValue string_value;
         string_value.init(value.gobj());

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -194,7 +194,7 @@ bool refreshFilesForeach(
             auto const child_priority = child[file_cols.priority];
             auto const child_enabled = child[file_cols.enabled];
 
-            if ((child_enabled != false) && (child_enabled != NOT_SET))
+            if (child_enabled != int{ false } && (child_enabled != NOT_SET))
             {
                 new_size += child_size;
                 new_have += child_have;
@@ -578,7 +578,7 @@ void renderDownload(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator 
 {
     auto const enabled = iter->get_value(file_cols.enabled);
     static_cast<Gtk::CellRendererToggle*>(renderer)->property_inconsistent() = enabled == MIXED;
-    static_cast<Gtk::CellRendererToggle*>(renderer)->property_active() = enabled == true;
+    static_cast<Gtk::CellRendererToggle*>(renderer)->property_active() = enabled == int{ true };
 }
 
 void renderPriority(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator const& iter)

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -492,7 +492,7 @@ struct PairHash
 
 void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
 {
-    if (torrent_id_ == tor_id && store_ != nullptr && store_->children().size() != 0)
+    if (torrent_id_ == tor_id && store_ != nullptr && !store_->children().empty())
     {
         return;
     }

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -173,7 +173,7 @@ bool refreshFilesForeach(
         auto const index = iter->get_value(file_cols.index);
         auto const file = tr_torrentFile(refresh_data.tor, index);
 
-        new_enabled = file.wanted;
+        new_enabled = static_cast<int>(file.wanted);
         new_priority = file.priority;
         new_have = file.have;
         new_size = file.length;
@@ -194,7 +194,7 @@ bool refreshFilesForeach(
             auto const child_priority = child[file_cols.priority];
             auto const child_enabled = child[file_cols.enabled];
 
-            if (child_enabled != int{ false } && (child_enabled != NOT_SET))
+            if (child_enabled != static_cast<int>(false) && (child_enabled != NOT_SET))
             {
                 new_size += child_size;
                 new_have += child_have;
@@ -462,7 +462,7 @@ void buildTree(FileRowNode& node, build_data& build)
     (*child_iter)[file_cols.size_str] = tr_strlsize(child_data.length);
     (*child_iter)[file_cols.icon] = icon;
     (*child_iter)[file_cols.priority] = priority;
-    (*child_iter)[file_cols.enabled] = enabled;
+    (*child_iter)[file_cols.enabled] = static_cast<int>(enabled);
 
     if (!isLeaf)
     {
@@ -578,7 +578,7 @@ void renderDownload(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator 
 {
     auto const enabled = iter->get_value(file_cols.enabled);
     static_cast<Gtk::CellRendererToggle*>(renderer)->property_inconsistent() = enabled == MIXED;
-    static_cast<Gtk::CellRendererToggle*>(renderer)->property_active() = enabled == int{ true };
+    static_cast<Gtk::CellRendererToggle*>(renderer)->property_active() = enabled == static_cast<int>(true);
 }
 
 void renderPriority(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator const& iter)
@@ -695,10 +695,8 @@ bool FileList::Impl::onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel:
         }
         else
         {
-            auto enabled = iter->get_value(file_cols.enabled);
-            enabled = !enabled;
-
-            tr_torrentSetFileDLs(tor, indexBuf.data(), indexBuf.size(), enabled);
+            auto const enabled = iter->get_value(file_cols.enabled);
+            tr_torrentSetFileDLs(tor, indexBuf.data(), indexBuf.size(), enabled == static_cast<int>(false));
         }
 
         refresh();

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -91,7 +91,7 @@ public:
 
     TR_DISABLE_COPY_MOVE(Impl)
 
-    void set_torrent(tr_torrent_id_t tor_id);
+    void set_torrent(tr_torrent_id_t torrent_id);
 
 private:
     void clearData();
@@ -474,9 +474,9 @@ void buildTree(FileRowNode& node, build_data& build)
 
 } // namespace
 
-void FileList::set_torrent(tr_torrent_id_t tor_id)
+void FileList::set_torrent(tr_torrent_id_t torrent_id)
 {
-    impl_->set_torrent(tor_id);
+    impl_->set_torrent(torrent_id);
 }
 
 struct PairHash
@@ -488,9 +488,9 @@ struct PairHash
     }
 };
 
-void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
+void FileList::Impl::set_torrent(tr_torrent_id_t torrent_id)
 {
-    if (torrent_id_ == tor_id && store_ != nullptr && !store_->children().empty())
+    if (torrent_id_ == torrent_id && store_ != nullptr && !store_->children().empty())
     {
         return;
     }
@@ -500,7 +500,7 @@ void FileList::Impl::set_torrent(tr_torrent_id_t tor_id)
 
     /* instantiate the model */
     store_ = Gtk::TreeStore::create(file_cols);
-    torrent_id_ = tor_id;
+    torrent_id_ = torrent_id;
 
     /* populate the model */
     if (torrent_id_ > 0)

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -408,11 +408,9 @@ std::vector<tr_file_index_t> FileList::Impl::getActiveFilesForPath(Gtk::TreeMode
         /* clicked in a selected row... use the current selection */
         return getSelectedFilesAndDescendants();
     }
-    else
-    {
-        /* clicked OUTSIDE of the selected row... just use the clicked row */
-        return getSubtree(path);
-    }
+
+    /* clicked OUTSIDE of the selected row... just use the clicked row */
+    return getSubtree(path);
 }
 
 /***

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -462,7 +462,7 @@ bool test_torrent_activity(tr_torrent* tor, int type)
         return st->activity == TR_STATUS_STOPPED;
 
     case ACTIVITY_FILTER_FINISHED:
-        return st->finished == true;
+        return st->finished;
 
     case ACTIVITY_FILTER_VERIFYING:
         return st->activity == TR_STATUS_CHECK || st->activity == TR_STATUS_CHECK_WAIT;

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -774,26 +774,26 @@ FilterBar::FilterBar(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& /*builder*/,
     tr_session* session,
-    Glib::RefPtr<Gtk::TreeModel> const& tmodel)
+    Glib::RefPtr<Gtk::TreeModel> const& torrent_model)
     : Glib::ObjectBase(typeid(FilterBar))
     , Gtk::Box(cast_item)
-    , impl_(std::make_unique<Impl>(*this, session, tmodel))
+    , impl_(std::make_unique<Impl>(*this, session, torrent_model))
 {
 }
 
 FilterBar::~FilterBar() = default;
 
-FilterBar::Impl::Impl(FilterBar& widget, tr_session* session, Glib::RefPtr<Gtk::TreeModel> const& tmodel)
+FilterBar::Impl::Impl(FilterBar& widget, tr_session* session, Glib::RefPtr<Gtk::TreeModel> const& torrent_model)
     : widget_(widget)
     , activity_(get_template_child<Gtk::ComboBox>("activity_combo"))
     , tracker_(get_template_child<Gtk::ComboBox>("tracker_combo"))
     , entry_(get_template_child<Gtk::Entry>("text_entry"))
     , show_lb_(get_template_child<Gtk::Label>("show_label"))
 {
-    activity_combo_box_init(activity_, tmodel);
-    tracker_combo_box_init(tracker_, tmodel);
+    activity_combo_box_init(activity_, torrent_model);
+    tracker_combo_box_init(tracker_, torrent_model);
 
-    filter_model_ = Gtk::TreeModelFilter::create(tmodel);
+    filter_model_ = Gtk::TreeModelFilter::create(torrent_model);
     filter_model_row_deleted_tag_ = filter_model_->signal_row_deleted().connect([this](auto const& /*path*/)
                                                                                 { update_count_label_idle(); });
     filter_model_row_inserted_tag_ = filter_model_->signal_row_inserted().connect(

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -56,8 +56,7 @@ bool FreeSpaceLabel::Impl::on_freespace_timer()
 }
 
 FreeSpaceLabel::FreeSpaceLabel(Glib::RefPtr<Session> const& core, std::string_view dir)
-    : Gtk::Label()
-    , impl_(std::make_unique<Impl>(*this, core, dir))
+    : impl_(std::make_unique<Impl>(*this, core, dir))
 {
 }
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -242,7 +242,7 @@ void gtr_notify_torrent_completed(Glib::RefPtr<Session> const& core, tr_torrent_
         [n](auto& res) { notify_callback(res, n); },
         make_variant_tuple(
             Glib::ustring("Transmission"),
-            0u,
+            0U,
             Glib::ustring("transmission"),
             Glib::ustring(_("Torrent Complete")),
             Glib::ustring(tr_torrentName(tor)),
@@ -276,7 +276,7 @@ void gtr_notify_torrent_added(Glib::RefPtr<Session> const& core, tr_torrent_id_t
         [n](auto& res) { notify_callback(res, n); },
         make_variant_tuple(
             Glib::ustring("Transmission"),
-            0u,
+            0U,
             Glib::ustring("transmission"),
             Glib::ustring(_("Torrent Added")),
             Glib::ustring(tr_torrentName(tor)),

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -454,7 +454,8 @@ private:
     void onBlocklistUpdated(int n);
     void onBlocklistUpdate();
     void on_blocklist_url_changed(Gtk::Editable* e);
-    void init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
+
+    static void init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
 
 private:
     Glib::RefPtr<Session> core_;
@@ -834,8 +835,8 @@ public:
 private:
     void refreshSchedSensitivity();
 
-    void init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
-    void init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
+    static void init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
+    static void init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
 
     static auto get_weekday_string(Glib::Date::Weekday weekday);
 

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -216,7 +216,7 @@ public:
     TR_DISABLE_COPY_MOVE(DownloadingPage)
 
 private:
-    void on_core_prefs_changed(tr_quark const key);
+    void on_core_prefs_changed(tr_quark key);
 
 private:
     Glib::RefPtr<Session> const core_;
@@ -455,7 +455,7 @@ private:
     void onBlocklistUpdate();
     void on_blocklist_url_changed(Gtk::Editable* e);
 
-    static void init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
+    static void init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
 
 private:
     Glib::RefPtr<Session> core_;
@@ -835,8 +835,8 @@ public:
 private:
     void refreshSchedSensitivity();
 
-    static void init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
-    static void init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key);
+    static void init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
+    static void init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
 
     static auto get_weekday_string(Glib::Date::Weekday weekday);
 
@@ -1013,7 +1013,7 @@ public:
     TR_DISABLE_COPY_MOVE(NetworkPage)
 
 private:
-    void onCorePrefsChanged(tr_quark const key);
+    void onCorePrefsChanged(tr_quark key);
     void onPortTested(bool isOpen);
     void onPortTest();
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1583,7 +1583,7 @@ void Session::set_pref(tr_quark const key, int newval)
 
 void Session::set_pref(tr_quark const key, double newval)
 {
-    if (gtr_compare_double(newval, gtr_pref_double_get(key), 4))
+    if (gtr_compare_double(newval, gtr_pref_double_get(key), 4) != 0)
     {
         gtr_pref_double_set(key, newval);
         impl_->commit_prefs_change(key);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1417,8 +1417,8 @@ void Session::start_now(tr_torrent_id_t id)
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-start-now");
 
-    auto args = tr_variantDictAddDict(&top, TR_KEY_arguments, 1);
-    auto ids = tr_variantDictAddList(args, TR_KEY_ids, 1);
+    auto* args = tr_variantDictAddDict(&top, TR_KEY_arguments, 1);
+    auto* ids = tr_variantDictAddList(args, TR_KEY_ids, 1);
     tr_variantListAddInt(ids, id);
     exec(&top);
     tr_variantClear(&top);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -91,7 +91,8 @@ public:
     tr_session* close();
 
     Glib::RefPtr<Gtk::ListStore> get_raw_model() const;
-    Glib::RefPtr<Gtk::TreeModelSort> get_model() const;
+    Glib::RefPtr<Gtk::TreeModelSort> get_model();
+    Glib::RefPtr<Gtk::TreeModelSort const> get_model() const;
     tr_session* get_session() const;
 
     size_t get_active_torrent_count() const;
@@ -119,7 +120,7 @@ public:
 private:
     Glib::RefPtr<Session> get_core_ptr() const;
 
-    bool is_busy();
+    bool is_busy() const;
     void add_to_busy(int addMe);
     void inc_busy();
     void dec_busy();
@@ -215,7 +216,12 @@ Glib::RefPtr<Gtk::TreeModel> Session::get_model() const
     return impl_->get_model();
 }
 
-Glib::RefPtr<Gtk::TreeModelSort> Session::Impl::get_model() const
+Glib::RefPtr<Gtk::TreeModelSort> Session::Impl::get_model()
+{
+    return sorted_model_;
+}
+
+Glib::RefPtr<Gtk::TreeModelSort const> Session::Impl::get_model() const
 {
     return sorted_model_;
 }
@@ -234,7 +240,7 @@ tr_session* Session::Impl::get_session() const
 ****  BUSY
 ***/
 
-bool Session::Impl::is_busy()
+bool Session::Impl::is_busy() const
 {
     return busy_count_ > 0;
 }
@@ -1774,7 +1780,7 @@ tr_torrent* Session::find_torrent(tr_torrent_id_t id) const
     return tor;
 }
 
-void Session::open_folder(tr_torrent_id_t torrent_id)
+void Session::open_folder(tr_torrent_id_t torrent_id) const
 {
     auto const* tor = find_torrent(torrent_id);
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -120,7 +120,7 @@ public:
 
     void exec(tr_variant const* benc);
 
-    void open_folder(tr_torrent_id_t torrent_id);
+    void open_folder(tr_torrent_id_t torrent_id) const;
 
     sigc::signal<void(ErrorCode, Glib::ustring const&)>& signal_add_error();
     sigc::signal<void(tr_ctor*)>& signal_add_prompt();

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -57,7 +57,7 @@ public:
      * Load saved state and return number of torrents added.
      * May trigger one or more "error" signals with ERR_ADD_TORRENT
      */
-    void load(bool forcepaused);
+    void load(bool force_paused);
 
     /**
      * Add a list of torrents.
@@ -118,7 +118,7 @@ public:
 
     void blocklist_update();
 
-    void exec(tr_variant const* benc);
+    void exec(tr_variant const* request);
 
     void open_folder(tr_torrent_id_t torrent_id) const;
 

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -961,7 +961,6 @@ TorrentCellRenderer::Impl::~Impl()
 
 TorrentCellRenderer::TorrentCellRenderer()
     : Glib::ObjectBase(typeid(TorrentCellRenderer))
-    , Gtk::CellRenderer()
     , impl_(std::make_unique<Impl>(*this))
 {
 }

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -695,7 +695,7 @@ void TorrentCellRenderer::Impl::render_compact(
     bool const active = st->activity != TR_STATUS_STOPPED && st->activity != TR_STATUS_DOWNLOAD_WAIT &&
         st->activity != TR_STATUS_SEED_WAIT;
     auto const percentDone = get_percent_done(tor, st, &seed);
-    bool const sensitive = active || st->error;
+    bool const sensitive = active || st->error != 0;
 
     if (st->activity == TR_STATUS_STOPPED)
     {
@@ -799,7 +799,7 @@ void TorrentCellRenderer::Impl::render_full(
     bool const active = st->activity != TR_STATUS_STOPPED && st->activity != TR_STATUS_DOWNLOAD_WAIT &&
         st->activity != TR_STATUS_SEED_WAIT;
     auto const percentDone = get_percent_done(tor, st, &seed);
-    bool const sensitive = active || st->error;
+    bool const sensitive = active || st->error != 0;
 
     if (st->activity == TR_STATUS_STOPPED)
     {

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -667,7 +667,8 @@ void TorrentCellRenderer::Impl::render_progress_bar(
         area.get_height());
 #endif
 
-    double dx = 0, dy = 0;
+    double dx = 0;
+    double dy = 0;
     context->device_to_user(dx, dy);
 
     adjust_progress_bar_hue(surface, temp_context, color, temp_area, dx - area.get_x(), dy - area.get_y());

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -527,7 +527,7 @@ void gtr_combo_box_set_active_enum(Gtk::ComboBox& combo_box, int value)
 
 Gtk::ComboBox* gtr_combo_box_new_enum(std::vector<std::pair<Glib::ustring, int>> const& items)
 {
-    auto w = Gtk::make_managed<Gtk::ComboBox>();
+    auto* w = Gtk::make_managed<Gtk::ComboBox>();
     gtr_combo_box_set_enum(*w, items);
     return w;
 }
@@ -565,7 +565,7 @@ int gtr_combo_box_get_active_enum(Gtk::ComboBox const& combo_box)
 
 Gtk::ComboBox* gtr_priority_combo_new()
 {
-    auto w = Gtk::make_managed<Gtk::ComboBox>();
+    auto* w = Gtk::make_managed<Gtk::ComboBox>();
     gtr_priority_combo_init(*w);
     return w;
 }

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -89,9 +89,9 @@ Glib::ustring tr_strlratio(double ratio)
     return tr_strratio(ratio, gtr_get_unicode_string(GtrUnicode::Inf).c_str());
 }
 
-Glib::ustring tr_strlsize(guint64 bytes)
+Glib::ustring tr_strlsize(guint64 size_in_bytes)
 {
-    return bytes == 0 ? Q_("None") : tr_formatter_size_B(bytes);
+    return size_in_bytes == 0 ? Q_("None") : tr_formatter_size_B(size_in_bytes);
 }
 
 namespace
@@ -163,24 +163,24 @@ std::string tr_format_past_time(time_t seconds)
 
 } // namespace
 
-std::string tr_format_time(time_t secs)
+std::string tr_format_time(time_t timestamp)
 {
-    if (auto const days = secs / 86400U; days > 0U)
+    if (auto const days = timestamp / 86400U; days > 0U)
     {
         return fmt::format(ngettext("{days:L} day", "{days:L} days", days), fmt::arg("days", days));
     }
 
-    if (auto const hours = (secs % 86400U) / 3600U; hours > 0U)
+    if (auto const hours = (timestamp % 86400U) / 3600U; hours > 0U)
     {
         return fmt::format(ngettext("{hours:L} hour", "{hours:L} hours", hours), fmt::arg("hours", hours));
     }
 
-    if (auto const minutes = (secs % 3600U) / 60U; minutes > 0U)
+    if (auto const minutes = (timestamp % 3600U) / 60U; minutes > 0U)
     {
         return fmt::format(ngettext("{minutes:L} minute", "{minutes:L} minutes", minutes), fmt::arg("minutes", minutes));
     }
 
-    if (auto const seconds = secs % 60U; seconds > 0U)
+    if (auto const seconds = timestamp % 60U; seconds > 0U)
     {
         return fmt::format(ngettext("{seconds:L} second", "{seconds:L} seconds", seconds), fmt::arg("seconds", seconds));
     }
@@ -188,30 +188,30 @@ std::string tr_format_time(time_t secs)
     return _("now");
 }
 
-std::string tr_format_time_left(time_t seconds)
+std::string tr_format_time_left(time_t timestamp)
 {
-    if (auto const days_left = seconds / 86400U; days_left > 0U)
+    if (auto const days_left = timestamp / 86400U; days_left > 0U)
     {
         return fmt::format(
             ngettext("{days_left:L} day left", "{days_left:L} days left", days_left),
             fmt::arg("days_left", days_left));
     }
 
-    if (auto const hours_left = (seconds % 86400U) / 3600U; hours_left > 0U)
+    if (auto const hours_left = (timestamp % 86400U) / 3600U; hours_left > 0U)
     {
         return fmt::format(
             ngettext("{hours_left:L} hour left", "{hours_left:L} hours left", hours_left),
             fmt::arg("hours_left", hours_left));
     }
 
-    if (auto const minutes_left = (seconds % 3600U) / 60U; minutes_left > 0U)
+    if (auto const minutes_left = (timestamp % 3600U) / 60U; minutes_left > 0U)
     {
         return fmt::format(
             ngettext("{minutes_left:L} minute left", "{minutes_left:L} minutes left", minutes_left),
             fmt::arg("minutes_left", minutes_left));
     }
 
-    if (auto const seconds_left = seconds % 60U; seconds_left > 0U)
+    if (auto const seconds_left = timestamp % 60U; seconds_left > 0U)
     {
         return fmt::format(
             ngettext("{seconds_left:L} second left", "{seconds_left:L} seconds left", seconds_left),
@@ -221,9 +221,9 @@ std::string tr_format_time_left(time_t seconds)
     return _("now");
 }
 
-std::string tr_format_time_relative(time_t src, time_t dst)
+std::string tr_format_time_relative(time_t timestamp, time_t origin)
 {
-    return src < dst ? tr_format_future_time(dst - src) : tr_format_past_time(src - dst);
+    return timestamp < origin ? tr_format_future_time(origin - timestamp) : tr_format_past_time(timestamp - origin);
 }
 
 namespace
@@ -748,11 +748,11 @@ void gtr_paste_clipboard_url_into_entry(Gtk::Entry& entry)
 ****
 ***/
 
-void gtr_label_set_text(Gtk::Label& lb, Glib::ustring const& newstr)
+void gtr_label_set_text(Gtk::Label& lb, Glib::ustring const& text)
 {
-    if (lb.get_text() != newstr)
+    if (lb.get_text() != text)
     {
-        lb.set_text(newstr);
+        lb.set_text(text);
     }
 }
 

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -141,14 +141,14 @@ enum class GtrUnicode
 Glib::ustring gtr_get_unicode_string(GtrUnicode);
 
 /* return a human-readable string for the size given in bytes. */
-Glib::ustring tr_strlsize(guint64 size);
+Glib::ustring tr_strlsize(guint64 size_in_bytes);
 
 /* return a human-readable string for the given ratio. */
 Glib::ustring tr_strlratio(double ratio);
 
-std::string tr_format_time_relative(time_t src, time_t tgt);
-std::string tr_format_time_left(time_t seconds);
-std::string tr_format_time(time_t seconds);
+std::string tr_format_time_relative(time_t timestamp, time_t origin);
+std::string tr_format_time_left(time_t timestamp);
+std::string tr_format_time(time_t timestamp);
 
 /***
 ****


### PR DESCRIPTION
Of the four disabled `readability` checks, three (`function-cognitive-complexity`, `identifier-length`, `magic-numbers`) require extensive refactoring and were left for later, and one (`redundant-access-specifiers`) is not planned to be fixed due to the current coding style - using extra sections to separate methods from variables of the same visibility.