### PR TITLE
refactor: fix thread sanitizer warnings in tr_sessionClose()

### DIFF
--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -160,7 +161,7 @@ public:
         thread_id_ = thread_.get_id();
 
         // wait for the session thread's main loop to start
-        is_looping_cv_.wait(lock, [this]() { return is_looping_; });
+        is_looping_cv_.wait(lock, [this]() { return is_looping_.load(); });
     }
 
     tr_session_thread_impl(tr_session_thread_impl&&) = delete;
@@ -285,9 +286,9 @@ private:
 
     std::mutex is_looping_mutex_;
     std::condition_variable is_looping_cv_;
-    bool is_looping_ = false;
+    std::atomic<bool> is_looping_ = false;
 
-    bool is_shutting_down_ = false;
+    std::atomic<bool> is_shutting_down_ = false;
     static constexpr std::chrono::seconds Deadline = 5s;
 };
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -12,6 +12,7 @@
 #define TR_NAME "Transmission"
 
 #include <array>
+#include <atomic>
 #include <cstddef> // size_t
 #include <cstdint> // uintX_t
 #include <memory>
@@ -679,7 +680,7 @@ public:
         return is_closing_;
     }
 
-    [[nodiscard]] constexpr auto isClosed() const noexcept
+    [[nodiscard]] constexpr bool isClosed() const noexcept
     {
         return is_closed_;
     }
@@ -897,8 +898,9 @@ private:
     void setSettings(tr_variant* settings_dict, bool force);
     void setSettings(tr_session_settings settings, bool force);
 
-    void closeImplPart1();
-    void closeImplPart2();
+    struct is_closed_data;
+    void closeImplPart1(is_closed_data*);
+    void closeImplPart2(is_closed_data*);
 
     void onNowTimer();
 
@@ -1001,7 +1003,7 @@ private:
 
     /// static fields
 
-    static std::recursive_mutex session_mutex;
+    static inline std::recursive_mutex session_mutex;
 
     /// trivial type fields
 
@@ -1044,7 +1046,7 @@ private:
     uint16_t peer_count_ = 0;
 
     bool is_closing_ = false;
-    bool is_closed_ = false;
+    std::atomic<bool> is_closed_ = false;
 
     /// fields that aren't trivial,
     /// but are self-contained / have no interdependencies

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -680,7 +680,7 @@ public:
         return is_closing_;
     }
 
-    [[nodiscard]] constexpr bool isClosed() const noexcept
+    [[nodiscard]] bool isClosed() const noexcept
     {
         return is_closed_;
     }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <condition_variable>
 #include <list>
@@ -307,7 +308,7 @@ public:
         CloseNow // exit now even if tasks are running
     };
 
-    RunMode run_mode = RunMode::Run;
+    std::atomic<RunMode> run_mode = RunMode::Run;
 
     static size_t onDataReceived(void* data, size_t size, size_t nmemb, void* vtask)
     {
@@ -595,7 +596,7 @@ public:
 
     static std::once_flag curl_init_flag;
 
-    bool is_closed_ = false;
+    std::atomic<bool> is_closed_ = false;
 
     std::multimap<uint64_t /*tr_time_msec()*/, CURL*> paused_easy_handles;
 


### PR DESCRIPTION
Another `tr_session` Lifecycle Arc PR.

Still doesn't _totally_ fix the crash-on-shutdown problem but the number of possible failures is getting ever-smaller.