### PR TITLE
Fix issues reported by clang-tidy `modernize` checks (GTK client)

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -1,8 +1,13 @@
 ---
 Checks: >
   -*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
   readability-*,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-redundant-access-specifiers
+
+CheckOptions:
+  modernize-pass-by-value.ValuesOnly: true

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -157,9 +157,9 @@ private:
     void on_add_torrent(tr_ctor* ctor);
     void on_prefs_changed(tr_quark key);
 
-    std::vector<tr_torrent_id_t> get_selected_torrent_ids() const;
-    tr_torrent* get_first_selected_torrent() const;
-    counts_data get_selected_torrent_counts() const;
+    [[nodiscard]] std::vector<tr_torrent_id_t> get_selected_torrent_ids() const;
+    [[nodiscard]] tr_torrent* get_first_selected_torrent() const;
+    [[nodiscard]] counts_data get_selected_torrent_counts() const;
 
     void start_all_torrents();
     void pause_all_torrents();

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -3,6 +3,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <csignal>
 #include <cstdlib> // exit()
 #include <ctime>
 #include <iterator> // std::back_inserter
@@ -14,9 +15,6 @@
 #include <tuple>
 #include <utility>
 #include <vector>
-
-#include <locale.h>
-#include <signal.h>
 
 #include <fmt/core.h>
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -12,13 +12,12 @@
 
 #include <algorithm>
 #include <array>
-#include <limits.h> // INT_MAX
+#include <cstddef>
+#include <cstdlib> // abort()
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <sstream>
-#include <stddef.h>
-#include <stdio.h> // sscanf()
-#include <stdlib.h> // abort()
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -470,7 +469,7 @@ void DetailsDialog::Impl::options_page_init(Glib::RefPtr<Gtk::Builder> const& /*
     down_limited_check_tag_ = down_limited_check_->signal_toggled().connect(
         [this]() { torrent_set_bool(TR_KEY_downloadLimited, down_limited_check_->get_active()); });
 
-    down_limit_spin_->set_adjustment(Gtk::Adjustment::create(0, 0, INT_MAX, 5));
+    down_limit_spin_->set_adjustment(Gtk::Adjustment::create(0, 0, std::numeric_limits<int>::max(), 5));
     down_limit_spin_tag_ = down_limit_spin_->signal_value_changed().connect(
         [this]() { torrent_set_int(TR_KEY_downloadLimit, down_limit_spin_->get_value_as_int()); });
 
@@ -478,7 +477,7 @@ void DetailsDialog::Impl::options_page_init(Glib::RefPtr<Gtk::Builder> const& /*
     up_limited_check_tag_ = up_limited_check_->signal_toggled().connect(
         [this]() { torrent_set_bool(TR_KEY_uploadLimited, up_limited_check_->get_active()); });
 
-    up_limit_sping_->set_adjustment(Gtk::Adjustment::create(0, 0, INT_MAX, 5));
+    up_limit_sping_->set_adjustment(Gtk::Adjustment::create(0, 0, std::numeric_limits<int>::max(), 5));
     up_limit_spin_tag_ = up_limit_sping_->signal_value_changed().connect(
         [this]() { torrent_set_int(TR_KEY_uploadLimit, up_limit_sping_->get_value_as_int()); });
 
@@ -1680,7 +1679,7 @@ void setPeerViewColumns(Gtk::TreeView* peer_view)
         }
         else
         {
-            abort();
+            std::abort();
         }
 
         c->set_resizable(false);

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -2165,12 +2165,15 @@ public:
         BaseObjectType* cast_item,
         Glib::RefPtr<Gtk::Builder> const& builder,
         DetailsDialog& parent,
-        Glib::RefPtr<Session> core,
+        Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
 
     TR_DISABLE_COPY_MOVE(EditTrackersDialog)
 
-    static std::unique_ptr<EditTrackersDialog> create(DetailsDialog& parent, Glib::RefPtr<Session> core, tr_torrent const* tor);
+    static std::unique_ptr<EditTrackersDialog> create(
+        DetailsDialog& parent,
+        Glib::RefPtr<Session> const& core,
+        tr_torrent const* tor);
 
 private:
     void on_response(int response) override;
@@ -2186,7 +2189,7 @@ EditTrackersDialog::EditTrackersDialog(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     DetailsDialog& parent,
-    Glib::RefPtr<Session> core,
+    Glib::RefPtr<Session> const& core,
     tr_torrent const* torrent)
     : Gtk::Dialog(cast_item)
     , parent_(parent)
@@ -2202,7 +2205,7 @@ EditTrackersDialog::EditTrackersDialog(
 
 std::unique_ptr<EditTrackersDialog> EditTrackersDialog::create(
     DetailsDialog& parent,
-    Glib::RefPtr<Session> core,
+    Glib::RefPtr<Session> const& core,
     tr_torrent const* torrent)
 {
     auto const builder = Gtk::Builder::create_from_resource(gtr_get_full_resource_path("EditTrackersDialog.ui"));
@@ -2280,12 +2283,15 @@ public:
         BaseObjectType* cast_item,
         Glib::RefPtr<Gtk::Builder> const& builder,
         DetailsDialog& parent,
-        Glib::RefPtr<Session> core,
+        Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
 
     TR_DISABLE_COPY_MOVE(AddTrackerDialog)
 
-    static std::unique_ptr<AddTrackerDialog> create(DetailsDialog& parent, Glib::RefPtr<Session> core, tr_torrent const* tor);
+    static std::unique_ptr<AddTrackerDialog> create(
+        DetailsDialog& parent,
+        Glib::RefPtr<Session> const& core,
+        tr_torrent const* tor);
 
 private:
     void on_response(int response) override;
@@ -2301,7 +2307,7 @@ AddTrackerDialog::AddTrackerDialog(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     DetailsDialog& parent,
-    Glib::RefPtr<Session> core,
+    Glib::RefPtr<Session> const& core,
     tr_torrent const* torrent)
     : Gtk::Dialog(cast_item)
     , parent_(parent)
@@ -2317,7 +2323,7 @@ AddTrackerDialog::AddTrackerDialog(
 
 std::unique_ptr<AddTrackerDialog> AddTrackerDialog::create(
     DetailsDialog& parent,
-    Glib::RefPtr<Session> core,
+    Glib::RefPtr<Session> const& core,
     tr_torrent const* torrent)
 {
     auto const builder = Gtk::Builder::create_from_resource(gtr_get_full_resource_path("AddTrackerDialog.ui"));

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1767,11 +1767,11 @@ void DetailsDialog::Impl::peer_page_init(Glib::RefPtr<Gtk::Builder> const& build
 namespace
 {
 
-auto constexpr ErrMarkupBegin = "<span color=\"red\">"sv;
+auto constexpr ErrMarkupBegin = "<span color='red'>"sv;
 auto constexpr ErrMarkupEnd = "</span>"sv;
-auto constexpr TimeoutMarkupBegin = "<span color=\"#246\">"sv;
+auto constexpr TimeoutMarkupBegin = "<span color='#246'>"sv;
 auto constexpr TimeoutMarkupEnd = "</span>"sv;
-auto constexpr SuccessMarkupBegin = "<span color=\"#080\">"sv;
+auto constexpr SuccessMarkupBegin = "<span color='#080'>"sv;
 auto constexpr SuccessMarkupEnd = "</span>"sv;
 
 std::array<std::string_view, 3> const text_dir_mark = { ""sv, "\u200E"sv, "\u200F"sv };

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <climits> // INT_MAX
 #include <cstddef>
 #include <list>
 #include <memory>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -99,9 +99,9 @@ private:
 
     bool getAndSelectEventPath(double view_x, double view_y, Gtk::TreeViewColumn*& col, Gtk::TreeModel::Path& path);
 
-    std::vector<tr_file_index_t> getActiveFilesForPath(Gtk::TreeModel::Path const& path) const;
-    std::vector<tr_file_index_t> getSelectedFilesAndDescendants() const;
-    std::vector<tr_file_index_t> getSubtree(Gtk::TreeModel::Path const& path) const;
+    [[nodiscard]] std::vector<tr_file_index_t> getActiveFilesForPath(Gtk::TreeModel::Path const& path) const;
+    [[nodiscard]] std::vector<tr_file_index_t> getSelectedFilesAndDescendants() const;
+    [[nodiscard]] std::vector<tr_file_index_t> getSubtree(Gtk::TreeModel::Path const& path) const;
 
     bool onViewButtonPressed(guint button, TrGdkModifierType state, double view_x, double view_y);
     bool onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel::Path const& path);

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::transform()
+#include <array>
 #include <memory>
 #include <set>
 #include <string>
@@ -510,13 +511,15 @@ bool activity_filter_model_update(Glib::RefPtr<Gtk::ListStore> const& activity_m
 
 Glib::RefPtr<Gtk::ListStore> activity_filter_model_new(Glib::RefPtr<Gtk::TreeModel> const& tmodel)
 {
-    static struct
+    struct FilterTypeInfo
     {
         int type;
         char const* context;
         char const* name;
         Glib::ustring icon_name;
-    } const types[] = {
+    };
+
+    static auto const types = std::array<FilterTypeInfo, 9>({ {
         { ACTIVITY_FILTER_ALL, nullptr, N_("All"), {} },
         { ACTIVITY_FILTER_SEPARATOR, nullptr, nullptr, {} },
         { ACTIVITY_FILTER_ACTIVE, nullptr, N_("Active"), "system-run" },
@@ -526,7 +529,7 @@ Glib::RefPtr<Gtk::ListStore> activity_filter_model_new(Glib::RefPtr<Gtk::TreeMod
         { ACTIVITY_FILTER_FINISHED, nullptr, N_("Finished"), "media-playback-stop" },
         { ACTIVITY_FILTER_VERIFYING, "Verb", NC_("Verb", "Verifying"), "view-refresh" },
         { ACTIVITY_FILTER_ERROR, nullptr, N_("Error"), "dialog-error" },
-    };
+    } });
 
     auto const store = Gtk::ListStore::create(activity_filter_cols);
 

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -38,7 +38,7 @@ public:
 
     TR_DISABLE_COPY_MOVE(Impl)
 
-    Glib::RefPtr<Gtk::TreeModel> get_filter_model() const;
+    [[nodiscard]] Glib::RefPtr<Gtk::TreeModel> get_filter_model() const;
 
 private:
     template<typename T>

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -65,8 +65,8 @@ private:
     void init_view(Gtk::TreeView* view, Glib::RefPtr<Gtk::TreeModel> const& model);
 
     Glib::RefPtr<Gio::MenuModel> createOptionsMenu();
-    Glib::RefPtr<Gio::MenuModel> createSpeedMenu(Glib::RefPtr<Gio::SimpleActionGroup> actions, tr_direction dir);
-    Glib::RefPtr<Gio::MenuModel> createRatioMenu(Glib::RefPtr<Gio::SimpleActionGroup> actions);
+    Glib::RefPtr<Gio::MenuModel> createSpeedMenu(Glib::RefPtr<Gio::SimpleActionGroup> const& actions, tr_direction dir);
+    Glib::RefPtr<Gio::MenuModel> createRatioMenu(Glib::RefPtr<Gio::SimpleActionGroup> const& actions);
 
     Glib::RefPtr<Gio::MenuModel> createStatsMenu();
 
@@ -292,7 +292,9 @@ void MainWindow::Impl::onSpeedSet(tr_direction dir, int KBps)
     core_->set_pref(dir == TR_UP ? TR_KEY_speed_limit_up_enabled : TR_KEY_speed_limit_down_enabled, true);
 }
 
-Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createSpeedMenu(Glib::RefPtr<Gio::SimpleActionGroup> actions, tr_direction dir)
+Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createSpeedMenu(
+    Glib::RefPtr<Gio::SimpleActionGroup> const& actions,
+    tr_direction dir)
 {
     auto& info = speed_menu_info_[dir];
 
@@ -353,7 +355,7 @@ void MainWindow::Impl::onRatioSet(double ratio)
     core_->set_pref(TR_KEY_ratio_limit_enabled, true);
 }
 
-Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createRatioMenu(Glib::RefPtr<Gio::SimpleActionGroup> actions)
+Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createRatioMenu(Glib::RefPtr<Gio::SimpleActionGroup> const& actions)
 {
     static auto const stockRatios = std::array<double, 7>({ 0.25, 0.5, 0.75, 1, 1.5, 2, 3 });
 

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -355,7 +355,7 @@ void MainWindow::Impl::onRatioSet(double ratio)
 
 Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createRatioMenu(Glib::RefPtr<Gio::SimpleActionGroup> actions)
 {
-    static double const stockRatios[] = { 0.25, 0.5, 0.75, 1, 1.5, 2, 3 };
+    static auto const stockRatios = std::array<double, 7>({ 0.25, 0.5, 0.75, 1, 1.5, 2, 3 });
 
     auto& info = ratio_menu_info_;
 
@@ -459,16 +459,18 @@ void MainWindow::Impl::onOptionsClicked()
 
 Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createStatsMenu()
 {
-    static struct
+    struct StatsModeInfo
     {
         char const* val;
         char const* i18n;
-    } const stats_modes[] = {
+    };
+
+    static auto const stats_modes = std::array<StatsModeInfo, 4>({ {
         { "total-ratio", N_("Total Ratio") },
         { "session-ratio", N_("Session Ratio") },
         { "total-transfer", N_("Total Transfer") },
         { "session-transfer", N_("Session Transfer") },
-    };
+    } });
 
     auto top = Gio::Menu::create();
     auto actions = Gio::SimpleActionGroup::create();

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -55,7 +55,7 @@ public:
 
     TR_DISABLE_COPY_MOVE(Impl)
 
-    Glib::RefPtr<Gtk::TreeSelection> get_selection() const;
+    [[nodiscard]] Glib::RefPtr<Gtk::TreeSelection> get_selection() const;
 
     void refresh();
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -64,8 +64,8 @@ private:
     void level_combo_changed_cb(Gtk::ComboBox* combo_box);
     void level_combo_init(Gtk::ComboBox* level_combo) const;
 
-    bool is_pinned_to_new() const;
-    bool isRowVisible(Gtk::TreeModel::const_iterator const& iter) const;
+    [[nodiscard]] bool is_pinned_to_new() const;
+    [[nodiscard]] bool isRowVisible(Gtk::TreeModel::const_iterator const& iter) const;
 
 private:
     MessageLogWindow& window_;

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -3,8 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 #include <map>
 #include <memory>
 
@@ -179,7 +179,7 @@ Glib::ustring gtr_asctime(time_t t)
 
 void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& filename)
 {
-    auto* fp = fopen(filename.c_str(), "w+");
+    auto* fp = std::fopen(filename.c_str(), "w+");
 
     if (fp == nullptr)
     {
@@ -211,7 +211,7 @@ void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& fi
             fmt::print(fp, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);
         }
 
-        fclose(fp);
+        std::fclose(fp);
     }
 }
 

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -2,7 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <errno.h>
 #include <string>
 #include <string_view>
 

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <climits> /* USHRT_MAX, INT_MAX */
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -274,7 +274,7 @@ DownloadingPage::DownloadingPage(
         TR_KEY_download_queue_size,
         core_,
         0,
-        INT_MAX,
+        std::numeric_limits<int>::max(),
         1);
 
     init_spin_button(
@@ -282,7 +282,7 @@ DownloadingPage::DownloadingPage(
         TR_KEY_queue_stalled_minutes,
         core_,
         1,
-        INT_MAX,
+        std::numeric_limits<int>::max(),
         15);
 
     init_check_button(
@@ -727,7 +727,7 @@ RemotePage::RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> con
 
     /* port */
     auto* port_spin = gtr_get_widget<Gtk::SpinButton>(builder, "rpc_port_spin");
-    init_spin_button(*port_spin, TR_KEY_rpc_port, core_, 0, USHRT_MAX, 1);
+    init_spin_button(*port_spin, TR_KEY_rpc_port, core_, 0, std::numeric_limits<uint16_t>::max(), 1);
 
     /* require authentication */
     init_check_button(*auth_tb_, TR_KEY_rpc_authentication_required, core_);
@@ -889,7 +889,7 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "upload_limit_spin");
-        init_spin_button(*w2, TR_KEY_speed_limit_up, core_, 0, INT_MAX, 5);
+        init_spin_button(*w2, TR_KEY_speed_limit_up, core_, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -898,7 +898,7 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "download_limit_spin");
-        init_spin_button(*w2, TR_KEY_speed_limit_down, core_, 0, INT_MAX, 5);
+        init_spin_button(*w2, TR_KEY_speed_limit_down, core_, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -906,7 +906,7 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "alt_upload_limit_spin");
-        init_spin_button(*w2, TR_KEY_alt_speed_up, core_, 0, INT_MAX, 5);
+        init_spin_button(*w2, TR_KEY_alt_speed_up, core_, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -914,7 +914,7 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "alt_download_limit_spin");
-        init_spin_button(*w2, TR_KEY_alt_speed_down, core_, 0, INT_MAX, 5);
+        init_spin_button(*w2, TR_KEY_alt_speed_down, core_, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -1022,7 +1022,7 @@ NetworkPage::NetworkPage(
     , portButton_(gtr_get_widget<Gtk::Button>(builder, "test_listening_port_button"))
     , portSpin_(gtr_get_widget<Gtk::SpinButton>(builder, "listening_port_spin"))
 {
-    init_spin_button(*portSpin_, TR_KEY_peer_port, core_, 1, USHRT_MAX, 1);
+    init_spin_button(*portSpin_, TR_KEY_peer_port, core_, 1, std::numeric_limits<uint16_t>::max(), 1);
 
     portButton_->signal_clicked().connect([this]() { onPortTest(); });
 

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::max()
-#include <climits> /* INT_MAX */
 #include <cstring> // strchr()
 #include <memory>
 #include <optional>

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -4,10 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
-#include <ctype.h> /* isxdigit() */
-#include <errno.h>
 #include <functional>
-#include <limits.h> /* INT_MAX */
 #include <memory>
 #include <utility>
 


### PR DESCRIPTION
Enable all `modernize` checks except for one (`use-trailing-return-type`) which is an extensive stylistic change for later.