### PR TITLE
Fix issues reported by clang-tidy `cppcoreguidelines` checks (GTK client)

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -1,6 +1,10 @@
 ---
 Checks: >
   -*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-narrowing-conversions,
   modernize-*,
   -modernize-use-trailing-return-type,
   readability-*,

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -87,6 +87,7 @@ class Application::Impl
 {
 public:
     Impl(Application& app, std::string const& config_dir, bool start_paused, bool is_iconified);
+    ~Impl() = default;
 
     TR_DISABLE_COPY_MOVE(Impl)
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -294,10 +294,9 @@ bool Application::Impl::refresh_actions()
         size_t const total = core_->get_torrent_count();
         size_t const active = core_->get_active_torrent_count();
         auto const torrent_count = core_->get_model()->children().size();
-        bool has_selection;
 
         auto const sel_counts = get_selected_torrent_counts();
-        has_selection = sel_counts.total_count > 0;
+        bool const has_selection = sel_counts.total_count > 0;
 
         gtr_action_set_sensitive("select-all", torrent_count != 0);
         gtr_action_set_sensitive("deselect-all", torrent_count != 0);
@@ -400,15 +399,15 @@ void Application::Impl::on_main_window_size_allocated()
     if (!is_maximized)
     {
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-        int x;
-        int y;
+        int x = 0;
+        int y = 0;
         wind_->get_position(x, y);
         gtr_pref_int_set(TR_KEY_main_window_x, x);
         gtr_pref_int_set(TR_KEY_main_window_y, y);
 #endif
 
-        int w;
-        int h;
+        int w = 0;
+        int h = 0;
 #if GTKMM_CHECK_VERSION(4, 0, 0)
         wind_->get_default_size(w, h);
 #else
@@ -450,9 +449,9 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torren
     case TR_RPC_SESSION_CHANGED:
         {
             tr_variant tmp;
-            tr_variant* newval;
+            tr_variant* newval = nullptr;
             tr_variant* oldvals = gtr_pref_get_all();
-            tr_quark key;
+            tr_quark key = TR_KEY_NONE;
             std::vector<tr_quark> changed_keys;
             auto const* const session = core_->get_session();
             tr_variantInitDict(&tmp, 100);
@@ -460,13 +459,9 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torren
 
             for (int i = 0; tr_variantDictChild(&tmp, i, &key, &newval); ++i)
             {
-                bool changed;
+                bool changed = true;
 
-                if (tr_variant const* oldval = tr_variantDictFind(oldvals, key); oldval == nullptr)
-                {
-                    changed = true;
-                }
-                else
+                if (tr_variant const* oldval = tr_variantDictFind(oldvals, key); oldval != nullptr)
                 {
                     auto const a = tr_variantToStr(oldval, TR_VARIANT_FMT_BENC);
                     auto const b = tr_variantToStr(newval, TR_VARIANT_FMT_BENC);
@@ -568,7 +563,7 @@ void Application::Impl::on_startup()
     std::ignore = FilterBar();
     std::ignore = PathButton();
 
-    tr_session* session;
+    tr_session* session = nullptr;
 
 #ifdef G_OS_UNIX
     g_unix_signal_add(SIGINT, &signal_handler, this);
@@ -1428,15 +1423,13 @@ void Application::Impl::show_about_dialog()
 bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method)
 {
     tr_variant top;
-    tr_variant* args;
-    tr_variant* ids;
     bool invoked = false;
     auto* session = core_->get_session();
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, method);
-    args = tr_variantDictAddDict(&top, TR_KEY_arguments, 1);
-    ids = tr_variantDictAddList(args, TR_KEY_ids, 0);
+    auto* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 1);
+    auto* const ids = tr_variantDictAddList(args, TR_KEY_ids, 0);
     sel_->selected_foreach(
         [ids](auto const& /*path*/, auto const& iter)
         {

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -971,8 +971,7 @@ void Application::Impl::on_app_exit()
     refresh_actions_tag_.disconnect();
 
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-    auto* c = static_cast<Gtk::Container*>(wind_.get());
-    c->remove(*static_cast<Gtk::Bin*>(c)->get_child());
+    wind_->remove();
 #endif
 
     wind_->set_show_menubar(false);
@@ -984,7 +983,7 @@ void Application::Impl::on_app_exit()
 #if GTKMM_CHECK_VERSION(4, 0, 0)
     wind_->set_child(*p);
 #else
-    c->add(*p);
+    wind_->add(*p);
 #endif
 
     auto* icon = Gtk::make_managed<Gtk::Image>();

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -366,12 +366,11 @@ void register_magnet_link_handler()
     }
     catch (Gio::Error const& e)
     {
-        auto const msg = fmt::format(
+        gtr_warning(fmt::format(
             _("Couldn't register Transmission as a {content_type} handler: {error} ({error_code})"),
             fmt::arg("content_type", content_type),
             fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code()));
-        g_warning("%s", msg.c_str());
+            fmt::arg("error_code", e.code())));
     }
 }
 
@@ -525,7 +524,7 @@ namespace
 
 gboolean signal_handler(gpointer user_data)
 {
-    g_message(_("Got termination signal, trying to shut down cleanly. Do it again if it gets stuck."));
+    gtr_message(_("Got termination signal, trying to shut down cleanly. Do it again if it gets stuck."));
     gtr_actions_handler("quit", user_data);
     return G_SOURCE_REMOVE;
 }
@@ -1661,7 +1660,7 @@ void Application::Impl::actions_handler(Glib::ustring const& action_name)
     }
     else
     {
-        g_error("%s", fmt::format("Unhandled action: {}", action_name).c_str());
+        gtr_error(fmt::format("Unhandled action: {}", action_name));
     }
 
     if (changed)

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1172,8 +1172,8 @@ void initPeerRow(
     }
 
     auto peer_addr4 = in_addr();
-    auto const collated_name = inet_pton(AF_INET, peer->addr, &peer_addr4) != 1 ?
-        peer->addr :
+    auto const collated_name = inet_pton(AF_INET, std::data(peer->addr), &peer_addr4) != 1 ?
+        std::data(peer->addr) :
         fmt::format(
             "{:03}",
             fmt::join(
@@ -1181,7 +1181,7 @@ void initPeerRow(
                 reinterpret_cast<uint8_t const*>(&peer_addr4.s_addr) + sizeof(peer_addr4.s_addr),
                 "."));
 
-    (*iter)[peer_cols.address] = peer->addr;
+    (*iter)[peer_cols.address] = std::data(peer->addr);
     (*iter)[peer_cols.address_collated] = collated_name;
     (*iter)[peer_cols.client] = client;
     (*iter)[peer_cols.encryption_stock_id] = peer->isEncrypted ? "lock" : "";
@@ -1251,7 +1251,7 @@ void refreshPeerRow(Gtk::TreeModel::iterator const& iter, tr_peer_stat const* pe
     (*iter)[peer_cols.download_rate_string] = down_speed;
     (*iter)[peer_cols.upload_rate_double] = peer->rateToPeer_KBps;
     (*iter)[peer_cols.upload_rate_string] = up_speed;
-    (*iter)[peer_cols.flags] = peer->flagStr;
+    (*iter)[peer_cols.flags] = std::data(peer->flagStr);
     (*iter)[peer_cols.was_updated] = true;
     (*iter)[peer_cols.blocks_downloaded_count_int] = (int)peer->blocksToClient;
     (*iter)[peer_cols.blocks_downloaded_count_string] = blocks_to_client;
@@ -1813,7 +1813,7 @@ void appendAnnounceInfo(tr_tracker_view const& tracker, time_t const now, Gtk::T
                 // {markup_begin} and {markup_end} should surround the error
                 _("Got an error '{markup_begin}{error}{markup_end}' {time_span_ago}"),
                 fmt::arg("markup_begin", ErrMarkupBegin),
-                fmt::arg("error", Glib::Markup::escape_text(tracker.lastAnnounceResult)),
+                fmt::arg("error", Glib::Markup::escape_text(std::data(tracker.lastAnnounceResult))),
                 fmt::arg("markup_end", ErrMarkupEnd),
                 fmt::arg("time_span_ago", time_span_ago));
         }
@@ -1885,7 +1885,7 @@ void appendScrapeInfo(tr_tracker_view const& tracker, time_t const now, Gtk::Tex
             gstr << fmt::format(
                 // {markup_begin} and {markup_end} should surround the error text
                 _("Got a scrape error '{markup_begin}{error}{markup_end}' {time_span_ago}"),
-                fmt::arg("error", Glib::Markup::escape_text(tracker.lastScrapeResult)),
+                fmt::arg("error", Glib::Markup::escape_text(std::data(tracker.lastScrapeResult))),
                 fmt::arg("time_span_ago", time_span_ago),
                 fmt::arg("markup_begin", ErrMarkupBegin),
                 fmt::arg("markup_end", ErrMarkupEnd));

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1172,13 +1172,15 @@ void initPeerRow(
     }
 
     auto peer_addr4 = in_addr();
+    auto const* const peer_addr4_octets = reinterpret_cast<uint8_t const*>(&peer_addr4.s_addr);
     auto const collated_name = inet_pton(AF_INET, std::data(peer->addr), &peer_addr4) != 1 ?
         std::data(peer->addr) :
         fmt::format(
             "{:03}",
             fmt::join(
-                reinterpret_cast<uint8_t const*>(&peer_addr4.s_addr),
-                reinterpret_cast<uint8_t const*>(&peer_addr4.s_addr) + sizeof(peer_addr4.s_addr),
+                peer_addr4_octets,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                peer_addr4_octets + sizeof(peer_addr4.s_addr), // TODO(C++20): Use std::span
                 "."));
 
     (*iter)[peer_cols.address] = std::data(peer->addr);

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1777,7 +1777,7 @@ std::array<std::string_view, 3> const text_dir_mark = { ""sv, "\u200E"sv, "\u200
 
 void appendAnnounceInfo(tr_tracker_view const& tracker, time_t const now, Gtk::TextDirection direction, std::ostream& gstr)
 {
-    auto const dir_mark = text_dir_mark[static_cast<int>(direction)];
+    auto const dir_mark = text_dir_mark.at(static_cast<int>(direction));
 
     if (tracker.hasAnnounced && tracker.announceState != TR_TRACKER_INACTIVE)
     {
@@ -1859,7 +1859,7 @@ void appendAnnounceInfo(tr_tracker_view const& tracker, time_t const now, Gtk::T
 
 void appendScrapeInfo(tr_tracker_view const& tracker, time_t const now, Gtk::TextDirection direction, std::ostream& gstr)
 {
-    auto const dir_mark = text_dir_mark[static_cast<int>(direction)];
+    auto const dir_mark = text_dir_mark.at(static_cast<int>(direction));
 
     if (tracker.hasScraped)
     {
@@ -1934,7 +1934,7 @@ void buildTrackerSummary(
     Gtk::TextDirection direction)
 {
     // hostname
-    gstr << text_dir_mark[static_cast<int>(direction)];
+    gstr << text_dir_mark.at(static_cast<int>(direction));
     gstr << (tracker.isBackup ? "<i>" : "<b>");
     gstr << Glib::Markup::escape_text(!key.empty() ? fmt::format(FMT_STRING("{:s} - {:s}"), tracker.host, key) : tracker.host);
     gstr << (tracker.isBackup ? "</i>" : "</b>");

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1172,6 +1172,7 @@ void initPeerRow(
     }
 
     auto peer_addr4 = in_addr();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto const* const peer_addr4_octets = reinterpret_cast<uint8_t const*>(&peer_addr4.s_addr);
     auto const collated_name = inet_pton(AF_INET, std::data(peer->addr), &peer_addr4) != 1 ?
         std::data(peer->addr) :

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -2167,6 +2167,7 @@ public:
         DetailsDialog& parent,
         Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
+    ~EditTrackersDialog() override = default;
 
     TR_DISABLE_COPY_MOVE(EditTrackersDialog)
 
@@ -2285,6 +2286,7 @@ public:
         DetailsDialog& parent,
         Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
+    ~AddTrackerDialog() override = default;
 
     TR_DISABLE_COPY_MOVE(AddTrackerDialog)
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1533,7 +1533,7 @@ namespace
 void setPeerViewColumns(Gtk::TreeView* peer_view)
 {
     std::vector<Gtk::TreeModelColumnBase const*> view_columns;
-    Gtk::TreeViewColumn* c;
+    Gtk::TreeViewColumn* c = nullptr;
     bool const more = gtr_pref_flag_get(TR_KEY_show_extra_peer_details);
 
     view_columns.push_back(&peer_cols.encryption_stock_id);
@@ -2346,14 +2346,12 @@ void AddTrackerDialog::on_response(int response)
             if (tr_urlIsValidTracker(url.c_str()))
             {
                 tr_variant top;
-                tr_variant* args;
-                tr_variant* trackers;
 
                 tr_variantInitDict(&top, 2);
                 tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
-                args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
+                auto* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
                 tr_variantDictAddInt(args, TR_KEY_id, torrent_id_);
-                trackers = tr_variantDictAddList(args, TR_KEY_trackerAdd, 1);
+                auto* const trackers = tr_variantDictAddList(args, TR_KEY_trackerAdd, 1);
                 tr_variantListAddStr(trackers, url.raw());
 
                 core_->exec(&top);
@@ -2397,14 +2395,12 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
         auto const torrent_id = iter->get_value(tracker_cols.torrent_id);
         auto const tracker_id = iter->get_value(tracker_cols.tracker_id);
         tr_variant top;
-        tr_variant* args;
-        tr_variant* trackers;
 
         tr_variantInitDict(&top, 2);
         tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
-        args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
+        auto* const args = tr_variantDictAddDict(&top, TR_KEY_arguments, 2);
         tr_variantDictAddInt(args, TR_KEY_id, torrent_id);
-        trackers = tr_variantDictAddList(args, TR_KEY_trackerRemove, 1);
+        auto* const trackers = tr_variantDictAddList(args, TR_KEY_trackerRemove, 1);
         tr_variantListAddInt(trackers, tracker_id);
 
         core_->exec(&top);

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -35,7 +35,7 @@ struct favicon_data
 
 Glib::ustring get_url(std::string const& host, size_t image_type)
 {
-    return fmt::format("http://{}/favicon.{}", host, image_types[image_type]);
+    return fmt::format("http://{}/favicon.{}", host, image_types.at(image_type));
 }
 
 std::string favicon_get_cache_dir()

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -575,13 +575,27 @@ namespace
 
 void renderDownload(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator const& iter)
 {
+    auto* const toggle_renderer = dynamic_cast<Gtk::CellRendererToggle*>(renderer);
+    g_assert(toggle_renderer != nullptr);
+    if (toggle_renderer == nullptr)
+    {
+        return;
+    }
+
     auto const enabled = iter->get_value(file_cols.enabled);
-    static_cast<Gtk::CellRendererToggle*>(renderer)->property_inconsistent() = enabled == MIXED;
-    static_cast<Gtk::CellRendererToggle*>(renderer)->property_active() = enabled == static_cast<int>(true);
+    toggle_renderer->property_inconsistent() = enabled == MIXED;
+    toggle_renderer->property_active() = enabled == static_cast<int>(true);
 }
 
 void renderPriority(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator const& iter)
 {
+    auto* const text_renderer = dynamic_cast<Gtk::CellRendererText*>(renderer);
+    g_assert(text_renderer != nullptr);
+    if (text_renderer == nullptr)
+    {
+        return;
+    }
+
     Glib::ustring text;
 
     switch (auto const priority = iter->get_value(file_cols.priority); priority)
@@ -603,7 +617,7 @@ void renderPriority(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator 
         break;
     }
 
-    static_cast<Gtk::CellRendererText*>(renderer)->property_text() = text;
+    text_renderer->property_text() = text;
 }
 
 /* build a filename from tr_torrentGetCurrentDir() + the model's FC_LABELs */
@@ -772,7 +786,7 @@ bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib:
     else
     {
         auto w = std::make_shared<Gtk::MessageDialog>(
-            *static_cast<Gtk::Window*>(TR_GTK_WIDGET_GET_ROOT(widget_)),
+            gtr_widget_get_window(widget_),
             fmt::format(
                 _("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})"),
                 fmt::arg("old_path", path_string),

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -426,8 +426,8 @@ namespace
 
 struct build_data
 {
-    Gtk::Widget* w;
-    tr_torrent* tor;
+    Gtk::Widget* w = nullptr;
+    tr_torrent* tor = nullptr;
     Gtk::TreeStore::iterator iter;
     Glib::RefPtr<Gtk::TreeStore> store;
 };
@@ -747,7 +747,7 @@ struct rename_data
 {
     Glib::ustring newname;
     Glib::ustring path_string;
-    gpointer impl;
+    gpointer impl = nullptr;
 };
 
 bool FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib::ustring const& newname, int error)

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -302,8 +302,8 @@ void FileList::Impl::refresh()
     }
     else
     {
-        Gtk::SortType order;
-        int sort_column_id;
+        Gtk::SortType order = TR_GTK_SORT_TYPE(ASCENDING);
+        int sort_column_id = 0;
         store_->get_sort_column_id(sort_column_id, order);
 
         RefreshData refresh_data{ sort_column_id, false, tor };
@@ -710,8 +710,8 @@ bool FileList::Impl::onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel:
  */
 bool FileList::Impl::getAndSelectEventPath(double view_x, double view_y, Gtk::TreeViewColumn*& col, Gtk::TreeModel::Path& path)
 {
-    int cell_x;
-    int cell_y;
+    int cell_x = 0;
+    int cell_y = 0;
 
     if (view_->get_path_at_pos(view_x, view_y, path, col, cell_x, cell_y))
     {
@@ -729,7 +729,7 @@ bool FileList::Impl::getAndSelectEventPath(double view_x, double view_y, Gtk::Tr
 
 bool FileList::Impl::onViewButtonPressed(guint button, TrGdkModifierType state, double view_x, double view_y)
 {
-    Gtk::TreeViewColumn* col;
+    Gtk::TreeViewColumn* col = nullptr;
     Gtk::TreeModel::Path path;
     bool handled = false;
 
@@ -931,8 +931,8 @@ FileList::Impl::Impl(
     {
         /* add "progress" column */
         auto const* title = _("Have");
-        int width;
-        int height;
+        int width = 0;
+        int height = 0;
         view_->create_pango_layout(title)->get_pixel_size(width, height);
         width += 30; /* room for the sort indicator */
         auto* rend = Gtk::make_managed<Gtk::CellRendererProgress>();
@@ -948,8 +948,8 @@ FileList::Impl::Impl(
     {
         /* add "enabled" column */
         auto const* title = _("Download");
-        int width;
-        int height;
+        int width = 0;
+        int height = 0;
         view_->create_pango_layout(title)->get_pixel_size(width, height);
         width += 30; /* room for the sort indicator */
         auto* rend = Gtk::make_managed<Gtk::CellRendererToggle>();
@@ -965,8 +965,8 @@ FileList::Impl::Impl(
     {
         /* add priority column */
         auto const* title = _("Priority");
-        int width;
-        int height;
+        int width = 0;
+        int height = 0;
         view_->create_pango_layout(title)->get_pixel_size(width, height);
         width += 30; /* room for the sort indicator */
         auto* rend = Gtk::make_managed<Gtk::CellRendererText>();

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -794,7 +794,7 @@ FilterBar::Impl::Impl(FilterBar& widget, tr_session* session, Glib::RefPtr<Gtk::
     filter_model_row_inserted_tag_ = filter_model_->signal_row_inserted().connect(
         [this](auto const& /*path*/, auto const& /*iter*/) { update_count_label_idle(); });
 
-    static_cast<Gtk::TreeStore*>(tracker_->get_model().get())->set_data(SESSION_KEY, session);
+    gtr_ptr_dynamic_cast<Gtk::TreeStore>(tracker_->get_model())->set_data(SESSION_KEY, session);
 
     filter_model_->set_visible_func(sigc::mem_fun(*this, &Impl::is_row_visible));
 

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -696,25 +696,17 @@ bool FilterBar::Impl::update_count_label()
     auto const visibleCount = static_cast<int>(filter_model_->children().size());
 
     /* get the tracker count */
-    int trackerCount;
+    int trackerCount = 0;
     if (auto const iter = tracker_->get_active(); iter)
     {
         trackerCount = iter->get_value(tracker_filter_cols.count);
     }
-    else
-    {
-        trackerCount = 0;
-    }
 
     /* get the activity count */
-    int activityCount;
+    int activityCount = 0;
     if (auto const iter = activity_->get_active(); iter)
     {
         activityCount = iter->get_value(activity_filter_cols.count);
-    }
-    else
-    {
-        activityCount = 0;
     }
 
     /* set the text */

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -847,6 +847,8 @@ T* FilterBar::Impl::get_template_child(char const* name) const
     auto full_type_name = std::string("gtkmm__CustomObject_");
     Glib::append_canonical_typename(full_type_name, typeid(FilterBar).name());
 
-    return Glib::wrap(reinterpret_cast<typename T::BaseObjectType*>(
-        gtk_widget_get_template_child(GTK_WIDGET(widget_.gobj()), g_type_from_name(full_type_name.c_str()), name)));
+    return Glib::wrap(G_TYPE_CHECK_INSTANCE_CAST(
+        gtk_widget_get_template_child(GTK_WIDGET(widget_.gobj()), g_type_from_name(full_type_name.c_str()), name),
+        T::get_base_type(),
+        typename T::BaseObjectType));
 }

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -185,7 +185,7 @@ bool tracker_filter_model_update(Glib::RefPtr<Gtk::TreeStore> const& tracker_mod
         for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
         {
             auto const view = tr_torrentTracker(tor, i);
-            torrent_sites_and_hosts.try_emplace(view.sitename, view.host);
+            torrent_sites_and_hosts.try_emplace(std::data(view.sitename), view.host);
         }
 
         for (auto const& [sitename, host] : torrent_sites_and_hosts)
@@ -391,7 +391,7 @@ bool test_tracker(tr_torrent const* tor, int active_tracker_type, Glib::ustring 
 
     for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
     {
-        if (tr_torrentTracker(tor, i).sitename == host)
+        if (auto const tracker = tr_torrentTracker(tor, i); std::data(tracker.sitename) == host)
         {
             return true;
         }

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -296,7 +296,7 @@ Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createSpeedMenu(
     Glib::RefPtr<Gio::SimpleActionGroup> const& actions,
     tr_direction dir)
 {
-    auto& info = speed_menu_info_[dir];
+    auto& info = speed_menu_info_.at(dir);
 
     auto m = Gio::Menu::create();
 

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -83,6 +83,7 @@ class MakeDialog::Impl
 {
 public:
     Impl(MakeDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~Impl() = default;
 
     TR_DISABLE_COPY_MOVE(Impl)
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -375,7 +375,7 @@ tr_log_message* addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_me
                 gstr += fmt::format(" ({})", message.name.c_str());
             }
 
-            g_warning("%s", gstr.c_str());
+            gtr_warning(gstr);
         }
     }
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -136,14 +136,11 @@ void dbus_proxy_ready_callback(Glib::RefPtr<Gio::AsyncResult>& res)
     }
     catch (Glib::Error const& e)
     {
-        g_warning(
-            "%s",
-            fmt::format(
-                _("Couldn't create proxy for '{bus}': {error} ({error_code})"),
-                fmt::arg("bus", NotificationsDbusName),
-                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-                fmt::arg("error_code", e.code()))
-                .c_str());
+        gtr_warning(fmt::format(
+            _("Couldn't create proxy for '{bus}': {error} ({error_code})"),
+            fmt::arg("bus", NotificationsDbusName),
+            fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
+            fmt::arg("error_code", e.code())));
         return;
     }
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -66,6 +66,7 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Glib::RefPtr<Session> const& core,
         std::unique_ptr<tr_ctor, void (*)(tr_ctor*)> ctor);
+    ~Impl() = default;
 
     TR_DISABLE_COPY_MOVE(Impl)
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -290,7 +290,7 @@ OptionsDialog::Impl::Impl(
     destination_chooser->signal_selection_changed().connect([this, destination_chooser]()
                                                             { downloadDirChanged(destination_chooser); });
 
-    bool flag;
+    bool flag = false;
     if (!tr_ctorGetPaused(ctor_.get(), TR_FORCE, &flag))
     {
         g_assert_not_reached();

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -134,7 +134,7 @@ void PathButton::Impl::show_dialog()
     auto const title = title_.get_value();
 
     auto dialog = std::make_shared<Gtk::FileChooserDialog>(!title.empty() ? title : _("Select a File"), action_.get_value());
-    dialog->set_transient_for(*static_cast<Gtk::Window*>(widget_.get_root()));
+    dialog->set_transient_for(gtr_widget_get_window(widget_));
     dialog->add_button(_("_Cancel"), Gtk::ResponseType::CANCEL);
     dialog->add_button(_("_Open"), Gtk::ResponseType::ACCEPT);
     dialog->set_modal(true);

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -14,6 +14,7 @@ class PathButton::Impl
 {
 public:
     explicit Impl(PathButton& widget);
+    ~Impl() = default;
 
     TR_DISABLE_COPY_MOVE(Impl)
 

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -129,7 +129,7 @@ tr_variant* gtr_pref_get_all()
 
 int64_t gtr_pref_int_get(tr_quark const key)
 {
-    int64_t i;
+    int64_t i = 0;
 
     return tr_variantDictFindInt(getPrefs(), key, &i) ? i : 0;
 }
@@ -141,7 +141,7 @@ void gtr_pref_int_set(tr_quark const key, int64_t value)
 
 double gtr_pref_double_get(tr_quark const key)
 {
-    double d;
+    double d = 0;
 
     return tr_variantDictFindReal(getPrefs(), key, &d) ? d : 0.0;
 }
@@ -157,7 +157,7 @@ void gtr_pref_double_set(tr_quark const key, double value)
 
 bool gtr_pref_flag_get(tr_quark const key)
 {
-    bool boolVal;
+    bool boolVal = false;
 
     return tr_variantDictFindBool(getPrefs(), key, &boolVal) ? boolVal : false;
 }

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -64,108 +64,141 @@ void PrefsDialog::Impl::response_cb(int response)
 namespace
 {
 
-void init_check_button(Gtk::CheckButton& button, tr_quark const key, Glib::RefPtr<Session> const& core)
+class PageBase : public Gtk::Box
 {
-    button.set_active(gtr_pref_flag_get(key));
-    button.signal_toggled().connect([&button, key, core]() { core->set_pref(key, button.get_active()); });
+public:
+    PageBase(BaseObjectType* cast_item, Glib::RefPtr<Session> const& core);
+
+    void init_check_button(Gtk::CheckButton& button, tr_quark key);
+
+    void init_spin_button(Gtk::SpinButton& button, tr_quark key, int low, int high, int step);
+    void init_spin_button_double(Gtk::SpinButton& button, tr_quark key, double low, double high, double step);
+
+    void init_entry(Gtk::Entry& entry, tr_quark key);
+
+    void init_text_view(Gtk::TextView& view, tr_quark key);
+
+    void init_chooser_button(PathButton& button, tr_quark key);
+
+    void init_encryption_combo(Gtk::ComboBox& combo, tr_quark key);
+
+    void init_time_combo(Gtk::ComboBox& combo, tr_quark key);
+    void init_week_combo(Gtk::ComboBox& combo, tr_quark key);
+
+private:
+    bool spun_cb_idle(Gtk::SpinButton& spin, tr_quark key, bool isDouble);
+    void spun_cb(Gtk::SpinButton& w, tr_quark key, bool isDouble);
+
+    void entry_changed_cb(Gtk::Entry& w, tr_quark key);
+
+    void chosen_cb(PathButton& w, tr_quark key);
+
+    void onIntComboChanged(Gtk::ComboBox& combo_box, tr_quark key);
+
+    static auto get_weekday_string(Glib::Date::Weekday weekday);
+
+private:
+    Glib::RefPtr<Session> const core_;
+
+    static Glib::Quark const IdleDataKey;
+};
+
+Glib::Quark const PageBase::IdleDataKey = "idle-data";
+
+PageBase::PageBase(BaseObjectType* cast_item, Glib::RefPtr<Session> const& core)
+    : Gtk::Box(cast_item)
+    , core_(core)
+{
 }
 
-auto const IdleDataKey = Glib::Quark("idle-data");
+void PageBase::init_check_button(Gtk::CheckButton& button, tr_quark const key)
+{
+    button.set_active(gtr_pref_flag_get(key));
+    button.signal_toggled().connect([this, &button, key]() { core_->set_pref(key, button.get_active()); });
+}
 
-bool spun_cb_idle(Gtk::SpinButton* spin, tr_quark const key, Glib::RefPtr<Session> const& core, bool isDouble)
+bool PageBase::spun_cb_idle(Gtk::SpinButton& spin, tr_quark const key, bool isDouble)
 {
     bool keep_waiting = true;
 
     /* has the user stopped making changes? */
-    if (auto const* const last_change = static_cast<Glib::Timer*>(spin->get_data(IdleDataKey)); last_change->elapsed() > 0.33)
+    if (auto const* const last_change = static_cast<Glib::Timer*>(spin.get_data(IdleDataKey)); last_change->elapsed() > 0.33)
     {
         /* update the core */
         if (isDouble)
         {
-            double const value = spin->get_value();
-            core->set_pref(key, value);
+            double const value = spin.get_value();
+            core_->set_pref(key, value);
         }
         else
         {
-            int const value = spin->get_value_as_int();
-            core->set_pref(key, value);
+            int const value = spin.get_value_as_int();
+            core_->set_pref(key, value);
         }
 
         /* cleanup */
-        spin->set_data(IdleDataKey, nullptr);
+        spin.set_data(IdleDataKey, nullptr);
         keep_waiting = false;
-        spin->unreference();
+        spin.unreference();
     }
 
     return keep_waiting;
 }
 
-void spun_cb(Gtk::SpinButton* w, tr_quark const key, Glib::RefPtr<Session> const& core, bool isDouble)
+void PageBase::spun_cb(Gtk::SpinButton& w, tr_quark const key, bool isDouble)
 {
     /* user may be spinning through many values, so let's hold off
        for a moment to keep from flooding the core with changes */
-    auto* last_change = static_cast<Glib::Timer*>(w->get_data(IdleDataKey));
+    auto* last_change = static_cast<Glib::Timer*>(w.get_data(IdleDataKey));
 
     if (last_change == nullptr)
     {
         last_change = new Glib::Timer();
-        w->set_data(IdleDataKey, last_change, [](gpointer p) { delete static_cast<Glib::Timer*>(p); });
-        w->reference();
-        Glib::signal_timeout().connect_seconds([w, key, core, isDouble]() { return spun_cb_idle(w, key, core, isDouble); }, 1);
+        w.set_data(IdleDataKey, last_change, [](gpointer p) { delete static_cast<Glib::Timer*>(p); });
+        w.reference();
+        Glib::signal_timeout().connect_seconds([this, &w, key, isDouble]() { return spun_cb_idle(w, key, isDouble); }, 1);
     }
 
     last_change->start();
 }
 
-void init_spin_button(
-    Gtk::SpinButton& button,
-    tr_quark const key,
-    Glib::RefPtr<Session> const& core,
-    int low,
-    int high,
-    int step)
+void PageBase::init_spin_button(Gtk::SpinButton& button, tr_quark const key, int low, int high, int step)
 {
     button.set_adjustment(Gtk::Adjustment::create(gtr_pref_int_get(key), low, high, step));
     button.set_digits(0);
-    button.signal_value_changed().connect([&button, key, core]() { spun_cb(&button, key, core, false); });
+    button.signal_value_changed().connect([this, &button, key]() { spun_cb(button, key, false); });
 }
 
-void init_spin_button_double(
-    Gtk::SpinButton& button,
-    tr_quark const key,
-    Glib::RefPtr<Session> const& core,
-    double low,
-    double high,
-    double step)
+void PageBase::init_spin_button_double(Gtk::SpinButton& button, tr_quark const key, double low, double high, double step)
 {
     button.set_adjustment(Gtk::Adjustment::create(gtr_pref_double_get(key), low, high, step));
     button.set_digits(2);
-    button.signal_value_changed().connect([&button, key, core]() { spun_cb(&button, key, core, true); });
+    button.signal_value_changed().connect([this, &button, key]() { spun_cb(button, key, true); });
 }
 
-void entry_changed_cb(Gtk::Entry* w, tr_quark const key, Glib::RefPtr<Session> const& core)
+void PageBase::entry_changed_cb(Gtk::Entry& w, tr_quark const key)
 {
-    core->set_pref(key, w->get_text());
+    core_->set_pref(key, w.get_text());
 }
 
-void init_entry(Gtk::Entry& entry, tr_quark const key, Glib::RefPtr<Session> const& core)
+void PageBase::init_entry(Gtk::Entry& entry, tr_quark const key)
 {
     if (auto const value = gtr_pref_string_get(key); !value.empty())
     {
         entry.set_text(value);
     }
 
-    entry.signal_changed().connect([&entry, key, core]() { entry_changed_cb(&entry, key, core); });
+    entry.signal_changed().connect([this, &entry, key]() { entry_changed_cb(entry, key); });
 }
 
-void init_text_view(Gtk::TextView& view, tr_quark const key, Glib::RefPtr<Session> const& core)
+void PageBase::init_text_view(Gtk::TextView& view, tr_quark const key)
 {
     auto buffer = view.get_buffer();
     buffer->set_text(gtr_pref_string_get(key));
 
-    auto const save_buffer = [buffer, key, core]()
+    auto const save_buffer = [this, buffer, key]()
     {
-        core->set_pref(key, buffer->get_text());
+        core_->set_pref(key, buffer->get_text());
     };
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
@@ -178,31 +211,115 @@ void init_text_view(Gtk::TextView& view, tr_quark const key, Glib::RefPtr<Sessio
 #endif
 }
 
-void chosen_cb(PathButton* w, tr_quark const key, Glib::RefPtr<Session> const& core)
+void PageBase::chosen_cb(PathButton& w, tr_quark const key)
 {
-    core->set_pref(key, w->get_filename());
+    core_->set_pref(key, w.get_filename());
 }
 
-void init_chooser_button(PathButton& button, tr_quark const key, Glib::RefPtr<Session> const& core)
+void PageBase::init_chooser_button(PathButton& button, tr_quark const key)
 {
     if (auto const path = gtr_pref_string_get(key); !path.empty())
     {
         button.set_filename(path);
     }
 
-    button.signal_selection_changed().connect([&button, key, core]() { chosen_cb(&button, key, core); });
+    button.signal_selection_changed().connect([this, &button, key]() { chosen_cb(button, key); });
 }
 
-} // namespace
+void PageBase::onIntComboChanged(Gtk::ComboBox& combo_box, tr_quark const key)
+{
+    core_->set_pref(key, gtr_combo_box_get_active_enum(combo_box));
+}
+
+void PageBase::init_encryption_combo(Gtk::ComboBox& combo, tr_quark const key)
+{
+    gtr_combo_box_set_enum(
+        combo,
+        {
+            { _("Allow encryption"), TR_CLEAR_PREFERRED },
+            { _("Prefer encryption"), TR_ENCRYPTION_PREFERRED },
+            { _("Require encryption"), TR_ENCRYPTION_REQUIRED },
+        });
+    gtr_combo_box_set_active_enum(combo, gtr_pref_int_get(key));
+    combo.signal_changed().connect([this, &combo, key]() { onIntComboChanged(combo, key); });
+}
+
+void PageBase::init_time_combo(Gtk::ComboBox& combo, tr_quark const key)
+{
+    class TimeModelColumns : public Gtk::TreeModelColumnRecord
+    {
+    public:
+        TimeModelColumns()
+        {
+            add(offset);
+            add(title);
+        }
+
+        Gtk::TreeModelColumn<int> offset;
+        Gtk::TreeModelColumn<Glib::ustring> title;
+    };
+
+    static TimeModelColumns const time_cols;
+
+    /* build a store at 15 minute intervals */
+    auto store = Gtk::ListStore::create(time_cols);
+
+    for (int i = 0; i < 60 * 24; i += 15)
+    {
+        auto const iter = store->append();
+        (*iter)[time_cols.offset] = i;
+        (*iter)[time_cols.title] = fmt::format("{:02}:{:02}", i / 60, i % 60);
+    }
+
+    /* build the widget */
+    combo.set_model(store);
+    auto* r = Gtk::make_managed<Gtk::CellRendererText>();
+    combo.pack_start(*r, true);
+    combo.add_attribute(r->property_text(), time_cols.title);
+    combo.set_active(gtr_pref_int_get(key) / 15);
+    combo.signal_changed().connect(
+        [this, &combo, key]()
+        {
+            if (auto const iter = combo.get_active(); iter)
+            {
+                core_->set_pref(key, iter->get_value(time_cols.offset));
+            }
+        });
+}
+
+auto PageBase::get_weekday_string(Glib::Date::Weekday weekday)
+{
+    auto date = Glib::Date{};
+    date.set_time_current();
+    date.add_days(static_cast<int>(weekday) - static_cast<int>(date.get_weekday()));
+    return date.format_string("%A");
+}
+
+void PageBase::init_week_combo(Gtk::ComboBox& combo, tr_quark const key)
+{
+    gtr_combo_box_set_enum(
+        combo,
+        {
+            { _("Every Day"), TR_SCHED_ALL },
+            { _("Weekdays"), TR_SCHED_WEEKDAY },
+            { _("Weekends"), TR_SCHED_WEEKEND },
+            { get_weekday_string(Glib::Date::Weekday::MONDAY), TR_SCHED_MON },
+            { get_weekday_string(Glib::Date::Weekday::TUESDAY), TR_SCHED_TUES },
+            { get_weekday_string(Glib::Date::Weekday::WEDNESDAY), TR_SCHED_WED },
+            { get_weekday_string(Glib::Date::Weekday::THURSDAY), TR_SCHED_THURS },
+            { get_weekday_string(Glib::Date::Weekday::FRIDAY), TR_SCHED_FRI },
+            { get_weekday_string(Glib::Date::Weekday::SATURDAY), TR_SCHED_SAT },
+            { get_weekday_string(Glib::Date::Weekday::SUNDAY), TR_SCHED_SUN },
+        });
+    gtr_combo_box_set_active_enum(combo, gtr_pref_int_get(key));
+    combo.signal_changed().connect([this, &combo, key]() { onIntComboChanged(combo, key); });
+}
 
 /****
 *****  Download Tab
 ****/
 
-namespace
-{
-
-class DownloadingPage : public Gtk::Box
+class DownloadingPage : public PageBase
 {
 public:
     DownloadingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
@@ -242,7 +359,7 @@ DownloadingPage::DownloadingPage(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
+    : PageBase(cast_item, core)
     , core_(core)
     , freespace_label_(gtr_get_widget_derived<FreeSpaceLabel>(builder, "download_dir_stats_label", core))
 {
@@ -250,29 +367,22 @@ DownloadingPage::DownloadingPage(
 
     {
         auto* l = gtr_get_widget<Gtk::CheckButton>(builder, "watch_dir_check");
-        init_check_button(*l, TR_KEY_watch_dir_enabled, core_);
+        init_check_button(*l, TR_KEY_watch_dir_enabled);
         auto* w = gtr_get_widget_derived<PathButton>(builder, "watch_dir_chooser");
-        init_chooser_button(*w, TR_KEY_watch_dir, core_);
+        init_chooser_button(*w, TR_KEY_watch_dir);
     }
 
-    init_check_button(
-        *gtr_get_widget<Gtk::CheckButton>(builder, "show_options_dialog_check"),
-        TR_KEY_show_options_window,
-        core);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "show_options_dialog_check"), TR_KEY_show_options_window);
 
-    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "start_on_add_check"), TR_KEY_start_added_torrents, core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "start_on_add_check"), TR_KEY_start_added_torrents);
 
-    init_check_button(
-        *gtr_get_widget<Gtk::CheckButton>(builder, "trash_on_add_check"),
-        TR_KEY_trash_original_torrent_files,
-        core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "trash_on_add_check"), TR_KEY_trash_original_torrent_files);
 
-    init_chooser_button(*gtr_get_widget_derived<PathButton>(builder, "download_dir_chooser"), TR_KEY_download_dir, core_);
+    init_chooser_button(*gtr_get_widget_derived<PathButton>(builder, "download_dir_chooser"), TR_KEY_download_dir);
 
     init_spin_button(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_active_downloads_spin"),
         TR_KEY_download_queue_size,
-        core_,
         0,
         std::numeric_limits<int>::max(),
         1);
@@ -280,118 +390,97 @@ DownloadingPage::DownloadingPage(
     init_spin_button(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_inactive_time_spin"),
         TR_KEY_queue_stalled_minutes,
-        core_,
         1,
         std::numeric_limits<int>::max(),
         15);
 
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "append_suffix_to_incomplete_check"),
-        TR_KEY_rename_partial_files,
-        core_);
+        TR_KEY_rename_partial_files);
 
     {
         auto* l = gtr_get_widget<Gtk::CheckButton>(builder, "incomplete_dir_check");
-        init_check_button(*l, TR_KEY_incomplete_dir_enabled, core_);
+        init_check_button(*l, TR_KEY_incomplete_dir_enabled);
         auto* w = gtr_get_widget_derived<PathButton>(builder, "incomplete_dir_chooser");
-        init_chooser_button(*w, TR_KEY_incomplete_dir, core_);
+        init_chooser_button(*w, TR_KEY_incomplete_dir);
     }
 
     {
         auto* l = gtr_get_widget<Gtk::CheckButton>(builder, "download_done_script_check");
-        init_check_button(*l, TR_KEY_script_torrent_done_enabled, core_);
+        init_check_button(*l, TR_KEY_script_torrent_done_enabled);
         auto* w = gtr_get_widget_derived<PathButton>(builder, "download_done_script_chooser");
-        init_chooser_button(*w, TR_KEY_script_torrent_done_filename, core_);
+        init_chooser_button(*w, TR_KEY_script_torrent_done_filename);
     }
 
     on_core_prefs_changed(TR_KEY_download_dir);
 }
 
-} // namespace
-
 /****
 *****  Torrent Tab
 ****/
 
-namespace
-{
-
-class SeedingPage : public Gtk::Box
+class SeedingPage : public PageBase
 {
 public:
     SeedingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
 
     TR_DISABLE_COPY_MOVE(SeedingPage)
-
-private:
-    Glib::RefPtr<Session> const core_;
 };
 
 SeedingPage::SeedingPage(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
-    , core_(core)
+    : PageBase(cast_item, core)
 {
     {
         auto* w = gtr_get_widget<Gtk::CheckButton>(builder, "stop_seeding_ratio_check");
-        init_check_button(*w, TR_KEY_ratio_limit_enabled, core_);
+        init_check_button(*w, TR_KEY_ratio_limit_enabled);
         auto* w2 = gtr_get_widget<Gtk::SpinButton>(builder, "stop_seeding_ratio_spin");
-        init_spin_button_double(*w2, TR_KEY_ratio_limit, core_, 0, 1000, .05);
+        init_spin_button_double(*w2, TR_KEY_ratio_limit, 0, 1000, .05);
     }
 
     {
         auto* w = gtr_get_widget<Gtk::CheckButton>(builder, "stop_seeding_timeout_check");
-        init_check_button(*w, TR_KEY_idle_seeding_limit_enabled, core_);
+        init_check_button(*w, TR_KEY_idle_seeding_limit_enabled);
         auto* w2 = gtr_get_widget<Gtk::SpinButton>(builder, "stop_seeding_timeout_spin");
-        init_spin_button(*w2, TR_KEY_idle_seeding_limit, core_, 1, 40320, 5);
+        init_spin_button(*w2, TR_KEY_idle_seeding_limit, 1, 40320, 5);
     }
 
     {
         auto* l = gtr_get_widget<Gtk::CheckButton>(builder, "seeding_done_script_check");
-        init_check_button(*l, TR_KEY_script_torrent_done_seeding_enabled, core_);
+        init_check_button(*l, TR_KEY_script_torrent_done_seeding_enabled);
         auto* w = gtr_get_widget_derived<PathButton>(builder, "seeding_done_script_chooser");
-        init_chooser_button(*w, TR_KEY_script_torrent_done_seeding_filename, core_);
+        init_chooser_button(*w, TR_KEY_script_torrent_done_seeding_filename);
     }
 }
-
-} // namespace
 
 /****
 *****  Desktop Tab
 ****/
 
-namespace
-{
-
-class DesktopPage : public Gtk::Box
+class DesktopPage : public PageBase
 {
 public:
     DesktopPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
 
     TR_DISABLE_COPY_MOVE(DesktopPage)
-
-private:
-    Glib::RefPtr<Session> const core_;
 };
 
 DesktopPage::DesktopPage(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
-    , core_(core)
+    : PageBase(cast_item, core)
 {
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "inhibit_hibernation_check"),
-        TR_KEY_inhibit_desktop_hibernation,
-        core_);
+        TR_KEY_inhibit_desktop_hibernation);
 
     if (auto* const show_systray_icon_check = gtr_get_widget<Gtk::CheckButton>(builder, "show_systray_icon_check");
         SystemTrayIcon::is_available())
     {
-        init_check_button(*show_systray_icon_check, TR_KEY_show_notification_area_icon, core_);
+        init_check_button(*show_systray_icon_check, TR_KEY_show_notification_area_icon);
     }
     else
     {
@@ -400,30 +489,22 @@ DesktopPage::DesktopPage(
 
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "notify_on_torrent_add_check"),
-        TR_KEY_torrent_added_notification_enabled,
-        core_);
+        TR_KEY_torrent_added_notification_enabled);
 
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "notify_on_torrent_finish_check"),
-        TR_KEY_torrent_complete_notification_enabled,
-        core_);
+        TR_KEY_torrent_complete_notification_enabled);
 
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "ding_no_torrent_finish_check"),
-        TR_KEY_torrent_complete_sound_enabled,
-        core_);
+        TR_KEY_torrent_complete_sound_enabled);
 }
-
-} // namespace
 
 /****
 *****  Peer Tab
 ****/
 
-namespace
-{
-
-class PrivacyPage : public Gtk::Box
+class PrivacyPage : public PageBase
 {
 public:
     PrivacyPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
@@ -437,8 +518,6 @@ private:
     void onBlocklistUpdated(int n);
     void onBlocklistUpdate();
     void on_blocklist_url_changed(Gtk::Editable* e);
-
-    static void init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
 
 private:
     Glib::RefPtr<Session> core_;
@@ -516,39 +595,21 @@ void PrivacyPage::on_blocklist_url_changed(Gtk::Editable* e)
     updateBlocklistButton_->set_sensitive(tr_urlIsValid(url.c_str()));
 }
 
-void onIntComboChanged(Gtk::ComboBox* combo_box, tr_quark const key, Glib::RefPtr<Session> const& core)
-{
-    core->set_pref(key, gtr_combo_box_get_active_enum(*combo_box));
-}
-
-void PrivacyPage::init_encryption_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key)
-{
-    gtr_combo_box_set_enum(
-        combo,
-        {
-            { _("Allow encryption"), TR_CLEAR_PREFERRED },
-            { _("Prefer encryption"), TR_ENCRYPTION_PREFERRED },
-            { _("Require encryption"), TR_ENCRYPTION_REQUIRED },
-        });
-    gtr_combo_box_set_active_enum(combo, gtr_pref_int_get(key));
-    combo.signal_changed().connect([&combo, key, core]() { onIntComboChanged(&combo, key, core); });
-}
-
 PrivacyPage::PrivacyPage(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
+    : PageBase(cast_item, core)
     , core_(core)
     , updateBlocklistButton_(gtr_get_widget<Gtk::Button>(builder, "update_blocklist_button"))
     , label_(gtr_get_widget<Gtk::Label>(builder, "blocklist_stats_label"))
     , check_(gtr_get_widget<Gtk::CheckButton>(builder, "blocklist_check"))
 {
-    init_encryption_combo(*gtr_get_widget<Gtk::ComboBox>(builder, "encryption_mode_combo"), core_, TR_KEY_encryption);
+    init_encryption_combo(*gtr_get_widget<Gtk::ComboBox>(builder, "encryption_mode_combo"), TR_KEY_encryption);
 
-    init_check_button(*check_, TR_KEY_blocklist_enabled, core_);
+    init_check_button(*check_, TR_KEY_blocklist_enabled);
     auto* const e = gtr_get_widget<Gtk::Entry>(builder, "blocklist_url_entry");
-    init_entry(*e, TR_KEY_blocklist_url, core_);
+    init_entry(*e, TR_KEY_blocklist_url);
 
     updateBlocklistText();
     updateBlocklistButton_->set_data("session", core_->get_session());
@@ -558,32 +619,61 @@ PrivacyPage::PrivacyPage(
     on_blocklist_url_changed(e);
 
     auto* update_check = gtr_get_widget<Gtk::CheckButton>(builder, "blocklist_autoupdate_check");
-    init_check_button(*update_check, TR_KEY_blocklist_updates_enabled, core_);
+    init_check_button(*update_check, TR_KEY_blocklist_updates_enabled);
 }
-
-} // namespace
 
 /****
 *****  Remote Tab
 ****/
 
-namespace
+class RemotePage : public PageBase
 {
-
-class WhitelistModelColumns : public Gtk::TreeModelColumnRecord
-{
-public:
-    WhitelistModelColumns()
+    class WhitelistModelColumns : public Gtk::TreeModelColumnRecord
     {
-        add(address);
-    }
+    public:
+        WhitelistModelColumns()
+        {
+            add(address);
+        }
 
-    Gtk::TreeModelColumn<Glib::ustring> address;
+        Gtk::TreeModelColumn<Glib::ustring> address;
+    };
+
+    static WhitelistModelColumns const whitelist_cols;
+
+public:
+    RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+
+    TR_DISABLE_COPY_MOVE(RemotePage)
+
+private:
+    void refreshWhitelist();
+    void onAddressEdited(Glib::ustring const& path, Glib::ustring const& address);
+    void onAddWhitelistClicked();
+    void onRemoveWhitelistClicked();
+    void refreshRPCSensitivity();
+
+    static void onLaunchClutchCB();
+
+    static Glib::RefPtr<Gtk::ListStore> whitelist_tree_model_new(std::string const& whitelist);
+
+private:
+    Glib::RefPtr<Session> core_;
+
+    Gtk::TreeView* view_;
+    Gtk::Button* remove_button_;
+    Gtk::CheckButton* rpc_tb_;
+    Gtk::CheckButton* auth_tb_;
+    Gtk::CheckButton* whitelist_tb_;
+
+    Glib::RefPtr<Gtk::ListStore> store_;
+    std::vector<Gtk::Widget*> auth_widgets_;
+    std::vector<Gtk::Widget*> whitelist_widgets_;
 };
 
-WhitelistModelColumns const whitelist_cols;
+RemotePage::WhitelistModelColumns const RemotePage::whitelist_cols;
 
-Glib::RefPtr<Gtk::ListStore> whitelist_tree_model_new(std::string const& whitelist)
+Glib::RefPtr<Gtk::ListStore> RemotePage::whitelist_tree_model_new(std::string const& whitelist)
 {
     auto const store = Gtk::ListStore::create(whitelist_cols);
 
@@ -605,34 +695,6 @@ Glib::RefPtr<Gtk::ListStore> whitelist_tree_model_new(std::string const& whiteli
 
     return store;
 }
-
-class RemotePage : public Gtk::Box
-{
-public:
-    RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
-
-    TR_DISABLE_COPY_MOVE(RemotePage)
-
-private:
-    void refreshWhitelist();
-    void onAddressEdited(Glib::ustring const& path, Glib::ustring const& address);
-    void onAddWhitelistClicked();
-    void onRemoveWhitelistClicked();
-    void refreshRPCSensitivity();
-
-private:
-    Glib::RefPtr<Session> core_;
-
-    Gtk::TreeView* view_;
-    Gtk::Button* remove_button_;
-    Gtk::CheckButton* rpc_tb_;
-    Gtk::CheckButton* auth_tb_;
-    Gtk::CheckButton* whitelist_tb_;
-
-    Glib::RefPtr<Gtk::ListStore> store_;
-    std::vector<Gtk::Widget*> auth_widgets_;
-    std::vector<Gtk::Widget*> whitelist_widgets_;
-};
 
 void RemotePage::refreshWhitelist()
 {
@@ -703,15 +765,13 @@ void RemotePage::refreshRPCSensitivity()
     remove_button_->set_sensitive(rpc_active && whitelist_active && have_addr && n_rules > 1);
 }
 
-void onLaunchClutchCB()
+void RemotePage::onLaunchClutchCB()
 {
     gtr_open_uri(fmt::format("http://localhost:{}/", gtr_pref_int_get(TR_KEY_rpc_port)));
 }
 
-} // namespace
-
 RemotePage::RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
+    : PageBase(cast_item, core)
     , core_(core)
     , view_(gtr_get_widget<Gtk::TreeView>(builder, "rpc_whitelist_view"))
     , remove_button_(gtr_get_widget<Gtk::Button>(builder, "remove_from_rpc_whistlist_button"))
@@ -720,33 +780,33 @@ RemotePage::RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> con
     , whitelist_tb_(gtr_get_widget<Gtk::CheckButton>(builder, "rpc_whitelist_check"))
 {
     /* "enabled" checkbutton */
-    init_check_button(*rpc_tb_, TR_KEY_rpc_enabled, core_);
+    init_check_button(*rpc_tb_, TR_KEY_rpc_enabled);
     rpc_tb_->signal_toggled().connect([this]() { refreshRPCSensitivity(); });
     auto* const open_button = gtr_get_widget<Gtk::Button>(builder, "open_web_client_button");
-    open_button->signal_clicked().connect(&onLaunchClutchCB);
+    open_button->signal_clicked().connect(&RemotePage::onLaunchClutchCB);
 
     /* port */
     auto* port_spin = gtr_get_widget<Gtk::SpinButton>(builder, "rpc_port_spin");
-    init_spin_button(*port_spin, TR_KEY_rpc_port, core_, 0, std::numeric_limits<uint16_t>::max(), 1);
+    init_spin_button(*port_spin, TR_KEY_rpc_port, 0, std::numeric_limits<uint16_t>::max(), 1);
 
     /* require authentication */
-    init_check_button(*auth_tb_, TR_KEY_rpc_authentication_required, core_);
+    init_check_button(*auth_tb_, TR_KEY_rpc_authentication_required);
     auth_tb_->signal_toggled().connect([this]() { refreshRPCSensitivity(); });
 
     /* username */
     auto* username_entry = gtr_get_widget<Gtk::Entry>(builder, "rpc_username_entry");
-    init_entry(*username_entry, TR_KEY_rpc_username, core_);
+    init_entry(*username_entry, TR_KEY_rpc_username);
     auth_widgets_.push_back(username_entry);
     auth_widgets_.push_back(gtr_get_widget<Gtk::Label>(builder, "rpc_username_label"));
 
     /* password */
     auto* password_entry = gtr_get_widget<Gtk::Entry>(builder, "rpc_password_entry");
-    init_entry(*password_entry, TR_KEY_rpc_password, core_);
+    init_entry(*password_entry, TR_KEY_rpc_password);
     auth_widgets_.push_back(password_entry);
     auth_widgets_.push_back(gtr_get_widget<Gtk::Label>(builder, "rpc_password_label"));
 
     /* require authentication */
-    init_check_button(*whitelist_tb_, TR_KEY_rpc_whitelist_enabled, core_);
+    init_check_button(*whitelist_tb_, TR_KEY_rpc_whitelist_enabled);
     whitelist_tb_->signal_toggled().connect([this]() { refreshRPCSensitivity(); });
 
     /* access control list */
@@ -788,117 +848,33 @@ RemotePage::RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> con
 *****  Bandwidth Tab
 ****/
 
-namespace
-{
-
-class SpeedPage : public Gtk::Box
+class SpeedPage : public PageBase
 {
 public:
     SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
 
     TR_DISABLE_COPY_MOVE(SpeedPage)
-
-private:
-    static void init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
-    static void init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark key);
-
-    static auto get_weekday_string(Glib::Date::Weekday weekday);
-
-private:
-    Glib::RefPtr<Session> core_;
 };
 
-void SpeedPage::init_time_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key)
-{
-    class TimeModelColumns : public Gtk::TreeModelColumnRecord
-    {
-    public:
-        TimeModelColumns()
-        {
-            add(offset);
-            add(title);
-        }
-
-        Gtk::TreeModelColumn<int> offset;
-        Gtk::TreeModelColumn<Glib::ustring> title;
-    };
-
-    static TimeModelColumns const time_cols;
-
-    /* build a store at 15 minute intervals */
-    auto store = Gtk::ListStore::create(time_cols);
-
-    for (int i = 0; i < 60 * 24; i += 15)
-    {
-        auto const iter = store->append();
-        (*iter)[time_cols.offset] = i;
-        (*iter)[time_cols.title] = fmt::format("{:02}:{:02}", i / 60, i % 60);
-    }
-
-    /* build the widget */
-    combo.set_model(store);
-    auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-    combo.pack_start(*r, true);
-    combo.add_attribute(r->property_text(), time_cols.title);
-    combo.set_active(gtr_pref_int_get(key) / 15);
-    combo.signal_changed().connect(
-        [&combo, key, core]()
-        {
-            if (auto const iter = combo.get_active(); iter)
-            {
-                core->set_pref(key, iter->get_value(time_cols.offset));
-            }
-        });
-}
-
-auto SpeedPage::get_weekday_string(Glib::Date::Weekday weekday)
-{
-    auto date = Glib::Date{};
-    date.set_time_current();
-    date.add_days(static_cast<int>(weekday) - static_cast<int>(date.get_weekday()));
-    return date.format_string("%A");
-}
-
-void SpeedPage::init_week_combo(Gtk::ComboBox& combo, Glib::RefPtr<Session> const& core, tr_quark const key)
-{
-    gtr_combo_box_set_enum(
-        combo,
-        {
-            { _("Every Day"), TR_SCHED_ALL },
-            { _("Weekdays"), TR_SCHED_WEEKDAY },
-            { _("Weekends"), TR_SCHED_WEEKEND },
-            { get_weekday_string(Glib::Date::Weekday::MONDAY), TR_SCHED_MON },
-            { get_weekday_string(Glib::Date::Weekday::TUESDAY), TR_SCHED_TUES },
-            { get_weekday_string(Glib::Date::Weekday::WEDNESDAY), TR_SCHED_WED },
-            { get_weekday_string(Glib::Date::Weekday::THURSDAY), TR_SCHED_THURS },
-            { get_weekday_string(Glib::Date::Weekday::FRIDAY), TR_SCHED_FRI },
-            { get_weekday_string(Glib::Date::Weekday::SATURDAY), TR_SCHED_SAT },
-            { get_weekday_string(Glib::Date::Weekday::SUNDAY), TR_SCHED_SUN },
-        });
-    gtr_combo_box_set_active_enum(combo, gtr_pref_int_get(key));
-    combo.signal_changed().connect([&combo, key, core]() { onIntComboChanged(&combo, key, core); });
-}
-
 SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
-    , core_(core)
+    : PageBase(cast_item, core)
 {
     {
         auto* const w = gtr_get_widget<Gtk::CheckButton>(builder, "upload_limit_check");
-        init_check_button(*w, TR_KEY_speed_limit_up_enabled, core_);
+        init_check_button(*w, TR_KEY_speed_limit_up_enabled);
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "upload_limit_spin");
-        init_spin_button(*w2, TR_KEY_speed_limit_up, core_, 0, std::numeric_limits<int>::max(), 5);
+        init_spin_button(*w2, TR_KEY_speed_limit_up, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
         auto* const w = gtr_get_widget<Gtk::CheckButton>(builder, "download_limit_check");
-        init_check_button(*w, TR_KEY_speed_limit_down_enabled, core_);
+        init_check_button(*w, TR_KEY_speed_limit_down_enabled);
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "download_limit_spin");
-        init_spin_button(*w2, TR_KEY_speed_limit_down, core_, 0, std::numeric_limits<int>::max(), 5);
+        init_spin_button(*w2, TR_KEY_speed_limit_down, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -906,7 +882,7 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "alt_upload_limit_spin");
-        init_spin_button(*w2, TR_KEY_alt_speed_up, core_, 0, std::numeric_limits<int>::max(), 5);
+        init_spin_button(*w2, TR_KEY_alt_speed_up, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
@@ -914,34 +890,29 @@ SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const
         w->set_label(fmt::format(w->get_label().raw(), fmt::arg("speed_units", speed_K_str)));
 
         auto* const w2 = gtr_get_widget<Gtk::SpinButton>(builder, "alt_download_limit_spin");
-        init_spin_button(*w2, TR_KEY_alt_speed_down, core_, 0, std::numeric_limits<int>::max(), 5);
+        init_spin_button(*w2, TR_KEY_alt_speed_down, 0, std::numeric_limits<int>::max(), 5);
     }
 
     {
         auto* start_combo = gtr_get_widget<Gtk::ComboBox>(builder, "alt_speed_start_time_combo");
-        init_time_combo(*start_combo, core_, TR_KEY_alt_speed_time_begin);
+        init_time_combo(*start_combo, TR_KEY_alt_speed_time_begin);
 
         auto* end_combo = gtr_get_widget<Gtk::ComboBox>(builder, "alt_speed_end_time_combo");
-        init_time_combo(*end_combo, core_, TR_KEY_alt_speed_time_end);
+        init_time_combo(*end_combo, TR_KEY_alt_speed_time_end);
 
         auto* w = gtr_get_widget<Gtk::CheckButton>(builder, "alt_schedule_time_check");
-        init_check_button(*w, TR_KEY_alt_speed_time_enabled, core_);
+        init_check_button(*w, TR_KEY_alt_speed_time_enabled);
     }
 
     auto* week_combo = gtr_get_widget<Gtk::ComboBox>(builder, "alt_speed_days_combo");
-    init_week_combo(*week_combo, core_, TR_KEY_alt_speed_time_day);
+    init_week_combo(*week_combo, TR_KEY_alt_speed_time_day);
 }
-
-} // namespace
 
 /****
 *****  Network Tab
 ****/
 
-namespace
-{
-
-class NetworkPage : public Gtk::Box
+class NetworkPage : public PageBase
 {
 public:
     NetworkPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
@@ -1016,13 +987,13 @@ NetworkPage::NetworkPage(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     Glib::RefPtr<Session> const& core)
-    : Gtk::Box(cast_item)
+    : PageBase(cast_item, core)
     , core_(core)
     , portLabel_(gtr_get_widget<Gtk::Label>(builder, "listening_port_status_label"))
     , portButton_(gtr_get_widget<Gtk::Button>(builder, "test_listening_port_button"))
     , portSpin_(gtr_get_widget<Gtk::SpinButton>(builder, "listening_port_spin"))
 {
-    init_spin_button(*portSpin_, TR_KEY_peer_port, core_, 1, std::numeric_limits<uint16_t>::max(), 1);
+    init_spin_button(*portSpin_, TR_KEY_peer_port, 1, std::numeric_limits<uint16_t>::max(), 1);
 
     portButton_->signal_clicked().connect([this]() { onPortTest(); });
 
@@ -1030,41 +1001,37 @@ NetworkPage::NetworkPage(
 
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "pick_random_listening_port_at_start_check"),
-        TR_KEY_peer_port_random_on_start,
-        core_);
+        TR_KEY_peer_port_random_on_start);
     init_check_button(
         *gtr_get_widget<Gtk::CheckButton>(builder, "enable_listening_port_forwarding_check"),
-        TR_KEY_port_forwarding_enabled,
-        core_);
+        TR_KEY_port_forwarding_enabled);
 
     init_spin_button(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_torrent_peers_spin"),
         TR_KEY_peer_limit_per_torrent,
-        core_,
         1,
         FD_SETSIZE,
         5);
     init_spin_button(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_total_peers_spin"),
         TR_KEY_peer_limit_global,
-        core_,
         1,
         FD_SETSIZE,
         5);
 
 #ifdef WITH_UTP
-    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_utp_check"), TR_KEY_utp_enabled, core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_utp_check"), TR_KEY_utp_enabled);
 #else
     gtr_get_widget<Gtk::CheckButton>(builder, "enable_utp_check")->hide();
 #endif
 
-    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_pex_check"), TR_KEY_pex_enabled, core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_pex_check"), TR_KEY_pex_enabled);
 
-    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_dht_check"), TR_KEY_dht_enabled, core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_dht_check"), TR_KEY_dht_enabled);
 
-    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_lpd_check"), TR_KEY_lpd_enabled, core_);
+    init_check_button(*gtr_get_widget<Gtk::CheckButton>(builder, "enable_lpd_check"), TR_KEY_lpd_enabled);
 
-    init_text_view(*gtr_get_widget<Gtk::TextView>(builder, "default_trackers_view"), TR_KEY_default_trackers, core_);
+    init_text_view(*gtr_get_widget<Gtk::TextView>(builder, "default_trackers_view"), TR_KEY_default_trackers);
 }
 
 } // namespace

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -586,7 +586,7 @@ void PrivacyPage::onBlocklistUpdated(int n)
 void PrivacyPage::onBlocklistUpdate()
 {
     updateBlocklistDialog_ = std::make_unique<Gtk::MessageDialog>(
-        *static_cast<Gtk::Window*>(TR_GTK_WIDGET_GET_ROOT(*this)),
+        gtr_widget_get_window(*this),
         _("Update Blocklist"),
         false,
         TR_GTK_MESSAGE_TYPE(INFO),

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -34,6 +34,7 @@ class PrefsDialog::Impl
 {
 public:
     Impl(PrefsDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~Impl() = default;
 
     TR_DISABLE_COPY_MOVE(Impl)
 
@@ -70,6 +71,8 @@ class PageBase : public Gtk::Box
 public:
     PageBase(BaseObjectType* cast_item, Glib::RefPtr<Session> const& core);
     ~PageBase() override;
+
+    TR_DISABLE_COPY_MOVE(PageBase)
 
     void init_check_button(Gtk::CheckButton& button, tr_quark key);
 
@@ -428,6 +431,7 @@ class SeedingPage : public PageBase
 {
 public:
     SeedingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~SeedingPage() override = default;
 
     TR_DISABLE_COPY_MOVE(SeedingPage)
 };
@@ -468,6 +472,7 @@ class DesktopPage : public PageBase
 {
 public:
     DesktopPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~DesktopPage() override = default;
 
     TR_DISABLE_COPY_MOVE(DesktopPage)
 };
@@ -648,6 +653,7 @@ class RemotePage : public PageBase
 
 public:
     RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~RemotePage() override = default;
 
     TR_DISABLE_COPY_MOVE(RemotePage)
 
@@ -857,6 +863,7 @@ class SpeedPage : public PageBase
 {
 public:
     SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    ~SpeedPage() override = default;
 
     TR_DISABLE_COPY_MOVE(SpeedPage)
 };

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -593,13 +593,12 @@ void rename_torrent(Glib::RefPtr<Gio::File> const& file)
     }
     catch (Glib::Error const& e)
     {
-        auto const errmsg = fmt::format(
+        gtr_message(fmt::format(
             _("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})"),
             fmt::arg("old_path", old_name),
             fmt::arg("path", new_name),
             fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code()));
-        g_message("%s", errmsg.c_str());
+            fmt::arg("error_code", e.code())));
     }
 }
 
@@ -1094,8 +1093,7 @@ void Session::Impl::add_file_async_callback(
 
         if (!file->load_contents_finish(result, contents, length))
         {
-            auto const errmsg = fmt::format(_("Couldn't read '{path}'"), fmt::arg("path", file->get_parse_name()));
-            g_message("%s", errmsg.c_str());
+            gtr_message(fmt::format(_("Couldn't read '{path}'"), fmt::arg("path", file->get_parse_name())));
         }
         else if (tr_ctorSetMetainfo(ctor, contents, length, nullptr))
         {
@@ -1108,12 +1106,11 @@ void Session::Impl::add_file_async_callback(
     }
     catch (Glib::Error const& e)
     {
-        auto const errmsg = fmt::format(
+        gtr_message(fmt::format(
             _("Couldn't read '{path}': {error} ({error_code})"),
             fmt::arg("path", file->get_parse_name()),
             fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code()));
-        g_message("%s", errmsg.c_str());
+            fmt::arg("error_code", e.code())));
     }
 
     dec_busy();
@@ -1576,7 +1573,7 @@ bool core_read_rpc_response_idle(TrVariantPtr const& response)
         }
         else
         {
-            g_warning("%s", fmt::format(_("Couldn't find pending RPC request for tag {tag}"), fmt::arg("tag", tag)).c_str());
+            gtr_warning(fmt::format(_("Couldn't find pending RPC request for tag {tag}"), fmt::arg("tag", tag)));
         }
     }
 
@@ -1598,7 +1595,7 @@ void Session::Impl::send_rpc_request(
 {
     if (session_ == nullptr)
     {
-        g_error("GTK+ client doesn't support connections to remote servers yet.");
+        gtr_error("GTK+ client doesn't support connections to remote servers yet.");
     }
     else
     {
@@ -1607,7 +1604,7 @@ void Session::Impl::send_rpc_request(
 
         /* make the request */
 #ifdef DEBUG_RPC
-        g_message("%s", fmt::format("request: [{}]", tr_variantToStr(request, TR_VARIANT_FMT_JSON_LEAN)).c_str());
+        gtr_message(fmt::format("request: [{}]", tr_variantToStr(request, TR_VARIANT_FMT_JSON_LEAN)));
 #endif
 
         tr_rpc_request_exec_json(session_, request, core_read_rpc_response, nullptr);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -51,7 +51,7 @@ TrVariantPtr create_variant(tr_variant&& other)
         [](tr_variant* ptr)
         {
             tr_variantClear(ptr);
-            delete ptr;
+            std::default_delete<tr_variant>()(ptr);
         });
     *result = std::move(other);
     tr_variantInitBool(&other, false);
@@ -821,6 +821,7 @@ void Session::Impl::on_pref_changed(tr_quark const key)
 
 Glib::RefPtr<Session> Session::create(tr_session* session)
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     return Glib::make_refptr_for_instance(new Session(session));
 }
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -29,16 +29,12 @@
 #include "SystemTrayIcon.h"
 #include "Utils.h"
 
-#define TR_SYS_TRAY_IMPL_NONE 0
-#define TR_SYS_TRAY_IMPL_APPINDICATOR 1
-#define TR_SYS_TRAY_IMPL_STATUS_ICON 2
-
 #ifdef HAVE_APPINDICATOR
-#define TR_SYS_TRAY_IMPL TR_SYS_TRAY_IMPL_APPINDICATOR
+#define TR_SYS_TRAY_IMPL_APPINDICATOR
 #elif !GTKMM_CHECK_VERSION(4, 0, 0)
-#define TR_SYS_TRAY_IMPL TR_SYS_TRAY_IMPL_STATUS_ICON
+#define TR_SYS_TRAY_IMPL_STATUS_ICON
 #else
-#define TR_SYS_TRAY_IMPL TR_SYS_TRAY_IMPL_NONE
+#define TR_SYS_TRAY_IMPL_NONE
 #endif
 
 using namespace std::literals;
@@ -46,12 +42,12 @@ using namespace std::literals;
 namespace
 {
 
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
 auto const TrayIconName = Glib::ustring("transmission-tray-icon"s);
 auto const AppIconName = Glib::ustring("transmission"s);
 #endif
 
-#if TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_APPINDICATOR
+#if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
 auto const AppName = Glib::ustring("transmission-gtk"s);
 #endif
 
@@ -76,18 +72,18 @@ private:
 private:
     Glib::RefPtr<Session> const core_;
 
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
     Gtk::Menu* menu_;
 #endif
 
-#if TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_APPINDICATOR
+#if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
     AppIndicator* indicator_;
-#elif TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_STATUS_ICON
+#elif defined(TR_SYS_TRAY_IMPL_STATUS_ICON)
     Glib::RefPtr<Gtk::StatusIcon> icon_;
 #endif
 };
 
-#if TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_APPINDICATOR
+#if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
 
 SystemTrayIcon::Impl::~Impl()
 {
@@ -98,7 +94,7 @@ void SystemTrayIcon::Impl::refresh()
 {
 }
 
-#elif TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_STATUS_ICON
+#elif defined(TR_SYS_TRAY_IMPL_STATUS_ICON)
 
 SystemTrayIcon::Impl::~Impl() = default;
 
@@ -126,7 +122,7 @@ SystemTrayIcon::Impl::~Impl() = default;
 namespace
 {
 
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
 
 Glib::ustring getIconName()
 {
@@ -162,14 +158,14 @@ SystemTrayIcon::~SystemTrayIcon() = default;
 
 void SystemTrayIcon::refresh()
 {
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
     impl_->refresh();
 #endif
 }
 
 bool SystemTrayIcon::is_available()
 {
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
     return true;
 #else
     return false;
@@ -184,18 +180,18 @@ std::unique_ptr<SystemTrayIcon> SystemTrayIcon::create(Gtk::Window& main_window,
 SystemTrayIcon::Impl::Impl([[maybe_unused]] Gtk::Window& main_window, Glib::RefPtr<Session> const& core)
     : core_(core)
 {
-#if TR_SYS_TRAY_IMPL != TR_SYS_TRAY_IMPL_NONE
+#if !defined(TR_SYS_TRAY_IMPL_NONE)
     auto const icon_name = getIconName();
     menu_ = Gtk::make_managed<Gtk::Menu>(gtr_action_get_object<Gio::Menu>("icon-popup"));
     menu_->attach_to_widget(main_window);
 #endif
 
-#if TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_APPINDICATOR
+#if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
     indicator_ = app_indicator_new(AppName.c_str(), icon_name.c_str(), APP_INDICATOR_CATEGORY_SYSTEM_SERVICES);
     app_indicator_set_status(indicator_, APP_INDICATOR_STATUS_ACTIVE);
     app_indicator_set_menu(indicator_, Glib::unwrap(menu_));
     app_indicator_set_title(indicator_, Glib::get_application_name().c_str());
-#elif TR_SYS_TRAY_IMPL == TR_SYS_TRAY_IMPL_STATUS_ICON
+#elif defined(TR_SYS_TRAY_IMPL_STATUS_ICON)
     icon_ = Gtk::StatusIcon::create(icon_name);
     icon_->signal_activate().connect(sigc::mem_fun(*this, &Impl::activated));
     icon_->signal_popup_menu().connect(sigc::mem_fun(*this, &Impl::popup));

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -973,13 +973,12 @@ TorrentCellRenderer::Impl::Impl(TorrentCellRenderer& renderer)
     , download_speed_KBps(renderer, "piece-download-speed", 0)
     , compact(renderer, "compact", false)
     , renderer_(renderer)
+    , text_renderer_(Gtk::make_managed<Gtk::CellRendererText>())
+    , progress_renderer_(Gtk::make_managed<Gtk::CellRendererProgress>())
+    , icon_renderer_(Gtk::make_managed<Gtk::CellRendererPixbuf>())
 {
-    text_renderer_ = Gtk::make_managed<Gtk::CellRendererText>();
     text_renderer_->property_xpad() = 0;
     text_renderer_->property_ypad() = 0;
-
-    progress_renderer_ = Gtk::make_managed<Gtk::CellRendererProgress>();
-    icon_renderer_ = Gtk::make_managed<Gtk::CellRendererPixbuf>();
 }
 
 Glib::PropertyProxy<gpointer> TorrentCellRenderer::property_torrent()

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -29,9 +29,6 @@
 ****
 ***/
 
-#define REQ_HEIGHT(Obj) IF_GTKMM4((Obj).get_height(), (Obj).height)
-#define REQ_WIDTH(Obj) IF_GTKMM4((Obj).get_width(), (Obj).width)
-
 namespace
 {
 
@@ -40,6 +37,16 @@ auto const CompactBarWidth = 50;
 auto const SmallScale = 0.9;
 auto const CompactIconSize = IF_GTKMM4(Gtk::IconSize::NORMAL, Gtk::ICON_SIZE_MENU);
 auto const FullIconSize = IF_GTKMM4(Gtk::IconSize::LARGE, Gtk::ICON_SIZE_DND);
+
+auto get_height(Gtk::Requisition const& req)
+{
+    return req.IF_GTKMM4(get_height(), height);
+}
+
+auto get_width(Gtk::Requisition const& req)
+{
+    return req.IF_GTKMM4(get_width(), width);
+}
 
 auto getProgressString(tr_torrent const* tor, uint64_t total_size, tr_stat const* st)
 {
@@ -451,8 +458,8 @@ void TorrentCellRenderer::Impl::get_size_compact(Gtk::Widget& widget, int& width
     *** LAYOUT
     **/
 
-    width = xpad * 2 + REQ_WIDTH(icon_size) + GUI_PAD + CompactBarWidth + GUI_PAD + REQ_WIDTH(stat_size);
-    height = ypad * 2 + std::max(REQ_HEIGHT(name_size), bar_height.get_value());
+    width = xpad * 2 + get_width(icon_size) + GUI_PAD + CompactBarWidth + GUI_PAD + get_width(stat_size);
+    height = ypad * 2 + std::max(get_height(name_size), bar_height.get_value());
 }
 
 void TorrentCellRenderer::Impl::get_size_full(Gtk::Widget& widget, int& width, int& height) const
@@ -494,9 +501,9 @@ void TorrentCellRenderer::Impl::get_size_full(Gtk::Widget& widget, int& width, i
     *** LAYOUT
     **/
 
-    width = xpad * 2 + REQ_WIDTH(icon_size) + GUI_PAD + std::max(REQ_WIDTH(prog_size), REQ_WIDTH(stat_size));
-    height = ypad * 2 + REQ_HEIGHT(name_size) + REQ_HEIGHT(prog_size) + GUI_PAD_SMALL + bar_height.get_value() + GUI_PAD_SMALL +
-        REQ_HEIGHT(stat_size);
+    width = xpad * 2 + get_width(icon_size) + GUI_PAD + std::max(get_width(prog_size), get_width(stat_size));
+    height = ypad * 2 + get_height(name_size) + get_height(prog_size) + GUI_PAD_SMALL + bar_height.get_value() + GUI_PAD_SMALL +
+        get_height(stat_size);
 }
 
 void TorrentCellRenderer::get_preferred_width_vfunc(Gtk::Widget& widget, int& minimum_width, int& natural_width) const
@@ -810,8 +817,8 @@ void TorrentCellRenderer::Impl::render_full(
     Gdk::Rectangle icon_area;
     set_icon(*icon_renderer_, icon, FullIconSize);
     icon_renderer_->get_preferred_size(widget, min_size, size);
-    icon_area.set_width(REQ_WIDTH(size));
-    icon_area.set_height(REQ_HEIGHT(size));
+    icon_area.set_width(get_width(size));
+    icon_area.set_height(get_height(size));
 
     Gdk::Rectangle name_area;
     text_renderer_->property_text() = name;
@@ -819,19 +826,19 @@ void TorrentCellRenderer::Impl::render_full(
     text_renderer_->property_ellipsize() = TR_PANGO_ELLIPSIZE_MODE(NONE);
     text_renderer_->property_scale() = 1.0;
     text_renderer_->get_preferred_size(widget, min_size, size);
-    name_area.set_height(REQ_HEIGHT(size));
+    name_area.set_height(get_height(size));
 
     Gdk::Rectangle prog_area;
     text_renderer_->property_text() = gstr_prog;
     text_renderer_->property_weight() = TR_PANGO_WEIGHT(NORMAL);
     text_renderer_->property_scale() = SmallScale;
     text_renderer_->get_preferred_size(widget, min_size, size);
-    prog_area.set_height(REQ_HEIGHT(size));
+    prog_area.set_height(get_height(size));
 
     Gdk::Rectangle stat_area;
     text_renderer_->property_text() = gstr_stat;
     text_renderer_->get_preferred_size(widget, min_size, size);
-    stat_area.set_height(REQ_HEIGHT(size));
+    stat_area.set_height(get_height(size));
 
     Gdk::Rectangle prct_area;
 

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -27,8 +27,16 @@ public:
     TR_DISABLE_COPY_MOVE(TorrentCellRenderer)
 
     Glib::PropertyProxy<gpointer> property_torrent();
+
+    /* Use this instead of tr_stat.pieceUploadSpeed so that the model can
+       control when the speed displays get updated. This is done to keep
+       the individual torrents' speeds and the status bar's overall speed
+       in sync even if they refresh at slightly different times */
     Glib::PropertyProxy<double> property_piece_upload_speed();
+
+    /* @see property_piece_upload_speed */
     Glib::PropertyProxy<double> property_piece_download_speed();
+
     Glib::PropertyProxy<int> property_bar_height();
     Glib::PropertyProxy<bool> property_compact();
 

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -60,6 +60,28 @@ char const* const speed_T_str = N_("TB/s");
 ****
 ***/
 
+void gtr_message(std::string const& message)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    g_message("%s", message.c_str());
+}
+
+void gtr_warning(std::string const& message)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    g_warning("%s", message.c_str());
+}
+
+void gtr_error(std::string const& message)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    g_error("%s", message.c_str());
+}
+
+/***
+****
+***/
+
 Glib::ustring gtr_get_unicode_string(GtrUnicode uni)
 {
     switch (uni)
@@ -390,14 +412,11 @@ bool gtr_file_trash_or_remove(std::string const& filename, tr_error** error)
         }
         catch (Glib::Error const& e)
         {
-            g_message(
-                "%s",
-                fmt::format(
-                    _("Couldn't move '{path}' to trash: {error} ({error_code})"),
-                    fmt::arg("path", filename),
-                    fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-                    fmt::arg("error_code", e.code()))
-                    .c_str());
+            gtr_message(fmt::format(
+                _("Couldn't move '{path}' to trash: {error} ({error_code})"),
+                fmt::arg("path", filename),
+                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
+                fmt::arg("error_code", e.code())));
             tr_error_set(error, e.code(), TR_GLIB_EXCEPTION_WHAT(e));
         }
     }
@@ -410,14 +429,11 @@ bool gtr_file_trash_or_remove(std::string const& filename, tr_error** error)
         }
         catch (Glib::Error const& e)
         {
-            g_message(
-                "%s",
-                fmt::format(
-                    _("Couldn't remove '{path}': {error} ({error_code})"),
-                    fmt::arg("path", filename),
-                    fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-                    fmt::arg("error_code", e.code()))
-                    .c_str());
+            gtr_message(fmt::format(
+                _("Couldn't remove '{path}': {error} ({error_code})"),
+                fmt::arg("path", filename),
+                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
+                fmt::arg("error_code", e.code())));
             tr_error_clear(error);
             tr_error_set(error, e.code(), TR_GLIB_EXCEPTION_WHAT(e));
             result = false;
@@ -469,7 +485,7 @@ void gtr_open_uri(Glib::ustring const& uri)
 
         if (!opened)
         {
-            g_message("%s", fmt::format(_("Couldn't open '{url}'"), fmt::arg("url", uri)).c_str());
+            gtr_message(fmt::format(_("Couldn't open '{url}'"), fmt::arg("url", uri)));
         }
     }
 }

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -130,6 +130,18 @@ extern char const* const speed_M_str;
 extern char const* const speed_G_str;
 extern char const* const speed_T_str;
 
+/***
+****
+***/
+
+void gtr_message(std::string const& message);
+void gtr_warning(std::string const& message);
+void gtr_error(std::string const& message);
+
+/***
+****
+***/
+
 enum class GtrUnicode
 {
     Up,

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -179,6 +179,8 @@ Glib::ustring gtr_get_help_uri();
 /* backwards-compatible wrapper around gtk_widget_set_visible() */
 void gtr_widget_set_visible(Gtk::Widget&, bool);
 
+Gtk::Window& gtr_widget_get_window(Gtk::Widget& widget);
+
 void gtr_window_set_skip_taskbar_hint(Gtk::Window& window, bool value);
 void gtr_window_set_urgency_hint(Gtk::Window& window, bool value);
 void gtr_window_raise(Gtk::Window& window);

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
     Gio::File::create_for_path(".");
     Glib::wrap_register(
         g_type_from_name("GLocalFile"),
-        [](GObject* object) -> Glib::ObjectBase* { return new Gio::File((GFile*)object); });
+        [](GObject* object) -> Glib::ObjectBase* { return new Gio::File(reinterpret_cast<GFile*>(object)); });
     g_type_ensure(Gio::File::get_type());
 
     /* default settings */

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
         fmt::print(
             stderr,
             _("Run '{program} --help' to see a full list of available command line options.\n"),
-            fmt::arg("program", argv[0]));
+            fmt::arg("program", *argv));
         return 1;
     }
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
     Gio::File::create_for_path(".");
     Glib::wrap_register(
         g_type_from_name("GLocalFile"),
-        [](GObject* object) -> Glib::ObjectBase* { return new Gio::File(reinterpret_cast<GFile*>(object)); });
+        [](GObject* object) -> Glib::ObjectBase* { return new Gio::File(G_FILE(object)); });
     g_type_ensure(Gio::File::get_type());
 
     /* default settings */


### PR DESCRIPTION
Enable all `cppcoreguidelines` checks except for three (`avoid-magic-numbers`, `avoid-non-const-global-variables`, `narrowing-conversions`) which require [more] extensive refactoring and were left for later.