### PR TITLE
refactor: use condition_variable in tr_torrent_verifier.remove()

### DIFF
--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -9,6 +9,8 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <list>
@@ -59,7 +61,7 @@ private:
     }
 
     void verifyThreadFunc();
-    [[nodiscard]] static bool verifyTorrent(tr_torrent* tor, bool const* stop_flag);
+    [[nodiscard]] static bool verifyTorrent(tr_torrent* tor, std::atomic<bool>& stop_flag);
 
     std::list<callback_func> callbacks_;
     std::mutex verify_mutex_;
@@ -68,5 +70,7 @@ private:
     std::optional<Node> current_node_;
 
     std::optional<std::thread::id> verify_thread_id_;
-    bool stop_current_ = false;
+
+    std::atomic<bool> stop_current_ = false;
+    std::condition_variable stop_current_cv_;
 };


### PR DESCRIPTION
Previously was doing it manually with a looped `tr_wait_msec()` 