### PR TITLE
Fix incorrect selection behavior when building against GTK 4

### DIFF
--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -118,7 +118,7 @@ private:
 ****
 ***/
 
-void MainWindow::Impl::on_popup_menu([[maybe_unused]] double view_x, [[maybe_unused]] double view_y)
+void MainWindow::Impl::on_popup_menu([[maybe_unused]] double event_x, [[maybe_unused]] double event_y)
 {
     if (popup_menu_ == nullptr)
     {
@@ -136,6 +136,9 @@ void MainWindow::Impl::on_popup_menu([[maybe_unused]] double view_x, [[maybe_unu
     }
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
+    int view_x = 0;
+    int view_y = 0;
+    view_->convert_bin_window_to_widget_coords(static_cast<int>(event_x), static_cast<int>(event_y), view_x, view_y);
     double window_x = 0;
     double window_y = 0;
     view_->translate_coordinates(window_, view_x, view_y, window_x, window_y);

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -211,13 +211,13 @@ void gtr_add_torrent_error_dialog(Gtk::Widget& window_or_child, tr_torrent* dupl
    if the row they right-click on isn't selected, select it. */
 bool on_tree_view_button_pressed(
     Gtk::TreeView& view,
-    double view_x,
-    double view_y,
+    double event_x,
+    double event_y,
     bool context_menu_requested,
     std::function<void(double, double)> const& callback = {});
 
 /* if the click didn't specify a row, clear the selection */
-bool on_tree_view_button_released(Gtk::TreeView& view, double view_x, double view_y);
+bool on_tree_view_button_released(Gtk::TreeView& view, double event_x, double event_y);
 
 using TrGdkModifierType = IF_GTKMM4(Gdk::ModifierType, guint);
 


### PR DESCRIPTION
View-relative coordinates were treated as bin window-relative, leading to incorrect selected item calculation.

Broken since the introduction of GTK 4 support in #3916.