### PR TITLE
Add sort by ETA for macOS

### DIFF
--- a/macosx/Base.lproj/MainMenu.xib
+++ b/macosx/Base.lproj/MainMenu.xib
@@ -454,6 +454,11 @@
                                                 <action selector="setSort:" target="206" id="1906"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="ETA" tag="8" id="zLF-YR-Oq6">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="fEQ-9j-ALl"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Size" tag="7" id="3430">
                                             <connections>
                                                 <action selector="setSort:" target="206" id="3431"/>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -87,6 +87,7 @@ static SortType const SortTypeTracker = @"Tracker";
 static SortType const SortTypeOrder = @"Order";
 static SortType const SortTypeActivity = @"Activity";
 static SortType const SortTypeSize = @"Size";
+static SortType const SortTypeETA = @"ETA";
 
 typedef NS_ENUM(unsigned int, sortTag) {
     SORT_ORDER_TAG = 0,
@@ -96,7 +97,8 @@ typedef NS_ENUM(unsigned int, sortTag) {
     SORT_STATE_TAG = 4,
     SORT_TRACKER_TAG = 5,
     SORT_ACTIVITY_TAG = 6,
-    SORT_SIZE_TAG = 7
+    SORT_SIZE_TAG = 7,
+    SORT_ETA_TAG = 8
 };
 
 typedef NS_ENUM(unsigned int, sortOrderTag) { //
@@ -2712,6 +2714,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     case SORT_SIZE_TAG:
         sortType = SortTypeSize;
         break;
+    case SORT_ETA_TAG:
+        sortType = SortTypeETA;
+        break;
     default:
         NSAssert1(NO, @"Unknown sort tag received: %ld", senderMenuItem.tag);
         return;
@@ -2771,6 +2776,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         NSSortDescriptor* ratioDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"ratio" ascending:asc];
 
         descriptors = @[ progressDescriptor, ratioProgressDescriptor, ratioDescriptor, nameDescriptor ];
+    }
+    else if ([sortType isEqualToString:SortTypeETA])
+    {
+        NSSortDescriptor* etaDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"eta" ascending:asc];
+        // falling back on sort by progress
+        NSSortDescriptor* progressDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"progress" ascending:asc];
+        NSSortDescriptor* ratioProgressDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"progressStopRatio" ascending:asc];
+        NSSortDescriptor* ratioDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"ratio" ascending:asc];
+
+        descriptors = @[ etaDescriptor, progressDescriptor, ratioProgressDescriptor, ratioDescriptor, nameDescriptor ];
     }
     else if ([sortType isEqualToString:SortTypeTracker])
     {
@@ -4714,6 +4729,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             break;
         case SORT_SIZE_TAG:
             sortType = SortTypeSize;
+            break;
+        case SORT_ETA_TAG:
+            sortType = SortTypeETA;
             break;
         default:
             NSAssert1(NO, @"Unknown sort tag received: %ld", [menuItem tag]);

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -121,6 +121,7 @@ extern NSString* const kTorrentDidChangeGroupNotification;
               withName:(NSString*)newName
      completionHandler:(void (^)(BOOL didRename))completionHandler;
 
+@property(nonatomic, readonly) time_t eta;
 @property(nonatomic, readonly) CGFloat progress;
 @property(nonatomic, readonly) CGFloat progressDone;
 @property(nonatomic, readonly) CGFloat progressLeft;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -814,6 +814,27 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     tr_torrentRenamePath(self.fHandle, oldPath.UTF8String, newName.UTF8String, renameCallback, (__bridge_retained void*)(contextInfo));
 }
 
+- (time_t)eta
+{
+    time_t eta = self.fStat->eta;
+    if (eta >= 0)
+    {
+        return eta;
+    }
+    time_t etaIdle = self.fStat->etaIdle;
+    if (etaIdle >= 0 && etaIdle < kETAIdleDisplaySec)
+    {
+        return etaIdle;
+    }
+    if (self.fStat->leftUntilDone <= 0)
+    {
+        // We return smallest amount of time remaining for simpliest compliance with sorting.
+        return 0;
+    }
+    // We return highest amount of time remaining for simpliest compliance with sorting.
+    return LONG_MAX;
+}
+
 - (CGFloat)progress
 {
     return self.fStat->percentComplete;
@@ -2069,13 +2090,13 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     time_t eta = self.fStat->eta;
     // if there's a regular ETA, the torrent isn't idle
     BOOL fromIdle = NO;
-    if (eta == TR_ETA_NOT_AVAIL || eta == TR_ETA_UNKNOWN)
+    if (eta < 0)
     {
         eta = self.fStat->etaIdle;
         fromIdle = YES;
     }
-    // Foundation undocumented behavior: values above INT_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451)
-    if (eta < 0 || eta > INT_MAX || (fromIdle && eta >= kETAIdleDisplaySec))
+    // Foundation undocumented behavior: values above INT32_MAX (68 years) are interpreted as negative values by `stringFromTimeInterval` (#3451)
+    if (eta < 0 || eta > INT32_MAX || (fromIdle && eta >= kETAIdleDisplaySec))
     {
         return NSLocalizedString(@"remaining time unknown", "Torrent -> eta string");
     }


### PR DESCRIPTION
(This supersedes #2302)
This fixes #2279.
This new feature for macOS adds one string for translation ("ETA" in the xib), so it's not appropriate for Transmission 4 and should be only merged for Transmission 5.

Presently, with the ETA sort, I sort seeding torrents by name (same logic as sorting by progress).
Alternatively, with the ETA sort, we could sort seeding torrents by completion date (but do we have this information?).