### PR TITLE
perf: tr_sys_path_basename() returns a std::string_view

### DIFF
--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -237,7 +237,7 @@ std::string tr_sys_path_resolve(std::string_view path, struct tr_error** error =
  * @return base name (last path component; parent path removed) on success,
  *         or empty string otherwise (with `error` set accordingly).
  */
-std::string tr_sys_path_basename(std::string_view path, struct tr_error** error = nullptr);
+std::string_view tr_sys_path_basename(std::string_view path, struct tr_error** error = nullptr);
 
 /**
  * @brief Portability wrapper for `dirname()`.

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -140,26 +140,30 @@ protected:
 
     struct XnameTestData
     {
-        char const* input;
-        char const* output;
+        std::string_view input;
+        std::string_view output;
     };
 
-    static void testPathXname(XnameTestData const* data, size_t data_size, std::string (*func)(std::string_view, tr_error**))
+    static void testPathXname(
+        XnameTestData const* data,
+        size_t data_size,
+        std::string_view (*func)(std::string_view, tr_error**))
     {
         for (size_t i = 0; i < data_size; ++i)
         {
             tr_error* err = nullptr;
-            auto const name = func(data[i].input, &err);
+            auto const& [input, output] = data[i];
+            auto const name = func(input, &err);
 
-            if (data[i].output != nullptr)
+            if (!std::empty(data[i].output))
             {
                 EXPECT_NE(""sv, name);
                 EXPECT_EQ(nullptr, err) << *err;
-                EXPECT_EQ(data[i].output, name);
+                EXPECT_EQ(output, name) << " in [" << input << ']';
             }
             else
             {
-                EXPECT_EQ(""sv, name);
+                EXPECT_EQ(""sv, name) << " in [" << input << ']';
                 EXPECT_NE(nullptr, err);
                 tr_error_clear(&err);
             }
@@ -720,30 +724,30 @@ TEST_F(FileTest, pathBasename)
 #ifdef _WIN32
         { "\\", "/" },
         /* Invalid paths */
-        { "\\\\\\", nullptr },
-        { "123:", nullptr },
+        { "\\\\\\", "" },
+        { "123:", "" },
         /* Reserved characters */
-        { "<", nullptr },
-        { ">", nullptr },
-        { ":", nullptr },
-        { "\"", nullptr },
-        { "|", nullptr },
-        { "?", nullptr },
-        { "*", nullptr },
-        { "a\\<", nullptr },
-        { "a\\>", nullptr },
-        { "a\\:", nullptr },
-        { "a\\\"", nullptr },
-        { "a\\|", nullptr },
-        { "a\\?", nullptr },
-        { "a\\*", nullptr },
-        { "c:\\a\\b<c\\d", nullptr },
-        { "c:\\a\\b>c\\d", nullptr },
-        { "c:\\a\\b:c\\d", nullptr },
-        { "c:\\a\\b\"c\\d", nullptr },
-        { "c:\\a\\b|c\\d", nullptr },
-        { "c:\\a\\b?c\\d", nullptr },
-        { "c:\\a\\b*c\\d", nullptr },
+        { "<", "" },
+        { ">", "" },
+        { ":", "" },
+        { "\"", "" },
+        { "|", "" },
+        { "?", "" },
+        { "*", "" },
+        { "a\\<", "" },
+        { "a\\>", "" },
+        { "a\\:", "" },
+        { "a\\\"", "" },
+        { "a\\|", "" },
+        { "a\\?", "" },
+        { "a\\*", "" },
+        { "c:\\a\\b<c\\d", "" },
+        { "c:\\a\\b>c\\d", "" },
+        { "c:\\a\\b:c\\d", "" },
+        { "c:\\a\\b\"c\\d", "" },
+        { "c:\\a\\b|c\\d", "" },
+        { "c:\\a\\b?c\\d", "" },
+        { "c:\\a\\b*c\\d", "" },
 #else
         { "////", "/" },
 #endif


### PR DESCRIPTION
I thought I did this when refactoring `tr_sys_path_dirname()`, but apparently not.