### PR TITLE
fix: ftbfs on Windows

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -438,7 +438,7 @@ private:
                     fmt::arg("address", host.sv()),
                     fmt::arg("port", port.host()),
                     fmt::arg("error", gai_strerror(rc)),
-                    fmt::arg("error_code", rc)));
+                    fmt::arg("error_code", static_cast<int>(rc))));
             return {};
         }
 

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -13,6 +13,12 @@
 #include <string_view>
 #include <vector>
 
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#undef gai_strerror
+#define gai_strerror gai_strerrorA
+#endif
+
 #include <fmt/core.h>
 #include <fmt/format.h>
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -903,8 +903,8 @@ static ReadState readPayloadStream(tr_handshake* handshake, tr_peerIo* peer_io)
     }
 
     /* parse the handshake ... */
-    handshake_parse_err_t const i = parseHandshake(handshake, peer_io);
-    tr_logAddTraceHand(handshake, fmt::format("parseHandshake returned {}", i));
+    auto const i = parseHandshake(handshake, peer_io);
+    tr_logAddTraceHand(handshake, fmt::format("parseHandshake returned {}", static_cast<int>(i)));
 
     if (i != HANDSHAKE_OK)
     {
@@ -989,7 +989,7 @@ static ReadState canRead(tr_peerIo* peer_io, void* vhandshake, size_t* piece)
 
         default:
 #ifdef TR_ENABLE_ASSERTS
-            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled handshake state {:d}"), handshake->state));
+            TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unhandled handshake state {:d}"), static_cast<int>(handshake->state)));
 #else
             ret = READ_ERR;
             break;

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -384,7 +384,7 @@ void tr_netClosePeerSocket(tr_session* session, tr_peer_socket socket)
 #endif
 
     default:
-        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unsupported peer socket type {:d}"), socket.type));
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unsupported peer socket type {:d}"), static_cast<int>(socket.type)));
     }
 }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -518,7 +518,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::create(
 #endif
 
     default:
-        TR_ASSERT_MSG(false, fmt::format("unsupported peer socket type {:d}", socket.type));
+        TR_ASSERT_MSG(false, fmt::format("unsupported peer socket type {:d}", static_cast<int>(socket.type)));
     }
 
     return io;
@@ -699,7 +699,7 @@ static void io_close_socket(tr_peerIo* io)
 #endif
 
     default:
-        tr_logAddDebugIo(io, fmt::format("unsupported peer socket type {}", io->socket.type));
+        tr_logAddDebugIo(io, fmt::format("unsupported peer socket type {}", static_cast<int>(io->socket.type)));
     }
 
     io->event_write.reset();
@@ -1010,7 +1010,9 @@ size_t tr_peerIo::flush(tr_direction dir, size_t limit, tr_error** error)
     TR_ASSERT(tr_isDirection(dir));
 
     auto const bytes_used = dir == TR_DOWN ? tr_peerIoTryRead(this, limit, error) : tr_peerIoTryWrite(this, limit, error);
-    tr_logAddTraceIo(this, fmt::format("flushing peer-io, direction:{}, limit:{}, byte_used:{}", dir, limit, bytes_used));
+    tr_logAddTraceIo(
+        this,
+        fmt::format("flushing peer-io, direction:{}, limit:{}, byte_used:{}", static_cast<int>(dir), limit, bytes_used));
     return bytes_used;
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2331,7 +2331,7 @@ void tr_torrentSetQueuePosition(tr_torrent* tor, size_t queue_position)
     size_t current = 0;
     auto const old_pos = tor->queuePosition;
 
-    tor->queuePosition = -1;
+    tor->queuePosition = static_cast<size_t>(-1);
 
     for (auto* const walk : tor->session->torrents())
     {

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -27,6 +27,8 @@ class AnnouncerUdpTest : public ::testing::Test
 private:
     void SetUp() override
     {
+        tr_net_init();
+
         ::testing::Test::SetUp();
         tr_timeUpdate(time(nullptr));
     }
@@ -230,8 +232,8 @@ protected:
         EXPECT_EQ(expected.up, actual.uploaded);
         // EXPECT_EQ(foo, actual.event); ; // 0: none; 1: completed; 2: started; 3: stopped // FIXME
         // EXPECT_EQ(foo, actual.ip_address); // FIXME
-        EXPECT_EQ(expected.key, actual.key);
-        EXPECT_EQ(expected.numwant, actual.num_want);
+        EXPECT_EQ(expected.key, static_cast<int>(actual.key));
+        EXPECT_EQ(expected.numwant, static_cast<int>(actual.num_want));
         EXPECT_EQ(expected.port.host(), actual.port);
     }
 
@@ -389,7 +391,7 @@ TEST_F(AnnouncerUdpTest, canDestructCleanlyEvenWhenBusy)
     // Inspect that request for validity.
     auto sent = waitForAnnouncerToSendMessage(mediator);
     auto const connect_transaction_id = parseConnectionRequest(sent);
-    EXPECT_NE(0, connect_transaction_id);
+    EXPECT_NE(0U, connect_transaction_id);
 
     // now just end the test before responding to the request.
     // the announcer and mediator will go out-of-scope & be destroyed.

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -235,8 +235,8 @@ protected:
         std::vector<Pinged> pinged_;
         std::vector<Searched> searched_;
         std::array<char, IdLength> id_ = {};
-        int dht_socket_ = TR_BAD_SOCKET;
-        int dht_socket6_ = TR_BAD_SOCKET;
+        tr_socket_t dht_socket_ = TR_BAD_SOCKET;
+        tr_socket_t dht_socket6_ = TR_BAD_SOCKET;
     };
 
     // Creates real timers, but with shortened intervals so that tests can run faster

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -61,7 +61,7 @@ TEST_F(NetTest, compact4)
     auto compact4 = std::array<std::byte, 6>{};
     auto out = std::data(compact4);
     out = addr.toCompact4(out, port);
-    EXPECT_EQ(std::size(Compact4), out - std::data(compact4));
+    EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(compact4)));
     EXPECT_EQ(Compact4, compact4);
 
     /// sockaddr --> compact
@@ -115,7 +115,7 @@ TEST_F(NetTest, compact6)
     auto compact6 = std::array<std::byte, 18>{};
     auto out = std::data(compact6);
     out = addr.toCompact6(out, port);
-    EXPECT_EQ(std::size(Compact6), out - std::data(compact6));
+    EXPECT_EQ(std::size(Compact6), static_cast<size_t>(out - std::data(compact6)));
     EXPECT_EQ(Compact6, compact6);
 
     /// sockaddr --> compact

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -327,7 +327,7 @@ TEST_F(SettingsTest, canSaveSizeT)
     settings.save(&dict);
     auto val = int64_t{};
     EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
-    EXPECT_EQ(expected_value, val);
+    EXPECT_EQ(expected_value, static_cast<size_t>(val));
     tr_variantClear(&dict);
 }
 


### PR DESCRIPTION
Fix a Windows build failure that snuck through in a45cc2a79d6551cee2f689e9f3a3d174687d36cb