### PR TITLE
refactor: incremental announcer refactor pt. 2

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <cstdint> // uint64_t
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -25,17 +26,9 @@
 
 struct tr_url_parsed_t;
 
-void tr_tracker_http_scrape(
-    tr_session const* session,
-    tr_scrape_request const* req,
-    tr_scrape_response_func response_func,
-    void* user_data);
+void tr_tracker_http_scrape(tr_session const* session, tr_scrape_request const& req, tr_scrape_response_func on_response);
 
-void tr_tracker_http_announce(
-    tr_session const* session,
-    tr_announce_request const* req,
-    tr_announce_response_func response_func,
-    void* user_data);
+void tr_tracker_http_announce(tr_session const* session, tr_announce_request const& req, tr_announce_response_func on_response);
 
 void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view benc, std::string_view log_name);
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -159,6 +159,7 @@ public:
     tr_announcer_impl& operator=(tr_announcer_impl&&) = delete;
     tr_announcer_impl& operator=(tr_announcer_impl const&) = delete;
 
+    tr_torrent_announcer* addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data) override;
     void resetTorrent(tr_torrent* tor) override;
     void removeTorrent(tr_torrent* tor) override;
 
@@ -664,11 +665,11 @@ static void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vecto
 ****
 ***/
 
-tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data)
+tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    auto* ta = new tr_torrent_announcer(dynamic_cast<tr_announcer_impl*>(tor->session->announcer_.get()), tor);
+    auto* ta = new tr_torrent_announcer{ this, tor };
     ta->callback = callback;
     ta->callback_data = callback_data;
     return ta;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -70,7 +70,7 @@ namespace
 
 struct StopsCompare
 {
-    [[nodiscard]] static int compare(tr_announce_request const& one, tr_announce_request const& two) noexcept // <=>
+    [[nodiscard]] static constexpr auto compare(tr_announce_request const& one, tr_announce_request const& two) noexcept // <=>
     {
         // primary key: volume of data transferred
         auto const ax = one.up + one.down;
@@ -85,13 +85,12 @@ struct StopsCompare
         }
 
         // secondary key: the torrent's info_hash
-        if (one.info_hash < two.info_hash)
+        for (size_t i = 0, n = sizeof(tr_sha1_digest_t); i < n; ++i)
         {
-            return -1;
-        }
-        if (one.info_hash > two.info_hash)
-        {
-            return 1;
+            if (one.info_hash[i] != two.info_hash[i])
+            {
+                return one.info_hash[i] < two.info_hash[i] ? -1 : 1;
+            }
         }
 
         // tertiary key: the tracker's announce url
@@ -107,7 +106,7 @@ struct StopsCompare
         return 0;
     }
 
-    [[nodiscard]] bool operator()(tr_announce_request const& one, tr_announce_request const& two) const noexcept
+    [[nodiscard]] constexpr auto operator()(tr_announce_request const& one, tr_announce_request const& two) const noexcept
     {
         return compare(one, two) < 0;
     }
@@ -125,7 +124,7 @@ struct tr_scrape_info
 
     tr_interned_string scrape_url;
 
-    tr_scrape_info(tr_interned_string scrape_url_in, int const multiscrape_max_in)
+    constexpr tr_scrape_info(tr_interned_string scrape_url_in, int const multiscrape_max_in)
         : multiscrape_max{ multiscrape_max_in }
         , scrape_url{ scrape_url_in }
     {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -596,14 +596,14 @@ static tr_tier* getTier(tr_announcer* announcer, tr_sha1_digest_t const& info_ha
 ****  PUBLISH
 ***/
 
-static void publishMessage(tr_tier* tier, std::string_view msg, TrackerEventType type)
+static void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event::Type type)
 {
     if (tier != nullptr && tier->tor != nullptr && tier->tor->torrent_announcer != nullptr &&
         tier->tor->torrent_announcer->callback != nullptr)
     {
         auto* const ta = tier->tor->torrent_announcer;
         auto event = tr_tracker_event{};
-        event.messageType = type;
+        event.type = type;
         event.text = msg;
 
         if (auto const* const current_tracker = tier->currentTracker(); current_tracker != nullptr)
@@ -617,17 +617,17 @@ static void publishMessage(tr_tier* tier, std::string_view msg, TrackerEventType
 
 static void publishErrorClear(tr_tier* tier)
 {
-    publishMessage(tier, ""sv, TR_TRACKER_ERROR_CLEAR);
+    publishMessage(tier, ""sv, tr_tracker_event::Type::ErrorClear);
 }
 
 static void publishWarning(tr_tier* tier, std::string_view msg)
 {
-    publishMessage(tier, msg, TR_TRACKER_WARNING);
+    publishMessage(tier, msg, tr_tracker_event::Type::Warning);
 }
 
 static void publishError(tr_tier* tier, std::string_view msg)
 {
-    publishMessage(tier, msg, TR_TRACKER_ERROR);
+    publishMessage(tier, msg, tr_tracker_event::Type::Error);
 }
 
 static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
@@ -635,7 +635,7 @@ static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
     if (tier->tor->torrent_announcer->callback != nullptr)
     {
         auto e = tr_tracker_event{};
-        e.messageType = TR_TRACKER_COUNTS;
+        e.type = tr_tracker_event::Type::Counts;
         e.seeders = seeders;
         e.leechers = leechers;
         tr_logAddDebugTier(tier, fmt::format("peer counts: {} seeders, {} leechers.", seeders, leechers));
@@ -649,7 +649,7 @@ static void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vecto
     if (tier->tor->torrent_announcer->callback != nullptr)
     {
         auto e = tr_tracker_event{};
-        e.messageType = TR_TRACKER_PEERS;
+        e.type = tr_tracker_event::Type::Peers;
         e.seeders = seeders;
         e.leechers = leechers;
         e.pex = pex;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -159,6 +159,7 @@ public:
     tr_announcer_impl& operator=(tr_announcer_impl&&) = delete;
     tr_announcer_impl& operator=(tr_announcer_impl const&) = delete;
 
+    void resetTorrent(tr_torrent* tor) override;
     void removeTorrent(tr_torrent* tor) override;
 
     void flushCloseMessages();
@@ -1729,11 +1730,11 @@ tr_tracker_view tr_announcerTracker(tr_torrent const* tor, size_t nth)
 
 // called after the torrent's announceList was rebuilt --
 // so announcer needs to update the tr_tier / tr_trackers to match
-void tr_announcerResetTorrent(tr_announcer* announcer, tr_torrent* tor)
+void tr_announcer_impl::resetTorrent(tr_torrent* tor)
 {
     // make a new tr_announcer_tier
     auto* const older = tor->torrent_announcer;
-    tor->torrent_announcer = new tr_torrent_announcer{ dynamic_cast<tr_announcer_impl*>(announcer), tor };
+    tor->torrent_announcer = new tr_torrent_announcer{ this, tor };
     auto* const newer = tor->torrent_announcer;
 
     // copy the tracker counts into the new replacementa

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -140,8 +140,9 @@ static void flushCloseMessages(tr_announcer* announcer);
 /**
  * "global" (per-tr_session) fields
  */
-struct tr_announcer
+class tr_announcer
 {
+public:
     explicit tr_announcer(tr_session* session_in)
         : session{ session_in }
         , upkeep_timer{ session_in->timerMaker().create() }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -159,6 +159,8 @@ public:
     tr_announcer_impl& operator=(tr_announcer_impl&&) = delete;
     tr_announcer_impl& operator=(tr_announcer_impl const&) = delete;
 
+    void removeTorrent(tr_torrent* tor) override;
+
     void flushCloseMessages();
     void upkeep();
 
@@ -865,10 +867,9 @@ static tr_announce_request* announce_request_new(
     return req;
 }
 
-void tr_announcerRemoveTorrent(tr_announcer* announcer_in, tr_torrent* tor)
+void tr_announcer_impl::removeTorrent(tr_torrent* tor)
 {
     // FIXME(ckerr)
-    auto* const announcer = dynamic_cast<tr_announcer_impl*>(announcer_in);
     auto* const ta = tor->torrent_announcer;
     if (ta == nullptr)
     {
@@ -880,15 +881,15 @@ void tr_announcerRemoveTorrent(tr_announcer* announcer_in, tr_torrent* tor)
         if (tier.isRunning)
         {
             auto const e = TR_ANNOUNCE_EVENT_STOPPED;
-            auto* req = announce_request_new(announcer, tor, &tier, e);
+            auto* req = announce_request_new(this, tor, &tier, e);
 
-            if (announcer->stops.count(req) != 0U)
+            if (stops.count(req) != 0U)
             {
                 delete req;
             }
             else
             {
-                announcer->stops.insert(req);
+                stops.insert(req);
             }
         }
     }

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -58,7 +58,14 @@ struct tr_tracker_event
 
 using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* event, void* client_data);
 
-std::shared_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
+class tr_announcer
+{
+public:
+    [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
+    virtual ~tr_announcer() = default;
+};
+
+std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 
 /**
 ***  For torrent customers

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -24,34 +24,34 @@ struct tr_announcer;
 struct tr_torrent_announcer;
 
 /**
- * ***  Tracker Publish / Subscribe
- * **/
-
-enum TrackerEventType
-{
-    TR_TRACKER_WARNING,
-    TR_TRACKER_ERROR,
-    TR_TRACKER_ERROR_CLEAR,
-    TR_TRACKER_PEERS,
-    TR_TRACKER_COUNTS,
-};
+***  Tracker Publish / Subscribe
+**/
 
 struct tr_pex;
 
 /** @brief Notification object to tell listeners about announce or scrape occurrences */
 struct tr_tracker_event
 {
-    /* what type of event this is */
-    TrackerEventType messageType;
+    enum class Type
+    {
+        Error,
+        ErrorClear,
+        Counts,
+        Peers,
+        Warning,
+    };
 
-    /* for TR_TRACKER_WARNING and TR_TRACKER_ERROR */
+    // What type of event this is
+    Type type;
+
+    // for Warning and Error events
     std::string_view text;
     tr_interned_string announce_url;
 
-    /* for TR_TRACKER_PEERS */
+    // for Peers events
     std::vector<tr_pex> pex;
 
-    /* for TR_TRACKER_PEERS and TR_TRACKER_COUNTS */
+    // for Peers and Counts events
     int leechers;
     int seeders;
 };

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -22,6 +22,7 @@
 #include "net.h"
 
 class tr_announcer;
+class tr_announcer_udp;
 struct tr_torrent_announcer;
 
 /**
@@ -62,7 +63,7 @@ using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* ev
 class tr_announcer
 {
 public:
-    [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
+    [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session, tr_announcer_udp&);
     virtual ~tr_announcer() = default;
 
     virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data) = 0;

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -58,13 +58,7 @@ struct tr_tracker_event
 
 using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* event, void* client_data);
 
-/**
-***  Session ctor/dtor
-**/
-
-void tr_announcerInit(tr_session*);
-
-void tr_announcerClose(tr_session*);
+std::shared_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 
 /**
 ***  For torrent customers

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -12,6 +12,7 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint32_t
 #include <ctime>
+#include <functional>
 #include <string_view>
 #include <vector>
 
@@ -64,7 +65,7 @@ public:
     [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
     virtual ~tr_announcer() = default;
 
-    virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data);
+    virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data) = 0;
     virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
 };
@@ -115,13 +116,14 @@ enum tr_announce_event
 
 struct tr_announce_request;
 struct tr_announce_response;
-using tr_announce_response_func = void (*)(tr_announce_response const* response, void* userdata);
 
 struct tr_scrape_request;
 struct tr_scrape_response;
-using tr_scrape_response_func = void (*)(tr_scrape_response const* response, void* user_data);
 
 /// UDP ANNOUNCER
+
+using tr_scrape_response_func = std::function<void(tr_scrape_response const&)>;
+using tr_announce_response_func = std::function<void(tr_announce_response const&)>;
 
 class tr_announcer_udp
 {
@@ -140,9 +142,9 @@ public:
 
     [[nodiscard]] virtual bool isIdle() const noexcept = 0;
 
-    virtual void announce(tr_announce_request const& request, tr_announce_response_func response_func, void* user_data) = 0;
+    virtual void announce(tr_announce_request const& request, tr_announce_response_func on_response) = 0;
 
-    virtual void scrape(tr_scrape_request const& request, tr_scrape_response_func response_func, void* user_data) = 0;
+    virtual void scrape(tr_scrape_request const& request, tr_scrape_response_func on_response) = 0;
 
     virtual void upkeep() = 0;
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -63,6 +63,8 @@ class tr_announcer
 public:
     [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
     virtual ~tr_announcer() = default;
+
+    virtual void removeTorrent(tr_torrent* tor) = 0;
 };
 
 std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
@@ -74,8 +76,6 @@ std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback callback, void* callback_data);
 
 void tr_announcerResetTorrent(tr_announcer*, tr_torrent*);
-
-void tr_announcerRemoveTorrent(tr_announcer*, tr_torrent*);
 
 void tr_announcerChangeMyPort(tr_torrent*);
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -64,6 +64,7 @@ public:
     [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
     virtual ~tr_announcer() = default;
 
+    virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
 };
 
@@ -74,8 +75,6 @@ std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 **/
 
 struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback callback, void* callback_data);
-
-void tr_announcerResetTorrent(tr_announcer*, tr_torrent*);
 
 void tr_announcerChangeMyPort(tr_torrent*);
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -20,7 +20,7 @@
 #include "interned-string.h"
 #include "net.h"
 
-struct tr_announcer;
+class tr_announcer;
 struct tr_torrent_announcer;
 
 /**
@@ -66,9 +66,9 @@ std::shared_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 
 struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback callback, void* callback_data);
 
-void tr_announcerResetTorrent(struct tr_announcer*, tr_torrent*);
+void tr_announcerResetTorrent(tr_announcer*, tr_torrent*);
 
-void tr_announcerRemoveTorrent(struct tr_announcer*, tr_torrent*);
+void tr_announcerRemoveTorrent(tr_announcer*, tr_torrent*);
 
 void tr_announcerChangeMyPort(tr_torrent*);
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -66,6 +66,8 @@ public:
     virtual ~tr_announcer() = default;
 
     virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data) = 0;
+    virtual void startTorrent(tr_torrent* tor) = 0;
+    virtual void stopTorrent(tr_torrent* tor) = 0;
     virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
 };
@@ -82,8 +84,6 @@ bool tr_announcerCanManualAnnounce(tr_torrent const*);
 
 void tr_announcerManualAnnounce(tr_torrent*);
 
-void tr_announcerTorrentStarted(tr_torrent*);
-void tr_announcerTorrentStopped(tr_torrent*);
 void tr_announcerTorrentCompleted(tr_torrent*);
 
 enum

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -64,6 +64,7 @@ public:
     [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session);
     virtual ~tr_announcer() = default;
 
+    virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data);
     virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
 };
@@ -73,8 +74,6 @@ std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
 /**
 ***  For torrent customers
 **/
-
-struct tr_torrent_announcer* tr_announcerAddTorrent(tr_torrent* torrent, tr_tracker_callback callback, void* callback_data);
 
 void tr_announcerChangeMyPort(tr_torrent*);
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -558,8 +558,6 @@ void tr_session::initImpl(init_data& data)
 
     this->blocklists_ = libtransmission::Blocklist::loadBlocklists(blocklist_dir_, useBlocklist());
 
-    tr_announcerInit(this);
-
     tr_logAddInfo(fmt::format(_("Transmission version {version} starting"), fmt::arg("version", LONG_VERSION_STRING)));
 
     setSettings(client_settings, true);
@@ -1248,7 +1246,7 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise)
     // remaining `event=stopped` announce messages are queued in
     // the announcer. The announcer's destructor sends all those
     // out via `web_`...
-    tr_announcerClose(this);
+    this->announcer_.reset();
     // ...and now that those are queued, tell web_ that we're
     // shutting down soon. This leaves the `event=stopped` messages
     // in the queue but refuses to take any _new_ tasks
@@ -1503,7 +1501,7 @@ void tr_session::setDefaultTrackers(std::string_view trackers)
         {
             if (tor->isPublic())
             {
-                tr_announcerResetTorrent(announcer, tor);
+                tr_announcerResetTorrent(announcer_.get(), tor);
             }
         }
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1501,7 +1501,7 @@ void tr_session::setDefaultTrackers(std::string_view trackers)
         {
             if (tor->isPublic())
             {
-                tr_announcerResetTorrent(announcer_.get(), tor);
+                announcer_->resetTorrent(tor);
             }
         }
     }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1150,7 +1150,7 @@ public:
     std::unique_ptr<tr_announcer_udp> announcer_udp_ = tr_announcer_udp::create(announcer_udp_mediator_);
 
     // depends-on: settings_, torrents_, web_, announcer_udp_
-    std::shared_ptr<tr_announcer> announcer_ = tr_announcerCreate(this);
+    std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this);
 
     // depends-on: public_peer_port_, udp_core_, dht_mediator_
     std::unique_ptr<tr_dht> dht_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1151,7 +1151,7 @@ public:
     std::unique_ptr<tr_announcer_udp> announcer_udp_ = tr_announcer_udp::create(announcer_udp_mediator_);
 
     // depends-on: settings_, torrents_, web_, announcer_udp_
-    struct tr_announcer* announcer = nullptr;
+    std::shared_ptr<tr_announcer> announcer_ = tr_announcerCreate(this);
 
     // depends-on: public_peer_port_, udp_core_, dht_mediator_
     std::unique_ptr<tr_dht> dht_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1150,7 +1150,7 @@ public:
     std::unique_ptr<tr_announcer_udp> announcer_udp_ = tr_announcer_udp::create(announcer_udp_mediator_);
 
     // depends-on: settings_, torrents_, web_, announcer_udp_
-    std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this);
+    std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this, *announcer_udp_);
 
     // depends-on: public_peer_port_, udp_core_, dht_mediator_
     std::unique_ptr<tr_dht> dht_;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -58,7 +58,6 @@ class tr_rpc_server;
 class tr_session_thread;
 class tr_web;
 struct struct_utp_context;
-struct tr_announcer;
 struct tr_variant;
 
 namespace libtransmission

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -762,7 +762,7 @@ static void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         }
     }
 
-    tor->torrent_announcer = tr_announcerAddTorrent(tor, onTrackerResponse, nullptr);
+    tor->torrent_announcer = session->announcer_->addTorrent(tor, onTrackerResponse, nullptr);
 
     if (is_new_torrent)
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1311,7 +1311,7 @@ static void torrentStartImpl(tr_torrent* const tor)
     tor->finishedSeedingByIdle = false;
 
     tr_torrentResetTransferStats(tor);
-    tr_announcerTorrentStarted(tor);
+    tor->session->announcer_->startTorrent(tor);
     tor->lpdAnnounceAt = now;
     tr_peerMgrStartTorrent(tor);
 }
@@ -1495,7 +1495,7 @@ static void stopTorrent(tr_torrent* const tor)
     tor->session->verifyRemove(tor);
 
     tr_peerMgrStopTorrent(tor);
-    tr_announcerTorrentStopped(tor);
+    tor->session->announcer_->stopTorrent(tor);
 
     tor->session->closeTorrentFiles(tor);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1263,7 +1263,7 @@ static void freeTorrent(tr_torrent* tor)
 
     tr_peerMgrRemoveTorrent(tor);
 
-    tr_announcerRemoveTorrent(session->announcer_.get(), tor);
+    session->announcer_->removeTorrent(tor);
 
     session->torrents().remove(tor, tr_time());
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -462,14 +462,14 @@ static void tr_torrentClearError(tr_torrent* tor)
 
 static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, void* /*user_data*/)
 {
-    switch (event->messageType)
+    switch (event->type)
     {
-    case TR_TRACKER_PEERS:
+    case tr_tracker_event::Type::Peers:
         tr_logAddTraceTor(tor, fmt::format("Got {} peers from tracker", std::size(event->pex)));
         tr_peerMgrAddPex(tor, TR_PEER_FROM_TRACKER, std::data(event->pex), std::size(event->pex));
         break;
 
-    case TR_TRACKER_COUNTS:
+    case tr_tracker_event::Type::Counts:
         if (tor->isPrivate() && (event->leechers == 0))
         {
             tr_peerMgrSetSwarmIsAllSeeds(tor);
@@ -477,20 +477,20 @@ static void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, vo
 
         break;
 
-    case TR_TRACKER_WARNING:
+    case tr_tracker_event::Type::Warning:
         tr_logAddWarnTor(tor, fmt::format(_("Tracker warning: '{warning}'"), fmt::arg("warning", event->text)));
         tor->error = TR_STAT_TRACKER_WARNING;
         tor->error_announce_url = event->announce_url;
         tor->error_string = event->text;
         break;
 
-    case TR_TRACKER_ERROR:
+    case tr_tracker_event::Type::Error:
         tor->error = TR_STAT_TRACKER_ERROR;
         tor->error_announce_url = event->announce_url;
         tor->error_string = event->text;
         break;
 
-    case TR_TRACKER_ERROR_CLEAR:
+    case tr_tracker_event::Type::ErrorClear:
         if (tor->error != TR_STAT_LOCAL_ERROR)
         {
             tr_torrentClearError(tor);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1991,7 +1991,7 @@ bool tr_torrent::setTrackerList(std::string_view text)
     }
 
     /* tell the announcer to reload this torrent's tracker list */
-    tr_announcerResetTorrent(this->session->announcer_.get(), this);
+    this->session->announcer_->resetTorrent(this);
 
     return true;
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1263,7 +1263,7 @@ static void freeTorrent(tr_torrent* tor)
 
     tr_peerMgrRemoveTorrent(tor);
 
-    tr_announcerRemoveTorrent(session->announcer, tor);
+    tr_announcerRemoveTorrent(session->announcer_.get(), tor);
 
     session->torrents().remove(tor, tr_time());
 
@@ -1991,7 +1991,7 @@ bool tr_torrent::setTrackerList(std::string_view text)
     }
 
     /* tell the announcer to reload this torrent's tracker list */
-    tr_announcerResetTorrent(this->session->announcer, this);
+    tr_announcerResetTorrent(this->session->announcer_.get(), this);
 
     return true;
 }

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -317,11 +317,7 @@ TEST_F(AnnouncerUdpTest, canScrape)
     // tell announcer to scrape
     auto [request, expected_response] = buildSimpleScrapeRequestAndResponse();
     auto response = std::optional<tr_scrape_response>{};
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
     EXPECT_FALSE(announcer->isIdle());
 
     // The announcer should have sent a UDP connection request.
@@ -362,11 +358,7 @@ TEST_F(AnnouncerUdpTest, canScrape)
     // Since the timestamp hasn't changed, the connection should be good
     // and announcer-udp should skip the `connect` step, going straight to the scrape.
     response.reset();
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
@@ -384,11 +376,7 @@ TEST_F(AnnouncerUdpTest, canDestructCleanlyEvenWhenBusy)
     // tell announcer to scrape
     auto [request, expected_response] = buildSimpleScrapeRequestAndResponse();
     auto response = std::optional<tr_scrape_response>{};
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
@@ -417,11 +405,7 @@ TEST_F(AnnouncerUdpTest, canMultiScrape)
 
     auto request = buildScrapeRequestFromResponse(expected_response);
     auto response = std::optional<tr_scrape_response>{};
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
 
     // Announcer will request a connection. Verify and grant the request
     auto sent = waitForAnnouncerToSendMessage(mediator);
@@ -480,11 +464,7 @@ TEST_F(AnnouncerUdpTest, canHandleScrapeError)
 
     // tell announcer to scrape
     auto response = std::optional<tr_scrape_response>{};
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
@@ -532,9 +512,7 @@ TEST_F(AnnouncerUdpTest, canHandleConnectError)
     auto response = std::optional<tr_scrape_response>{};
     announcer->scrape(
         buildScrapeRequestFromResponse(expected_response),
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+        [&response](tr_scrape_response const& resp) { response = resp; });
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
@@ -564,11 +542,7 @@ TEST_F(AnnouncerUdpTest, handleMessageReturnsFalseOnInvalidMessage)
 
     // tell the announcer to scrape
     auto response = std::optional<tr_scrape_response>{};
-    announcer->scrape(
-        request,
-        [](tr_scrape_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_scrape_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
@@ -649,11 +623,7 @@ TEST_F(AnnouncerUdpTest, canAnnounce)
     auto upkeep_timer = createUpkeepTimer(mediator, announcer);
 
     auto response = std::optional<tr_announce_response>{};
-    announcer->announce(
-        request,
-        [](tr_announce_response const* resp, void* vresponse)
-        { *static_cast<std::optional<tr_announce_response>*>(vresponse) = *resp; },
-        &response);
+    announcer->announce(request, [&response](tr_announce_response const& resp) { response = resp; });
 
     // Announcer will request a connection. Verify and grant the request
     auto sent = waitForAnnouncerToSendMessage(mediator);


### PR DESCRIPTION
- make tr_announcer a class that is owned by tr_session via a unique_ptr
- reduce use of new / delete in announcer module
- begin limiting scope inside announcer.cc by making some fields, methods private. (de-C-ification)