### PR TITLE
perf: minor perf wins

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2431,9 +2431,8 @@ void closeBadPeers(tr_swarm* s, time_t const now_sec)
 void enforceTorrentPeerLimit(tr_swarm* swarm)
 {
     // do we have too many peers?
-    auto const n = swarm->peerCount();
     auto const max = swarm->tor->peerLimit();
-    if (n <= max)
+    if (auto const n = swarm->peerCount(); n <= max)
     {
         return;
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2422,8 +2422,6 @@ struct ComparePeerByActivity
 
 void closeBadPeers(tr_swarm* s, time_t const now_sec)
 {
-    auto const lock = s->unique_lock();
-
     for (auto* peer : getPeersToClose(s, now_sec))
     {
         closePeer(peer);
@@ -2480,6 +2478,7 @@ void tr_peerMgr::reconnectPulse()
 {
     using namespace disconnect_helpers;
 
+    auto const lock = session->unique_lock();
     auto const now_sec = tr_time();
 
     // remove crappy peers

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -54,12 +54,12 @@ public:
 
         [[nodiscard]] Iterator operator+(int n_bytes)
         {
-            return Iterator(buf_, offset_ + n_bytes);
+            return Iterator{ buf_, offset_ + n_bytes };
         }
 
         [[nodiscard]] Iterator operator-(int n_bytes)
         {
-            return Iterator(buf_, offset_ - n_bytes);
+            return Iterator{ buf_, offset_ - n_bytes };
         }
 
         [[nodiscard]] constexpr auto operator-(Iterator const& that) const noexcept
@@ -351,7 +351,7 @@ public:
     [[nodiscard]] std::string toString() const
     {
         auto str = std::string{};
-        str.reserve(size());
+        str.resize(size());
         evbuffer_copyout(buf_.get(), std::data(str), std::size(str));
         return str;
     }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -352,10 +352,7 @@ public:
     {
         auto str = std::string{};
         str.reserve(size());
-        for (auto const& by : *this)
-        {
-            str.push_back(*reinterpret_cast<char const*>(&by));
-        }
+        evbuffer_copyout(buf_.get(), std::data(str), std::size(str));
         return str;
     }
 


### PR DESCRIPTION
Minor performance improvements found from using [hotspot](https://github.com/KDAB/hotspot). 

CMake build type: `-DCMAKE_BUILD_TYPE=RelWithDebInfo`

perf recording: `$ perf record --call-graph dwarf --freq=max ./build/daemon/transmission-daemon -f` and then ran for 15 minutes before manually shutting down, then ran the output into hotspot with `hotspot perf.data`