### PR TITLE
Update crypto-utils-cyassl.cc

### DIFF
--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -26,6 +26,7 @@
 #include API_HEADER_CRYPT(sha.h)
 #include API_HEADER_CRYPT(sha256.h)
 #include API_HEADER(version.h)
+#include API_HEADER(ssl.h)
 
 #include <fmt/core.h>
 
@@ -41,8 +42,26 @@ using TR_WC_RNG = WC_RNG;
 using TR_WC_RNG = RNG;
 #endif
 
-#define TR_CRYPTO_X509_FALLBACK
-#include "crypto-utils-fallback.cc" // NOLINT(bugprone-suspicious-include)
+tr_x509_store_t tr_ssl_get_x509_store(tr_ssl_ctx_t handle)
+{
+    wolfSSL_CTX_load_system_CA_certs((WOLFSSL_CTX*)handle);
+    return nullptr;
+}
+
+bool tr_x509_store_add(tr_x509_store_t handle, tr_x509_cert_t cert)
+{
+    return false;
+}
+
+tr_x509_cert_t tr_x509_cert_new(void const* der, size_t der_length)
+{
+    return nullptr;
+}
+
+void tr_x509_cert_free(tr_x509_cert_t handle)
+{
+
+}
 
 /***
 ****


### PR DESCRIPTION
Use build-in function for loading system certificates. Working both on Windows and Linux. For Android needs additional fix: https://github.com/wolfSSL/wolfssl/pull/5805/files