### PR TITLE
perf: constexpr and move work outside of loops

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -144,11 +144,10 @@ void tr_bandwidth::allocateBandwidth(
     tr_priority_t const priority = std::max(parent_priority, this->priority_);
 
     /* set the available bandwidth */
-    auto bandwidth = &this->band_[dir];
-    if (bandwidth->is_limited_)
+    if (auto& bandwidth = band_[dir]; bandwidth.is_limited_)
     {
-        auto const next_pulse_speed = bandwidth->desired_speed_bps_;
-        bandwidth->bytes_left_ = next_pulse_speed * period_msec / 1000U;
+        auto const next_pulse_speed = bandwidth.desired_speed_bps_;
+        bandwidth.bytes_left_ = next_pulse_speed * period_msec / 1000U;
     }
 
     /* add this bandwidth's peer, if any, to the peer pool */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -391,14 +391,12 @@ public:
         return tor->unique_lock();
     }
 
-    [[nodiscard]] size_t countActiveWebseeds() const noexcept
+    [[nodiscard]] size_t countActiveWebseeds(uint64_t now) const noexcept
     {
         if (!tor->isRunning || tor->isDone())
         {
             return {};
         }
-
-        auto const now = tr_time_msec();
 
         return std::count_if(
             std::begin(webseeds),
@@ -2564,6 +2562,7 @@ void tr_peerMgr::bandwidthPulse()
     session->top_bandwidth_.allocate(TR_DOWN, msec);
 
     /* torrent upkeep */
+    auto const now = tr_time_msec();
     for (auto* const tor : session->torrents())
     {
         /* run the completeness check for any torrents that need it */
@@ -2581,7 +2580,7 @@ void tr_peerMgr::bandwidthPulse()
         }
 
         /* update the torrent's stats */
-        tor->swarm->stats.active_webseed_count = tor->swarm->countActiveWebseeds();
+        tor->swarm->stats.active_webseed_count = tor->swarm->countActiveWebseeds(now);
     }
 
     /* pump the queues */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2565,10 +2565,12 @@ void tr_peerMgr::bandwidthPulse()
     auto const now = tr_time_msec();
     for (auto* const tor : session->torrents())
     {
+        auto* const swarm = tor->swarm;
+
         /* run the completeness check for any torrents that need it */
-        if (tor->swarm->needs_completeness_check)
+        if (swarm->needs_completeness_check)
         {
-            tor->swarm->needs_completeness_check = false;
+            swarm->needs_completeness_check = false;
             tor->recheckCompleteness();
         }
 
@@ -2580,7 +2582,7 @@ void tr_peerMgr::bandwidthPulse()
         }
 
         /* update the torrent's stats */
-        tor->swarm->stats.active_webseed_count = tor->swarm->countActiveWebseeds(now);
+        swarm->stats.active_webseed_count = swarm->countActiveWebseeds(now);
     }
 
     /* pump the queues */

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -255,7 +255,7 @@ struct peer_atom
         blocklisted_.reset();
     }
 
-    std::optional<bool> isReachable() const
+    [[nodiscard]] constexpr std::optional<bool> isReachable() const
     {
         if ((flags2 & MyflagUnreachable) != 0)
         {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2556,9 +2556,9 @@ void tr_peerMgr::bandwidthPulse()
     pumpAllPeers(this);
 
     /* allocate bandwidth to the peers */
-    static auto constexpr msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
-    session->top_bandwidth_.allocate(TR_UP, msec);
-    session->top_bandwidth_.allocate(TR_DOWN, msec);
+    static auto constexpr Msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
+    session->top_bandwidth_.allocate(TR_UP, Msec);
+    session->top_bandwidth_.allocate(TR_DOWN, Msec);
 
     /* torrent upkeep */
     for (auto* const tor : session->torrents())

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2482,13 +2482,15 @@ void tr_peerMgr::reconnectPulse()
     // remove crappy peers
     for (auto* const tor : session->torrents())
     {
-        if (!tor->swarm->is_running)
+        auto* const swarm = tor->swarm;
+
+        if (!swarm->is_running)
         {
-            tor->swarm->removeAllPeers();
+            swarm->removeAllPeers();
         }
         else
         {
-            closeBadPeers(tor->swarm, now_sec);
+            closeBadPeers(swarm, now_sec);
         }
     }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2556,7 +2556,7 @@ void tr_peerMgr::bandwidthPulse()
     pumpAllPeers(this);
 
     /* allocate bandwidth to the peers */
-    auto const msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
+    static auto constexpr msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
     session->top_bandwidth_.allocate(TR_UP, msec);
     session->top_bandwidth_.allocate(TR_DOWN, msec);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -190,7 +190,7 @@ struct peer_atom
         return value;
     }
 
-    [[nodiscard]] int getReconnectIntervalSecs(time_t const now) const noexcept
+    [[nodiscard]] constexpr int getReconnectIntervalSecs(time_t const now) const noexcept
     {
         auto sec = int{};
         bool const unreachable = (this->flags2 & MyflagUnreachable) != 0;
@@ -246,7 +246,6 @@ struct peer_atom
             }
         }
 
-        tr_logAddTrace(fmt::format("reconnect interval for {} is {} seconds", this->readable(), sec));
         return sec;
     }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -677,13 +677,10 @@ static struct peer_atom* getExistingAtom(tr_swarm const* cswarm, tr_address cons
     return it != std::end(swarm->pool) ? &*it : nullptr;
 }
 
-static bool peerIsInUse(tr_swarm const* cs, struct peer_atom const* atom)
+static bool peerIsInUse(tr_swarm const* swarm, struct peer_atom const* atom)
 {
-    auto const* const s = const_cast<tr_swarm*>(cs);
-    auto const lock = s->unique_lock();
-
-    return atom->is_connected || s->outgoing_handshakes.contains(atom->addr) ||
-        s->manager->incoming_handshakes.contains(atom->addr);
+    return atom->is_connected || swarm->outgoing_handshakes.contains(atom->addr) ||
+        swarm->manager->incoming_handshakes.contains(atom->addr);
 }
 
 static void swarmFree(tr_swarm* s)
@@ -2861,6 +2858,8 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
 void tr_peerMgr::makeNewPeerConnections(size_t max)
 {
     using namespace connect_helpers;
+
+    auto const lock = session->unique_lock();
 
     for (auto& candidate : getPeerCandidates(session, max))
     {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2734,10 +2734,11 @@ struct peer_candidate
     /* count how many peers and atoms we've got */
     auto atom_count = size_t{};
     auto peer_count = size_t{};
-    for (auto const* tor : session->torrents())
+    for (auto const* const tor : session->torrents())
     {
-        atom_count += std::size(tor->swarm->pool);
-        peer_count += tor->swarm->peerCount();
+        auto const* const swarm = tor->swarm;
+        atom_count += std::size(swarm->pool);
+        peer_count += swarm->peerCount();
     }
 
     /* don't start any new handshakes if we're full up */
@@ -2751,9 +2752,11 @@ struct peer_candidate
 
     /* populate the candidate array */
     auto salter = tr_salt_shaker{};
-    for (auto* tor : session->torrents())
+    for (auto* const tor : session->torrents())
     {
-        if (!tor->swarm->is_running)
+        auto* const swarm = tor->swarm;
+
+        if (!swarm->is_running)
         {
             continue;
         }
@@ -2761,13 +2764,13 @@ struct peer_candidate
         /* if everyone in the swarm is seeds and pex is disabled because
          * the torrent is private, then don't initiate connections */
         bool const seeding = tor->isDone();
-        if (seeding && tor->swarm->isAllSeeds() && tor->isPrivate())
+        if (seeding && swarm->isAllSeeds() && tor->isPrivate())
         {
             continue;
         }
 
         /* if we've already got enough peers in this torrent... */
-        if (tor->peerLimit() <= tor->swarm->peerCount())
+        if (tor->peerLimit() <= swarm->peerCount())
         {
             continue;
         }
@@ -2778,7 +2781,7 @@ struct peer_candidate
             continue;
         }
 
-        for (auto& atom : tor->swarm->pool)
+        for (auto& atom : swarm->pool)
         {
             if (isPeerCandidate(tor, atom, now))
             {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -753,13 +753,13 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bo
 
     if ((fields_to_load & tr_resume::TimeSeeding) != 0 && tr_variantDictFindInt(&top, TR_KEY_seeding_time_seconds, &i))
     {
-        tor->secondsSeeding = i;
+        tor->seconds_seeding_before_current_start_ = i;
         fields_loaded |= tr_resume::TimeSeeding;
     }
 
     if ((fields_to_load & tr_resume::TimeDownloading) != 0 && tr_variantDictFindInt(&top, TR_KEY_downloading_time_seconds, &i))
     {
-        tor->secondsDownloading = i;
+        tor->seconds_downloading_before_current_start_ = i;
         fields_loaded |= tr_resume::TimeDownloading;
     }
 
@@ -906,10 +906,11 @@ void save(tr_torrent* tor)
         return;
     }
 
+    auto const now = tr_time();
     auto top = tr_variant{};
     tr_variantInitDict(&top, 50); /* arbitrary "big enough" number */
-    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding);
-    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading);
+    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding(now));
+    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading(now));
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->corruptPrev + tor->corruptCur);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -753,13 +753,13 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bo
 
     if ((fields_to_load & tr_resume::TimeSeeding) != 0 && tr_variantDictFindInt(&top, TR_KEY_seeding_time_seconds, &i))
     {
-        tor->seconds_seeding_before_current_start_ = i;
+        tor->secondsSeeding = i;
         fields_loaded |= tr_resume::TimeSeeding;
     }
 
     if ((fields_to_load & tr_resume::TimeDownloading) != 0 && tr_variantDictFindInt(&top, TR_KEY_downloading_time_seconds, &i))
     {
-        tor->seconds_downloading_before_current_start_ = i;
+        tor->secondsDownloading = i;
         fields_loaded |= tr_resume::TimeDownloading;
     }
 
@@ -906,11 +906,10 @@ void save(tr_torrent* tor)
         return;
     }
 
-    auto const now = tr_time();
     auto top = tr_variant{};
     tr_variantInitDict(&top, 50); /* arbitrary "big enough" number */
-    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding(now));
-    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading(now));
+    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding);
+    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading);
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->corruptPrev + tor->corruptCur);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -176,7 +176,7 @@ std::vector<tr_lpd::Mediator::TorrentInfo> tr_session::LpdMediator::torrents() c
     {
         auto info = tr_lpd::Mediator::TorrentInfo{};
         info.info_hash_str = tor->infoHashString();
-        info.activity = tr_torrentGetActivity(tor);
+        info.activity = tor->activity();
         info.allows_lpd = tor->allowsLpd();
         info.announce_after = tor->lpdAnnounceAt;
         ret.emplace_back(info);
@@ -1976,7 +1976,7 @@ size_t tr_session::countQueueFreeSlots(tr_direction dir) const noexcept
     for (auto const* const tor : torrents())
     {
         /* is it the right activity? */
-        if (activity != tr_torrentGetActivity(tor))
+        if (activity != tor->activity())
         {
             continue;
         }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -505,6 +505,24 @@ void tr_session::onNowTimer()
     tr_timeUpdate(time(nullptr));
     alt_speeds_.checkScheduler();
 
+    // TODO: this seems a little silly. Why do we increment this
+    // every second instead of computing the value as needed by
+    // subtracting the current time from a start time?
+    for (auto* const tor : torrents())
+    {
+        if (tor->isRunning)
+        {
+            if (tor->isDone())
+            {
+                ++tor->secondsSeeding;
+            }
+            else
+            {
+                ++tor->secondsDownloading;
+            }
+        }
+    }
+
     // set the timer to kick again right after (10ms after) the next second
     auto const now = std::chrono::system_clock::now();
     auto const target_time = std::chrono::time_point_cast<std::chrono::seconds>(now) + 1s + 10ms;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -505,24 +505,6 @@ void tr_session::onNowTimer()
     tr_timeUpdate(time(nullptr));
     alt_speeds_.checkScheduler();
 
-    // TODO: this seems a little silly. Why do we increment this
-    // every second instead of computing the value as needed by
-    // subtracting the current time from a start time?
-    for (auto* const tor : torrents())
-    {
-        if (tor->isRunning)
-        {
-            if (tor->isDone())
-            {
-                ++tor->secondsSeeding;
-            }
-            else
-            {
-                ++tor->secondsDownloading;
-            }
-        }
-    }
-
     // set the timer to kick again right after (10ms after) the next second
     auto const now = std::chrono::system_clock::now();
     auto const target_time = std::chrono::time_point_cast<std::chrono::seconds>(now) + 1s + 10ms;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -967,7 +967,6 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->leftUntilDone = tor->completion.leftUntilDone();
     s->sizeWhenDone = tor->completion.sizeWhenDone();
 
-    auto const now_sec = tr_time();
     auto const verify_progress = tor->verifyProgress();
     s->recheckProgress = verify_progress ? *verify_progress : 0.0F;
     s->activityDate = tor->activityDate;
@@ -975,8 +974,8 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->doneDate = tor->doneDate;
     s->editDate = tor->editDate;
     s->startDate = tor->startDate;
-    s->secondsSeeding = tor->secondsSeeding(now_sec);
-    s->secondsDownloading = tor->secondsDownloading(now_sec);
+    s->secondsSeeding = tor->secondsSeeding;
+    s->secondsDownloading = tor->secondsDownloading;
 
     s->corruptEver = tor->corruptCur + tor->corruptPrev;
     s->downloadedEver = tor->downloadedCur + tor->downloadedPrev;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -967,6 +967,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->leftUntilDone = tor->completion.leftUntilDone();
     s->sizeWhenDone = tor->completion.sizeWhenDone();
 
+    auto const now_sec = tr_time();
     auto const verify_progress = tor->verifyProgress();
     s->recheckProgress = verify_progress ? *verify_progress : 0.0F;
     s->activityDate = tor->activityDate;
@@ -974,8 +975,8 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->doneDate = tor->doneDate;
     s->editDate = tor->editDate;
     s->startDate = tor->startDate;
-    s->secondsSeeding = tor->secondsSeeding;
-    s->secondsDownloading = tor->secondsDownloading;
+    s->secondsSeeding = tor->secondsSeeding(now_sec);
+    s->secondsDownloading = tor->secondsDownloading(now_sec);
 
     s->corruptEver = tor->corruptCur + tor->corruptPrev;
     s->downloadedEver = tor->downloadedCur + tor->downloadedPrev;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -639,35 +639,37 @@ public:
 
     [[nodiscard]] constexpr auto activity() const noexcept
     {
-        auto ret = TR_STATUS_STOPPED;
-
         bool const is_seed = this->isDone();
 
         if (this->verifyState() == TR_VERIFY_NOW)
         {
-            ret = TR_STATUS_CHECK;
+            return TR_STATUS_CHECK;
         }
-        else if (this->verifyState() == TR_VERIFY_WAIT)
+
+        if (this->verifyState() == TR_VERIFY_WAIT)
         {
-            ret = TR_STATUS_CHECK_WAIT;
+            return TR_STATUS_CHECK_WAIT;
         }
-        else if (this->isRunning)
+
+        if (this->isRunning)
         {
-            ret = is_seed ? TR_STATUS_SEED : TR_STATUS_DOWNLOAD;
+            return is_seed ? TR_STATUS_SEED : TR_STATUS_DOWNLOAD;
         }
-        else if (this->isQueued())
+
+        if (this->isQueued())
         {
             if (is_seed && this->session->queueEnabled(TR_UP))
             {
-                ret = TR_STATUS_SEED_WAIT;
+                return TR_STATUS_SEED_WAIT;
             }
-            else if (!is_seed && this->session->queueEnabled(TR_DOWN))
+
+            if (!is_seed && this->session->queueEnabled(TR_DOWN))
             {
-                ret = TR_STATUS_DOWNLOAD_WAIT;
+                return TR_STATUS_DOWNLOAD_WAIT;
             }
         }
 
-        return ret;
+        return TR_STATUS_STOPPED;
     }
 
     void setLabels(std::vector<tr_quark> const& new_labels);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -731,6 +731,37 @@ public:
         }
     }
 
+    [[nodiscard]] constexpr auto secondsDownloading(time_t now) const noexcept
+    {
+        auto n_secs = seconds_downloading_before_current_start_;
+
+        if (isRunning)
+        {
+            if (doneDate > startDate)
+            {
+                n_secs += doneDate - startDate;
+            }
+            else if (doneDate == 0)
+            {
+                n_secs += now - startDate;
+            }
+        }
+
+        return n_secs;
+    }
+
+    [[nodiscard]] constexpr auto secondsSeeding(time_t now) const noexcept
+    {
+        auto n_secs = seconds_seeding_before_current_start_;
+
+        if (isRunning)
+        {
+            n_secs += now - std::max(doneDate, startDate);
+        }
+
+        return n_secs;
+    }
+
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
@@ -818,8 +849,8 @@ public:
 
     tr_bytes_per_second_t etaSpeed_Bps = 0;
 
-    time_t secondsDownloading = 0;
-    time_t secondsSeeding = 0;
+    time_t seconds_downloading_before_current_start_ = 0;
+    time_t seconds_seeding_before_current_start_ = 0;
 
     size_t queuePosition = 0;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -731,37 +731,6 @@ public:
         }
     }
 
-    [[nodiscard]] constexpr auto secondsDownloading(time_t now) const noexcept
-    {
-        auto n_secs = seconds_downloading_before_current_start_;
-
-        if (isRunning)
-        {
-            if (doneDate > startDate)
-            {
-                n_secs += doneDate - startDate;
-            }
-            else if (doneDate == 0)
-            {
-                n_secs += now - startDate;
-            }
-        }
-
-        return n_secs;
-    }
-
-    [[nodiscard]] constexpr auto secondsSeeding(time_t now) const noexcept
-    {
-        auto n_secs = seconds_seeding_before_current_start_;
-
-        if (isRunning)
-        {
-            n_secs += now - std::max(doneDate, startDate);
-        }
-
-        return n_secs;
-    }
-
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
@@ -849,8 +818,8 @@ public:
 
     tr_bytes_per_second_t etaSpeed_Bps = 0;
 
-    time_t seconds_downloading_before_current_start_ = 0;
-    time_t seconds_seeding_before_current_start_ = 0;
+    time_t secondsDownloading = 0;
+    time_t secondsSeeding = 0;
 
     size_t queuePosition = 0;
 


### PR DESCRIPTION
More performance microimprovements found from profiling. 

- make tr_torrentGetActivity() constexpr
- reduce the number of mutex locks in tr_bandwidthPulse()
- lazy-calculate tr_swarm_stats.active_webseed_count