### PR TITLE
fix: eta display in GTK client details dialog

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -805,7 +805,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
         {
             str = mixed;
         }
-        else if (baseline == TR_ETA_NOT_AVAIL || baseline == TR_ETA_UNKNOWN)
+        else if (baseline < 0)
         {
             str = _("Unknown");
         }

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -795,8 +795,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     }
     else
     {
-        int const baseline = stats.front()->eta;
-        bool const is_uniform = std::all_of(
+        auto const baseline = stats.front()->eta;
+        auto const is_uniform = std::all_of(
             stats.begin(),
             stats.end(),
             [baseline](auto const* st) { return baseline == st->eta; });
@@ -805,13 +805,13 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
         {
             str = mixed;
         }
-        else if (baseline < 0)
+        else if (baseline == TR_ETA_NOT_AVAIL || baseline == TR_ETA_UNKNOWN)
         {
             str = _("Unknown");
         }
         else
         {
-            str = tr_format_time_relative(now, baseline);
+            str = tr_format_time_left(baseline);
         }
     }
 


### PR DESCRIPTION
Fix broken ETA formatting in the GTK client's display dialog.