### PR TITLE
fixup: heap-use-after-free in announce, scrape response on shutdown

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1192,8 +1192,13 @@ static void tierAnnounce(tr_announcer_impl* announcer, tr_tier* tier)
 
     announcer->announce(
         req,
-        [announcer, tier_id, event, is_running_on_success](tr_announce_response const& response)
-        { announcer->onAnnounceDone(tier_id, event, is_running_on_success, response); });
+        [session = announcer->session, announcer, tier_id, event, is_running_on_success](tr_announce_response const& response)
+        {
+            if (session->announcer_)
+            {
+                announcer->onAnnounceDone(tier_id, event, is_running_on_success, response);
+            }
+        });
 }
 
 /***
@@ -1435,7 +1440,15 @@ static void multiscrape(tr_announcer_impl* announcer, std::vector<tr_tier*> cons
     /* send the requests we just built */
     for (size_t i = 0; i < request_count; ++i)
     {
-        announcer->scrape(requests[i], [announcer](tr_scrape_response const& response) { announcer->onScrapeDone(response); });
+        announcer->scrape(
+            requests[i],
+            [session = announcer->session, announcer](tr_scrape_response const& response)
+            {
+                if (session->announcer_)
+                {
+                    announcer->onScrapeDone(response);
+                }
+            });
     }
 }
 


### PR DESCRIPTION
fixes #4222.

Checks to ensure that the session is still managing the announcer before using it in scrape & announce responses.