### PR TITLE
fix: new sonarcloud, coverity, gcc warnings

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1111,17 +1111,17 @@ public:
         add(upload_rate_string);
         add(client);
         add(progress);
-        add(upload_request_count_int);
+        add(upload_request_count_number);
         add(upload_request_count_string);
-        add(download_request_count_int);
+        add(download_request_count_number);
         add(download_request_count_string);
-        add(blocks_downloaded_count_int);
+        add(blocks_downloaded_count_number);
         add(blocks_downloaded_count_string);
-        add(blocks_uploaded_count_int);
+        add(blocks_uploaded_count_number);
         add(blocks_uploaded_count_string);
-        add(reqs_cancelled_by_client_count_int);
+        add(reqs_cancelled_by_client_count_number);
         add(reqs_cancelled_by_client_count_string);
-        add(reqs_cancelled_by_peer_count_int);
+        add(reqs_cancelled_by_peer_count_number);
         add(reqs_cancelled_by_peer_count_string);
         add(encryption_stock_id);
         add(flags);
@@ -1138,17 +1138,17 @@ public:
     Gtk::TreeModelColumn<Glib::ustring> upload_rate_string;
     Gtk::TreeModelColumn<Glib::ustring> client;
     Gtk::TreeModelColumn<int> progress;
-    Gtk::TreeModelColumn<int> upload_request_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::activeReqsToClient)> upload_request_count_number;
     Gtk::TreeModelColumn<Glib::ustring> upload_request_count_string;
-    Gtk::TreeModelColumn<int> download_request_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::activeReqsToPeer)> download_request_count_number;
     Gtk::TreeModelColumn<Glib::ustring> download_request_count_string;
-    Gtk::TreeModelColumn<int> blocks_downloaded_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::blocksToClient)> blocks_downloaded_count_number;
     Gtk::TreeModelColumn<Glib::ustring> blocks_downloaded_count_string;
-    Gtk::TreeModelColumn<int> blocks_uploaded_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::blocksToPeer)> blocks_uploaded_count_number;
     Gtk::TreeModelColumn<Glib::ustring> blocks_uploaded_count_string;
-    Gtk::TreeModelColumn<int> reqs_cancelled_by_client_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::cancelsToPeer)> reqs_cancelled_by_client_count_number;
     Gtk::TreeModelColumn<Glib::ustring> reqs_cancelled_by_client_count_string;
-    Gtk::TreeModelColumn<int> reqs_cancelled_by_peer_count_int;
+    Gtk::TreeModelColumn<decltype(tr_peer_stat::cancelsToClient)> reqs_cancelled_by_peer_count_number;
     Gtk::TreeModelColumn<Glib::ustring> reqs_cancelled_by_peer_count_string;
     Gtk::TreeModelColumn<Glib::ustring> encryption_stock_id;
     Gtk::TreeModelColumn<Glib::ustring> flags;
@@ -1245,10 +1245,10 @@ void refreshPeerRow(Gtk::TreeModel::iterator const& iter, tr_peer_stat const* pe
         cancelled_by_peer = std::to_string(peer->cancelsToClient);
     }
 
-    (*iter)[peer_cols.progress] = (int)(100.0 * peer->progress);
-    (*iter)[peer_cols.upload_request_count_int] = peer->activeReqsToClient;
+    (*iter)[peer_cols.progress] = static_cast<int>(100.0 * peer->progress);
+    (*iter)[peer_cols.upload_request_count_number] = peer->activeReqsToClient;
     (*iter)[peer_cols.upload_request_count_string] = up_count;
-    (*iter)[peer_cols.download_request_count_int] = peer->activeReqsToPeer;
+    (*iter)[peer_cols.download_request_count_number] = peer->activeReqsToPeer;
     (*iter)[peer_cols.download_request_count_string] = down_count;
     (*iter)[peer_cols.download_rate_double] = peer->rateToClient_KBps;
     (*iter)[peer_cols.download_rate_string] = down_speed;
@@ -1256,13 +1256,13 @@ void refreshPeerRow(Gtk::TreeModel::iterator const& iter, tr_peer_stat const* pe
     (*iter)[peer_cols.upload_rate_string] = up_speed;
     (*iter)[peer_cols.flags] = std::data(peer->flagStr);
     (*iter)[peer_cols.was_updated] = true;
-    (*iter)[peer_cols.blocks_downloaded_count_int] = (int)peer->blocksToClient;
+    (*iter)[peer_cols.blocks_downloaded_count_number] = peer->blocksToClient;
     (*iter)[peer_cols.blocks_downloaded_count_string] = blocks_to_client;
-    (*iter)[peer_cols.blocks_uploaded_count_int] = (int)peer->blocksToPeer;
+    (*iter)[peer_cols.blocks_uploaded_count_number] = peer->blocksToPeer;
     (*iter)[peer_cols.blocks_uploaded_count_string] = blocks_to_peer;
-    (*iter)[peer_cols.reqs_cancelled_by_client_count_int] = (int)peer->cancelsToPeer;
+    (*iter)[peer_cols.reqs_cancelled_by_client_count_number] = peer->cancelsToPeer;
     (*iter)[peer_cols.reqs_cancelled_by_client_count_string] = cancelled_by_client;
-    (*iter)[peer_cols.reqs_cancelled_by_peer_count_int] = (int)peer->cancelsToClient;
+    (*iter)[peer_cols.reqs_cancelled_by_peer_count_number] = peer->cancelsToClient;
     (*iter)[peer_cols.reqs_cancelled_by_peer_count_string] = cancelled_by_peer;
 }
 
@@ -1615,42 +1615,42 @@ void setPeerViewColumns(Gtk::TreeView* peer_view)
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Dn Reqs"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.download_request_count_int;
+            sort_col = &peer_cols.download_request_count_number;
         }
         else if (*col == peer_cols.upload_request_count_string)
         {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Up Reqs"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.upload_request_count_int;
+            sort_col = &peer_cols.upload_request_count_number;
         }
         else if (*col == peer_cols.blocks_downloaded_count_string)
         {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Dn Blocks"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.blocks_downloaded_count_int;
+            sort_col = &peer_cols.blocks_downloaded_count_number;
         }
         else if (*col == peer_cols.blocks_uploaded_count_string)
         {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Up Blocks"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.blocks_uploaded_count_int;
+            sort_col = &peer_cols.blocks_uploaded_count_number;
         }
         else if (*col == peer_cols.reqs_cancelled_by_client_count_string)
         {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("We Cancelled"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.reqs_cancelled_by_client_count_int;
+            sort_col = &peer_cols.reqs_cancelled_by_client_count_number;
         }
         else if (*col == peer_cols.reqs_cancelled_by_peer_count_string)
         {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("They Cancelled"), *r);
             c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.reqs_cancelled_by_peer_count_int;
+            sort_col = &peer_cols.reqs_cancelled_by_peer_count_number;
         }
         else if (*col == peer_cols.download_rate_string)
         {

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -101,7 +101,7 @@ struct tau_scrape_request
         return !!on_response_;
     }
 
-    void requestFinished()
+    void requestFinished() const
     {
         if (on_response_)
         {
@@ -194,7 +194,7 @@ struct tau_announce_request
         return !!on_response_;
     }
 
-    void requestFinished()
+    void requestFinished() const
     {
         if (on_response_)
         {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1647,7 +1647,6 @@ static tr_tracker_view trackerView(tr_torrent const& tor, size_t tier_index, tr_
         }
     }
 
-    TR_ASSERT(0 <= view.tier);
     return view;
 }
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -271,19 +271,19 @@ size_t tr_bandwidth::clamp(uint64_t now, tr_direction dir, size_t byte_count) co
 
             auto const current = this->getRawSpeedBytesPerSecond(now, TR_DOWN);
             auto const desired = this->getDesiredSpeedBytesPerSecond(TR_DOWN);
-            auto const r = desired >= 1 ? double(current) / desired : 0;
+            auto const r = desired >= 1 ? static_cast<double>(current) / desired : 0.0;
 
             if (r > 1.0)
             {
-                byte_count = 0;
+                byte_count = 0; // none left
             }
             else if (r > 0.9)
             {
-                byte_count = static_cast<unsigned int>(byte_count * 0.8);
+                byte_count -= (byte_count / 5U); // cap at 80%
             }
             else if (r > 0.8)
             {
-                byte_count = static_cast<unsigned int>(byte_count * 0.9);
+                byte_count -= (byte_count / 10U); // cap at 90%
             }
         }
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -390,7 +390,7 @@ public:
         return tor->unique_lock();
     }
 
-    [[nodiscard]] size_t countActiveWebseeds(uint64_t now) const noexcept
+    [[nodiscard]] uint16_t countActiveWebseeds(uint64_t now) const noexcept
     {
         if (!tor->isRunning || tor->isDone())
         {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2545,12 +2545,10 @@ void tr_peerMgr::bandwidthPulse()
     /* torrent upkeep */
     for (auto* const tor : session->torrents())
     {
-        auto* const swarm = tor->swarm;
-
-        /* run the completeness check for any torrents that need it */
-        if (swarm->needs_completeness_check)
+        // run the completeness check for any torrents that need it
+        if (auto& needs_check = tor->swarm->needs_completeness_check; needs_check)
         {
-            swarm->needs_completeness_check = false;
+            needs_check = false;
             tor->recheckCompleteness();
         }
 

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -81,7 +81,8 @@ class Filter
 public:
     void decryptInit(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
 
-    constexpr void decrypt(size_t buf_len, void* buf)
+    template<typename T>
+    constexpr void decrypt(size_t buf_len, T* buf)
     {
         if (dec_active_)
         {
@@ -91,7 +92,8 @@ public:
 
     void encryptInit(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
 
-    constexpr void encrypt(size_t buf_len, void* buf)
+    template<typename T>
+    constexpr void encrypt(size_t buf_len, T* buf)
     {
         if (enc_active_)
         {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1982,13 +1982,9 @@ size_t tr_session::countQueueFreeSlots(tr_direction dir) const noexcept
         }
 
         /* is it stalled? */
-        if (stalled_enabled)
+        if (stalled_enabled && difftime(now, std::max(tor->startDate, tor->activityDate)) >= stalled_if_idle_for_n_seconds)
         {
-            auto const idle_secs = static_cast<size_t>(difftime(now, std::max(tor->startDate, tor->activityDate)));
-            if (idle_secs >= stalled_if_idle_for_n_seconds)
-            {
-                continue;
-            }
+            continue;
         }
 
         ++active_count;

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -337,7 +337,7 @@ TEST(Bitfield, percent)
     EXPECT_NEAR(0.25F, field.percent(), 0.01);
 }
 
-TEST(Bitfield, bitwise_or)
+TEST(Bitfield, bitwiseOr)
 {
     auto a = tr_bitfield{ 100 };
     auto b = tr_bitfield{ 100 };
@@ -386,7 +386,7 @@ TEST(Bitfield, bitwise_or)
     EXPECT_TRUE(a.hasAll());
 }
 
-TEST(Bitfield, bitwise_and)
+TEST(Bitfield, bitwiseAnd)
 {
     auto a = tr_bitfield{ 100 };
     auto b = tr_bitfield{ 100 };


### PR DESCRIPTION
Fix new warnings found by gcc, Sonarcloud, and Coverity.

These are small changes, but since this touches some code that y'all have been working in recently, courtesy CC to @mikedld for changes to GTK DetailsDialog and to @Coeur for implicit conversions in libtransmission. Code review welcome but not required :smile_cat: