### PR TITLE
fixup! refactor: remove unused vars, code simplify and minor optimize…

### DIFF
--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -197,6 +197,7 @@ bool isValidUtf8(QByteArray const& byteArray)
 
     auto const* const codec = QTextCodec::codecForName("UTF-8");
     auto state = QTextCodec::ConverterState{};
+    codec->toUnicode(byteArray.constData(), byteArray.size(), &state);
     return state.invalidChars == 0;
 
 #endif


### PR DESCRIPTION
… (#4172)

set the converter state in isValidUtf8()

Fix Nov 19 regression that broke `Prefs::isValidUtf8()` in the Qt client