### PR TITLE
Fix building on macOS Mojave

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */


### PR DESCRIPTION
Fix a build regression from #4195.

And I hope to get Transmission 4.0 released soon: I don't want to maintain Mojave forever. :)