### PR TITLE
Fix building with cmake on macOS Mojave

### DIFF
--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -449,7 +449,7 @@ target_link_libraries(${TR_NAME}-mac
 
 if(NOT CMAKE_GENERATOR STREQUAL Xcode)
     add_custom_command(TARGET ${TR_NAME}-mac POST_BUILD
-        COMMAND ${CODESIGN_EXECUTABLE} -s - -o linker-signed $<TARGET_BUNDLE_DIR:${TR_NAME}-mac>)
+        COMMAND ${CODESIGN_EXECUTABLE} -s - $<TARGET_BUNDLE_DIR:${TR_NAME}-mac>)
 endif()
 
 set(MAC_BUNDLE_NAME Transmission)


### PR DESCRIPTION
Fix build regression from #4147

Tested: Sparkle and User Notifications are still working with this change.