### PR TITLE
Fix tr_rand_int modulo bias and fix tr_rand_int for values larger than INT_MAX

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -175,7 +175,7 @@ void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peer_array, tr_direction di
     auto n = peer_array.size();
     while (n > 0)
     {
-        int const i = tr_rand_int_weak(n); /* pick a peer at random */
+        auto const i = tr_rand_int_weak(n); /* pick a peer at random */
 
         // value of 3000 bytes chosen so that when using µTP we'll send a full-size
         // frame right away and leave enough buffered data for the next frame to go

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -89,7 +89,8 @@ void tr_x509_cert_free(tr_x509_cert_t handle);
 /**
  * @brief Returns a random number in the range of [0...upper_bound).
  */
-[[nodiscard]] int tr_rand_int(int upper_bound);
+template<class IntType>
+[[nodiscard]] IntType tr_rand_int(IntType upper_bound);
 
 /**
  * @brief Returns a pseudorandom number in the range of [0...upper_bound).
@@ -97,7 +98,8 @@ void tr_x509_cert_free(tr_x509_cert_t handle);
  * This is faster, BUT WEAKER, than tr_rand_int() and never be used in sensitive cases.
  * @see tr_rand_int()
  */
-[[nodiscard]] int tr_rand_int_weak(int upper_bound);
+template<class IntType>
+[[nodiscard]] IntType tr_rand_int_weak(IntType upper_bound);
 
 /**
  * @brief Fill a buffer with random bytes.


### PR DESCRIPTION
1. Fix the modulo bias in `tr_rand_int` (https://stackoverflow.com/questions/10984974/why-do-people-say-there-is-modulo-bias-when-using-a-random-number-generator).

2. Fix the warning "_Implicit conversion loses integer precision_" in some usages of `tr_rand_int` and `tr_rand_int_weak` by adding support for `size_t`.
