### PR TITLE
refactor: log UTP_ETIMEDOUT errors to 'trace' messages

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -387,7 +387,21 @@ static void utp_on_state_change(tr_peerIo* const io, int const state)
 
 static void utp_on_error(tr_peerIo* const io, int const errcode)
 {
-    tr_logAddDebugIo(io, fmt::format("utp_on_error -- errcode is {}", errcode));
+    switch (errcode)
+    {
+    case UTP_ETIMEDOUT:
+        tr_logAddTraceIo(io, fmt::format("utp_on_error -- timed out"));
+        break;
+    case UTP_ECONNRESET:
+        tr_logAddDebugIo(io, fmt::format("utp_on_error -- connection reset"));
+        break;
+    case UTP_ECONNREFUSED:
+        tr_logAddDebugIo(io, fmt::format("utp_on_error -- connection refused"));
+        break;
+    default:
+        tr_logAddDebugIo(io, fmt::format("utp_on_error -- errcode is {}", errcode));
+        break;
+    }
 
     if (io->gotError != nullptr)
     {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -387,20 +387,14 @@ static void utp_on_state_change(tr_peerIo* const io, int const state)
 
 static void utp_on_error(tr_peerIo* const io, int const errcode)
 {
-    switch (errcode)
+    if (errcode == UTP_ETIMEDOUT)
     {
-    case UTP_ETIMEDOUT:
-        tr_logAddTraceIo(io, fmt::format("utp_on_error -- timed out"));
-        break;
-    case UTP_ECONNRESET:
-        tr_logAddDebugIo(io, fmt::format("utp_on_error -- connection reset"));
-        break;
-    case UTP_ECONNREFUSED:
-        tr_logAddDebugIo(io, fmt::format("utp_on_error -- connection refused"));
-        break;
-    default:
-        tr_logAddDebugIo(io, fmt::format("utp_on_error -- errcode is {}", errcode));
-        break;
+        // high frequency error: we log as trace
+        tr_logAddTraceIo(io, fmt::format("utp_on_error -- UTP_ETIMEDOUT"));
+    }
+    else
+    {
+        tr_logAddDebugIo(io, fmt::format("utp_on_error -- {}", utp_error_code_names[errcode]));
     }
 
     if (io->gotError != nullptr)


### PR DESCRIPTION
See https://github.com/transmission/transmission/issues/2996#issuecomment-1164703109 and https://github.com/transmission/transmission/issues/4233#issuecomment-1326682226

>Trying to interpret the code that leads to "utp_on_error -- errcode is 2", it seems to theoretically happen after 2-4 absences of responses:
https://github.com/transmission/libutp/blob/bf695bdfb047cdca9710ea9cffc4018669cf9548/utp_internal.cpp#L1187-L1191
>
>...with a timer set to fire every 50-150ms:
https://github.com/transmission/transmission/blob/6b861806a653c6490c247819f7959ca39f54e752/libtransmission/tr-utp.cc#L160-L163
>
>So total it seems equivalent to a peer not connecting in less than 0.1s-0.3s.
