### PR TITLE
refactor: add tr_rand_obj()

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -28,7 +28,7 @@
 
 #include "announcer.h"
 #include "announcer-common.h"
-#include "crypto-utils.h" /* tr_rand_buffer() */
+#include "crypto-utils.h" // for tr_rand_obj()
 #include "log.h"
 #include "peer-io.h"
 #include "peer-mgr.h" // for tr_pex::fromCompact4()
@@ -52,9 +52,7 @@ static auto constexpr TauConnectionTtlSecs = int{ 60 };
 
 static tau_transaction_t tau_transaction_new()
 {
-    auto tmp = tau_transaction_t{};
-    tr_rand_buffer(&tmp, sizeof(tau_transaction_t));
-    return tmp;
+    return tr_rand_obj<tau_transaction_t>();
 }
 
 // used in the "action" field of a request. Values defined in bep 15.

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes> // PRIu64
 #include <climits> // INT_MAX
 #include <cstdio>
 #include <ctime>

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -91,8 +91,7 @@ std::string tr_ssha1(std::string_view plaintext)
     auto constexpr Salter = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ./"sv;
     static_assert(std::size(Salter) == 64);
     auto constexpr SaltSize = size_t{ 8 };
-    auto salt = std::array<char, SaltSize>{};
-    tr_rand_buffer(std::data(salt), std::size(salt));
+    auto salt = tr_rand_obj<std::array<char, SaltSize>>();
     std::transform(
         std::begin(salt),
         std::end(salt),

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -104,6 +104,14 @@ void tr_x509_cert_free(tr_x509_cert_t handle);
  */
 bool tr_rand_buffer(void* buffer, size_t length);
 
+template<typename T>
+T tr_rand_obj()
+{
+    auto t = T{};
+    tr_rand_buffer(&t, sizeof(T));
+    return t;
+}
+
 /**
  * @brief Generate a SSHA password from its plaintext source.
  */

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -13,7 +13,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" // tr_rand_buffer()
+#include "crypto-utils.h" // for tr_salt_shaker
 #include "peer-mgr-wishlist.h"
 #include "tr-assert.h"
 

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -69,9 +69,7 @@ namespace tr_message_stream_encryption
 
 [[nodiscard]] DH::private_key_bigend_t DH::randomPrivateKey() noexcept
 {
-    auto key = DH::private_key_bigend_t{};
-    tr_rand_buffer(std::data(key), std::size(key));
-    return key;
+    return tr_rand_obj<DH::private_key_bigend_t>();
 }
 
 [[nodiscard]] auto generatePublicKey(DH::private_key_bigend_t const& private_key) noexcept

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -32,7 +32,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" /* tr_rand_buffer(), tr_ssha1_matches() */
+#include "crypto-utils.h" /* tr_ssha1_matches() */
 #include "error.h"
 #include "log.h"
 #include "net.h"

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -17,7 +17,7 @@
 
 #include "session-id.h"
 
-#include "crypto-utils.h" // for tr_rand_buf()
+#include "crypto-utils.h" // for tr_rand_obj()
 #include "error-types.h"
 #include "error.h"
 #include "file.h"
@@ -103,8 +103,7 @@ auto constexpr WouldBlock = ERROR_LOCK_VIOLATION;
 
 tr_session_id::session_id_t tr_session_id::make_session_id()
 {
-    auto session_id = session_id_t{};
-    tr_rand_buffer(std::data(session_id), std::size(session_id));
+    auto session_id = tr_rand_obj<session_id_t>();
     static auto constexpr Pool = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"sv;
     for (auto& chr : session_id)
     {

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -458,8 +458,7 @@ private:
     {
         // Note that DHT ids need to be distributed uniformly,
         // so it should be something truly random
-        auto id = Id{};
-        tr_rand_buffer(std::data(id), std::size(id));
+        auto id = tr_rand_obj<Id>();
 
         auto nodes = Nodes{};
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -24,7 +24,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" // for tr_rand_buffer()
+#include "crypto-utils.h" // for tr_rand_obj()
 #include "log.h"
 #include "net.h"
 #include "timer.h"
@@ -48,8 +48,7 @@ auto makeCookie()
 {
     static auto constexpr Pool = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"sv;
 
-    auto buf = std::array<char, 12>{};
-    tr_rand_buffer(std::data(buf), std::size(buf));
+    auto buf = tr_rand_obj<std::array<char, 12>>();
     for (auto& ch : buf)
     {
         ch = Pool[static_cast<unsigned char>(ch) % std::size(Pool)];

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -16,7 +16,7 @@
 
 #include "announcer.h"
 #include "announcer-common.h"
-#include "crypto-utils.h"
+#include "crypto-utils.h" // for tr_rand_obj()
 #include "peer-mgr.h" // for tr_pex
 #include "timer-ev.h"
 #include "tr-buffer.h"
@@ -111,14 +111,6 @@ protected:
         }
     }
 
-    template<typename T>
-    [[nodiscard]] static auto randomFilled()
-    {
-        auto tmp = T{};
-        tr_rand_buffer(&tmp, sizeof(tmp));
-        return tmp;
-    }
-
     [[nodiscard]] static uint32_t parseConnectionRequest(libtransmission::Buffer& buf)
     {
         EXPECT_EQ(ProtocolId, buf.toUint64());
@@ -144,7 +136,7 @@ protected:
         response.did_connect = true;
         response.did_timeout = false;
         response.row_count = 1;
-        response.rows[0].info_hash = randomFilled<tr_sha1_digest_t>();
+        response.rows[0].info_hash = tr_rand_obj<tr_sha1_digest_t>();
         response.rows[0].seeders = 1;
         response.rows[0].leechers = 2;
         response.rows[0].downloads = 3;
@@ -194,7 +186,7 @@ protected:
 
     [[nodiscard]] static auto sendConnectionResponse(tr_announcer_udp& announcer, uint32_t transaction_id)
     {
-        auto const connection_id = randomFilled<uint64_t>();
+        auto const connection_id = tr_rand_obj<uint64_t>();
         auto buf = libtransmission::Buffer{};
         buf.addUint32(ConnectAction);
         buf.addUint32(transaction_id);
@@ -398,8 +390,8 @@ TEST_F(AnnouncerUdpTest, canMultiScrape)
     expected_response.did_connect = true;
     expected_response.did_timeout = false;
     expected_response.row_count = 2;
-    expected_response.rows[0] = { randomFilled<tr_sha1_digest_t>(), 1, 2, 3, 0 };
-    expected_response.rows[1] = { randomFilled<tr_sha1_digest_t>(), 4, 5, 6, 0 };
+    expected_response.rows[0] = { tr_rand_obj<tr_sha1_digest_t>(), 1, 2, 3, 0 };
+    expected_response.rows[1] = { tr_rand_obj<tr_sha1_digest_t>(), 4, 5, 6, 0 };
     expected_response.scrape_url = DefaultScrapeUrl;
     expected_response.min_request_interval = 0;
 
@@ -445,7 +437,7 @@ TEST_F(AnnouncerUdpTest, canHandleScrapeError)
     expected_response.did_connect = true;
     expected_response.did_timeout = false;
     expected_response.row_count = 1;
-    expected_response.rows[0].info_hash = randomFilled<tr_sha1_digest_t>();
+    expected_response.rows[0].info_hash = tr_rand_obj<tr_sha1_digest_t>();
     expected_response.rows[0].seeders = -1;
     expected_response.rows[0].leechers = -1;
     expected_response.rows[0].downloads = -1;
@@ -494,7 +486,7 @@ TEST_F(AnnouncerUdpTest, canHandleConnectError)
     expected_response.did_connect = true;
     expected_response.did_timeout = false;
     expected_response.row_count = 1;
-    expected_response.rows[0].info_hash = randomFilled<tr_sha1_digest_t>();
+    expected_response.rows[0].info_hash = tr_rand_obj<tr_sha1_digest_t>();
     expected_response.rows[0].seeders = -1; // -1 here & on next lines means error
     expected_response.rows[0].leechers = -1;
     expected_response.rows[0].downloads = -1;
@@ -533,7 +525,7 @@ TEST_F(AnnouncerUdpTest, handleMessageReturnsFalseOnInvalidMessage)
     auto request = tr_scrape_request{};
     request.scrape_url = DefaultScrapeUrl;
     request.info_hash_count = 1;
-    request.info_hash[0] = randomFilled<tr_sha1_digest_t>();
+    request.info_hash[0] = tr_rand_obj<tr_sha1_digest_t>();
 
     // build the announcer
     auto mediator = MockMediator{};
@@ -553,7 +545,7 @@ TEST_F(AnnouncerUdpTest, handleMessageReturnsFalseOnInvalidMessage)
     auto buf = libtransmission::Buffer{};
     buf.addUint32(ConnectAction);
     buf.addUint32(transaction_id + 1);
-    buf.addUint64(randomFilled<uint64_t>());
+    buf.addUint64(tr_rand_obj<uint64_t>());
     auto response_size = std::size(buf);
     auto arr = std::array<uint8_t, 256>{};
     buf.toBuf(std::data(arr), response_size);
@@ -563,7 +555,7 @@ TEST_F(AnnouncerUdpTest, handleMessageReturnsFalseOnInvalidMessage)
     buf.clear();
     buf.addUint32(ScrapeAction);
     buf.addUint32(transaction_id);
-    buf.addUint64(randomFilled<uint64_t>());
+    buf.addUint64(tr_rand_obj<uint64_t>());
     response_size = std::size(buf);
     buf.toBuf(std::data(arr), response_size);
     EXPECT_FALSE(announcer->handleMessage(std::data(arr), response_size));
@@ -597,7 +589,7 @@ TEST_F(AnnouncerUdpTest, canAnnounce)
     request.announce_url = "https://127.0.0.1/announce";
     request.tracker_id = "fnord";
     request.peer_id = tr_peerIdInit();
-    request.info_hash = randomFilled<tr_sha1_digest_t>();
+    request.info_hash = tr_rand_obj<tr_sha1_digest_t>();
 
     auto expected_response = tr_announce_response{};
     expected_response.info_hash = request.info_hash;

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -9,7 +9,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" // tr_rand_buffer()
+#include "crypto-utils.h" // tr_rand_obj()
 #include "clients.h"
 
 #include "gtest/gtest.h"
@@ -76,8 +76,7 @@ TEST(Client, clientForId)
 
     for (auto const& test : Tests)
     {
-        auto peer_id = tr_peer_id_t{};
-        tr_rand_buffer(std::data(peer_id), std::size(peer_id));
+        auto peer_id = tr_rand_obj<tr_peer_id_t>();
         std::copy(std::begin(test.peer_id), std::end(test.peer_id), std::begin(peer_id));
 
         auto buf = std::array<char, 128>{};
@@ -107,8 +106,7 @@ TEST(Client, clientForIdFuzz)
 {
     for (size_t i = 0; i < 10000; ++i)
     {
-        auto peer_id = tr_peer_id_t{};
-        tr_rand_buffer(std::data(peer_id), std::size(peer_id));
+        auto peer_id = tr_rand_obj<tr_peer_id_t>();
         auto buf = std::array<char, 128>{};
         tr_clientForId(buf.data(), buf.size(), peer_id);
     }

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -11,7 +11,7 @@
 #include "transmission.h"
 
 #include "block-info.h"
-#include "crypto-utils.h" // tr_rand_buffer()
+#include "crypto-utils.h" // for tr_rand_obj()
 #include "completion.h"
 
 #include "gtest/gtest.h"
@@ -335,9 +335,8 @@ TEST_F(CompletionTest, createPieceBitfield)
 
     // make a completion object that has a random assortment of pieces
     auto completion = tr_completion(&torrent, &block_info);
-    auto buf = std::array<char, 65>{};
+    auto buf = tr_rand_obj<std::array<char, 65>>();
     ASSERT_EQ(std::size(buf), block_info.pieceCount());
-    EXPECT_TRUE(tr_rand_buffer(std::data(buf), std::size(buf)));
     for (uint64_t i = 0; i < block_info.pieceCount(); ++i)
     {
         if ((buf[i] % 2) != 0)

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -17,6 +17,7 @@
 #define tr_rand_buffer tr_rand_buffer_
 #define tr_rand_int tr_rand_int_
 #define tr_rand_int_weak tr_rand_int_weak_
+#define tr_rand_obj tr_rand_obj_
 #define tr_salt_shaker tr_salt_shaker_
 #define tr_sha1 tr_sha1_
 #define tr_sha1_from_string tr_sha1_from_string_
@@ -49,6 +50,7 @@
 #undef tr_rand_buffer
 #undef tr_rand_int
 #undef tr_rand_int_weak
+#undef tr_rand_obj
 #undef tr_salt_shaker
 #undef tr_sha1
 #undef tr_sha1_from_string
@@ -76,6 +78,7 @@
 #define tr_rand_buffer_ tr_rand_buffer
 #define tr_rand_int_ tr_rand_int
 #define tr_rand_int_weak_ tr_rand_int_weak
+#define tr_rand_obj_ tr_rand_obj
 #define tr_salt_shaker_ tr_salt_shaker
 #define tr_sha1_ tr_sha1
 #define tr_sha1_ctx_t_ tr_sha1_ctx_t

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -53,7 +53,7 @@ protected:
     {
         // Fake data to be written to the test state file
 
-        std::array<char, IdLength> id_ = tr_randObj<std::array<char, IdLength>>();
+        std::array<char, IdLength> const id_ = tr_rand_obj<std::array<char, IdLength>>();
 
         std::vector<std::pair<tr_address, tr_port>> ipv4_nodes_ = {
             std::make_pair(*tr_address::fromString("10.10.10.1"), tr_port::fromHost(128)),
@@ -597,7 +597,7 @@ TEST_F(DhtTest, announcesTorrents)
 {
     auto constexpr Id = tr_torrent_id_t{ 1 };
     auto constexpr PeerPort = tr_port::fromHost(999);
-    auto const info_hash = tr_randObj<tr_sha1_digest_t>();
+    auto const info_hash = tr_rand_obj<tr_sha1_digest_t>();
 
     tr_timeUpdate(time(nullptr));
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -196,8 +196,7 @@ public:
 
     static auto makeRandomPeerId()
     {
-        auto peer_id = tr_peer_id_t{};
-        tr_rand_buffer(std::data(peer_id), std::size(peer_id));
+        auto peer_id = tr_rand_obj<tr_peer_id_t>();
         auto const peer_id_prefix = "-UW110Q-"sv;
         std::copy(std::begin(peer_id_prefix), std::end(peer_id_prefix), std::begin(peer_id));
         return peer_id;

--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -11,7 +11,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h"
+#include "crypto-utils.h" // tr_rand_obj()
 #include "session.h"
 #include "tr-lpd.h"
 
@@ -83,9 +83,7 @@ public:
 
 auto makeRandomHash()
 {
-    auto buf = std::array<char, 256>{};
-    tr_rand_buffer(std::data(buf), std::size(buf));
-    return tr_sha1::digest(buf);
+    return tr_sha1::digest(tr_rand_obj<std::array<char, 256>>());
 }
 
 auto makeRandomHashString()

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -106,13 +106,13 @@ TEST(WebUtilsTest, parseMagnetFuzzRegressions)
 
 TEST(WebUtilsTest, parseMagnetFuzz)
 {
-    auto buf = std::vector<char>{};
+    auto buf = std::array<char, 1024>{};
 
     for (size_t i = 0; i < 100000; ++i)
     {
-        buf.resize(tr_rand_int(1024));
-        tr_rand_buffer(std::data(buf), std::size(buf));
+        auto const len = static_cast<size_t>(tr_rand_int(1024));
+        tr_rand_buffer(std::data(buf), len);
         auto mm = tr_magnet_metainfo{};
-        EXPECT_FALSE(mm.parseMagnet({ std::data(buf), std::size(buf) }));
+        EXPECT_FALSE(mm.parseMagnet({ std::data(buf), len }));
     }
 }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -43,14 +43,6 @@ namespace libtransmission
 namespace test
 {
 
-template<typename T>
-[[nodiscard]] static auto tr_randObj()
-{
-    auto ret = T{};
-    tr_rand_buffer(&ret, sizeof(ret));
-    return ret;
-}
-
 using file_func_t = std::function<void(char const* filename)>;
 
 static void depthFirstWalk(char const* path, file_func_t func)


### PR DESCRIPTION
There are a lot of places in the codebase where we need to populate an integral type or a fixed-size array with random data. To do this, we instantiate a local on the stack, fill it with tr_rand_buffer(), and then use it.

This PR creates a helper function to make this a one-liner.