### PR TITLE
refactor: make tr_announcer.key a uint32_t

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -62,8 +62,12 @@ struct tr_announce_request
     /* the port we listen for incoming peers on */
     tr_port port;
 
-    /* per-session key */
-    int key = 0;
+    /* Per-session key. BEP 0015 defines this key as a 32-bit number and
+     * explains its purpose: "Clients that resolve hostnames to v4 and v6
+     * and then announce to both should use the same key for both so that
+     * trackers that care about accurate statistics-keeping can match the
+     * two announces." */
+    uint32_t key;
 
     /* the number of peers we'd like to get back in the response */
     int numwant = 0;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -212,7 +212,7 @@ public:
 
     tr_session* const session;
 
-    int const key = tr_rand_int(INT_MAX);
+    uint32_t const key = tr_rand_obj<uint32_t>();
 
 private:
     void flushCloseMessages()


### PR DESCRIPTION
Discussed in part [here](https://github.com/transmission/transmission/pull/4235#issuecomment-1327815003).

This PR changes the key type from `int` to `uint32_t` to more accurately reflect BEP 15.