### PR TITLE
refactor: reduce scope of TR_NATIVE_EOL_STR, TR_NATIVE_EOL_STR_SIZE

### DIFF
--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -13,6 +13,12 @@
 
 using namespace std::literals;
 
+#ifdef _WIN32
+static auto constexpr NativeEol = "\r\n"sv;
+#else
+static auto constexpr NativeEol = "\n"sv;
+#endif
+
 bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
@@ -21,7 +27,7 @@ bool tr_sys_file_write_line(tr_sys_file_t handle, std::string_view buffer, tr_er
 
     if (ret)
     {
-        ret = tr_sys_file_write(handle, TR_NATIVE_EOL_STR, TR_NATIVE_EOL_STR_SIZE, nullptr, error);
+        ret = tr_sys_file_write(handle, std::data(NativeEol), std::size(NativeEol), nullptr, error);
     }
 
     return ret;

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -33,10 +33,6 @@ using tr_sys_file_t = int;
 #define TR_BAD_SYS_FILE (-1)
 /** @brief Platform-specific directory descriptor type. */
 using tr_sys_dir_t = void*;
-/** @brief Platform-specific end-of-line sequence. */
-#define TR_NATIVE_EOL_STR "\n"
-/** @brief Platform-specific end-of-line sequence length. */
-#define TR_NATIVE_EOL_STR_SIZE 1
 
 #else
 
@@ -44,8 +40,6 @@ using tr_sys_file_t = HANDLE;
 #define TR_BAD_SYS_FILE INVALID_HANDLE_VALUE
 struct tr_sys_dir_win32;
 using tr_sys_dir_t = tr_sys_dir_win32*;
-#define TR_NATIVE_EOL_STR "\r\n"
-#define TR_NATIVE_EOL_STR_SIZE 2
 
 #endif
 


### PR DESCRIPTION
`TR_NATIVE_EOL_STR` and `TR_NATIVE_EOL_STR_SIZE` are only used in one function, so remove them from the global namespace.