### PR TITLE
refactor: use std::optional.value_or()

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -968,7 +968,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->sizeWhenDone = tor->completion.sizeWhenDone();
 
     auto const verify_progress = tor->verifyProgress();
-    s->recheckProgress = verify_progress ? *verify_progress : 0.0F;
+    s->recheckProgress = verify_progress.value_or(0.0);
     s->activityDate = tor->activityDate;
     s->addedDate = tor->addedDate;
     s->doneDate = tor->doneDate;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -616,12 +616,7 @@ double tr_truncd(double x, int decimal_places)
         pt[decimal_places != 0 ? decimal_places + 1 : 0] = '\0';
     }
 
-    if (auto parsed = tr_parseNum<double>(std::data(buf)); parsed)
-    {
-        return *parsed;
-    }
-
-    return {};
+    return tr_parseNum<double>(std::data(buf)).value_or(0.0);
 }
 
 std::string tr_strpercent(double x)

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -329,8 +329,7 @@ static void action_callback_POP(
         if ((state->special_flags & JSONSL_SPECIALf_NUMNOINT) != 0)
         {
             auto sv = std::string_view{ jsn->base + state->pos_begin, jsn->pos - state->pos_begin };
-            auto const val = tr_parseNum<double>(sv);
-            tr_variantInitReal(get_node(jsn), val ? *val : double{});
+            tr_variantInitReal(get_node(jsn), tr_parseNum<double>(sv).value_or(0.0));
         }
         else if ((state->special_flags & JSONSL_SPECIALf_NUMERIC) != 0)
         {

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -87,7 +87,7 @@ void FreeSpaceLabel::onTimer()
 
             // update the tooltip
             auto const path = dictFind<QString>(r.args.get(), TR_KEY_path);
-            setToolTip(QDir::toNativeSeparators(path ? *path : QString()));
+            setToolTip(QDir::toNativeSeparators(path.value_or(QString{})));
 
             timer_.start();
         });


### PR DESCRIPTION
Use `std::optional.value_or()` to simplify the code a little.

Fixes Sonarcloud cpp:S6023 warnings.,