### PR TITLE
perf: remove cpu bottleneck in tr_peerIo::write()

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -796,11 +796,8 @@ size_t tr_peerIo::getWriteBufferSpace(uint64_t now) const noexcept
 
 void tr_peerIo::write(libtransmission::Buffer& buf, bool is_piece_data)
 {
-    for (auto& ch : buf)
-    {
-        encrypt(1, &ch);
-    }
-
+    auto [bytes, len] = buf.pullup();
+    encrypt(len, bytes);
     outbuf_info.emplace_back(std::size(buf), is_piece_data);
     outbuf.add(buf);
 }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -266,6 +266,11 @@ public:
         return iov;
     }
 
+    [[nodiscard]] std::pair<std::byte*, size_t> pullup()
+    {
+        return { reinterpret_cast<std::byte*>(evbuffer_pullup(buf_.get(), -1)), size() };
+    }
+
     void commit(Iovec iov)
     {
         evbuffer_commit_space(buf_.get(), &iov, 1);


### PR DESCRIPTION
The use of `tr_buffer::Iterator` -- even though it got a speedup in #4220 -- is still using too much CPU in `tr_peerIo::write()`. Change write() to avoid it.

Notes: Lowered CPU overhead in `tr_peerIo::write()` when writing to encrypted streams.