### PR TITLE
fix: TR_TORRENT_LABELS env var in scripts

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1593,7 +1593,7 @@ static std::string buildLabelsString(tr_torrent const* tor)
 
     for (auto it = std::begin(tor->labels), end = std::end(tor->labels); it != end;)
     {
-        buf << *it;
+        buf << tr_quark_get_string_view(*it);
 
         if (++it != end)
         {


### PR DESCRIPTION
Fixes #4259.

Notes: Fixed `4.0.0-beta.1` regression that broke the `TR_TORRENT_LABELS` environment variable when running user scripts.