### PR TITLE
refactor: add std::unique_ptr<evhttp> handler to utils-ev

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1002,6 +1002,8 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
         return;
     }
 
+    fmt::print("{:s}\n", tr_variantToStr(&val, TR_VARIANT_FMT_JSON));
+
     logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(handshake_sv)));
 
     /* does the peer prefer encrypted connections? */

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1002,8 +1002,6 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
         return;
     }
 
-    fmt::print("{:s}\n", tr_variantToStr(&val, TR_VARIANT_FMT_JSON));
-
     logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(handshake_sv)));
 
     /* does the peer prefer encrypted connections? */

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -716,7 +716,7 @@ static void startServer(tr_rpc_server* server)
     else
     {
         evhttp_set_gencb(httpd, handle_request, server);
-        server->httpd = std::unique_ptr<evhttp, void (*)(evhttp*)>{ httpd, &evhttp_free };
+        server->httpd.reset(httpd);
 
         tr_logAddInfo(fmt::format(_("Listening for RPC and Web requests on '{address}'"), fmt::arg("address", addr_port_str)));
     }

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -17,6 +17,7 @@
 #include "transmission.h"
 
 #include "net.h"
+#include "utils-ev.h"
 
 struct evhttp;
 struct tr_variant;
@@ -155,8 +156,7 @@ public:
     std::unique_ptr<struct tr_rpc_address> bind_address_;
 
     std::unique_ptr<libtransmission::Timer> start_retry_timer;
-    std::unique_ptr<struct evhttp, void (*)(struct evhttp*)> httpd{ nullptr, [](evhttp*) {
-                                                                   } };
+    libtransmission::evhelpers::evhttp_unique_ptr httpd;
     tr_session* const session;
 
     size_t login_attempts_ = 0U;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -21,8 +21,10 @@
 #include <string>
 #include <string_view>
 #include <tuple>
-#include <utility> // std::pair
+#include <utility> // for std::pair
 #include <vector>
+
+#include <event2/util.h> // for evutil_socket_t
 
 #include "transmission.h"
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -18,6 +18,7 @@
 #include <netinet/in.h> /* sockaddr_in */
 #endif
 
+#include <event2/event.h>
 #include <event2/util.h>
 
 #include <fmt/format.h>

--- a/libtransmission/utils-ev.h
+++ b/libtransmission/utils-ev.h
@@ -11,8 +11,19 @@
 
 #include <memory>
 
-#include <event2/buffer.h>
-#include <event2/event.h>
+extern "C"
+{
+    struct evbuffer;
+    struct event;
+    struct event_base;
+    struct evhttp;
+
+    void evbuffer_free(struct evbuffer*);
+    void event_base_free(struct event_base*);
+    int event_del(struct event*);
+    void event_free(struct event*);
+    void evhttp_free(struct evhttp*);
+}
 
 namespace libtransmission::evhelpers
 {
@@ -56,5 +67,18 @@ struct EventDeleter
 };
 
 using event_unique_ptr = std::unique_ptr<struct event, EventDeleter>;
+
+struct EvhttpDeleter
+{
+    void operator()(struct evhttp* evh) const noexcept
+    {
+        if (evh != nullptr)
+        {
+            evhttp_free(evh);
+        }
+    }
+};
+
+using evhttp_unique_ptr = std::unique_ptr<struct evhttp, EvhttpDeleter>;
 
 } // namespace libtransmission::evhelpers


### PR DESCRIPTION
Small code cleanup: add an RAII helper for managing evhttp objects.