### PR TITLE
refactor: make some local pointer vars pointer-to-const

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -319,11 +319,11 @@ struct http_announce_data
 static bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announce_response* const response)
 {
     auto const& [status, body, did_connect, did_timeout, vdata] = web_response;
-    auto* data = static_cast<struct http_announce_data*>(vdata);
+    auto const& log_name = static_cast<http_announce_data const*>(vdata)->log_name;
 
     response->did_connect = did_connect;
     response->did_timeout = did_timeout;
-    tr_logAddTrace("Got announce response", data->log_name);
+    tr_logAddTrace("Got announce response", log_name);
 
     if (status != HTTP_OK)
     {
@@ -333,16 +333,16 @@ static bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr
         return false;
     }
 
-    tr_announcerParseHttpAnnounceResponse(*response, body, data->log_name);
+    tr_announcerParseHttpAnnounceResponse(*response, body, log_name);
 
     if (!std::empty(response->pex6))
     {
-        tr_logAddTrace(fmt::format("got a peers6 length of {}", std::size(response->pex6)), data->log_name);
+        tr_logAddTrace(fmt::format("got a peers6 length of {}", std::size(response->pex6)), log_name);
     }
 
     if (!std::empty(response->pex))
     {
-        tr_logAddTrace(fmt::format("got a peers length of {}", std::size(response->pex)), data->log_name);
+        tr_logAddTrace(fmt::format("got a peers length of {}", std::size(response->pex)), log_name);
     }
 
     return true;

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -211,7 +211,7 @@ void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
      * 2. accumulate an array of all the peerIos from b and its subtree. */
     this->allocateBandwidth(TR_PRI_LOW, dir, period_msec, refs);
 
-    for (auto& io : refs)
+    for (auto const& io : refs)
     {
         io->flushOutgoingProtocolMsgs();
 
@@ -242,7 +242,7 @@ void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
      * enable on-demand IO for peers with bandwidth left to burn.
      * This on-demand IO is enabled until (1) the peer runs out of bandwidth,
      * or (2) the next tr_bandwidth::allocate () call, when we start over again. */
-    for (auto& io : refs)
+    for (auto const& io : refs)
     {
         io->setEnabled(dir, io->hasBandwidthLeft(dir));
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -121,7 +121,7 @@ public:
 
     [[nodiscard]] bool isPeerKnownSeed(tr_torrent_id_t tor_id, tr_address addr) const override
     {
-        auto* const tor = session_.torrents().get(tor_id);
+        auto const* const tor = session_.torrents().get(tor_id);
         return tor != nullptr && tr_peerMgrPeerIsSeed(tor, addr);
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -861,7 +861,7 @@ static void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
 {
     if (auto const must_send_rej = msgs->io->supportsFEXT(); must_send_rej)
     {
-        for (auto& req : msgs->peer_requested_)
+        for (auto const& req : msgs->peer_requested_)
         {
             protocolSendReject(msgs, &req);
         }
@@ -1161,7 +1161,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen)
 
 static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen)
 {
-    tr_torrent* tor = msgs->torrent;
+    auto const* const tor = msgs->torrent;
     if (!tor->allowsPex())
     {
         return;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1161,7 +1161,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen)
 
 static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen)
 {
-    auto const* const tor = msgs->torrent;
+    auto* const tor = msgs->torrent;
     if (!tor->allowsPex())
     {
         return;
@@ -1766,7 +1766,7 @@ static int clientGotBlock(
 {
     TR_ASSERT(msgs != nullptr);
 
-    tr_torrent* const tor = msgs->torrent;
+    tr_torrent const* const tor = msgs->torrent;
     auto const n_expected = msgs->torrent->blockSize(block);
 
     if (!block_data)

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -521,7 +521,7 @@ private:
         }
 
         auto const next_announce_after = now + TorrentAnnounceIntervalSec;
-        for (auto& info_hash_string : info_hash_strings)
+        for (auto const& info_hash_string : info_hash_strings)
         {
             mediator_.setNextAnnounceTime(info_hash_string, next_announce_after);
         }

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -278,7 +278,7 @@ using Buffer = libtransmission::Buffer;
 static void saveIntFunc(tr_variant const* val, void* vout)
 {
     auto buf = std::array<char, 64>{};
-    auto const out = fmt::format_to(std::data(buf), FMT_COMPILE("i{:d}e"), val->val.i);
+    auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("i{:d}e"), val->val.i);
     static_cast<Buffer*>(vout)->add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
 }
 
@@ -291,7 +291,7 @@ static void saveStringImpl(Buffer* tgt, std::string_view sv)
 {
     // `${sv.size()}:${sv}`
     auto prefix = std::array<char, 32>{};
-    auto out = fmt::format_to(std::data(prefix), FMT_COMPILE("{:d}:"), std::size(sv));
+    auto const* const out = fmt::format_to(std::data(prefix), FMT_COMPILE("{:d}:"), std::size(sv));
     tgt->add(std::data(prefix), out - std::data(prefix));
     tgt->add(sv);
 }
@@ -308,7 +308,7 @@ static void saveRealFunc(tr_variant const* val, void* vout)
     // the benc spec doesn't handle floats; save it as a string.
 
     auto buf = std::array<char, 64>{};
-    auto out = fmt::format_to(std::data(buf), FMT_COMPILE("{:f}"), val->val.d);
+    auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:f}"), val->val.d);
     saveStringImpl(static_cast<Buffer*>(vout), { std::data(buf), static_cast<size_t>(out - std::data(buf)) });
 }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -497,7 +497,7 @@ static void jsonPopParent(struct JsonWalk* data)
 static void jsonIntFunc(tr_variant const* val, void* vdata)
 {
     auto buf = std::array<char, 64>{};
-    auto const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:d}"), val->val.i);
+    auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:d}"), val->val.i);
     auto* const data = static_cast<JsonWalk*>(vdata);
     data->out.add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
     jsonChildFunc(data);
@@ -526,13 +526,13 @@ static void jsonRealFunc(tr_variant const* val, void* vdata)
     if (fabs(val->val.d - (int)val->val.d) < 0.00001)
     {
         auto buf = std::array<char, 64>{};
-        auto const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:.0f}"), val->val.d);
+        auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:.0f}"), val->val.d);
         data->out.add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
     }
     else
     {
         auto buf = std::array<char, 64>{};
-        auto const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:.4f}"), val->val.d);
+        auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:.4f}"), val->val.d);
         data->out.add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
     }
 

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -52,9 +52,9 @@ private:
         }
     };
 
-    void callCallback(tr_torrent* tor, bool aborted)
+    void callCallback(tr_torrent* tor, bool aborted) const
     {
-        for (auto& callback : callbacks_)
+        for (auto const& callback : callbacks_)
         {
             callback(tor, aborted);
         }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -352,7 +352,7 @@ public:
 
     void write_block_func()
     {
-        if (auto* const tor = tr_torrentFindFromId(session_, tor_id_); tor != nullptr)
+        if (auto const* const tor = tr_torrentFindFromId(session_, tor_id_); tor != nullptr)
         {
             session_->cache->writeBlock(tor_id_, block_, data_);
             webseed_->publish(tr_peer_event::GotBlock(tor->blockInfo(), block_));
@@ -510,7 +510,7 @@ void makeUrl(tr_webseed const* const webseed, std::string_view name, OutputIt ou
 void task_request_next_chunk(tr_webseed_task* task)
 {
     auto* const webseed = task->webseed;
-    auto* const tor = webseed->getTorrent();
+    auto const* const tor = webseed->getTorrent();
     if (tor == nullptr)
     {
         return;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -288,7 +288,7 @@ public:
             return {};
         }
 
-        if (auto* const tor = getTorrent(); tor == nullptr || !tor->isRunning || tor->isDone())
+        if (auto const* const tor = getTorrent(); tor == nullptr || !tor->isRunning || tor->isDone())
         {
             return {};
         }


### PR DESCRIPTION
Literally just making variables `const`.

Addresses a handful of cpp:S5350 sonarcloud warnings.