### PR TITLE
refactor: remove references to FD_SETSIZE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,8 +181,6 @@ if(WIN32)
         set(CMAKE_${L}_FLAGS "${CMAKE_${L}_FLAGS} -DUNICODE -D_UNICODE")
         # Ignore various deprecation and security warnings (at least for now)
         set(CMAKE_${L}_FLAGS "${CMAKE_${L}_FLAGS} -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS")
-        # Increase maximum FD_SET size
-        set(CMAKE_${L}_FLAGS "${CMAKE_${L}_FLAGS} -DFD_SETSIZE=1024")
         if(MSVC)
             # Reduce noise (at least for now)
             set(CMAKE_${L}_FLAGS "${CMAKE_${L}_FLAGS} /wd4244 /wd4267")

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -1023,13 +1023,13 @@ NetworkPage::NetworkPage(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_torrent_peers_spin"),
         TR_KEY_peer_limit_per_torrent,
         1,
-        FD_SETSIZE,
+        INT_MAX,
         5);
     init_spin_button(
         *gtr_get_widget<Gtk::SpinButton>(builder, "max_total_peers_spin"),
         TR_KEY_peer_limit_global,
         1,
-        FD_SETSIZE,
+        INT_MAX,
         5);
 
 #ifdef WITH_UTP

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -5,12 +5,6 @@
 
 #include "PrefsDialog.h"
 
-#ifdef _WIN32
-#include <winsock2.h> // FD_SETSIZE
-#else
-#include <sys/select.h> // FD_SETSIZE
-#endif
-
 #include <cassert>
 
 #include <QCheckBox>
@@ -458,8 +452,8 @@ void PrefsDialog::onPortTest()
 
 void PrefsDialog::initNetworkTab()
 {
-    ui_.torrentPeerLimitSpin->setRange(1, FD_SETSIZE);
-    ui_.globalPeerLimitSpin->setRange(1, FD_SETSIZE);
+    ui_.torrentPeerLimitSpin->setRange(1, INT_MAX);
+    ui_.globalPeerLimitSpin->setRange(1, INT_MAX);
 
     linkWidgetToPref(ui_.peerPortSpin, Prefs::PEER_PORT);
     linkWidgetToPref(ui_.randomPeerPortCheck, Prefs::PEER_PORT_RANDOM_ON_START);


### PR DESCRIPTION
These are not needed anymore after #893.

Fixes #309.