### PR TITLE
Qt: Add trackerview

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr MyStatic = std::array<std::string_view, 401>{ ""sv,
+auto constexpr MyStatic = std::array<std::string_view, 402>{ ""sv,
                                                              "activeTorrentCount"sv,
                                                              "activity-date"sv,
                                                              "activityDate"sv,
@@ -335,6 +335,7 @@ auto constexpr MyStatic = std::array<std::string_view, 401>{ ""sv,
                                                              "show-backup-trackers"sv,
                                                              "show-extra-peer-details"sv,
                                                              "show-filterbar"sv,
+                                                             "show-filterbar_alt_view"sv,
                                                              "show-notification-area-icon"sv,
                                                              "show-options-window"sv,
                                                              "show-statusbar"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -338,6 +338,7 @@ enum
     TR_KEY_show_backup_trackers,
     TR_KEY_show_extra_peer_details,
     TR_KEY_show_filterbar,
+    TR_KEY_show_filterbar_alt_view,
     TR_KEY_show_notification_area_icon,
     TR_KEY_show_options_window,
     TR_KEY_show_statusbar,

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -34,8 +34,12 @@ target_sources(${TR_NAME}-qt
         FilterBar.h
         FilterBarComboBox.cc
         FilterBarComboBox.h
-        FilterBarComboBoxDelegate.cc
-        FilterBarComboBoxDelegate.h
+        FilterUI.cc
+        FilterUI.h
+        FilterUIDelegate.cc
+        FilterUIDelegate.h
+        FilterView.cc
+        FilterView.h
         Filters.cc
         Filters.h
         Formatter.cc

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -14,10 +14,13 @@
 #include <QWidget>
 
 #include <libtransmission/tr-macros.h>
+#include <QComboBox>
 
 #include "FaviconCache.h"
 #include "Torrent.h"
 #include "Typedefs.h"
+#include "FilterUI.h"
+#include "IconToolButton.h"
 
 class QLabel;
 class QString;
@@ -27,7 +30,7 @@ class Prefs;
 class TorrentFilter;
 class TorrentModel;
 
-class FilterBar : public QWidget
+class FilterBar : public FilterUI
 {
     Q_OBJECT
     TR_DISABLE_COPY_MOVE(FilterBar)
@@ -38,57 +41,20 @@ public:
 public slots:
     void clear();
 
-private:
-    FilterBarComboBox* createTrackerCombo(QStandardItemModel*);
-    FilterBarComboBox* createActivityCombo();
-    void refreshTrackers();
+protected:
+    QComboBox* createTrackerUI(QStandardItemModel*);
+    QComboBox* createActivityUI();
 
-    enum
-    {
-        ACTIVITY,
-        TRACKERS,
-
-        NUM_FLAGS
-    };
-
-    using Pending = std::bitset<NUM_FLAGS>;
-
-    Prefs& prefs_;
-    TorrentModel const& torrents_;
-    TorrentFilter const& filter_;
-
-    std::map<QString, int> sitename_counts_;
-    FilterBarComboBox* const activity_combo_ = createActivityCombo();
-    FilterBarComboBox* tracker_combo_ = {};
+    QComboBox* const activity_ui_ = createActivityUI();
+    QComboBox* tracker_ui_ = {};
     QLabel* count_label_ = {};
-    QStandardItemModel* const tracker_model_ = new QStandardItemModel{ this };
-    QTimer recount_timer_;
-    QLineEdit* const line_edit_ = new QLineEdit{ this };
-    Pending pending_ = {};
-    bool is_bootstrapping_ = {};
+    QLineEdit* line_edit_ = new QLineEdit{ this };
+    IconToolButton* btn_ = new IconToolButton(this);
 
 private slots:
-    void recount();
-    void recountSoon(Pending const& fields);
+    void recount() override;
 
-    void recountActivitySoon()
-    {
-        recountSoon(Pending().set(ACTIVITY));
-    }
-
-    void recountTrackersSoon()
-    {
-        recountSoon(Pending().set(TRACKERS));
-    }
-
-    void recountAllSoon()
-    {
-        recountSoon(Pending().set(ACTIVITY).set(TRACKERS));
-    }
-
-    void refreshPref(int key);
+    void refreshPref(int key) override;
     void onActivityIndexChanged(int index);
-    void onTextChanged(QString const&);
-    void onTorrentsChanged(torrent_ids_t const&, Torrent::fields_t const& fields);
     void onTrackerIndexChanged(int index);
 };

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -10,6 +10,7 @@
 #include "FilterBarComboBox.h"
 #include "StyleHelper.h"
 #include "Utils.h"
+#include "FilterUI.h"
 
 namespace
 {
@@ -31,7 +32,7 @@ QSize FilterBarComboBox::minimumSizeHint() const
 {
     QFontMetrics const fm(fontMetrics());
     QSize const text_size = fm.size(0, itemText(0));
-    QSize const count_size = fm.size(0, itemData(0, CountStringRole).toString());
+    QSize const count_size = fm.size(0, itemData(0, FilterUI::CountStringRole).toString());
     return calculateSize(text_size, count_size);
 }
 
@@ -47,7 +48,7 @@ QSize FilterBarComboBox::sizeHint() const
         max_text_size.setHeight(qMax(max_text_size.height(), text_size.height()));
         max_text_size.setWidth(qMax(max_text_size.width(), text_size.width()));
 
-        QSize const count_size = fm.size(0, itemData(i, CountStringRole).toString());
+        QSize const count_size = fm.size(0, itemData(i, FilterUI::CountStringRole).toString());
         max_count_size.setHeight(qMax(max_count_size.height(), count_size.height()));
         max_count_size.setWidth(qMax(max_count_size.width(), count_size.width()));
     }
@@ -102,7 +103,7 @@ void FilterBarComboBox::paintEvent(QPaintEvent* e)
         }
 
         // draw the count
-        QString text = model_index.data(CountStringRole).toString();
+        QString text = model_index.data(FilterUI::CountStringRole).toString();
 
         if (!text.isEmpty())
         {

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -15,13 +15,6 @@ class FilterBarComboBox : public QComboBox
     TR_DISABLE_COPY_MOVE(FilterBarComboBox)
 
 public:
-    enum
-    {
-        CountRole = Qt::UserRole + 1,
-        CountStringRole,
-        UserRole
-    };
-
     explicit FilterBarComboBox(QWidget* parent = nullptr);
 
     // QWidget

--- a/qt/FilterUI.cc
+++ b/qt/FilterUI.cc
@@ -1,0 +1,222 @@
+// This file Copyright © 2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#include "FilterUI.h"
+
+#include <cstdint> // uint64_t
+#include <map>
+#include <unordered_map>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QStandardItemModel>
+
+#include "Application.h"
+#include "FaviconCache.h"
+#include "Filters.h"
+#include "Prefs.h"
+#include "Torrent.h"
+#include "TorrentFilter.h"
+#include "TorrentModel.h"
+#include "FilterBarComboBox.h"
+#include "FilterUIDelegate.h"
+
+enum
+{
+    ACTIVITY_ROLE = FilterUI::UserRole,
+    TRACKER_ROLE
+};
+
+QStandardItemModel* FilterUI::createActivityModel(QObject* object)
+{
+    auto* model = new QStandardItemModel(object);
+
+    auto* row = new QStandardItem(object->tr("All"));
+    row->setData(FilterMode::SHOW_ALL, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    model->appendRow(new QStandardItem); // separator
+    FilterUIDelegate::setSeparator(model, model->index(1, 0));
+
+    auto const& icons = IconCache::get();
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("system-run")), object->tr("Active"));
+    row->setData(FilterMode::SHOW_ACTIVE, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("go-down")), object->tr("Downloading"));
+    row->setData(FilterMode::SHOW_DOWNLOADING, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("go-up")), object->tr("Seeding"));
+    row->setData(FilterMode::SHOW_SEEDING, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("media-playback-pause")), object->tr("Paused"));
+    row->setData(FilterMode::SHOW_PAUSED, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("dialog-ok")), object->tr("Finished"));
+    row->setData(FilterMode::SHOW_FINISHED, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("view-refresh")), object->tr("Verifying"));
+    row->setData(FilterMode::SHOW_VERIFYING, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("process-stop")), object->tr("Error"));
+    row->setData(FilterMode::SHOW_ERROR, ACTIVITY_ROLE);
+    model->appendRow(row);
+
+    return model;
+}
+
+namespace
+{
+
+QString getCountString(size_t n)
+{
+    return QStringLiteral("%L1").arg(n);
+}
+
+Torrent::fields_t constexpr TrackerFields = {
+    static_cast<uint64_t>(1) << Torrent::TRACKER_STATS,
+};
+
+auto constexpr ActivityFields = FilterMode::TorrentFields;
+
+} // namespace
+
+void FilterUI::refreshTrackers()
+{
+    enum
+    {
+        ROW_TOTALS = 0,
+        ROW_SEPARATOR,
+        ROW_FIRST_TRACKER
+    };
+
+    auto torrents_per_sitename = std::unordered_map<QString, int>{};
+    for (auto const& tor : torrents_.torrents())
+    {
+        for (auto const& sitename : tor->sitenames())
+        {
+            ++torrents_per_sitename[sitename];
+        }
+    }
+
+    // update the "All" row
+    auto const num_trackers = torrents_per_sitename.size();
+    auto* item = tracker_model_->item(ROW_TOTALS);
+    item->setData(static_cast<int>(num_trackers), CountRole);
+    item->setData(getCountString(num_trackers), CountStringRole);
+
+    auto update_tracker_item = [](QStandardItem* i, auto const& it)
+    {
+        auto const& [sitename, count] = *it;
+        auto const display_name = FaviconCache::getDisplayName(sitename);
+        auto const icon = trApp->faviconCache().find(sitename);
+
+        i->setData(display_name, Qt::DisplayRole);
+        i->setData(display_name, TRACKER_ROLE);
+        i->setData(getCountString(static_cast<size_t>(count)), CountStringRole);
+        i->setData(icon, Qt::DecorationRole);
+        i->setData(static_cast<int>(count), CountRole);
+
+        return i;
+    };
+
+    auto new_trackers = std::map<QString, int>(torrents_per_sitename.begin(), torrents_per_sitename.end());
+    auto old_it = sitename_counts_.cbegin();
+    auto new_it = new_trackers.cbegin();
+    auto const old_end = sitename_counts_.cend();
+    auto const new_end = new_trackers.cend();
+    bool any_added = false;
+    int row = ROW_FIRST_TRACKER;
+
+    while ((old_it != old_end) || (new_it != new_end))
+    {
+        if ((old_it == old_end) || ((new_it != new_end) && (old_it->first > new_it->first)))
+        {
+            tracker_model_->insertRow(row, update_tracker_item(new QStandardItem(1), new_it));
+            any_added = true;
+            ++new_it;
+            ++row;
+        }
+        else if ((new_it == new_end) || ((old_it != old_end) && (old_it->first < new_it->first)))
+        {
+            tracker_model_->removeRow(row);
+            ++old_it;
+        }
+        else // update
+        {
+            update_tracker_item(tracker_model_->item(row), new_it);
+            ++old_it;
+            ++new_it;
+            ++row;
+        }
+    }
+
+    if (any_added) // the one added might match our filter...
+    {
+        refreshPref(Prefs::FILTER_TRACKERS);
+    }
+
+    sitename_counts_.swap(new_trackers);
+}
+
+FilterUI::FilterUI(Prefs& prefs, TorrentModel const& torrents, TorrentFilter const& filter, QWidget* parent)
+    : QWidget(parent)
+    , prefs_(prefs)
+    , torrents_(torrents)
+    , filter_(filter)
+    , is_bootstrapping_(true)
+{
+    connect(&prefs_, &Prefs::changed, this, &FilterUI::refreshPref);
+    connect(&torrents_, &TorrentModel::modelReset, this, &FilterUI::recountAllSoon);
+    connect(&torrents_, &TorrentModel::rowsInserted, this, &FilterUI::recountAllSoon);
+    connect(&torrents_, &TorrentModel::rowsRemoved, this, &FilterUI::recountAllSoon);
+    connect(&torrents_, &TorrentModel::torrentsChanged, this, &FilterUI::onTorrentsChanged);
+    connect(&recount_timer_, &QTimer::timeout, this, &FilterUI::recount);
+    connect(&trApp->faviconCache(), &FaviconCache::pixmapReady, this, &FilterUI::recountTrackersSoon);
+}
+
+void FilterUI::toggleUI(bool checked)
+{
+    prefs_.toggleBool(Prefs::FILTERBAR_ALT_VIEW);
+}
+
+void FilterUI::onTextChanged(QString const& str)
+{
+    if (!is_bootstrapping_)
+    {
+        prefs_.set(Prefs::FILTER_TEXT, str.trimmed());
+    }
+}
+
+void FilterUI::onTorrentsChanged(torrent_ids_t const& ids, Torrent::fields_t const& changed_fields)
+{
+    Q_UNUSED(ids)
+
+    if ((changed_fields & TrackerFields).any())
+    {
+        recountTrackersSoon();
+    }
+
+    if ((changed_fields & ActivityFields).any())
+    {
+        recountActivitySoon();
+    }
+}
+
+void FilterUI::recountSoon(Pending const& fields)
+{
+    pending_ |= fields;
+
+    if (!recount_timer_.isActive())
+    {
+        recount_timer_.setSingleShot(true);
+        recount_timer_.start(800);
+    }
+}

--- a/qt/FilterUI.h
+++ b/qt/FilterUI.h
@@ -1,0 +1,91 @@
+// This file Copyright © 2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <bitset>
+#include <map>
+
+#include <QLineEdit>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QWidget>
+
+#include <libtransmission/tr-macros.h>
+
+#include "FaviconCache.h"
+#include "Torrent.h"
+#include "Typedefs.h"
+
+class QString;
+
+class Prefs;
+class TorrentFilter;
+class TorrentModel;
+
+class FilterUI : public QWidget
+{
+    Q_OBJECT
+    TR_DISABLE_COPY_MOVE(FilterUI)
+
+public:
+    FilterUI(Prefs& prefs, TorrentModel const& torrents, TorrentFilter const& filter, QWidget* parent = nullptr);
+
+    enum
+    {
+        CountRole = Qt::UserRole + 1,
+        CountStringRole,
+        UserRole
+    };
+
+    QStandardItemModel* createActivityModel(QObject* object);
+
+protected:
+    void refreshTrackers();
+
+    enum
+    {
+        ACTIVITY,
+        TRACKERS,
+
+        NUM_FLAGS
+    };
+
+    using Pending = std::bitset<NUM_FLAGS>;
+
+    Prefs& prefs_;
+    TorrentModel const& torrents_;
+    TorrentFilter const& filter_;
+
+    std::map<QString, int> sitename_counts_;
+    QStandardItemModel* tracker_model_ = new QStandardItemModel{ this };
+    QTimer recount_timer_;
+    Pending pending_ = {};
+    bool is_bootstrapping_ = {};
+
+protected slots:
+    virtual void recount() = 0;
+    void recountSoon(Pending const& fields);
+
+    void recountActivitySoon()
+    {
+        recountSoon(Pending().set(ACTIVITY));
+    }
+
+    void recountTrackersSoon()
+    {
+        recountSoon(Pending().set(TRACKERS));
+    }
+
+    void recountAllSoon()
+    {
+        recountSoon(Pending().set(ACTIVITY).set(TRACKERS));
+    }
+
+    virtual void refreshPref(int key) = 0;
+
+    void toggleUI(bool checked);
+    void onTextChanged(QString const&);
+    void onTorrentsChanged(torrent_ids_t const&, Torrent::fields_t const& fields);
+};

--- a/qt/FilterUIDelegate.cc
+++ b/qt/FilterUIDelegate.cc
@@ -1,0 +1,120 @@
+// This file Copyright © 2012-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <QAbstractItemView>
+#include <QStandardItemModel>
+#include <QStyle>
+
+#include "StyleHelper.h"
+#include "Utils.h"
+#include "FilterUIDelegate.h"
+#include "FilterUI.h"
+
+namespace
+{
+
+int getHSpacing(QWidget const* w)
+{
+    return qMax(3, w->style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing, nullptr, w));
+}
+
+} // namespace
+
+FilterUIDelegate::FilterUIDelegate(QObject* parent, QWidget* widget)
+    : QItemDelegate(parent)
+    , widget_(widget)
+{
+}
+
+bool FilterUIDelegate::isSeparator(QModelIndex const& index)
+{
+    return index.data(Qt::AccessibleDescriptionRole).toString() == QStringLiteral("separator");
+}
+
+void FilterUIDelegate::setSeparator(QAbstractItemModel* model, QModelIndex const& index)
+{
+    model->setData(index, QStringLiteral("separator"), Qt::AccessibleDescriptionRole);
+
+    if (auto const* const m = qobject_cast<QStandardItemModel*>(model))
+    {
+        if (QStandardItem* item = m->itemFromIndex(index))
+        {
+            item->setFlags(item->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+        }
+    }
+}
+
+void FilterUIDelegate::paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const
+{
+    if (isSeparator(index))
+    {
+        QRect rect = option.rect;
+
+        if (auto const* view = qobject_cast<QAbstractItemView const*>(option.widget))
+        {
+            rect.setWidth(view->viewport()->width());
+        }
+
+        QStyleOption opt;
+        opt.rect = rect;
+        widget_->style()->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, &opt, painter, widget_);
+    }
+    else
+    {
+        QStyleOptionViewItem disabled_option = option;
+        QPalette::ColorRole const disabled_color_role = (disabled_option.state & QStyle::State_Selected) != 0 ?
+            QPalette::HighlightedText :
+            QPalette::Text;
+        disabled_option.palette.setColor(
+            disabled_color_role,
+            Utils::getFadedColor(disabled_option.palette.color(disabled_color_role)));
+
+        QRect bounding_box = option.rect;
+
+        int const hmargin = getHSpacing(widget_);
+        bounding_box.adjust(hmargin, 0, -hmargin, 0);
+
+        QRect decoration_rect = rect(option, index, Qt::DecorationRole);
+        decoration_rect.setSize(QSize(16, 16));
+        decoration_rect = QStyle::alignedRect(
+            option.direction,
+            Qt::AlignLeft | Qt::AlignVCenter,
+            decoration_rect.size(),
+            bounding_box);
+        Utils::narrowRect(bounding_box, decoration_rect.width() + hmargin, 0, option.direction);
+
+        QRect count_rect = rect(option, index, FilterUI::CountStringRole);
+        count_rect = QStyle::alignedRect(option.direction, Qt::AlignRight | Qt::AlignVCenter, count_rect.size(), bounding_box);
+        Utils::narrowRect(bounding_box, 0, count_rect.width() + hmargin, option.direction);
+        QRect const display_rect = bounding_box;
+
+        QIcon const icon = Utils::getIconFromIndex(index);
+
+        drawBackground(painter, option, index);
+        icon.paint(painter, decoration_rect, Qt::AlignCenter, StyleHelper::getIconMode(option.state), QIcon::Off);
+        drawDisplay(painter, option, display_rect, index.data(Qt::DisplayRole).toString());
+        drawDisplay(painter, disabled_option, count_rect, index.data(FilterUI::CountStringRole).toString());
+        drawFocus(painter, option, display_rect | count_rect);
+    }
+}
+
+QSize FilterUIDelegate::sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const
+{
+    if (isSeparator(index))
+    {
+        int const pm = widget_->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, widget_);
+        return { pm, pm + 10 };
+    }
+
+    QStyle const* const s = widget_->style();
+    int const hmargin = getHSpacing(widget_);
+
+    QSize size = QItemDelegate::sizeHint(option, index);
+    size.setHeight(qMax(size.height(), 22));
+    size.rwidth() += s->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, widget_);
+    size.rwidth() += rect(option, index, FilterUI::CountStringRole).width();
+    size.rwidth() += hmargin * 4;
+    return size;
+}

--- a/qt/FilterUIDelegate.h
+++ b/qt/FilterUIDelegate.h
@@ -1,0 +1,33 @@
+// This file Copyright © 2010-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <QItemDelegate>
+
+#include <libtransmission/tr-macros.h>
+
+class QAbstractItemModel;
+class QComboBox;
+
+class FilterUIDelegate : public QItemDelegate
+{
+    Q_OBJECT
+    TR_DISABLE_COPY_MOVE(FilterUIDelegate)
+
+public:
+    FilterUIDelegate(QObject* parent, QWidget* widget);
+
+    static bool isSeparator(QModelIndex const& index);
+    static void setSeparator(QAbstractItemModel* model, QModelIndex const& index);
+
+protected:
+    // QAbstractItemDelegate
+    void paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const override;
+    QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const override;
+
+private:
+    QWidget* const widget_ = {};
+};

--- a/qt/FilterView.h
+++ b/qt/FilterView.h
@@ -1,0 +1,59 @@
+// This file Copyright © 2022 Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <bitset>
+#include <map>
+
+#include <QLineEdit>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QWidget>
+
+#include <libtransmission/tr-macros.h>
+#include <QListView>
+
+#include "FaviconCache.h"
+#include "Torrent.h"
+#include "Typedefs.h"
+#include "FilterUI.h"
+#include "IconToolButton.h"
+
+class QString;
+
+class Prefs;
+class TorrentFilter;
+class TorrentModel;
+
+class FilterView : public FilterUI
+{
+    Q_OBJECT
+    TR_DISABLE_COPY_MOVE(FilterView)
+
+public:
+    FilterView(Prefs& prefs, TorrentModel const& torrents, TorrentFilter const& filter, QWidget* parent = nullptr);
+
+public slots:
+    void clear();
+
+protected:
+    QSize sizeHint() const override;
+
+private:
+    QListView* createTrackerUI(QStandardItemModel*);
+    QListView* createActivityUI();
+
+    QListView* const activity_ui_ = createActivityUI();
+    QListView* tracker_ui_ = {};
+    QLineEdit* line_edit_ = new QLineEdit{ this };
+    IconToolButton* btn_ = new IconToolButton(this);
+
+private slots:
+    void recount() override;
+
+    void refreshPref(int key) override;
+    void onActivityIndexChanged(QModelIndex);
+    void onTrackerIndexChanged(QModelIndex);
+};

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -175,6 +175,7 @@ private:
     QAction* ratio_on_action_ = {};
     QWidgetList hidden_;
     QWidget* filter_bar_ = {};
+    QWidget* filter_view_ = {};
     QAction* alt_speed_action_ = {};
     QString error_message_;
     bool auto_add_clipboard_links = {};

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -18,48 +18,95 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="spacing">
-     <number>0</number>
-    </property>
-    <property name="margin">
-     <number>0</number>
-    </property>
     <item>
-     <widget class="TorrentView" name="listView">
+     <widget class="QSplitter" name="splitter">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
-      <property name="alternatingRowColors">
+      <property name="opaqueResize">
        <bool>true</bool>
       </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::ExtendedSelection</enum>
-      </property>
-      <property name="verticalScrollMode">
-       <enum>QAbstractItemView::ScrollPerPixel</enum>
-      </property>
-      <property name="uniformItemSizes">
+      <property name="childrenCollapsible">
        <bool>false</bool>
       </property>
+      <widget class="QWidget" name="torrentwidget" native="true">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>1</number>
+        </property>
+        <property name="leftMargin">
+         <number>1</number>
+        </property>
+        <property name="topMargin">
+         <number>1</number>
+        </property>
+        <property name="rightMargin">
+         <number>1</number>
+        </property>
+        <property name="bottomMargin">
+         <number>1</number>
+        </property>
+        <item>
+         <widget class="TorrentView" name="listView">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+          <property name="verticalScrollMode">
+           <enum>QAbstractItemView::ScrollPerPixel</enum>
+          </property>
+          <property name="uniformItemSizes">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item>
      <widget class="QWidget" name="statusBar" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="styleSheet">
        <string notr="true">QLabel { margin: 3px 0; }</string>
       </property>
       <layout class="QHBoxLayout" name="statusBarLayout">
        <property name="spacing">
-        <number>3</number>
+        <number>1</number>
        </property>
-       <property name="margin">
-        <number>3</number>
+       <property name="leftMargin">
+        <number>1</number>
+       </property>
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="rightMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
        </property>
        <item>
         <widget class="IconToolButton" name="optionsButton">
@@ -181,7 +228,7 @@
      <x>0</x>
      <y>0</y>
      <width>472</width>
-     <height>24</height>
+     <height>30</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -782,6 +829,17 @@
    </property>
    <property name="text">
     <string>Sort by &amp;Queue</string>
+   </property>
+  </action>
+  <action name="action_Filterview">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Filterview</string>
+   </property>
+   <property name="toolTip">
+    <string>Filterview</string>
    </property>
   </action>
  </widget>

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -75,6 +75,7 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items{
     { SORT_REVERSED, TR_KEY_sort_reversed, QMetaType::Bool },
     { COMPACT_VIEW, TR_KEY_compact_view, QMetaType::Bool },
     { FILTERBAR, TR_KEY_show_filterbar, QMetaType::Bool },
+    { FILTERBAR_ALT_VIEW, TR_KEY_show_filterbar_alt_view, QMetaType::Bool },
     { STATUSBAR, TR_KEY_show_statusbar, QMetaType::Bool },
     { STATUSBAR_STATS, TR_KEY_statusbar_stats, QMetaType::QString },
     { SHOW_TRACKER_SCRAPES, TR_KEY_show_extra_peer_details, QMetaType::Bool },

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -45,6 +45,7 @@ public:
         SORT_REVERSED,
         COMPACT_VIEW,
         FILTERBAR,
+        FILTERBAR_ALT_VIEW,
         STATUSBAR,
         STATUSBAR_STATS,
         SHOW_TRACKER_SCRAPES,

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -237,14 +237,33 @@ bool TorrentFilter::filterAcceptsRow(int source_row, QModelIndex const& source_p
 
     if (accepts)
     {
-        auto const m = prefs_.get<FilterMode>(Prefs::FILTER_MODE);
-        accepts = m.test(tor);
+        bool included_in_activities = false;
+        auto const modes = prefs_.get<QList<FilterMode>>(Prefs::FILTER_MODE);
+
+        for (const FilterMode& mode : modes) {
+            included_in_activities = included_in_activities || mode.test(tor);
+        }
+
+        if (modes.isEmpty()) {
+            included_in_activities = true;
+        }
+
+        accepts = included_in_activities;
     }
 
     if (accepts)
     {
-        auto const display_name = prefs_.getString(Prefs::FILTER_TRACKERS);
-        accepts = display_name.isEmpty() || tor.includesTracker(display_name.toLower());
+        bool included_in_trackers = false;
+        auto const display_names = prefs_.get<QStringList>(Prefs::FILTER_TRACKERS);
+        for (const QString& display_name : display_names) {
+            included_in_trackers = included_in_trackers || tor.includesTracker(display_name.toLower());
+        }
+
+        if (display_names.isEmpty()) {
+            included_in_trackers = true;
+        }
+
+        accepts = included_in_trackers;
     }
 
     if (accepts)


### PR DESCRIPTION
Adds "trackerview", which is intended as a replacement/enhancement of the filterbar. This new GUI element allows the user to more granularly select which torrents to display:
- Group of torrents from different trackers
- Group of torrents with different activity states
- torrents that contain a specific search term
- any combination of the above

trackerview and filterbar work simultaneously, so users can choose to adopt the new method of filtering their torrents or stay with the old one.