### PR TITLE
Dropped tr_rand_int_weak (where possible).

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -27,7 +27,7 @@
 #include "announce-list.h"
 #include "announcer-common.h"
 #include "announcer.h"
-#include "crypto-utils.h" /* tr_rand_int(), tr_rand_int_weak() */
+#include "crypto-utils.h" /* tr_rand_int() */
 #include "log.h"
 #include "session.h"
 #include "timer.h"
@@ -303,19 +303,19 @@ struct tr_tracker
             return 20;
 
         case 2:
-            return tr_rand_int_weak(60) + 60 * 5;
+            return tr_rand_int(60) + 60 * 5;
 
         case 3:
-            return tr_rand_int_weak(60) + 60 * 15;
+            return tr_rand_int(60) + 60 * 15;
 
         case 4:
-            return tr_rand_int_weak(60) + 60 * 30;
+            return tr_rand_int(60) + 60 * 30;
 
         case 5:
-            return tr_rand_int_weak(60) + 60 * 60;
+            return tr_rand_int(60) + 60 * 60;
 
         default:
-            return tr_rand_int_weak(60) + 60 * 120;
+            return tr_rand_int(60) + 60 * 120;
         }
     }
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -12,7 +12,7 @@
 #include "transmission.h"
 
 #include "bandwidth.h"
-#include "crypto-utils.h" // tr_rand_int_weak()
+#include "crypto-utils.h" // tr_rand_int()
 #include "log.h"
 #include "peer-io.h"
 #include "tr-assert.h"
@@ -175,7 +175,7 @@ void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peer_array, tr_direction di
     auto n = peer_array.size();
     while (n > 0)
     {
-        auto const i = tr_rand_int_weak(n); /* pick a peer at random */
+        auto const i = tr_rand_int(n); /* pick a peer at random */
 
         // value of 3000 bytes chosen so that when using µTP we'll send a full-size
         // frame right away and leave enough buffered data for the next frame to go

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -95,6 +95,7 @@ static int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
 {
     for (size_t i = 0; i < buffer_size; ++i)
     {
+        // my_rand is used to initialize tr_rand_buffer itself used by tr_rand_int, so we can only use tr_rand_int_weak here
         buffer[i] = tr_rand_int_weak(256);
     }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2176,7 +2176,7 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
 
         if (auto const n = std::size(rand_pool); n != 0)
         {
-            auto* c = rand_pool[tr_rand_int_weak(n)];
+            auto* c = rand_pool[tr_rand_int(n)];
             c->is_choked = false;
             s->optimistic = c->msgs;
             s->optimistic_unchoke_time_scaler = OptimisticUnchokeMultiplier;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -75,7 +75,7 @@ tr_port tr_session::randomPort() const
     auto const lower = std::min(settings_.peer_port_random_low.host(), settings_.peer_port_random_high.host());
     auto const upper = std::max(settings_.peer_port_random_low.host(), settings_.peer_port_random_high.host());
     auto const range = upper - lower;
-    return tr_port::fromHost(lower + tr_rand_int_weak(range + 1));
+    return tr_port::fromHost(lower + tr_rand_int(range + 1));
 }
 
 /* Generate a peer id : "-TRxyzb-" + 12 random alphanumeric

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -204,7 +204,7 @@ public:
 
         // Being slightly late is fine,
         // and has the added benefit of adding some jitter.
-        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int_weak(1000) };
+        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000) };
         periodic_timer_->startSingleShot(interval);
     }
 
@@ -323,8 +323,8 @@ private:
     {
         auto const* dht_hash = reinterpret_cast<unsigned char const*>(std::data(info_hash));
         auto const rc = mediator_.api().search(dht_hash, port.host(), af, callback, this);
-        auto const announce_again_in_n_secs = rc < 0 ? 5s + std::chrono::seconds{ tr_rand_int_weak(5) } :
-                                                       25min + std::chrono::seconds{ tr_rand_int_weak(3 * 60) };
+        auto const announce_again_in_n_secs = rc < 0 ? 5s + std::chrono::seconds{ tr_rand_int(5) } :
+                                                       25min + std::chrono::seconds{ tr_rand_int(3 * 60) };
         return announce_again_in_n_secs;
     }
 
@@ -363,7 +363,7 @@ private:
 
         // Being slightly late is fine,
         // and has the added benefit of adding some jitter.
-        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int_weak(1000) };
+        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000) };
         periodic_timer_->startSingleShot(interval);
     }
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -12,7 +12,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" // tr_rand_int_weak()
+#include "crypto-utils.h" // tr_rand_int()
 #include "log.h"
 #include "net.h"
 #include "peer-io.h"
@@ -153,7 +153,7 @@ static uint64 utp_callback(utp_callback_arguments* args)
 static void reset_timer(tr_session* session)
 {
     auto interval = std::chrono::milliseconds{};
-    auto const random_percent = tr_rand_int_weak(1000) / 1000.0;
+    auto const random_percent = tr_rand_int(1000) / 1000.0;
 
     if (session->allowsUTP())
     {

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -20,21 +20,21 @@ TEST(Bitfield, count)
 
     for (auto i = 0; i < IterCount; ++i)
     {
-        int const bit_count = 100 + tr_rand_int_weak(1000);
+        int const bit_count = 100 + tr_rand_int(1000);
 
         // generate a random bitfield
         tr_bitfield bf(bit_count);
 
-        for (int j = 0, n = tr_rand_int_weak(bit_count); j < n; ++j)
+        for (int j = 0, n = tr_rand_int(bit_count); j < n; ++j)
         {
-            bf.set(tr_rand_int_weak(bit_count));
+            bf.set(tr_rand_int(bit_count));
         }
 
-        int begin = tr_rand_int_weak(bit_count);
+        int begin = tr_rand_int(bit_count);
         int end = 0;
         do
         {
-            end = tr_rand_int_weak(bit_count);
+            end = tr_rand_int(bit_count);
         } while (end == begin);
 
         // ensure end <= begin

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -266,14 +266,14 @@ TEST(Crypto, base64)
         auto buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
-            buf += static_cast<char>(tr_rand_int_weak(256));
+            buf += static_cast<char>(tr_rand_int(256));
         }
         EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
 
         buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
-            buf += static_cast<char>(1 + tr_rand_int_weak(255));
+            buf += static_cast<char>(1 + tr_rand_int(255));
         }
         EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
     }

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -37,7 +37,7 @@ protected:
 
     auto makeRandomFiles(
         std::string_view top,
-        size_t n_files = std::max(size_t{ 1U }, static_cast<size_t>(tr_rand_int_weak(DefaultMaxFileCount))),
+        size_t n_files = std::max(size_t{ 1U }, static_cast<size_t>(tr_rand_int(DefaultMaxFileCount))),
         size_t max_size = DefaultMaxFileSize)
     {
         auto files = std::vector<std::pair<std::string, std::vector<std::byte>>>{};
@@ -50,7 +50,7 @@ protected:
             // builder-to-metainfo comparisons here. tr_torrent_metainfo
             // will behave when BEP52 support is added in Transmission 5.
             static auto constexpr MinFileSize = size_t{ 1U };
-            payload.resize(std::max(MinFileSize, static_cast<size_t>(tr_rand_int_weak(max_size))));
+            payload.resize(std::max(MinFileSize, static_cast<size_t>(tr_rand_int(max_size))));
             tr_rand_buffer(std::data(payload), std::size(payload));
 
             auto filename = tr_pathbuf{ top, '/', "test.XXXXXX" };

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -22,7 +22,7 @@
 
 #include "transmission.h"
 
-#include "crypto-utils.h" // tr_rand_int_weak()
+#include "crypto-utils.h" // tr_rand_int()
 #include "platform.h"
 #include "tr-strbuf.h"
 #include "utils.h"


### PR DESCRIPTION
Adopting tr_rand_int instead of tr_rand_int_weak everywhere except in Polar SSL, because in Polar SSL my_rand is used to seed the initial tr_rand_int.