### PR TITLE
refactor: UDP and TCP announces use same timeout interval

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <array>
+#include <chrono>
 #include <cstdint> // uint64_t
 #include <functional>
 #include <optional>
@@ -163,6 +164,9 @@ struct tr_announce_response
  * length, announcer will incrementally lower the batch size.
  */
 auto inline constexpr TR_MULTISCRAPE_MAX = 60;
+
+auto inline constexpr TR_ANNOUNCE_TIMEOUT_SEC = std::chrono::seconds{ 45 };
+auto inline constexpr TR_SCRAPE_TIMEOUT_SEC = std::chrono::seconds{ 30 };
 
 struct tr_scrape_request
 {

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -426,7 +426,7 @@ void tr_tracker_http_announce(
     auto url = tr_urlbuf{};
     announce_url_new(url, session, request);
     auto options = tr_web::FetchOptions{ url.sv(), onAnnounceDone, d };
-    options.timeout_secs = 45s;
+    options.timeout_secs = TR_ANNOUNCE_TIMEOUT_SEC;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
 
@@ -698,7 +698,7 @@ void tr_tracker_http_scrape(tr_session const* session, tr_scrape_request const& 
     scrape_url_new(scrape_url, request);
     tr_logAddTrace(fmt::format("Sending scrape to libcurl: '{}'", scrape_url), request.log_name);
     auto options = tr_web::FetchOptions{ scrape_url, onScrapeDone, d };
-    options.timeout_secs = 30s;
+    options.timeout_secs = TR_SCRAPE_TIMEOUT_SEC;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
     session->fetch(std::move(options));


### PR DESCRIPTION
TCP and UDP announces had been using different timeout values. This PR makes them consistent.