### PR TITLE
refactor: add tr_announcer.startShutdown()

### DIFF
--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -71,6 +71,9 @@ public:
     virtual void stopTorrent(tr_torrent* tor) = 0;
     virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
+
+    virtual void startShutdown() = 0;
+    [[nodiscard]] virtual size_t pendingAnnounces() const = 0;
 };
 
 std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
@@ -141,15 +144,11 @@ public:
 
     [[nodiscard]] static std::unique_ptr<tr_announcer_udp> create(Mediator&);
 
-    [[nodiscard]] virtual bool isIdle() const noexcept = 0;
-
     virtual void announce(tr_announce_request const& request, tr_announce_response_func on_response) = 0;
 
     virtual void scrape(tr_scrape_request const& request, tr_scrape_response_func on_response) = 0;
 
     virtual void upkeep() = 0;
-
-    virtual void startShutdown() = 0;
 
     // @brief process an incoming udp message if it's a tracker response.
     // @return true if msg was a tracker response; false otherwise

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -310,22 +310,18 @@ TEST_F(AnnouncerUdpTest, canScrape)
     auto [request, expected_response] = buildSimpleScrapeRequestAndResponse();
     auto response = std::optional<tr_scrape_response>{};
     announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
-    EXPECT_FALSE(announcer->isIdle());
 
     // The announcer should have sent a UDP connection request.
     // Inspect that request for validity.
     auto sent = waitForAnnouncerToSendMessage(mediator);
-    EXPECT_FALSE(announcer->isIdle());
     auto connect_transaction_id = parseConnectionRequest(sent);
 
     // Have the tracker respond to the request
     auto const connection_id = sendConnectionResponse(*announcer, connect_transaction_id);
-    EXPECT_FALSE(announcer->isIdle());
 
     // The announcer should have sent a UDP scrape request.
     // Inspect that request for validity.
     sent = waitForAnnouncerToSendMessage(mediator);
-    EXPECT_FALSE(announcer->isIdle());
     auto [scrape_transaction_id, info_hashes] = parseScrapeRequest(sent, connection_id);
     expectEqual(request, info_hashes);
 
@@ -340,7 +336,6 @@ TEST_F(AnnouncerUdpTest, canScrape)
     auto arr = std::array<uint8_t, 256>{};
     buf.toBuf(std::data(arr), response_size);
     EXPECT_TRUE(announcer->handleMessage(std::data(arr), response_size));
-    EXPECT_TRUE(announcer->isIdle());
 
     // confirm that announcer processed the response
     EXPECT_TRUE(response);


### PR DESCRIPTION
Move announcer shutdown responsibilities from `tr_announcer_udp` to `tr_announcer`