### PR TITLE
fix: shut down utp sooner during session shutdown

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1213,6 +1213,8 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
     is_closing_ = true;
 
     // close the low-hanging fruit that can be closed immediately w/o consequences
+    utp_timer.reset();
+    tr_utpClose(this);
     verifier_.reset();
     save_timer_.reset();
     now_timer_.reset();
@@ -1277,7 +1279,6 @@ void tr_session::closeImplPart2(std::promise<void>* closed_promise, std::chrono:
 
     stats().saveIfDirty();
     peer_mgr_.reset();
-    tr_utpClose(this);
     openFiles().closeAll();
 
     // tada we are done!


### PR DESCRIPTION
This prevents uTP callbacks from being routed to other pieces that have already been shutdown. :boom: 