### PR TITLE
Fixed missing tracker icons.

### DIFF
--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -32,12 +32,13 @@ static CGFloat const kCountWidth = 60.0;
 @implementation TrackerCell
 
 //make the favicons accessible to all tracker cells
-NSCache* fTrackerIconCache;
+NSCache<NSString*, id>* fTrackerIconCache;
 NSMutableSet* fTrackerIconLoading;
 
 + (void)initialize
 {
     fTrackerIconCache = [[NSCache alloc] init];
+    fTrackerIconCache.evictsObjectsWithDiscardedContent = NO;
     fTrackerIconLoading = [[NSMutableSet alloc] init];
 }
 


### PR DESCRIPTION
Problem: tracker icons show the default icon because fTrackerIconCache always return empty objects.
Solution: adopt `evictsObjectsWithDiscardedContent` to avoid icons being discarded immediately.