### PR TITLE
refactor, ci: switch clang-format to LLVM 15

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -84,7 +84,10 @@ jobs:
           submodules: recursive
       - name: Get Dependencies
         run: |
-          sudo apt-get install clang-format-12 npm yarn
+          set -ex
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+          sudo apt-get install -y clang-format-15 npm yarn
       - name: Check for style diffs
         id: check-for-diffs
         working-directory: .

--- a/code_style.sh
+++ b/code_style.sh
@@ -40,10 +40,10 @@ find_cfiles() {
        ! \( $(get_find_path_args $(trim_comments .clang-format-ignore)) \) "$@"
 }
 
-# We're targeting clang-format version 12 and other versions give slightly
-# different results, so prefer `clang-format-12` if it's installed.
+# We're targeting clang-format version 15 and other versions give slightly
+# different results, so prefer `clang-format-15` if it's installed.
 clang_format_exe_names=(
-  'clang-format-12'
+  'clang-format-15'
   'clang-format'
 )
 for name in ${clang_format_exe_names[@]}; do

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -55,7 +55,7 @@ static void tr_variant_string_clear(struct tr_variant_string* str)
 {
     if (str->type == TR_STRING_TYPE_HEAP)
     {
-        delete[]((char*)(str->str.str));
+        delete[] ((char*)(str->str.str));
     }
 
     *str = StringInit;

--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -98,8 +98,7 @@
 
 //  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
 //  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
-typedef NS_OPTIONS(u_int, VDKQueueNotify)
-{
+typedef NS_OPTIONS(u_int, VDKQueueNotify) {
     VDKQueueNotifyAboutRename = NOTE_RENAME, ///< Item was renamed.
     VDKQueueNotifyAboutWrite = NOTE_WRITE, ///< Item contents changed (also folder contents changed).
     VDKQueueNotifyAboutDelete = NOTE_DELETE, ///< Item was removed.


### PR DESCRIPTION
Bump required `clang-format` version to 15 and fix the following noise:
```
./macosx/VDKQueue/VDKQueue.h:101:42: error: code should be clang-formatted [-Wclang-format-violations]
typedef NS_OPTIONS(u_int, VDKQueueNotify)
                                         ^
./libtransmission/variant.cc:58:17: error: code should be clang-formatted [-Wclang-format-violations]
        delete[]((char*)(str->str.str));
                ^
```
Signed-off-by: Mike Gelfand <mikedld@mikedld.com>
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>