### PR TITLE
libtransmission: restore libevent headers

### DIFF
--- a/libtransmission/utils-ev.h
+++ b/libtransmission/utils-ev.h
@@ -9,21 +9,11 @@
 
 #pragma once
 
+#include <event2/buffer.h>
+#include <event2/event.h>
+#include <event2/http.h>
+
 #include <memory>
-
-extern "C"
-{
-    struct evbuffer;
-    struct event;
-    struct event_base;
-    struct evhttp;
-
-    void evbuffer_free(struct evbuffer*);
-    void event_base_free(struct event_base*);
-    int event_del(struct event*);
-    void event_free(struct event*);
-    void evhttp_free(struct evhttp*);
-}
 
 namespace libtransmission::evhelpers
 {

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -55,7 +55,7 @@ static void tr_variant_string_clear(struct tr_variant_string* str)
 {
     if (str->type == TR_STRING_TYPE_HEAP)
     {
-        delete[]((char*)(str->str.str));
+        delete[] ((char*)(str->str.str));
     }
 
     *str = StringInit;

--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -98,8 +98,7 @@
 
 //  Logical OR these values into the u_int that you pass in the -addPath:notifyingAbout: method
 //  to specify the types of notifications you're interested in. Pass the default value to receive all of them.
-typedef NS_OPTIONS(u_int, VDKQueueNotify)
-{
+typedef NS_OPTIONS(u_int, VDKQueueNotify) {
     VDKQueueNotifyAboutRename = NOTE_RENAME, ///< Item was renamed.
     VDKQueueNotifyAboutWrite = NOTE_WRITE, ///< Item contents changed (also folder contents changed).
     VDKQueueNotifyAboutDelete = NOTE_DELETE, ///< Item was removed.


### PR DESCRIPTION
 Restore `libevent` headers to prevent the following `-Wredundant-decls`:
```
In file included from libtransmission/rpc-server.h:20,
                 from libtransmission/rpc-server.cc:41:
libtransmission/utils-ev.h:21:10: warning: redundant redeclaration 
of ‘void evbuffer_free(evbuffer*)’ in same scope [-Wredundant-decls]
   21 |     void evbuffer_free(struct evbuffer*);
      |          ^~~~~~~~~~~~~
In file included from libtransmission/rpc-server.cc:23:
/usr/include/event2/buffer.h:159:6: note: previous declaration of ‘void evbuffer_free(evbuffer*)’
  159 | void evbuffer_free(struct evbuffer *buf);
      |      ^~~~~~~~~~~~~
libtransmission/utils-ev.h:22:10: warning: redundant redeclaration of ‘void event_base_free(event_base*)’ in same scope [-Wredundant-decls]
   22 |     void event_base_free(struct event_base*);
      |          ^~~~~~~~~~~~~~~
In file included from /usr/include/event2/listener.h:36,
                 from libtransmission/rpc-server.cc:26:
/usr/include/event2/event.h:692:6: note: previous declaration of ‘void event_base_free(event_base*)’
  692 | void event_base_free(struct event_base *);
      |      ^~~~~~~~~~~~~~~
libtransmission/utils-ev.h:23:9: warning: redundant redeclaration of ‘int event_del(event*)’ in same scope [-Wredundant-decls]
   23 |     int event_del(struct event*);
      |         ^~~~~~~~~
/usr/include/event2/event.h:1259:5: note: previous declaration of ‘int event_del(event*)’
 1259 | int event_del(struct event *);
      |     ^~~~~~~~~
libtransmission/utils-ev.h:24:10: warning: redundant redeclaration of ‘void event_free(event*)’ in same scope [-Wredundant-decls]
   24 |     void event_free(struct event*);
      |          ^~~~~~~~~~
/usr/include/event2/event.h:1141:6: note: previous declaration of ‘void event_free(event*)’
 1141 | void event_free(struct event *);
      |      ^~~~~~~~~~
libtransmission/utils-ev.h:25:10: warning: redundant redeclaration of ‘void evhttp_free(evhttp*)’ in same scope [-Wredundant-decls]
   25 |     void evhttp_free(struct evhttp*);
      |          ^~~~~~~~~~~
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>