### PR TITLE
Fixed `archivedDataWithRootObject:` is deprecated

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3724,7 +3724,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         }
 
         [pasteboard declareTypes:@[ kTorrentTableViewDataType ] owner:self];
-        [pasteboard setData:[NSKeyedArchiver archivedDataWithRootObject:indexSet] forType:kTorrentTableViewDataType];
+        [pasteboard setData:[NSKeyedArchiver archivedDataWithRootObject:indexSet requiringSecureCoding:YES error:nil]
+                    forType:kTorrentTableViewDataType];
         return YES;
     }
     return NO;

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -356,7 +356,9 @@ GroupsController* fGroupsInstance = nil;
         [groups addObject:tempDict];
     }
 
-    [NSUserDefaults.standardUserDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:groups] forKey:@"GroupDicts"];
+    [NSUserDefaults.standardUserDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:groups requiringSecureCoding:YES
+                                                                                         error:nil]
+                                            forKey:@"GroupDicts"];
 }
 
 - (NSImage*)imageForGroupNone

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -93,7 +93,8 @@ typedef NS_ENUM(NSInteger, SegmentTag) {
 - (BOOL)tableView:(NSTableView*)tableView writeRowsWithIndexes:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard*)pboard
 {
     [pboard declareTypes:@[ kGroupTableViewDataType ] owner:self];
-    [pboard setData:[NSKeyedArchiver archivedDataWithRootObject:rowIndexes] forType:kGroupTableViewDataType];
+    [pboard setData:[NSKeyedArchiver archivedDataWithRootObject:rowIndexes requiringSecureCoding:YES error:nil]
+            forType:kGroupTableViewDataType];
     return YES;
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -156,7 +156,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)saveCollapsedGroups
 {
-    [self.fDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:self.fCollapsedGroups] forKey:@"CollapsedGroupIndexes"];
+    [self.fDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:self.fCollapsedGroups requiringSecureCoding:YES error:nil]
+                       forKey:@"CollapsedGroupIndexes"];
 }
 
 - (BOOL)outlineView:(NSOutlineView*)outlineView isGroupItem:(id)item


### PR DESCRIPTION
Tested: secure coding is already supported (since #2973 + #3053)