### PR TITLE
refactor: fine-granted control over libevent prototypes

### DIFF
--- a/libtransmission/utils-ev.h
+++ b/libtransmission/utils-ev.h
@@ -11,19 +11,38 @@
 
 #include <memory>
 
+#ifndef EVENT2_EVENT_H_INCLUDED_
+
 extern "C"
 {
-    struct evbuffer;
     struct event;
     struct event_base;
-    struct evhttp;
-
-    void evbuffer_free(struct evbuffer*);
     void event_base_free(struct event_base*);
     int event_del(struct event*);
     void event_free(struct event*);
+}
+
+#endif // EVENT2_EVENT_H_INCLUDED_
+
+#ifndef EVENT2_BUFFER_H_INCLUDED_
+
+extern "C"
+{
+    struct evbuffer;
+    void evbuffer_free(struct evbuffer*);
+}
+
+#endif // EVENT2_BUFFER_H_INCLUDED_
+
+#ifndef EVENT2_HTTP_H_INCLUDED_
+
+extern "C"
+{
+    struct evhttp;
     void evhttp_free(struct evhttp*);
 }
+
+#endif // EVENT2_HTTP_H_INCLUDED_
 
 namespace libtransmission::evhelpers
 {


### PR DESCRIPTION
This is intended to avoid a lot of warnings emitted with `-Wredundant-decls`.