### PR TITLE
deps: bump libdeflate to v1.15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,7 +32,7 @@
 [submodule "third-party/libdeflate"]
 	path = third-party/libdeflate
 	url = https://github.com/transmission/libdeflate
-	branch = v1.11-plus-cmake
+	branch = v1.15.x
 [submodule "third-party/libpsl"]
 	path = third-party/libpsl
 	url = https://github.com/transmission/libpsl.git


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/3831.

Notes: Use a newer version of [libdeflate](https://github.com/ebiggers/libdeflate/) as a fallback when no preinstalled version can be found on the system.