### PR TITLE
Moving CMAKE_OSX_DEPLOYMENT_TARGET FATAL_ERROR next to its default setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,17 @@ if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW)
 endif()
 
-# The value of this variable should be set prior to the first project() command invocation.
-# See: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
-if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X version to target for deployment" FORCE)
-endif()
-if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.13)
-    message(FATAL_ERROR "Targeting macOS versions before 10.13 is not supported, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
-endif()
+function(tr_set_apple_deployment_targets OSX_DEPLOYMENT_TARGET)
+    # The value of this variable should be set prior to the first project() command invocation.
+    # See: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET ${OSX_DEPLOYMENT_TARGET} CACHE STRING "Minimum OS X version to target for deployment" FORCE)
+    endif()
+    if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS OSX_DEPLOYMENT_TARGET)
+        message(FATAL_ERROR "Targeting macOS versions before ${OSX_DEPLOYMENT_TARGET} is not supported, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
+    endif()
+endfunction()
+tr_set_apple_deployment_targets("10.13")
 
 project(transmission)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,14 @@ if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW)
 endif()
 
-function(tr_set_apple_deployment_targets OSX_DEPLOYMENT_TARGET)
-    # The value of this variable should be set prior to the first project() command invocation.
-    # See: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
-    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET ${OSX_DEPLOYMENT_TARGET} CACHE STRING "Minimum OS X version to target for deployment" FORCE)
-    endif()
-    if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS OSX_DEPLOYMENT_TARGET)
-        message(FATAL_ERROR "Targeting macOS versions before ${OSX_DEPLOYMENT_TARGET} is not supported, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
-    endif()
-endfunction()
-tr_set_apple_deployment_targets("10.13")
+# Value should follow latest stable Xcode's RECOMMENDED_MACOSX_DEPLOYMENT_TARGET
+set(MACOS_SUPPORT_MINIMUM 10.13)
+
+# The value of this variable should be set prior to the first project() command invocation.
+# See: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET ${MACOS_SUPPORT_MINIMUM} CACHE STRING "Minimum macOS version to target for deployment" FORCE)
+endif()
 
 project(transmission)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X version to target for deployment" FORCE)
 endif()
+if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.13)
+    message(FATAL_ERROR "Targeting macOS versions before 10.13 is not supported, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
+endif()
 
 project(transmission)
 

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(trmac)
 
-if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.9)
-    # 10.9 required for actool to produce Assets.car
-    message(FATAL_ERROR "Targeting macOS versions before 10.9 is not supported, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
-endif()
-
 include_directories(${CMAKE_SOURCE_DIR})
 
 add_compile_options(

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(trmac)
 
+if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS MACOS_SUPPORT_MINIMUM)
+    message(FATAL_ERROR "Targeting macOS versions before ${MACOS_SUPPORT_MINIMUM} is not supported for the macOS project, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
+endif()
+
 include_directories(${CMAKE_SOURCE_DIR})
 
 add_compile_options(


### PR DESCRIPTION
This refactor is to ensure consistency and unique source of truth between the default value and the minimum value of CMAKE_OSX_DEPLOYMENT_TARGET.