### PR TITLE
refactor: fix shutdown order of utp

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1214,7 +1214,6 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
 
     // close the low-hanging fruit that can be closed immediately w/o consequences
     utp_timer.reset();
-    tr_utpClose(this);
     verifier_.reset();
     save_timer_.reset();
     now_timer_.reset();
@@ -1244,6 +1243,7 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
         tr_torrentFreeInSessionThread(tor);
     }
     torrents.clear();
+    tr_utpClose(this);
     // ...now that all the torrents have been closed, any remaining
     // `&event=stopped` announce messages are queued in the announcer.
     // Tell the announcer to start shutdown, which sends out the stop

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1125,6 +1125,10 @@ private:
     AltSpeedMediator alt_speed_mediator_{ *this };
     tr_session_alt_speeds alt_speeds_{ alt_speed_mediator_ };
 
+public:
+    struct struct_utp_context* utp_context = nullptr;
+
+private:
     // depends-on: open_files_
     tr_torrents torrents_;
 
@@ -1175,7 +1179,6 @@ private:
     std::unique_ptr<tr_verify_worker> verifier_ = std::make_unique<tr_verify_worker>();
 
 public:
-    struct struct_utp_context* utp_context = nullptr;
     std::unique_ptr<libtransmission::Timer> utp_timer;
 };
 


### PR DESCRIPTION
Fixes #4316.

Notes: Fixed `4.0.0-beta.2` crash on shutdown in `utp_set_userdata()`.