### PR TITLE
refactor: tr_address::display_name()

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -181,7 +181,7 @@ struct tr_handshake
 ***
 **/
 
-#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->io->to_text())
+#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->io->display_name())
 
 static constexpr std::string_view getStateName(handshake_state_t const state)
 {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -181,7 +181,7 @@ struct tr_handshake
 ***
 **/
 
-#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->io->addrStr())
+#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->io->to_text())
 
 static constexpr std::string_view getStateName(handshake_state_t const state)
 {

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -298,7 +298,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't set source address {address} on {socket}: {error} ({error_code})"),
-            fmt::arg("address", source_addr.readable()),
+            fmt::arg("address", source_addr.to_text()),
             fmt::arg("socket", s),
             fmt::arg("error", tr_net_strerror(sockerrno)),
             fmt::arg("error_code", sockerrno)));
@@ -318,7 +318,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
             tr_logAddWarn(fmt::format(
                 _("Couldn't connect socket {socket} to {address}:{port}: {error} ({error_code})"),
                 fmt::arg("socket", s),
-                fmt::arg("address", addr.readable()),
+                fmt::arg("address", addr.to_text()),
                 fmt::arg("port", port.host()),
                 fmt::arg("error", tr_net_strerror(tmperrno)),
                 fmt::arg("error_code", tmperrno)));
@@ -331,7 +331,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
         ret = tr_peer_socket{ session, addr, port, s };
     }
 
-    tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, addr.readable(port)));
+    tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, addr.to_text(port)));
 
     return ret;
 }
@@ -409,7 +409,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
                 err == EADDRINUSE ?
                     _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
                     _("Couldn't bind port {port} on {address}: {error} ({error_code})"),
-                fmt::arg("address", addr.readable()),
+                fmt::arg("address", addr.to_text()),
                 fmt::arg("port", port.host()),
                 fmt::arg("error", tr_net_strerror(err)),
                 fmt::arg("error_code", err)));
@@ -422,7 +422,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
 
     if (!suppress_msgs)
     {
-        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.readable()));
+        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.to_text()));
     }
 
 #ifdef TCP_FASTOPEN
@@ -776,7 +776,7 @@ std::optional<tr_address> tr_address::fromString(std::string_view address_sv)
     return {};
 }
 
-std::string_view tr_address::readable(char* out, size_t outlen, tr_port port) const
+std::string_view tr_address::to_text(char* out, size_t outlen, tr_port port) const
 {
     if (std::empty(port))
     {
@@ -784,26 +784,26 @@ std::string_view tr_address::readable(char* out, size_t outlen, tr_port port) co
     }
 
     auto buf = std::array<char, INET6_ADDRSTRLEN>{};
-    auto const addr_sv = readable(std::data(buf), std::size(buf));
+    auto const addr_sv = to_text(std::data(buf), std::size(buf));
     auto const [end, size] = fmt::format_to_n(out, outlen - 1, FMT_STRING("[{:s}]:{:d}"), addr_sv, port.host());
     return { out, size };
 }
 
 template<typename OutputIt>
-OutputIt tr_address::readable(OutputIt out, tr_port port) const
+OutputIt tr_address::to_text(OutputIt out, tr_port port) const
 {
     auto addrbuf = std::array<char, TR_ADDRSTRLEN + 16>{};
-    auto const addr_sv = readable(std::data(addrbuf), std::size(addrbuf), port);
+    auto const addr_sv = to_text(std::data(addrbuf), std::size(addrbuf), port);
     return std::copy(std::begin(addr_sv), std::end(addr_sv), out);
 }
 
-template char* tr_address::readable<char*>(char*, tr_port) const;
+template char* tr_address::to_text<char*>(char*, tr_port) const;
 
-[[nodiscard]] std::string tr_address::readable(tr_port port) const
+[[nodiscard]] std::string tr_address::to_text(tr_port port) const
 {
     auto buf = std::string{};
     buf.reserve(INET6_ADDRSTRLEN + 16);
-    this->readable(std::back_inserter(buf), port);
+    this->to_text(std::back_inserter(buf), port);
     return buf;
 }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -298,7 +298,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
     {
         tr_logAddWarn(fmt::format(
             _("Couldn't set source address {address} on {socket}: {error} ({error_code})"),
-            fmt::arg("address", source_addr.to_text()),
+            fmt::arg("address", source_addr.display_name()),
             fmt::arg("socket", s),
             fmt::arg("error", tr_net_strerror(sockerrno)),
             fmt::arg("error_code", sockerrno)));
@@ -318,7 +318,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
             tr_logAddWarn(fmt::format(
                 _("Couldn't connect socket {socket} to {address}:{port}: {error} ({error_code})"),
                 fmt::arg("socket", s),
-                fmt::arg("address", addr.to_text()),
+                fmt::arg("address", addr.display_name()),
                 fmt::arg("port", port.host()),
                 fmt::arg("error", tr_net_strerror(tmperrno)),
                 fmt::arg("error_code", tmperrno)));
@@ -331,7 +331,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
         ret = tr_peer_socket{ session, addr, port, s };
     }
 
-    tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, addr.to_text(port)));
+    tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, addr.display_name(port)));
 
     return ret;
 }
@@ -409,7 +409,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
                 err == EADDRINUSE ?
                     _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
                     _("Couldn't bind port {port} on {address}: {error} ({error_code})"),
-                fmt::arg("address", addr.to_text()),
+                fmt::arg("address", addr.display_name()),
                 fmt::arg("port", port.host()),
                 fmt::arg("error", tr_net_strerror(err)),
                 fmt::arg("error_code", err)));
@@ -422,7 +422,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
 
     if (!suppress_msgs)
     {
-        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.to_text()));
+        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.display_name()));
     }
 
 #ifdef TCP_FASTOPEN
@@ -776,7 +776,7 @@ std::optional<tr_address> tr_address::fromString(std::string_view address_sv)
     return {};
 }
 
-std::string_view tr_address::to_text(char* out, size_t outlen, tr_port port) const
+std::string_view tr_address::display_name(char* out, size_t outlen, tr_port port) const
 {
     if (std::empty(port))
     {
@@ -784,26 +784,26 @@ std::string_view tr_address::to_text(char* out, size_t outlen, tr_port port) con
     }
 
     auto buf = std::array<char, INET6_ADDRSTRLEN>{};
-    auto const addr_sv = to_text(std::data(buf), std::size(buf));
+    auto const addr_sv = display_name(std::data(buf), std::size(buf));
     auto const [end, size] = fmt::format_to_n(out, outlen - 1, FMT_STRING("[{:s}]:{:d}"), addr_sv, port.host());
     return { out, size };
 }
 
 template<typename OutputIt>
-OutputIt tr_address::to_text(OutputIt out, tr_port port) const
+OutputIt tr_address::display_name(OutputIt out, tr_port port) const
 {
     auto addrbuf = std::array<char, TR_ADDRSTRLEN + 16>{};
-    auto const addr_sv = to_text(std::data(addrbuf), std::size(addrbuf), port);
+    auto const addr_sv = display_name(std::data(addrbuf), std::size(addrbuf), port);
     return std::copy(std::begin(addr_sv), std::end(addr_sv), out);
 }
 
-template char* tr_address::to_text<char*>(char*, tr_port) const;
+template char* tr_address::display_name<char*>(char*, tr_port) const;
 
-[[nodiscard]] std::string tr_address::to_text(tr_port port) const
+[[nodiscard]] std::string tr_address::display_name(tr_port port) const
 {
     auto buf = std::string{};
     buf.reserve(INET6_ADDRSTRLEN + 16);
-    this->to_text(std::back_inserter(buf), port);
+    this->display_name(std::back_inserter(buf), port);
     return buf;
 }
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -158,11 +158,11 @@ struct tr_address
     [[nodiscard]] static std::pair<tr_address, std::byte const*> fromCompact4(std::byte const* compact) noexcept;
     [[nodiscard]] static std::pair<tr_address, std::byte const*> fromCompact6(std::byte const* compact) noexcept;
 
-    // human-readable formatting
+    // write the text form of the address, e.g. inet_ntop()
     template<typename OutputIt>
-    OutputIt readable(OutputIt out, tr_port port = {}) const;
-    std::string_view readable(char* out, size_t outlen, tr_port port = {}) const;
-    [[nodiscard]] std::string readable(tr_port port = {}) const;
+    OutputIt to_text(OutputIt out, tr_port port = {}) const;
+    std::string_view to_text(char* out, size_t outlen, tr_port port = {}) const;
+    [[nodiscard]] std::string to_text(tr_port port = {}) const;
 
     template<typename OutputIt>
     static OutputIt toCompact4(OutputIt out, in_addr const* addr4, tr_port port)

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -160,9 +160,9 @@ struct tr_address
 
     // write the text form of the address, e.g. inet_ntop()
     template<typename OutputIt>
-    OutputIt to_text(OutputIt out, tr_port port = {}) const;
-    std::string_view to_text(char* out, size_t outlen, tr_port port = {}) const;
-    [[nodiscard]] std::string to_text(tr_port port = {}) const;
+    OutputIt display_name(OutputIt out, tr_port port = {}) const;
+    std::string_view display_name(char* out, size_t outlen, tr_port port = {}) const;
+    [[nodiscard]] std::string display_name(tr_port port = {}) const;
 
     template<typename OutputIt>
     static OutputIt toCompact4(OutputIt out, in_addr const* addr4, tr_port port)

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -202,7 +202,7 @@ public:
         return has().hasAll();
     }
 
-    [[nodiscard]] virtual std::string to_text() const = 0;
+    [[nodiscard]] virtual std::string display_name() const = 0;
 
     [[nodiscard]] virtual tr_bitfield const& has() const noexcept = 0;
 

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -202,7 +202,7 @@ public:
         return has().hasAll();
     }
 
-    [[nodiscard]] virtual std::string readable() const = 0;
+    [[nodiscard]] virtual std::string to_text() const = 0;
 
     [[nodiscard]] virtual tr_bitfield const& has() const noexcept = 0;
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -42,10 +42,10 @@
 
 static constexpr auto UtpReadBufferSize = 256 * 1024;
 
-#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->addrStr())
-#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->addrStr())
-#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->addrStr())
-#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->addrStr())
+#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->to_text())
+#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->to_text())
+#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->to_text())
+#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->to_text())
 
 static constexpr size_t guessPacketOverhead(size_t d)
 {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -42,10 +42,10 @@
 
 static constexpr auto UtpReadBufferSize = 256 * 1024;
 
-#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->to_text())
-#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->to_text())
-#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->to_text())
-#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->to_text())
+#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->display_name())
+#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->display_name())
+#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
+#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
 static constexpr size_t guessPacketOverhead(size_t d)
 {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -101,9 +101,9 @@ public:
         return socket.socketAddress();
     }
 
-    [[nodiscard]] auto to_text() const
+    [[nodiscard]] auto display_name() const
     {
-        return socket.to_text();
+        return socket.display_name();
     }
 
     void readBufferDrain(size_t byte_count);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -101,7 +101,7 @@ public:
         return socket.socketAddress();
     }
 
-    [[nodiscard]] auto addrStr() const
+    [[nodiscard]] auto to_text() const
     {
         return socket.to_text();
     }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -103,7 +103,7 @@ public:
 
     [[nodiscard]] auto addrStr() const
     {
-        return socket.readable();
+        return socket.to_text();
     }
 
     void readBufferDrain(size_t byte_count);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -173,9 +173,9 @@ struct peer_atom
         return (flags & ADDED_F_SEED_FLAG) != 0;
     }
 
-    [[nodiscard]] auto readable() const
+    [[nodiscard]] auto to_text() const
     {
-        return addr.readable(port);
+        return addr.to_text(port);
     }
 
     [[nodiscard]] bool isBlocklisted(tr_session const* session) const
@@ -465,13 +465,13 @@ public:
 
     void addStrike(tr_peer* peer) const
     {
-        tr_logAddTraceSwarm(this, fmt::format("increasing peer {} strike count to {}", peer->readable(), peer->strikes + 1));
+        tr_logAddTraceSwarm(this, fmt::format("increasing peer {} strike count to {}", peer->to_text(), peer->strikes + 1));
 
         if (++peer->strikes >= MaxBadPiecesPerPeer)
         {
             peer->atom->flags2 |= MyflagBanned;
             peer->do_purge = true;
-            tr_logAddTraceSwarm(this, fmt::format("banning peer {}", peer->readable()));
+            tr_logAddTraceSwarm(this, fmt::format("banning peer {}", peer->to_text()));
         }
     }
 
@@ -733,7 +733,7 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
 
 static void atomSetSeed(tr_swarm* swarm, peer_atom& atom)
 {
-    tr_logAddTraceSwarm(swarm, fmt::format("marking peer {} as a seed", atom.readable()));
+    tr_logAddTraceSwarm(swarm, fmt::format("marking peer {} as a seed", atom.to_text()));
     atom.flags |= ADDED_F_SEED_FLAG;
     swarm->markAllSeedsFlagDirty();
 }
@@ -1064,9 +1064,7 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const& event, void* vs
             peer->do_purge = true;
             tr_logAddDebugSwarm(
                 s,
-                fmt::format(
-                    "setting {} do_purge flag because we got an ERANGE, EMSGSIZE, or ENOTCONN error",
-                    peer->readable()));
+                fmt::format("setting {} do_purge flag because we got an ERANGE, EMSGSIZE, or ENOTCONN error", peer->to_text()));
         }
         else
         {
@@ -1168,7 +1166,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
                 {
                     tr_logAddTraceSwarm(
                         s,
-                        fmt::format("marking peer {} as unreachable... num_fails is {}", atom->readable(), atom->num_fails));
+                        fmt::format("marking peer {} as unreachable... num_fails is {}", atom->to_text(), atom->num_fails));
                     atom->flags2 |= MyflagUnreachable;
                 }
             }
@@ -1197,7 +1195,7 @@ static bool on_handshake_done(tr_handshake_result const& result)
 
         if ((atom->flags2 & MyflagBanned) != 0)
         {
-            tr_logAddTraceSwarm(s, fmt::format("banned peer {} tried to reconnect", atom->readable()));
+            tr_logAddTraceSwarm(s, fmt::format("banned peer {} tried to reconnect", atom->to_text()));
         }
         else if (result.io->isIncoming() && s->peerCount() >= s->tor->peerLimit())
         {
@@ -1236,7 +1234,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
 
     if (session->addressIsBlocked(socket.address()))
     {
-        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", socket.readable()));
+        tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", socket.to_text()));
         socket.close(session);
     }
     else if (manager->incoming_handshakes.contains(socket.address()))
@@ -1347,7 +1345,7 @@ void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t piece_index)
                 swarm,
                 fmt::format(
                     "peer {} contributed to corrupt piece ({}); now has {} strikes",
-                    peer->readable(),
+                    peer->to_text(),
                     piece_index,
                     peer->strikes + 1));
             swarm->addStrike(peer);
@@ -1668,7 +1666,7 @@ namespace peer_stat_helpers
 
     auto const [addr, port] = peer->socketAddress();
 
-    addr.readable(stats.addr, sizeof(stats.addr));
+    addr.to_text(stats.addr, sizeof(stats.addr));
     stats.client = peer->client.c_str();
     stats.port = port.host();
     stats.from = atom->fromFirst;
@@ -2280,7 +2278,7 @@ auto constexpr MaxUploadIdleSecs = time_t{ 60 * 5 };
     /* if it's marked for purging, close it */
     if (peer->do_purge)
     {
-        tr_logAddTraceSwarm(s, fmt::format("purging peer {} because its do_purge flag is set", peer->readable()));
+        tr_logAddTraceSwarm(s, fmt::format("purging peer {} because its do_purge flag is set", peer->to_text()));
         return true;
     }
 
@@ -2311,7 +2309,7 @@ auto constexpr MaxUploadIdleSecs = time_t{ 60 * 5 };
         {
             tr_logAddTraceSwarm(
                 s,
-                fmt::format("purging peer {} because it's been {} secs since we shared anything", peer->readable(), idle_time));
+                fmt::format("purging peer {} because it's been {} secs since we shared anything", peer->to_text(), idle_time));
             return true;
         }
     }
@@ -2329,16 +2327,16 @@ void closePeer(tr_peer* peer)
        to them fruitlessly, so mark it as another fail */
     if (auto* const atom = peer->atom; atom->piece_data_time != 0)
     {
-        tr_logAddTraceSwarm(s, fmt::format("resetting atom {} num_fails to 0", peer->readable()));
+        tr_logAddTraceSwarm(s, fmt::format("resetting atom {} num_fails to 0", peer->to_text()));
         atom->num_fails = 0;
     }
     else
     {
         ++atom->num_fails;
-        tr_logAddTraceSwarm(s, fmt::format("incremented atom {} num_fails to {}", peer->readable(), atom->num_fails));
+        tr_logAddTraceSwarm(s, fmt::format("incremented atom {} num_fails to {}", peer->to_text(), atom->num_fails));
     }
 
-    tr_logAddTraceSwarm(s, fmt::format("removing bad peer {}", peer->readable()));
+    tr_logAddTraceSwarm(s, fmt::format("removing bad peer {}", peer->to_text()));
     peer->swarm->removePeer(peer);
 }
 
@@ -2793,7 +2791,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
         return;
     }
 
-    tr_logAddTraceSwarm(s, fmt::format("Starting an OUTGOING {} connection with {}", utp ? " µTP" : "TCP", atom.readable()));
+    tr_logAddTraceSwarm(s, fmt::format("Starting an OUTGOING {} connection with {}", utp ? " µTP" : "TCP", atom.to_text()));
 
     auto io = tr_peerIo::newOutgoing(
         mgr->session,
@@ -2806,7 +2804,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
 
     if (io == nullptr)
     {
-        tr_logAddTraceSwarm(s, fmt::format("peerIo not created; marking peer {} as unreachable", atom.readable()));
+        tr_logAddTraceSwarm(s, fmt::format("peerIo not created; marking peer {} as unreachable", atom.to_text()));
         atom.flags2 |= MyflagUnreachable;
         ++atom.num_fails;
     }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -109,14 +109,14 @@ struct tr_pex
         size_t added_f_len);
 
     template<typename OutputIt>
-    [[nodiscard]] OutputIt to_text(OutputIt out) const
+    [[nodiscard]] OutputIt display_name(OutputIt out) const
     {
-        return addr.to_text(out, port);
+        return addr.display_name(out, port);
     }
 
-    [[nodiscard]] std::string to_text() const
+    [[nodiscard]] std::string display_name() const
     {
-        return addr.to_text(port);
+        return addr.display_name(port);
     }
 
     [[nodiscard]] int compare(tr_pex const& that) const noexcept // <=>

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -109,14 +109,14 @@ struct tr_pex
         size_t added_f_len);
 
     template<typename OutputIt>
-    [[nodiscard]] OutputIt readable(OutputIt out) const
+    [[nodiscard]] OutputIt to_text(OutputIt out) const
     {
-        return addr.readable(out, port);
+        return addr.to_text(out, port);
     }
 
-    [[nodiscard]] std::string readable() const
+    [[nodiscard]] std::string to_text() const
     {
-        return addr.readable(port);
+        return addr.to_text(port);
     }
 
     [[nodiscard]] int compare(tr_pex const& that) const noexcept // <=>

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -223,7 +223,7 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs);
                 __FILE__, \
                 __LINE__, \
                 (level), \
-                fmt::format(FMT_STRING("{:s} [{:s}]: {:s}"), (msgs)->io->addrStr(), (msgs)->client, text), \
+                fmt::format(FMT_STRING("{:s} [{:s}]: {:s}"), (msgs)->io->to_text(), (msgs)->client, text), \
                 (msgs)->torrent->name()); \
         } \
     } while (0)
@@ -2144,7 +2144,7 @@ static void gotError(tr_peerIo* io, short what, void* vmsgs)
 
     if ((what & BEV_EVENT_EOF) != 0)
     {
-        logdbg(msgs, fmt::format("peer closed connection. {:s}", io->addrStr()));
+        logdbg(msgs, fmt::format("peer closed connection. {:s}", io->to_text()));
     }
     else if (what == BEV_EVENT_ERROR)
     {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -223,7 +223,7 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs);
                 __FILE__, \
                 __LINE__, \
                 (level), \
-                fmt::format(FMT_STRING("{:s} [{:s}]: {:s}"), (msgs)->io->to_text(), (msgs)->client, text), \
+                fmt::format(FMT_STRING("{:s} [{:s}]: {:s}"), (msgs)->io->display_name(), (msgs)->client, text), \
                 (msgs)->torrent->name()); \
         } \
     } while (0)
@@ -412,10 +412,10 @@ public:
         return io->socketAddress();
     }
 
-    [[nodiscard]] std::string to_text() const override
+    [[nodiscard]] std::string display_name() const override
     {
         auto const [addr, port] = socketAddress();
-        return addr.to_text(port);
+        return addr.display_name(port);
     }
 
     [[nodiscard]] tr_bitfield const& has() const noexcept override
@@ -2144,7 +2144,7 @@ static void gotError(tr_peerIo* io, short what, void* vmsgs)
 
     if ((what & BEV_EVENT_EOF) != 0)
     {
-        logdbg(msgs, fmt::format("peer closed connection. {:s}", io->to_text()));
+        logdbg(msgs, fmt::format("peer closed connection. {:s}", io->display_name()));
     }
     else if (what == BEV_EVENT_ERROR)
     {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -412,10 +412,10 @@ public:
         return io->socketAddress();
     }
 
-    [[nodiscard]] std::string readable() const override
+    [[nodiscard]] std::string to_text() const override
     {
         auto const [addr, port] = socketAddress();
-        return addr.readable(port);
+        return addr.to_text(port);
     }
 
     [[nodiscard]] tr_bitfield const& has() const noexcept override

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -13,10 +13,10 @@
 #include "net.h"
 #include "session.h"
 
-#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->to_text())
-#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->to_text())
-#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->to_text())
-#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->to_text())
+#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->display_name())
+#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->display_name())
+#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
+#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
 tr_peer_socket::tr_peer_socket(tr_session* session, tr_address const& address, tr_port port, tr_socket_t sock)
     : handle{ sock }

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -13,10 +13,10 @@
 #include "net.h"
 #include "session.h"
 
-#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->readable())
-#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->readable())
-#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->readable())
-#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->readable())
+#define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->to_text())
+#define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->to_text())
+#define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->to_text())
+#define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->to_text())
 
 tr_peer_socket::tr_peer_socket(tr_session* session, tr_address const& address, tr_port port, tr_socket_t sock)
     : handle{ sock }

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -51,19 +51,19 @@ public:
     }
 
     template<typename OutputIt>
-    OutputIt readable(OutputIt out)
+    OutputIt to_text(OutputIt out)
     {
-        return address_.readable(out, port_);
+        return address_.to_text(out, port_);
     }
 
-    [[nodiscard]] std::string_view readable(char* out, size_t outlen) const
+    [[nodiscard]] std::string_view to_text(char* out, size_t outlen) const
     {
-        return address_.readable(out, outlen, port_);
+        return address_.to_text(out, outlen, port_);
     }
 
-    [[nodiscard]] std::string readable() const
+    [[nodiscard]] std::string to_text() const
     {
-        return address_.readable(port_);
+        return address_.to_text(port_);
     }
 
     [[nodiscard]] constexpr auto is_utp() const noexcept

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -51,19 +51,19 @@ public:
     }
 
     template<typename OutputIt>
-    OutputIt to_text(OutputIt out)
+    OutputIt display_name(OutputIt out)
     {
-        return address_.to_text(out, port_);
+        return address_.display_name(out, port_);
     }
 
-    [[nodiscard]] std::string_view to_text(char* out, size_t outlen) const
+    [[nodiscard]] std::string_view display_name(char* out, size_t outlen) const
     {
-        return address_.to_text(out, outlen, port_);
+        return address_.display_name(out, outlen, port_);
     }
 
-    [[nodiscard]] std::string to_text() const
+    [[nodiscard]] std::string display_name() const
     {
-        return address_.to_text(port_);
+        return address_.display_name(port_);
     }
 
     [[nodiscard]] constexpr auto is_utp() const noexcept

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -208,7 +208,7 @@ private:
             mediator_.localPeerPort(),
             is_enabled,
             do_check,
-            mediator_.incomingPeerAddress().to_text());
+            mediator_.incomingPeerAddress().display_name());
 
         if (auto const new_state = state(); new_state != old_state)
         {

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -208,7 +208,7 @@ private:
             mediator_.localPeerPort(),
             is_enabled,
             do_check,
-            mediator_.incomingPeerAddress().readable());
+            mediator_.incomingPeerAddress().to_text());
 
         if (auto const new_state = state(); new_state != old_state)
         {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -164,7 +164,7 @@ bool tr_session::LpdMediator::onPeerFound(std::string_view info_hash_str, tr_add
     // we found a suitable peer, add it to the torrent
     auto pex = tr_pex{ address, port };
     tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, &pex, 1U);
-    tr_logAddDebugTor(tor, fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), address.readable(port)));
+    tr_logAddDebugTor(tor, fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), address.to_text(port)));
     return true;
 }
 
@@ -221,7 +221,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
     auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET);
     if (!is_default_value)
     {
-        return addr.readable();
+        return addr.to_text();
     }
 
     return std::nullopt;
@@ -232,7 +232,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV6() const
     auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET6);
     if (!is_default_value)
     {
-        return addr.readable();
+        return addr.to_text();
     }
 
     return std::nullopt;
@@ -296,7 +296,7 @@ void tr_session::onIncomingPeerConnection(tr_socket_t fd, void* vsession)
     if (auto const incoming_info = tr_netAccept(session, fd); incoming_info)
     {
         auto const& [addr, port, sock] = *incoming_info;
-        tr_logAddTrace(fmt::format("new incoming connection {} ({})", sock, addr.readable(port)));
+        tr_logAddTrace(fmt::format("new incoming connection {} ({})", sock, addr.to_text(port)));
         session->addIncoming(tr_peer_socket{ session, addr, port, sock });
     }
 }
@@ -318,7 +318,7 @@ tr_session::BoundSocket::BoundSocket(
     }
 
     tr_logAddInfo(
-        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr.readable(port))));
+        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr.to_text(port))));
     event_add(ev_.get(), nullptr);
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -164,7 +164,7 @@ bool tr_session::LpdMediator::onPeerFound(std::string_view info_hash_str, tr_add
     // we found a suitable peer, add it to the torrent
     auto pex = tr_pex{ address, port };
     tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, &pex, 1U);
-    tr_logAddDebugTor(tor, fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), address.to_text(port)));
+    tr_logAddDebugTor(tor, fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), address.display_name(port)));
     return true;
 }
 
@@ -221,7 +221,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
     auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET);
     if (!is_default_value)
     {
-        return addr.to_text();
+        return addr.display_name();
     }
 
     return std::nullopt;
@@ -232,7 +232,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV6() const
     auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET6);
     if (!is_default_value)
     {
-        return addr.to_text();
+        return addr.display_name();
     }
 
     return std::nullopt;
@@ -296,7 +296,7 @@ void tr_session::onIncomingPeerConnection(tr_socket_t fd, void* vsession)
     if (auto const incoming_info = tr_netAccept(session, fd); incoming_info)
     {
         auto const& [addr, port, sock] = *incoming_info;
-        tr_logAddTrace(fmt::format("new incoming connection {} ({})", sock, addr.to_text(port)));
+        tr_logAddTrace(fmt::format("new incoming connection {} ({})", sock, addr.display_name(port)));
         session->addIncoming(tr_peer_socket{ session, addr, port, sock });
     }
 }
@@ -318,7 +318,7 @@ tr_session::BoundSocket::BoundSocket(
     }
 
     tr_logAddInfo(
-        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr.to_text(port))));
+        fmt::format(_("Listening to incoming peer connections on {hostport}"), fmt::arg("hostport", addr.display_name(port))));
     event_add(ev_.get(), nullptr);
 }
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -259,7 +259,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
             auto const error_code = errno;
             tr_logAddWarn(fmt::format(
                 _("Couldn't bind IPv4 socket {address}: {error} ({error_code})"),
-                fmt::arg("address", public_addr.readable(udp_port_)),
+                fmt::arg("address", public_addr.to_text(udp_port_)),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
             tr_netCloseSocket(udp_socket_);

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -259,7 +259,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
             auto const error_code = errno;
             tr_logAddWarn(fmt::format(
                 _("Couldn't bind IPv4 socket {address}: {error} ({error_code})"),
-                fmt::arg("address", public_addr.to_text(udp_port_)),
+                fmt::arg("address", public_addr.display_name(udp_port_)),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
             tr_netCloseSocket(udp_socket_);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -230,7 +230,7 @@ public:
         return {};
     }
 
-    [[nodiscard]] std::string to_text() const override
+    [[nodiscard]] std::string display_name() const override
     {
         if (auto const parsed = tr_urlParse(base_url); parsed)
         {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -230,7 +230,7 @@ public:
         return {};
     }
 
-    [[nodiscard]] std::string readable() const override
+    [[nodiscard]] std::string to_text() const override
     {
         if (auto const parsed = tr_urlParse(base_url); parsed)
         {

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -80,7 +80,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexCompact)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[127.0.0.1]:64551"sv, response.pex[0].to_text());
+        EXPECT_EQ("[127.0.0.1]:64551"sv, response.pex[0].display_name());
     }
 }
 
@@ -119,7 +119,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexList)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[8.8.4.4]:53"sv, response.pex[0].to_text());
+        EXPECT_EQ("[8.8.4.4]:53"sv, response.pex[0].display_name());
     }
 }
 

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -80,7 +80,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexCompact)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[127.0.0.1]:64551"sv, response.pex[0].readable());
+        EXPECT_EQ("[127.0.0.1]:64551"sv, response.pex[0].to_text());
     }
 }
 
@@ -119,7 +119,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexList)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[8.8.4.4]:53"sv, response.pex[0].readable());
+        EXPECT_EQ("[8.8.4.4]:53"sv, response.pex[0].to_text());
     }
 }
 

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -76,12 +76,12 @@ protected:
             auto str = std::string{};
             for (auto const& [addr, port] : ipv4_nodes_)
             {
-                str += addr.readable(port);
+                str += addr.to_text(port);
                 str += ',';
             }
             for (auto const& [addr, port] : ipv6_nodes_)
             {
-                str += addr.readable(port);
+                str += addr.to_text(port);
                 str += ',';
             }
             return str;
@@ -457,7 +457,7 @@ TEST_F(DhtTest, loadsStateFromStateFile)
     auto actual_nodes_str = std::string{};
     for (auto const& [addr, port, timestamp] : pinged)
     {
-        actual_nodes_str += addr.readable(port);
+        actual_nodes_str += addr.to_text(port);
         actual_nodes_str += ',';
     }
 
@@ -573,7 +573,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     auto const actual = pinged.front();
     EXPECT_EQ(expected.first, actual.address);
     EXPECT_EQ(expected.second, actual.port);
-    EXPECT_EQ(expected.first.readable(expected.second), actual.address.readable(actual.port));
+    EXPECT_EQ(expected.first.to_text(expected.second), actual.address.to_text(actual.port));
 }
 
 TEST_F(DhtTest, pingsAddedNodes)

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -76,12 +76,12 @@ protected:
             auto str = std::string{};
             for (auto const& [addr, port] : ipv4_nodes_)
             {
-                str += addr.to_text(port);
+                str += addr.display_name(port);
                 str += ',';
             }
             for (auto const& [addr, port] : ipv6_nodes_)
             {
-                str += addr.to_text(port);
+                str += addr.display_name(port);
                 str += ',';
             }
             return str;
@@ -457,7 +457,7 @@ TEST_F(DhtTest, loadsStateFromStateFile)
     auto actual_nodes_str = std::string{};
     for (auto const& [addr, port, timestamp] : pinged)
     {
-        actual_nodes_str += addr.to_text(port);
+        actual_nodes_str += addr.display_name(port);
         actual_nodes_str += ',';
     }
 
@@ -573,7 +573,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     auto const actual = pinged.front();
     EXPECT_EQ(expected.first, actual.address);
     EXPECT_EQ(expected.second, actual.port);
-    EXPECT_EQ(expected.first.to_text(expected.second), actual.address.to_text(actual.port));
+    EXPECT_EQ(expected.first.display_name(expected.second), actual.address.display_name(actual.port));
 }
 
 TEST_F(DhtTest, pingsAddedNodes)

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -20,7 +20,7 @@ TEST_F(NetTest, conversionsIPv4)
 
     auto addr = tr_address::fromString(AddrStr);
     EXPECT_TRUE(addr);
-    EXPECT_EQ(AddrStr, addr->to_text());
+    EXPECT_EQ(AddrStr, addr->display_name());
 
     auto [ss, sslen] = addr->toSockaddr(Port);
     EXPECT_EQ(AF_INET, ss.ss_family);
@@ -34,8 +34,8 @@ TEST_F(NetTest, conversionsIPv4)
 
 TEST_F(NetTest, trAddress)
 {
-    EXPECT_EQ("0.0.0.0", tr_address::AnyIPv4().to_text());
-    EXPECT_EQ("::", tr_address::AnyIPv6().to_text());
+    EXPECT_EQ("0.0.0.0", tr_address::AnyIPv4().display_name());
+    EXPECT_EQ("::", tr_address::AnyIPv6().display_name());
 }
 
 TEST_F(NetTest, compact4)
@@ -54,7 +54,7 @@ TEST_F(NetTest, compact4)
     std::tie(addr, in) = tr_address::fromCompact4(in);
     std::tie(port, in) = tr_port::fromCompact(in);
     EXPECT_EQ(std::data(Compact4) + std::size(Compact4), in);
-    EXPECT_EQ(ExpectedReadable, addr.to_text());
+    EXPECT_EQ(ExpectedReadable, addr.display_name());
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again
@@ -108,7 +108,7 @@ TEST_F(NetTest, compact6)
     std::tie(addr, in) = tr_address::fromCompact6(in);
     std::tie(port, in) = tr_port::fromCompact(in);
     EXPECT_EQ(std::data(Compact6) + std::size(Compact6), in);
-    EXPECT_EQ(ExpectedReadable, addr.to_text());
+    EXPECT_EQ(ExpectedReadable, addr.display_name());
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -20,7 +20,7 @@ TEST_F(NetTest, conversionsIPv4)
 
     auto addr = tr_address::fromString(AddrStr);
     EXPECT_TRUE(addr);
-    EXPECT_EQ(AddrStr, addr->readable());
+    EXPECT_EQ(AddrStr, addr->to_text());
 
     auto [ss, sslen] = addr->toSockaddr(Port);
     EXPECT_EQ(AF_INET, ss.ss_family);
@@ -34,8 +34,8 @@ TEST_F(NetTest, conversionsIPv4)
 
 TEST_F(NetTest, trAddress)
 {
-    EXPECT_EQ("0.0.0.0", tr_address::AnyIPv4().readable());
-    EXPECT_EQ("::", tr_address::AnyIPv6().readable());
+    EXPECT_EQ("0.0.0.0", tr_address::AnyIPv4().to_text());
+    EXPECT_EQ("::", tr_address::AnyIPv6().to_text());
 }
 
 TEST_F(NetTest, compact4)
@@ -54,7 +54,7 @@ TEST_F(NetTest, compact4)
     std::tie(addr, in) = tr_address::fromCompact4(in);
     std::tie(port, in) = tr_port::fromCompact(in);
     EXPECT_EQ(std::data(Compact4) + std::size(Compact4), in);
-    EXPECT_EQ(ExpectedReadable, addr.readable());
+    EXPECT_EQ(ExpectedReadable, addr.to_text());
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again
@@ -108,7 +108,7 @@ TEST_F(NetTest, compact6)
     std::tie(addr, in) = tr_address::fromCompact6(in);
     std::tie(port, in) = tr_port::fromCompact(in);
     EXPECT_EQ(std::data(Compact6) + std::size(Compact6), in);
-    EXPECT_EQ(ExpectedReadable, addr.readable());
+    EXPECT_EQ(ExpectedReadable, addr.to_text());
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again


### PR DESCRIPTION
Minor housekeeping PR: rename a few class' methods to `display_name()` for consistency and for commonly-used naming.

Renamed:
- `tr_address::readable()`
- `tr_peer_socket::readable()`
- `tr_peerIo::addrStr()`