### PR TITLE
fix: re-enable port forwarding

### DIFF
--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -284,11 +284,11 @@ tr_port_forwarding_state tr_upnpPulse(tr_upnp* handle, tr_port port, bool is_ena
 
         FreeUPNPUrls(&handle->urls);
         auto lanaddr = std::array<char, TR_ADDRSTRLEN>{};
-        if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr)) ==
+        if (UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1) ==
             UPNP_IGD_VALID_CONNECTED)
         {
             tr_logAddInfo(fmt::format(_("Found Internet Gateway Device '{url}'"), fmt::arg("url", handle->urls.controlURL)));
-            tr_logAddInfo(fmt::format(_("Local Address is '{address}'"), fmt::arg("address", handle->lanaddr.data())));
+            tr_logAddInfo(fmt::format(_("Local Address is '{address}'"), fmt::arg("address", lanaddr.data())));
             handle->state = UpnpState::Idle;
             handle->hasDiscovered = true;
             handle->lanaddr = std::data(lanaddr);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -666,6 +666,11 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
         addr_changed = true;
     }
 
+    if (auto const& val = new_settings.port_forwarding_enabled; force || val != old_settings.port_forwarding_enabled)
+    {
+        tr_sessionSetPortForwardingEnabled(this, val);
+    }
+
     if (port_changed)
     {
         port_forwarding_->localPortChanged();


### PR DESCRIPTION
Notes: Fixed `4.0.0-beta.2` regression that broke port forwarding in some settings.