### PR TITLE
fix: remove invalid assertion from bitfield code

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -459,8 +459,6 @@ void tr_bitfield::setSpan(size_t begin, size_t end, bool value)
 
 tr_bitfield& tr_bitfield::operator|=(tr_bitfield const& that) noexcept
 {
-    TR_ASSERT(size() == std::size(that));
-
     if (hasAll() || that.hasNone())
     {
         return *this;
@@ -485,8 +483,6 @@ tr_bitfield& tr_bitfield::operator|=(tr_bitfield const& that) noexcept
 
 tr_bitfield& tr_bitfield::operator&=(tr_bitfield const& that) noexcept
 {
-    TR_ASSERT(size() == std::size(that));
-
     if (hasNone() || that.hasAll())
     {
         return *this;


### PR DESCRIPTION
These two assertion are failing because they were invalid; it's OK for the bitfields to have different sizes.

Fixes #4312.