### PR TITLE
Fixed crash when pausing with partial rollback of refactor tr_peer_socket ~ tr_peerIo.

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -457,13 +457,15 @@ tr_peerIo::tr_peerIo(
     bool is_seed,
     tr_bandwidth* parent_bandwidth,
     tr_peer_socket sock)
-    : socket{ std::move(sock) }
+    : address_{ sock.address() }
+    , port_{ sock.port() }
     , session{ session_in }
     , bandwidth_{ parent_bandwidth }
     , torrent_hash_{ torrent_hash != nullptr ? *torrent_hash : tr_sha1_digest_t{} }
     , is_seed_{ is_seed }
     , is_incoming_{ is_incoming }
 {
+    socket = std::move(sock);
     if (socket.is_tcp())
     {
         event_read.reset(event_new(session->eventBase(), socket.handle.tcp, EV_READ, event_read_cb, this));

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -98,7 +98,7 @@ public:
 
     [[nodiscard]] constexpr auto socketAddress() const noexcept
     {
-        return socket.socketAddress();
+        return std::make_pair(address_, port_);
     }
 
     [[nodiscard]] auto display_name() const
@@ -300,6 +300,9 @@ private:
         bool is_incoming,
         bool is_seed,
         tr_peer_socket socket);
+
+    tr_address const address_;
+    tr_port const port_;
 
     tr_bandwidth bandwidth_;
 


### PR DESCRIPTION
Fix: #4329
Minimal rollback of #4325 to prevent the crash when pausing torrents.

I do not know the reason why this works: I just basically rollbacked every single line one by one until I found the guilty one, which seems to be the one with `std::make_pair`.