### PR TITLE
Show "Enable uTP" checkbox in preferences if supported (GTK client)

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -196,6 +196,10 @@ add_definitions(
     ${GTK${GTK_VERSION}_CFLAGS_OTHER}
 )
 
+if(ENABLE_UTP)
+    add_definitions(-DWITH_UTP)
+endif()
+
 if(WITH_APPINDICATOR)
     set_property(SOURCE SystemTrayIcon.cc APPEND PROPERTY COMPILE_DEFINITIONS HAVE_APPINDICATOR)
     if(APPINDICATOR_IS_AYATANA)


### PR DESCRIPTION
Broken with switch to CMake. Ideally, need an API/RPC method to request core capabilities to support remote sessions.

Notes: Fixed an issue with "Enable µTP for peer communication" checkbox in preferences dialog being always hidden for CMake-based builds.