### PR TITLE
Fixed logic in tr_wildmat

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -203,7 +203,7 @@ bool tr_wildmat(std::string_view text, std::string_view pattern)
 {
     // TODO(ckerr): replace wildmat with base/strings/pattern.cc
     // wildmat wants these to be zero-terminated.
-    return pattern == "*"sv || DoMatch(std::string{ text }.c_str(), std::string{ pattern }.c_str()) != 0;
+    return pattern == "*"sv || DoMatch(std::string{ text }.c_str(), std::string{ pattern }.c_str()) > 0;
 }
 
 char const* tr_strerror(int errnum)


### PR DESCRIPTION
Problem: DoMatch returns `ABORT` (`-1`) for some pattern failures, `false` for some other failures and `true` for successes.
Solution: tr_wildmat shall assert success with `> 0` instead of `!= 0`.

Example: `tr_wildmat("", "a")` should return false, not true.