### PR TITLE
refactor: tr_handshake

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -887,6 +887,8 @@ std::string_view tr_handshake::state_string(State state) noexcept
     case State::AwaitingPadD:
         return "awaiting pad d";
     }
+
+    return "unknown state";
 }
 
 uint32_t tr_handshake::crypto_provide() const noexcept

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -7,7 +7,6 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
-#include <climits>
 #include <string_view>
 #include <utility>
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -87,7 +87,7 @@ static auto constexpr VC = vc_t{};
 ***
 **/
 
-#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->display_name())
+#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->peer_io_->display_name())
 
 using DH = tr_message_stream_encryption::DH;
 
@@ -881,7 +881,7 @@ void tr_handshake::on_error(tr_peerIo* io, short what, void* vhandshake)
         /* Don't mark a peer as non-µTP unless it's really a connect failure. */
         if ((errcode == ETIMEDOUT || errcode == ECONNREFUSED) && info)
         {
-            handshake->set_utp_failed(info_hash, io->address());
+            handshake->mediator_->set_utp_failed(info_hash, io->address());
         }
 
         if (handshake->mediator_->allows_tcp() && io->reconnect() == 0)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -75,10 +75,6 @@ auto constexpr HandshakeFlagsLen = int{ 8 };
 auto constexpr HandshakeSize = int{ 68 };
 auto constexpr IncomingHandshakeLen = int{ 48 };
 
-// encryption constants
-auto constexpr CryptoProvidePlaintext = int{ 1 };
-auto constexpr CryptoProvideCrypto = int{ 2 };
-
 // "VC is a verification constant that is used to verify whether the
 // other side knows S and SKEY and thus defeats replay attacks of the
 // SKEY hash. As of this version VC is a String of 8 bytes set to 0x00."
@@ -191,7 +187,7 @@ void tr_handshake::send_ya(tr_peerIo* io)
     set_state(tr_handshake::State::AwaitingYb);
 }
 
-static constexpr uint32_t getCryptoSelect(tr_encryption_mode encryption_mode, uint32_t crypto_provide)
+[[nodiscard]] uint32_t tr_handshake::get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept
 {
     auto choices = std::array<uint32_t, 2>{};
     int n_choices = 0;
@@ -683,7 +679,7 @@ ReadState tr_handshake::read_ia(tr_peerIo* peer_io)
     outbuf.add(VC);
 
     /* send crypto_select */
-    uint32_t const crypto_select = getCryptoSelect(encryption_mode_, crypto_provide_);
+    uint32_t const crypto_select = get_crypto_select(encryption_mode_, crypto_provide_);
 
     if (crypto_select != 0)
     {

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -202,10 +202,18 @@ private:
         std::byte{ 't' }, std::byte{ ' ' }, std::byte{ 'p' }, std::byte{ 'r' }, std::byte{ 'o' },
         std::byte{ 't' }, std::byte{ 'o' }, std::byte{ 'c' }, std::byte{ 'o' }, std::byte{ 'l' }
     };
+
     // [Next comes] eight reserved bytes [used for enabling ltep, dht, fext]
-    static auto constexpr HandshakeFlagsLen = size_t{ 8 };
+    static auto constexpr HandshakeFlagsBytes = size_t{ 8 };
+    static auto constexpr HandshakeFlagsBits = size_t{ 64 };
+    // https://www.bittorrent.org/beps/bep_0004.html
+    // https://wiki.theory.org/BitTorrentSpecification#Reserved_Bytes
+    static auto constexpr LtepFlag = size_t{ 43U };
+    static auto constexpr FextFlag = size_t{ 61U };
+    static auto constexpr DhtFlag = size_t{ 63U };
+
     // Next comes the 20 byte sha1 info_hash and the 20-byte peer_id
-    static auto constexpr HandshakeSize = sizeof(HandshakeName) + HandshakeFlagsLen + sizeof(tr_sha1_digest_t) +
+    static auto constexpr HandshakeSize = sizeof(HandshakeName) + HandshakeFlagsBytes + sizeof(tr_sha1_digest_t) +
         sizeof(tr_peer_id_t);
     static_assert(HandshakeSize == 68);
 
@@ -214,7 +222,7 @@ private:
     // > the recipient must respond as soon as it sees the info_hash part
     // > of the handshake (the peer id will presumably be sent after the
     // > recipient sends its own handshake).
-    static auto constexpr IncomingHandshakeLen = sizeof(HandshakeName) + HandshakeFlagsLen + sizeof(tr_sha1_digest_t);
+    static auto constexpr IncomingHandshakeLen = sizeof(HandshakeName) + HandshakeFlagsBytes + sizeof(tr_sha1_digest_t);
     static_assert(IncomingHandshakeLen == 48);
 
     // MSE constants.

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -9,11 +9,11 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <algorithm>
+#include <algorithm> // for std::copy()
 #include <array>
 #include <chrono>
 #include <cstdint> // for uintX_t
-#include <cstddef> // for size_t
+#include <cstddef> // for std::byte, size_t
 #include <functional>
 #include <memory>
 #include <optional>
@@ -36,8 +36,8 @@ public:
     {
         std::shared_ptr<tr_peerIo> io;
         std::optional<tr_peer_id_t> peer_id;
-        bool read_anything_from_peer;
-        bool is_connected;
+        bool read_anything_from_peer = false;
+        bool is_connected = false;
     };
 
     using DoneFunc = std::function<bool(Result const&)>;
@@ -55,9 +55,8 @@ public:
 
         virtual ~Mediator() = default;
 
-        [[nodiscard]] virtual std::optional<TorrentInfo> torrent_info(tr_sha1_digest_t const& info_hash) const = 0;
-        [[nodiscard]] virtual std::optional<TorrentInfo> torrent_info_from_obfuscated(
-            tr_sha1_digest_t const& info_hash) const = 0;
+        [[nodiscard]] virtual std::optional<TorrentInfo> torrent(tr_sha1_digest_t const& info_hash) const = 0;
+        [[nodiscard]] virtual std::optional<TorrentInfo> torrent_from_obfuscated(tr_sha1_digest_t const& info_hash) const = 0;
         [[nodiscard]] virtual libtransmission::TimerMaker& timer_maker() = 0;
         [[nodiscard]] virtual bool allows_dht() const = 0;
         [[nodiscard]] virtual bool allows_tcp() const = 0;
@@ -71,7 +70,7 @@ public:
         virtual void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_address const&) = 0;
     };
 
-    tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc done_func);
+    tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);
 
 private:
     enum class ParseResult
@@ -103,6 +102,14 @@ private:
 
     ///
 
+    [[nodiscard]] static std::string_view state_string(State state) noexcept;
+
+    [[nodiscard]] static uint32_t get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept;
+
+    static ReadState can_read(tr_peerIo* peer_io, void* vhandshake, size_t* piece);
+
+    static void on_error(tr_peerIo* io, short what, void* vhandshake);
+
     bool build_handshake_message(tr_peerIo* io, uint8_t* buf) const;
 
     ReadState read_crypto_provide(tr_peerIo*);
@@ -121,9 +128,6 @@ private:
     void send_ya(tr_peerIo*);
 
     ParseResult parse_handshake(tr_peerIo* peer_io);
-
-    static ReadState can_read(tr_peerIo* peer_io, void* vhandshake, size_t* piece);
-    static void on_error(tr_peerIo* io, short what, void* vhandshake);
 
     constexpr void set_peer_id(tr_peer_id_t const& id) noexcept
     {
@@ -161,18 +165,12 @@ private:
         state_ = state;
     }
 
-    [[nodiscard]] static std::string_view state_string(State state) noexcept;
-
     [[nodiscard]] std::string_view state_string() const noexcept
     {
         return state_string(state_);
     }
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
-
-    [[nodiscard]] static uint32_t get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept;
-
-    bool fire_done(bool is_connected);
 
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)
@@ -186,19 +184,48 @@ private:
         io->writeBytes(data, walk - data, false);
     }
 
+    bool fire_done(bool is_connected);
+
     ///
 
     static auto constexpr HandshakeTimeoutSec = std::chrono::seconds{ 30 };
 
-    // MSE constatnts.
-    // http://wiki.vuze.com/w/Message_Stream_Encryption
-    // crypto_provide and crypto_select are a 32bit bitfields.
-    // As of now 0x01 means plaintext, 0x02 means RC4. (see Functions)
-    // The remaining bits are reserved for future use.
-    static auto constexpr CryptoProvidePlaintext = size_t{ 1U };
-    static auto constexpr CryptoProvideCrypto = size_t{ 2U };
+    // bittorrent handshake constants
+    // https://www.bittorrent.org/beps/bep_0003.html#peer-protocol
+    // https://wiki.theory.org/BitTorrentSpecification#Handshake
 
-    // MSE constatnts.
+    // > The handshake starts with character ninteen (decimal) followed by the string
+    // > 'BitTorrent protocol'. The leading character is a length prefix.
+    static auto constexpr HandshakeName = std::array<std::byte, 20>{
+        std::byte{ 19 },  std::byte{ 'B' }, std::byte{ 'i' }, std::byte{ 't' }, std::byte{ 'T' },
+        std::byte{ 'o' }, std::byte{ 'r' }, std::byte{ 'r' }, std::byte{ 'e' }, std::byte{ 'n' },
+        std::byte{ 't' }, std::byte{ ' ' }, std::byte{ 'p' }, std::byte{ 'r' }, std::byte{ 'o' },
+        std::byte{ 't' }, std::byte{ 'o' }, std::byte{ 'c' }, std::byte{ 'o' }, std::byte{ 'l' }
+    };
+    // [Next comes] eight reserved bytes [used for enabling ltep, dht, fext]
+    static auto constexpr HandshakeFlagsLen = size_t{ 8 };
+    // Next comes the 20 byte sha1 info_hash and the 20-byte peer_id
+    static auto constexpr HandshakeSize = sizeof(HandshakeName) + HandshakeFlagsLen + sizeof(tr_sha1_digest_t) +
+        sizeof(tr_peer_id_t);
+    static_assert(HandshakeSize == 68);
+
+    // Length of handhshake up through the info_hash. From theory.org:
+    // > The recipient may wait for the initiator's handshake... however,
+    // > the recipient must respond as soon as it sees the info_hash part
+    // > of the handshake (the peer id will presumably be sent after the
+    // > recipient sends its own handshake).
+    static auto constexpr IncomingHandshakeLen = sizeof(HandshakeName) + HandshakeFlagsLen + sizeof(tr_sha1_digest_t);
+    static_assert(IncomingHandshakeLen == 48);
+
+    // MSE constants.
+    // http://wiki.vuze.com/w/Message_Stream_Encryption
+    // > crypto_provide and crypto_select are a 32bit bitfields.
+    // > As of now 0x01 means plaintext, 0x02 means RC4. (see Functions)
+    // > The remaining bits are reserved for future use.
+    static auto constexpr CryptoProvidePlaintext = size_t{ 0x01 };
+    static auto constexpr CryptoProvideCrypto = size_t{ 0x02 };
+
+    // MSE constants.
     // http://wiki.vuze.com/w/Message_Stream_Encryption
     // > PadA, PadB: Random data with a random length of 0 to 512 bytes each
     // > PadC, PadD: Arbitrary data with a length of 0 to 512 bytes
@@ -206,11 +233,18 @@ private:
     static auto constexpr PadbMaxlen = int{ 512 };
     static auto constexpr PadcMaxlen = int{ 512 };
 
+    // "VC is a verification constant that is used to verify whether the
+    // other side knows S and SKEY and thus defeats replay attacks of the
+    // SKEY hash. As of this version VC is a String of 8 bytes set to 0x00."
+    // https://wiki.vuze.com/w/Message_Stream_Encryption
+    using vc_t = std::array<std::byte, 8>;
+    static auto constexpr VC = vc_t{};
+
     ///
 
     DH dh_ = {};
 
-    DoneFunc done_func_;
+    DoneFunc on_done_;
 
     std::optional<tr_peer_id_t> peer_id_;
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -9,11 +9,15 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <cstdint> // for uintX_t
 #include <cstddef> // for size_t
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string_view>
 
 #include "transmission.h"
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -191,6 +191,14 @@ private:
     static auto constexpr CryptoProvidePlaintext = int{ 1 };
     static auto constexpr CryptoProvideCrypto = int{ 2 };
 
+    // MSE constatnts.
+    // http://wiki.vuze.com/w/Message_Stream_Encryption
+    // > PadA, PadB: Random data with a random length of 0 to 512 bytes each
+    // > PadC, PadD: Arbitrary data with a length of 0 to 512 bytes
+    static auto constexpr PadaMaxlen = int{ 512 };
+    static auto constexpr PadbMaxlen = int{ 512 };
+    static auto constexpr PadcMaxlen = int{ 512 };
+
     ///
 
     DH dh_ = {};

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -17,21 +17,12 @@
 
 #include "transmission.h"
 
-#include "net.h" // tr_address
+#include "net.h"
 #include "peer-mse.h" // tr_message_stream_encryption::DH
 #include "peer-io.h"
 #include "timer.h"
 
-namespace libtransmission
-{
-class TimerMaker;
-}
-
-class tr_peerIo;
-
-/** @brief opaque struct holding handshake state information.
-           freed when the handshake is completed. */
-
+// short-term class which manages the handshake phase of a tr_peerIo
 class tr_handshake
 {
 public:
@@ -100,20 +91,20 @@ private:
 
     bool build_handshake_message(tr_peerIo* io, uint8_t* buf) const;
 
-    ReadState read_crypto_provide(tr_peerIo* peer_io);
-    ReadState read_crypto_select(tr_peerIo* peer_io);
-    ReadState read_handshake(tr_peerIo* peer_io);
-    ReadState read_ia(tr_peerIo* peer_io);
-    ReadState read_pad_a(tr_peerIo* peer_io);
-    ReadState read_pad_c(tr_peerIo* peer_io);
-    ReadState read_pad_d(tr_peerIo* peer_io);
-    ReadState read_payload_stream(tr_peerIo* peer_io);
-    ReadState read_peer_id(tr_peerIo* peer_io);
-    ReadState read_vc(tr_peerIo* peer_io);
-    ReadState read_ya(tr_peerIo* peer_io);
-    ReadState read_yb(tr_peerIo* peer_io);
+    ReadState read_crypto_provide(tr_peerIo*);
+    ReadState read_crypto_select(tr_peerIo*);
+    ReadState read_handshake(tr_peerIo*);
+    ReadState read_ia(tr_peerIo*);
+    ReadState read_pad_a(tr_peerIo*);
+    ReadState read_pad_c(tr_peerIo*);
+    ReadState read_pad_d(tr_peerIo*);
+    ReadState read_payload_stream(tr_peerIo*);
+    ReadState read_peer_id(tr_peerIo*);
+    ReadState read_vc(tr_peerIo*);
+    ReadState read_ya(tr_peerIo*);
+    ReadState read_yb(tr_peerIo*);
 
-    void send_ya(tr_peerIo* io);
+    void send_ya(tr_peerIo*);
 
     enum class ParseResult
     {
@@ -147,16 +138,6 @@ private:
     [[nodiscard]] auto is_incoming() const noexcept
     {
         return peer_io_->isIncoming();
-    }
-
-    [[nodiscard]] auto display_name() const
-    {
-        return peer_io_->display_name();
-    }
-
-    void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_address const& addr)
-    {
-        mediator_->set_utp_failed(info_hash, addr);
     }
 
     [[nodiscard]] constexpr auto state() const noexcept

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -129,7 +129,7 @@ private:
 
     ParseResult parse_handshake(tr_peerIo* peer_io);
 
-    constexpr void set_peer_id(tr_peer_id_t const& id) noexcept
+    void set_peer_id(tr_peer_id_t const& id) noexcept
     {
         peer_id_ = id;
     }

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -170,6 +170,8 @@ private:
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
 
+    [[nodiscard]] static uint32_t get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept;
+
     bool fire_done(bool is_connected);
 
     template<size_t PadMax>
@@ -188,8 +190,13 @@ private:
 
     static auto constexpr HandshakeTimeoutSec = std::chrono::seconds{ 30 };
 
-    static auto constexpr CryptoProvidePlaintext = int{ 1 };
-    static auto constexpr CryptoProvideCrypto = int{ 2 };
+    // MSE constatnts.
+    // http://wiki.vuze.com/w/Message_Stream_Encryption
+    // crypto_provide and crypto_select are a 32bit bitfields.
+    // As of now 0x01 means plaintext, 0x02 means RC4. (see Functions)
+    // The remaining bits are reserved for future use.
+    static auto constexpr CryptoProvidePlaintext = size_t{ 1U };
+    static auto constexpr CryptoProvideCrypto = size_t{ 2U };
 
     // MSE constatnts.
     // http://wiki.vuze.com/w/Message_Stream_Encryption

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -70,7 +70,7 @@ static bool tr_peerMgrPeerIsSeed(tr_torrent const* tor, tr_address const& addr);
 class HandshakeMediator final : public tr_handshake::Mediator
 {
 private:
-    [[nodiscard]] static std::optional<TorrentInfo> torrent_info(tr_torrent* tor)
+    [[nodiscard]] static std::optional<TorrentInfo> torrent(tr_torrent* tor)
     {
         if (tor == nullptr)
         {
@@ -91,15 +91,14 @@ public:
     {
     }
 
-    [[nodiscard]] std::optional<TorrentInfo> torrent_info(tr_sha1_digest_t const& info_hash) const override
+    [[nodiscard]] std::optional<TorrentInfo> torrent(tr_sha1_digest_t const& info_hash) const override
     {
-        return torrent_info(session_.torrents().get(info_hash));
+        return torrent(session_.torrents().get(info_hash));
     }
 
-    [[nodiscard]] std::optional<TorrentInfo> torrent_info_from_obfuscated(
-        tr_sha1_digest_t const& obfuscated_info_hash) const override
+    [[nodiscard]] std::optional<TorrentInfo> torrent_from_obfuscated(tr_sha1_digest_t const& info_hash) const override
     {
-        return torrent_info(tr_torrentFindFromObfuscatedHash(&session_, obfuscated_info_hash));
+        return torrent(tr_torrentFindFromObfuscatedHash(&session_, info_hash));
     }
 
     [[nodiscard]] bool allows_dht() const override

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -214,7 +214,7 @@ static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void*
         }
         else
         {
-            if (session->allowsUTP() && session->utp_context)
+            if (session->allowsUTP() && (session->utp_context != nullptr))
             {
                 if (!tr_utpPacket(std::data(buf), rc, (struct sockaddr*)&from, fromlen, session))
                 {

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -43,7 +43,7 @@ public:
         {
         }
 
-        [[nodiscard]] std::optional<TorrentInfo> torrent_info(tr_sha1_digest_t const& info_hash) const override
+        [[nodiscard]] std::optional<TorrentInfo> torrent(tr_sha1_digest_t const& info_hash) const override
         {
             if (auto const iter = torrents.find(info_hash); iter != std::end(torrents))
             {
@@ -53,7 +53,7 @@ public:
             return {};
         }
 
-        [[nodiscard]] std::optional<TorrentInfo> torrent_info_from_obfuscated(tr_sha1_digest_t const& obfuscated) const override
+        [[nodiscard]] std::optional<TorrentInfo> torrent_from_obfuscated(tr_sha1_digest_t const& obfuscated) const override
         {
             for (auto const& [info_hash, info] : torrents)
             {


### PR DESCRIPTION
Code cleanup from yesterday's refactor:

1. simplify flag handling
2. move larger functions from header to cc
3. make more fields private static constexpr
4. iwyu