### PR TITLE
Sorting by size should be instead by sizeWhenDone

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2775,7 +2775,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else if ([sortType isEqualToString:SortTypeSize])
     {
-        NSSortDescriptor* sizeDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"size" ascending:asc];
+        NSSortDescriptor* sizeDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"totalSizeSelected" ascending:asc];
 
         descriptors = @[ sizeDescriptor, nameDescriptor ];
     }


### PR DESCRIPTION
Fix #4361

Notes: Sorting by size is now sorting by total size of selected files.