### PR TITLE
Disconnect some more signals on widgets destruction

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -964,11 +964,9 @@ void Application::Impl::on_app_exit()
 
     is_closing_ = true;
 
-    /* stop the update timer */
-    timer_.disconnect();
-
-    /* stop the refresh-actions timer */
     refresh_actions_tag_.disconnect();
+    update_model_soon_tag_.disconnect();
+    timer_.disconnect();
 
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
     wind_->remove();

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -168,7 +168,6 @@ private:
     Glib::Quark const URL_ENTRY_KEY = Glib::Quark("tr-url-entry-key");
 
     static guint last_page_;
-    sigc::connection last_page_tag_;
 };
 
 guint DetailsDialog::Impl::last_page_ = 0;
@@ -2502,7 +2501,6 @@ void DetailsDialog::Impl::on_details_window_size_allocated()
 DetailsDialog::Impl::~Impl()
 {
     periodic_refresh_tag_.disconnect();
-    last_page_tag_.disconnect();
 }
 
 std::unique_ptr<DetailsDialog> DetailsDialog::create(Gtk::Window& parent, Glib::RefPtr<Session> const& core)
@@ -2589,7 +2587,7 @@ DetailsDialog::Impl::Impl(DetailsDialog& dialog, Glib::RefPtr<Gtk::Builder> cons
 
     auto* const n = gtr_get_widget<Gtk::Notebook>(builder, "dialog_pages");
     n->set_current_page(last_page_);
-    last_page_tag_ = n->signal_switch_page().connect([](Widget*, guint page) { DetailsDialog::Impl::last_page_ = page; });
+    n->signal_switch_page().connect([](Gtk::Widget* /*page*/, guint page_number) { last_page_ = page_number; });
 }
 
 void DetailsDialog::set_torrents(std::vector<tr_torrent_id_t> const& ids)

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -398,10 +398,7 @@ void DownloadingPage::on_core_prefs_changed(tr_quark const key)
 
 DownloadingPage::~DownloadingPage()
 {
-    if (core_prefs_tag_.connected())
-    {
-        core_prefs_tag_.disconnect();
-    }
+    core_prefs_tag_.disconnect();
 }
 
 DownloadingPage::DownloadingPage(
@@ -535,10 +532,7 @@ void PrivacyPage::updateBlocklistText()
 /* prefs dialog is being destroyed, so stop listening to blocklist updates */
 PrivacyPage::~PrivacyPage()
 {
-    if (updateBlocklistTag_.connected())
-    {
-        updateBlocklistTag_.disconnect();
-    }
+    updateBlocklistTag_.disconnect();
 }
 
 /* user hit "close" in the blocklist-update dialog */
@@ -901,15 +895,8 @@ void NetworkPage::onCorePrefsChanged(tr_quark const key)
 
 NetworkPage::~NetworkPage()
 {
-    if (prefsTag_.connected())
-    {
-        prefsTag_.disconnect();
-    }
-
-    if (portTag_.connected())
-    {
-        portTag_.disconnect();
-    }
+    prefsTag_.disconnect();
+    portTag_.disconnect();
 }
 
 void NetworkPage::onPortTested(bool isOpen)

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -90,6 +90,7 @@ class Session::Impl
 {
 public:
     Impl(Session& core, tr_session* session);
+    ~Impl();
 
     tr_session* close();
 
@@ -847,6 +848,11 @@ Session::Impl::Impl(Session& core, tr_session* session)
         [](auto* tor, auto completeness, bool was_running, gpointer impl)
         { static_cast<Impl*>(impl)->on_torrent_completeness_changed(tor, completeness, was_running); },
         this);
+}
+
+Session::Impl::~Impl()
+{
+    monitor_idle_tag_.disconnect();
 }
 
 tr_session* Session::close()


### PR DESCRIPTION
This is applicable to any signals where emitter's lifetime isn't controlled by the receiver.

There're still about 7 `Glib::signal_idle()` connections which aren't tracked but I see the possibility of it leading to major issues as quite low.