### PR TITLE
Make preferences dialog non-modal

### DIFF
--- a/gtk/ui/gtk3/PrefsDialog.ui
+++ b/gtk/ui/gtk3/PrefsDialog.ui
@@ -7,7 +7,7 @@
     <property name="border-width">6</property>
     <property name="title" translatable="yes">Transmission Preferences</property>
     <property name="role">transmission-preferences-dialog</property>
-    <property name="modal">True</property>
+    <property name="modal">False</property>
     <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog_layout">

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="PrefsDialog">
     <property name="title" translatable="1">Transmission Preferences</property>
-    <property name="modal">1</property>
+    <property name="modal">0</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>


### PR DESCRIPTION
This regressed with the switch to `Gtk::Builder` because the dialog was non-modal before.

This is the cause of the issue with blocklist update status dialog: it seems that if there's a modal dialog running, showing another non-modal dialog will make it inaccessible to the user until the first dialog is closed thus leaving the modal mode.

Fixes: #4311

Notes: Fixed `4.0.0-beta.1` regression causing preferences dialog to be modal and making it impossble to close the blocklist update status dialog.