### PR TITLE
Don't use message dialog to display blocklist update status

### DIFF
--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -496,6 +496,8 @@ DesktopPage::DesktopPage(
 
 class PrivacyPage : public PageBase
 {
+    static auto const BlocklistUpdateResultDisplayTimeoutInSeconds = 3U;
+
 public:
     PrivacyPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
     ~PrivacyPage() override;
@@ -504,8 +506,7 @@ public:
 
 private:
     void updateBlocklistText();
-    void onBlocklistUpdateResponse();
-    void onBlocklistUpdated(int n);
+    void onBlocklistUpdated(bool success);
     void onBlocklistUpdate();
     void on_blocklist_url_changed(Gtk::Editable* e);
 
@@ -517,7 +518,7 @@ private:
     Gtk::CheckButton* check_ = nullptr;
 
     sigc::connection updateBlocklistTag_;
-    std::unique_ptr<Gtk::MessageDialog> updateBlocklistDialog_;
+    sigc::connection blocklist_update_result_tag_;
 };
 
 void PrivacyPage::updateBlocklistText()
@@ -526,54 +527,36 @@ void PrivacyPage::updateBlocklistText()
     auto const msg = fmt::format(
         ngettext("Blocklist has {count:L} entry", "Blocklist has {count:L} entries", n),
         fmt::arg("count", n));
-    label_->set_markup(fmt::format(FMT_STRING("<i>{:s}</i>"), msg));
+    label_->set_text(msg);
 }
 
 /* prefs dialog is being destroyed, so stop listening to blocklist updates */
 PrivacyPage::~PrivacyPage()
 {
-    updateBlocklistTag_.disconnect();
-}
-
-/* user hit "close" in the blocklist-update dialog */
-void PrivacyPage::onBlocklistUpdateResponse()
-{
-    updateBlocklistButton_->set_sensitive(true);
-    updateBlocklistDialog_.reset();
+    blocklist_update_result_tag_.disconnect();
     updateBlocklistTag_.disconnect();
 }
 
 /* core says the blocklist was updated */
-void PrivacyPage::onBlocklistUpdated(int n)
+void PrivacyPage::onBlocklistUpdated(bool success)
 {
-    bool const success = n >= 0;
-    int const count = n >= 0 ? n : tr_blocklistGetRuleCount(core_->get_session());
-    auto const msg = fmt::format(
-        ngettext("Blocklist has {count:L} entry", "Blocklist has {count:L} entries", count),
-        fmt::arg("count", count));
     updateBlocklistButton_->set_sensitive(true);
-    updateBlocklistDialog_->set_message(
-        fmt::format(FMT_STRING("<b>{:s}</b>"), success ? _("Blocklist updated!") : _("Couldn't update blocklist")),
-        true);
-    updateBlocklistDialog_->set_secondary_text(msg);
-    updateBlocklistText();
+    label_->set_text(success ? _("Blocklist updated!") : _("Couldn't update blocklist"));
+
+    blocklist_update_result_tag_ = Glib::signal_timeout().connect_seconds(
+        sigc::bind_return(sigc::mem_fun(*this, &PrivacyPage::updateBlocklistText), false),
+        BlocklistUpdateResultDisplayTimeoutInSeconds);
 }
 
 /* user pushed a button to update the blocklist */
 void PrivacyPage::onBlocklistUpdate()
 {
-    updateBlocklistDialog_ = std::make_unique<Gtk::MessageDialog>(
-        gtr_widget_get_window(*this),
-        _("Update Blocklist"),
-        false,
-        TR_GTK_MESSAGE_TYPE(INFO),
-        TR_GTK_BUTTONS_TYPE(CLOSE));
     updateBlocklistButton_->set_sensitive(false);
-    updateBlocklistDialog_->set_secondary_text(_("Getting new blocklist…"));
-    updateBlocklistDialog_->signal_response().connect([this](int /*response*/) { onBlocklistUpdateResponse(); });
-    updateBlocklistDialog_->show();
+
+    label_->set_text(_("Getting new blocklist…"));
+    blocklist_update_result_tag_.disconnect();
+
     core_->blocklist_update();
-    updateBlocklistTag_ = core_->signal_blocklist_updated().connect([this](auto n) { onBlocklistUpdated(n); });
 }
 
 void PrivacyPage::on_blocklist_url_changed(Gtk::Editable* e)
@@ -597,7 +580,6 @@ PrivacyPage::PrivacyPage(
     auto* const blocklist_url_entry = init_entry("blocklist_url_entry", TR_KEY_blocklist_url);
 
     updateBlocklistText();
-    updateBlocklistButton_->set_data("session", core_->get_session());
     updateBlocklistButton_->signal_clicked().connect([this]() { onBlocklistUpdate(); });
     updateBlocklistButton_->set_sensitive(check_->get_active());
     blocklist_url_entry->signal_changed().connect([this, blocklist_url_entry]()
@@ -605,6 +587,8 @@ PrivacyPage::PrivacyPage(
     on_blocklist_url_changed(blocklist_url_entry);
 
     init_check_button("blocklist_autoupdate_check", TR_KEY_blocklist_updates_enabled);
+
+    updateBlocklistTag_ = core_->signal_blocklist_updated().connect(sigc::mem_fun(*this, &PrivacyPage::onBlocklistUpdated));
 }
 
 /****

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -185,7 +185,7 @@ private:
 
     sigc::signal<void(ErrorCode, Glib::ustring const&)> signal_add_error_;
     sigc::signal<void(tr_ctor*)> signal_add_prompt_;
-    sigc::signal<void(int)> signal_blocklist_updated_;
+    sigc::signal<void(bool)> signal_blocklist_updated_;
     sigc::signal<void(bool)> signal_busy_;
     sigc::signal<void(tr_quark)> signal_prefs_changed_;
     sigc::signal<void(bool)> signal_port_tested_;
@@ -1715,7 +1715,7 @@ void Session::blocklist_update()
                 gtr_pref_int_set(TR_KEY_blocklist_date, tr_time());
             }
 
-            impl_->signal_blocklist_updated().emit(ruleCount);
+            impl_->signal_blocklist_updated().emit(ruleCount >= 0);
         });
     tr_variantClear(&request);
 }
@@ -1803,7 +1803,7 @@ sigc::signal<void(tr_ctor*)>& Session::signal_add_prompt()
     return impl_->signal_add_prompt();
 }
 
-sigc::signal<void(int)>& Session::signal_blocklist_updated()
+sigc::signal<void(bool)>& Session::signal_blocklist_updated()
 {
     return impl_->signal_blocklist_updated();
 }

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -124,7 +124,7 @@ public:
 
     sigc::signal<void(ErrorCode, Glib::ustring const&)>& signal_add_error();
     sigc::signal<void(tr_ctor*)>& signal_add_prompt();
-    sigc::signal<void(int)>& signal_blocklist_updated();
+    sigc::signal<void(bool)>& signal_blocklist_updated();
     sigc::signal<void(bool)>& signal_busy();
     sigc::signal<void(tr_quark)>& signal_prefs_changed();
     sigc::signal<void(bool)>& signal_port_tested();


### PR DESCRIPTION
Make it behave [almost] the same way port test works: display update status and final result in the label below the URL entry. The only difference is that label returns to its usual mode showing total number of rules after a while once update is finished; could probably have done it differently but decided against it to avoid affecting translations.