### PR TITLE
perf: lazy-calculate torrent seconds-seeding stat

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -752,13 +752,13 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bo
 
     if ((fields_to_load & tr_resume::TimeSeeding) != 0 && tr_variantDictFindInt(&top, TR_KEY_seeding_time_seconds, &i))
     {
-        tor->secondsSeeding = i;
+        tor->seconds_seeding_ = i;
         fields_loaded |= tr_resume::TimeSeeding;
     }
 
     if ((fields_to_load & tr_resume::TimeDownloading) != 0 && tr_variantDictFindInt(&top, TR_KEY_downloading_time_seconds, &i))
     {
-        tor->secondsDownloading = i;
+        tor->seconds_downloading_ = i;
         fields_loaded |= tr_resume::TimeDownloading;
     }
 
@@ -907,8 +907,8 @@ void save(tr_torrent* tor)
 
     auto top = tr_variant{};
     tr_variantInitDict(&top, 50); /* arbitrary "big enough" number */
-    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding);
-    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading);
+    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->seconds_seeding_);
+    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->seconds_downloading_);
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->corruptPrev + tor->corruptCur);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -752,13 +752,13 @@ static auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bo
 
     if ((fields_to_load & tr_resume::TimeSeeding) != 0 && tr_variantDictFindInt(&top, TR_KEY_seeding_time_seconds, &i))
     {
-        tor->seconds_seeding_ = i;
+        tor->seconds_seeding_before_current_start_ = i;
         fields_loaded |= tr_resume::TimeSeeding;
     }
 
     if ((fields_to_load & tr_resume::TimeDownloading) != 0 && tr_variantDictFindInt(&top, TR_KEY_downloading_time_seconds, &i))
     {
-        tor->seconds_downloading_ = i;
+        tor->seconds_downloading_before_current_start_ = i;
         fields_loaded |= tr_resume::TimeDownloading;
     }
 
@@ -906,9 +906,10 @@ void save(tr_torrent* tor)
     }
 
     auto top = tr_variant{};
+    auto const now = tr_time();
     tr_variantInitDict(&top, 50); /* arbitrary "big enough" number */
-    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->seconds_seeding_);
-    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->seconds_downloading_);
+    tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, tor->secondsSeeding(now));
+    tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->secondsDownloading(now));
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->corruptPrev + tor->corruptCur);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -508,24 +508,6 @@ void tr_session::onNowTimer()
     tr_timeUpdate(time(nullptr));
     alt_speeds_.checkScheduler();
 
-    // TODO: this seems a little silly. Why do we increment this
-    // every second instead of computing the value as needed by
-    // subtracting the current time from a start time?
-    for (auto* const tor : torrents())
-    {
-        if (tor->isRunning)
-        {
-            if (tor->isDone())
-            {
-                ++tor->seconds_seeding_;
-            }
-            else
-            {
-                ++tor->seconds_downloading_;
-            }
-        }
-    }
-
     // set the timer to kick again right after (10ms after) the next second
     auto const now = std::chrono::system_clock::now();
     auto const target_time = std::chrono::time_point_cast<std::chrono::seconds>(now) + 1s + 10ms;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -517,11 +517,11 @@ void tr_session::onNowTimer()
         {
             if (tor->isDone())
             {
-                ++tor->secondsSeeding;
+                ++tor->seconds_seeding_;
             }
             else
             {
-                ++tor->secondsDownloading;
+                ++tor->seconds_downloading_;
             }
         }
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -974,8 +974,8 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->doneDate = tor->doneDate;
     s->editDate = tor->editDate;
     s->startDate = tor->startDate;
-    s->secondsSeeding = tor->secondsSeeding;
-    s->secondsDownloading = tor->secondsDownloading;
+    s->secondsSeeding = tor->seconds_seeding_;
+    s->secondsDownloading = tor->seconds_downloading_;
 
     s->corruptEver = tor->corruptCur + tor->corruptPrev;
     s->downloadedEver = tor->downloadedCur + tor->downloadedPrev;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -925,11 +925,12 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    uint64_t const now = tr_time_msec();
+    auto const now = tr_time_msec();
+    auto const now_sec = tr_time();
 
     auto swarm_stats = tr_swarm_stats{};
 
-    tor->lastStatTime = tr_time();
+    tor->lastStatTime = now_sec;
 
     if (tor->swarm != nullptr)
     {
@@ -974,8 +975,8 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     s->doneDate = tor->doneDate;
     s->editDate = tor->editDate;
     s->startDate = tor->startDate;
-    s->secondsSeeding = tor->seconds_seeding_;
-    s->secondsDownloading = tor->seconds_downloading_;
+    s->secondsSeeding = tor->secondsSeeding(now_sec);
+    s->secondsDownloading = tor->secondsDownloading(now_sec);
 
     s->corruptEver = tor->corruptCur + tor->corruptPrev;
     s->downloadedEver = tor->downloadedCur + tor->downloadedPrev;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -731,6 +731,44 @@ public:
         }
     }
 
+    [[nodiscard]] constexpr auto secondsDownloading(time_t now) const noexcept
+    {
+        auto n_secs = seconds_downloading_before_current_start_;
+
+        if (isRunning)
+        {
+            if (doneDate > startDate)
+            {
+                n_secs += doneDate - startDate;
+            }
+            else if (doneDate == 0)
+            {
+                n_secs += now - startDate;
+            }
+        }
+
+        return n_secs;
+    }
+
+    [[nodiscard]] constexpr auto secondsSeeding(time_t now) const noexcept
+    {
+        auto n_secs = seconds_seeding_before_current_start_;
+
+        if (isRunning)
+        {
+            if (doneDate > startDate)
+            {
+                n_secs += now - doneDate;
+            }
+            else if (doneDate != 0)
+            {
+                n_secs += now - startDate;
+            }
+        }
+
+        return n_secs;
+    }
+
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
@@ -792,8 +830,8 @@ public:
 
     time_t lastStatTime = 0;
 
-    time_t seconds_downloading_ = 0;
-    time_t seconds_seeding_ = 0;
+    time_t seconds_downloading_before_current_start_ = 0;
+    time_t seconds_seeding_before_current_start_ = 0;
 
     uint64_t downloadedCur = 0;
     uint64_t downloadedPrev = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -792,6 +792,9 @@ public:
 
     time_t lastStatTime = 0;
 
+    time_t seconds_downloading_ = 0;
+    time_t seconds_seeding_ = 0;
+
     uint64_t downloadedCur = 0;
     uint64_t downloadedPrev = 0;
     uint64_t uploadedCur = 0;
@@ -817,9 +820,6 @@ public:
     tr_stat_errtype error = TR_STAT_OK;
 
     tr_bytes_per_second_t etaSpeed_Bps = 0;
-
-    time_t secondsDownloading = 0;
-    time_t secondsSeeding = 0;
 
     size_t queuePosition = 0;
 


### PR DESCRIPTION
The current codebase's CPU profiling is looking pretty good when permaseeding -- there's not a lot of low-hanging fruit left for easy performance wins.

Once per second in `tr_session::onNowTimer()` we iterate through all the torrents and update their `secondsSeeding` and `secondsDownloading` fields, which uses about 1.98% of cycles according to perf. This PR removes that update and instead lazy-evaluates it based on current time, startTime, and doneTime.

Notes: Made small performance improvements in libtransmission.