### PR TITLE
fixup: 3899255

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -50,7 +50,7 @@ bool tr_handshake::build_handshake_message(tr_peerIo* io, uint8_t* buf) const
     }
     auto const flag_bytes = flags.raw();
 
-    auto* walk = buf;
+    [[maybe_unused]] auto* walk = buf;
     walk = std::copy_n(reinterpret_cast<uint8_t const*>(std::data(HandshakeName)), std::size(HandshakeName), walk);
     walk = std::copy(std::begin(flag_bytes), std::end(flag_bytes), walk);
     walk = std::copy_n(reinterpret_cast<char const*>(std::data(info_hash)), std::size(info_hash), walk);

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -293,7 +293,7 @@ size_t tr_peerIo::try_write(size_t max)
     return n_written;
 }
 
-void tr_peerIo::event_write_cb(evutil_socket_t fd, short /*event*/, void* vio)
+void tr_peerIo::event_write_cb([[maybe_unused]] evutil_socket_t fd, short /*event*/, void* vio)
 {
     auto* const io = static_cast<tr_peerIo*>(vio);
     tr_logAddTraceIo(io, "libevent says this peer socket is ready for writing");
@@ -415,7 +415,7 @@ size_t tr_peerIo::try_read(size_t max)
     return n_read;
 }
 
-void tr_peerIo::event_read_cb(evutil_socket_t fd, short /*event*/, void* vio)
+void tr_peerIo::event_read_cb([[maybe_unused]] evutil_socket_t fd, short /*event*/, void* vio)
 {
     static auto constexpr MaxLen = RcvBuf;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1279,12 +1279,12 @@ void tr_session::closeImplPart2(std::promise<void>* closed_promise, std::chrono:
 
     this->announcer_.reset();
     this->announcer_udp_.reset();
-    this->udp_core_.reset();
 
     stats().saveIfDirty();
     peer_mgr_.reset();
-    tr_utpClose(this);
     openFiles().closeAll();
+    tr_utpClose(this);
+    this->udp_core_.reset();
 
     // tada we are done!
     closed_promise->set_value();

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1126,6 +1126,7 @@ private:
     tr_session_alt_speeds alt_speeds_{ alt_speed_mediator_ };
 
 public:
+    // depends-on: udp_core_
     struct struct_utp_context* utp_context = nullptr;
 
 private:
@@ -1141,7 +1142,7 @@ public:
     std::unique_ptr<Cache> cache = std::make_unique<Cache>(torrents_, 1024 * 1024 * 2);
 
 private:
-    // depends-on: timer_maker_, top_bandwidth_, utp_comntext, torrents_, web_
+    // depends-on: timer_maker_, top_bandwidth_, utp_context, torrents_, web_
     std::unique_ptr<struct tr_peerMgr, void (*)(struct tr_peerMgr*)> peer_mgr_;
 
     // depends-on: peer_mgr_, advertised_peer_port_, torrents_


### PR DESCRIPTION
Fix Yet Another Permutation of the tr_session shutdown bug.

Since UTP relies on udp_core, ensure that udp-core is cleared _after_ UTP in shutdown part 2.