### PR TITLE
Fixed implicit conversion warning: __LINE__ is a long

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -314,7 +314,7 @@ static void printMessage(
     std::string_view name,
     std::string_view message,
     std::string_view filename,
-    int line)
+    long line)
 {
     auto const out = std::empty(name) ? fmt::format(FMT_STRING("{:s} ({:s}:{:d})"), message, filename, line) :
                                         fmt::format(FMT_STRING("{:s} {:s} ({:s}:{:d})"), name, message, filename, line);

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -63,7 +63,7 @@ char const* ccrypto_error_to_str(CCCryptorStatus error_code)
     return "Unknown error";
 }
 
-void log_ccrypto_error(CCCryptorStatus error_code, char const* file, int line)
+void log_ccrypto_error(CCCryptorStatus error_code, char const* file, long line)
 {
     if (tr_logLevelIsActive(TR_LOG_ERROR))
     {
@@ -79,7 +79,7 @@ void log_ccrypto_error(CCCryptorStatus error_code, char const* file, int line)
     }
 }
 
-bool check_ccrypto_result(CCCryptorStatus result, char const* file, int line)
+bool check_ccrypto_result(CCCryptorStatus result, char const* file, long line)
 {
     bool const ret = result == kCCSuccess;
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -87,7 +87,7 @@ tr_sys_file_t tr_logGetFile()
 
 void logAddImpl(
     [[maybe_unused]] char const* file,
-    [[maybe_unused]] int line,
+    [[maybe_unused]] long line,
     [[maybe_unused]] tr_log_level level,
     std::string_view msg,
     [[maybe_unused]] std::string_view name)
@@ -243,7 +243,7 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
     return buf;
 }
 
-void tr_logAddMessage(char const* file, int line, tr_log_level level, std::string_view msg, std::string_view name)
+void tr_logAddMessage(char const* file, long line, tr_log_level level, std::string_view msg, std::string_view name)
 {
     TR_ASSERT(!std::empty(msg));
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -52,7 +52,7 @@ struct tr_log_message
 
     // location in the source code
     std::string_view file;
-    size_t line;
+    long line;
 
     // when the message was generated
     time_t when;
@@ -91,7 +91,7 @@ void tr_logSetLevel(tr_log_level);
 
 void tr_logAddMessage(
     char const* source_file,
-    int source_line,
+    long source_line,
     tr_log_level level,
     std::string_view msg,
     std::string_view module_name = {});

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -12,7 +12,7 @@
 
 #if !defined(NDEBUG) || defined(TR_FORCE_ASSERTIONS)
 
-[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
+[[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message)
 {
     std::cerr << "assertion failed: " << message << " (" << file << ':' << line << ')' << std::endl;
     abort();

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -11,7 +11,7 @@
 
 #include "tr-macros.h"
 
-[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message);
+[[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message);
 
 #define TR_ASSERT(x) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, #x)))
 #define TR_ASSERT_MSG(x, message) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, message)))

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -16,7 +16,7 @@
 // macOS implementation of tr_assert_report() that provides the message in the crash report
 // This replaces the generic implementation of the function in tr-assert.cc
 
-[[noreturn]] bool tr_assert_report(std::string_view file, int line, std::string_view message)
+[[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message)
 {
     auto const full_text = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), message, file, line);
     [NSException raise:NSInternalInconsistencyException format:@"%s", full_text.c_str()];


### PR DESCRIPTION
Problem: tr_log_message declares line as `size_t`, but that type is too large for usage and triggers a warning.
Solution: adopt `long`, as the maximum value supported for `__LINE__`, see https://stackoverflow.com/questions/5075928/cwhat-is-the-type-of-the-line-macro