### PR TITLE
perf: remove libtransmission::Buffer.vecs()

### DIFF
--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -80,19 +80,19 @@ size_t tr_peer_socket::try_write(Buffer& buf, size_t max, tr_error** error) cons
 #ifdef WITH_UTP
     if (is_utp())
     {
-        auto iov = buf.vecs(max);
+        auto [data, datalen] = buf.pullup();
 
         errno = 0;
-        auto const n = utp_writev(handle.utp, reinterpret_cast<struct utp_iovec*>(std::data(iov)), std::size(iov));
+        auto const n_written = utp_write(handle.utp, data, std::min(datalen, max));
         auto const error_code = errno;
 
-        if (n > 0)
+        if (n_written > 0)
         {
-            buf.drain(n);
-            return static_cast<size_t>(n);
+            buf.drain(n_written);
+            return static_cast<size_t>(n_written);
         }
 
-        if (n < 0 && error_code != 0)
+        if (n_written < 0 && error_code != 0)
         {
             tr_error_set(error, error_code, tr_strerror(error_code));
         }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -158,18 +158,6 @@ public:
         return evbuffer_get_length(buf_.get()) == 0;
     }
 
-    [[nodiscard]] auto vecs(size_t n_bytes) const
-    {
-        auto chains = std::vector<Iovec>(evbuffer_peek(buf_.get(), n_bytes, nullptr, nullptr, 0));
-        evbuffer_peek(buf_.get(), n_bytes, nullptr, std::data(chains), std::size(chains));
-        return chains;
-    }
-
-    [[nodiscard]] auto vecs() const
-    {
-        return vecs(size());
-    }
-
     [[nodiscard]] auto begin() noexcept
     {
         return Iterator{ buf_.get(), 0U };


### PR DESCRIPTION
Its two calls to evbuffer_peek() used 3.5% of CPU use (measured with perf when built with RelWithDebInfo). I added vecs() so that libtransmsision could send noncontiguous buffers via utp_writev(); but in my testing, all the buffers being sent are contiguous and so this is unnecessary work.

Notes: Made small performance improvements in libtransmission.