### PR TITLE
perf: recycle Diffie-Hellman keys iff peer was unreachable

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -833,6 +833,8 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
 
 bool tr_handshake::fire_done(bool is_connected)
 {
+    maybe_recycle_dh();
+
     if (!on_done_)
     {
         return false;
@@ -910,7 +912,7 @@ uint32_t tr_handshake::crypto_provide() const noexcept
 **/
 
 tr_handshake::tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode, DoneFunc on_done)
-    : dh_{ mediator->private_key() }
+    : dh_{ tr_handshake::get_dh(mediator) }
     , on_done_{ std::move(on_done) }
     , peer_io_{ std::move(peer_io) }
     , timeout_timer_{ mediator->timer_maker().create([this]() { fire_done(false); }) }

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -70,7 +70,7 @@ public:
     [[nodiscard]] static private_key_bigend_t randomPrivateKey() noexcept;
 
 private:
-    private_key_bigend_t const private_key_;
+    private_key_bigend_t private_key_;
     key_bigend_t public_key_ = {};
     key_bigend_t secret_ = {};
 };


### PR DESCRIPTION
Generating these keys is expensive, so recycle them if the peer was unreachable. We do not recycle keys that were shared in handshakes that succeeded / handshakes that failed due to invalid communication.

This can be a substantial savings in cases where you have a long list of peers that may be invalid, e.g. when resuming from an old session s.t. you have a cold cache of peers that may not be online anymore.

Notes: Made small performance improvements in libtransmission.