### PR TITLE
Remove unused UTP Socket code.

### DIFF
--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -129,34 +129,3 @@ size_t tr_peer_socket::try_read(Buffer& buf, size_t max, tr_error** error) const
 
     return {};
 }
-
-tr_peer_socket tr_netOpenPeerUTPSocket(
-    tr_session* session,
-    tr_address const& addr,
-    tr_port port,
-    bool /*client_is_seed*/,
-    void* userdata)
-{
-    auto ret = tr_peer_socket{};
-
-    if (session->utp_context != nullptr && addr.is_valid_for_peers(port))
-    {
-        auto const [ss, sslen] = addr.to_sockaddr(port);
-
-        if (auto* const sock = utp_create_socket(session->utp_context); sock != nullptr)
-        {
-            utp_set_userdata(sock, userdata);
-
-            if (utp_connect(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != -1)
-            {
-                ret = tr_peer_socket{ addr, port, sock };
-            }
-            else
-            {
-                utp_close(sock);
-            }
-        }
-    }
-
-    return ret;
-}

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -139,9 +139,3 @@ private:
 };
 
 tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr, tr_port port, bool client_is_seed);
-tr_peer_socket tr_netOpenPeerUTPSocket(
-    tr_session* session,
-    tr_address const& addr,
-    tr_port port,
-    bool client_is_seed,
-    void* userdata);


### PR DESCRIPTION
### What
- Remove unused `tr_netOpenPeerUTPSocket` function.  Apologies if I'm mistaken but I couldn't find other uses of it and I think call to `utp_create_socket` is in the `tr_peerIo::new_outgoing` function in `peer-io.cc`.  Not important -just cleanup if indeed it is unused.