### PR TITLE
refactor: Addressed various warnings

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3728,7 +3728,6 @@
 					"-DHAVE_STRLCPY",
 					"-DHAVE_ICONV",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3759,9 +3758,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
+					"$(inherited)",
 					"-fmodules",
 					"-fcxx-modules",
 				);
@@ -3786,8 +3784,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -3813,7 +3809,6 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -3835,8 +3830,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -3980,7 +3973,6 @@
 					"-DHAVE_STRLCPY",
 					"-DHAVE_ICONV",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4006,8 +3998,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4034,9 +4024,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
+					"$(inherited)",
 					"-fmodules",
 					"-fcxx-modules",
 				);
@@ -4125,8 +4114,6 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				GENERATE_MASTER_OBJECT_FILE = YES;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = Debug;
@@ -4137,8 +4124,6 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				GENERATE_MASTER_OBJECT_FILE = YES;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = "Release - Debug";
@@ -4149,8 +4134,6 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
 				GENERATE_MASTER_OBJECT_FILE = YES;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				PRODUCT_NAME = dht;
 			};
 			name = Release;
@@ -4242,9 +4225,8 @@
 					.,
 				);
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
+					"$(inherited)",
 					"-fmodules",
 					"-fcxx-modules",
 				);
@@ -4269,8 +4251,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = transmissioncli;
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4310,7 +4290,6 @@
 					"-DHAVE_STRLCPY",
 					"-DHAVE_ICONV",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = transmission;
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4340,7 +4319,6 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4362,8 +4340,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4437,11 +4413,10 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-fcxx-modules",
+					"$(inherited)",
 					"-fmodules",
+					"-fcxx-modules",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
@@ -4467,11 +4442,10 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-fcxx-modules",
+					"$(inherited)",
 					"-fmodules",
+					"-fcxx-modules",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
@@ -4497,11 +4471,10 @@
 				);
 				INFOPLIST_FILE = "macosx/QuickLookPlugin/QuickLookPlugin-Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
-				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
-					"$(OTHER_CFLAGS)",
-					"-fcxx-modules",
+					"$(inherited)",
 					"-fmodules",
+					"-fcxx-modules",
 				);
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.m0k.transmission.${PRODUCT_NAME:rfc1034identifier}";
@@ -4573,7 +4546,6 @@
 					"$(inherited)",
 					"-DHAVE_DAEMON",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "transmission-daemon";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4595,8 +4567,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4777,8 +4747,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4800,8 +4768,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4823,8 +4789,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4846,8 +4810,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4869,8 +4831,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4892,8 +4852,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4915,8 +4873,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4938,8 +4894,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (
@@ -4961,8 +4915,6 @@
 					"$(inherited)",
 					.,
 				);
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SYSTEM_HEADER_SEARCH_PATHS = (

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -418,7 +418,7 @@ static tr_rpc_callback_status on_rpc_callback(
     return TR_RPC_OK;
 }
 
-bool tr_daemon::parse_args(int argc, char const** argv, bool* dump_settings, bool* foreground, int* exit_code)
+bool tr_daemon::parse_args(int argc, char const* const* argv, bool* dump_settings, bool* foreground, int* exit_code)
 {
     int c;
     char const* optstr;
@@ -877,9 +877,9 @@ CLEANUP:
     return 0;
 }
 
-bool tr_daemon::init(int argc, char* argv[], bool* foreground, int* ret)
+bool tr_daemon::init(int argc, char const* const argv[], bool* foreground, int* ret)
 {
-    config_dir_ = getConfigDir(argc, (char const* const*)argv);
+    config_dir_ = getConfigDir(argc, argv);
 
     /* load settings from defaults + config file */
     tr_variantInitDict(&settings_, 0);
@@ -891,7 +891,7 @@ bool tr_daemon::init(int argc, char* argv[], bool* foreground, int* ret)
     *ret = 0;
 
     /* overwrite settings from the command line */
-    if (!parse_args(argc, (char const**)argv, &dumpSettings, foreground, ret))
+    if (!parse_args(argc, argv, &dumpSettings, foreground, ret))
     {
         goto EXIT_EARLY;
     }

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -32,7 +32,7 @@ public:
     }
 
     bool spawn(bool foreground, int* exit_code, tr_error** error);
-    bool init(int argc, char* argv[], bool* foreground, int* ret);
+    bool init(int argc, char const* const argv[], bool* foreground, int* ret);
     void handle_error(tr_error*) const;
     int start(bool foreground);
     void periodic_update();
@@ -54,7 +54,7 @@ private:
     tr_quark key_pidfile_ = tr_quark_new("pidfile");
     tr_quark key_watch_dir_force_generic_ = tr_quark_new("watch-dir-force-generic");
 
-    bool parse_args(int argc, char const** argv, bool* dump_settings, bool* foreground, int* exit_code);
+    bool parse_args(int argc, char const* const* argv, bool* dump_settings, bool* foreground, int* exit_code);
     bool reopen_log_file(char const* filename);
     bool setup_signals();
     void report_status();

--- a/macosx/BadgeView.h
+++ b/macosx/BadgeView.h
@@ -4,11 +4,7 @@
 
 #import <AppKit/AppKit.h>
 
-#include <libtransmission/transmission.h>
-
 @interface BadgeView : NSView
-
-- (instancetype)initWithLib:(tr_session*)lib;
 
 - (BOOL)setRatesWithDownload:(CGFloat)downloadRate upload:(CGFloat)uploadRate;
 

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -9,8 +9,6 @@ static CGFloat const kBetweenPadding = 2.0;
 
 @interface BadgeView ()
 
-@property(nonatomic, readonly) tr_session* fLib;
-
 @property(nonatomic) NSMutableDictionary* fAttributes;
 
 @property(nonatomic) CGFloat fDownloadRate;
@@ -20,12 +18,10 @@ static CGFloat const kBetweenPadding = 2.0;
 
 @implementation BadgeView
 
-- (instancetype)initWithLib:(tr_session*)lib
+- (instancetype)init
 {
     if ((self = [super init]))
     {
-        _fLib = lib;
-
         _fDownloadRate = 0.0;
         _fUploadRate = 0.0;
     }

--- a/macosx/Badger.h
+++ b/macosx/Badger.h
@@ -4,13 +4,9 @@
 
 #import <Foundation/Foundation.h>
 
-#include <libtransmission/transmission.h>
-
 @class Torrent;
 
 @interface Badger : NSObject
-
-- (instancetype)initWithLib:(tr_session*)lib;
 
 - (void)updateBadgeWithDownload:(CGFloat)downloadRate upload:(CGFloat)uploadRate;
 - (void)addCompletedTorrent:(Torrent*)torrent;

--- a/macosx/Badger.mm
+++ b/macosx/Badger.mm
@@ -9,21 +9,17 @@
 
 @interface Badger ()
 
-@property(nonatomic, readonly) tr_session* fLib;
-
 @property(nonatomic, readonly) NSMutableSet* fHashes;
 
 @end
 
 @implementation Badger
 
-- (instancetype)initWithLib:(tr_session*)lib
+- (instancetype)init
 {
     if ((self = [super init]))
     {
-        _fLib = lib;
-
-        BadgeView* view = [[BadgeView alloc] initWithLib:lib];
+        BadgeView* view = [[BadgeView alloc] init];
         NSApp.dockTile.contentView = view;
 
         _fHashes = [[NSMutableSet alloc] init];

--- a/macosx/BlocklistDownloaderViewController.h
+++ b/macosx/BlocklistDownloaderViewController.h
@@ -4,8 +4,6 @@
 
 #import <Foundation/Foundation.h>
 
-#include <libtransmission/transmission.h>
-
 @class PrefsController;
 
 @interface BlocklistDownloaderViewController : NSObject

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -103,7 +103,7 @@ BlocklistDownloaderViewController* fBLViewController = nil;
 
     alert.informativeText = error;
 
-    [alert beginSheetModalForWindow:self.fPrefsController.window completionHandler:^(NSModalResponse returnCode) {
+    [alert beginSheetModalForWindow:self.fPrefsController.window completionHandler:^(NSModalResponse /*returnCode*/) {
         fBLViewController = nil;
     }];
 }

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -391,9 +391,11 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/VDKQueue
 )
 
-add_definitions(
-    -Wno-unused-parameter
+add_compile_options(
+    # #warnings are good practice in development
     "-Wno-#warnings"
+    # GNU extensions are good practice in Objective-C
+    -Wno-gnu
 )
 
 add_library(vdkqueue STATIC

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -137,7 +137,7 @@ static tr_rpc_callback_status rpcCallback([[maybe_unused]] tr_session* handle, t
     return TR_RPC_NOREMOVE; //we'll do the remove manually
 }
 
-static void sleepCallback(void* controller, io_service_t y, natural_t messageType, void* messageArgument)
+static void sleepCallback(void* controller, io_service_t /*y*/, natural_t messageType, void* messageArgument)
 {
     [(__bridge Controller*)controller sleepCallback:messageType argument:messageArgument];
 }
@@ -363,7 +363,7 @@ static void removeKeRangerRansomware()
     }
 }
 
-void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
+void onStartQueue(tr_session* /*session*/, tr_torrent* tor, void* vself)
 {
     auto* controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
@@ -374,7 +374,7 @@ void onStartQueue(tr_session* session, tr_torrent* tor, void* vself)
     });
 }
 
-void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
+void onIdleLimitHit(tr_session* /*session*/, tr_torrent* tor, void* vself)
 {
     auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
@@ -385,7 +385,7 @@ void onIdleLimitHit(tr_session* session, tr_torrent* tor, void* vself)
     });
 }
 
-void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
+void onRatioLimitHit(tr_session* /*session*/, tr_torrent* tor, void* vself)
 {
     auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
@@ -396,7 +396,7 @@ void onRatioLimitHit(tr_session* session, tr_torrent* tor, void* vself)
     });
 }
 
-void onMetadataCompleted(tr_session* session, tr_torrent* tor, void* vself)
+void onMetadataCompleted(tr_session* /*session*/, tr_torrent* tor, void* vself)
 {
     auto* const controller = (__bridge Controller*)(vself);
     auto const hashstr = @(tr_torrentView(tor).hash_string);
@@ -784,7 +784,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         }
     }
 
-    self.fBadger = [[Badger alloc] initWithLib:self.fLib];
+    self.fBadger = [[Badger alloc] init];
 
     //observe notifications
     NSNotificationCenter* nc = NSNotificationCenter.defaultCenter;
@@ -859,7 +859,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         [UNUserNotificationCenter.currentNotificationCenter setNotificationCategories:[NSSet setWithObject:categoryShow]];
         [UNUserNotificationCenter.currentNotificationCenter
             requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge)
-                          completionHandler:^(BOOL granted, NSError* _Nullable error) {
+                          completionHandler:^(BOOL /*granted*/, NSError* _Nullable error) {
                               if (error.code > 0)
                               {
                                   NSLog(@"UserNotifications not configured: %@", error.localizedDescription);
@@ -1683,7 +1683,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)resumeAllTorrents:(id)sender
 {
-    NSMutableArray* torrents = [NSMutableArray arrayWithCapacity:self.fTorrents.count];
+    NSMutableArray<Torrent*>* torrents = [NSMutableArray arrayWithCapacity:self.fTorrents.count];
 
     for (Torrent* torrent in self.fTorrents)
     {
@@ -1713,7 +1713,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)resumeWaitingTorrents:(id)sender
 {
-    NSMutableArray* torrents = [NSMutableArray arrayWithCapacity:self.fTorrents.count];
+    NSMutableArray<Torrent*>* torrents = [NSMutableArray arrayWithCapacity:self.fTorrents.count];
 
     for (Torrent* torrent in self.fTorrents)
     {
@@ -1887,7 +1887,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
     //#5106 - don't try to remove torrents that have already been removed (fix for a bug, but better safe than crash anyway)
     NSIndexSet* indexesToRemove = [torrents indexesOfObjectsWithOptions:NSEnumerationConcurrent
-                                                            passingTest:^BOOL(Torrent* torrent, NSUInteger idx, BOOL* stop) {
+                                                            passingTest:^BOOL(Torrent* torrent, NSUInteger /*idx*/, BOOL* /*stop*/) {
                                                                 return [self.fTorrents indexOfObjectIdenticalTo:torrent] != NSNotFound;
                                                             }];
     if (torrents.count != indexesToRemove.count)
@@ -1910,9 +1910,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     //set up helpers to remove from the table
     __block BOOL beganUpdate = NO;
 
-    void (^doTableRemoval)(NSMutableArray*, id) = ^(NSMutableArray* displayedTorrents, id parent) {
+    void (^doTableRemoval)(NSMutableArray*, id) = ^(NSMutableArray<Torrent*>* displayedTorrents, id parent) {
         NSIndexSet* indexes = [displayedTorrents indexesOfObjectsWithOptions:NSEnumerationConcurrent
-                                                                 passingTest:^(id obj, NSUInteger idx, BOOL* stop) {
+                                                                 passingTest:^BOOL(Torrent* obj, NSUInteger /*idx*/, BOOL* /*stop*/) {
                                                                      return [torrents containsObject:obj];
                                                                  }];
 
@@ -2447,7 +2447,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         {
             __block TorrentGroup* parent = nil;
             [self.fDisplayedTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                                      usingBlock:^(TorrentGroup* group, NSUInteger idx, BOOL* stop) {
+                                                      usingBlock:^(TorrentGroup* group, NSUInteger /*idx*/, BOOL* stop) {
                                                           if ([group.torrents containsObject:torrent])
                                                           {
                                                               parent = group;
@@ -2474,7 +2474,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             {
                 __block TorrentGroup* parent = nil;
                 [self.fDisplayedTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                                          usingBlock:^(TorrentGroup* group, NSUInteger idx, BOOL* stop) {
+                                                          usingBlock:^(TorrentGroup* group, NSUInteger /*idx*/, BOOL* stop) {
                                                               if ([group.torrents containsObject:torrent])
                                                               {
                                                                   parent = group;
@@ -2503,7 +2503,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     NSParameterAssert(hash != nil);
 
     __block Torrent* torrent = nil;
-    [self.fTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(Torrent* obj, NSUInteger idx, BOOL* stop) {
+    [self.fTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(Torrent* obj, NSUInteger /*idx*/, BOOL* stop) {
         if ([obj.hashString isEqualToString:hash])
         {
             torrent = obj;
@@ -2554,14 +2554,14 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         else
         {
             // Fallback on earlier versions
-            NSUserNotification* notification = [[NSUserNotification alloc] init];
-            notification.title = title;
-            notification.informativeText = body;
-            notification.hasActionButton = YES;
-            notification.actionButtonTitle = NSLocalizedString(@"Show", "notification button");
-            notification.userInfo = userInfo;
+            NSUserNotification* userNotification = [[NSUserNotification alloc] init];
+            userNotification.title = title;
+            userNotification.informativeText = body;
+            userNotification.hasActionButton = YES;
+            userNotification.actionButtonTitle = NSLocalizedString(@"Show", "notification button");
+            userNotification.userInfo = userInfo;
 
-            [NSUserNotificationCenter.defaultUserNotificationCenter deliverNotification:notification];
+            [NSUserNotificationCenter.defaultUserNotificationCenter deliverNotification:userNotification];
         }
 
         if (!self.fWindow.mainWindow)
@@ -2903,7 +2903,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     NSInteger const groupFilterValue = [self.fDefaults integerForKey:@"FilterGroup"];
     BOOL const filterGroup = groupFilterValue != kGroupFilterAllTag;
 
-    NSArray* searchStrings = self.fFilterBar.searchStrings;
+    NSArray<NSString*>* searchStrings = self.fFilterBar.searchStrings;
     if (searchStrings && searchStrings.count == 0)
     {
         searchStrings = nil;
@@ -2919,7 +2919,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     auto* errorRef = &error;
     //filter & get counts of each type
     NSIndexSet* indexesOfNonFilteredTorrents = [self.fTorrents
-        indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(Torrent* torrent, NSUInteger idx, BOOL* stop) {
+        indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(Torrent* torrent, NSUInteger /*torrentIdx*/, BOOL* /*stopTorrentsEnumeration*/) {
             //check status
             if (torrent.active && !torrent.checkingWaiting)
             {
@@ -2976,38 +2976,41 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                 __block BOOL removeTextField = NO;
                 if (filterTracker)
                 {
-                    NSArray* trackers = torrent.allTrackersFlat;
+                    NSArray<NSString*>* trackers = torrent.allTrackersFlat;
 
                     //to count, we need each string in at least 1 tracker
-                    [searchStrings enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id searchString, NSUInteger idx, BOOL* stop) {
-                        __block BOOL found = NO;
-                        [trackers enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                                   usingBlock:^(NSString* tracker, NSUInteger idx, BOOL* stopTracker) {
-                                                       if ([tracker rangeOfString:searchString
-                                                                          options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)]
-                                                               .location != NSNotFound)
-                                                       {
-                                                           found = YES;
-                                                           *stopTracker = YES;
-                                                       }
-                                                   }];
-                        if (!found)
-                        {
-                            removeTextField = YES;
-                            *stop = YES;
-                        }
-                    }];
+                    [searchStrings
+                        enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString* searchString, NSUInteger /*idx*/, BOOL* stop) {
+                            __block BOOL found = NO;
+                            [trackers enumerateObjectsWithOptions:NSEnumerationConcurrent
+                                                       usingBlock:^(NSString* tracker, NSUInteger /*trackerIdx*/, BOOL* stopEnumerateTrackers) {
+                                                           if ([tracker rangeOfString:searchString
+                                                                              options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)]
+                                                                   .location != NSNotFound)
+                                                           {
+                                                               found = YES;
+                                                               *stopEnumerateTrackers = YES;
+                                                           }
+                                                       }];
+                            if (!found)
+                            {
+                                removeTextField = YES;
+                                *stop = YES;
+                            }
+                        }];
                 }
                 else
                 {
-                    [searchStrings enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id searchString, NSUInteger idx, BOOL* stop) {
-                        if ([torrent.name rangeOfString:searchString options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)]
-                                .location == NSNotFound)
-                        {
-                            removeTextField = YES;
-                            *stop = YES;
-                        }
-                    }];
+                    [searchStrings enumerateObjectsWithOptions:NSEnumerationConcurrent
+                                                    usingBlock:^(NSString* searchString, NSUInteger /*idx*/, BOOL* stop) {
+                                                        if ([torrent.name rangeOfString:searchString
+                                                                                options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)]
+                                                                .location == NSNotFound)
+                                                        {
+                                                            removeTextField = YES;
+                                                            *stop = YES;
+                                                        }
+                                                    }];
                 }
 
                 if (removeTextField)
@@ -3041,7 +3044,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     if (self.fDisplayedTorrents.count > 0)
     {
         //for each torrent, removes the previous piece info if it's not in allTorrents, and keeps track of which torrents we already found in allTorrents
-        void (^removePreviousFinishedPieces)(id, NSUInteger, BOOL*) = ^(Torrent* torrent, NSUInteger idx, BOOL* stop) {
+        void (^removePreviousFinishedPieces)(id, NSUInteger, BOOL*) = ^(Torrent* torrent, NSUInteger /*idx*/, BOOL* /*stop*/) {
             //we used to keep track of which torrents we already found in allTorrents, but it wasn't safe fo concurrent enumeration
             if (![allTorrents containsObject:torrent])
             {
@@ -3051,10 +3054,11 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         if (wasGroupRows)
         {
-            [self.fDisplayedTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id obj, NSUInteger idx, BOOL* stop) {
-                [((TorrentGroup*)obj).torrents enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                                                usingBlock:removePreviousFinishedPieces];
-            }];
+            [self.fDisplayedTorrents
+                enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id obj, NSUInteger /*idx*/, BOOL* /*stop*/) {
+                    [((TorrentGroup*)obj).torrents enumerateObjectsWithOptions:NSEnumerationConcurrent
+                                                                    usingBlock:removePreviousFinishedPieces];
+                }];
         }
         else
         {
@@ -3079,12 +3083,13 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             indexSetWithIndexesInRange:NSMakeRange(0, self.fDisplayedTorrents.count)];
 
         //for each of the torrents to add, find if it already exists (and keep track of those we've already added & those we need to remove)
-        [allTorrents enumerateObjectsWithOptions:0 usingBlock:^(id objAll, NSUInteger previousIndex, BOOL* stop) {
-            NSUInteger const currentIndex = [self.fDisplayedTorrents indexOfObjectAtIndexes:removePreviousIndexes
-                                                                                    options:NSEnumerationConcurrent
-                                                                                passingTest:^(id objDisplay, NSUInteger idx, BOOL* stop) {
-                                                                                    return (BOOL)(objAll == objDisplay);
-                                                                                }];
+        [allTorrents enumerateObjectsWithOptions:0 usingBlock:^(Torrent* obj, NSUInteger previousIndex, BOOL* /*stopEnumerate*/) {
+            NSUInteger const currentIndex = [self.fDisplayedTorrents
+                indexOfObjectAtIndexes:removePreviousIndexes
+                               options:NSEnumerationConcurrent
+                           passingTest:^BOOL(id objDisplay, NSUInteger /*idx*/, BOOL* /*stop*/) {
+                               return obj == objDisplay;
+                           }];
             if (currentIndex == NSNotFound)
             {
                 [addIndexes addIndex:previousIndex];
@@ -3113,10 +3118,12 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                 //slide new torrents in differently
                 if (self.fAddingTransfers)
                 {
-                    NSIndexSet* newAddIndexes = [allTorrents indexesOfObjectsAtIndexes:addIndexes options:NSEnumerationConcurrent
-                                                                           passingTest:^BOOL(Torrent* obj, NSUInteger idx, BOOL* stop) {
-                                                                               return [self.fAddingTransfers containsObject:obj];
-                                                                           }];
+                    NSIndexSet* newAddIndexes = [allTorrents
+                        indexesOfObjectsAtIndexes:addIndexes
+                                          options:NSEnumerationConcurrent
+                                      passingTest:^BOOL(Torrent* obj, NSUInteger /*idx*/, BOOL* /*stop*/) {
+                                          return [self.fAddingTransfers containsObject:obj];
+                                      }];
 
                     [addIndexes removeIndexes:newAddIndexes];
 
@@ -3167,8 +3174,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             {
                 Torrent* torrent = group.torrents[indexInGroup];
                 NSUInteger const allIndex = [allTorrents indexOfObjectAtIndexes:unusedAllTorrentsIndexes options:NSEnumerationConcurrent
-                                                                    passingTest:^(id obj, NSUInteger idx, BOOL* stop) {
-                                                                        return (BOOL)(obj == torrent);
+                                                                    passingTest:^BOOL(Torrent* obj, NSUInteger /*idx*/, BOOL* /*stop*/) {
+                                                                        return obj == torrent;
                                                                     }];
                 if (allIndex == NSNotFound)
                 {
@@ -3245,7 +3252,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
             [group.torrents addObject:torrent];
 
-            BOOL const newTorrent = self.fAddingTransfers && [self.fAddingTransfers containsObject:torrent];
+            BOOL const newTorrent = [self.fAddingTransfers containsObject:torrent];
             [self.fTableView insertItemsAtIndexes:[NSIndexSet indexSetWithIndex:group.torrents.count - 1] inParent:group
                                     withAnimation:newTorrent ? NSTableViewAnimationSlideLeft : NSTableViewAnimationSlideDown];
         }
@@ -3253,7 +3260,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         //remove empty groups
         NSIndexSet* removeGroupIndexes = [self.fDisplayedTorrents
             indexesOfObjectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, originalGroupCount)]
-                              options:NSEnumerationConcurrent passingTest:^BOOL(id obj, NSUInteger idx, BOOL* stop) {
+                              options:NSEnumerationConcurrent passingTest:^BOOL(id obj, NSUInteger /*idx*/, BOOL* /*stop*/) {
                                   return ((TorrentGroup*)obj).torrents.count == 0;
                               }];
 
@@ -3908,23 +3915,23 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         BOOL torrent = NO;
         NSArray<NSURL*>* files = [pasteboard readObjectsForClasses:@[ NSURL.class ]
                                                            options:@{ NSPasteboardURLReadingFileURLsOnlyKey : @YES }];
-        for (NSURL* file in files)
+        for (NSURL* fileToParse in files)
         {
-            if ([[NSWorkspace.sharedWorkspace typeOfFile:file.path error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-                [file.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame)
+            if ([[NSWorkspace.sharedWorkspace typeOfFile:fileToParse.path error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
+                [fileToParse.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame)
             {
                 torrent = YES;
                 auto metainfo = tr_torrent_metainfo{};
-                if (metainfo.parseTorrentFile(file.path.UTF8String))
+                if (metainfo.parseTorrentFile(fileToParse.path.UTF8String))
                 {
                     if (!self.fOverlayWindow)
                     {
-                        self.fOverlayWindow = [[DragOverlayWindow alloc] initWithLib:self.fLib forWindow:self.fWindow];
+                        self.fOverlayWindow = [[DragOverlayWindow alloc] initForWindow:self.fWindow];
                     }
                     NSMutableArray<NSString*>* filesToOpen = [NSMutableArray arrayWithCapacity:files.count];
-                    for (NSURL* file in files)
+                    for (NSURL* fileToOpen in files)
                     {
-                        [filesToOpen addObject:file.path];
+                        [filesToOpen addObject:fileToOpen.path];
                     }
                     [self.fOverlayWindow setTorrents:filesToOpen];
 
@@ -3938,7 +3945,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         {
             if (!self.fOverlayWindow)
             {
-                self.fOverlayWindow = [[DragOverlayWindow alloc] initWithLib:self.fLib forWindow:self.fWindow];
+                self.fOverlayWindow = [[DragOverlayWindow alloc] initForWindow:self.fWindow];
             }
             [self.fOverlayWindow setFile:[files[0] lastPathComponent]];
 
@@ -3949,7 +3956,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         if (!self.fOverlayWindow)
         {
-            self.fOverlayWindow = [[DragOverlayWindow alloc] initWithLib:self.fLib forWindow:self.fWindow];
+            self.fOverlayWindow = [[DragOverlayWindow alloc] initForWindow:self.fWindow];
         }
         [self.fOverlayWindow setURL:[NSURL URLFromPasteboard:pasteboard].relativeString];
 
@@ -5458,7 +5465,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         if (torrentStruct != NULL && (type != TR_RPC_TORRENT_ADDED && type != TR_RPC_SESSION_CHANGED && type != TR_RPC_SESSION_CLOSE))
         {
             [self.fTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                             usingBlock:^(Torrent* checkTorrent, NSUInteger idx, BOOL* stop) {
+                                             usingBlock:^(Torrent* checkTorrent, NSUInteger /*idx*/, BOOL* stop) {
                                                  if (torrentStruct == checkTorrent.torrentStruct)
                                                  {
                                                      torrent = checkTorrent;

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -682,7 +682,7 @@ NSMutableSet* creatorWindowControllerSet = nil;
         alert.alertStyle = NSAlertStyleWarning;
 
         alert.informativeText = [NSString stringWithFormat:@"%s (%d)", error->message, error->code];
-        [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
+        [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse /*returnCode*/) {
             [self.window close];
         }];
         tr_error_free(error);

--- a/macosx/DragOverlayWindow.h
+++ b/macosx/DragOverlayWindow.h
@@ -4,11 +4,9 @@
 
 #import <AppKit/AppKit.h>
 
-#include <libtransmission/transmission.h>
-
 @interface DragOverlayWindow : NSWindow
 
-- (instancetype)initWithLib:(tr_session*)lib forWindow:(NSWindow*)window;
+- (instancetype)initForWindow:(NSWindow*)window;
 
 - (void)setTorrents:(NSArray<NSString*>*)files;
 - (void)setFile:(NSString*)file;

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -10,8 +10,6 @@
 
 @interface DragOverlayWindow ()
 
-@property(nonatomic, readonly) tr_session* fLib;
-
 @property(nonatomic, readonly) NSViewAnimation* fFadeInAnimation;
 @property(nonatomic, readonly) NSViewAnimation* fFadeOutAnimation;
 
@@ -19,13 +17,11 @@
 
 @implementation DragOverlayWindow
 
-- (instancetype)initWithLib:(tr_session*)lib forWindow:(NSWindow*)window
+- (instancetype)initForWindow:(NSWindow*)window
 {
     if ((self = ([super initWithContentRect:window.frame styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered
                                       defer:NO])))
     {
-        _fLib = lib;
-
         self.backgroundColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.5];
         self.alphaValue = 0.0;
         self.opaque = NO;

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -112,7 +112,7 @@
         lookupPathComponents = [lookupPathComponents arrayByAddingObject:oldName];
         BOOL const allSame = NSNotFound ==
             [lookupPathComponents indexOfObjectWithOptions:NSEnumerationConcurrent
-                                               passingTest:^BOOL(NSString* name, NSUInteger idx, BOOL* stop) {
+                                               passingTest:^BOOL(NSString* name, NSUInteger idx, BOOL* /*stop*/) {
                                                    return ![name isEqualToString:thesePathComponents[idx]];
                                                }];
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -94,7 +94,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
         __block BOOL filter = NO;
         if (components)
         {
-            [components enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString* obj, NSUInteger idx, BOOL* stop) {
+            [components enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString* obj, NSUInteger /*idx*/, BOOL* stop) {
                 if ([item.name rangeOfString:obj options:(NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)].location == NSNotFound)
                 {
                     filter = YES;
@@ -691,7 +691,10 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
     using FindFileNode = void (^)(FileListNode*, NSArray<FileListNode*>*, NSIndexSet*, FileListNode*);
     __weak __block FindFileNode weakFindFileNode;
     FindFileNode findFileNode;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
     weakFindFileNode = findFileNode = ^(FileListNode* node, NSArray<FileListNode*>* list, NSIndexSet* indexes, FileListNode* currentParent) {
+#pragma clang diagnostic pop
         [list enumerateObjectsAtIndexes:indexes options:NSEnumerationConcurrent
                              usingBlock:^(FileListNode* checkNode, NSUInteger index, BOOL* stop) {
                                  if ([checkNode.indexes containsIndex:node.indexes.firstIndex])

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -284,34 +284,11 @@ GroupsController* fGroupsInstance = nil;
 {
     NSMenu* menu = [[NSMenu alloc] initWithTitle:@""];
 
-    NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"None", "Groups -> Menu") action:action
-                                           keyEquivalent:@""];
-    item.target = target;
-    item.tag = -1;
-
-    NSImage* icon = [self imageForGroupNone];
-    if (small)
-    {
-        icon = [icon copy];
-        icon.size = NSMakeSize(kIconWidthSmall, kIconWidthSmall);
-
-        item.image = icon;
-    }
-    else
-    {
-        item.image = icon;
-    }
-
-    [menu addItem:item];
-
-    for (NSMutableDictionary* dict in self.fGroups)
-    {
-        item = [[NSMenuItem alloc] initWithTitle:dict[@"Name"] action:action keyEquivalent:@""];
+    void (^addItemWithTitleTagIcon)(NSString*, NSInteger, NSImage*) = ^void(NSString* title, NSInteger tag, NSImage* icon) {
+        NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:title action:action keyEquivalent:@""];
         item.target = target;
+        item.tag = tag;
 
-        item.tag = [dict[@"Index"] integerValue];
-
-        NSImage* icon = [self imageForGroup:dict];
         if (small)
         {
             icon = [icon copy];
@@ -325,6 +302,13 @@ GroupsController* fGroupsInstance = nil;
         }
 
         [menu addItem:item];
+    };
+
+    addItemWithTitleTagIcon(NSLocalizedString(@"None", "Groups -> Menu"), -1, [self imageForGroupNone]);
+
+    for (NSMutableDictionary* dict in self.fGroups)
+    {
+        addItemWithTitleTagIcon(dict[@"Name"], [dict[@"Index"] integerValue], [self imageForGroup:dict]);
     }
 
     return menu;

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -44,7 +44,7 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 @property(nonatomic) IBOutlet NSStackView* fActivityStackView;
 @property(nonatomic) IBOutlet NSView* fDatesView;
-@property(nonatomic, readwrite) CGFloat fHeightChange;
+@property(nonatomic, readonly) CGFloat fHeightChange;
 @property(nonatomic, readwrite) CGFloat fCurrentHeight;
 @property(nonatomic, readonly) CGFloat fHorizLayoutHeight;
 @property(nonatomic, readonly) CGFloat fHorizLayoutWidth;
@@ -96,14 +96,13 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 - (NSRect)viewRect
 {
-    CGFloat difference = self.fHeightChange;
-
-    NSRect windowRect = self.view.window.frame;
     NSRect viewRect = self.view.frame;
+
+    CGFloat difference = self.fHeightChange;
     if (difference != 0)
     {
         viewRect.size.height -= difference;
-        viewRect.size.width = NSWidth(windowRect);
+        viewRect.size.width = NSWidth(self.view.window.frame);
     }
 
     return viewRect;
@@ -133,7 +132,7 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
     [self checkLayout];
 
-    if (self.oldHeight != self.fCurrentHeight)
+    if (self.fHeightChange != 0)
     {
         [self updateWindowLayout];
     }

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -545,13 +545,14 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
     }
     else
     {
-        [self.fTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(Torrent* torrent, NSUInteger idx, BOOL* stop) {
-            if (torrent.webSeedCount > 0)
-            {
-                hasWebSeeds = YES;
-                *stop = YES;
-            }
-        }];
+        [self.fTorrents enumerateObjectsWithOptions:NSEnumerationConcurrent
+                                         usingBlock:^(Torrent* torrent, NSUInteger /*idx*/, BOOL* stop) {
+                                             if (torrent.webSeedCount > 0)
+                                             {
+                                                 hasWebSeeds = YES;
+                                                 *stop = YES;
+                                             }
+                                         }];
     }
 
     if (!hasWebSeeds)

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -193,7 +193,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
 
 - (void)setInfoForTorrents:(NSArray<Torrent*>*)torrents
 {
-    if (self.fTorrents && [self.fTorrents isEqualToArray:torrents])
+    if ([self.fTorrents isEqualToArray:torrents])
     {
         return;
     }

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -509,7 +509,7 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
     NSString* filterString = self.fFilterField.stringValue;
 
     NSIndexSet* indexes = [self.fMessages
-        indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(NSDictionary* message, NSUInteger idx, BOOL* stop) {
+        indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(NSDictionary* message, NSUInteger /*idx*/, BOOL* /*stop*/) {
             return [message[@"Level"] integerValue] <= level && [self shouldIncludeMessageForFilter:filterString message:message];
         }];
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -48,9 +48,9 @@
     }
     else
     {
-        unsigned int const magnitudePartial = log(partialSize) / log(1000);
+        auto const magnitudePartial = static_cast<unsigned int>(log(partialSize) / log(1000));
         // we have to catch 0 with a special case, so might as well avoid the math for all of magnitude 0
-        unsigned int const magnitudeFull = fullSize < 1000 ? 0 : log(fullSize) / log(1000);
+        auto const magnitudeFull = static_cast<unsigned int>(fullSize < 1000 ? 0 : log(fullSize) / log(1000));
         partialUnitsSame = magnitudePartial == magnitudeFull;
     }
 
@@ -76,12 +76,12 @@
 {
     //N/A is different than libtransmission's
 
-    if ((int)ratio == TR_RATIO_NA)
+    if (static_cast<int>(ratio) == TR_RATIO_NA)
     {
         return NSLocalizedString(@"N/A", "No Ratio");
     }
 
-    if ((int)ratio == TR_RATIO_INF)
+    if (static_cast<int>(ratio) == TR_RATIO_INF)
     {
         return @"\xE2\x88\x9E";
     }

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -70,11 +70,11 @@ enum
     {
         //determine relevant values
         _fNumPieces = MIN(_torrent.pieceCount, kMaxAcross * kMaxAcross);
-        _fAcross = ceil(sqrt(_fNumPieces));
+        _fAcross = static_cast<NSInteger>(ceil(sqrt(_fNumPieces)));
 
         CGFloat const width = self.bounds.size.width;
-        _fWidth = (width - (_fAcross + 1) * kBetweenPadding) / _fAcross;
-        _fExtraBorder = (width - ((_fWidth + kBetweenPadding) * _fAcross + kBetweenPadding)) / 2;
+        _fWidth = static_cast<NSInteger>((width - (_fAcross + 1) * kBetweenPadding) / _fAcross);
+        _fExtraBorder = static_cast<NSInteger>((width - ((_fWidth + kBetweenPadding) * _fAcross + kBetweenPadding)) / 2);
     }
 
     NSImage* back = [[NSImage alloc] initWithSize:self.bounds.size];

--- a/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
+++ b/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
@@ -14,7 +14,7 @@ QL_EXTERN_C_END
 
 OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize)
 {
-    // To complete your generator please implement the function GenerateThumbnailForURL in GenerateThumbnailForURL.c
+    // To complete the generator, please implement the function GenerateThumbnailForURL here
     return noErr;
 }
 

--- a/macosx/QuickLookPlugin/main.cc
+++ b/macosx/QuickLookPlugin/main.cc
@@ -3,7 +3,7 @@
 //	DO NO MODIFY THE CONTENT OF THIS FILE
 //
 //	This file contains the generic CFPlug-in code necessary for your generator
-//	To complete your generator implement the function in GenerateThumbnailForURL/GeneratePreviewForURL.c
+//	To complete the generator implement the function in GenerateThumbnailForURL/GeneratePreviewForURL.*
 //
 //==============================================================================
 
@@ -30,7 +30,7 @@
 // -----------------------------------------------------------------------------
 
 QL_EXTERN_C_BEGIN
-// The thumbnail generation function to be implemented in GenerateThumbnailForURL.c
+// The thumbnail generation function to be implemented in GenerateThumbnailForURL.*
 OSStatus GenerateThumbnailForURL(
     void* thisInterface,
     QLThumbnailRequestRef thumbnail,
@@ -40,7 +40,7 @@ OSStatus GenerateThumbnailForURL(
     CGSize maxSize);
 void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail);
 
-// The preview generation function to be implemented in GeneratePreviewForURL.c
+// The preview generation function to be implemented in GeneratePreviewForURL.*
 OSStatus GeneratePreviewForURL(
     void* thisInterface,
     QLPreviewRequestRef preview,

--- a/macosx/SparkleProxy.mm
+++ b/macosx/SparkleProxy.mm
@@ -7,7 +7,7 @@
 #import "NSStringAdditions.h"
 
 // Development-only proxy when app is not signed for running Sparkle
-void SUUpdater_checkForUpdates(id self, SEL _cmd, ...)
+void SUUpdater_checkForUpdates(id /*self*/, SEL /*_cmd*/, ...)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSAlert* alert = [[NSAlert alloc] init];

--- a/macosx/StatsWindowController.h
+++ b/macosx/StatsWindowController.h
@@ -4,8 +4,6 @@
 
 #import <AppKit/AppKit.h>
 
-#include <libtransmission/transmission.h>
-
 @interface StatsWindowController : NSWindowController
 
 @property(nonatomic, class, readonly) StatsWindowController* statsWindow;

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -196,7 +196,7 @@ tr_session* fLib = NULL;
 
     self.fRatioField.stringValue = [NSString stringForRatio:statsSession.ratio];
 
-    NSString* totalRatioString = statsAll.ratio != TR_RATIO_NA ?
+    NSString* totalRatioString = static_cast<int>(statsAll.ratio) != TR_RATIO_NA ?
         [NSString stringWithFormat:NSLocalizedString(@"%@ total", "stats total"), [NSString stringForRatio:statsAll.ratio]] :
         NSLocalizedString(@"Total N/A", "stats total");
     self.fRatioAllField.stringValue = totalRatioString;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -59,7 +59,7 @@ static int const kETAIdleDisplaySec = 2 * 60;
 
 @end
 
-void renameCallback(tr_torrent* torrent, char const* oldPathCharString, char const* newNameCharString, int error, void* contextInfo)
+void renameCallback(tr_torrent* /*torrent*/, char const* oldPathCharString, char const* newNameCharString, int error, void* contextInfo)
 {
     @autoreleasepool
     {
@@ -1852,7 +1852,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     if (isFolder)
     {
         [parent.children enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                          usingBlock:^(FileListNode* searchNode, NSUInteger idx, BOOL* stop) {
+                                          usingBlock:^(FileListNode* searchNode, NSUInteger /*idx*/, BOOL* stop) {
                                               if ([searchNode.name isEqualToString:name] && searchNode.isFolder)
                                               {
                                                   node = searchNode;
@@ -1897,9 +1897,11 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
                                                                   selector:@selector(localizedStandardCompare:)];
     [fileNodes sortUsingDescriptors:@[ descriptor ]];
 
-    [fileNodes enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(FileListNode* node, NSUInteger idx, BOOL* stop) {
+    [fileNodes enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(FileListNode* node, NSUInteger /*idx*/, BOOL* /*stop*/) {
         if (node.isFolder)
+        {
             [self sortFileList:node.children];
+        }
     }];
 }
 
@@ -2006,7 +2008,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
             if (node.isFolder)
             {
                 [node.children enumerateObjectsWithOptions:NSEnumerationConcurrent
-                                                usingBlock:^(FileListNode* childNode, NSUInteger idx, BOOL* stop) {
+                                                usingBlock:^(FileListNode* childNode, NSUInteger /*idx*/, BOOL* /*stop*/) {
                                                     weakUpdateNodeAndChildrenForRename(childNode);
                                                 }];
             }
@@ -2016,7 +2018,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
         {
             nodes = self.flatFileList;
         }
-        [nodes enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(FileListNode* node, NSUInteger idx, BOOL* stop) {
+        [nodes enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(FileListNode* node, NSUInteger /*idx*/, BOOL* /*stop*/) {
             updateNodeAndChildrenForRename(node);
         }];
 

--- a/macosx/TorrentTableView.h
+++ b/macosx/TorrentTableView.h
@@ -4,8 +4,6 @@
 
 #import <AppKit/AppKit.h>
 
-#include <libtransmission/transmission.h>
-
 @class Torrent;
 
 extern const CGFloat kGroupSeparatorHeight;

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -209,9 +209,15 @@ NSMutableSet* fTrackerIconLoading;
 
     NSURLSessionDataTask* task = [NSURLSession.sharedSession
         dataTaskWithRequest:request completionHandler:^(NSData* iconData, NSURLResponse* response, NSError* error) {
+            if (error)
+            {
+                NSLog(@"Unable to get tracker icon: task failed (%@)", error.localizedDescription);
+                return;
+            }
             BOOL ok = ((NSHTTPURLResponse*)response).statusCode == 200 ? YES : NO;
             if (!ok)
             {
+                NSLog(@"Unable to get tracker icon: status code not OK (%ld)", (long)((NSHTTPURLResponse*)response).statusCode);
                 return;
             }
 

--- a/macosx/WebSeedTableView.mm
+++ b/macosx/WebSeedTableView.mm
@@ -16,9 +16,10 @@
 {
     NSIndexSet* indexes = self.selectedRowIndexes;
     NSMutableArray* addresses = [NSMutableArray arrayWithCapacity:indexes.count];
-    [self.webSeeds enumerateObjectsAtIndexes:indexes options:0 usingBlock:^(NSDictionary* webSeed, NSUInteger idx, BOOL* stop) {
-        [addresses addObject:webSeed[@"Address"]];
-    }];
+    [self.webSeeds enumerateObjectsAtIndexes:indexes options:0
+                                  usingBlock:^(NSDictionary* webSeed, NSUInteger /*idx*/, BOOL* /*stop*/) {
+                                      [addresses addObject:webSeed[@"Address"]];
+                                  }];
 
     NSString* text = [addresses componentsJoinedByString:@"\n"];
 


### PR DESCRIPTION
While all the Apple recommended warnings were already turned on (since https://github.com/transmission/transmission/pull/3940), a bunch of extra warning flags were just added for the macOS app with https://github.com/transmission/transmission/pull/4395.

This PR resolves most of those:
- warnings for unused parameter -> unnamed parameter
- warnings for shadowing variable -> renamed variable
- warnings for not using _fHeightChange -> changed to readonly
- warnings for not using error -> added a log for the error
- warnings for comparing signed with unsigned types -> replaced usage of `kInvalidValue` with `multiple*Limits` BOOLs.
- warnings for using `?:` -> added `-Wno-gnu`
- warnings for implicit float to int conversion -> added `static_cast<int>`

This PR does not resolve the float-equal warnings and leaves those for discussion at #4400.

(you may ignore the TeamCity Sanity failures: it's just some flakiness and unrelated to those changes)

pinging @ckerr, @sweetppro or @nevack for review, thanks.