### PR TITLE
refactor: tr_rand_buffer(), tr_rand_int() again

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -292,30 +292,30 @@ struct tr_tracker
     {
     }
 
-    [[nodiscard]] int getRetryInterval() const
+    [[nodiscard]] time_t getRetryInterval() const
     {
         switch (consecutive_failures)
         {
         case 0:
-            return 0;
+            return 0U;
 
         case 1:
-            return 20;
+            return 20U;
 
         case 2:
-            return tr_rand_int(60) + 60 * 5;
+            return tr_rand_int(60U) + 60U * 5U;
 
         case 3:
-            return tr_rand_int(60) + 60 * 15;
+            return tr_rand_int(60U) + 60U * 15U;
 
         case 4:
-            return tr_rand_int(60) + 60 * 30;
+            return tr_rand_int(60U) + 60U * 30U;
 
         case 5:
-            return tr_rand_int(60) + 60 * 60;
+            return tr_rand_int(60U) + 60U * 60U;
 
         default:
-            return tr_rand_int(60) + 60 * 120;
+            return tr_rand_int(60U) + 60U * 120U;
         }
     }
 

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -198,7 +198,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer(void* buffer, size_t length)
+bool tr_rand_buffer_impl(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -198,7 +198,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer_impl(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -204,7 +204,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer(void* buffer, size_t length)
+bool tr_rand_buffer_impl(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-cyassl.cc
+++ b/libtransmission/crypto-utils-cyassl.cc
@@ -204,7 +204,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer_impl(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -298,7 +298,7 @@ void tr_x509_cert_free(tr_x509_cert_t handle)
 ****
 ***/
 
-bool tr_rand_buffer(void* buffer, size_t length)
+bool tr_rand_buffer_impl(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -298,7 +298,7 @@ void tr_x509_cert_free(tr_x509_cert_t handle)
 ****
 ***/
 
-bool tr_rand_buffer_impl(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -91,7 +91,7 @@ static bool check_polarssl_result(int result, int expected_result, char const* f
 ****
 ***/
 
-static int my_rand(void* /*context*/, unsigned char* buffer, size_ buffer_size)
+static int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
 {
     // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
     tr_rand_buffer_std(buffer, buffer_size);

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -93,7 +93,7 @@ static bool check_polarssl_result(int result, int expected_result, char const* f
 
 static int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
 {
-    // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
+    // since we're initializing tr_rand_buffer()'s rng, we can't use tr_rand_buffer() here
     tr_rand_buffer_std(buffer, buffer_size);
     return 0;
 }

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -91,27 +91,27 @@ static bool check_polarssl_result(int result, int expected_result, char const* f
 ****
 ***/
 
+static int my_rand(void* /*context*/, unsigned char* buffer, size_ buffer_size)
+{
+    // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
+    tr_rand_buffer_std(buffer, buffer_size);
+    return 0;
+};
+
 static api_ctr_drbg_context* get_rng()
 {
     static api_ctr_drbg_context rng;
     static bool rng_initialized = false;
-
-    static auto my_rand = [](void* /*context*/, unsigned char* buffer, size_t buffer_size)
-    {
-        // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
-        tr_rand_buffer_std(buffer, buffer_size);
-        return 0;
-    };
 
     if (!rng_initialized)
     {
 #if API_VERSION_NUMBER >= 0x02000000
         API(ctr_drbg_init)(&rng);
 
-        if (!check_result(API(ctr_drbg_seed)(&rng, &my_rand, nullptr, nullptr, 0)))
+        if (!check_result(API(ctr_drbg_seed)(&rng, my_rand, nullptr, nullptr, 0)))
 #else
 
-        if (!check_result(API(ctr_drbg_init)(&rng, &my_rand, nullptr, nullptr, 0)))
+        if (!check_result(API(ctr_drbg_init)(&rng, my_rand, nullptr, nullptr, 0)))
 #endif
         {
             return nullptr;

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -91,21 +91,17 @@ static bool check_polarssl_result(int result, int expected_result, char const* f
 ****
 ***/
 
-static int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
-{
-    for (size_t i = 0; i < buffer_size; ++i)
-    {
-        // my_rand is used to initialize tr_rand_buffer itself used by tr_rand_int, so we can only use tr_rand_int_weak here
-        buffer[i] = tr_rand_int_weak(256);
-    }
-
-    return 0;
-}
-
 static api_ctr_drbg_context* get_rng()
 {
     static api_ctr_drbg_context rng;
     static bool rng_initialized = false;
+
+    static int my_rand = [](void* /*context*/, unsigned char* buffer, size_t buffer_size)
+    {
+        // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
+        tr_rand_buffer_fallback(buffer, buffer_size);
+        return 0;
+    };
 
     if (!rng_initialized)
     {

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -264,7 +264,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer(void* buffer, size_t length)
+bool tr_rand_buffer_impl(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -96,7 +96,7 @@ static int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
     // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
     tr_rand_buffer_std(buffer, buffer_size);
     return 0;
-};
+}
 
 static api_ctr_drbg_context* get_rng()
 {

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -96,7 +96,7 @@ static api_ctr_drbg_context* get_rng()
     static api_ctr_drbg_context rng;
     static bool rng_initialized = false;
 
-    static int my_rand = [](void* /*context*/, unsigned char* buffer, size_t buffer_size)
+    static auto my_rand = [](void* /*context*/, unsigned char* buffer, size_t buffer_size)
     {
         // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
         tr_rand_buffer_std(buffer, buffer_size);

--- a/libtransmission/crypto-utils-polarssl.cc
+++ b/libtransmission/crypto-utils-polarssl.cc
@@ -99,7 +99,7 @@ static api_ctr_drbg_context* get_rng()
     static int my_rand = [](void* /*context*/, unsigned char* buffer, size_t buffer_size)
     {
         // since we're initializing tr_rand_buffer()'s rng, we cant use tr_rand_buffer() here
-        tr_rand_buffer_fallback(buffer, buffer_size);
+        tr_rand_buffer_std(buffer, buffer_size);
         return 0;
     };
 
@@ -260,7 +260,7 @@ std::unique_ptr<tr_sha256> tr_sha256::create()
 ****
 ***/
 
-bool tr_rand_buffer_impl(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(void* buffer, size_t length)
 {
     if (length == 0)
     {

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -275,3 +275,11 @@ void tr_rand_buffer_std(void* buffer, size_t length)
             return dist(engine);
         });
 }
+
+void tr_rand_buffer(void* buffer, size_t length)
+{
+    if (!tr_rand_buffer_crypto(buffer, length))
+    {
+        tr_rand_buffer_std(buffer, length);
+    }
+}

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -44,7 +44,6 @@ template<class T>
 }
 
 template size_t tr_rand_int(size_t upper_bound);
-template unsigned char tr_rand_int(unsigned char upper_bound);
 template unsigned int tr_rand_int(unsigned int upper_bound);
 
 ///

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -275,11 +275,3 @@ void tr_rand_buffer_std(void* buffer, size_t length)
             return dist(engine);
         });
 }
-
-void tr_rand_buffer(void* buffer, size_t length)
-{
-    if (!tr_rand_buffer_crypto(buffer, length))
-    {
-        tr_rand_buffer_std(buffer, length);
-    }
-}

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -265,15 +265,14 @@ std::optional<tr_sha256_digest_t> tr_sha256_from_string(std::string_view hex)
 // fallback implementation in case the system crypto library's RNG fails
 void tr_rand_buffer_std(void* buffer, size_t length)
 {
-    std::generate_n(
-        static_cast<uint8_t*>(buffer),
-        length,
-        []()
-        {
-            thread_local auto engine = std::mt19937{ std::random_device{}() };
-            thread_local auto dist = std::uniform_int_distribution<uint8_t>(uint8_t{});
-            return dist(engine);
-        });
+    thread_local auto generator = []()
+    {
+        thread_local auto engine = std::mt19937{ std::random_device{}() };
+        thread_local auto dist = std::uniform_int_distribution<uint8_t>(uint8_t{});
+        return dist(engine);
+    };
+
+    std::generate_n(static_cast<uint8_t*>(buffer), length, generator);
 }
 
 void tr_rand_buffer(void* buffer, size_t length)

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -263,7 +263,7 @@ std::optional<tr_sha256_digest_t> tr_sha256_from_string(std::string_view hex)
 }
 
 // fallback implementation in case the system crypto library's RNG fails
-void tr_rand_buffer_fallback(void* buffer, size_t length)
+void tr_rand_buffer_std(void* buffer, size_t length)
 {
     std::generate_n(
         static_cast<uint8_t*>(buffer),
@@ -278,10 +278,8 @@ void tr_rand_buffer_fallback(void* buffer, size_t length)
 
 void tr_rand_buffer(void* buffer, size_t length)
 {
-    extern bool tr_rand_buffer_impl(void* buffer, size_t length);
-
-    if (!tr_rand_buffer_impl(buffer, length))
+    if (!tr_rand_buffer_crypto(buffer, length))
     {
-        tr_rand_buffer_fallback(buffer, length);
+        tr_rand_buffer_std(buffer, length);
     }
 }

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -11,6 +11,7 @@
 #include <random>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 extern "C"
@@ -28,82 +29,25 @@ extern "C"
 
 using namespace std::literals;
 
-template<class IntType>
-[[nodiscard]] IntType tr_rand_integer(IntType upper_bound);
-template<class IntType>
-[[nodiscard]] IntType tr_rand_integer_weak(IntType upper_bound);
+///
 
-/***
-****
-***/
-
-template<>
-[[nodiscard]] int tr_rand_int<int>(int upper_bound)
+template<class T>
+[[nodiscard]] T tr_rand_int(T upper_bound)
 {
-    return tr_rand_integer<int>(upper_bound);
+    static_assert(!std::is_signed<T>());
+    TR_ASSERT(upper_bound > std::numeric_limits<T>::min());
+
+    using dist_type = std::uniform_int_distribution<T>;
+    thread_local auto rng = tr_urbg<T>{};
+    thread_local auto dist = dist_type{};
+    return dist(rng, typename dist_type::param_type(0, upper_bound - 1));
 }
 
-template<>
-[[nodiscard]] size_t tr_rand_int<size_t>(size_t upper_bound)
-{
-    return tr_rand_integer<size_t>(upper_bound);
-}
+template size_t tr_rand_int(size_t upper_bound);
+template unsigned char tr_rand_int(unsigned char upper_bound);
+template unsigned int tr_rand_int(unsigned int upper_bound);
 
-template<>
-[[nodiscard]] int tr_rand_int_weak<int>(int upper_bound)
-{
-    return tr_rand_integer_weak<int>(upper_bound);
-}
-
-template<>
-[[nodiscard]] size_t tr_rand_int_weak<size_t>(size_t upper_bound)
-{
-    return tr_rand_integer_weak<size_t>(upper_bound);
-}
-
-template<class IntType>
-[[nodiscard]] IntType tr_rand_integer(IntType upper_bound_integer)
-{
-    TR_ASSERT(upper_bound_integer > 0);
-
-    using UIntType = std::make_unsigned_t<IntType>;
-    auto upper_bound = static_cast<UIntType>(upper_bound_integer);
-
-    // random uniform algorithm for unsigned type
-    // (https://github.com/openbsd/src/blob/master/lib/libc/crypt/arc4random_uniform.c)
-    if (upper_bound < 2)
-    {
-        return 0;
-    }
-    UIntType min = -upper_bound % upper_bound;
-    UIntType noise = 0;
-    for (;;)
-    {
-        tr_rand_buffer(&noise, sizeof(noise));
-
-        if (noise >= min)
-        {
-            return noise % upper_bound;
-        }
-    }
-}
-
-template<class IntType>
-[[nodiscard]] IntType tr_rand_integer_weak(IntType upper_bound)
-{
-    TR_ASSERT(upper_bound > 0);
-
-    thread_local auto random_engine = std::mt19937{ std::random_device{}() };
-    using distribution_type = std::uniform_int_distribution<IntType>;
-    thread_local distribution_type distribution;
-
-    // Upper bound is inclusive in std::uniform_int_distribution.
-    return distribution(random_engine, typename distribution_type::param_type{ 0, upper_bound - 1 });
-}
-
-/***
-****
-***/
+///
 
 namespace
 {

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -94,15 +94,6 @@ template<class IntType>
 [[nodiscard]] IntType tr_rand_int(IntType upper_bound);
 
 /**
- * @brief Returns a pseudorandom number in the range of [0...upper_bound).
- *
- * This is faster, BUT WEAKER, than tr_rand_int() and never be used in sensitive cases.
- * @see tr_rand_int()
- */
-template<class IntType>
-[[nodiscard]] IntType tr_rand_int_weak(IntType upper_bound);
-
-/**
  * @brief Fill a buffer with random bytes.
  */
 void tr_rand_buffer(void* buffer, size_t length);

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -93,21 +93,15 @@ void tr_x509_cert_free(tr_x509_cert_t handle);
 template<class IntType>
 [[nodiscard]] IntType tr_rand_int(IntType upper_bound);
 
+/**
+ * @brief Fill a buffer with random bytes.
+ */
+void tr_rand_buffer(void* buffer, size_t length);
+
 // Client code should use `tr_rand_buffer()`.
 // These helpers are only exposed here to permit open-box tests.
 bool tr_rand_buffer_crypto(void* buffer, size_t length);
 void tr_rand_buffer_std(void* buffer, size_t length);
-
-/**
- * @brief Fill a buffer with random bytes.
- */
-void tr_rand_buffer(void* buffer, size_t length)
-{
-    if (!tr_rand_buffer_crypto(buffer, length))
-    {
-        tr_rand_buffer_std(buffer, length);
-    }
-}
 
 template<typename T>
 T tr_rand_obj()

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -93,15 +93,21 @@ void tr_x509_cert_free(tr_x509_cert_t handle);
 template<class IntType>
 [[nodiscard]] IntType tr_rand_int(IntType upper_bound);
 
-/**
- * @brief Fill a buffer with random bytes.
- */
-void tr_rand_buffer(void* buffer, size_t length);
-
 // Client code should use `tr_rand_buffer()`.
 // These helpers are only exposed here to permit open-box tests.
 bool tr_rand_buffer_crypto(void* buffer, size_t length);
 void tr_rand_buffer_std(void* buffer, size_t length);
+
+/**
+ * @brief Fill a buffer with random bytes.
+ */
+void tr_rand_buffer(void* buffer, size_t length)
+{
+    if (!tr_rand_buffer_crypto(buffer, length))
+    {
+        tr_rand_buffer_std(buffer, length);
+    }
+}
 
 template<typename T>
 T tr_rand_obj()

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -105,7 +105,11 @@ template<class IntType>
 /**
  * @brief Fill a buffer with random bytes.
  */
-bool tr_rand_buffer(void* buffer, size_t length);
+void tr_rand_buffer(void* buffer, size_t length);
+
+// don't use this in client code.
+// it's only exposed here for unit tests.
+void tr_rand_buffer_fallback(void* buffer, size_t length);
 
 template<typename T>
 T tr_rand_obj()

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -98,9 +98,10 @@ template<class IntType>
  */
 void tr_rand_buffer(void* buffer, size_t length);
 
-// don't use this in client code.
-// it's only exposed here for unit tests.
-void tr_rand_buffer_fallback(void* buffer, size_t length);
+// Client code should use `tr_rand_buffer()`.
+// These helpers are only exposed here to permit open-box tests.
+bool tr_rand_buffer_crypto(void* buffer, size_t length);
+void tr_rand_buffer_std(void* buffer, size_t length);
 
 template<typename T>
 T tr_rand_obj()

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -320,8 +320,8 @@ static void create_temp_path(
 
         while (i > 0 && path_template[i - 1] == 'X')
         {
-            int const c = tr_rand_int(26 + 26 + 10);
-            path[i - 1] = c < 26 ? c + 'A' : (c < 26 + 26 ? (c - 26) + 'a' : (c - 26 - 26) + '0');
+            static auto constexpr Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"sv;
+            path[i - 1] = Chars[tr_rand_int(std::size(Chars))];
             --i;
         }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -75,7 +75,7 @@ tr_port tr_session::randomPort() const
     auto const lower = std::min(settings_.peer_port_random_low.host(), settings_.peer_port_random_high.host());
     auto const upper = std::max(settings_.peer_port_random_low.host(), settings_.peer_port_random_high.host());
     auto const range = upper - lower;
-    return tr_port::fromHost(lower + tr_rand_int(range + 1));
+    return tr_port::fromHost(lower + tr_rand_int(range + 1U));
 }
 
 /* Generate a peer id : "-TRxyzb-" + 12 random alphanumeric

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -84,10 +84,7 @@ extern "C"
 
     int dht_random_bytes(void* buf, size_t size)
     {
-        if (!tr_rand_buffer(buf, size))
-        {
-            return -1;
-        }
+        tr_rand_buffer(buf, size);
         return static_cast<int>(size);
     }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -201,7 +201,7 @@ public:
 
         // Being slightly late is fine,
         // and has the added benefit of adding some jitter.
-        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000) };
+        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000U) };
         periodic_timer_->startSingleShot(interval);
     }
 
@@ -320,8 +320,8 @@ private:
     {
         auto const* dht_hash = reinterpret_cast<unsigned char const*>(std::data(info_hash));
         auto const rc = mediator_.api().search(dht_hash, port.host(), af, callback, this);
-        auto const announce_again_in_n_secs = rc < 0 ? 5s + std::chrono::seconds{ tr_rand_int(5) } :
-                                                       25min + std::chrono::seconds{ tr_rand_int(3 * 60) };
+        auto const announce_again_in_n_secs = rc < 0 ? 5s + std::chrono::seconds{ tr_rand_int(5U) } :
+                                                       25min + std::chrono::seconds{ tr_rand_int(3U * 60U) };
         return announce_again_in_n_secs;
     }
 
@@ -360,7 +360,7 @@ private:
 
         // Being slightly late is fine,
         // and has the added benefit of adding some jitter.
-        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000) };
+        auto const interval = call_again_in_n_secs + std::chrono::milliseconds{ tr_rand_int(1000U) };
         periodic_timer_->startSingleShot(interval);
     }
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -142,7 +142,7 @@ static uint64 utp_callback(utp_callback_arguments* args)
 static void reset_timer(tr_session* session)
 {
     auto interval = std::chrono::milliseconds{};
-    auto const random_percent = tr_rand_int(1000) / 1000.0;
+    auto const random_percent = tr_rand_int(1000U) / 1000.0;
 
     if (session->allowsUTP())
     {

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -20,12 +20,12 @@ TEST(Bitfield, count)
 
     for (auto i = 0; i < IterCount; ++i)
     {
-        int const bit_count = 100 + tr_rand_int(1000);
+        auto const bit_count = 100U + tr_rand_int(1000U);
 
         // generate a random bitfield
         tr_bitfield bf(bit_count);
 
-        for (int j = 0, n = tr_rand_int(bit_count); j < n; ++j)
+        for (size_t j = 0, n = tr_rand_int(bit_count); j < n; ++j)
         {
             bf.set(tr_rand_int(bit_count));
         }

--- a/tests/libtransmission/crypto-test-ref.h
+++ b/tests/libtransmission/crypto-test-ref.h
@@ -15,6 +15,8 @@
 #define tr_base64_encode tr_base64_encode_
 #define tr_base64_encode_impl tr_base64_encode_impl_
 #define tr_rand_buffer tr_rand_buffer_
+#define tr_rand_buffer_crypto tr_rand_buffer_crypto_
+#define tr_rand_buffer_std tr_rand_buffer_std_
 #define tr_rand_int tr_rand_int_
 #define tr_rand_int_weak tr_rand_int_weak_
 #define tr_rand_obj tr_rand_obj_
@@ -49,6 +51,8 @@
 #undef tr_base64_encode
 #undef tr_base64_encode_impl
 #undef tr_rand_buffer
+#undef tr_rand_buffer_crypto
+#undef tr_rand_buffer_std
 #undef tr_rand_int
 #undef tr_rand_int_weak
 #undef tr_rand_obj
@@ -78,6 +82,8 @@
 #define tr_base64_encode_ tr_base64_encode
 #define tr_base64_encode_impl_ tr_base64_encode_impl
 #define tr_rand_buffer_ tr_rand_buffer
+#define tr_rand_buffer_crypto_ tr_rand_buffer_crypto
+#define tr_rand_buffer_std_ tr_rand_buffer_std
 #define tr_rand_int_ tr_rand_int
 #define tr_rand_int_weak_ tr_rand_int_weak
 #define tr_rand_obj_ tr_rand_obj

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -244,9 +244,36 @@ TEST(Crypto, random)
     /* test that tr_rand_int() stays in-bounds */
     for (int i = 0; i < 100000; ++i)
     {
-        int const val = tr_rand_int(100);
-        EXPECT_LE(0, val);
-        EXPECT_LT(val, 100);
+        auto const val = tr_rand_int(100U);
+        EXPECT_LE(0U, val);
+        EXPECT_LT(val, 100U);
+    }
+}
+
+TEST(Crypto, randBuf)
+{
+    static auto constexpr Width = 32U;
+    static auto constexpr Iterations = 1000U;
+    static auto constexpr Empty = std::array<uint8_t, Width>{};
+
+    auto buf = Empty;
+
+    for (size_t i = 0; i < Iterations; ++i)
+    {
+        auto tmp = buf;
+        tr_rand_buffer(std::data(tmp), std::size(tmp));
+        EXPECT_NE(tmp, Empty);
+        EXPECT_NE(tmp, buf);
+        buf = tmp;
+    }
+
+    for (size_t i = 0; i < Iterations; ++i)
+    {
+        auto tmp = buf;
+        tr_rand_buffer_fallback(std::data(tmp), std::size(tmp));
+        EXPECT_NE(tmp, Empty);
+        EXPECT_NE(tmp, buf);
+        buf = tmp;
     }
 }
 
@@ -266,14 +293,14 @@ TEST(Crypto, base64)
         auto buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
-            buf += static_cast<char>(tr_rand_int(256));
+            buf += static_cast<char>(tr_rand_int(256U));
         }
         EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
 
         buf = std::string{};
         for (size_t j = 0; j < i; ++j)
         {
-            buf += static_cast<char>(1 + tr_rand_int(255));
+            buf += static_cast<char>(1U + tr_rand_int(255U));
         }
         EXPECT_EQ(buf, tr_base64_decode(tr_base64_encode(buf)));
     }

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -253,7 +253,7 @@ TEST(Crypto, random)
 TEST(Crypto, randBuf)
 {
     static auto constexpr Width = 32U;
-    static auto constexpr Iterations = 1000U;
+    static auto constexpr Iterations = 100000U;
     static auto constexpr Empty = std::array<uint8_t, Width>{};
 
     auto buf = Empty;

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -270,7 +270,7 @@ TEST(Crypto, randBuf)
     for (size_t i = 0; i < Iterations; ++i)
     {
         auto tmp = buf;
-        tr_rand_buffer_fallback(std::data(tmp), std::size(tmp));
+        tr_rand_buffer_std(std::data(tmp), std::size(tmp));
         EXPECT_NE(tmp, Empty);
         EXPECT_NE(tmp, buf);
         buf = tmp;

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -110,7 +110,7 @@ TEST(WebUtilsTest, parseMagnetFuzz)
 
     for (size_t i = 0; i < 100000; ++i)
     {
-        auto const len = static_cast<size_t>(tr_rand_int(1024));
+        auto const len = static_cast<size_t>(tr_rand_int(1024U));
         tr_rand_buffer(std::data(buf), len);
         auto mm = tr_magnet_metainfo{};
         EXPECT_FALSE(mm.parseMagnet({ std::data(buf), len }));

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -99,9 +99,9 @@ TEST_F(TorrentMetainfoTest, parseBencFuzz)
 {
     auto buf = std::vector<char>{};
 
-    for (size_t i = 0; i < 100000; ++i)
+    for (size_t i = 0; i < 100000U; ++i)
     {
-        buf.resize(tr_rand_int(1024));
+        buf.resize(tr_rand_int(1024U));
         tr_rand_buffer(std::data(buf), std::size(buf));
         // std::cerr << '[' << tr_base64_encode({ std::data(buf), std::size(buf) }) << ']' << std::endl;
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -156,7 +156,7 @@ TEST_F(UtilsTest, trStrvUtf8CleanFuzz)
     auto buf = std::vector<char>{};
     for (size_t i = 0; i < 1000; ++i)
     {
-        buf.resize(tr_rand_int(4096));
+        buf.resize(tr_rand_int(4096U));
         tr_rand_buffer(std::data(buf), std::size(buf));
         auto const out = tr_strvUtf8Clean({ std::data(buf), std::size(buf) });
         EXPECT_EQ(out, tr_strvUtf8Clean(out));

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -543,7 +543,7 @@ TEST_F(VariantTest, variantFromBufFuzz)
 
     for (size_t i = 0; i < 100000; ++i)
     {
-        buf.resize(tr_rand_int(4096));
+        buf.resize(tr_rand_int(4096U));
         tr_rand_buffer(std::data(buf), std::size(buf));
         // std::cerr << '[' << tr_base64_encode({ std::data(buf), std::size(buf) }) << ']' << std::endl;
 

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -126,9 +126,9 @@ TEST(WebUtilsTest, urlParseFuzz)
 {
     auto buf = std::vector<char>{};
 
-    for (size_t i = 0; i < 100000; ++i)
+    for (size_t i = 0; i < 100000U; ++i)
     {
-        buf.resize(tr_rand_int(1024));
+        buf.resize(tr_rand_int(1024U));
         tr_rand_buffer(std::data(buf), std::size(buf));
         (void)tr_urlParse({ std::data(buf), std::size(buf) });
     }


### PR DESCRIPTION
Another pass at refactoring our RNG. Previous discussion: #4235, #2089

1. `tr_rand_buffer()` now tries the system's crypto library first, then uses `std::mt19937` as a fallback if the crypto library fails for whatever reason. Since `tr_rand_buffer()` doesn't fail anymore, it now returns `void` instead of a success flag. Remove client code that checked for and handled failure.

2. Remove `tr_rand_int_weak()`. It was used as a fallback in case `tr_rand_int()` failed, but `tr_rand_int()` is implemented `tr_raned_buffer()` which now has its own fallback mode (described in previous bullet point).

3. Reimplement `tr_rand_int()`. It now has an internal thread_local buffer and calls `tr_rand_buffer()` so it can buffer up a batch of numbers that can be returned by subsequent calls to `tr_rand_int()`. It now uses a `std::uniform_int_distribution<>`  so we don't need to roll our own modulo bias correction.

4. We don't have any code that actually needs to generate signed random numbers, so simplify the templates a little by changing calling code to request unsigned numbers.

CC @Coeur, @mikedld, @nevack 