### PR TITLE
Add missing GroupPopUpButtonCell and PriorityPopUpButtonCell to CMakeLists.txt

### DIFF
--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -58,6 +58,7 @@ set(${PROJECT_NAME}_SOURCES
     GlobalOptionsPopoverViewController.mm
     GroupTextCell.mm
     GroupToolbarItem.mm
+    GroupPopUpButtonCell.mm
     GroupsController.mm
     GroupsPrefsController.mm
     InfoActivityViewController.mm
@@ -83,9 +84,11 @@ set(${PROJECT_NAME}_SOURCES
     PredicateEditorRowTemplateAny.mm
     PrefsController.mm
     PrefsWindow.mm
+    PriorityPopUpButtonCell.mm
     ProgressGradients.mm
     ShareToolbarItem.mm
     ShareTorrentFileHelper.mm
+    SparkleProxy.mm
     StatsWindowController.mm
     StatusBarController.mm
     StatusBarView.mm
@@ -112,6 +115,7 @@ set(${PROJECT_NAME}_HEADERS
     BlocklistScheduler.h
     BonjourController.h
     ButtonToolbarItem.h
+    CocoaCompatibility.h
     ColorTextField.h
     Controller.h
     CreatorWindowController.h
@@ -129,6 +133,7 @@ set(${PROJECT_NAME}_HEADERS
     FilterBarView.h
     FilterButton.h
     GlobalOptionsPopoverViewController.h
+    GroupPopUpButtonCell.h
     GroupToolbarItem.h
     GroupsController.h
     GroupsPrefsController.h
@@ -155,6 +160,7 @@ set(${PROJECT_NAME}_HEADERS
     PredicateEditorRowTemplateAny.h
     PrefsController.h
     PrefsWindow.h
+    PriorityPopUpButtonCell.h
     ProgressGradients.h
     ShareToolbarItem.h
     ShareTorrentFileHelper.h

--- a/macosx/GroupPopUpButtonCell.h
+++ b/macosx/GroupPopUpButtonCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors.
+// This file Copyright © 2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupPopUpButtonCell.mm
+++ b/macosx/GroupPopUpButtonCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors.
+// This file Copyright © 2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PriorityPopUpButtonCell.h
+++ b/macosx/PriorityPopUpButtonCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors.
+// This file Copyright © 2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/PriorityPopUpButtonCell.mm
+++ b/macosx/PriorityPopUpButtonCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2022 Transmission authors and contributors.
+// This file Copyright © 2022 Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 


### PR DESCRIPTION
They were added with #3156. The missing files were unnoticed because the difference is small (icon and title moved a pixel or two):
![Capture d’écran 2022-12-20 à 18 13 05](https://user-images.githubusercontent.com/839992/208643190-1f99730a-a90d-4982-a3ac-355d5812408e.png)
![Capture d’écran 2022-12-20 à 18 14 16](https://user-images.githubusercontent.com/839992/208643209-54752566-2143-4f62-9171-e4890cd3c8dd.png)

And SparkleProxy.mm (from #3050) for alerting devs when signing is incorrect.
Also adding CocoaCompatibility.h (from #2844) for older Xcodes.
