### PR TITLE
feat: added support for displaying "Show Toolbar"

### DIFF
--- a/macosx/Base.lproj/MainMenu.xib
+++ b/macosx/Base.lproj/MainMenu.xib
@@ -516,7 +516,7 @@
                             </menuItem>
                             <menuItem title="Hide Toolbar" id="1222">
                                 <connections>
-                                    <action selector="toggleToolbarShown:" target="-1" id="1251"/>
+                                    <action selector="toggleToolbarShown:" target="206" id="1251"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Customize Toolbar…" id="545">

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -153,6 +153,7 @@ typedef NS_ENUM(unsigned int, addType) { //
 
 - (IBAction)toggleStatusBar:(id)sender;
 - (IBAction)toggleFilterBar:(id)sender;
+- (IBAction)toggleToolbarShown:(id)sender;
 - (void)focusFilterField;
 
 - (void)allToolbarClicked:(id)sender;

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4125,6 +4125,11 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     [self updateMainWindow];
 }
 
+- (IBAction)toggleToolbarShown:(id)sender
+{
+    [self.fWindow toggleToolbarShown:sender];
+}
+
 - (void)focusFilterField
 {
     if (!self.fFilterBar)
@@ -4809,6 +4814,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         NSString* title = !self.fFilterBar ? NSLocalizedString(@"Show Filter Bar", "View menu -> Filter Bar") :
                                              NSLocalizedString(@"Hide Filter Bar", "View menu -> Filter Bar");
+        menuItem.title = title;
+
+        return self.fWindow.visible;
+    }
+
+    // enable toggle toolbar
+    if (action == @selector(toggleToolbarShown:))
+    {
+        NSString* title = !self.fWindow.toolbar.isVisible ? NSLocalizedString(@"Show Toolbar", "View menu -> Toolbar") :
+                                                            NSLocalizedString(@"Hide Toolbar", "View menu -> Toolbar");
         menuItem.title = title;
 
         return self.fWindow.visible;


### PR DESCRIPTION
This is a enhancement for the macOS app: added missing support for showing "Show Toolbar" after hiding the toolbar.
![Capture d’écran 2022-12-20 à 20 27 54](https://user-images.githubusercontent.com/839992/208667515-b7c5a0f5-53e0-40eb-8be0-054b9513390d.png)

As this requires translations, setting Milestone to "Decide after 4.0".