### PR TITLE
build: fix utils tests on win32 CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -375,7 +375,7 @@ jobs:
             -DENABLE_MAC=OFF `
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_TESTS=ON `
-            -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} `
+            -DENABLE_UTILS=ON `
             -DENABLE_WEB=OFF `
             -DENABLE_WERROR=ON `
             -DRUN_CLANG_TIDY=OFF


### PR DESCRIPTION
tests depend on utils; so if we unconditionally enable tests, we need to do the same for utils.

This should fix a CI edge case that was showing up in https://github.com/transmission/transmission/pull/4418