### PR TITLE
perf: make bandwidth.allocate() bidirectional

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -137,17 +137,19 @@ void tr_bandwidth::setParent(tr_bandwidth* new_parent)
 
 void tr_bandwidth::allocateBandwidth(
     tr_priority_t parent_priority,
-    tr_direction dir,
     unsigned int period_msec,
     std::vector<std::shared_ptr<tr_peerIo>>& peer_pool)
 {
-    tr_priority_t const priority = std::max(parent_priority, this->priority_);
+    auto const priority = std::max(parent_priority, this->priority_);
 
-    /* set the available bandwidth */
-    if (auto& bandwidth = band_[dir]; bandwidth.is_limited_)
+    // set the available bandwidth
+    for (auto const dir : { TR_UP, TR_DOWN })
     {
-        auto const next_pulse_speed = bandwidth.desired_speed_bps_;
-        bandwidth.bytes_left_ = next_pulse_speed * period_msec / 1000U;
+        if (auto& bandwidth = band_[dir]; bandwidth.is_limited_)
+        {
+            auto const next_pulse_speed = bandwidth.desired_speed_bps_;
+            bandwidth.bytes_left_ = next_pulse_speed * period_msec / 1000U;
+        }
     }
 
     // add this bandwidth's peer, if any, to the peer pool
@@ -160,7 +162,7 @@ void tr_bandwidth::allocateBandwidth(
     // traverse & repeat for the subtree
     for (auto* child : this->children_)
     {
-        child->allocateBandwidth(priority, dir, period_msec, peer_pool);
+        child->allocateBandwidth(priority, period_msec, peer_pool);
     }
 }
 
@@ -202,21 +204,20 @@ void tr_bandwidth::phaseOne(std::vector<tr_peerIo*>& peers, tr_direction dir)
     }
 }
 
-void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
+void tr_bandwidth::allocate(unsigned int period_msec)
 {
-    TR_ASSERT(tr_isDirection(dir));
-
     // keep these peers alive for the scope of this function
     auto refs = std::vector<std::shared_ptr<tr_peerIo>>{};
 
-    auto high = std::vector<tr_peerIo*>{};
-    auto low = std::vector<tr_peerIo*>{};
-    auto normal = std::vector<tr_peerIo*>{};
+    auto peer_arrays = std::array<std::vector<tr_peerIo*>, 3>{};
+    auto& high = peer_arrays[0];
+    auto& normal = peer_arrays[1];
+    auto& low = peer_arrays[2];
 
-    /* allocateBandwidth () is a helper function with two purposes:
-     * 1. allocate bandwidth to b and its subtree
-     * 2. accumulate an array of all the peerIos from b and its subtree. */
-    this->allocateBandwidth(TR_PRI_LOW, dir, period_msec, refs);
+    // allocateBandwidth () is a helper function with two purposes:
+    // 1. allocate bandwidth to b and its subtree
+    // 2. accumulate an array of all the peerIos from b and its subtree.
+    this->allocateBandwidth(TR_PRI_LOW, period_msec, refs);
 
     for (auto const& io : refs)
     {
@@ -237,21 +238,24 @@ void tr_bandwidth::allocate(tr_direction dir, unsigned int period_msec)
         }
     }
 
-    /* First phase of IO. Tries to distribute bandwidth fairly to keep faster
-     * peers from starving the others. Loop through the peers, giving each a
-     * small chunk of bandwidth. Keep looping until we run out of bandwidth
-     * and/or peers that can use it */
-    phaseOne(high, dir);
-    phaseOne(normal, dir);
-    phaseOne(low, dir);
+    // First phase of IO. Tries to distribute bandwidth fairly to keep faster
+    // peers from starving the others. Loop through the peers, giving each a
+    // small chunk of bandwidth. Keep looping until we run out of bandwidth
+    // and/or peers that can use it
+    for (auto& peers : peer_arrays)
+    {
+        phaseOne(peers, TR_UP);
+        phaseOne(peers, TR_DOWN);
+    }
 
-    /* Second phase of IO. To help us scale in high bandwidth situations,
-     * enable on-demand IO for peers with bandwidth left to burn.
-     * This on-demand IO is enabled until (1) the peer runs out of bandwidth,
-     * or (2) the next tr_bandwidth::allocate () call, when we start over again. */
+    // Second phase of IO. To help us scale in high bandwidth situations,
+    // enable on-demand IO for peers with bandwidth left to burn.
+    // This on-demand IO is enabled until (1) the peer runs out of bandwidth,
+    // or (2) the next tr_bandwidth::allocate () call, when we start over again.
     for (auto const& io : refs)
     {
-        io->set_enabled(dir, io->has_bandwidth_left(dir));
+        io->set_enabled(TR_UP, io->has_bandwidth_left(TR_UP));
+        io->set_enabled(TR_DOWN, io->has_bandwidth_left(TR_DOWN));
     }
 }
 

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -115,7 +115,7 @@ public:
     /**
      * @brief allocate the next period_msec's worth of bandwidth for the peer-ios to consume
      */
-    void allocate(tr_direction dir, unsigned int period_msec);
+    void allocate(unsigned int period_msec);
 
     void setParent(tr_bandwidth* new_parent);
 
@@ -256,7 +256,6 @@ private:
 
     void allocateBandwidth(
         tr_priority_t parent_priority,
-        tr_direction dir,
         unsigned int period_msec,
         std::vector<std::shared_ptr<tr_peerIo>>& peer_pool);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2492,10 +2492,9 @@ void tr_peerMgr::bandwidthPulse()
 
     pumpAllPeers(this);
 
-    /* allocate bandwidth to the peers */
+    // allocate bandwidth to the peers
     static auto constexpr Msec = std::chrono::duration_cast<std::chrono::milliseconds>(BandwidthPeriod).count();
-    session->top_bandwidth_.allocate(TR_UP, Msec);
-    session->top_bandwidth_.allocate(TR_DOWN, Msec);
+    session->top_bandwidth_.allocate(Msec);
 
     /* torrent upkeep */
     for (auto* const tor : session->torrents())


### PR DESCRIPTION
Previously `bandwidth.allocate()` was called twice in a row, once for upload bandwidth and once for download bandwidth.

It has some semi-expensive housekeeping though, so avoid doing that work twice by having a single call to `bandwidth.allocate()` operate on both up and down bandwidth.

Notes: Made small performance improvements in libtransmission.