### PR TITLE
perf: cache the result of thread_current_id()

### DIFF
--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -107,7 +107,8 @@ int cond_wait(void* vcond, void* vlock, struct timeval const* tv)
 
 unsigned long thread_current_id()
 {
-    return std::hash<std::thread::id>()(std::this_thread::get_id());
+    thread_local long const hashed = std::hash<std::thread::id>()(std::this_thread::get_id());
+    return hashed;
 }
 
 void initEvthreadsOnce()

--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -107,7 +107,7 @@ int cond_wait(void* vcond, void* vlock, struct timeval const* tv)
 
 unsigned long thread_current_id()
 {
-    thread_local long const hashed = std::hash<std::thread::id>()(std::this_thread::get_id());
+    thread_local auto const hashed = std::hash<std::thread::id>()(std::this_thread::get_id());
     return hashed;
 }
 


### PR DESCRIPTION
This function took 1% of runtime during an 8hr transmission-daemon session. Instead of rehashing it every time, hash it once and cache the result in a const thread_local variable.

Notes: Made small performance improvements in libtransmission.