### PR TITLE
macOS fix torrent options popover height

### DIFF
--- a/macosx/InfoOptionsViewController.h
+++ b/macosx/InfoOptionsViewController.h
@@ -35,5 +35,6 @@
 
 @property(nonatomic) IBOutlet NSView* fPriorityView;
 @property(nonatomic) CGFloat oldHeight;
+@property(nonatomic) BOOL isPopover;
 
 @end

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -120,6 +120,11 @@ static CGFloat const kStackViewSpacing = 8.0;
         viewRect.size.width = NSWidth(windowRect);
     }
 
+    if (self.isPopover)
+    {
+        viewRect.size.height = self.fVertLayoutHeight;
+    }
+
     return viewRect;
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -817,6 +817,9 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     popover.behavior = NSPopoverBehaviorTransient;
     InfoOptionsViewController* infoViewController = [[InfoOptionsViewController alloc] init];
     popover.contentViewController = infoViewController;
+
+    //ignore custom height calculations in infoViewController and force height size
+    infoViewController.isPopover = YES;
     popover.delegate = self;
 
     [popover showRelativeToRect:rect ofView:self preferredEdge:NSMaxYEdge];


### PR DESCRIPTION
Notes: macOS fixed torrent options popover height

### current build:
![before](https://user-images.githubusercontent.com/7323792/208877776-9d8cb505-9f14-48ad-8d60-c95fe0f0dfee.jpg)

### this PR:
![after](https://user-images.githubusercontent.com/7323792/208877819-5e347cfd-977f-47d9-8a74-1f23b4020e66.jpg)

