### PR TITLE
fix: 4.0.0-beta.2 regression transmission-show --scrape did not exit cleanly

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -261,6 +261,11 @@ void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchRes
     session_->runInSessionThread(std::move(func), std::move(response));
 }
 
+time_t tr_session::WebMediator::now() const
+{
+    return tr_time();
+}
+
 void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)
 {
     session->fetch(std::move(options));

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -232,6 +232,7 @@ private:
         [[nodiscard]] std::optional<std::string> publicAddressV6() const override;
         [[nodiscard]] std::optional<std::string_view> userAgent() const override;
         [[nodiscard]] size_t clamp(int torrent_id, size_t byte_count) const override;
+        [[nodiscard]] time_t now() const override;
         void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
         // runs the tr_web::fetch response callback in the libtransmission thread
         void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const override;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -199,14 +199,14 @@ public:
 
     ~Impl()
     {
-        deadline_ = tr_time();
+        deadline_ = mediator.now();
         queued_tasks_cv_.notify_one();
         curl_thread->join();
     }
 
     void startShutdown(std::chrono::milliseconds deadline)
     {
-        deadline_ = tr_time() + std::chrono::duration_cast<std::chrono::seconds>(deadline).count();
+        deadline_ = mediator.now() + std::chrono::duration_cast<std::chrono::seconds>(deadline).count();
         queued_tasks_cv_.notify_one();
     }
 
@@ -402,7 +402,7 @@ public:
 
     [[nodiscard]] bool deadline_reached() const
     {
-        return deadline_exists() && deadline() <= tr_time();
+        return deadline_exists() && deadline() <= mediator.now();
     }
 
     [[nodiscard]] CURL* get_easy(std::string_view host)
@@ -764,7 +764,10 @@ tr_web::tr_web(Mediator& mediator)
 {
 }
 
-tr_web::~tr_web() = default;
+tr_web::~tr_web()
+{
+    impl_->startShutdown(0ms);
+}
 
 std::unique_ptr<tr_web> tr_web::create(Mediator& mediator)
 {

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -155,6 +155,8 @@ public:
         {
             func(response);
         }
+
+        [[nodiscard]] virtual time_t now() const = 0;
     };
 
     // Note that tr_web does no management of the `mediator` reference.

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -305,7 +305,15 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
 
 void doScrape(tr_torrent_metainfo const& metainfo)
 {
-    auto mediator = tr_web::Mediator{};
+    class Mediator final : public tr_web::Mediator
+    {
+        [[nodiscard]] time_t now() const override
+        {
+            return time(nullptr);
+        }
+    };
+
+    auto mediator = Mediator{};
     auto web = tr_web::create(mediator);
 
     for (auto const& tracker : metainfo.announceList())


### PR DESCRIPTION
Fixes #4294.

Notes: FIxed 4.0.0-beta.2 regression that caused `transmission-show --scrape` to not exit cleanly.