### PR TITLE
Fixed crash on exit while downloading from webseed

### DIFF
--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -452,15 +452,15 @@ void onPartialDataFetched(tr_web::FetchResponse const& web_response)
     bool const success = status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);
-    auto* const webseed = task->webseed;
-
-    webseed->connection_limiter.taskFinished(success);
 
     if (task->dead)
     {
         delete task;
         return;
     }
+
+    auto* const webseed = task->webseed;
+    webseed->connection_limiter.taskFinished(success);
 
     if (auto const* const tor = webseed->getTorrent(); tor == nullptr)
     {


### PR DESCRIPTION
Fix #4450.
Fix #3899.

That code was from #2689, so it might have been an old regression.