### PR TITLE
Support localized punctuation for "Port:"

### DIFF
--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -428,9 +428,8 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
         {
             portString = NSLocalizedString(@"N/A", "Inspector -> Peers tab -> table row tooltip");
         }
-        [components addObject:[NSString stringWithFormat:@"%@: %@",
-                                                         NSLocalizedString(@"Port", "Inspector -> Peers tab -> table row tooltip"),
-                                                         portString]];
+        [components
+            addObject:[NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Port:", "Inspector -> Peers tab -> table row tooltip"), portString]];
 
         NSInteger const peerFrom = [peer[@"From"] integerValue];
         switch (peerFrom)

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -428,8 +428,8 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
         {
             portString = NSLocalizedString(@"N/A", "Inspector -> Peers tab -> table row tooltip");
         }
-        [components
-            addObject:[NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Port:", "Inspector -> Peers tab -> table row tooltip"), portString]];
+        [components addObject:[NSString stringWithFormat:NSLocalizedString(@"Port: %@", "Inspector -> Peers tab -> table row tooltip"),
+                                                         portString]];
 
         NSInteger const peerFrom = [peer[@"From"] integerValue];
         switch (peerFrom)

--- a/macosx/da.lproj/Localizable.strings
+++ b/macosx/da.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Modparter";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Port";
+"Port: %@" = "Port: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Port checksite er nede";

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Teilnehmer";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Port";
+"Port: %@" = "Port: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Site zum Überprüfen des Ports ist nicht erreichbar.";

--- a/macosx/en.lproj/Localizable.strings
+++ b/macosx/en.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Peers";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port:" = "Port:";
+"Port: %@" = "Port: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Port check site is down";

--- a/macosx/en.lproj/Localizable.strings
+++ b/macosx/en.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Peers";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Port";
+"Port:" = "Port:";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Port check site is down";

--- a/macosx/es.lproj/Localizable.strings
+++ b/macosx/es.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Clientes";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Puerto";
+"Port: %@" = "Puerto: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Sitio de comprobación de puertos caido";

--- a/macosx/fr.lproj/Localizable.strings
+++ b/macosx/fr.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Pairs";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Port";
+"Port: %@" = "Port : %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Le site de vérification de ports est hors service";

--- a/macosx/it.lproj/Localizable.strings
+++ b/macosx/it.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Peer";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Porta";
+"Port: %@" = "Porta: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Il sito di test non è disponibile";

--- a/macosx/nl.lproj/Localizable.strings
+++ b/macosx/nl.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Peers";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Poort";
+"Port: %@" = "Poort: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Poortcontrolesite onbereikbaar";

--- a/macosx/pt_PT.lproj/Localizable.strings
+++ b/macosx/pt_PT.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Peers";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Porta";
+"Port: %@" = "Porta: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Website de verificação inacessível";

--- a/macosx/ru.lproj/Localizable.strings
+++ b/macosx/ru.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Пользователи";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Порт";
+"Port: %@" = "Порт: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Сайт проверки порта недоступен";

--- a/macosx/tr.lproj/Localizable.strings
+++ b/macosx/tr.lproj/Localizable.strings
@@ -674,7 +674,7 @@
 "Peers" = "Eşler";
 
 /* Inspector -> Peers tab -> table row tooltip */
-"Port" = "Kapı";
+"Port: %@" = "Kapı: %@";
 
 /* Preferences -> Network -> port status */
 "Port check site is down" = "Kapı denetim alanı çalışmıyor";


### PR DESCRIPTION
In French, "Port:" should be "Port :", like the other strings.
![Capture d’écran 2022-12-23 à 18 15 09](https://user-images.githubusercontent.com/839992/209319795-daa7ab7a-26a7-4a47-8999-e94668aa3491.png)

Harmonizing the format with other strings, I'm changing the localized string "Port" with "Port:".
This breaks existing strings, so setting Milestone to "decide after 4.0".