### PR TITLE
Fix tr_torrent_view incorrectly returning is_folder false for single files in a single folder

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1154,7 +1154,7 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.n_pieces = tor->pieceCount();
     ret.is_private = tor->isPrivate();
     ret.is_folder = tor->fileCount() > 1 ||
-        (tor->fileCount() == 1 && tor->fileSubpath(0).find_first_of('/') != std::string_view::npos);
+        (tor->fileCount() == 1 && tr_strvContains(tor->fileSubpath(0), '/');
 
     return ret;
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1153,7 +1153,8 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.piece_size = tor->pieceSize();
     ret.n_pieces = tor->pieceCount();
     ret.is_private = tor->isPrivate();
-    ret.is_folder = tor->fileCount() > 1;
+    ret.is_folder = tor->fileCount() > 1 ||
+        (tor->fileCount() == 1 && tor->fileSubpath(0).find_first_of('/') != std::string_view::npos);
 
     return ret;
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1153,8 +1153,7 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.piece_size = tor->pieceSize();
     ret.n_pieces = tor->pieceCount();
     ret.is_private = tor->isPrivate();
-    ret.is_folder = tor->fileCount() > 1 ||
-        (tor->fileCount() == 1 && tr_strvContains(tor->fileSubpath(0), '/');
+    ret.is_folder = tor->fileCount() > 1 || (tor->fileCount() == 1 && tr_strvContains(tor->fileSubpath(0), '/'));
 
     return ret;
 }


### PR DESCRIPTION
Problem: torrents with a single folder containing a single file are only showing their folder name, but not the file name in the File Inspector.
Solution: torrents with a single folder containing a single file should return true for `is_folder`.


(Alternative solution considered: in Torrent.mm createFileList, we ignore `is_folder` and we parse `fileCount()` and `fileSubpath(0)` manually to get the real information about whether it's a folder or not... but then that would make the `is_folder` property useless and always ignored)