### PR TITLE
refactor: add TR_CONSTEXPR20 to make future C++20 migration easier

### DIFF
--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -61,34 +61,34 @@ private:
     using trackers_t = std::vector<tracker_info>;
 
 public:
-    [[nodiscard]] auto begin() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto begin() const noexcept
     {
         return std::begin(trackers_);
     }
 
-    [[nodiscard]] auto end() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto end() const noexcept
     {
         return std::end(trackers_);
     }
 
-    [[nodiscard]] bool empty() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 bool empty() const noexcept
     {
         return std::empty(trackers_);
     }
 
-    [[nodiscard]] size_t size() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 size_t size() const noexcept
     {
         return std::size(trackers_);
     }
 
-    [[nodiscard]] tracker_info const& at(size_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 tracker_info const& at(size_t i) const
     {
         return trackers_.at(i);
     }
 
     [[nodiscard]] tr_tracker_tier_t nextTier() const;
 
-    [[nodiscard]] bool operator==(tr_announce_list const& that) const
+    [[nodiscard]] TR_CONSTEXPR20 bool operator==(tr_announce_list const& that) const
     {
         return trackers_ == that.trackers_;
     }

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -13,6 +13,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "tr-macros.h"
+
 /**
  * @brief Implementation of the BitTorrent spec's Bitfield array of bits.
  *
@@ -117,7 +119,7 @@ private:
     [[nodiscard]] size_t countFlags() const noexcept;
     [[nodiscard]] size_t countFlags(size_t begin, size_t end) const noexcept;
 
-    [[nodiscard]] bool testFlag(size_t n) const
+    [[nodiscard]] TR_CONSTEXPR20 bool testFlag(size_t n) const
     {
         if (n >> 3U >= std::size(flags_))
         {

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -150,7 +150,7 @@ struct tr_completion
 
     [[nodiscard]] uint64_t countHasBytesInSpan(tr_byte_span_t) const;
 
-    [[nodiscard]] constexpr bool hasMetainfo() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 bool hasMetainfo() const noexcept
     {
         return !std::empty(blocks_);
     }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -150,7 +150,7 @@ struct tr_completion
 
     [[nodiscard]] uint64_t countHasBytesInSpan(tr_byte_span_t) const;
 
-    [[nodiscard]] TR_CONSTEXPR20 bool hasMetainfo() const noexcept
+    [[nodiscard]] constexpr bool hasMetainfo() const noexcept
     {
         return !std::empty(blocks_);
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -57,7 +57,7 @@ public:
 
     [[nodiscard]] file_offset_t fileOffset(uint64_t offset) const;
 
-    [[nodiscard]] size_t size() const
+    [[nodiscard]] TR_CONSTEXPR20 size_t size() const
     {
         return std::size(file_pieces_);
     }

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -37,14 +37,14 @@ public:
         return name_;
     }
 
-    [[nodiscard]] constexpr auto webseedCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto webseedCount() const noexcept
     {
         return std::size(webseed_urls_);
     }
 
-    [[nodiscard]] auto const& webseed(size_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto const& webseed(size_t i) const
     {
-        return webseed_urls_[i];
+        return webseed_urls_.at(i);
     }
 
     [[nodiscard]] constexpr auto& announceList() noexcept

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -123,12 +123,12 @@ public:
         return comment_;
     }
 
-    [[nodiscard]] auto fileCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto fileCount() const noexcept
     {
         return files_.fileCount();
     }
 
-    [[nodiscard]] auto fileSize(tr_file_index_t i) const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto fileSize(tr_file_index_t i) const noexcept
     {
         return files_.fileSize(i);
     }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -95,7 +95,7 @@ public:
 
     ///
 
-    [[nodiscard]] auto read_buffer_size() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto read_buffer_size() const noexcept
     {
         return std::size(inbuf_);
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -413,7 +413,7 @@ public:
         is_endgame_ = uint64_t(std::size(active_requests)) * tr_block_info::BlockSize >= tor->leftUntilDone();
     }
 
-    [[nodiscard]] auto constexpr isEndgame() const noexcept
+    [[nodiscard]] constexpr auto isEndgame() const noexcept
     {
         return is_endgame_;
     }
@@ -447,7 +447,7 @@ public:
         stats.active_webseed_count = 0;
     }
 
-    [[nodiscard]] auto isAllSeeds() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto isAllSeeds() const noexcept
     {
         if (!pool_is_all_seeds_)
         {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -878,7 +878,7 @@ public:
         web_->fetch(std::move(options));
     }
 
-    [[nodiscard]] auto const& bandwidthGroups() const noexcept
+    [[nodiscard]] constexpr auto const& bandwidthGroups() const noexcept
     {
         return bandwidth_groups_;
     }

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -29,17 +29,17 @@ struct tr_error;
 struct tr_torrent_files
 {
 public:
-    [[nodiscard]] bool empty() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 bool empty() const noexcept
     {
         return std::empty(files_);
     }
 
-    [[nodiscard]] size_t fileCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 size_t fileCount() const noexcept
     {
         return std::size(files_);
     }
 
-    [[nodiscard]] uint64_t fileSize(tr_file_index_t file_index) const
+    [[nodiscard]] TR_CONSTEXPR20 uint64_t fileSize(tr_file_index_t file_index) const
     {
         return files_.at(file_index).size_;
     }
@@ -49,7 +49,7 @@ public:
         return total_size_;
     }
 
-    [[nodiscard]] std::string const& path(tr_file_index_t file_index) const
+    [[nodiscard]] TR_CONSTEXPR20 std::string const& path(tr_file_index_t file_index) const
     {
         return files_.at(file_index).path_;
     }

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -23,7 +23,7 @@ struct tr_error;
 struct tr_torrent_metainfo : public tr_magnet_metainfo
 {
 public:
-    [[nodiscard]] constexpr auto empty() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto empty() const noexcept
     {
         return std::empty(files_);
     }
@@ -42,15 +42,15 @@ public:
     {
         return files_;
     }
-    [[nodiscard]] auto fileCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto fileCount() const noexcept
     {
         return files().fileCount();
     }
-    [[nodiscard]] auto fileSize(tr_file_index_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto fileSize(tr_file_index_t i) const
     {
         return files().fileSize(i);
     }
-    [[nodiscard]] auto const& fileSubpath(tr_file_index_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto const& fileSubpath(tr_file_index_t i) const
     {
         return files().path(i);
     }
@@ -130,7 +130,7 @@ public:
 
     [[nodiscard]] tr_sha1_digest_t const& pieceHash(tr_piece_index_t piece) const;
 
-    [[nodiscard]] bool hasV1Metadata() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 bool hasV1Metadata() const noexcept
     {
         // need 'pieces' field and 'files' or 'length'
         // TODO check for 'files' or 'length'

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -386,17 +386,17 @@ public:
 
     /// METAINFO - FILES
 
-    [[nodiscard]] tr_file_index_t fileCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto fileCount() const noexcept
     {
         return metainfo_.fileCount();
     }
 
-    [[nodiscard]] std::string const& fileSubpath(tr_file_index_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto const& fileSubpath(tr_file_index_t i) const
     {
         return metainfo_.fileSubpath(i);
     }
 
-    [[nodiscard]] auto fileSize(tr_file_index_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto fileSize(tr_file_index_t i) const
     {
         return metainfo_.fileSize(i);
     }
@@ -412,22 +412,22 @@ public:
 
     /// METAINFO - TRACKERS
 
-    [[nodiscard]] auto const& announceList() const noexcept
+    [[nodiscard]] constexpr auto const& announceList() const noexcept
     {
         return metainfo_.announceList();
     }
 
-    [[nodiscard]] auto& announceList() noexcept
+    [[nodiscard]] constexpr auto& announceList() noexcept
     {
         return metainfo_.announceList();
     }
 
-    [[nodiscard]] auto trackerCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto trackerCount() const noexcept
     {
         return std::size(this->announceList());
     }
 
-    [[nodiscard]] auto const& tracker(size_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto const& tracker(size_t i) const
     {
         return this->announceList().at(i);
     }
@@ -441,12 +441,12 @@ public:
 
     /// METAINFO - WEBSEEDS
 
-    [[nodiscard]] auto webseedCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto webseedCount() const noexcept
     {
         return metainfo_.webseedCount();
     }
 
-    [[nodiscard]] auto const& webseed(size_t i) const
+    [[nodiscard]] TR_CONSTEXPR20 auto const& webseed(size_t i) const
     {
         return metainfo_.webseed(i);
     }

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -42,22 +42,6 @@ struct CompareTorrentByHash
 
 } // namespace
 
-tr_torrent* tr_torrents::get(tr_torrent_id_t id)
-{
-    TR_ASSERT(static_cast<size_t>(id) < std::size(by_id_));
-    if (static_cast<size_t>(id) >= std::size(by_id_))
-    {
-        return nullptr;
-    }
-
-    auto* const tor = by_id_.at(id);
-    TR_ASSERT(tor == nullptr || tor->id() == id);
-    TR_ASSERT(
-        std::count_if(std::begin(removed_), std::end(removed_), [&id](auto const& removed) { return id == removed.first; }) ==
-        (tor == nullptr ? 1 : 0));
-    return tor;
-}
-
 tr_torrent* tr_torrents::get(std::string_view magnet_link)
 {
     auto magnet = tr_magnet_metainfo{};

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -31,7 +31,11 @@ public:
     void remove(tr_torrent const* tor, time_t current_time);
 
     // O(1)
-    [[nodiscard]] tr_torrent* get(tr_torrent_id_t id);
+    [[nodiscard]] TR_CONSTEXPR20 tr_torrent* get(tr_torrent_id_t id)
+    {
+        auto const uid = static_cast<size_t>(id);
+        return uid >= std::size(by_id_) ? nullptr : by_id_.at(uid);
+    }
 
     // O(log n)
     [[nodiscard]] tr_torrent const* get(tr_sha1_digest_t const& hash) const;
@@ -60,40 +64,40 @@ public:
 
     [[nodiscard]] std::vector<tr_torrent_id_t> removedSince(time_t) const;
 
-    [[nodiscard]] auto cbegin() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto cbegin() const noexcept
     {
         return std::cbegin(by_hash_);
     }
-    [[nodiscard]] auto begin() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto begin() const noexcept
     {
         return cbegin();
     }
-    [[nodiscard]] auto begin() noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto begin() noexcept
     {
         return std::begin(by_hash_);
     }
 
-    [[nodiscard]] auto cend() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto cend() const noexcept
     {
         return std::cend(by_hash_);
     }
 
-    [[nodiscard]] auto end() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto end() const noexcept
     {
         return cend();
     }
 
-    [[nodiscard]] auto end() noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto end() noexcept
     {
         return std::end(by_hash_);
     }
 
-    [[nodiscard]] constexpr auto size() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto size() const noexcept
     {
         return std::size(by_hash_);
     }
 
-    [[nodiscard]] constexpr auto empty() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 auto empty() const noexcept
     {
         return std::empty(by_hash_);
     }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -189,7 +189,7 @@ public:
     }
 
     template<typename T>
-    [[nodiscard]] bool startsWith(T const& needle) const
+    [[nodiscard]] TR_CONSTEXPR20 bool startsWith(T const& needle) const
     {
         auto const n_bytes = std::size(needle);
         auto const needle_begin = reinterpret_cast<std::byte const*>(std::data(needle));

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -8,6 +8,27 @@
 #include <array>
 #include <cstddef> // size_t
 
+///
+
+#ifdef _MSVC_LANG
+#define TR_CPLUSPLUS _MSVC_LANG
+#else
+#define TR_CPLUSPLUS __cplusplus
+#endif
+
+#if ((TR_CPLUSPLUS >= 202002L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) || \
+    (TR_CPLUSPLUS >= 201709L && TR_GCC_VERSION >= 1002)
+#define TR_CONSTEXPR20 constexpr
+#else
+#define TR_CONSTEXPR20
+#endif
+
+// Placeholder for future use.
+// Can't implement right now because __cplusplus version for C++23 is currently TBD
+#define TR_CONSTEXPR23
+
+///
+
 /***
 ****
 ***/

--- a/libtransmission/tr-popcount.h
+++ b/libtransmission/tr-popcount.h
@@ -11,6 +11,7 @@
 #define TR_POPCNT_H
 
 #include <cstdint>
+#include <type_traits>
 
 /* Avoid defining irrelevant helpers that might interfere with other
  * preprocessor logic. */
@@ -58,7 +59,7 @@ struct tr_popcnt
 
 #if defined(TR_HAVE_STD_POPCOUNT)
     /* If we have std::popcount just use that. */
-    static inline unsigned count(T v)
+    static constexpr inline unsigned count(T v)
     {
         unsigned_T unsigned_v = static_cast<unsigned_T>(v);
         return static_cast<unsigned>(std::popcount(unsigned_v));

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -43,17 +43,17 @@ public:
         return children_.at(row);
     }
 
-    [[nodiscard]] int childCount() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 int childCount() const noexcept
     {
         return std::size(children_);
     }
 
-    [[nodiscard]] auto* parent() noexcept
+    [[nodiscard]] constexpr auto* parent() noexcept
     {
         return parent_;
     }
 
-    [[nodiscard]] auto const* parent() const noexcept
+    [[nodiscard]] constexpr auto const* parent() const noexcept
     {
         return parent_;
     }

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -135,14 +135,14 @@ public:
         }
     }
 
-    [[nodiscard]] auto operator==(TorrentHash const& that) const
+    [[nodiscard]] TR_CONSTEXPR20 auto operator==(TorrentHash const& that) const
     {
         return data_ == that.data_;
     }
 
-    [[nodiscard]] auto operator!=(TorrentHash const& that) const
+    [[nodiscard]] TR_CONSTEXPR20 auto operator!=(TorrentHash const& that) const
     {
-        return data_ != that.data_;
+        return !(*this == that);
     }
 
     [[nodiscard]] auto operator<(TorrentHash const& that) const


### PR DESCRIPTION
No behavioral changes.

Add `TR_CONSTEXPR20` and `TR_CONSTEXPR23` placeholders that we can use for easily migrating code if/when we bump the C++ dependency from 17 to 20 or 23 in the future.