### PR TITLE
set selected torrentTableView backgroundstyle

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -211,6 +211,14 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             torrentCell.hoverControl = (row == self.controlButtonHoverRow);
             torrentCell.hoverReveal = (row == self.revealButtonHoverRow);
             torrentCell.hoverAction = (row == self.actionButtonHoverRow);
+
+            // if cell is selected, set backgroundStyle
+            // then can provide alternate font color in TorrentCell - drawInteriorWithFrame
+            NSIndexSet* selectedRowIndexes = self.selectedRowIndexes;
+            if ([selectedRowIndexes containsIndex:row])
+            {
+                torrentCell.backgroundStyle = NSBackgroundStyleEmphasized;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: #4375
Notes: Fix for selected torrents font color in macOS client

### Dark Mode
<img width="639" alt="dark" src="https://user-images.githubusercontent.com/7323792/209424777-a43f0ca3-b0b3-48c3-920a-dc75b7cac222.png">

### Light Mode
<img width="639" alt="light" src="https://user-images.githubusercontent.com/7323792/209424826-20f73672-ec71-4ae6-afd8-991dc3eeb531.png">
