### PR TITLE
Fixed dead code in "Open Torrent Address"

### DIFF
--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -16,8 +16,6 @@
 
 @implementation URLSheetWindowController
 
-NSString* urlString = nil;
-
 - (instancetype)init
 {
     self = [self initWithWindowNibName:@"URLSheetWindow"];
@@ -27,15 +25,6 @@ NSString* urlString = nil;
 - (void)awakeFromNib
 {
     self.fLabelField.stringValue = NSLocalizedString(@"Internet address of torrent file:", "URL sheet label");
-
-    if (urlString)
-    {
-        self.fTextField.stringValue = urlString;
-        [self.fTextField selectText:self];
-
-        [self updateOpenButtonForURL:urlString];
-    }
-
     self.fOpenButton.title = NSLocalizedString(@"Open", "URL sheet button");
     self.fCancelButton.title = NSLocalizedString(@"Cancel", "URL sheet button");
 
@@ -76,8 +65,7 @@ NSString* urlString = nil;
 
 - (NSString*)urlString
 {
-    urlString = self.fTextField.stringValue;
-    return urlString;
+    return self.fTextField.stringValue;
 }
 
 - (void)controlTextDidChange:(NSNotification*)notification

--- a/macosx/URLSheetWindowController.mm
+++ b/macosx/URLSheetWindowController.mm
@@ -28,12 +28,12 @@ NSString* urlString = nil;
 {
     self.fLabelField.stringValue = NSLocalizedString(@"Internet address of torrent file:", "URL sheet label");
 
-    if (self.urlString)
+    if (urlString)
     {
-        self.fTextField.stringValue = self.urlString;
+        self.fTextField.stringValue = urlString;
         [self.fTextField selectText:self];
 
-        [self updateOpenButtonForURL:self.urlString];
+        [self updateOpenButtonForURL:urlString];
     }
 
     self.fOpenButton.title = NSLocalizedString(@"Open", "URL sheet button");
@@ -76,7 +76,8 @@ NSString* urlString = nil;
 
 - (NSString*)urlString
 {
-    return self.fTextField.stringValue;
+    urlString = self.fTextField.stringValue;
+    return urlString;
 }
 
 - (void)controlTextDidChange:(NSNotification*)notification


### PR DESCRIPTION
This was a minor regression from b6c21343387de783f91cf5e38de58131b65b73e4 (10 years ago, @livings124).

Now... I'll add "needs UI review", because I'd like to confirm first if returning to that behavior from 10 years ago is good or not.

To test it:
- Transmission menu, "Open Torrent Address", and attempt to open any URL.
- Transmission menu, "Open Torrent Address" a second time: the previous URL should be pre-filled (only for the duration of the session: if you quit the app, it won't remember it).