### PR TITLE
refactor: udp_core constructor

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -225,7 +225,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
     auto const [sock, addrlen] = addr.to_sockaddr(port);
 
     // set source address
-    auto const [source_addr, is_default_addr] = session->publicAddress(addr.type);
+    auto const [source_addr, is_any] = session->publicAddress(addr.type);
     auto const [source_sock, sourcelen] = source_addr.to_sockaddr({});
 
     if (bind(s, reinterpret_cast<sockaddr const*>(&source_sock), sourcelen) == -1)
@@ -491,7 +491,7 @@ namespace global_ipv6_helpers
 } // namespace global_ipv6_helpers
 
 /* Return our global IPv6 address, with caching. */
-std::optional<tr_address> tr_globalIPv6(tr_session const* session)
+std::optional<tr_address> tr_globalIPv6()
 {
     using namespace global_ipv6_helpers;
 
@@ -505,18 +505,7 @@ std::optional<tr_address> tr_globalIPv6(tr_session const* session)
         cache_val = global_address(AF_INET6);
     }
 
-    auto ret = cache_val;
-
-    // check to see if the session is overriding this address
-    if (session != nullptr)
-    {
-        if (auto const [ipv6_bindaddr, is_default] = session->publicAddress(TR_AF_INET6); !is_default)
-        {
-            ret = ipv6_bindaddr;
-        }
-    }
-
-    return ret;
+    return cache_val;
 }
 
 ///

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -368,4 +368,4 @@ void tr_netSetTOS(tr_socket_t sock, int tos, tr_address_type type);
  */
 [[nodiscard]] std::string tr_net_strerror(int err);
 
-[[nodiscard]] std::optional<tr_address> tr_globalIPv6(tr_session const* session = nullptr);
+[[nodiscard]] std::optional<tr_address> tr_globalIPv6();

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -290,7 +290,7 @@ public:
         if (session->allowsDHT() && io->supports_dht())
         {
             // only send PORT over IPv6 iff IPv6 DHT is running (BEP-32).
-            if (io->address().is_ipv4() || tr_globalIPv6().has_value())
+            if (auto const [addr, is_any] = session->publicAddress(TR_AF_INET6); !is_any)
             {
                 protocolSendPort(this, session->udpPort());
             }
@@ -915,10 +915,10 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
-    if (auto const ipv6 = tr_globalIPv6(msgs->session); ipv6.has_value())
+    if (auto const [addr, is_any] = msgs->session->publicAddress(TR_AF_INET6); !is_any)
     {
-        TR_ASSERT(ipv6->is_ipv6());
-        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &ipv6->addr.addr6, sizeof(ipv6->addr.addr6));
+        TR_ASSERT(addr.is_ipv6());
+        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr.addr.addr6, sizeof(addr.addr.addr6));
     }
 
     // http://bittorrent.org/beps/bep_0009.html

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -218,8 +218,7 @@ std::optional<std::string_view> tr_session::WebMediator::userAgent() const
 
 std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
 {
-    auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET);
-    if (!is_default_value)
+    if (auto const [addr, is_any] = session_->publicAddress(TR_AF_INET); !is_any)
     {
         return addr.display_name();
     }
@@ -229,8 +228,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
 
 std::optional<std::string> tr_session::WebMediator::publicAddressV6() const
 {
-    auto const [addr, is_default_value] = session_->publicAddress(TR_AF_INET6);
-    if (!is_default_value)
+    if (auto const [addr, is_any] = session_->publicAddress(TR_AF_INET6); !is_any)
     {
         return addr.display_name();
     }
@@ -342,6 +340,8 @@ tr_session::PublicAddressResult tr_session::publicAddress(tr_address_type type) 
 {
     if (type == TR_AF_INET)
     {
+        // if user provided an address, use it.
+        // otherwise, use any_ipv4 (0.0.0.0).
         static auto constexpr DefaultAddr = tr_address::any_ipv4();
         auto addr = tr_address::from_string(settings_.bind_address_ipv4).value_or(DefaultAddr);
         return { addr, addr == DefaultAddr };
@@ -349,9 +349,13 @@ tr_session::PublicAddressResult tr_session::publicAddress(tr_address_type type) 
 
     if (type == TR_AF_INET6)
     {
-        static auto constexpr DefaultAddr = tr_address::any_ipv6();
-        auto addr = tr_address::from_string(settings_.bind_address_ipv6).value_or(DefaultAddr);
-        return { addr, addr == DefaultAddr };
+        // if user provided an address, use it.
+        // otherwise, if we can determine which one to use via tr_globalIPv6 magic, use it.
+        // otherwise, use any_ipv6 (::).
+        static auto constexpr AnyAddr = tr_address::any_ipv6();
+        auto const default_addr = tr_globalIPv6().value_or(AnyAddr);
+        auto addr = tr_address::from_string(settings_.bind_address_ipv6).value_or(default_addr);
+        return { addr, addr == AnyAddr };
     }
 
     TR_ASSERT_MSG(false, "invalid type");

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -285,7 +285,7 @@ private:
 
         [[nodiscard]] constexpr auto socket4() const noexcept
         {
-            return udp_socket_;
+            return udp4_socket_;
         }
 
         [[nodiscard]] constexpr auto socket6() const noexcept
@@ -294,23 +294,12 @@ private:
         }
 
     private:
-        void set_socket_buffers();
-
-        void set_socket_tos()
-        {
-            session_.setSocketTOS(udp_socket_, TR_AF_INET);
-            session_.setSocketTOS(udp6_socket_, TR_AF_INET6);
-        }
-
         tr_port const udp_port_;
         tr_session& session_;
-        tr_socket_t udp_socket_ = TR_BAD_SOCKET;
+        tr_socket_t udp4_socket_ = TR_BAD_SOCKET;
         tr_socket_t udp6_socket_ = TR_BAD_SOCKET;
         libtransmission::evhelpers::event_unique_ptr udp4_event_;
         libtransmission::evhelpers::event_unique_ptr udp6_event_;
-        std::optional<tr_address> udp6_bound_;
-
-        void rebind_ipv6(bool);
     };
 
 public:

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -799,7 +799,7 @@ public:
     struct PublicAddressResult
     {
         tr_address address;
-        bool is_default_value;
+        bool is_any_addr;
     };
 
     [[nodiscard]] PublicAddressResult publicAddress(tr_address_type type) const noexcept;

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -83,93 +83,6 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
     }
 }
 
-void tr_session::tr_udp_core::set_socket_buffers()
-{
-    bool const utp = session_.allowsUTP();
-
-    if (udp_socket_ != TR_BAD_SOCKET)
-    {
-        ::set_socket_buffers(udp_socket_, utp);
-    }
-    if (udp6_socket_ != TR_BAD_SOCKET)
-    {
-        ::set_socket_buffers(udp6_socket_, utp);
-    }
-}
-
-static tr_socket_t rebind_ipv6_impl(tr_address const& addr, tr_port port)
-{
-    auto const sock = socket(PF_INET6, SOCK_DGRAM, 0);
-    if (sock == TR_BAD_SOCKET)
-    {
-        return TR_BAD_SOCKET;
-    }
-
-#ifdef IPV6_V6ONLY
-    /* Since we always open an IPv4 socket on the same port,
-     * this shouldn't matter.  But I'm superstitious. */
-    int one = 1;
-    (void)setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char const*>(&one), sizeof(one));
-#endif
-
-    TR_ASSERT(addr.is_ipv6());
-    auto const [ss, sslen] = addr.to_sockaddr(port);
-    if (::bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) == -1)
-    {
-        tr_netCloseSocket(sock);
-        return TR_BAD_SOCKET;
-    }
-
-    tr_logAddInfo("Bound UDP IPv6 address {:s}", addr.display_name(port));
-    return sock;
-}
-
-/* BEP-32 has a rather nice explanation of why we need to bind to one
-   IPv6 address, if I may say so myself. */
-void tr_session::tr_udp_core::rebind_ipv6(bool force)
-{
-    auto const ipv6 = tr_globalIPv6(&session_);
-
-    /* We currently have no way to enable or disable IPv6 after initialisation.
-       No way to fix that without some surgery to the DHT code itself. */
-    if (!ipv6 || (!force && udp6_socket_ == TR_BAD_SOCKET))
-    {
-        udp6_bound_.reset();
-        return;
-    }
-
-    if (udp6_bound_ && *udp6_bound_ == *ipv6) // unchanged
-    {
-        return;
-    }
-
-    auto const sock = rebind_ipv6_impl(*ipv6, udp_port_);
-    if (sock == TR_BAD_SOCKET)
-    {
-        /* Something went wrong.  It's difficult to recover, so let's
-         * simply set things up so that we try again next time. */
-        auto const error_code = errno;
-        auto ipv6_readable = std::array<char, INET6_ADDRSTRLEN>{};
-        evutil_inet_ntop(AF_INET6, &*ipv6, std::data(ipv6_readable), std::size(ipv6_readable));
-        tr_logAddWarn(fmt::format(
-            _("Couldn't rebind IPv6 socket {address}: {error} ({error_code})"),
-            fmt::arg("address", ipv6->display_name()),
-            fmt::arg("error", tr_strerror(error_code)),
-            fmt::arg("error_code", error_code)));
-
-        udp6_bound_.reset();
-        return;
-    }
-
-    if (udp6_socket_ != TR_BAD_SOCKET)
-    {
-        tr_netCloseSocket(udp6_socket_);
-    }
-
-    udp6_socket_ = sock;
-    udp6_bound_ = ipv6;
-}
-
 static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
 {
     TR_ASSERT(vsession != nullptr);
@@ -224,6 +137,8 @@ static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void*
     }
 }
 
+// BEP-32 explains why we need to bind to one IPv6 address
+
 tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     : udp_port_{ udp_port }
     , session_{ session }
@@ -233,65 +148,68 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         return;
     }
 
-    udp_socket_ = socket(PF_INET, SOCK_DGRAM, 0);
-
-    if (udp_socket_ == TR_BAD_SOCKET)
+    if (auto sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        tr_logAddWarn(_("Couldn't create IPv4 socket"));
-    }
-    else
-    {
-        auto const [public_addr, is_default] = session_.publicAddress(TR_AF_INET);
+        auto const [addr, is_default] = session_.publicAddress(TR_AF_INET);
+        auto const [ss, sslen] = addr.to_sockaddr(udp_port_);
 
-        auto sin = sockaddr_in{};
-        sin.sin_family = AF_INET;
-        if (!is_default)
-        {
-            sin.sin_addr = public_addr.addr.addr4;
-        }
-
-        sin.sin_port = udp_port_.network();
-        int const rc = bind(udp_socket_, (struct sockaddr*)&sin, sizeof(sin));
-
-        if (rc == -1)
+        if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)
         {
             auto const error_code = errno;
             tr_logAddWarn(fmt::format(
                 _("Couldn't bind IPv4 socket {address}: {error} ({error_code})"),
-                fmt::arg("address", public_addr.display_name(udp_port_)),
+                fmt::arg("address", addr.display_name(udp_port_)),
                 fmt::arg("error", tr_strerror(error_code)),
                 fmt::arg("error_code", error_code)));
-            tr_netCloseSocket(udp_socket_);
-            udp_socket_ = TR_BAD_SOCKET;
+
+            tr_netCloseSocket(sock);
         }
         else
         {
-            udp4_event_.reset(event_new(session_.eventBase(), udp_socket_, EV_READ | EV_PERSIST, event_callback, &session_));
+            tr_logAddInfo("Bound UDP IPv4 address {:s}", addr.display_name(udp_port_));
+            session_.setSocketTOS(sock, TR_AF_INET);
+            set_socket_buffers(sock, session_.allowsUTP());
+            udp4_socket_ = sock;
+            udp4_event_.reset(event_new(session_.eventBase(), udp4_socket_, EV_READ | EV_PERSIST, event_callback, &session_));
+            event_add(udp4_event_.get(), nullptr);
         }
     }
 
-    // IPV6
-
-    if (tr_globalIPv6(nullptr).has_value())
+    if (auto const addr = tr_globalIPv6(&session); !addr.has_value())
     {
-        rebind_ipv6(true);
+        tr_logAddWarn("Unable to find global IPv6 address");
     }
-
-    if (udp6_socket_ != TR_BAD_SOCKET)
+    else if (auto sock = socket(PF_INET6, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        udp6_event_.reset(event_new(session_.eventBase(), udp6_socket_, EV_READ | EV_PERSIST, event_callback, &session_));
-    }
+        auto const [ss, sslen] = addr->to_sockaddr(udp_port_);
 
-    set_socket_buffers();
-    set_socket_tos();
+        if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)
+        {
+            auto const error_code = errno;
+            tr_logAddWarn(fmt::format(
+                _("Couldn't bind IPv6 socket {address}: {error} ({error_code})"),
+                fmt::arg("address", addr->display_name()),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
 
-    if (udp4_event_ != nullptr)
-    {
-        event_add(udp4_event_.get(), nullptr);
-    }
-    if (udp6_event_)
-    {
-        event_add(udp6_event_.get(), nullptr);
+            tr_netCloseSocket(sock);
+        }
+        else
+        {
+            tr_logAddInfo("Bound UDP IPv6 address {:s}", addr->display_name(udp_port_));
+            session_.setSocketTOS(sock, TR_AF_INET6);
+            set_socket_buffers(sock, session_.allowsUTP());
+            udp6_socket_ = sock;
+            udp6_event_.reset(event_new(session_.eventBase(), udp6_socket_, EV_READ | EV_PERSIST, event_callback, &session_));
+            event_add(udp6_event_.get(), nullptr);
+
+#ifdef IPV6_V6ONLY
+            // Since we always open an IPv4 socket on the same port,
+            // this shouldn't matter.  But I'm superstitious.
+            int one = 1;
+            (void)setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char const*>(&one), sizeof(one));
+#endif
+        }
     }
 }
 
@@ -307,13 +225,11 @@ tr_session::tr_udp_core::~tr_udp_core()
 
     udp4_event_.reset();
 
-    if (udp_socket_ != TR_BAD_SOCKET)
+    if (udp4_socket_ != TR_BAD_SOCKET)
     {
-        tr_netCloseSocket(udp_socket_);
-        udp_socket_ = TR_BAD_SOCKET;
+        tr_netCloseSocket(udp4_socket_);
+        udp4_socket_ = TR_BAD_SOCKET;
     }
-
-    udp6_bound_.reset();
 }
 
 void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sockaddr const* to, socklen_t const tolen) const
@@ -323,9 +239,9 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
 
     if (to->sa_family == AF_INET)
     {
-        if (udp_socket_ != TR_BAD_SOCKET)
+        if (udp4_socket_ != TR_BAD_SOCKET)
         {
-            if (::sendto(udp_socket_, static_cast<char const*>(buf), buflen, 0, to, tolen) == -1)
+            if (::sendto(udp4_socket_, static_cast<char const*>(buf), buflen, 0, to, tolen) == -1)
             {
                 error = -1;
             }


### PR DESCRIPTION
Fixes #4406.

Fixes #4410.

Notes: Fixed `4.0.0-beta.2` IPv6 μTP socket binding regression.