### PR TITLE
Fix BlockListDownloader unzipFrom

### DIFF
--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -312,7 +312,7 @@ BlocklistDownloader* fBLDownloader = nil;
     zipinfo.launchPath = @"/usr/bin/zipinfo";
     zipinfo.arguments = @[
         @"-1", /* just the filename */
-        file /* source zip file */
+        file.path /* source zip file */
     ];
     NSPipe* pipe = [[NSPipe alloc] init];
     zipinfo.standardOutput = pipe;


### PR DESCRIPTION
Problem: arguments only accept an array of strings.
Solution: use file.path like with `untarFrom:` and `gunzipFrom:`.

This was a regression from #2191.
But I didn't test it... as I don't know any blocklist address where I can download one. If you know of any blocklist provider in **zip** format, I'd be thankful for further testing.