### PR TITLE
Include individual headers (GTK client)

### DIFF
--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -12,8 +12,18 @@
 
 #include <libtransmission/transmission.h>
 
-#include <glibmm.h>
+#include <giomm/liststore.h>
+#include <giomm/menuattributeiter.h>
+#include <giomm/menulinkiter.h>
+#include <giomm/simpleaction.h>
 #include <glibmm/i18n.h>
+#include <glibmm/variant.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/shortcut.h>
+#include <gtkmm/shortcutaction.h>
+#include <gtkmm/shortcuttrigger.h>
+#endif
 
 #include <array>
 #include <stack>

--- a/gtk/Actions.h
+++ b/gtk/Actions.h
@@ -7,7 +7,13 @@
 
 #include "Utils.h"
 
-#include <gtkmm.h>
+#include <giomm/listmodel.h>
+#include <giomm/menumodel.h>
+#include <giomm/simpleactiongroup.h>
+#include <glibmm/object.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/builder.h>
 
 class Session;
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -29,8 +29,35 @@
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 
-#include <giomm.h>
+#include <gdkmm/display.h>
+#include <giomm/appinfo.h>
+#include <giomm/error.h>
+#include <giomm/menu.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/value.h>
+#include <glibmm/vectorutils.h>
+#include <gtkmm/aboutdialog.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/button.h>
+#include <gtkmm/cssprovider.h>
+#include <gtkmm/grid.h>
+#include <gtkmm/icontheme.h>
+#include <gtkmm/image.h>
+#include <gtkmm/label.h>
+#include <gtkmm/messagedialog.h>
+#include <gtkmm/stylecontext.h>
+#include <gtkmm/window.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/droptarget.h>
+#include <gtkmm/eventcontrollerfocus.h>
+#include <gtkmm/shortcutcontroller.h>
+#else
+#include <gdkmm/dragcontext.h>
+#include <gtkmm/selectiondata.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -6,8 +6,10 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <giomm/file.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/application.h>
 
 #include <memory>
 #include <string>

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -17,7 +17,34 @@
 #include <libtransmission/utils.h>
 #include <libtransmission/web-utils.h>
 
+#include <gdkmm/pixbuf.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/markup.h>
+#include <glibmm/quark.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/adjustment.h>
+#include <gtkmm/button.h>
+#include <gtkmm/cellrendererpixbuf.h>
+#include <gtkmm/cellrendererprogress.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/label.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/messagedialog.h>
+#include <gtkmm/notebook.h>
+#include <gtkmm/scrolledwindow.h>
+#include <gtkmm/spinbutton.h>
+#include <gtkmm/textbuffer.h>
+#include <gtkmm/textview.h>
+#include <gtkmm/tooltip.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelfilter.h>
+#include <gtkmm/treemodelsort.h>
+#include <gtkmm/treerowreference.h>
+#include <gtkmm/treeview.h>
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -8,8 +8,10 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 #include <vector>

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -7,8 +7,9 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <glibmm.h>
 #include <glibmm/i18n.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/messagedialog.h>
 
 #include <fmt/core.h>
 

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -6,7 +6,8 @@
 
 #include <libtransmission/transmission.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/window.h>
 
 #include <vector>
 

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -11,6 +11,11 @@
 #include <libtransmission/web-utils.h>
 #include <libtransmission/web.h> // tr_sessionFetch()
 
+#include <glibmm/error.h>
+#include <glibmm/fileutils.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+
 #include <fmt/core.h>
 
 #include <array>

--- a/gtk/FaviconCache.h
+++ b/gtk/FaviconCache.h
@@ -7,8 +7,9 @@
 
 #include <libtransmission/transmission.h>
 
-#include <gdkmm.h>
-#include <glibmm.h>
+#include <gdkmm/pixbuf.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
 
 #include <functional>
 #include <string>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -13,8 +13,23 @@
 
 #include <libtransmission/utils.h>
 
-#include <glibmm.h>
+#include <giomm/icon.h>
+#include <glibmm/fileutils.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/markup.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/nodetree.h>
+#include <gtkmm/cellrendererpixbuf.h>
+#include <gtkmm/cellrendererprogress.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/cellrenderertoggle.h>
+#include <gtkmm/messagedialog.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
+#include <gtkmm/treeselection.h>
+#include <gtkmm/treestore.h>
+#include <gtkmm/treeview.h>
 
 #include <fmt/core.h>
 

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -8,7 +8,10 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/scrolledwindow.h>
 
 #include <memory>
 

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -13,8 +13,28 @@
 #include "TorrentFilter.h"
 #include "Utils.h"
 
-#include <glibmm.h>
+#include <gdkmm/pixbuf.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/unicode.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/cellrendererpixbuf.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/label.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
+#include <gtkmm/treemodelfilter.h>
+#include <gtkmm/treerowreference.h>
+#include <gtkmm/treestore.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/filterlistmodel.h>
+#else
+#include <gtkmm/treemodelfilter.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/FilterBar.h
+++ b/gtk/FilterBar.h
@@ -9,8 +9,12 @@
 
 #include <libtransmission/tr-macros.h>
 
+#include <giomm/listmodel.h>
 #include <glibmm/extraclassinit.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/box.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/treemodel.h>
 
 #include <memory>
 

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -11,6 +11,7 @@
 #include <libtransmission/utils.h>
 
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
 
 #include <fmt/core.h>
 

--- a/gtk/FreeSpaceLabel.h
+++ b/gtk/FreeSpaceLabel.h
@@ -5,8 +5,9 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/label.h>
 
 #include <memory>
 #include <string_view>

--- a/gtk/IconCache.cc
+++ b/gtk/IconCache.cc
@@ -9,8 +9,7 @@
 
 #include "Utils.h"
 
-#include <giomm.h>
-#include <glibmm.h>
+#include <giomm/contenttype.h>
 
 #include <algorithm>
 #include <map>

--- a/gtk/IconCache.h
+++ b/gtk/IconCache.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <gtkmm.h>
+#include <giomm/icon.h>
+#include <glibmm/refptr.h>
 
 #include <string_view>
 

--- a/gtk/ListModelAdapter.h
+++ b/gtk/ListModelAdapter.h
@@ -7,8 +7,12 @@
 
 #include "Utils.h"
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <giomm/listmodel.h>
+#include <glibmm/object.h>
+#include <glibmm/refptr.h>
+#include <glibmm/value.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
 
 #include <optional>
 #include <unordered_map>

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -17,7 +17,37 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_formatter_speed_KBps()
 
+#include <gdkmm/cursor.h>
+#include <gdkmm/rectangle.h>
+#include <giomm/menu.h>
+#include <giomm/menuitem.h>
+#include <giomm/menumodel.h>
+#include <giomm/simpleaction.h>
+#include <giomm/simpleactiongroup.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/variant.h>
+#include <gtkmm/image.h>
+#include <gtkmm/label.h>
+#include <gtkmm/menubutton.h>
+#include <gtkmm/scrolledwindow.h>
+#include <gtkmm/togglebutton.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treeselection.h>
+#include <gtkmm/treeview.h>
+#include <gtkmm/treeviewcolumn.h>
+#include <gtkmm/widget.h>
+#include <gtkmm/window.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/popovermenu.h>
+#else
+#include <gdkmm/display.h>
+#include <gdkmm/window.h>
+#include <gtkmm/menu.h>
+#endif
 
 #include <array>
 #include <memory>

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -6,8 +6,11 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <giomm/actiongroup.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/application.h>
+#include <gtkmm/applicationwindow.h>
+#include <gtkmm/builder.h>
 
 #include <memory>
 

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -15,8 +15,30 @@
 #include <libtransmission/makemeta.h>
 #include <libtransmission/utils.h> /* tr_formatter_mem_B() */
 
-#include <glibmm.h>
+#include <giomm/file.h>
+#include <glibmm/convert.h>
+#include <glibmm/fileutils.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/value.h>
+#include <glibmm/vectorutils.h>
+#include <gtkmm/adjustment.h>
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/label.h>
+#include <gtkmm/progressbar.h>
+#include <gtkmm/scale.h>
+#include <gtkmm/textbuffer.h>
+#include <gtkmm/textview.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/droptarget.h>
+#else
+#include <gdkmm/dragcontext.h>
+#include <gtkmm/selectiondata.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/MakeDialog.h
+++ b/gtk/MakeDialog.h
@@ -7,7 +7,10 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -14,8 +14,24 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/log.h>
 
-#include <glibmm.h>
+#include <giomm/simpleaction.h>
+#include <glibmm/convert.h>
+#include <glibmm/datetime.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/variant.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/filechooserdialog.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/messagedialog.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
+#include <gtkmm/treemodelfilter.h>
+#include <gtkmm/treemodelsort.h>
+#include <gtkmm/treeview.h>
 
 #include <fmt/core.h>
 #include <fmt/ostream.h>

--- a/gtk/MessageLogWindow.h
+++ b/gtk/MessageLogWindow.h
@@ -7,7 +7,9 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -10,8 +10,14 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <giomm.h>
+#include <giomm/asyncresult.h>
+#include <giomm/dbusproxy.h>
+#include <glibmm/error.h>
 #include <glibmm/i18n.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/spawn.h>
+#include <glibmm/ustring.h>
+#include <glibmm/variant.h>
 
 #include <fmt/core.h>
 

--- a/gtk/Notify.h
+++ b/gtk/Notify.h
@@ -7,7 +7,7 @@
 
 #include <libtransmission/transmission.h>
 
-#include <glibmm.h>
+#include <glibmm/refptr.h>
 
 class Session;
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -16,8 +16,11 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/file.h> /* tr_sys_path_is_same() */
 
-#include <glibmm.h>
+#include <giomm/file.h>
 #include <glibmm/i18n.h>
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/filefilter.h>
 
 #include <memory>
 #include <utility>

--- a/gtk/OptionsDialog.h
+++ b/gtk/OptionsDialog.h
@@ -7,7 +7,12 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/filechooserdialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -5,8 +5,15 @@
 
 #include "PathButton.h"
 
-#include <glibmm.h>
+#include <giomm/file.h>
+#include <glibmm/error.h>
 #include <glibmm/i18n.h>
+#include <glibmm/property.h>
+#include <gtkmm/box.h>
+#include <gtkmm/filechooserdialog.h>
+#include <gtkmm/image.h>
+#include <gtkmm/label.h>
+#include <gtkmm/separator.h>
 
 #include <vector>
 

--- a/gtk/PathButton.h
+++ b/gtk/PathButton.h
@@ -9,7 +9,18 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/propertyproxy.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/filechooser.h>
+#include <gtkmm/filefilter.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/button.h>
+#else
+#include <gtkmm/filechooserbutton.h>
+#endif
 
 #include <list>
 #include <memory>

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -11,8 +11,7 @@
 #include <libtransmission/utils.h>
 #include <libtransmission/variant.h>
 
-#include <glibmm.h>
-#include <glibmm/i18n.h>
+#include <glibmm/miscutils.h>
 
 #include <string>
 #include <string_view>

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -16,8 +16,29 @@
 #include <libtransmission/version.h>
 #include <libtransmission/web-utils.h>
 
-#include <glibmm.h>
+#include <glibmm/date.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/timer.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/adjustment.h>
+#include <gtkmm/box.h>
+#include <gtkmm/button.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/editable.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/label.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/spinbutton.h>
+#include <gtkmm/textview.h>
+#include <gtkmm/treemodelcolumn.h>
+#include <gtkmm/widget.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/eventcontrollerfocus.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/PrefsDialog.h
+++ b/gtk/PrefsDialog.h
@@ -7,7 +7,10 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -10,8 +10,11 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <glibmm.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/messagedialog.h>
 
 #include <fmt/core.h>
 

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -8,7 +8,10 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 #include <vector>

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -22,7 +22,24 @@
 #include <libtransmission/variant.h>
 #include <libtransmission/web-utils.h> // tr_urlIsValid()
 
+#include <giomm/asyncresult.h>
+#include <giomm/dbusconnection.h>
+#include <giomm/fileinfo.h>
+#include <giomm/filemonitor.h>
+#include <giomm/liststore.h>
+#include <glibmm/error.h>
+#include <glibmm/fileutils.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/stringutils.h>
+#include <glibmm/variant.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/sortlistmodel.h>
+#else
+#include <gtkmm/treemodelsort.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -11,9 +11,12 @@
 #include <libtransmission/tr-macros.h>
 #include <libtransmission/variant.h>
 
-#include <giomm.h>
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <giomm/file.h>
+#include <giomm/listmodel.h>
+#include <glibmm/object.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/treemodel.h>
 
 #include <cstddef>
 #include <memory>

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -9,8 +9,11 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <glibmm.h>
 #include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/label.h>
+#include <gtkmm/messagedialog.h>
 
 #include <fmt/core.h>
 

--- a/gtk/StatsDialog.h
+++ b/gtk/StatsDialog.h
@@ -7,7 +7,10 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/dialog.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -17,8 +17,18 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 
-#include <glibmm.h>
 #include <glibmm/i18n.h>
+#include <glibmm/ustring.h>
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+#include <giomm/menu.h>
+#include <glibmm/miscutils.h>
+#include <gtkmm/icontheme.h>
+#include <gtkmm/menu.h>
+#if !defined(HAVE_APPINDICATOR)
+#include <gtkmm/statusicon.h>
+#endif
+#endif
 
 #include <string>
 

--- a/gtk/SystemTrayIcon.h
+++ b/gtk/SystemTrayIcon.h
@@ -7,7 +7,8 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/window.h>
 
 #include <memory>
 

--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -12,6 +12,7 @@
 #include <libtransmission/utils.h>
 
 #include <glibmm/i18n.h>
+#include <glibmm/value.h>
 
 #include <fmt/core.h>
 

--- a/gtk/Torrent.h
+++ b/gtk/Torrent.h
@@ -9,8 +9,11 @@
 
 #include <libtransmission/transmission.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <giomm/icon.h>
+#include <glibmm/object.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/treemodelcolumn.h>
 
 #include <algorithm>
 #include <bitset>

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -12,8 +12,23 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> /* tr_truncd() */
 
+#include <cairomm/context.h>
+#include <cairomm/refptr.h>
+#include <cairomm/surface.h>
+#include <gdkmm/rectangle.h>
+#include <gdkmm/rgba.h>
+#include <giomm/icon.h>
 #include <glibmm.h>
 #include <glibmm/i18n.h>
+#include <glibmm/property.h>
+#include <gtkmm/cellrendererpixbuf.h>
+#include <gtkmm/cellrendererprogress.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/requisition.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/snapshot.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -9,8 +9,8 @@
 
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <glibmm/propertyproxy.h>
+#include <gtkmm/cellrenderer.h>
 
 #include <memory>
 

--- a/gtk/TorrentFilter.h
+++ b/gtk/TorrentFilter.h
@@ -8,7 +8,14 @@
 #include "Torrent.h"
 #include "Utils.h"
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/filter.h>
+#else
+#include <glibmm/object.h>
+#endif
 
 class TorrentFilter : public IF_GTKMM4(Gtk::Filter, Glib::Object)
 {

--- a/gtk/TorrentSorter.h
+++ b/gtk/TorrentSorter.h
@@ -8,8 +8,13 @@
 #include "Torrent.h"
 #include "Utils.h"
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/sorter.h>
+#else
+#include <glibmm/object.h>
+#endif
 
 class TorrentSorter : public IF_GTKMM4(Gtk::Sorter, Glib::Object)
 {

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -16,8 +16,29 @@
 #include <libtransmission/version.h> /* SHORT_VERSION_STRING */
 #include <libtransmission/web-utils.h>
 
-#include <giomm.h> /* g_file_trash() */
+#include <gdkmm/display.h>
+#include <giomm/appinfo.h>
+#include <giomm/asyncresult.h>
+#include <giomm/file.h>
+#include <glibmm/error.h>
 #include <glibmm/i18n.h>
+#include <glibmm/quark.h>
+#include <glibmm/spawn.h>
+#include <gtkmm/cellrenderertext.h>
+#include <gtkmm/eventcontroller.h>
+#include <gtkmm/gesture.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/messagedialog.h>
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gdkmm/clipboard.h>
+#include <gtkmm/gestureclick.h>
+#else
+#include <gdkmm/window.h>
+#include <gtkmm/clipboard.h>
+#endif
 
 #include <fmt/core.h>
 

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -8,8 +8,17 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/tr-macros.h>
 
-#include <glibmm.h>
-#include <gtkmm.h>
+#include <glibmm/objectbase.h>
+#include <glibmm/refptr.h>
+#include <glibmm/signalproxy.h>
+#include <glibmm/ustring.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/combobox.h>
+#include <gtkmm/entry.h>
+#include <gtkmm/label.h>
+#include <gtkmm/treeview.h>
+#include <gtkmm/widget.h>
+#include <gtkmm/window.h>
 
 #include <fmt/core.h>
 #include <fmt/format.h>

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -11,8 +11,17 @@
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 
-#include <glibmm.h>
+#include <giomm/file.h>
+#include <giomm/init.h>
 #include <glibmm/i18n.h>
+#include <glibmm/init.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/objectbase.h>
+#include <glibmm/optioncontext.h>
+#include <glibmm/optionentry.h>
+#include <glibmm/optiongroup.h>
+#include <glibmm/ustring.h>
+#include <glibmm/wrap.h>
 #include <gtkmm.h>
 
 #include <fmt/core.h>


### PR DESCRIPTION
This results in up to 15% single-threaded build time reduction.