### PR TITLE
Fix progress bars positioning in Qt client on Mac

### DIFF
--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -8,6 +8,7 @@
 
 #include "FileTreeDelegate.h"
 #include "FileTreeModel.h"
+#include "StyleHelper.h"
 
 QSize FileTreeDelegate::sizeHint(QStyleOptionViewItem const& item, QModelIndex const& index) const
 {
@@ -58,7 +59,7 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
         p.textVisible = true;
         p.progress = static_cast<int>(100.0 * index.data().toDouble());
         p.text = QStringLiteral("%1%").arg(p.progress);
-        style->drawControl(QStyle::CE_ProgressBar, &p, painter);
+        StyleHelper::drawProgressBar(*style, *painter, p);
     }
     else if (column == FileTreeModel::COL_WANTED)
     {

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -3,6 +3,9 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <QPainter>
+#include <QStyleOptionProgressBar>
+
 #include "StyleHelper.h"
 
 QIcon::Mode StyleHelper::getIconMode(QStyle::State const& state)
@@ -18,4 +21,21 @@ QIcon::Mode StyleHelper::getIconMode(QStyle::State const& state)
     }
 
     return QIcon::Normal;
+}
+
+void StyleHelper::drawProgressBar(QStyle const& style, QPainter& painter, QStyleOptionProgressBar const& option)
+{
+    // Workaround for https://bugreports.qt.io/browse/QTBUG-67830
+
+#ifdef Q_OS_DARWIN
+    auto my_option = option;
+    my_option.rect.translate(-option.rect.topLeft());
+
+    painter.save();
+    painter.translate(option.rect.topLeft());
+    style.drawControl(QStyle::CE_ProgressBar, &my_option, &painter);
+    painter.restore();
+#else
+    style.drawControl(QStyle::CE_ProgressBar, &option, &painter);
+#endif
 }

--- a/qt/StyleHelper.h
+++ b/qt/StyleHelper.h
@@ -8,8 +8,13 @@
 #include <QIcon>
 #include <QStyle>
 
+class QPainter;
+class QStyleOptionProgressBar;
+
 class StyleHelper
 {
 public:
     static QIcon::Mode getIconMode(QStyle::State const& state);
+
+    static void drawProgressBar(QStyle const& style, QPainter& painter, QStyleOptionProgressBar const& option);
 };

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -17,6 +17,7 @@
 
 #include "Formatter.h"
 #include "IconCache.h"
+#include "StyleHelper.h"
 #include "Torrent.h"
 #include "TorrentDelegate.h"
 #include "TorrentModel.h"
@@ -600,7 +601,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     progress_bar_style_.state = progress_bar_state;
     setProgressBarPercentDone(option, tor);
 
-    style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
+    StyleHelper::drawProgressBar(*style, *painter, progress_bar_style_);
 
     painter->restore();
 }

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -21,6 +21,7 @@
 
 #include <libtransmission/utils.h>
 
+#include "StyleHelper.h"
 #include "Torrent.h"
 #include "TorrentDelegateMin.h"
 #include "TorrentModel.h"
@@ -288,7 +289,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);
-    style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
+    StyleHelper::drawProgressBar(*style, *painter, progress_bar_style_);
 
     painter->restore();
 }


### PR DESCRIPTION
This is a workaround for [QTBUG-67830](https://bugreports.qt.io/browse/QTBUG-67830), where progress bars seem to be drawn regardless of style option's rect top-left coordinates.

Fixes: #4470