### PR TITLE
fix: remove announce ipv4 ipv6 query params

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -464,11 +464,6 @@ public:
 
     [[nodiscard]] bool useRpcWhitelist() const;
 
-    [[nodiscard]] constexpr auto externalIP() const noexcept
-    {
-        return external_ip_;
-    }
-
     void setExternalIP(tr_address external_ip)
     {
         external_ip_ = external_ip;


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/4501.

Notes: Followed [BEP7](https://www.bittorrent.org/beps/bep_0007.html) suggestion to remove ipv4 and ipv6 query parameters from tracker announcements.