### PR TITLE
fix(remote): Fix tr_strltime to output days correctly

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -143,7 +143,7 @@ static std::string tr_strltime(time_t seconds)
 
     if (days > 0)
     {
-        auto const dstr = fmt::format(FMT_STRING("{:d} {:s}"), hours, tr_ngettext("day", "days", days));
+        auto const dstr = fmt::format(FMT_STRING("{:d} {:s}"), days, tr_ngettext("day", "days", days));
         tmpstr = days >= 4 || hours == 0 ? dstr : fmt::format(FMT_STRING("{:s}, {:s}"), dstr, hstr);
     }
     else if (hours > 0)


### PR DESCRIPTION
### BEFORE
![image](https://user-images.githubusercontent.com/31856315/210171587-a74f269a-b3a2-4ece-9c00-b0bb0fe4dde2.png)

### AFTER
![image](https://user-images.githubusercontent.com/31856315/210171602-d397adb5-57c9-4ae9-be80-19c7ef123e66.png)

Fixes #4318.