### PR TITLE
perf: avoid vector temporary in announcer-udp

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -230,8 +230,8 @@ struct tau_announce_request
             response.leechers = buf.toUint32();
             response.seeders = buf.toUint32();
 
-            auto const contiguous = std::vector<std::byte>{ std::begin(buf), std::end(buf) };
-            response.pex = tr_pex::from_compact_ipv4(std::data(contiguous), std::size(contiguous), nullptr, 0);
+            auto const [bytes, n_bytes] = buf.pullup();
+            response.pex = tr_pex::from_compact_ipv4(bytes, n_bytes, nullptr, 0);
             requestFinished();
         }
         else
@@ -383,8 +383,8 @@ struct tau_tracker
             buf.addUint32(TAU_ACTION_CONNECT);
             buf.addUint32(this->connection_transaction_id);
 
-            auto const contiguous = std::vector<std::byte>(std::begin(buf), std::end(buf));
-            this->sendto(std::data(contiguous), std::size(contiguous));
+            auto const [bytes, n_bytes] = buf.pullup();
+            this->sendto(bytes, n_bytes);
         }
 
         if (timeout_reqs)
@@ -544,8 +544,8 @@ private:
         buf.addUint64(this->connection_id);
         buf.add(payload, payload_len);
 
-        auto const contiguous = std::vector<std::byte>(std::begin(buf), std::end(buf));
-        this->sendto(std::data(contiguous), std::size(contiguous));
+        auto const [bytes, n_bytes] = buf.pullup();
+        this->sendto(bytes, n_bytes);
     }
 
 public:

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -80,7 +80,7 @@ size_t tr_peer_socket::try_write(Buffer& buf, size_t max, tr_error** error) cons
 #ifdef WITH_UTP
     if (is_utp())
     {
-        auto [data, datalen] = buf.pullup();
+        auto const [data, datalen] = buf.pullup();
 
         errno = 0;
         auto const n_written = utp_write(handle.utp, data, std::min(datalen, max));


### PR DESCRIPTION
Notes: Made small performance improvements in libtransmission.