### PR TITLE
fix: clang-tidy-15 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,7 +696,7 @@ endif()
 
 if(RUN_CLANG_TIDY)
     message(STATUS "Looking for clang-tidy")
-    find_program(CLANG_TIDY clang-tidy)
+    find_program(CLANG_TIDY clang-tidy-15 clang-tidy)
     if(CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
         message(STATUS "Looking for clang-tidy - not found")
     else()

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -471,7 +471,7 @@ namespace global_ipv6_helpers
     return {};
 }
 
-[[nodiscard]] auto global_address(int af)
+[[nodiscard]] std::optional<tr_address> global_address(int af)
 {
     // Pick some destination address to pretend to send a packet to
     static auto constexpr DstIPv4 = "91.121.74.28"sv;
@@ -481,11 +481,17 @@ namespace global_ipv6_helpers
 
     // In order for address selection to work right,
     // this should be a native IPv6 address, not Teredo or 6to4
-    TR_ASSERT(dst_addr.has_value());
-    TR_ASSERT(dst_addr->is_global_unicast_address());
+    TR_ASSERT(dst_addr.has_value() && dst_addr->is_global_unicast_address());
 
-    auto src_addr = get_source_address(*dst_addr, dst_port);
-    return src_addr && src_addr->is_global_unicast_address() ? *src_addr : std::optional<tr_address>{};
+    if (dst_addr)
+    {
+        if (auto addr = get_source_address(*dst_addr, dst_port); addr && addr->is_global_unicast_address())
+        {
+            return addr;
+        }
+    }
+
+    return {};
 }
 
 } // namespace global_ipv6_helpers

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -158,18 +158,23 @@ struct peer_atom
         , fromBest{ from }
         , flags{ flags_in }
     {
-        ++n_atoms_;
+        ++n_atoms;
     }
+
+    peer_atom(peer_atom&&) = delete;
+    peer_atom(peer_atom const&) = delete;
+    peer_atom& operator=(peer_atom&&) = delete;
+    peer_atom& operator=(peer_atom const&) = delete;
 
     ~peer_atom()
     {
-        [[maybe_unused]] auto const n_prev = n_atoms_--;
+        [[maybe_unused]] auto const n_prev = n_atoms--;
         TR_ASSERT(n_prev > 0U);
     }
 
     [[nodiscard]] static auto atom_count() noexcept
     {
-        return n_atoms_.load();
+        return n_atoms.load();
     }
 
     [[nodiscard]] constexpr auto isSeed() const noexcept
@@ -299,7 +304,7 @@ private:
     // the minimum we'll wait before attempting to reconnect to a peer
     static auto constexpr MinimumReconnectIntervalSecs = int{ 5 };
 
-    static auto inline n_atoms_ = std::atomic<size_t>{};
+    static auto inline n_atoms = std::atomic<size_t>{};
 };
 
 using Handshakes = std::map<tr_address, tr_handshake>;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -228,8 +228,10 @@ public:
         Task(tr_web::Impl& impl_in, tr_web::FetchOptions&& options_in)
             : impl{ impl_in }
             , options{ std::move(options_in) }
-            , easy_{ impl.get_easy(tr_urlParse(options.url)->host) }
         {
+            auto const parsed = tr_urlParse(options.url);
+            easy_ = parsed ? impl.get_easy(parsed->host) : nullptr;
+
             response.user_data = options.done_func_user_data;
         }
 
@@ -365,7 +367,7 @@ public:
 
         tr_web::FetchOptions options;
 
-        CURL* const easy_;
+        CURL* easy_;
     };
 
     static auto constexpr BandwidthPauseMsec = long{ 500 };


### PR DESCRIPTION
No functional changes.

Fix a couple of clang-tidy-15 warnings e.g. unchecked `std::optional` accesses