### PR TITLE
fix: -Wredundant-decls warning when building with g++

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1081,7 +1081,7 @@
 		BE1183680CE160D50002D0F3 /* miniupnpc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = miniupnpc.c; sourceTree = "<group>"; };
 		BE75C3490C729E9500DBEFE0 /* libevent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libevent.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE7AA337F6752914B0C416B1 /* utils-ev.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "utils-ev.h"; sourceTree = "<group>"; };
-		BE7AA337F6752914B0C416B3 /* utils-ev.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "utils-ev.cpp"; sourceTree = "<group>"; };
+		BE7AA337F6752914B0C416B3 /* utils-ev.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "utils-ev.cc"; sourceTree = "<group>"; };
 		BEFC1C000C07750000B0BB3C /* transmission-daemon */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "transmission-daemon"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEFC1C0E0C07756200B0BB3C /* daemon.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = daemon.cc; sourceTree = "<group>"; };
 		BEFC1C140C07756200B0BB3C /* remote.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = remote.cc; sourceTree = "<group>"; };

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		BE1183780CE161390002D0F3 /* libminiupnp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE1183480CE160960002D0F3 /* libminiupnp.a */; };
 		BE75C38A0C72A1ED00DBEFE0 /* libevent.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE75C3490C729E9500DBEFE0 /* libevent.a */; };
 		BE7AA337F6752914B0C416B0 /* utils-ev.h in Headers */ = {isa = PBXBuildFile; fileRef = BE7AA337F6752914B0C416B1 /* utils-ev.h */; };
+		BE7AA337F6752914B0C416B2 /* utils-ev.cc in Sources */ = {isa = PBXBuildFile; fileRef = BE7AA337F6752914B0C416B3 /* utils-ev.cc */; };
 		BEFC1C050C07753500B0BB3C /* libtransmission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D18389709DEC0030047D688 /* libtransmission.a */; };
 		BEFC1C1A0C07756200B0BB3C /* daemon.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1C0E0C07756200B0BB3C /* daemon.cc */; };
 		BEFC1D050C07825A00B0BB3C /* remote.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1C140C07756200B0BB3C /* remote.cc */; };
@@ -1080,6 +1081,7 @@
 		BE1183680CE160D50002D0F3 /* miniupnpc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = miniupnpc.c; sourceTree = "<group>"; };
 		BE75C3490C729E9500DBEFE0 /* libevent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libevent.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE7AA337F6752914B0C416B1 /* utils-ev.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "utils-ev.h"; sourceTree = "<group>"; };
+		BE7AA337F6752914B0C416B3 /* utils-ev.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "utils-ev.cpp"; sourceTree = "<group>"; };
 		BEFC1C000C07750000B0BB3C /* transmission-daemon */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "transmission-daemon"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEFC1C0E0C07756200B0BB3C /* daemon.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = daemon.cc; sourceTree = "<group>"; };
 		BEFC1C140C07756200B0BB3C /* remote.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = remote.cc; sourceTree = "<group>"; };
@@ -1784,6 +1786,7 @@
 				A24621360C769CF400088E81 /* session-thread.cc */,
 				A24621350C769CF400088E81 /* session-thread.h */,
 				BE7AA337F6752914B0C416B1 /* utils-ev.h */,
+				BE7AA337F6752914B0C416B3 /* utils-ev.cc */,
 				BEFC1DF40C07861A00B0BB3C /* port-forwarding-upnp.cc */,
 				BEFC1DF30C07861A00B0BB3C /* port-forwarding-upnp.h */,
 				BEFC1DF20C07861A00B0BB3C /* utils.cc */,
@@ -3023,6 +3026,7 @@
 				D9057D68C13B75636539B680 /* variant-converters.cc in Sources */,
 				BEFC1E320C07861A00B0BB3C /* torrent.cc in Sources */,
 				2B9BA6C508B488FE586A0AB0 /* torrents.cc in Sources */,
+				BE7AA337F6752914B0C416B2 /* utils-ev.cc in Sources */,
 				A47A7C87B8B57BE50DF0D410 /* torrent-files.cc in Sources */,
 				BEFC1E360C07861A00B0BB3C /* port-forwarding.cc in Sources */,
 				BEFC1E3C0C07861A00B0BB3C /* platform.cc in Sources */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(${TR_NAME}
         tr-utp.cc
         tr-utp.h
         transmission.h
+        utils-ev.cc
         utils-ev.h
         utils.cc
         utils.h

--- a/libtransmission/utils-ev.cc
+++ b/libtransmission/utils-ev.cc
@@ -1,0 +1,52 @@
+// This file Copyright © 2022 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <memory>
+
+#include "event2/buffer.h"
+#include "event2/event.h"
+#include "event2/http.h"
+
+#include "transmission.h"
+
+#include "utils-ev.h"
+
+namespace libtransmission::evhelpers
+{
+
+void BufferDeleter::operator()(struct evbuffer* buf) const noexcept
+{
+    if (buf != nullptr)
+    {
+        evbuffer_free(buf);
+    }
+}
+
+void EventBaseDeleter::operator()(struct event_base* evbase) const noexcept
+{
+    if (evbase != nullptr)
+    {
+        event_base_free(evbase);
+    }
+}
+
+void EventDeleter::operator()(struct event* event) const
+{
+    if (event != nullptr)
+    {
+        event_del(event);
+        event_free(event);
+    }
+}
+
+void EvhttpDeleter::operator()(struct evhttp* evh) const noexcept
+{
+    if (evh != nullptr)
+    {
+        evhttp_free(evh);
+    }
+}
+
+} // namespace libtransmission::evhelpers

--- a/libtransmission/utils-ev.h
+++ b/libtransmission/utils-ev.h
@@ -11,72 +11,38 @@
 
 #include <memory>
 
-extern "C"
-{
-    struct evbuffer;
-    struct event;
-    struct event_base;
-    struct evhttp;
-
-    void evbuffer_free(struct evbuffer*);
-    void event_base_free(struct event_base*);
-    int event_del(struct event*);
-    void event_free(struct event*);
-    void evhttp_free(struct evhttp*);
-}
+struct evbuffer;
+struct event;
+struct event_base;
+struct evhttp;
 
 namespace libtransmission::evhelpers
 {
 
 struct BufferDeleter
 {
-    void operator()(struct evbuffer* buf) const noexcept
-    {
-        if (buf != nullptr)
-        {
-            evbuffer_free(buf);
-        }
-    }
+    void operator()(struct evbuffer* buf) const noexcept;
 };
 
 using evbuffer_unique_ptr = std::unique_ptr<struct evbuffer, BufferDeleter>;
 
 struct EventBaseDeleter
 {
-    void operator()(struct event_base* evbase) const noexcept
-    {
-        if (evbase != nullptr)
-        {
-            event_base_free(evbase);
-        }
-    }
+    void operator()(struct event_base* evbase) const noexcept;
 };
 
 using evbase_unique_ptr = std::unique_ptr<struct event_base, EventBaseDeleter>;
 
 struct EventDeleter
 {
-    void operator()(struct event* event) const
-    {
-        if (event != nullptr)
-        {
-            event_del(event);
-            event_free(event);
-        }
-    }
+    void operator()(struct event* event) const;
 };
 
 using event_unique_ptr = std::unique_ptr<struct event, EventDeleter>;
 
 struct EvhttpDeleter
 {
-    void operator()(struct evhttp* evh) const noexcept
-    {
-        if (evh != nullptr)
-        {
-            evhttp_free(evh);
-        }
-    }
+    void operator()(struct evhttp* evh) const noexcept;
 };
 
 using evhttp_unique_ptr = std::unique_ptr<struct evhttp, EvhttpDeleter>;


### PR DESCRIPTION
No functional changes.

Move the libevent helpers' implementations into a .cc file to prevent a `-Wredundant-decls` warning