### PR TITLE
refactor: fix readability-redundant-string-cstr clang-tidy-16 warnings 

### DIFF
--- a/libtransmission/platform-quota.cc
+++ b/libtransmission/platform-quota.cc
@@ -474,7 +474,7 @@ tr_device_info tr_device_info_create(std::string_view path)
     out.path = path;
 #ifndef _WIN32
     out.device = getblkdev(out.path);
-    auto const* const fstype = getfstype(out.path.c_str());
+    auto const* const fstype = getfstype(out.path);
     out.fstype = fstype != nullptr ? fstype : "";
 #endif
     return out;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -382,10 +382,7 @@ static bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request const*
     }
 
     auto const& src = server->host_whitelist_;
-    return std::any_of(
-        std::begin(src),
-        std::end(src),
-        [&hostname](auto const& str) { return tr_wildmat(hostname.c_str(), str.c_str()); });
+    return std::any_of(std::begin(src), std::end(src), [&hostname](auto const& str) { return tr_wildmat(hostname, str); });
 }
 
 static bool test_session_id(tr_rpc_server const* server, evhttp_request const* req)


### PR DESCRIPTION
No functional changes; just silencing some minor warnings