### PR TITLE
fixup! fix: Couldnt send to IPv6 address warnings (#4527)

### DIFF
--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -239,7 +239,7 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
     {
         errno = EAFNOSUPPORT;
     }
-    else if (auto const sock = to->sa_family == AF_INET ? udp4_socket_ : udp6_socket_; sock != TR_BAD_SOCKET)
+    else if (auto const sock = to->sa_family == AF_INET ? udp4_socket_ : udp6_socket_; sock == TR_BAD_SOCKET)
     {
         // don't warn on bad sockets; the system may not support IPv6
         return;


### PR DESCRIPTION
fix regression [reported by Coverity](https://scan5.scan.coverity.com/reports.htm#v48014/p10174/fileInstanceId=230611125&defectInstanceId=53050531&mergedDefectId=1518899)