### PR TITLE
refactor: misc-use-anonymous-namespace pt. 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,7 +696,7 @@ endif()
 
 if(RUN_CLANG_TIDY)
     message(STATUS "Looking for clang-tidy")
-    find_program(CLANG_TIDY clang-tidy-15 clang-tidy)
+    find_program(CLANG_TIDY clang-tidy)
     if(CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
         message(STATUS "Looking for clang-tidy - not found")
     else()

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -42,15 +42,17 @@
 #define logdbg(interned, msg) tr_logAddDebug(msg, (interned).sv())
 #define logtrace(interned, msg) tr_logAddTrace(msg, (interned).sv())
 
+namespace
+{
 using namespace std::literals;
 
 // size defined by bep15
 using tau_connection_t = uint64_t;
 using tau_transaction_t = uint32_t;
 
-static constexpr auto TauConnectionTtlSecs = time_t{ 45 };
+constexpr auto TauConnectionTtlSecs = time_t{ 45 };
 
-static auto tau_transaction_new()
+auto tau_transaction_new()
 {
     return tr_rand_obj<tau_transaction_t>();
 }
@@ -64,9 +66,7 @@ enum tau_action_t
     TAU_ACTION_ERROR = 3
 };
 
-/****
-*****  SCRAPE
-****/
+/// SCRAPE
 
 struct tau_scrape_request
 {
@@ -162,9 +162,7 @@ private:
     tr_scrape_response_func on_response_;
 };
 
-/****
-*****  ANNOUNCE
-****/
+/// ANNOUNCE
 
 struct tau_announce_request
 {
@@ -287,9 +285,7 @@ private:
     tr_announce_response_func on_response_;
 };
 
-/****
-*****  TRACKER
-****/
+/// TRACKER
 
 struct tau_tracker
 {
@@ -573,9 +569,7 @@ private:
     static inline constexpr auto ConnectionRequestTtl = int{ 30 };
 };
 
-/****
-*****  SESSION
-****/
+/// SESSION
 
 class tr_announcer_udp_impl final : public tr_announcer_udp
 {
@@ -750,6 +744,8 @@ private:
 
     Mediator& mediator_;
 };
+
+} // namespace
 
 std::unique_ptr<tr_announcer_udp> tr_announcer_udp::create(Mediator& mediator)
 {

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -97,7 +97,9 @@
 
 using namespace std::literals;
 
-static void set_system_error(tr_error** error, int code)
+namespace
+{
+void set_system_error(tr_error** error, int code)
 {
     if (error == nullptr)
     {
@@ -107,7 +109,7 @@ static void set_system_error(tr_error** error, int code)
     tr_error_set(error, code, tr_strerror(code));
 }
 
-static void set_system_error_if_file_found(tr_error** error, int code)
+void set_system_error_if_file_found(tr_error** error, int code)
 {
     if (code != ENOENT)
     {
@@ -115,7 +117,7 @@ static void set_system_error_if_file_found(tr_error** error, int code)
     }
 }
 
-static void set_file_for_single_pass(tr_sys_file_t handle)
+void set_file_for_single_pass(tr_sys_file_t handle)
 {
     /* Set hints about the lookahead buffer and caching. It's okay
        for these to fail silently, so don't let them affect errno */
@@ -142,6 +144,7 @@ static void set_file_for_single_pass(tr_sys_file_t handle)
 
     errno = err;
 }
+} // namespace
 
 bool tr_sys_path_exists(char const* path, tr_error** error)
 {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2468,11 +2468,7 @@ int renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view
     return err;
 }
 
-void renameTorrentFileString(
-    tr_torrent* tor,
-    std::string_view oldpath,
-    std::string_view newname,
-    tr_file_index_t file_index)
+void renameTorrentFileString(tr_torrent* tor, std::string_view oldpath, std::string_view newname, tr_file_index_t file_index)
 {
     auto name = std::string{};
     auto const subpath = std::string_view{ tor->fileSubpath(file_index) };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -401,10 +401,95 @@ static bool tr_torrentIsSeedIdleLimitDone(tr_torrent const* tor)
         difftime(tr_time(), std::max(tor->startDate, tor->activityDate)) >= idle_minutes * 60U;
 }
 
-static void torrentCallScript(tr_torrent const* tor, std::string const& script);
-
-static void callScriptIfEnabled(tr_torrent const* tor, TrScript type)
+namespace
 {
+namespace script_helpers
+{
+[[nodiscard]] std::string buildLabelsString(tr_torrent const* tor)
+{
+    auto buf = std::stringstream{};
+
+    for (auto it = std::begin(tor->labels), end = std::end(tor->labels); it != end;)
+    {
+        buf << tr_quark_get_string_view(*it);
+
+        if (++it != end)
+        {
+            buf << ',';
+        }
+    }
+
+    return buf.str();
+}
+
+[[nodiscard]] std::string buildTrackersString(tr_torrent const* tor)
+{
+    auto buf = std::stringstream{};
+
+    for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
+    {
+        buf << tr_torrentTracker(tor, i).host;
+
+        if (++i < n)
+        {
+            buf << ',';
+        }
+    }
+
+    return buf.str();
+}
+
+void torrentCallScript(tr_torrent const* tor, std::string const& script)
+{
+    if (std::empty(script))
+    {
+        return;
+    }
+
+    auto torrent_dir = tr_pathbuf{ tor->currentDir() };
+    tr_sys_path_native_separators(std::data(torrent_dir));
+
+    auto const cmd = std::array<char const*, 2>{ script.c_str(), nullptr };
+
+    auto const id_str = std::to_string(tr_torrentId(tor));
+    auto const labels_str = buildLabelsString(tor);
+    auto const trackers_str = buildTrackersString(tor);
+    auto const bytes_downloaded_str = std::to_string(tor->downloadedCur + tor->downloadedPrev);
+
+    auto const env = std::map<std::string_view, std::string_view>{
+        { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
+        { "TR_TIME_LOCALTIME"sv, fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time())) },
+        { "TR_TORRENT_BYTES_DOWNLOADED"sv, bytes_downloaded_str },
+        { "TR_TORRENT_DIR"sv, torrent_dir.c_str() },
+        { "TR_TORRENT_HASH"sv, tor->infoHashString() },
+        { "TR_TORRENT_ID"sv, id_str },
+        { "TR_TORRENT_LABELS"sv, labels_str },
+        { "TR_TORRENT_NAME"sv, tr_torrentName(tor) },
+        { "TR_TORRENT_TRACKERS"sv, trackers_str },
+    };
+
+    tr_logAddInfoTor(tor, fmt::format(_("Calling script '{path}'"), fmt::arg("path", script)));
+
+    tr_error* error = nullptr;
+
+    if (!tr_spawn_async(std::data(cmd), env, TR_IF_WIN32("\\", "/"), &error))
+    {
+        tr_logAddWarnTor(
+            tor,
+            fmt::format(
+                _("Couldn't call script '{path}': {error} ({error_code})"),
+                fmt::arg("path", script),
+                fmt::arg("error", error->message),
+                fmt::arg("error_code", error->code)));
+        tr_error_free(error);
+    }
+}
+} // namespace script_helpers
+
+void callScriptIfEnabled(tr_torrent const* tor, TrScript type)
+{
+    using namespace script_helpers;
+
     auto const* session = tor->session;
 
     if (tr_sessionIsScriptEnabled(session, type))
@@ -413,9 +498,9 @@ static void callScriptIfEnabled(tr_torrent const* tor, TrScript type)
     }
 }
 
-/***
-****
-***/
+} // namespace
+
+///
 
 void tr_torrentCheckSeedLimit(tr_torrent* tor)
 {
@@ -1568,7 +1653,11 @@ void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func
 ***  Completeness
 **/
 
-static char const* getCompletionString(int type)
+namespace
+{
+namespace completeness_helpers
+{
+[[nodiscard]] constexpr char const* get_completion_string(int type)
 {
     switch (type)
     {
@@ -1587,89 +1676,13 @@ static char const* getCompletionString(int type)
         return "Incomplete";
     }
 }
-
-static std::string buildLabelsString(tr_torrent const* tor)
-{
-    auto buf = std::stringstream{};
-
-    for (auto it = std::begin(tor->labels), end = std::end(tor->labels); it != end;)
-    {
-        buf << tr_quark_get_string_view(*it);
-
-        if (++it != end)
-        {
-            buf << ',';
-        }
-    }
-
-    return buf.str();
-}
-
-static std::string buildTrackersString(tr_torrent const* tor)
-{
-    auto buf = std::stringstream{};
-
-    for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
-    {
-        buf << tr_torrentTracker(tor, i).host;
-
-        if (++i < n)
-        {
-            buf << ',';
-        }
-    }
-
-    return buf.str();
-}
-
-static void torrentCallScript(tr_torrent const* tor, std::string const& script)
-{
-    if (std::empty(script))
-    {
-        return;
-    }
-
-    auto torrent_dir = tr_pathbuf{ tor->currentDir() };
-    tr_sys_path_native_separators(std::data(torrent_dir));
-
-    auto const cmd = std::array<char const*, 2>{ script.c_str(), nullptr };
-
-    auto const id_str = std::to_string(tr_torrentId(tor));
-    auto const labels_str = buildLabelsString(tor);
-    auto const trackers_str = buildTrackersString(tor);
-    auto const bytes_downloaded_str = std::to_string(tor->downloadedCur + tor->downloadedPrev);
-
-    auto const env = std::map<std::string_view, std::string_view>{
-        { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
-        { "TR_TIME_LOCALTIME"sv, fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time())) },
-        { "TR_TORRENT_BYTES_DOWNLOADED"sv, bytes_downloaded_str },
-        { "TR_TORRENT_DIR"sv, torrent_dir.c_str() },
-        { "TR_TORRENT_HASH"sv, tor->infoHashString() },
-        { "TR_TORRENT_ID"sv, id_str },
-        { "TR_TORRENT_LABELS"sv, labels_str },
-        { "TR_TORRENT_NAME"sv, tr_torrentName(tor) },
-        { "TR_TORRENT_TRACKERS"sv, trackers_str },
-    };
-
-    tr_logAddInfoTor(tor, fmt::format(_("Calling script '{path}'"), fmt::arg("path", script)));
-
-    tr_error* error = nullptr;
-
-    if (!tr_spawn_async(std::data(cmd), env, TR_IF_WIN32("\\", "/"), &error))
-    {
-        tr_logAddWarnTor(
-            tor,
-            fmt::format(
-                _("Couldn't call script '{path}': {error} ({error_code})"),
-                fmt::arg("path", script),
-                fmt::arg("error", error->message),
-                fmt::arg("error_code", error->code)));
-        tr_error_free(error);
-    }
-}
+} // namespace completeness_helpers
+} // namespace
 
 void tr_torrent::recheckCompleteness()
 {
+    using namespace completeness_helpers;
+
     auto const lock = unique_lock();
 
     needs_completeness_check_ = false;
@@ -1688,8 +1701,8 @@ void tr_torrent::recheckCompleteness()
                 this,
                 fmt::format(
                     "State changed from {} to {}",
-                    getCompletionString(this->completeness),
-                    getCompletionString(completeness)));
+                    get_completion_string(this->completeness),
+                    get_completion_string(completeness)));
         }
 
         this->completeness = new_completeness;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2395,19 +2395,19 @@ static void torrentSetQueued(tr_torrent* tor, bool queued)
     }
 }
 
-/***
-****
-****  RENAME
-****
-***/
+/// RENAME
 
-static bool renameArgsAreValid(std::string_view oldpath, std::string_view newname)
+namespace
+{
+namespace rename_helpers
+{
+bool renameArgsAreValid(std::string_view oldpath, std::string_view newname)
 {
     return !std::empty(oldpath) && !std::empty(newname) && newname != "."sv && newname != ".."sv &&
         !tr_strvContains(newname, TR_PATH_DELIMITER);
 }
 
-static auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldpath)
+auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldpath)
 {
     auto indices = std::vector<tr_file_index_t>{};
     auto const oldpath_as_dir = tr_pathbuf{ oldpath, '/' };
@@ -2425,7 +2425,7 @@ static auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldp
     return indices;
 }
 
-static int renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
+int renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
 {
     int err = 0;
 
@@ -2468,7 +2468,7 @@ static int renamePath(tr_torrent const* tor, std::string_view oldpath, std::stri
     return err;
 }
 
-static void renameTorrentFileString(
+void renameTorrentFileString(
     tr_torrent* tor,
     std::string_view oldpath,
     std::string_view newname,
@@ -2514,7 +2514,7 @@ static void renameTorrentFileString(
     }
 }
 
-static void torrentRenamePath(
+void torrentRenamePath(
     tr_torrent* const tor,
     std::string oldpath, // NOLINT performance-unnecessary-value-param
     std::string newname, // NOLINT performance-unnecessary-value-param
@@ -2522,10 +2522,6 @@ static void torrentRenamePath(
     void* const callback_user_data)
 {
     TR_ASSERT(tr_isTorrent(tor));
-
-    /***
-    ****
-    ***/
 
     int error = 0;
 
@@ -2560,9 +2556,7 @@ static void torrentRenamePath(
         }
     }
 
-    /***
-    ****
-    ***/
+    ///
 
     tor->markChanged();
 
@@ -2573,12 +2567,17 @@ static void torrentRenamePath(
     }
 }
 
+} // namespace rename_helpers
+} // namespace
+
 void tr_torrent::renamePath(
     std::string_view oldpath,
     std::string_view newname,
     tr_torrent_rename_done_func callback,
     void* callback_user_data)
 {
+    using namespace rename_helpers;
+
     this->session->runInSessionThread(
         torrentRenamePath,
         this,
@@ -2600,6 +2599,8 @@ void tr_torrentRenamePath(
 
     tor->renamePath(oldpath, newname, callback, callback_user_data);
 }
+
+///
 
 void tr_torrentSetFilePriorities(
     tr_torrent* tor,

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -20,7 +20,9 @@ using namespace std::literals;
 
 int tr_optind = 1;
 
-static std::string_view getArgName(tr_option const* opt)
+namespace
+{
+[[nodiscard]] constexpr std::string_view getArgName(tr_option const* opt)
 {
     if (!opt->has_arg)
     {
@@ -35,7 +37,7 @@ static std::string_view getArgName(tr_option const* opt)
     return "<args>"sv;
 }
 
-static size_t get_next_line_len(std::string_view description, size_t maxlen)
+[[nodiscard]] constexpr size_t get_next_line_len(std::string_view description, size_t maxlen)
 {
     auto len = std::size(description);
     if (len > maxlen)
@@ -47,7 +49,7 @@ static size_t get_next_line_len(std::string_view description, size_t maxlen)
     return len;
 }
 
-static void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t short_width, size_t arg_width)
+void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t short_width, size_t arg_width)
 {
     auto const long_name = std::string_view{ opt->longName != nullptr ? opt->longName : "" };
     auto const short_name = std::string_view{ opt->shortName != nullptr ? opt->shortName : "" };
@@ -82,7 +84,7 @@ static void getopts_usage_line(tr_option const* const opt, size_t long_width, si
     }
 }
 
-static void maxWidth(struct tr_option const* o, size_t& long_width, size_t& short_width, size_t& arg_width)
+void maxWidth(struct tr_option const* o, size_t& long_width, size_t& short_width, size_t& arg_width)
 {
     if (o->longName != nullptr)
     {
@@ -100,36 +102,7 @@ static void maxWidth(struct tr_option const* o, size_t& long_width, size_t& shor
     }
 }
 
-void tr_getopt_usage(char const* app_name, char const* description, struct tr_option const* opts)
-{
-    auto long_width = size_t{ 0 };
-    auto short_width = size_t{ 0 };
-    auto arg_width = size_t{ 0 };
-
-    for (tr_option const* o = opts; o->val != 0; ++o)
-    {
-        maxWidth(o, long_width, short_width, arg_width);
-    }
-
-    auto const help = tr_option{ -1, "help", "Display this help page and exit", "h", false, nullptr };
-    maxWidth(&help, long_width, short_width, arg_width);
-
-    if (description == nullptr)
-    {
-        description = "Usage: %s [options]";
-    }
-
-    printf(description, app_name);
-    printf("\n\nOptions:\n");
-    getopts_usage_line(&help, long_width, short_width, arg_width);
-
-    for (tr_option const* o = opts; o->val != 0; ++o)
-    {
-        getopts_usage_line(o, long_width, short_width, arg_width);
-    }
-}
-
-static tr_option const* findOption(tr_option const* opts, char const* str, char const** setme_arg)
+tr_option const* findOption(tr_option const* opts, char const* str, char const** setme_arg)
 {
     size_t matchlen = 0;
     char const* arg = nullptr;
@@ -178,6 +151,37 @@ static tr_option const* findOption(tr_option const* opts, char const* str, char 
     }
 
     return match;
+}
+
+} // namespace
+
+void tr_getopt_usage(char const* app_name, char const* description, struct tr_option const* opts)
+{
+    auto long_width = size_t{ 0 };
+    auto short_width = size_t{ 0 };
+    auto arg_width = size_t{ 0 };
+
+    for (tr_option const* o = opts; o->val != 0; ++o)
+    {
+        maxWidth(o, long_width, short_width, arg_width);
+    }
+
+    auto const help = tr_option{ -1, "help", "Display this help page and exit", "h", false, nullptr };
+    maxWidth(&help, long_width, short_width, arg_width);
+
+    if (description == nullptr)
+    {
+        description = "Usage: %s [options]";
+    }
+
+    printf(description, app_name);
+    printf("\n\nOptions:\n");
+    getopts_usage_line(&help, long_width, short_width, arg_width);
+
+    for (tr_option const* o = opts; o->val != 0; ++o)
+    {
+        getopts_usage_line(o, long_width, short_width, arg_width);
+    }
 }
 
 int tr_getopt(char const* usage, int argc, char const* const* argv, tr_option const* opts, char const** setme_optarg)

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -28,10 +28,7 @@ using namespace std::literals;
 
 auto constexpr MaxBencStrLength = size_t{ 128 * 1024 * 1024 }; // arbitrary
 
-/***
-****
-****
-***/
+///
 
 namespace transmission::benc::impl
 {
@@ -126,11 +123,12 @@ std::optional<std::string_view> ParseString(std::string_view* benc)
 
 } // namespace transmission::benc::impl
 
-/***
-****  tr_variantParse()
-****  tr_variantLoad()
-***/
+///
 
+namespace
+{
+namespace parse_helpers
+{
 struct MyHandler : public transmission::benc::Handler
 {
     tr_variant* const top_;
@@ -260,34 +258,40 @@ private:
         return node;
     }
 };
+} // namespace parse_helpers
+} // namespace
 
 bool tr_variantParseBenc(tr_variant& top, int parse_opts, std::string_view benc, char const** setme_end, tr_error** error)
 {
+    using namespace parse_helpers;
     using Stack = transmission::benc::ParserStack<512>;
+
     auto stack = Stack{};
     auto handler = MyHandler{ &top, parse_opts };
     return transmission::benc::parse(benc, stack, handler, setme_end, error) && std::empty(stack);
 }
 
-/****
-*****
-****/
+///
 
+namespace
+{
+namespace to_string_helpers
+{
 using Buffer = libtransmission::Buffer;
 
-static void saveIntFunc(tr_variant const* val, void* vout)
+void saveIntFunc(tr_variant const* val, void* vout)
 {
     auto buf = std::array<char, 64>{};
     auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("i{:d}e"), val->val.i);
     static_cast<Buffer*>(vout)->add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
 }
 
-static void saveBoolFunc(tr_variant const* val, void* vout)
+void saveBoolFunc(tr_variant const* val, void* vout)
 {
     static_cast<Buffer*>(vout)->add(val->val.b ? "i1e"sv : "i0e"sv);
 }
 
-static void saveStringImpl(Buffer* tgt, std::string_view sv)
+void saveStringImpl(Buffer* tgt, std::string_view sv)
 {
     // `${sv.size()}:${sv}`
     auto prefix = std::array<char, 32>{};
@@ -296,14 +300,14 @@ static void saveStringImpl(Buffer* tgt, std::string_view sv)
     tgt->add(sv);
 }
 
-static void saveStringFunc(tr_variant const* v, void* vout)
+void saveStringFunc(tr_variant const* v, void* vout)
 {
     auto sv = std::string_view{};
     (void)!tr_variantGetStrView(v, &sv);
     saveStringImpl(static_cast<Buffer*>(vout), sv);
 }
 
-static void saveRealFunc(tr_variant const* val, void* vout)
+void saveRealFunc(tr_variant const* val, void* vout)
 {
     // the benc spec doesn't handle floats; save it as a string.
 
@@ -312,22 +316,22 @@ static void saveRealFunc(tr_variant const* val, void* vout)
     saveStringImpl(static_cast<Buffer*>(vout), { std::data(buf), static_cast<size_t>(out - std::data(buf)) });
 }
 
-static void saveDictBeginFunc(tr_variant const* /*val*/, void* vbuf)
+void saveDictBeginFunc(tr_variant const* /*val*/, void* vbuf)
 {
     static_cast<Buffer*>(vbuf)->push_back('d');
 }
 
-static void saveListBeginFunc(tr_variant const* /*val*/, void* vbuf)
+void saveListBeginFunc(tr_variant const* /*val*/, void* vbuf)
 {
     static_cast<Buffer*>(vbuf)->push_back('l');
 }
 
-static void saveContainerEndFunc(tr_variant const* /*val*/, void* vbuf)
+void saveContainerEndFunc(tr_variant const* /*val*/, void* vbuf)
 {
     static_cast<Buffer*>(vbuf)->push_back('e');
 }
 
-static struct VariantWalkFuncs const walk_funcs = {
+struct VariantWalkFuncs const walk_funcs = {
     saveIntFunc, //
     saveBoolFunc, //
     saveRealFunc, //
@@ -337,8 +341,13 @@ static struct VariantWalkFuncs const walk_funcs = {
     saveContainerEndFunc, //
 };
 
+} // namespace to_string_helpers
+} // namespace
+
 std::string tr_variantToStrBenc(tr_variant const* top)
 {
+    using namespace to_string_helpers;
+
     auto buf = libtransmission::Buffer{};
     tr_variantWalk(top, &walk_funcs, &buf, true);
     return buf.toString();


### PR DESCRIPTION
No functional changes.

Fix another batch of `misc-use-anonymous-namespace` clang-tidy-16 warnings.