### PR TITLE
refactor: misc-use-anonymous-namespace pt. 3

### DIFF
--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -148,7 +148,7 @@ struct tr_announce_response
     std::optional<tr_address> external_ip;
 };
 
-/// SCRAPE
+// --- SCRAPE
 
 /* pick a number small enough for common tracker software:
  *  - ocelot has no upper bound

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -66,7 +66,7 @@ enum tau_action_t
     TAU_ACTION_ERROR = 3
 };
 
-/// SCRAPE
+// --- SCRAPE
 
 struct tau_scrape_request
 {
@@ -162,7 +162,7 @@ private:
     tr_scrape_response_func on_response_;
 };
 
-/// ANNOUNCE
+// --- ANNOUNCE
 
 struct tau_announce_request
 {
@@ -285,7 +285,7 @@ private:
     tr_announce_response_func on_response_;
 };
 
-/// TRACKER
+// --- TRACKER
 
 struct tau_tracker
 {
@@ -569,7 +569,7 @@ private:
     static inline constexpr auto ConnectionRequestTtl = int{ 30 };
 };
 
-/// SESSION
+// --- SESSION
 
 class tr_announcer_udp_impl final : public tr_announcer_udp
 {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -56,7 +56,7 @@ static auto constexpr MaxScrapesPerUpkeep = int{ 20 };
 /* how many infohashes to remove when we get a scrape-too-long error */
 static auto constexpr TrMultiscrapeStep = int{ 5 };
 
-///
+// ---
 
 namespace
 {
@@ -107,7 +107,7 @@ struct StopsCompare
 
 } // namespace
 
-///
+// ---
 
 struct tr_scrape_info
 {
@@ -267,7 +267,7 @@ std::unique_ptr<tr_announcer> tr_announcer::create(
     return std::make_unique<tr_announcer_impl>(session, announcer_udp, n_pending_stops);
 }
 
-///
+// ---
 
 /* a row in tr_tier's list of trackers */
 struct tr_tracker
@@ -336,7 +336,7 @@ tr_interned_string tr_announcerGetKey(tr_url_parsed_t const& parsed)
     return tr_interned_string{ sv };
 }
 
-///
+// ---
 
 /** @brief A group of trackers in a single tier, as per the multitracker spec */
 struct tr_tier
@@ -544,7 +544,7 @@ private:
     static inline int next_key = 0;
 };
 
-///
+// ---
 
 /**
  * @brief Opaque, per-torrent data structure for tracker announce information
@@ -659,7 +659,7 @@ static tr_tier* getTier(tr_announcer_impl* announcer, tr_sha1_digest_t const& in
     return tor->torrent_announcer->getTier(tier_id);
 }
 
-/// PUBLISH
+// --- PUBLISH
 
 namespace
 {
@@ -736,7 +736,7 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
 } // namespace publish_helpers
 } // namespace
 
-///
+// ---
 
 tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data)
 {
@@ -748,7 +748,7 @@ tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_
     return ta;
 }
 
-///
+// ---
 
 bool tr_announcerCanManualAnnounce(tr_torrent const* tor)
 {
@@ -894,7 +894,7 @@ void tr_announcerChangeMyPort(tr_torrent* tor)
     torrentAddAnnounce(tor, TR_ANNOUNCE_EVENT_STARTED, tr_time());
 }
 
-///
+// ---
 
 void tr_announcerAddBytes(tr_torrent* tor, int type, uint32_t n_bytes)
 {
@@ -907,7 +907,7 @@ void tr_announcerAddBytes(tr_torrent* tor, int type, uint32_t n_bytes)
     }
 }
 
-///
+// ---
 
 [[nodiscard]] static tr_announce_request create_announce_request(
     tr_announcer_impl const* const announcer,
@@ -1222,7 +1222,7 @@ static void tierAnnounce(tr_announcer_impl* announcer, tr_tier* tier)
         });
 }
 
-/// SCRAPE
+// --- SCRAPE
 
 static bool multiscrape_too_big(std::string_view errmsg)
 {
@@ -1574,7 +1574,7 @@ void tr_announcer_impl::upkeep()
     announcer_udp_.upkeep();
 }
 
-///
+// ---
 
 static tr_tracker_view trackerView(tr_torrent const& tor, size_t tier_index, tr_tier const& tier, tr_tracker const& tracker)
 {
@@ -1703,7 +1703,7 @@ tr_tracker_view tr_announcerTracker(tr_torrent const* tor, size_t nth)
     return {};
 }
 
-///
+// ---
 
 // called after the torrent's announceList was rebuilt --
 // so announcer needs to update the tr_tier / tr_trackers to match

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -56,9 +56,7 @@ static auto constexpr MaxScrapesPerUpkeep = int{ 20 };
 /* how many infohashes to remove when we get a scrape-too-long error */
 static auto constexpr TrMultiscrapeStep = int{ 5 };
 
-/***
-****
-***/
+///
 
 namespace
 {
@@ -109,9 +107,7 @@ struct StopsCompare
 
 } // namespace
 
-/***
-****
-***/
+///
 
 struct tr_scrape_info
 {
@@ -271,9 +267,7 @@ std::unique_ptr<tr_announcer> tr_announcer::create(
     return std::make_unique<tr_announcer_impl>(session, announcer_udp, n_pending_stops);
 }
 
-/***
-****
-***/
+///
 
 /* a row in tr_tier's list of trackers */
 struct tr_tracker
@@ -342,9 +336,7 @@ tr_interned_string tr_announcerGetKey(tr_url_parsed_t const& parsed)
     return tr_interned_string{ sv };
 }
 
-/***
-****
-***/
+///
 
 /** @brief A group of trackers in a single tier, as per the multitracker spec */
 struct tr_tier
@@ -552,9 +544,7 @@ private:
     static inline int next_key = 0;
 };
 
-/***
-****
-***/
+///
 
 /**
  * @brief Opaque, per-torrent data structure for tracker announce information
@@ -669,11 +659,13 @@ static tr_tier* getTier(tr_announcer_impl* announcer, tr_sha1_digest_t const& in
     return tor->torrent_announcer->getTier(tier_id);
 }
 
-/***
-****  PUBLISH
-***/
+/// PUBLISH
 
-static void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event::Type type)
+namespace
+{
+namespace publish_helpers
+{
+void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event::Type type)
 {
     if (tier != nullptr && tier->tor != nullptr && tier->tor->torrent_announcer != nullptr &&
         tier->tor->torrent_announcer->callback != nullptr)
@@ -692,22 +684,22 @@ static void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event
     }
 }
 
-static void publishErrorClear(tr_tier* tier)
+void publishErrorClear(tr_tier* tier)
 {
     publishMessage(tier, ""sv, tr_tracker_event::Type::ErrorClear);
 }
 
-static void publishWarning(tr_tier* tier, std::string_view msg)
+void publishWarning(tr_tier* tier, std::string_view msg)
 {
     publishMessage(tier, msg, tr_tracker_event::Type::Warning);
 }
 
-static void publishError(tr_tier* tier, std::string_view msg)
+void publishError(tr_tier* tier, std::string_view msg)
 {
     publishMessage(tier, msg, tr_tracker_event::Type::Error);
 }
 
-static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
+void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
 {
     if (tier->tor->torrent_announcer->callback != nullptr)
     {
@@ -721,7 +713,7 @@ static void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
     }
 }
 
-static void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pex> const& pex)
+void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pex> const& pex)
 {
     if (tier->tor->torrent_announcer->callback != nullptr)
     {
@@ -741,10 +733,10 @@ static void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vecto
         (*tier->tor->torrent_announcer->callback)(tier->tor, &e, nullptr);
     }
 }
+} // namespace publish_helpers
+} // namespace
 
-/***
-****
-***/
+///
 
 tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data)
 {
@@ -756,9 +748,7 @@ tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_
     return ta;
 }
 
-/***
-****
-***/
+///
 
 bool tr_announcerCanManualAnnounce(tr_torrent const* tor)
 {
@@ -904,9 +894,7 @@ void tr_announcerChangeMyPort(tr_torrent* tor)
     torrentAddAnnounce(tor, TR_ANNOUNCE_EVENT_STARTED, tr_time());
 }
 
-/***
-****
-***/
+///
 
 void tr_announcerAddBytes(tr_torrent* tor, int type, uint32_t n_bytes)
 {
@@ -919,9 +907,7 @@ void tr_announcerAddBytes(tr_torrent* tor, int type, uint32_t n_bytes)
     }
 }
 
-/***
-****
-***/
+///
 
 [[nodiscard]] static tr_announce_request create_announce_request(
     tr_announcer_impl const* const announcer,
@@ -1022,6 +1008,8 @@ void tr_announcer_impl::onAnnounceDone(
     bool is_running_on_success,
     tr_announce_response const& response)
 {
+    using namespace publish_helpers;
+
     auto* const tier = getTier(this, response.info_hash, tier_id);
     if (tier == nullptr)
     {
@@ -1234,11 +1222,7 @@ static void tierAnnounce(tr_announcer_impl* announcer, tr_tier* tier)
         });
 }
 
-/***
-****
-****  SCRAPE
-****
-***/
+/// SCRAPE
 
 static bool multiscrape_too_big(std::string_view errmsg)
 {
@@ -1322,6 +1306,8 @@ static void checkMultiscrapeMax(tr_announcer_impl* announcer, tr_scrape_response
 
 void tr_announcer_impl::onScrapeDone(tr_scrape_response const& response)
 {
+    using namespace publish_helpers;
+
     auto const now = tr_time();
 
     for (int i = 0; i < response.row_count; ++i)
@@ -1588,9 +1574,7 @@ void tr_announcer_impl::upkeep()
     announcer_udp_.upkeep();
 }
 
-/***
-****
-***/
+///
 
 static tr_tracker_view trackerView(tr_torrent const& tor, size_t tier_index, tr_tier const& tier, tr_tracker const& tracker)
 {
@@ -1719,9 +1703,7 @@ tr_tracker_view tr_announcerTracker(tr_torrent const* tor, size_t nth)
     return {};
 }
 
-/***
-****
-***/
+///
 
 // called after the torrent's announceList was rebuilt --
 // so announcer needs to update the tr_tier / tr_trackers to match

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -107,7 +107,7 @@ tr_tracker_view tr_announcerTracker(tr_torrent const* torrent, size_t nth);
 
 size_t tr_announcerTrackerCount(tr_torrent const* tor);
 
-/// ANNOUNCE
+// --- ANNOUNCE
 
 enum tr_announce_event
 {
@@ -126,7 +126,7 @@ struct tr_announce_response;
 struct tr_scrape_request;
 struct tr_scrape_response;
 
-/// UDP ANNOUNCER
+// --- UDP ANNOUNCER
 
 using tr_scrape_response_func = std::function<void(tr_scrape_response const&)>;
 using tr_announce_response_func = std::function<void(tr_announce_response const&)>;

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -121,7 +121,7 @@ std::vector<uint8_t> tr_completion::createPieceBitfield() const
     return pieces.raw();
 }
 
-/// mutators
+// --- mutators
 
 void tr_completion::addBlock(tr_block_index_t block)
 {

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -29,7 +29,7 @@ extern "C"
 
 using namespace std::literals;
 
-///
+// ---
 
 namespace
 {

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -55,7 +55,7 @@ public:
 
 auto log_state = tr_log_state{};
 
-///
+// ---
 
 tr_sys_file_t tr_logGetFile()
 {
@@ -295,7 +295,7 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
     errno = err;
 }
 
-///
+// ---
 
 namespace
 {

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <string_view>
 
-///
+// ---
 
 enum tr_log_level
 {
@@ -42,7 +42,7 @@ enum tr_log_level
 
 std::optional<tr_log_level> tr_logGetLevelFromKey(std::string_view key);
 
-///
+// ---
 
 struct tr_log_message
 {
@@ -65,7 +65,7 @@ struct tr_log_message
     struct tr_log_message* next;
 };
 
-////
+// ---
 
 #define TR_LOG_MAX_QUEUE_LENGTH 10000
 
@@ -77,7 +77,7 @@ void tr_logSetQueueEnabled(bool is_enabled);
 
 void tr_logFreeQueue(tr_log_message* freeme);
 
-////
+// ---
 
 void tr_logSetLevel(tr_log_level);
 
@@ -85,7 +85,7 @@ void tr_logSetLevel(tr_log_level);
 
 [[nodiscard]] bool tr_logLevelIsActive(tr_log_level level);
 
-////
+// ---
 
 void tr_logAddMessage(
     char const* source_file,
@@ -110,6 +110,6 @@ void tr_logAddMessage(
 #define tr_logAddDebug(...) tr_logAddLevel(TR_LOG_DEBUG, __VA_ARGS__)
 #define tr_logAddTrace(...) tr_logAddLevel(TR_LOG_TRACE, __VA_ARGS__)
 
-////
+// ---
 
 char* tr_logGetTimeStr(char* buf, size_t buflen);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -502,7 +502,7 @@ std::optional<tr_address> tr_globalIPv6()
     return cache_val;
 }
 
-///
+// ---
 
 namespace is_valid_for_peers_helpers
 {
@@ -553,7 +553,7 @@ bool tr_address::is_valid_for_peers(tr_port port) const noexcept
         !is_martian_addr(*this);
 }
 
-/// tr_port
+// --- tr_port
 
 std::pair<tr_port, std::byte const*> tr_port::fromCompact(std::byte const* compact) noexcept
 {
@@ -567,7 +567,7 @@ std::pair<tr_port, std::byte const*> tr_port::fromCompact(std::byte const* compa
     return std::make_pair(tr_port::fromNetwork(nport), compact);
 }
 
-/// tr_address
+// --- tr_address
 
 std::optional<tr_address> tr_address::from_string(std::string_view address_sv)
 {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -326,7 +326,7 @@ void tr_net_close_socket(tr_socket_t fd);
 
 bool tr_net_hasIPv6(tr_port);
 
-/// TOS / DSCP
+// --- TOS / DSCP
 
 /**
  * A toString() / from_string() convenience wrapper around the TOS int value

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -111,7 +111,7 @@ bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error** error)
 
 } // unnamed namespace
 
-///
+// ---
 
 std::optional<tr_sys_file_t> tr_open_files::get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable)
 {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -140,7 +140,7 @@ tr_peerIo::~tr_peerIo()
     close();
 }
 
-///
+// ---
 
 void tr_peerIo::set_socket(tr_peer_socket socket_in)
 {
@@ -211,7 +211,7 @@ bool tr_peerIo::reconnect()
     return true;
 }
 
-///
+// ---
 
 // Helps us to ignore errors that say "try again later"
 // since that's what peer-io does by default anyway.
@@ -220,7 +220,7 @@ bool tr_peerIo::reconnect()
     return error_code == 0 || error_code == EAGAIN || error_code == EINTR || error_code == EINPROGRESS;
 }
 
-///
+// ---
 
 void tr_peerIo::did_write_wrapper(size_t bytes_transferred)
 {
@@ -314,7 +314,7 @@ void tr_peerIo::event_write_cb([[maybe_unused]] evutil_socket_t fd, short /*even
     io->try_write(SIZE_MAX);
 }
 
-///
+// ---
 
 void tr_peerIo::can_read_wrapper()
 {
@@ -439,7 +439,7 @@ void tr_peerIo::event_read_cb([[maybe_unused]] evutil_socket_t fd, short /*event
     io->try_read(n_left);
 }
 
-///
+// ---
 
 void tr_peerIo::event_enable(short event)
 {
@@ -547,7 +547,7 @@ size_t tr_peerIo::flush_outgoing_protocol_msgs()
     return flush(TR_UP, byte_count);
 }
 
-///
+// ---
 
 static size_t get_desired_output_buffer_size(tr_peerIo const* io, uint64_t now)
 {
@@ -594,7 +594,7 @@ void tr_peerIo::write_bytes(void const* bytes, size_t n_bytes, bool is_piece_dat
     outbuf_info_.emplace_back(n_bytes, is_piece_data);
 }
 
-///
+// ---
 
 void tr_peerIo::read_bytes(void* bytes, size_t byte_count)
 {
@@ -634,7 +634,7 @@ void tr_peerIo::read_buffer_drain(size_t byte_count)
     }
 }
 
-/// UTP
+// --- UTP
 
 #ifdef WITH_UTP
 

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -65,7 +65,7 @@ auto WIDE_INTEGER_CONSTEXPR const prime = wi::key_t{
 namespace tr_message_stream_encryption
 {
 
-/// DH
+// --- DH
 
 [[nodiscard]] DH::private_key_bigend_t DH::randomPrivateKey() noexcept
 {
@@ -98,7 +98,7 @@ void DH::setPeerPublicKey(key_bigend_t const& peer_public_key)
     secret_ = wi::export_bits(secret);
 }
 
-/// Filter
+// --- Filter
 
 void Filter::decryptInit(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)
 {

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -75,7 +75,7 @@ private:
     key_bigend_t secret_ = {};
 };
 
-/// arc4 encryption for both incoming and outgoing stream
+// --- arc4 encryption for both incoming and outgoing stream
 class Filter
 {
 public:

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -138,11 +138,11 @@ auto constexpr PrefetchMax = size_t{ 18 };
 // meet our bandwidth goals for the next N seconds
 auto constexpr RequestBufSecs = int{ 10 };
 
-///
+// ---
 
 auto constexpr MaxPexPeerCount = size_t{ 50 };
 
-///
+// ---
 
 enum class AwaitingBt
 {
@@ -159,7 +159,7 @@ enum class EncryptionPreference
     No
 };
 
-///
+// ---
 
 struct peer_request
 {
@@ -179,7 +179,7 @@ peer_request blockToReq(tr_torrent const* tor, tr_block_index_t block)
     return peer_request{ loc.piece, loc.piece_offset, tor->blockSize(block) };
 }
 
-///
+// ---
 
 /* this is raw, unchanged data from the peer regarding
  * the current message that it's sending us. */
@@ -804,7 +804,7 @@ void protocolSendHaveNone(tr_peerMsgsImpl* msgs)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-/// INTEREST
+// --- INTEREST
 
 void sendInterest(tr_peerMsgsImpl* msgs, bool b)
 {
@@ -846,7 +846,7 @@ void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
     msgs->peer_requested_.clear();
 }
 
-///
+// ---
 
 void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 {
@@ -1856,7 +1856,7 @@ ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
     return ret;
 }
 
-///
+// ---
 
 void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
 {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -48,12 +48,10 @@
 
 using namespace std::literals;
 
-/**
-***
-**/
+namespace
+{
 
 // these values are hardcoded by various BEPs as noted
-
 namespace BtPeerMsgs
 {
 
@@ -118,34 +116,33 @@ auto constexpr Reject = int{ 2 };
 
 } // namespace MetadataMsgType
 
-static auto constexpr MinChokePeriodSec = int{ 10 };
+auto constexpr MinChokePeriodSec = int{ 10 };
 
 // idle seconds before we send a keepalive
-static auto constexpr KeepaliveIntervalSecs = int{ 100 };
+auto constexpr KeepaliveIntervalSecs = int{ 100 };
 
-static auto constexpr MetadataReqQ = int{ 64 };
+auto constexpr MetadataReqQ = int{ 64 };
 
-static auto constexpr ReqQ = int{ 512 };
+auto constexpr ReqQ = int{ 512 };
 
 // used in lowering the outMessages queue period
-static auto constexpr ImmediatePriorityIntervalSecs = int{ 0 };
-static auto constexpr HighPriorityIntervalSecs = int{ 2 };
-static auto constexpr LowPriorityIntervalSecs = int{ 10 };
+auto constexpr ImmediatePriorityIntervalSecs = int{ 0 };
+auto constexpr HighPriorityIntervalSecs = int{ 2 };
+auto constexpr LowPriorityIntervalSecs = int{ 10 };
 
 // how many blocks to keep prefetched per peer
-static auto constexpr PrefetchMax = size_t{ 18 };
+auto constexpr PrefetchMax = size_t{ 18 };
 
 // when we're making requests from another peer,
 // batch them together to send enough requests to
 // meet our bandwidth goals for the next N seconds
-static auto constexpr RequestBufSecs = int{ 10 };
+auto constexpr RequestBufSecs = int{ 10 };
 
-namespace
-{
+///
 
 auto constexpr MaxPexPeerCount = size_t{ 50 };
 
-} // unnamed namespace
+///
 
 enum class AwaitingBt
 {
@@ -162,9 +159,7 @@ enum class EncryptionPreference
     No
 };
 
-/**
-***
-**/
+///
 
 struct peer_request
 {
@@ -178,15 +173,13 @@ struct peer_request
     }
 };
 
-static peer_request blockToReq(tr_torrent const* tor, tr_block_index_t block)
+peer_request blockToReq(tr_torrent const* tor, tr_block_index_t block)
 {
     auto const loc = tor->blockLoc(block);
     return peer_request{ loc.piece, loc.piece_offset, tor->blockSize(block) };
 }
 
-/**
-***
-**/
+///
 
 /* this is raw, unchanged data from the peer regarding
  * the current message that it's sending us. */
@@ -200,19 +193,19 @@ struct tr_incoming
 
 class tr_peerMsgsImpl;
 // TODO: make these to be member functions
-static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece);
-static void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs);
-static void didWrite(tr_peerIo* io, size_t bytes_written, bool was_piece_data, void* vmsgs);
-static void gotError(tr_peerIo* io, tr_error const& err, void* vmsgs);
-static void peerPulse(void* vmsgs);
-static void protocolSendCancel(tr_peerMsgsImpl* msgs, struct peer_request const& req);
-static void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke);
-static void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index);
-static void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port);
-static void sendInterest(tr_peerMsgsImpl* msgs, bool b);
-static void sendLtepHandshake(tr_peerMsgsImpl* msgs);
-static void tellPeerWhatWeHave(tr_peerMsgsImpl* msgs);
-static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs);
+ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece);
+void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs);
+void didWrite(tr_peerIo* io, size_t bytes_written, bool was_piece_data, void* vmsgs);
+void gotError(tr_peerIo* io, tr_error const& err, void* vmsgs);
+void peerPulse(void* vmsgs);
+void protocolSendCancel(tr_peerMsgsImpl* msgs, struct peer_request const& req);
+void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke);
+void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index);
+void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port);
+void sendInterest(tr_peerMsgsImpl* msgs, bool b);
+void sendLtepHandshake(tr_peerMsgsImpl* msgs);
+void tellPeerWhatWeHave(tr_peerMsgsImpl* msgs);
+void updateDesiredRequestCount(tr_peerMsgsImpl* msgs);
 
 #define myLogMacro(msgs, level, text) \
     do \
@@ -230,12 +223,6 @@ static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs);
 
 #define logdbg(msgs, text) myLogMacro(msgs, TR_LOG_DEBUG, text)
 #define logtrace(msgs, text) myLogMacro(msgs, TR_LOG_TRACE, text)
-
-tr_peerMsgs::~tr_peerMsgs()
-{
-    [[maybe_unused]] auto const n_prev = n_peers_--;
-    TR_ASSERT(n_prev > 0U);
-}
 
 /**
  * Low-level communication state information about a connected peer.
@@ -719,21 +706,11 @@ private:
     static auto constexpr SendPexInterval = 90s;
 };
 
-tr_peerMsgs* tr_peerMsgsNew(
-    tr_torrent* torrent,
-    peer_atom* atom,
-    std::shared_ptr<tr_peerIo> io,
-    tr_peer_callback callback,
-    void* callback_data)
-{
-    return new tr_peerMsgsImpl(torrent, atom, std::move(io), callback, callback_data);
-}
-
 /**
 ***
 **/
 
-static void protocolSendReject(tr_peerMsgsImpl* msgs, struct peer_request const* req)
+void protocolSendReject(tr_peerMsgsImpl* msgs, struct peer_request const* req)
 {
     TR_ASSERT(msgs->io->supports_fext());
 
@@ -749,7 +726,7 @@ static void protocolSendReject(tr_peerMsgsImpl* msgs, struct peer_request const*
     msgs->dbgOutMessageLen();
 }
 
-static void protocolSendCancel(tr_peerMsgsImpl* msgs, peer_request const& req)
+void protocolSendCancel(tr_peerMsgsImpl* msgs, peer_request const& req)
 {
     auto& out = msgs->outMessages;
 
@@ -764,7 +741,7 @@ static void protocolSendCancel(tr_peerMsgsImpl* msgs, peer_request const& req)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-static void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port)
+void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port)
 {
     auto& out = msgs->outMessages;
 
@@ -774,7 +751,7 @@ static void protocolSendPort(tr_peerMsgsImpl* msgs, tr_port port)
     out.addPort(port);
 }
 
-static void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index)
+void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index)
 {
     auto& out = msgs->outMessages;
 
@@ -787,7 +764,7 @@ static void protocolSendHave(tr_peerMsgsImpl* msgs, tr_piece_index_t index)
     msgs->pokeBatchPeriod(LowPriorityIntervalSecs);
 }
 
-static void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke)
+void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke)
 {
     auto& out = msgs->outMessages;
 
@@ -799,7 +776,7 @@ static void protocolSendChoke(tr_peerMsgsImpl* msgs, bool choke)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-static void protocolSendHaveAll(tr_peerMsgsImpl* msgs)
+void protocolSendHaveAll(tr_peerMsgsImpl* msgs)
 {
     TR_ASSERT(msgs->io->supports_fext());
 
@@ -813,7 +790,7 @@ static void protocolSendHaveAll(tr_peerMsgsImpl* msgs)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-static void protocolSendHaveNone(tr_peerMsgsImpl* msgs)
+void protocolSendHaveNone(tr_peerMsgsImpl* msgs)
 {
     TR_ASSERT(msgs->io->supports_fext());
 
@@ -827,11 +804,9 @@ static void protocolSendHaveNone(tr_peerMsgsImpl* msgs)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-/**
-***  INTEREST
-**/
+/// INTEREST
 
-static void sendInterest(tr_peerMsgsImpl* msgs, bool b)
+void sendInterest(tr_peerMsgsImpl* msgs, bool b)
 {
     TR_ASSERT(msgs != nullptr);
 
@@ -845,7 +820,7 @@ static void sendInterest(tr_peerMsgsImpl* msgs, bool b)
     msgs->dbgOutMessageLen();
 }
 
-static bool popNextMetadataRequest(tr_peerMsgsImpl* msgs, int* setme)
+bool popNextMetadataRequest(tr_peerMsgsImpl* msgs, int* setme)
 {
     if (std::empty(msgs->peerAskedForMetadata))
     {
@@ -858,7 +833,7 @@ static bool popNextMetadataRequest(tr_peerMsgsImpl* msgs, int* setme)
     return true;
 }
 
-static void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
+void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
 {
     if (auto const must_send_rej = msgs->io->supports_fext(); must_send_rej)
     {
@@ -871,11 +846,9 @@ static void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
     msgs->peer_requested_.clear();
 }
 
-/**
-***
-**/
+///
 
-static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
+void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 {
     auto& out = msgs->outMessages;
     static tr_quark version_quark = 0;
@@ -998,7 +971,7 @@ static void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantClear(&val);
 }
 
-static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
+void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
 {
     msgs->peerSentLtepHandshake = true;
 
@@ -1104,7 +1077,7 @@ static void parseLtepHandshake(tr_peerMsgsImpl* msgs, uint32_t len)
     tr_variantClear(&val);
 }
 
-static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen)
+void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen)
 {
     int64_t msg_type = -1;
     int64_t piece = -1;
@@ -1173,7 +1146,7 @@ static void parseUtMetadata(tr_peerMsgsImpl* msgs, uint32_t msglen)
     }
 }
 
-static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen)
+void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen)
 {
     auto* const tor = msgs->torrent;
     if (!tor->allowsPex())
@@ -1223,7 +1196,7 @@ static void parseUtPex(tr_peerMsgsImpl* msgs, uint32_t msglen)
     }
 }
 
-static void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen)
+void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen)
 {
     TR_ASSERT(msglen > 0);
 
@@ -1261,7 +1234,7 @@ static void parseLtep(tr_peerMsgsImpl* msgs, uint32_t msglen)
     }
 }
 
-static ReadState readBtLength(tr_peerMsgsImpl* msgs, size_t inlen)
+ReadState readBtLength(tr_peerMsgsImpl* msgs, size_t inlen)
 {
     auto len = uint32_t{};
     if (inlen < sizeof(len))
@@ -1283,9 +1256,9 @@ static ReadState readBtLength(tr_peerMsgsImpl* msgs, size_t inlen)
     return READ_NOW;
 }
 
-static ReadState readBtMessage(tr_peerMsgsImpl* /*msgs*/, size_t /*inlen*/);
+ReadState readBtMessage(tr_peerMsgsImpl* /*msgs*/, size_t /*inlen*/);
 
-static ReadState readBtId(tr_peerMsgsImpl* msgs, size_t inlen)
+ReadState readBtId(tr_peerMsgsImpl* msgs, size_t inlen)
 {
     if (inlen < sizeof(uint8_t))
     {
@@ -1314,7 +1287,7 @@ static ReadState readBtId(tr_peerMsgsImpl* msgs, size_t inlen)
     return readBtMessage(msgs, inlen - 1);
 }
 
-static void prefetchPieces(tr_peerMsgsImpl* msgs)
+void prefetchPieces(tr_peerMsgsImpl* msgs)
 {
     if (!msgs->session->allowsPrefetch())
     {
@@ -1333,7 +1306,7 @@ static void prefetchPieces(tr_peerMsgsImpl* msgs)
     }
 }
 
-[[nodiscard]] static bool canAddRequestFromPeer(tr_peerMsgsImpl const* const msgs, struct peer_request const& req)
+[[nodiscard]] bool canAddRequestFromPeer(tr_peerMsgsImpl const* const msgs, struct peer_request const& req)
 {
     if (msgs->peer_is_choked_)
     {
@@ -1362,7 +1335,7 @@ static void prefetchPieces(tr_peerMsgsImpl* msgs)
     return true;
 }
 
-static void peerMadeRequest(tr_peerMsgsImpl* msgs, struct peer_request const* req)
+void peerMadeRequest(tr_peerMsgsImpl* msgs, struct peer_request const* req)
 {
     if (canAddRequestFromPeer(msgs, *req))
     {
@@ -1375,7 +1348,7 @@ static void peerMadeRequest(tr_peerMsgsImpl* msgs, struct peer_request const* re
     }
 }
 
-static bool messageLengthIsCorrect(tr_peerMsgsImpl const* msg, uint8_t id, uint32_t len)
+bool messageLengthIsCorrect(tr_peerMsgsImpl const* msg, uint8_t id, uint32_t len)
 {
     switch (id)
     {
@@ -1426,9 +1399,9 @@ static bool messageLengthIsCorrect(tr_peerMsgsImpl const* msg, uint8_t id, uint3
     }
 }
 
-static int clientGotBlock(tr_peerMsgsImpl* msgs, std::unique_ptr<std::vector<uint8_t>>& block_data, tr_block_index_t block);
+int clientGotBlock(tr_peerMsgsImpl* msgs, std::unique_ptr<std::vector<uint8_t>>& block_data, tr_block_index_t block);
 
-static ReadState readBtPiece(tr_peerMsgsImpl* msgs, size_t inlen, size_t* setme_piece_bytes_read)
+ReadState readBtPiece(tr_peerMsgsImpl* msgs, size_t inlen, size_t* setme_piece_bytes_read)
 {
     TR_ASSERT(msgs->io->read_buffer_size() >= inlen);
 
@@ -1508,7 +1481,7 @@ static ReadState readBtPiece(tr_peerMsgsImpl* msgs, size_t inlen, size_t* setme_
     return clientGotBlock(msgs, block_buf, block) != 0 ? READ_ERR : READ_NOW;
 }
 
-static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
+ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 {
     uint8_t const id = msgs->incoming.id;
 #ifdef TR_ENABLE_ASSERTS
@@ -1773,10 +1746,7 @@ static ReadState readBtMessage(tr_peerMsgsImpl* msgs, size_t inlen)
 }
 
 /* returns 0 on success, or an errno on failure */
-static int clientGotBlock(
-    tr_peerMsgsImpl* msgs,
-    std::unique_ptr<std::vector<uint8_t>>& block_data,
-    tr_block_index_t const block)
+int clientGotBlock(tr_peerMsgsImpl* msgs, std::unique_ptr<std::vector<uint8_t>>& block_data, tr_block_index_t const block)
 {
     TR_ASSERT(msgs != nullptr);
 
@@ -1827,7 +1797,7 @@ static int clientGotBlock(
     return 0;
 }
 
-static void didWrite(tr_peerIo* /*io*/, size_t bytes_written, bool was_piece_data, void* vmsgs)
+void didWrite(tr_peerIo* /*io*/, size_t bytes_written, bool was_piece_data, void* vmsgs)
 {
     auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
 
@@ -1839,7 +1809,7 @@ static void didWrite(tr_peerIo* /*io*/, size_t bytes_written, bool was_piece_dat
     peerPulse(msgs);
 }
 
-static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
+ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
 {
     auto* msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
     size_t const inlen = io->read_buffer_size();
@@ -1886,16 +1856,14 @@ static ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
     return ret;
 }
 
-/**
-***
-**/
+///
 
-static void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
+void updateDesiredRequestCount(tr_peerMsgsImpl* msgs)
 {
     msgs->desired_request_count = msgs->canRequest().max_blocks;
 }
 
-static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
+void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
 {
     if (!msgs->peerSupportsMetadataXfer)
     {
@@ -1928,7 +1896,7 @@ static void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
     }
 }
 
-static void updateBlockRequests(tr_peerMsgsImpl* msgs)
+void updateBlockRequests(tr_peerMsgsImpl* msgs)
 {
     auto* const tor = msgs->torrent;
 
@@ -1958,7 +1926,7 @@ static void updateBlockRequests(tr_peerMsgsImpl* msgs)
     }
 }
 
-static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
+size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
 {
     size_t bytes_written = 0;
     struct peer_request req;
@@ -2132,7 +2100,7 @@ static size_t fillOutputBuffer(tr_peerMsgsImpl* msgs, time_t now)
     return bytes_written;
 }
 
-static void peerPulse(void* vmsgs)
+void peerPulse(void* vmsgs)
 {
     auto* msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
     time_t const now = tr_time();
@@ -2150,12 +2118,12 @@ static void peerPulse(void* vmsgs)
     }
 }
 
-static void gotError(tr_peerIo* /*io*/, tr_error const& /*error*/, void* vmsgs)
+void gotError(tr_peerIo* /*io*/, tr_error const& /*error*/, void* vmsgs)
 {
     static_cast<tr_peerMsgsImpl*>(vmsgs)->publish(tr_peer_event::GotError(ENOTCONN));
 }
 
-static void sendBitfield(tr_peerMsgsImpl* msgs)
+void sendBitfield(tr_peerMsgsImpl* msgs)
 {
     TR_ASSERT(msgs->torrent->hasMetainfo());
 
@@ -2169,7 +2137,7 @@ static void sendBitfield(tr_peerMsgsImpl* msgs)
     msgs->pokeBatchPeriod(ImmediatePriorityIntervalSecs);
 }
 
-static void tellPeerWhatWeHave(tr_peerMsgsImpl* msgs)
+void tellPeerWhatWeHave(tr_peerMsgsImpl* msgs)
 {
     bool const fext = msgs->io->supports_fext();
 
@@ -2327,4 +2295,22 @@ void tr_peerMsgsImpl::sendPex()
     this->dbgOutMessageLen();
 
     tr_variantClear(&val);
+}
+
+} // namespace
+
+tr_peerMsgs::~tr_peerMsgs()
+{
+    [[maybe_unused]] auto const n_prev = n_peers_--;
+    TR_ASSERT(n_prev > 0U);
+}
+
+tr_peerMsgs* tr_peerMsgsNew(
+    tr_torrent* torrent,
+    peer_atom* atom,
+    std::shared_ptr<tr_peerIo> io,
+    tr_peer_callback callback,
+    void* callback_data)
+{
+    return new tr_peerMsgsImpl(torrent, atom, std::move(io), callback, callback_data);
 }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -34,7 +34,7 @@ namespace
 {
 constexpr int MaxRememberedPeers = 200;
 
-///
+// ---
 
 void savePeers(tr_variant* dict, tr_torrent const* tor)
 {
@@ -82,7 +82,7 @@ auto loadPeers(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void saveLabels(tr_variant* dict, tr_torrent const* tor)
 {
@@ -118,7 +118,7 @@ auto loadLabels(tr_variant* dict, tr_torrent* tor)
     return tr_resume::Labels;
 }
 
-///
+// ---
 
 void saveGroup(tr_variant* dict, tr_torrent const* tor)
 {
@@ -136,7 +136,7 @@ auto loadGroup(tr_variant* dict, tr_torrent* tor)
     return tr_resume::fields_t{};
 }
 
-///
+// ---
 
 void saveDND(tr_variant* dict, tr_torrent const* tor)
 {
@@ -193,7 +193,7 @@ auto loadDND(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void saveFilePriorities(tr_variant* dict, tr_torrent const* tor)
 {
@@ -229,7 +229,7 @@ auto loadFilePriorities(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void saveSingleSpeedLimit(tr_variant* d, tr_torrent const* tor, tr_direction dir)
 {
@@ -344,7 +344,7 @@ auto loadIdleLimits(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void saveName(tr_variant* dict, tr_torrent const* tor)
 {
@@ -373,7 +373,7 @@ auto loadName(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void saveFilenames(tr_variant* dict, tr_torrent const* tor)
 {
@@ -410,7 +410,7 @@ auto loadFilenames(tr_variant* dict, tr_torrent* tor)
     return ret;
 }
 
-///
+// ---
 
 void bitfieldToRaw(tr_bitfield const& b, tr_variant* benc)
 {
@@ -619,7 +619,7 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
     return tr_resume::fields_t{};
 }
 
-///
+// ---
 
 auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bool* did_migrate_filename)
 {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -111,7 +111,7 @@ bool constexpr tr_rpc_address_is_valid(tr_rpc_address const& a)
 }
 #endif
 
-///
+// ---
 
 void send_simple_response(struct evhttp_request* req, int code, char const* text)
 {
@@ -130,7 +130,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
     evbuffer_free(body);
 }
 
-///
+// ---
 
 [[nodiscard]] constexpr char const* mimetype_guess(std::string_view path)
 {
@@ -820,7 +820,7 @@ void tr_rpc_server::setWhitelist(std::string_view whitelist)
     this->whitelist_ = parseWhitelist(whitelist);
 }
 
-/// PASSWORD
+// --- PASSWORD
 
 void tr_rpc_server::setUsername(std::string_view username)
 {
@@ -858,7 +858,7 @@ void tr_rpc_server::setAntiBruteForceEnabled(bool enabled) noexcept
     }
 }
 
-/// LIFECYCLE
+// --- LIFECYCLE
 
 tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant* settings)
     : compressor{ libdeflate_alloc_compressor(DeflateLevel), libdeflate_free_compressor }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -57,7 +57,7 @@ enum class TrFormat
     Table
 };
 
-///
+// ---
 
 /* For functions that can't be immediately executed, like torrentAdd,
  * this is the callback data used to pass a response to the caller
@@ -83,7 +83,7 @@ void tr_idle_function_done(struct tr_rpc_idle_data* data, std::string_view resul
     delete data;
 }
 
-///
+// ---
 
 auto getTorrents(tr_session* session, tr_variant* args)
 {
@@ -298,7 +298,7 @@ char const* torrentVerify(tr_session* session, tr_variant* args_in, tr_variant* 
     return nullptr;
 }
 
-///
+// ---
 
 void addLabels(tr_torrent const* tor, tr_variant* list)
 {
@@ -960,7 +960,7 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
     return errmsg;
 }
 
-///
+// ---
 
 [[nodiscard]] std::pair<std::vector<tr_quark>, char const* /*errmsg*/> makeLabels(tr_variant* list)
 {
@@ -1327,7 +1327,7 @@ char const* torrentSetLocation(
     return nullptr;
 }
 
-///
+// ---
 
 void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char const* newname, int error, void* user_data)
 {
@@ -1366,7 +1366,7 @@ char const* torrentRenamePath(
     return errmsg;
 }
 
-///
+// ---
 
 void onPortTested(tr_web::FetchResponse const& web_response)
 {
@@ -1398,7 +1398,7 @@ char const* portTest(tr_session* session, tr_variant* /*args_in*/, tr_variant* /
     return nullptr;
 }
 
-///
+// ---
 
 void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 {
@@ -1482,7 +1482,7 @@ char const* blocklistUpdate(
     return nullptr;
 }
 
-///
+// ---
 
 void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
 {
@@ -1708,7 +1708,7 @@ char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_variant* /*a
     return nullptr;
 }
 
-///
+// ---
 
 char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args_out, struct tr_rpc_idle_data* /*idle_data*/)
 {
@@ -1788,7 +1788,7 @@ char const* groupSet(tr_session* session, tr_variant* args_in, tr_variant* /*arg
     return nullptr;
 }
 
-///
+// ---
 
 char const* sessionSet(tr_session* session, tr_variant* args_in, tr_variant* /*args_out*/, tr_rpc_idle_data* /*idle_data*/)
 {
@@ -2403,7 +2403,7 @@ char const* freeSpace(tr_session* /*session*/, tr_variant* args_in, tr_variant* 
     return err;
 }
 
-///
+// ---
 
 char const* sessionClose(
     tr_session* session,
@@ -2415,7 +2415,7 @@ char const* sessionClose(
     return nullptr;
 }
 
-///
+// ---
 
 using handler = char const* (*)(tr_session*, tr_variant*, tr_variant*, struct tr_rpc_idle_data*);
 

--- a/libtransmission/session-alt-speeds.cc
+++ b/libtransmission/session-alt-speeds.cc
@@ -51,7 +51,7 @@ void tr_session_alt_speeds::defaultSettings(tr_variant* tgt)
 #undef V
 }
 
-/// minutes
+// --- minutes
 
 void tr_session_alt_speeds::updateMinutes()
 {

--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -32,7 +32,7 @@
 
 using namespace std::literals;
 
-///
+// ---
 
 namespace
 {
@@ -141,7 +141,7 @@ auto makeEventBase()
 
 } // namespace
 
-///
+// ---
 
 void tr_session_thread::tr_evthread_init()
 {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -184,7 +184,7 @@ tr_peer_id_t tr_peerIdInit()
     return peer_id;
 }
 
-///
+// ---
 
 std::vector<tr_torrent_id_t> tr_session::DhtMediator::torrentsAllowingDHT() const
 {
@@ -221,7 +221,7 @@ void tr_session::DhtMediator::addPex(tr_sha1_digest_t const& info_hash, tr_pex c
     }
 }
 
-///
+// ---
 
 bool tr_session::LpdMediator::onPeerFound(std::string_view info_hash_str, tr_address address, tr_port port)
 {
@@ -2071,7 +2071,7 @@ size_t tr_session::countQueueFreeSlots(tr_direction dir) const noexcept
     return max - active_count;
 }
 
-///
+// ---
 
 void tr_session::closeTorrentFiles(tr_torrent* tor) noexcept
 {
@@ -2085,7 +2085,7 @@ void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noe
     openFiles().closeFile(tor->id(), file_num);
 }
 
-///
+// ---
 
 void tr_sessionSetQueueStartCallback(tr_session* session, void (*callback)(tr_session*, tr_torrent*, void*), void* user_data)
 {

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -108,7 +108,7 @@ bool isJunkFile(std::string_view filename)
 
 } // unnamed namespace
 
-///
+// ---
 
 std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     tr_file_index_t file_index,
@@ -151,7 +151,7 @@ bool tr_torrent_files::hasAnyLocalData(std::string_view const* search_paths, siz
     return false;
 }
 
-///
+// ---
 
 bool tr_torrent_files::move(
     std::string_view old_parent_in,
@@ -233,7 +233,7 @@ bool tr_torrent_files::move(
     return !err;
 }
 
-///
+// ---
 
 /**
  * This convoluted code does something (seemingly) simple:

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -500,7 +500,7 @@ void callScriptIfEnabled(tr_torrent const* tor, TrScript type)
 
 } // namespace
 
-///
+// ---
 
 void tr_torrentCheckSeedLimit(tr_torrent* tor)
 {
@@ -2024,7 +2024,7 @@ uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor)
     return bytes_left;
 }
 
-///
+// ---
 
 static void setLocationInSessionThread(
     tr_torrent* tor,
@@ -2114,7 +2114,7 @@ void tr_torrentSetLocation(
     tor->setLocation(location, move_from_old_path, setme_progress, setme_state);
 }
 
-///
+// ---
 
 std::string_view tr_torrent::primaryMimeType() const
 {
@@ -2408,7 +2408,7 @@ static void torrentSetQueued(tr_torrent* tor, bool queued)
     }
 }
 
-/// RENAME
+// --- RENAME
 
 namespace
 {
@@ -2609,7 +2609,7 @@ void tr_torrentRenamePath(
     tor->renamePath(oldpath, newname, callback, callback_user_data);
 }
 
-///
+// ---
 
 void tr_torrentSetFilePriorities(
     tr_torrent* tor,

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -9,7 +9,7 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint32_t
 
-///
+// ---
 
 #ifdef _MSVC_LANG
 #define TR_CPLUSPLUS _MSVC_LANG
@@ -28,11 +28,7 @@
 // Can't implement right now because __cplusplus version for C++23 is currently TBD
 #define TR_CONSTEXPR23
 
-///
-
-/***
-****
-***/
+// ---
 
 #ifndef __has_builtin
 #define __has_builtin(x) 0

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -19,15 +19,16 @@
 #include "tr-utp.h"
 #include "utils.h"
 
+namespace
+{
 /* Since we use a single UDP socket in order to implement multiple
    µTP sockets, try to set up huge buffers. */
-
-static auto constexpr RecvBufferSize = 4 * 1024 * 1024;
-static auto constexpr SendBufferSize = 1 * 1024 * 1024;
-static auto constexpr SmallBufferSize = 32 * 1024;
-
-static void set_socket_buffers(tr_socket_t fd, bool large)
+void set_socket_buffers(tr_socket_t fd, bool large)
 {
+    static auto constexpr RecvBufferSize = 4 * 1024 * 1024;
+    static auto constexpr SendBufferSize = 1 * 1024 * 1024;
+    static auto constexpr SmallBufferSize = 32 * 1024;
+
     int rbuf = 0;
     int sbuf = 0;
     socklen_t rbuf_len = sizeof(rbuf);
@@ -83,7 +84,7 @@ static void set_socket_buffers(tr_socket_t fd, bool large)
     }
 }
 
-static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
+void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsession)
 {
     TR_ASSERT(vsession != nullptr);
     TR_ASSERT(type == EV_READ);
@@ -130,6 +131,7 @@ static void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void*
         }
     }
 }
+} // namespace
 
 // BEP-32 explains why we need to bind to one IPv6 address
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -1029,7 +1029,7 @@ void tr_net_init()
 #endif
 }
 
-/// mime-type
+// --- mime-type
 
 std::string_view tr_get_mime_type_for_filename(std::string_view filename)
 {
@@ -1055,7 +1055,7 @@ std::string_view tr_get_mime_type_for_filename(std::string_view filename)
     return Fallback;
 }
 
-/// parseNum()
+// --- parseNum()
 
 #if defined(__GNUC__) && !__has_include(<charconv>)
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -28,7 +28,7 @@ using namespace std::literals;
 
 auto constexpr MaxBencStrLength = size_t{ 128 * 1024 * 1024 }; // arbitrary
 
-///
+// ---
 
 namespace transmission::benc::impl
 {
@@ -123,7 +123,7 @@ std::optional<std::string_view> ParseString(std::string_view* benc)
 
 } // namespace transmission::benc::impl
 
-///
+// ---
 
 namespace
 {
@@ -271,7 +271,7 @@ bool tr_variantParseBenc(tr_variant& top, int parse_opts, std::string_view benc,
     return transmission::benc::parse(benc, stack, handler, setme_end, error) && std::empty(stack);
 }
 
-///
+// ---
 
 namespace
 {

--- a/libtransmission/variant-converters.cc
+++ b/libtransmission/variant-converters.cc
@@ -34,7 +34,7 @@ void VariantConverter::save<bool>(tr_variant* tgt, bool const& val)
     tr_variantInitBool(tgt, val);
 }
 
-///
+// ---
 
 template<>
 std::optional<double> VariantConverter::load<double>(tr_variant* src)
@@ -53,7 +53,7 @@ void VariantConverter::save<double>(tr_variant* tgt, double const& val)
     tr_variantInitReal(tgt, val);
 }
 
-///
+// ---
 
 namespace EncryptionHelpers
 {
@@ -104,7 +104,7 @@ void VariantConverter::save<tr_encryption_mode>(tr_variant* tgt, tr_encryption_m
     tr_variantInitInt(tgt, val);
 }
 
-///
+// ---
 
 namespace LogLevelHelpers
 {
@@ -159,7 +159,7 @@ void VariantConverter::save<tr_log_level>(tr_variant* tgt, tr_log_level const& v
     tr_variantInitInt(tgt, val);
 }
 
-///
+// ---
 
 template<>
 std::optional<tr_mode_t> VariantConverter::load<tr_mode_t>(tr_variant* src)
@@ -186,7 +186,7 @@ void VariantConverter::save<tr_mode_t>(tr_variant* tgt, tr_mode_t const& val)
     tr_variantInitStr(tgt, fmt::format("{:#03o}", val));
 }
 
-///
+// ---
 
 template<>
 std::optional<tr_port> VariantConverter::load<tr_port>(tr_variant* src)
@@ -205,7 +205,7 @@ void VariantConverter::save<tr_port>(tr_variant* tgt, tr_port const& val)
     tr_variantInitInt(tgt, val.host());
 }
 
-///
+// ---
 
 namespace PreallocationModeHelpers
 {
@@ -258,7 +258,7 @@ void VariantConverter::save<tr_preallocation_mode>(tr_variant* tgt, tr_prealloca
     tr_variantInitInt(tgt, val);
 }
 
-///
+// ---
 
 template<>
 std::optional<size_t> VariantConverter::load<size_t>(tr_variant* src)
@@ -277,7 +277,7 @@ void VariantConverter::save<size_t>(tr_variant* tgt, size_t const& val)
     tr_variantInitInt(tgt, val);
 }
 
-///
+// ---
 
 template<>
 std::optional<std::string> VariantConverter::load<std::string>(tr_variant* src)
@@ -296,7 +296,7 @@ void VariantConverter::save<std::string>(tr_variant* tgt, std::string const& val
     tr_variantInitStr(tgt, val);
 }
 
-///
+// ---
 
 template<>
 std::optional<tr_tos_t> VariantConverter::load<tr_tos_t>(tr_variant* src)

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -398,7 +398,7 @@ bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view jso
     return success;
 }
 
-///
+// ---
 
 namespace
 {

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -39,7 +39,7 @@ constexpr bool tr_variantIsContainer(tr_variant const* v)
     return tr_variantIsList(v) || tr_variantIsDict(v);
 }
 
-///
+// ---
 
 auto constexpr StringInit = tr_variant_string{
     TR_STRING_TYPE_QUARK,
@@ -114,7 +114,7 @@ void tr_variant_string_set_string(struct tr_variant_string* str, std::string_vie
     }
 }
 
-///
+// ---
 
 constexpr char const* getStr(tr_variant const* v)
 {
@@ -407,7 +407,7 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, std::byte const
     return tr_variantGetRaw(child, setme_raw, setme_len);
 }
 
-///
+// ---
 
 void tr_variantInitRaw(tr_variant* initme, void const* raw, size_t raw_len)
 {
@@ -635,7 +635,7 @@ bool tr_variantDictRemove(tr_variant* dict, tr_quark const key)
     return removed;
 }
 
-/// BENC WALKING
+// --- BENC WALKING
 
 class WalkNode
 {
@@ -864,7 +864,7 @@ void tr_variantWalk(tr_variant const* top, struct VariantWalkFuncs const* walk_f
     }
 }
 
-///
+// ---
 
 namespace
 {
@@ -908,7 +908,7 @@ void tr_variantClear(tr_variant* v)
     *v = {};
 }
 
-///
+// ---
 
 bool tr_variantDictChild(tr_variant* dict, size_t pos, tr_quark* key, tr_variant** setme_value)
 {
@@ -1069,7 +1069,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
     }
 }
 
-///
+// ---
 
 std::string tr_variantToStr(tr_variant const* v, tr_variant_fmt fmt)
 {
@@ -1107,7 +1107,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view f
     return error_code;
 }
 
-///
+// ---
 
 bool tr_variantFromBuf(tr_variant* setme, int opts, std::string_view buf, char const** setme_end, tr_error** error)
 {

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -28,9 +28,7 @@
 
 using namespace std::literals;
 
-/***
-****
-***/
+// ---
 
 bool tr_addressIsIP(char const* address)
 {
@@ -172,7 +170,7 @@ char const* tr_webGetResponseStr(long code)
     }
 }
 
-//// URLs
+// --- URLs
 
 namespace
 {


### PR DESCRIPTION
No functional changes.

Fix another batch of `misc-use-anonymous-namespace` clang-tidy-16 warnings.