### PR TITLE
refactor: misc-use-anonymous-namespace pt. 5

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -18,10 +18,6 @@
 #include "tr-assert.h"
 #include "utils.h" // tr_time_msec()
 
-/***
-****
-***/
-
 tr_bytes_per_second_t tr_bandwidth::getSpeedBytesPerSecond(RateControl& r, unsigned int interval_msec, uint64_t now)
 {
     if (now == 0)
@@ -77,20 +73,20 @@ void tr_bandwidth::notifyBandwidthConsumedBytes(uint64_t const now, RateControl*
     r->cache_time_ = 0;
 }
 
-/***
-****
-***/
+// ---
 
 tr_bandwidth::tr_bandwidth(tr_bandwidth* parent)
 {
     this->setParent(parent);
 }
 
-/***
-****
-***/
+// ---
 
-static void remove_child(std::vector<tr_bandwidth*>& v, tr_bandwidth* remove_me) noexcept
+namespace
+{
+namespace deparent_helpers
+{
+void remove_child(std::vector<tr_bandwidth*>& v, tr_bandwidth* remove_me) noexcept
 {
     // the list isn't sorted -- so instead of erase()ing `it`,
     // do the cheaper option of overwriting it with the final item
@@ -100,9 +96,13 @@ static void remove_child(std::vector<tr_bandwidth*>& v, tr_bandwidth* remove_me)
         v.resize(v.size() - 1);
     }
 }
+} // namespace deparent_helpers
+} // namespace
 
 void tr_bandwidth::deparent() noexcept
 {
+    using namespace deparent_helpers;
+
     if (parent_ == nullptr)
     {
         return;
@@ -131,9 +131,7 @@ void tr_bandwidth::setParent(tr_bandwidth* new_parent)
     }
 }
 
-/***
-****
-***/
+// ---
 
 void tr_bandwidth::allocateBandwidth(
     tr_priority_t parent_priority,
@@ -259,9 +257,7 @@ void tr_bandwidth::allocate(unsigned int period_msec)
     }
 }
 
-/***
-****
-***/
+// ---
 
 size_t tr_bandwidth::clamp(uint64_t now, tr_direction dir, size_t byte_count) const
 {
@@ -347,9 +343,7 @@ void tr_bandwidth::notifyBandwidthConsumed(tr_direction dir, size_t byte_count, 
     }
 }
 
-/***
-****
-***/
+// ---
 
 tr_bandwidth_limits tr_bandwidth::getLimits() const
 {

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -168,6 +168,18 @@ public:
         return did_change;
     }
 
+    [[nodiscard]] bool is_maxed_out(tr_direction dir, uint64_t now_msec) const noexcept
+    {
+        if (!isLimited(dir))
+        {
+            return false;
+        }
+
+        auto const got = getPieceSpeedBytesPerSecond(now_msec, dir);
+        auto const want = getDesiredSpeedBytesPerSecond(dir);
+        return got >= want;
+    }
+
     /**
      * @brief Get the desired speed for the bandwidth subtree.
      * @see tr_bandwidth::setDesiredSpeed

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -1097,9 +1097,10 @@ std::string tr_sys_dir_get_current(tr_error** error)
     }
 }
 
+namespace
+{
 #ifndef HAVE_MKDIRP
-
-static bool tr_mkdirp_(std::string_view path, int permissions, tr_error** error)
+[[nodiscard]] bool tr_mkdirp_(std::string_view path, int permissions, tr_error** error)
 {
     auto walk = path.find_first_not_of('/'); // walk past the root
     auto subpath = tr_pathbuf{};
@@ -1128,8 +1129,8 @@ static bool tr_mkdirp_(std::string_view path, int permissions, tr_error** error)
 
     return true;
 }
-
 #endif
+} // namespace
 
 bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error** error)
 {

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -211,6 +211,13 @@ public:
     // requests that have been made but haven't been fulfilled yet
     [[nodiscard]] virtual size_t activeReqCount(tr_direction) const noexcept = 0;
 
+    [[nodiscard]] tr_bytes_per_second_t get_piece_speed_bytes_per_second(uint64_t now, tr_direction direction) const
+    {
+        auto bytes_per_second = tr_bytes_per_second_t{};
+        isTransferringPieces(now, direction, &bytes_per_second);
+        return bytes_per_second;
+    }
+
     virtual void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) = 0;
 
     struct RequestLimit

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -43,6 +43,33 @@
 #define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
 #define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
+namespace
+{
+// Helps us to ignore errors that say "try again later"
+// since that's what peer-io does by default anyway.
+[[nodiscard]] auto constexpr canRetryFromError(int error_code) noexcept
+{
+    return error_code == 0 || error_code == EAGAIN || error_code == EINTR || error_code == EINPROGRESS;
+}
+
+size_t get_desired_output_buffer_size(tr_peerIo const* io, uint64_t now)
+{
+    // this is all kind of arbitrary, but what seems to work well is
+    // being large enough to hold the next 20 seconds' worth of input,
+    // or a few blocks, whichever is bigger. OK to tweak this as needed.
+    static auto constexpr PeriodSecs = 15U;
+
+    // the 3 is an arbitrary number of blocks;
+    // the .5 is to leave room for protocol messages
+    static auto constexpr Floor = static_cast<size_t>(tr_block_info::BlockSize * 3.5);
+
+    auto const current_speed_bytes_per_second = io->get_piece_speed_bytes_per_second(now, TR_UP);
+    return std::max(Floor, current_speed_bytes_per_second * PeriodSecs);
+}
+} // namespace
+
+// ---
+
 tr_peerIo::tr_peerIo(
     tr_session* session,
     tr_sha1_digest_t const* info_hash,
@@ -209,15 +236,6 @@ bool tr_peerIo::reconnect()
     event_enable(pending_events);
 
     return true;
-}
-
-// ---
-
-// Helps us to ignore errors that say "try again later"
-// since that's what peer-io does by default anyway.
-[[nodiscard]] static auto constexpr canRetryFromError(int error_code) noexcept
-{
-    return error_code == 0 || error_code == EAGAIN || error_code == EINTR || error_code == EINPROGRESS;
 }
 
 // ---
@@ -548,21 +566,6 @@ size_t tr_peerIo::flush_outgoing_protocol_msgs()
 }
 
 // ---
-
-static size_t get_desired_output_buffer_size(tr_peerIo const* io, uint64_t now)
-{
-    // this is all kind of arbitrary, but what seems to work well is
-    // being large enough to hold the next 20 seconds' worth of input,
-    // or a few blocks, whichever is bigger. OK to tweak this as needed.
-    static auto constexpr PeriodSecs = 15U;
-
-    // the 3 is an arbitrary number of blocks;
-    // the .5 is to leave room for protocol messages
-    static auto constexpr Floor = static_cast<size_t>(tr_block_info::BlockSize * 3.5);
-
-    auto const current_speed_bytes_per_second = io->get_piece_speed_bytes_per_second(now, TR_UP);
-    return std::max(Floor, current_speed_bytes_per_second * PeriodSecs);
-}
 
 size_t tr_peerIo::get_write_buffer_space(uint64_t now) const noexcept
 {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -60,9 +60,7 @@ static auto constexpr MyflagUnreachable = int{ 2 };
 
 static auto constexpr CancelHistorySec = int{ 60 };
 
-/**
-***
-**/
+// ---
 
 class HandshakeMediator final : public tr_handshake::Mediator
 {
@@ -782,9 +780,7 @@ tr_peer::~tr_peer()
     }
 }
 
-/**
-***
-**/
+// ---
 
 tr_peerMgr* tr_peerMgrNew(tr_session* session)
 {
@@ -796,9 +792,7 @@ void tr_peerMgrFree(tr_peerMgr* manager)
     delete manager;
 }
 
-/***
-****
-***/
+// ---
 
 void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
 {
@@ -813,9 +807,7 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
     }
 }
 
-/***
-****
-***/
+// ---
 
 void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr)
 {
@@ -1224,9 +1216,7 @@ std::vector<tr_pex> tr_pex::from_compact_ipv6(
     return pex;
 }
 
-/**
-***
-**/
+// ---
 
 void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t piece_index)
 {
@@ -1921,9 +1911,7 @@ void rechokeDownloads(tr_swarm* s)
 
 } // namespace rechoke_downloads_helpers
 
-/**
-***
-**/
+// ---
 
 namespace rechoke_uploads_helpers
 {
@@ -2429,11 +2417,7 @@ void tr_peerMgr::bandwidthPulse()
     reconnectPulse();
 }
 
-/***
-****
-****
-****
-***/
+// ---
 
 bool tr_swarm::peer_is_in_use(peer_atom const& atom) const
 {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -343,6 +343,8 @@ public:
         TR_ASSERT(std::empty(peers));
     }
 
+    [[nodiscard]] bool peer_is_in_use(peer_atom const& atom) const;
+
     void cancelOldRequests()
     {
         auto const now = tr_time();
@@ -673,12 +675,6 @@ tr_peer::~tr_peer()
 /**
 ***
 **/
-
-static TR_CONSTEXPR20 bool peerIsInUse(tr_swarm const* swarm, struct peer_atom const* atom)
-{
-    return atom->is_connected || swarm->outgoing_handshakes.count(atom->addr) != 0U ||
-        swarm->manager->incoming_handshakes.count(atom->addr) != 0U;
-}
 
 tr_peerMgr* tr_peerMgrNew(tr_session* session)
 {
@@ -2443,6 +2439,12 @@ void tr_peerMgr::bandwidthPulse()
 ****
 ***/
 
+bool tr_swarm::peer_is_in_use(peer_atom const& atom) const
+{
+    return atom.is_connected || outgoing_handshakes.count(atom.addr) != 0U ||
+        manager->incoming_handshakes.count(atom.addr) != 0U;
+}
+
 namespace connect_helpers
 {
 namespace
@@ -2464,7 +2466,7 @@ namespace
     }
 
     // not if we've already got a connection to them...
-    if (peerIsInUse(tor->swarm, &atom))
+    if (tor->swarm->peer_is_in_use(&atom))
     {
         return false;
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -869,61 +869,6 @@ void tr_peerMgr::refillUpkeep() const
     }
 }
 
-static void peerSuggestedPiece(
-    tr_swarm const* /*s*/,
-    tr_peer const* /*peer*/,
-    tr_piece_index_t /*pieceIndex*/,
-    bool /*isFastAllowed*/)
-{
-#if 0
-
-    TR_ASSERT(t != nullptr);
-    TR_ASSERT(peer != nullptr);
-    TR_ASSERT(peer->msgs != nullptr);
-
-    /* is this a valid piece? */
-    if (pieceIndex >= t->tor->pieceCount())
-    {
-        return;
-    }
-
-    /* don't ask for it if we've already got it */
-    if (t->tor->hasPiece(pieceIndex))
-    {
-        return;
-    }
-
-    /* don't ask for it if they don't have it */
-    if (!peer->have.readBit(pieceIndex))
-    {
-        return;
-    }
-
-    /* don't ask for it if we're choked and it's not fast */
-    if (!isFastAllowed && peer->clientIsChoked)
-    {
-        return;
-    }
-
-    /* request the blocks that we don't have in this piece */
-    {
-        tr_torrent const* tor = t->tor;
-        auto const [begin, end] = tor->blockSpanForPiece(pieceIndex);
-
-        for (tr_block_index_t b = begin; b < end; ++b)
-        {
-            if (tor->hasBlock(b))
-            {
-                uint32_t const offset = getBlockOffsetInPiece(tor, b);
-                uint32_t const length = tor->blockSize(b);
-                tr_peerMsgsAddRequest(peer->msgs, pieceIndex, offset, length);
-                incrementPieceRequests(t, pieceIndex);
-            }
-        }
-    }
-#endif
-}
-
 void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t p)
 {
     bool piece_came_from_peers = false;
@@ -1018,11 +963,8 @@ static void peerCallbackFunc(tr_peer* peer, tr_peer_event const& event, void* vs
         break;
 
     case tr_peer_event::Type::ClientGotSuggest:
-        peerSuggestedPiece(s, peer, event.pieceIndex, false);
-        break;
-
     case tr_peer_event::Type::ClientGotAllowedFast:
-        peerSuggestedPiece(s, peer, event.pieceIndex, true);
+        // not currently supported
         break;
 
     case tr_peer_event::Type::ClientGotBlock:

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -216,11 +216,6 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr);
 
 [[nodiscard]] tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);
 
-[[nodiscard]] tr_bytes_per_second_t tr_peerGetPieceSpeedBytesPerSecond(
-    tr_peer const* peer,
-    uint64_t now,
-    tr_direction direction);
-
 void tr_peerMgrClearInterest(tr_torrent* tor);
 
 void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t piece_index);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -549,7 +549,7 @@ private:
         // Get the rate limit we should use.
         // TODO: this needs to consider all the other peers as well...
         uint64_t const now = tr_time_msec();
-        auto rate_bytes_per_second = tr_peerGetPieceSpeedBytesPerSecond(this, now, TR_PEER_TO_CLIENT);
+        auto rate_bytes_per_second = get_piece_speed_bytes_per_second(now, TR_PEER_TO_CLIENT);
         if (torrent->usesSpeedLimit(TR_PEER_TO_CLIENT))
         {
             rate_bytes_per_second = std::min(rate_bytes_per_second, torrent->speedLimitBps(TR_PEER_TO_CLIENT));

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -24,7 +24,9 @@
 #include "port-forwarding.h"
 #include "utils.h"
 
-static void logVal(char const* func, int ret)
+namespace
+{
+void log_val(char const* func, int ret)
 {
     if (ret == NATPMP_TRYAGAIN)
     {
@@ -46,6 +48,7 @@ static void logVal(char const* func, int ret)
             tr_strerror(errno)));
     }
 }
+} // namespace
 
 bool tr_natpmp::canSendCommand() const
 {
@@ -62,9 +65,9 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
     if (is_enabled && state_ == State::Discover)
     {
         int val = initnatpmp(&natpmp_, 0, 0);
-        logVal("initnatpmp", val);
+        log_val("initnatpmp", val);
         val = sendpublicaddressrequest(&natpmp_);
-        logVal("sendpublicaddressrequest", val);
+        log_val("sendpublicaddressrequest", val);
         state_ = val < 0 ? State::Err : State::RecvPub;
         has_discovered_ = true;
         setCommandTime();
@@ -74,7 +77,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
     {
         natpmpresp_t response;
         auto const val = readnatpmpresponseorretry(&natpmp_, &response);
-        logVal("readnatpmpresponseorretry", val);
+        log_val("readnatpmpresponseorretry", val);
 
         if (val >= 0)
         {
@@ -102,7 +105,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
             local_port_.host(),
             advertised_port_.host(),
             0);
-        logVal("sendnewportmappingrequest", val);
+        log_val("sendnewportmappingrequest", val);
         state_ = val < 0 ? State::Err : State::RecvUnmap;
         setCommandTime();
     }
@@ -111,7 +114,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
     {
         auto resp = natpmpresp_t{};
         auto const val = readnatpmpresponseorretry(&natpmp_, &resp);
-        logVal("readnatpmpresponseorretry", val);
+        log_val("readnatpmpresponseorretry", val);
 
         if (val >= 0)
         {
@@ -153,7 +156,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
             local_port.host(),
             local_port.host(),
             LifetimeSecs);
-        logVal("sendnewportmappingrequest", val);
+        log_val("sendnewportmappingrequest", val);
         state_ = val < 0 ? State::Err : State::RecvMap;
         setCommandTime();
     }
@@ -162,7 +165,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
     {
         auto resp = natpmpresp_t{};
         auto const val = readnatpmpresponseorretry(&natpmp_, &resp);
-        logVal("readnatpmpresponseorretry", val);
+        log_val("readnatpmpresponseorretry", val);
 
         if (val >= 0)
         {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1238,9 +1238,7 @@ uint16_t tr_sessionGetPeerLimitPerTorrent(tr_session const* session)
     return session->peerLimitPerTorrent();
 }
 
-/***
-****
-***/
+// ---
 
 void tr_sessionSetPaused(tr_session* session, bool is_paused)
 {
@@ -1263,18 +1261,12 @@ void tr_sessionSetDeleteSource(tr_session* session, bool delete_source)
     session->settings_.should_delete_source_torrents = delete_source;
 }
 
-/***
-****
-***/
-
-static tr_kilobytes_per_second_t tr_sessionGetRawSpeed_Bps(tr_session const* session, tr_direction dir)
-{
-    return session != nullptr ? session->top_bandwidth_.getRawSpeedBytesPerSecond(0, dir) : 0;
-}
+// ---
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
 {
-    return tr_toSpeedKBps(tr_sessionGetRawSpeed_Bps(session, dir));
+    auto const bps = session != nullptr ? session->top_bandwidth_.getRawSpeedBytesPerSecond(0, dir) : 0;
+    return tr_toSpeedKBps(bps);
 }
 
 void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono::time_point<std::chrono::steady_clock> deadline)

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -62,9 +62,7 @@ struct tr_ctor
     }
 };
 
-/***
-****
-***/
+// ---
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error)
 {
@@ -128,9 +126,7 @@ bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_erro
     return tr_saveFile(filename, ctor->contents, error);
 }
 
-/***
-****
-***/
+// ---
 
 void tr_ctorSetFilePriorities(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t file_count, tr_priority_t priority)
 {
@@ -169,9 +165,7 @@ void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor)
     tor->initFilesWanted(std::data(ctor->wanted), std::size(ctor->wanted), true);
 }
 
-/***
-****
-***/
+// ---
 
 void tr_ctorSetDeleteSource(tr_ctor* ctor, bool delete_source)
 {
@@ -194,9 +188,7 @@ bool tr_ctorGetDeleteSource(tr_ctor const* ctor, bool* setme)
     return true;
 }
 
-/***
-****
-***/
+// ---
 
 void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool paused)
 {
@@ -308,21 +300,16 @@ tr_session* tr_ctorGetSession(tr_ctor const* ctor)
     return const_cast<tr_session*>(ctor->session);
 }
 
-/***
-****
-***/
-
-static bool isPriority(int i)
-{
-    return i == TR_PRI_LOW || i == TR_PRI_NORMAL || i == TR_PRI_HIGH;
-}
+// ---
 
 void tr_ctorSetBandwidthPriority(tr_ctor* ctor, tr_priority_t priority)
 {
-    if (isPriority(priority))
+    if (priority != TR_PRI_LOW && priority != TR_PRI_NORMAL && priority != TR_PRI_HIGH)
     {
-        ctor->priority = priority;
+        return;
     }
+
+    ctor->priority = priority;
 }
 
 tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
@@ -330,9 +317,7 @@ tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
     return ctor->priority;
 }
 
-/***
-****
-***/
+// ---
 
 void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels)
 {
@@ -344,9 +329,7 @@ tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor)
     return ctor->labels;
 }
 
-/***
-****
-***/
+// ---
 
 tr_ctor* tr_ctorNew(tr_session const* session)
 {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -122,9 +122,19 @@ public:
 
     /// SPEED LIMIT
 
+    [[nodiscard]] constexpr auto& bandwidth() noexcept
+    {
+        return bandwidth_;
+    }
+
+    [[nodiscard]] constexpr auto const& bandwidth() const noexcept
+    {
+        return bandwidth_;
+    }
+
     constexpr void setSpeedLimitBps(tr_direction dir, tr_bytes_per_second_t bytes_per_second)
     {
-        if (bandwidth_.setDesiredSpeedBytesPerSecond(dir, bytes_per_second))
+        if (bandwidth().setDesiredSpeedBytesPerSecond(dir, bytes_per_second))
         {
             setDirty();
         }
@@ -132,7 +142,7 @@ public:
 
     constexpr void useSpeedLimit(tr_direction dir, bool do_use)
     {
-        if (bandwidth_.setLimited(dir, do_use))
+        if (bandwidth().setLimited(dir, do_use))
         {
             setDirty();
         }
@@ -140,17 +150,17 @@ public:
 
     [[nodiscard]] constexpr auto speedLimitBps(tr_direction dir) const
     {
-        return bandwidth_.getDesiredSpeedBytesPerSecond(dir);
+        return bandwidth().getDesiredSpeedBytesPerSecond(dir);
     }
 
     [[nodiscard]] constexpr auto usesSessionLimits() const noexcept
     {
-        return bandwidth_.areParentLimitsHonored(TR_UP);
+        return bandwidth().areParentLimitsHonored(TR_UP);
     }
 
     [[nodiscard]] constexpr auto usesSpeedLimit(tr_direction dir) const noexcept
     {
-        return bandwidth_.isLimited(dir);
+        return bandwidth().isLimited(dir);
     }
 
     /// BLOCK INFO
@@ -673,7 +683,7 @@ public:
 
     [[nodiscard]] constexpr auto getPriority() const noexcept
     {
-        return bandwidth_.getPriority();
+        return bandwidth().getPriority();
     }
 
     [[nodiscard]] constexpr auto const& bandwidthGroup() const noexcept


### PR DESCRIPTION
No functional changes.

Another batch of moving static methods into an anonymous namespace for the clang-tidy-16 check `misc-use-anonymous-namespace`

This fixes the final batch of warnings & is the last in the series.