### PR TITLE
refactor: cppcoreguidelines-avoid-const-or-ref-data-members

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -343,7 +343,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
         using BasicHandler = transmission::benc::BasicHandler<MaxBencDepth>;
 
         tr_announce_response& response_;
-        std::string_view const log_name_;
+        std::string_view log_name_;
         std::optional<size_t> row_;
         tr_pex pex_ = {};
 
@@ -588,7 +588,7 @@ void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::stri
         using BasicHandler = transmission::benc::BasicHandler<MaxBencDepth>;
 
         tr_scrape_response& response_;
-        std::string_view const log_name_;
+        std::string_view log_name_;
         std::optional<size_t> row_;
 
         explicit ScrapeHandler(tr_scrape_response& response, std::string_view const log_name)

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -152,12 +152,12 @@ struct tau_scrape_request
     std::vector<std::byte> payload;
 
     time_t sent_at = 0;
-    tau_transaction_t const transaction_id = tau_transaction_new();
+    tau_transaction_t transaction_id = tau_transaction_new();
 
     tr_scrape_response response = {};
 
 private:
-    time_t const created_at_ = tr_time();
+    time_t created_at_ = tr_time();
 
     tr_scrape_response_func on_response_;
 };
@@ -257,7 +257,7 @@ struct tau_announce_request
     std::vector<std::byte> payload;
 
     time_t sent_at = 0;
-    tau_transaction_t const transaction_id = tau_transaction_new();
+    tau_transaction_t transaction_id = tau_transaction_new();
 
     tr_announce_response response = {};
 
@@ -280,7 +280,7 @@ private:
         }
     }
 
-    time_t const created_at_ = tr_time();
+    time_t created_at_ = tr_time();
 
     tr_announce_response_func on_response_;
 };
@@ -545,9 +545,9 @@ private:
     }
 
 public:
-    tr_interned_string const key;
-    tr_interned_string const host;
-    tr_port const port;
+    tr_interned_string key;
+    tr_interned_string host;
+    tr_port port;
 
     time_t connecting_at = 0;
     time_t connection_expiration_time = 0;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -226,7 +226,7 @@ public:
         }
     }
 
-    tr_session* const session;
+    tr_session* session;
 
 private:
     void flushCloseMessages()
@@ -245,7 +245,7 @@ private:
 
     std::map<tr_interned_string, tr_scrape_info> scrape_info_;
 
-    std::unique_ptr<libtransmission::Timer> const upkeep_timer_;
+    std::unique_ptr<libtransmission::Timer> upkeep_timer_;
 
     std::set<tr_announce_request, StopsCompare> stops_;
 
@@ -305,10 +305,10 @@ struct tr_tracker
         }
     }
 
-    tr_interned_string const host;
-    tr_interned_string const announce_url;
-    std::string_view const sitename;
-    tr_scrape_info* const scrape_info;
+    tr_interned_string host;
+    tr_interned_string announce_url;
+    std::string_view sitename;
+    tr_scrape_info* scrape_info;
 
     std::string tracker_id;
 
@@ -319,7 +319,7 @@ struct tr_tracker
 
     int consecutive_failures = 0;
 
-    tr_tracker_id_t const id;
+    tr_tracker_id_t id;
 };
 
 // format: `${host}:${port}`
@@ -480,7 +480,7 @@ struct tr_tier
 
     std::optional<size_t> current_tracker_index_;
 
-    tr_torrent* const tor;
+    tr_torrent* tor;
 
     time_t scrapeAt = 0;
     time_t lastScrapeStartTime = 0;
@@ -491,7 +491,7 @@ struct tr_tier
     time_t lastAnnounceStartTime = 0;
     time_t lastAnnounceTime = 0;
 
-    int const id = next_key++;
+    int id = next_key++;
 
     int announce_event_priority = 0;
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -270,7 +270,7 @@ struct peer_atom
         return std::nullopt;
     }
 
-    tr_address const addr;
+    tr_address addr;
 
     tr_port port = {};
 
@@ -282,7 +282,7 @@ struct peer_atom
     time_t lastConnectionAttemptAt = {};
     time_t lastConnectionAt = {};
 
-    uint8_t const fromFirst; /* where the peer was first found */
+    uint8_t fromFirst; /* where the peer was first found */
     uint8_t fromBest; /* the "best" value of where the peer has been found */
     uint8_t flags = {}; /* these match the added_f flags */
     uint8_t flags2 = {}; /* flags that aren't defined in added_f */
@@ -640,9 +640,9 @@ public:
 
     bool is_running = false;
 
-    tr_peerMgr* const manager;
+    tr_peerMgr* manager;
 
-    tr_torrent* const tor;
+    tr_torrent* tor;
 
     std::vector<std::unique_ptr<tr_peer>> webseeds;
     std::vector<tr_peerMsgs*> peers;
@@ -727,7 +727,7 @@ struct tr_peerMgr
         return tor == nullptr ? nullptr : tor->swarm;
     }
 
-    tr_session* const session;
+    tr_session* session;
     Handshakes incoming_handshakes;
 
     HandshakeMediator handshake_mediator_;
@@ -739,9 +739,9 @@ private:
         rechoke_timer_->setInterval(RechokePeriod);
     }
 
-    std::unique_ptr<libtransmission::Timer> const bandwidth_timer_;
-    std::unique_ptr<libtransmission::Timer> const rechoke_timer_;
-    std::unique_ptr<libtransmission::Timer> const refill_upkeep_timer_;
+    std::unique_ptr<libtransmission::Timer> bandwidth_timer_;
+    std::unique_ptr<libtransmission::Timer> rechoke_timer_;
+    std::unique_ptr<libtransmission::Timer> refill_upkeep_timer_;
 
     static auto constexpr BandwidthPeriod = 500ms;
     static auto constexpr RechokePeriod = 10s;
@@ -915,9 +915,9 @@ std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_p
         }
 
     private:
-        tr_torrent const* const torrent_;
-        tr_swarm const* const swarm_;
-        tr_peer const* const peer_;
+        tr_torrent const* torrent_;
+        tr_swarm const* swarm_;
+        tr_peer const* peer_;
     };
 
     torrent->swarm->updateEndgame();

--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -274,8 +274,8 @@ private:
         }
     }
 
-    libtransmission::evhelpers::evbase_unique_ptr const evbase_{ makeEventBase() };
-    libtransmission::evhelpers::event_unique_ptr const work_queue_event_{
+    libtransmission::evhelpers::evbase_unique_ptr evbase_{ makeEventBase() };
+    libtransmission::evhelpers::event_unique_ptr work_queue_event_{
         event_new(evbase_.get(), -1, 0, onWorkAvailableStatic, this)
     };
 

--- a/libtransmission/timer-ev.cc
+++ b/libtransmission/timer-ev.cc
@@ -153,8 +153,8 @@ private:
     bool is_running_ = false;
     std::function<void()> callback_;
 
-    struct event_base* const base_;
-    evhelpers::event_unique_ptr const evtimer_{ event_new(base_, -1, events(is_repeating_), &EvTimer::onTimer, this) };
+    struct event_base* base_;
+    evhelpers::event_unique_ptr evtimer_{ event_new(base_, -1, events(is_repeating_), &EvTimer::onTimer, this) };
 };
 
 std::unique_ptr<Timer> EvTimerMaker::create()

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -34,7 +34,7 @@ struct optional_args
  * @ingroup tr_ctor */
 struct tr_ctor
 {
-    tr_session const* const session;
+    tr_session const* session;
     std::optional<bool> delete_source;
 
     tr_torrent_metainfo metainfo = {};

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -572,15 +572,15 @@ private:
 
     ///
 
-    tr_port const peer_port_;
-    tr_socket_t const udp4_socket_;
-    tr_socket_t const udp6_socket_;
+    tr_port peer_port_;
+    tr_socket_t udp4_socket_;
+    tr_socket_t udp6_socket_;
 
     Mediator& mediator_;
-    std::string const state_filename_;
-    std::unique_ptr<libtransmission::Timer> const announce_timer_;
-    std::unique_ptr<libtransmission::Timer> const bootstrap_timer_;
-    std::unique_ptr<libtransmission::Timer> const periodic_timer_;
+    std::string state_filename_;
+    std::unique_ptr<libtransmission::Timer> announce_timer_;
+    std::unique_ptr<libtransmission::Timer> bootstrap_timer_;
+    std::unique_ptr<libtransmission::Timer> periodic_timer_;
 
     Id id_ = {};
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -131,8 +131,8 @@ namespace parse_helpers
 {
 struct MyHandler : public transmission::benc::Handler
 {
-    tr_variant* const top_;
-    int const parse_opts_;
+    tr_variant* top_;
+    int parse_opts_;
     std::deque<tr_variant*> stack_;
     std::optional<tr_quark> key_;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -374,9 +374,9 @@ public:
     static auto constexpr DnsCacheTimeoutSecs = long{ 60 * 60 };
     static auto constexpr MaxRedirects = long{ 10 };
 
-    bool const curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
-    bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
-    bool const curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
+    bool curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
+    bool curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
+    bool curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
 
     Mediator& mediator;
 
@@ -473,7 +473,7 @@ public:
     }
 #endif
 
-    void initEasy(Task& task)
+    void initEasy(Task& task) const
     {
         TR_ASSERT(std::this_thread::get_id() == curl_thread->get_id());
         auto* const e = task.easy();
@@ -710,7 +710,7 @@ public:
         }
     }
 
-    curl_helpers::shared_unique_ptr const curlsh_{ curl_share_init() };
+    curl_helpers::shared_unique_ptr curlsh_{ curl_share_init() };
 
     std::map<std::string /*host*/, std::stack<curl_helpers::easy_unique_ptr>, std::less<>> easy_pool_;
 
@@ -719,12 +719,12 @@ public:
     std::list<Task> queued_tasks_;
     std::list<Task> running_tasks_;
 
-    CURLSH* shared()
+    [[nodiscard]] CURLSH* shared() const
     {
         return curlsh_.get();
     }
 
-    void shareEverything()
+    void shareEverything() const
     {
         // Tell curl to share whatever it can.
         // https://curl.se/libcurl/c/CURLSHOPT_SHARE.html

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -41,7 +41,7 @@ void on_idle(tr_webseed* w);
 class tr_webseed_task
 {
 private:
-    libtransmission::evhelpers::evbuffer_unique_ptr const content_{ evbuffer_new() };
+    libtransmission::evhelpers::evbuffer_unique_ptr content_{ evbuffer_new() };
 
 public:
     tr_webseed_task(tr_torrent* tor, tr_webseed* webseed_in, tr_block_span_t blocks_in)
@@ -53,16 +53,16 @@ public:
     {
     }
 
-    tr_webseed* const webseed;
+    tr_webseed* webseed;
 
     [[nodiscard]] auto* content() const
     {
         return content_.get();
     }
 
-    tr_session* const session;
-    tr_block_span_t const blocks;
-    uint64_t const end_byte;
+    tr_session* session;
+    tr_block_span_t blocks;
+    uint64_t end_byte;
 
     // the current position in the task; i.e., the next block to save
     tr_block_info::Location loc;
@@ -308,10 +308,10 @@ public:
         }
     }
 
-    tr_torrent_id_t const torrent_id;
-    std::string const base_url;
-    tr_peer_callback const callback;
-    void* const callback_data;
+    tr_torrent_id_t torrent_id;
+    std::string base_url;
+    tr_peer_callback callback;
+    void* callback_data;
 
     ConnectionLimiter connection_limiter;
     std::set<tr_webseed_task*> tasks;
@@ -319,7 +319,7 @@ public:
 private:
     static auto constexpr IdleTimerInterval = 2s;
 
-    std::unique_ptr<libtransmission::Timer> const idle_timer_;
+    std::unique_ptr<libtransmission::Timer> idle_timer_;
 
     tr_bitfield have_;
 
@@ -333,7 +333,7 @@ private:
 struct write_block_data
 {
 private:
-    libtransmission::evhelpers::evbuffer_unique_ptr const content_{ evbuffer_new() };
+    libtransmission::evhelpers::evbuffer_unique_ptr content_{ evbuffer_new() };
 
 public:
     write_block_data(
@@ -362,11 +362,11 @@ public:
     }
 
 private:
-    tr_session* const session_;
-    tr_torrent_id_t const tor_id_;
-    tr_block_index_t const block_;
+    tr_session* session_;
+    tr_torrent_id_t tor_id_;
+    tr_block_index_t block_;
     std::unique_ptr<std::vector<uint8_t>> data_;
-    tr_webseed* const webseed_;
+    tr_webseed* webseed_;
 };
 
 void useFetchedBlocks(tr_webseed_task* task)


### PR DESCRIPTION
No functional changes.

Fix new clang-tidy-16 `cppcoreguidelines-avoid-const-or-ref-data-members` warnings.