### PR TITLE
Increase font size in TorrentCell

### DIFF
--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -88,7 +88,7 @@ static NSInteger const kMaxPieces = 18 * 18;
         _fTitleAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
 
         _fStatusAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
-        _fStatusAttributes[NSFontAttributeName] = [NSFont messageFontOfSize:9.0];
+        _fStatusAttributes[NSFontAttributeName] = [NSFont messageFontOfSize:10.0];
         _fStatusAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
 
         _fBluePieceColor = [NSColor colorWithCalibratedRed:0.0 green:0.4 blue:0.8 alpha:1.0];


### PR DESCRIPTION
An ongoing battle. This is my last attempt to increase the minimum font size within the main window of the macOS client. 

This is not deficient, nor is it 'arbitrary'. 9.0 should not be used as a baseline font size for the main window of an application such as Transmission. This change breaks nothing in the design or code, and does nothing but increase information values.

I have suggested elsewhere that the gui could adopt a better methodology for increasing font size values for user needs across the client. In the absence of that, there is this. 