### PR TITLE
Refactor sorting and filtering compatibility code (GTK client)

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -18,6 +18,10 @@ target_sources(${TR_NAME}-gtk
         FileList.h
         FilterBar.cc
         FilterBar.h
+        FilterBase.h
+        FilterBase.hh
+        FilterListModel.h
+        FilterListModel.hh
         Flags.h
         FreeSpaceLabel.cc
         FreeSpaceLabel.h
@@ -48,6 +52,10 @@ target_sources(${TR_NAME}-gtk
         RelocateDialog.h
         Session.cc
         Session.h
+        SorterBase.h
+        SorterBase.hh
+        SortListModel.h
+        SortListModel.hh
         StatsDialog.cc
         StatsDialog.h
         SystemTrayIcon.cc

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2012-2022 Mnemosyne LLC.
+// This file Copyright © 2012-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
@@ -6,6 +6,7 @@
 #include "FilterBar.h"
 
 #include "FaviconCache.h" // gtr_get_favicon()
+#include "FilterListModel.hh"
 #include "HigWorkarea.h" // GUI_PAD
 #include "ListModelAdapter.h"
 #include "Session.h" // torrent_cols
@@ -110,11 +111,9 @@ private:
     Gtk::Entry* entry_ = nullptr;
     Gtk::Label* show_lb_ = nullptr;
     Glib::RefPtr<TorrentFilter> filter_ = TorrentFilter::create();
-    Glib::RefPtr<FilterModel> filter_model_;
+    Glib::RefPtr<FilterListModel<Torrent>> filter_model_;
 
-#if GTKMM_CHECK_VERSION(4, 0, 0)
     sigc::connection filter_model_items_changed_tag_;
-#endif
     sigc::connection update_count_label_tag_;
     sigc::connection update_filter_models_tag_;
     sigc::connection update_filter_models_on_add_remove_tag_;
@@ -567,7 +566,7 @@ void FilterBar::Impl::update_filter_tracker()
 bool FilterBar::Impl::update_count_label()
 {
     /* get the visible count */
-    auto const visibleCount = static_cast<int>(filter_model_->IF_GTKMM4(get_n_items(), children().size()));
+    auto const visibleCount = static_cast<int>(filter_model_->get_n_items());
 
     /* get the tracker count */
     int trackerCount = 0;
@@ -701,22 +700,9 @@ FilterBar::Impl::Impl(FilterBar& widget, Glib::RefPtr<Session> const& core)
     activity_combo_box_init(*activity_);
     tracker_combo_box_init(*tracker_);
 
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-    filter_model_ = Gtk::FilterListModel::create(core_->get_sorted_model(), filter_);
+    filter_model_ = FilterListModel<Torrent>::create(core_->get_sorted_model(), filter_);
     filter_model_items_changed_tag_ = filter_model_->signal_items_changed().connect(
         [this](guint /*position*/, guint /*removed*/, guint /*added*/) { update_count_label_idle(); });
-#else
-    static auto const& self_col = Torrent::get_columns().self;
-
-    auto const filter_func = [this](FilterModel::const_iterator const& iter)
-    {
-        return filter_->match(*iter->get_value(self_col));
-    };
-
-    filter_model_ = Gtk::TreeModelFilter::create(core_->get_sorted_model());
-    filter_model_->set_visible_func(filter_func);
-    filter_->signal_changed().connect([this]() { filter_model_->refilter(); });
-#endif
 
     tracker_->signal_changed().connect(sigc::mem_fun(*this, &Impl::update_filter_tracker));
     activity_->signal_changed().connect(sigc::mem_fun(*this, &Impl::update_filter_activity));
@@ -735,9 +721,7 @@ FilterBar::Impl::~Impl()
     update_filter_models_on_add_remove_tag_.disconnect();
     update_filter_models_tag_.disconnect();
     update_count_label_tag_.disconnect();
-#if GTKMM_CHECK_VERSION(4, 0, 0)
     filter_model_items_changed_tag_.disconnect();
-#endif
 }
 
 Glib::RefPtr<FilterBar::Model> FilterBar::get_filter_model() const

--- a/gtk/FilterBase.h
+++ b/gtk/FilterBase.h
@@ -1,0 +1,53 @@
+// This file Copyright © 2022-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "GtkCompat.h"
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/filter.h>
+#else
+#include <glibmm/object.h>
+#endif
+
+template<typename T>
+class FilterBase : public IF_GTKMM4(Gtk::Filter, Glib::Object)
+{
+public:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    enum class Change{
+        DIFFERENT,
+        LESS_STRICT,
+        MORE_STRICT,
+    };
+#endif
+
+public:
+    ~FilterBase() override = default;
+
+    virtual bool match(T const& item) const = 0;
+
+    virtual bool matches_all() const;
+    virtual bool matches_none() const;
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    sigc::signal<void(Change)>& signal_changed();
+#endif
+
+protected:
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+    // Gtk::Filter
+    bool match_vfunc(Glib::RefPtr<Glib::ObjectBase> const& object) override;
+    Match get_strictness_vfunc() override;
+#else
+    void changed(Change change);
+#endif
+
+private:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    sigc::signal<void(Change)> signal_changed_;
+#endif
+};

--- a/gtk/FilterBase.hh
+++ b/gtk/FilterBase.hh
@@ -1,0 +1,67 @@
+// This file Copyright © 2022-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "FilterBase.h"
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include "Utils.h"
+#endif
+
+template<typename T>
+bool FilterBase<T>::matches_all() const
+{
+    return false;
+}
+
+template<typename T>
+bool FilterBase<T>::matches_none() const
+{
+    return false;
+}
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+
+template<typename T>
+bool FilterBase<T>::match_vfunc(Glib::RefPtr<Glib::ObjectBase> const& object)
+{
+    auto const concrete_object = gtr_ptr_dynamic_cast<T>(object);
+    g_return_val_if_fail(concrete_object != nullptr, false);
+
+    return match(*concrete_object);
+}
+
+template<typename T>
+typename FilterBase<T>::Match FilterBase<T>::get_strictness_vfunc()
+{
+    if (matches_all())
+    {
+        return Match::ALL;
+    }
+
+    if (matches_none())
+    {
+        return Match::NONE;
+    }
+
+    return Match::SOME;
+}
+
+#else
+
+template<typename T>
+sigc::signal<void(typename FilterBase<T>::Change)>& FilterBase<T>::signal_changed()
+{
+    return signal_changed_;
+}
+
+template<typename T>
+void FilterBase<T>::changed(Change change)
+{
+    signal_changed_.emit(change);
+}
+
+#endif

--- a/gtk/FilterListModel.h
+++ b/gtk/FilterListModel.h
@@ -1,0 +1,54 @@
+// This file Copyright © 2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "GtkCompat.h"
+
+#include <giomm/listmodel.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/filterlistmodel.h>
+#else
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelfilter.h>
+#endif
+
+template<typename ItemT>
+class FilterBase;
+
+template<typename ItemT>
+class FilterListModel : public IF_GTKMM4(Gtk::FilterListModel, Gtk::TreeModelFilter)
+{
+public:
+    using FilterType = FilterBase<ItemT>;
+
+public:
+    FilterListModel(Glib::RefPtr<Gio::ListModel> const& model, Glib::RefPtr<FilterType> const& filter);
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    FilterListModel(Glib::RefPtr<Gtk::TreeModel> const& model, Glib::RefPtr<FilterType> const& filter);
+    ~FilterListModel() override;
+
+    guint get_n_items() const;
+
+    sigc::signal<void(guint, guint, guint)>& signal_items_changed();
+#endif
+
+    template<typename ModelT>
+    static Glib::RefPtr<FilterListModel<ItemT>> create(
+        Glib::RefPtr<ModelT> const& model,
+        Glib::RefPtr<FilterType> const& filter);
+
+private:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    bool matches_all_ = false;
+    bool matches_none_ = false;
+
+    sigc::signal<void(guint, guint, guint)> signal_items_changed_;
+
+    sigc::connection signal_changed_tag_;
+#endif
+};

--- a/gtk/FilterListModel.hh
+++ b/gtk/FilterListModel.hh
@@ -1,0 +1,96 @@
+// This file Copyright © 2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "FilterBase.hh"
+#include "FilterListModel.h"
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+#include "ListModelAdapter.h"
+#include "Utils.h"
+#endif
+
+template<typename ItemT>
+FilterListModel<ItemT>::FilterListModel(Glib::RefPtr<Gio::ListModel> const& model, Glib::RefPtr<FilterType> const& filter)
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+    : Gtk::FilterListModel(model, filter)
+#else
+    : FilterListModel(gtr_ptr_static_cast<Gtk::TreeModel>(ListModelAdapter::create<ItemT>(model)), filter)
+#endif
+{
+}
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+
+template<typename ItemT>
+FilterListModel<ItemT>::FilterListModel(Glib::RefPtr<Gtk::TreeModel> const& model, Glib::RefPtr<FilterType> const& filter)
+    : Gtk::TreeModelFilter(model)
+    , matches_all_(filter->matches_all())
+    , matches_none_(filter->matches_none())
+{
+    static auto const& self_col = ItemT::get_columns().self;
+
+    auto const filter_func = [this, filter](const_iterator const& iter)
+    {
+        if (matches_all_)
+        {
+            return true;
+        }
+
+        if (matches_none_)
+        {
+            return false;
+        }
+
+        auto const* const self = iter->get_value(self_col);
+        g_return_val_if_fail(self != nullptr, false);
+
+        return filter->match(*self);
+    };
+
+    set_visible_func(filter_func);
+
+    signal_changed_tag_ = filter->signal_changed().connect(
+        [this, filter](auto /*changes*/)
+        {
+            matches_all_ = filter->matches_all();
+            matches_none_ = filter->matches_none();
+            refilter();
+        });
+
+    signal_row_inserted().connect([this](auto const& path, auto const& /*iter*/)
+                                  { signal_items_changed_.emit(path.front(), 0, 1); });
+    signal_row_deleted().connect([this](auto const& path) { signal_items_changed_.emit(path.front(), 1, 0); });
+}
+
+template<typename ItemT>
+FilterListModel<ItemT>::~FilterListModel()
+{
+    signal_changed_tag_.disconnect();
+}
+
+template<typename ItemT>
+guint FilterListModel<ItemT>::get_n_items() const
+{
+    return children().size();
+}
+
+template<typename ItemT>
+sigc::signal<void(guint, guint, guint)>& FilterListModel<ItemT>::signal_items_changed()
+{
+    return signal_items_changed_;
+}
+
+#endif
+
+template<typename ItemT>
+template<typename ModelT>
+Glib::RefPtr<FilterListModel<ItemT>> FilterListModel<ItemT>::create(
+    Glib::RefPtr<ModelT> const& model,
+    Glib::RefPtr<FilterType> const& filter)
+{
+    return Glib::make_refptr_for_instance(new FilterListModel(model, filter));
+}

--- a/gtk/SortListModel.h
+++ b/gtk/SortListModel.h
@@ -1,0 +1,43 @@
+// This file Copyright © 2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "GtkCompat.h"
+
+#include <giomm/listmodel.h>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/sortlistmodel.h>
+#else
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelsort.h>
+#endif
+
+template<typename ItemT>
+class SorterBase;
+
+template<typename ItemT>
+class SortListModel : public IF_GTKMM4(Gtk::SortListModel, Gtk::TreeModelSort)
+{
+public:
+    using SorterType = SorterBase<ItemT>;
+
+public:
+    SortListModel(Glib::RefPtr<Gio::ListModel> const& model, Glib::RefPtr<SorterType> const& sorter);
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    SortListModel(Glib::RefPtr<Gtk::TreeModel> const& model, Glib::RefPtr<SorterType> const& sorter);
+    ~SortListModel() override;
+#endif
+
+    template<typename ModelT>
+    static Glib::RefPtr<SortListModel<ItemT>> create(Glib::RefPtr<ModelT> const& model, Glib::RefPtr<SorterType> const& sorter);
+
+private:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    sigc::connection signal_changed_tag_;
+#endif
+};

--- a/gtk/SortListModel.hh
+++ b/gtk/SortListModel.hh
@@ -31,7 +31,7 @@ SortListModel<ItemT>::SortListModel(Glib::RefPtr<Gtk::TreeModel> const& model, G
 {
     static auto const& self_col = ItemT::get_columns().self;
 
-    auto const sort_func = [this, sorter](const_iterator const& lhs, const_iterator const& rhs)
+    auto const sort_func = [sorter](const_iterator const& lhs, const_iterator const& rhs)
     {
         auto const* const lhs_self = lhs->get_value(self_col);
         auto const* const rhs_self = rhs->get_value(self_col);

--- a/gtk/SortListModel.hh
+++ b/gtk/SortListModel.hh
@@ -1,0 +1,71 @@
+// This file Copyright © 2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "SorterBase.hh"
+#include "SortListModel.h"
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+#include "ListModelAdapter.h"
+#include "Utils.h"
+#endif
+
+template<typename ItemT>
+SortListModel<ItemT>::SortListModel(Glib::RefPtr<Gio::ListModel> const& model, Glib::RefPtr<SorterType> const& sorter)
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+    : Gtk::SortListModel(model, sorter)
+#else
+    : SortListModel(gtr_ptr_static_cast<Gtk::TreeModel>(ListModelAdapter::create<ItemT>(model)), sorter)
+#endif
+{
+}
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+
+template<typename ItemT>
+SortListModel<ItemT>::SortListModel(Glib::RefPtr<Gtk::TreeModel> const& model, Glib::RefPtr<SorterType> const& sorter)
+    : Gtk::TreeModelSort(model)
+{
+    static auto const& self_col = ItemT::get_columns().self;
+
+    auto const sort_func = [this, sorter](const_iterator const& lhs, const_iterator const& rhs)
+    {
+        auto const* const lhs_self = lhs->get_value(self_col);
+        auto const* const rhs_self = rhs->get_value(self_col);
+
+        if (lhs_self == nullptr && rhs_self == nullptr)
+        {
+            g_return_val_if_reached(0);
+        }
+
+        g_return_val_if_fail(lhs_self != nullptr, -1);
+        g_return_val_if_fail(rhs_self != nullptr, 1);
+
+        return sorter->compare(*lhs_self, *rhs_self);
+    };
+
+    set_default_sort_func(sort_func);
+
+    signal_changed_tag_ = sorter->signal_changed().connect([this, sort_func](auto /*changes*/)
+                                                           { set_default_sort_func(sort_func); });
+}
+
+template<typename ItemT>
+SortListModel<ItemT>::~SortListModel()
+{
+    signal_changed_tag_.disconnect();
+}
+
+#endif
+
+template<typename ItemT>
+template<typename ModelT>
+Glib::RefPtr<SortListModel<ItemT>> SortListModel<ItemT>::create(
+    Glib::RefPtr<ModelT> const& model,
+    Glib::RefPtr<SorterType> const& sorter)
+{
+    return Glib::make_refptr_for_instance(new SortListModel(model, sorter));
+}

--- a/gtk/SorterBase.h
+++ b/gtk/SorterBase.h
@@ -1,0 +1,51 @@
+// This file Copyright © 2022-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "GtkCompat.h"
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <gtkmm/sorter.h>
+#else
+#include <glibmm/object.h>
+#endif
+
+template<typename T>
+class SorterBase : public IF_GTKMM4(Gtk::Sorter, Glib::Object)
+{
+public:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    enum class Change{
+        DIFFERENT,
+        INVERTED,
+        LESS_STRICT,
+        MORE_STRICT,
+    };
+#endif
+
+public:
+    ~SorterBase() override = default;
+
+    virtual int compare(T const& lhs, T const& rhs) const = 0;
+
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    sigc::signal<void(Change)>& signal_changed();
+#endif
+
+protected:
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+    // Gtk::Sorter
+    Gtk::Ordering compare_vfunc(gpointer lhs, gpointer rhs) override;
+    Order get_order_vfunc() override;
+#else
+    void changed(Change change);
+#endif
+
+private:
+#if !GTKMM_CHECK_VERSION(4, 0, 0)
+    sigc::signal<void(Change)> signal_changed_;
+#endif
+};

--- a/gtk/SorterBase.hh
+++ b/gtk/SorterBase.hh
@@ -1,0 +1,49 @@
+// This file Copyright © 2022-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "SorterBase.h"
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+
+template<typename T>
+Gtk::Ordering SorterBase<T>::compare_vfunc(gpointer lhs, gpointer rhs)
+{
+    auto const* const concrete_lhs = dynamic_cast<T const*>(Glib::wrap_auto(static_cast<GObject*>(lhs)));
+    auto const* const concrete_rhs = dynamic_cast<T const*>(Glib::wrap_auto(static_cast<GObject*>(rhs)));
+
+    if (concrete_lhs == nullptr && concrete_lhs == nullptr)
+    {
+        g_return_val_if_reached(Gtk::Ordering::EQUAL);
+    }
+
+    g_return_val_if_fail(concrete_lhs != nullptr, Gtk::Ordering::SMALLER);
+    g_return_val_if_fail(concrete_rhs != nullptr, Gtk::Ordering::LARGER);
+
+    return Gtk::Ordering{ compare(*concrete_lhs, *concrete_rhs) };
+}
+
+template<typename T>
+Gtk::Sorter::Order SorterBase<T>::get_order_vfunc()
+{
+    return Gtk::Sorter::Order::PARTIAL;
+}
+
+#else
+
+template<typename T>
+sigc::signal<void(typename SorterBase<T>::Change)>& SorterBase<T>::signal_changed()
+{
+    return signal_changed_;
+}
+
+template<typename T>
+void SorterBase<T>::changed(Change change)
+{
+    signal_changed_.emit(change);
+}
+
+#endif

--- a/gtk/TorrentFilter.h
+++ b/gtk/TorrentFilter.h
@@ -1,32 +1,18 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
 #pragma once
 
-#include "GtkCompat.h"
+#include "FilterBase.h"
 #include "Torrent.h"
 
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
 
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-#include <gtkmm/filter.h>
-#else
-#include <glibmm/object.h>
-#endif
-
-class TorrentFilter : public IF_GTKMM4(Gtk::Filter, Glib::Object)
+class TorrentFilter : public FilterBase<Torrent>
 {
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change{
-        DIFFERENT,
-        LESS_STRICT,
-        MORE_STRICT,
-    };
-#endif
-
 public:
     enum class Activity
     {
@@ -55,27 +41,17 @@ public:
     bool match_tracker(Torrent const& torrent) const;
     bool match_text(Torrent const& torrent) const;
 
-    bool match(Torrent const& torrent) const;
+    // FilterBase<Torrent>
+    bool match(Torrent const& torrent) const override;
+    bool matches_all() const override;
 
     void update(Torrent::ChangeFlags changes);
-
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    sigc::signal<void()>& signal_changed();
-#endif
 
     static Glib::RefPtr<TorrentFilter> create();
 
     static bool match_activity(Torrent const& torrent, Activity type);
     static bool match_tracker(Torrent const& torrent, Tracker type, Glib::ustring const& host);
     static bool match_text(Torrent const& torrent, Glib::ustring const& text);
-
-protected:
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-    bool match_vfunc(Glib::RefPtr<Glib::ObjectBase> const& item) override;
-    Match get_strictness_vfunc() override;
-#else
-    void changed(Change change);
-#endif
 
 private:
     TorrentFilter();
@@ -85,8 +61,4 @@ private:
     Tracker tracker_type_ = Tracker::ALL;
     Glib::ustring tracker_host_;
     Glib::ustring text_;
-
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    sigc::signal<void()> signal_changed_;
-#endif
 };

--- a/gtk/TorrentSorter.h
+++ b/gtk/TorrentSorter.h
@@ -1,55 +1,29 @@
-// This file Copyright © 2022 Mnemosyne LLC.
+// This file Copyright © 2022-2023 Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
 #pragma once
 
-#include "GtkCompat.h"
+#include "SorterBase.h"
 #include "Torrent.h"
 
 #include <glibmm/refptr.h>
 
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-#include <gtkmm/sorter.h>
-#else
-#include <glibmm/object.h>
-#endif
-
-class TorrentSorter : public IF_GTKMM4(Gtk::Sorter, Glib::Object)
+class TorrentSorter : public SorterBase<Torrent>
 {
     using CompareFunc = int (*)(Torrent const&, Torrent const&);
-
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change{
-        DIFFERENT,
-        INVERTED,
-        LESS_STRICT,
-        MORE_STRICT,
-    };
-#endif
 
 public:
     void set_mode(std::string_view mode);
     void set_reversed(bool is_reversed);
 
-    int compare(Torrent const& lhs, Torrent const& rhs) const;
+    // SorterBase<Torrent>
+    int compare(Torrent const& lhs, Torrent const& rhs) const override;
 
     void update(Torrent::ChangeFlags changes);
 
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    sigc::signal<void()>& signal_changed();
-#endif
-
     static Glib::RefPtr<TorrentSorter> create();
-
-protected:
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-    Gtk::Ordering compare_vfunc(gpointer lhs, gpointer rhs) override;
-    Order get_order_vfunc() override;
-#else
-    void changed(Change change);
-#endif
 
 private:
     TorrentSorter();
@@ -57,8 +31,4 @@ private:
 private:
     CompareFunc compare_func_ = nullptr;
     bool is_reversed_ = false;
-
-#if !GTKMM_CHECK_VERSION(4, 0, 0)
-    sigc::signal<void()> signal_changed_;
-#endif
 };


### PR DESCRIPTION
Factor out parts of `TorrentFilter` and `TorrentSorter` classes into reusable `FilterBase<>` and `SorterBase<>` templates.

Factor out filter and sort models setup from `FilterBar` and `Session` classes into reusable `FilterListModel<>` and `SortListModel<>` templates.