### PR TITLE
test: GH Action should only try pack-msi if making dist or qt

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -389,7 +389,7 @@ jobs:
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install
       - name: Package
-        if: ${{ needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true' }}
+        if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
           cmake --build obj --config RelWithDebInfo --target pack-msi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -389,6 +389,7 @@ jobs:
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install
       - name: Package
+        if: ${{ needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true' }}
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
           cmake --build obj --config RelWithDebInfo --target pack-msi


### PR DESCRIPTION
Try to fix a recent CI issue where the Windows GitHub actions will  fail on `error: unknown target 'pack-msi'` e.g. [this build](https://github.com/transmission/transmission/actions/runs/3868921795/jobs/6594694631).

@mikedld I _think_ this is right but am not sure; would appreciate a 2nd opinion here