### PR TITLE
Fix GitHub CI actions warning for set-output

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -93,7 +93,7 @@ jobs:
           ./code_style.sh
           set +e
           git diff --exit-code > style.diff
-          echo "::set-output name=differs::$?"
+          echo "differs=$?" >> $GITHUB_OUTPUT
           cat style.diff
           set -e
       - name: Upload Diffs


### PR DESCRIPTION
Closes #4478