### PR TITLE
feat: change 403 error message

### DIFF
--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -204,7 +204,7 @@ constexpr bool tr_strvSep(std::string_view* sv, std::string_view* token, char de
 
 [[nodiscard]] std::string_view tr_strvStrip(std::string_view str);
 
-[[nodiscard]] std::string tr_strv_replace_invalid(std::string_view cleanme, uint32_t replacement = 0xFFFD /*�*/);
+[[nodiscard]] std::string tr_strv_replace_invalid(std::string_view sv, uint32_t replacement = 0xFFFD /*�*/);
 
 /**
  * @brief copies `src` into `buf`.


### PR DESCRIPTION
Change the http server's error messages to be more generic, on the theory that it will be harder for an attacker to determine what software is running.

Fixes #693.