### PR TITLE
chore: simplify announcer add callback

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -145,7 +145,7 @@ public:
     tr_announcer_impl& operator=(tr_announcer_impl&&) = delete;
     tr_announcer_impl& operator=(tr_announcer_impl const&) = delete;
 
-    tr_torrent_announcer* addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data) override;
+    tr_torrent_announcer* addTorrent(tr_torrent* tor, tr_tracker_callback callback) override;
     void startTorrent(tr_torrent* tor) override;
     void stopTorrent(tr_torrent* tor) override;
     void resetTorrent(tr_torrent* tor) override;
@@ -623,7 +623,6 @@ struct tr_torrent_announcer
     std::vector<tr_tier> tiers;
 
     tr_tracker_callback callback = nullptr;
-    void* callback_data = nullptr;
 
 private:
     [[nodiscard]] static tr_announce_list getAnnounceList(tr_torrent const* tor)
@@ -661,7 +660,7 @@ void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event::Type 
             event.announce_url = current_tracker->announce_url;
         }
 
-        (*ta->callback)(tier->tor, &event, ta->callback_data);
+        (*ta->callback)(tier->tor, &event);
     }
 }
 
@@ -690,7 +689,7 @@ void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
         e.leechers = leechers;
         tr_logAddDebugTier(tier, fmt::format("peer counts: {} seeders, {} leechers.", seeders, leechers));
 
-        (*tier->tor->torrent_announcer->callback)(tier->tor, &e, nullptr);
+        (*tier->tor->torrent_announcer->callback)(tier->tor, &e);
     }
 }
 
@@ -711,7 +710,7 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
                 leechers,
                 std::size(pex)));
 
-        (*tier->tor->torrent_announcer->callback)(tier->tor, &e, nullptr);
+        (*tier->tor->torrent_announcer->callback)(tier->tor, &e);
     }
 }
 } // namespace publish_helpers
@@ -719,13 +718,12 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
 
 // ---
 
-tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_callback callback, void* callback_data)
+tr_torrent_announcer* tr_announcer_impl::addTorrent(tr_torrent* tor, tr_tracker_callback callback)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
     auto* ta = new tr_torrent_announcer{ this, tor };
     ta->callback = callback;
-    ta->callback_data = callback_data;
     return ta;
 }
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -59,7 +59,7 @@ struct tr_tracker_event
     int seeders;
 };
 
-using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* event, void* client_data);
+using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* event);
 
 class tr_announcer
 {
@@ -70,7 +70,7 @@ public:
         std::atomic<size_t>& n_pending_stops);
     virtual ~tr_announcer() = default;
 
-    virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback, void* callback_data) = 0;
+    virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback) = 0;
     virtual void startTorrent(tr_torrent* tor) = 0;
     virtual void stopTorrent(tr_torrent* tor) = 0;
     virtual void resetTorrent(tr_torrent* tor) = 0;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1025,7 +1025,7 @@ bool isNewTorrentASeed(tr_torrent* tor)
     return tor->ensurePieceIsChecked(0);
 }
 
-void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event, void* /*user_data*/)
+void onTrackerResponse(tr_torrent* tor, tr_tracker_event const* event)
 {
     switch (event->type)
     {
@@ -1212,7 +1212,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         }
     }
 
-    tor->torrent_announcer = session->announcer_->addTorrent(tor, onTrackerResponse, nullptr);
+    tor->torrent_announcer = session->announcer_->addTorrent(tor, onTrackerResponse);
 
     if (is_new_torrent)
     {


### PR DESCRIPTION
Extra callback data is not actually used and so can be dropped