### PR TITLE
refactor: use std::function for announcer callback

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -622,7 +622,7 @@ struct tr_torrent_announcer
 
     std::vector<tr_tier> tiers;
 
-    tr_tracker_callback callback = nullptr;
+    tr_tracker_callback callback;
 
 private:
     [[nodiscard]] static tr_announce_list getAnnounceList(tr_torrent const* tor)
@@ -660,7 +660,7 @@ void publishMessage(tr_tier* tier, std::string_view msg, tr_tracker_event::Type 
             event.announce_url = current_tracker->announce_url;
         }
 
-        (*ta->callback)(tier->tor, &event);
+        ta->callback(*tier->tor, &event);
     }
 }
 
@@ -689,7 +689,7 @@ void publishPeerCounts(tr_tier* tier, int seeders, int leechers)
         e.leechers = leechers;
         tr_logAddDebugTier(tier, fmt::format("peer counts: {} seeders, {} leechers.", seeders, leechers));
 
-        (*tier->tor->torrent_announcer->callback)(tier->tor, &e);
+        tier->tor->torrent_announcer->callback(*tier->tor, &e);
     }
 }
 
@@ -710,7 +710,7 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
                 leechers,
                 std::size(pex)));
 
-        (*tier->tor->torrent_announcer->callback)(tier->tor, &e);
+        tier->tor->torrent_announcer->callback(*tier->tor, &e);
     }
 }
 } // namespace publish_helpers

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -59,7 +59,7 @@ struct tr_tracker_event
     int seeders;
 };
 
-using tr_tracker_callback = void (*)(tr_torrent* tor, tr_tracker_event const* event);
+using tr_tracker_callback = std::function<void(tr_torrent&, tr_tracker_event const*)>;
 
 class tr_announcer
 {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -432,6 +432,8 @@ public:
 
     bool setTrackerList(std::string_view text);
 
+    void onTrackerResponse(tr_tracker_event const* event);
+
     /// METAINFO - WEBSEEDS
 
     [[nodiscard]] TR_CONSTEXPR20 auto webseedCount() const noexcept


### PR DESCRIPTION
This is a follow-up for the recently merged https://github.com/transmission/transmission/pull/4573 and mostly intended to use `tr_torrent` methods as an announcer callback functions.