### PR TITLE
add https checkbox

### DIFF
--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -286,6 +286,7 @@ enum
     TR_KEY_recent_relocate_dir_4,
     TR_KEY_recheckProgress,
     TR_KEY_remote_session_enabled,
+    TR_KEY_remote_session_https,
     TR_KEY_remote_session_host,
     TR_KEY_remote_session_password,
     TR_KEY_remote_session_port,

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -91,6 +91,7 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items{
     { FILTER_TRACKERS, TR_KEY_filter_trackers, QVariant::String },
     { FILTER_TEXT, TR_KEY_filter_text, QVariant::String },
     { SESSION_IS_REMOTE, TR_KEY_remote_session_enabled, QVariant::Bool },
+    { SESSION_REMOTE_HTTPS, TR_KEY_remote_session_https, QVariant::Bool },
     { SESSION_REMOTE_HOST, TR_KEY_remote_session_host, QVariant::String },
     { SESSION_REMOTE_PORT, TR_KEY_remote_session_port, QVariant::Int },
     { SESSION_REMOTE_AUTH, TR_KEY_remote_session_requres_authentication, QVariant::Bool },
@@ -466,6 +467,7 @@ void Prefs::initDefaults(tr_variant* d) const
     dictAdd(d, TR_KEY_filter_mode, FilterMode);
     dictAdd(d, TR_KEY_main_window_layout_order, WindowLayout);
     dictAdd(d, TR_KEY_open_dialog_dir, QDir::home().absolutePath());
+    dictAdd(d, TR_KEY_remote_session_https, false);
     dictAdd(d, TR_KEY_remote_session_host, SessionHost);
     dictAdd(d, TR_KEY_remote_session_password, SessionPassword);
     dictAdd(d, TR_KEY_remote_session_username, SessionUsername);

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -70,6 +70,7 @@ public:
         COMPLETE_SOUND_ENABLED,
         USER_HAS_GIVEN_INFORMED_CONSENT,
         READ_CLIPBOARD,
+        SESSION_REMOTE_HTTPS,
         /* core prefs */
         FIRST_CORE_PREF,
         ALT_SPEED_LIMIT_UP = FIRST_CORE_PREF,

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -330,7 +330,14 @@ void Session::start()
     if (prefs_.get<bool>(Prefs::SESSION_IS_REMOTE))
     {
         QUrl url;
-        url.setScheme(QStringLiteral("http"));
+        if (prefs_.get<bool>(Prefs::SESSION_REMOTE_HTTPS))
+        {
+            url.setScheme(QStringLiteral("https"));
+        }
+        else
+        {
+            url.setScheme(QStringLiteral("http"));
+        }
         url.setHost(prefs_.get<QString>(Prefs::SESSION_REMOTE_HOST));
         url.setPort(prefs_.get<int>(Prefs::SESSION_REMOTE_PORT));
         url.setPath(QStringLiteral("/transmission/rpc"));

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -14,6 +14,7 @@
 void SessionDialog::accept()
 {
     prefs_.set(Prefs::SESSION_IS_REMOTE, ui_.remoteSessionRadio->isChecked());
+    prefs_.set(Prefs::SESSION_REMOTE_HTTPS, ui_.httpsCheck->isChecked());
     prefs_.set(Prefs::SESSION_REMOTE_HOST, ui_.hostEdit->text());
     prefs_.set(Prefs::SESSION_REMOTE_PORT, ui_.portSpin->value());
     prefs_.set(Prefs::SESSION_REMOTE_AUTH, ui_.authCheck->isChecked());
@@ -55,6 +56,9 @@ SessionDialog::SessionDialog(Session& session, Prefs& prefs, QWidget* parent)
 
     ui_.remoteSessionRadio->setChecked(prefs.get<bool>(Prefs::SESSION_IS_REMOTE));
     connect(ui_.remoteSessionRadio, &QAbstractButton::toggled, this, &SessionDialog::resensitize);
+
+    ui_.httpsCheck->setChecked(prefs.get<bool>(Prefs::SESSION_REMOTE_HTTPS));
+    remote_widgets_ << ui_.httpsCheck;
 
     ui_.hostEdit->setText(prefs.get<QString>(Prefs::SESSION_REMOTE_HOST));
     remote_widgets_ << ui_.hostLabel << ui_.hostEdit;

--- a/qt/SessionDialog.ui
+++ b/qt/SessionDialog.ui
@@ -46,7 +46,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="2" column="0" colspan="2">
+      <widget class="QCheckBox" name="httpsCheck">
+       <property name="text">
+        <string>&amp;Use HTTPS</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
       <widget class="QLabel" name="hostLabel">
        <property name="text">
         <string>&amp;Host:</string>
@@ -56,10 +63,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QLineEdit" name="hostEdit"/>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="portLabel">
        <property name="text">
         <string>&amp;Port:</string>
@@ -69,7 +76,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QSpinBox" name="portSpin">
        <property name="minimum">
         <number>1</number>
@@ -79,14 +86,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="2">
+     <item row="5" column="0" colspan="2">
       <widget class="QCheckBox" name="authCheck">
        <property name="text">
         <string>&amp;Authentication required</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="usernameLabel">
        <property name="text">
         <string>&amp;Username:</string>
@@ -96,10 +103,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLineEdit" name="usernameEdit"/>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="passwordLabel">
        <property name="text">
         <string>Pass&amp;word:</string>
@@ -109,7 +116,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QLineEdit" name="passwordEdit">
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>


### PR DESCRIPTION
This is a rather naive implementation that copies parts of the SESSION_REMOTE_HOST settings and replaces HOST with HTTPS, basically. We pull some ideas from the SESSION_REMOTE_AUTH parameter as well (because it's a boolean) and we otherwise do not really know what we are doing here.

In particular, we didn't add a new commandline flag for this, as I am not sure what it would be called.

I would have much rather this be turned in a single URL instead of having flags, UI elements and settings for what is ultimately just a string, but that is yet another yak to shave...

Closes: #1294