### PR TITLE
fix: when comparing priority for rpc call, cast to string first

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1184,12 +1184,12 @@ $video-image: '../img/film.svg';
 
   > * {
     appearance: none;
-    background-color: var(--color-bg-primary);
     background-position: center;
     background-repeat: no-repeat;
     background-size: $halfsize, $size;
     border: 1px solid var(--color-border);
     height: $size;
+    background-color: var(--color-border-selected);
     margin: 0;
     padding: 0;
     width: $size;
@@ -1209,9 +1209,9 @@ $video-image: '../img/film.svg';
     border-left-width: 0;
   }
 
-  //if input is not checked, change background color
-  > *:not(:checked) {
-    background-color: var(--color-border-selected);
+  //if input is checked then change the background color
+  > .checked {
+    background-color: var(--color-bg-hover);
   }
 }
 

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1184,12 +1184,12 @@ $video-image: '../img/film.svg';
 
   > * {
     appearance: none;
+    background-color: var(--color-border-selected);
     background-position: center;
     background-repeat: no-repeat;
     background-size: $halfsize, $size;
     border: 1px solid var(--color-border);
     height: $size;
-    background-color: var(--color-border-selected);
     margin: 0;
     padding: 0;
     width: $size;

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -513,11 +513,6 @@ $video-image: '../img/film.svg';
     &.selected {
       background-color: var(--color-bg-selected);
     }
-
-    &.selected .torrent-progress-details.error,
-    &.selected .torrent-peer-details.error {
-      color: $white;
-    }
   }
 
   .icon {

--- a/web/src/file-row.js
+++ b/web/src/file-row.js
@@ -4,7 +4,12 @@
    License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
-import { addCheckedClass, makeUUID, setEnabled, setTextContent } from './utils.js';
+import {
+  addCheckedClass,
+  makeUUID,
+  setEnabled,
+  setTextContent,
+} from './utils.js';
 
 export class FileRow extends EventTarget {
   isDone() {

--- a/web/src/file-row.js
+++ b/web/src/file-row.js
@@ -4,7 +4,7 @@
    License text can be found in the licenses/ folder. */
 
 import { Formatter } from './formatter.js';
-import { makeUUID, setChecked, setEnabled, setTextContent } from './utils.js';
+import { addCheckedClass, makeUUID, setEnabled, setTextContent } from './utils.js';
 
 export class FileRow extends EventTarget {
   isDone() {
@@ -48,11 +48,11 @@ export class FileRow extends EventTarget {
       have += file.bytesCompleted;
       size += file.length;
       wanted |= file.wanted;
-      switch (file.priority) {
-        case -1:
+      switch (file.priority.toString()) {
+        case '-1':
           low = true;
           break;
-        case 1:
+        case '1':
           high = true;
           break;
         default:
@@ -61,9 +61,9 @@ export class FileRow extends EventTarget {
       }
     }
 
-    setChecked(this.elements.priority_low_button, low);
-    setChecked(this.elements.priority_normal_button, normal);
-    setChecked(this.elements.priority_high_button, high);
+    addCheckedClass(this.elements.priority_low_button, low);
+    addCheckedClass(this.elements.priority_normal_button, normal);
+    addCheckedClass(this.elements.priority_high_button, high);
 
     if (this.fields.have !== have || this.fields.size !== size) {
       this.fields.have = have;
@@ -132,7 +132,7 @@ export class FileRow extends EventTarget {
 
     e = document.createElement('input');
     e.type = 'radio';
-    e.value = -1;
+    e.value = '-1';
     e.className = 'low';
     e.title = 'Low Priority';
     e.addEventListener('click', priority_click_listener);
@@ -141,7 +141,7 @@ export class FileRow extends EventTarget {
 
     e = document.createElement('input');
     e.type = 'radio';
-    e.value = 0;
+    e.value = '0';
     e.className = 'normal';
     e.title = 'Normal Priority';
     e.addEventListener('click', priority_click_listener);
@@ -150,7 +150,7 @@ export class FileRow extends EventTarget {
 
     e = document.createElement('input');
     e.type = 'radio';
-    e.value = 1;
+    e.value = '1';
     e.title = 'High Priority';
     e.className = 'high';
     e.addEventListener('click', priority_click_listener);

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -825,11 +825,11 @@ export class Inspector extends EventTarget {
     const { indices, priority } = event_;
 
     let command = null;
-    switch (priority) {
-      case -1:
+    switch (priority.toString()) {
+      case '-1':
         command = 'priority-low';
         break;
-      case 1:
+      case '1':
         command = 'priority-high';
         break;
       default:

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -268,6 +268,10 @@ export function setChecked(element, b) {
   setOrDeleteAttribute(element, 'checked', b);
 }
 
+export function addCheckedClass(element, b) {
+  element.classList.toggle('checked', b);
+}
+
 function getBestMenuPos(r, bounds) {
   let { x, y } = r;
   const { width, height } = r;


### PR DESCRIPTION
fix: when comparing priority for rpc call, cast to string first https://github.com/transmission/transmission/issues/3763
When clicking on priority buttons, you could only set to normal, not high or low.

This is because the switch was comparing "1" to `1`, `-1`, or default. (And default was getting selected.)

I believe this was from the original rewrite from 2 years ago.

- use toString on file.priority
- compare string to string instead of number to string
- use that!

Fixes #3763.

Notes: Fixed `4.0.0-beta.1` regression that broke file priority buttons in the web client.