### PR TITLE
daemon: check whether log file is regular and may be flushed

### DIFF
--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -47,6 +47,7 @@ private:
     bool seen_hup_ = false;
     std::string config_dir_;
     tr_variant settings_ = {};
+    bool logfile_flush_ = false;
     tr_session* my_session_ = nullptr;
     char const* log_file_name_ = nullptr;
     struct event_base* ev_base_ = nullptr;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -798,7 +798,7 @@ bool tr_sys_file_flush(tr_sys_file_t handle, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
 
-    bool const ret = (isatty(handle) != 0) || (fsync(handle) != -1);
+    bool const ret = (fsync(handle) != -1);
 
     if (!ret)
     {
@@ -806,6 +806,21 @@ bool tr_sys_file_flush(tr_sys_file_t handle, tr_error** error)
     }
 
     return ret;
+}
+
+bool tr_sys_file_flush_possible(tr_sys_file_t handle, tr_error** error)
+{
+    TR_ASSERT(handle != TR_BAD_SYS_FILE);
+
+    struct stat statbuf;
+
+    if (fstat(handle, &statbuf) != 0)
+    {
+        set_system_error(error, errno);
+        return false;
+    }
+
+    return S_ISREG(statbuf.st_mode);
 }
 
 bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error** error)

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1106,6 +1106,21 @@ bool tr_sys_file_flush(tr_sys_file_t handle, tr_error** error)
     return ret;
 }
 
+bool tr_sys_file_flush_possible(tr_sys_file_t handle, tr_error** error)
+{
+    TR_ASSERT(handle != TR_BAD_SYS_FILE);
+
+    DWORD type = GetFileType(handle);
+
+    if (type == FILE_TYPE_UNKNOWN)
+    {
+        set_system_error(error, GetLastError());
+        return false;
+    }
+
+    return type == FILE_TYPE_DISK;
+}
+
 bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error** error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -445,6 +445,9 @@ bool tr_sys_file_write_at(
  */
 bool tr_sys_file_flush(tr_sys_file_t handle, struct tr_error** error = nullptr);
 
+/* @brief Check whether `handle` may be flushed via `tr_sys_file_flush()`. */
+bool tr_sys_file_flush_possible(tr_sys_file_t handle, struct tr_error** error = nullptr);
+
 /**
  * @brief Portability wrapper for `ftruncate()`.
  *


### PR DESCRIPTION
When running as a `systemd` unit, standard error of `transmission-daemon` is redirected to a socket, so `isatty()` precaution added in https://github.com/transmission/transmission/commit/2bcb8f8535a08764ff51e836cb5a9ecbc614a7fc is not enough. This is the real one.