### PR TITLE
Add valid dtor, move ctor, and move operator= for tr_peer_socket

### DIFF
--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -32,12 +32,28 @@ public:
     tr_peer_socket() = default;
     tr_peer_socket(tr_session const* session, tr_address const& address, tr_port port, tr_socket_t sock);
     tr_peer_socket(tr_address const& address, tr_port port, struct UTPSocket* const sock);
-    tr_peer_socket(tr_peer_socket&&) = default;
+    tr_peer_socket(tr_peer_socket&& s)
+    {
+        *this = std::move(s);
+    }
     tr_peer_socket(tr_peer_socket const&) = delete;
-    tr_peer_socket& operator=(tr_peer_socket&&) = default;
+    tr_peer_socket& operator=(tr_peer_socket&& s)
+    {
+        close();
+        handle = s.handle;
+        address_ = s.address_;
+        port_ = s.port_;
+        type_ = s.type_;
+        // invalidate s.type_, s.handle so s.close() won't break anything
+        s.type_ = Type::None;
+        s.handle = {};
+        return *this;
+    }
     tr_peer_socket& operator=(tr_peer_socket const&) = delete;
-    ~tr_peer_socket() = default;
-
+    ~tr_peer_socket()
+    {
+        close();
+    }
     void close();
 
     size_t try_write(Buffer& buf, size_t max, tr_error** error) const;


### PR DESCRIPTION
Default implementations for these functions may leak sockets during destructing and moving.
For example, the original default destructor and move assignment operator of tr_peer_socket will leak the socket the object originally holds when called, and the original move constructor and move assignment operator do not cleanly invalidate or "absorb" the object passed in.

Sadly this commit does not fix what issue #3677, the leaked sockets seem to come from the http tracker client based on libcurl.