### PR TITLE
Destroy message dialog on error (#3805 regression)

### DIFF
--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -99,17 +99,19 @@ bool RelocateDialog::Impl::onTimer()
             TR_GTK_BUTTONS_TYPE(CLOSE),
             true);
 
-        timer_.block();
         d->signal_response().connect(
             [this, d](int /*response*/) mutable
             {
-                timer_.unblock();
                 d.reset();
+                message_dialog_.reset();
+                dialog_.close();
             });
 
         d->show();
+        return false;
     }
-    else if (done_ == TR_LOC_DONE)
+
+    if (done_ == TR_LOC_DONE)
     {
         if (!torrent_ids_.empty())
         {
@@ -117,11 +119,13 @@ bool RelocateDialog::Impl::onTimer()
         }
         else
         {
+            message_dialog_.reset();
             dialog_.close();
+            return false;
         }
     }
 
-    return G_SOURCE_CONTINUE;
+    return true;
 }
 
 void RelocateDialog::Impl::onResponse(int response)


### PR DESCRIPTION
Notes: Fixed `4.0.0-beta.1` regression making it impossible to close "Set location" dialog (GTK 3 only).

Fixes: #4606