### PR TITLE
fix: largefile support cmake tests

### DIFF
--- a/cmake/LargeFileSupport.cmake
+++ b/cmake/LargeFileSupport.cmake
@@ -7,8 +7,8 @@ if(NOT DEFINED NO_LFS_MACROS_REQUIRED)
     # We can't simply define LARGE_OFF_T to be 9223372036854775807,
     # since some C++ compilers masquerading as C compilers
     # incorrectly reject 9223372036854775807.
-    set(LFS_TEST_PROGRAM
-        "#include <sys/types.h>
+    set(LFS_TEST_PROGRAM "
+        #include <sys/types.h>
         #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
         int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1];
         int main() { return 0; }")

--- a/cmake/LargeFileSupport.cmake
+++ b/cmake/LargeFileSupport.cmake
@@ -7,6 +7,9 @@ if(NOT DEFINED NO_LFS_MACROS_REQUIRED)
     # We can't simply define LARGE_OFF_T to be 9223372036854775807,
     # since some C++ compilers masquerading as C compilers
     # incorrectly reject 9223372036854775807.
+    #
+    # Begin with a linefeed to ensure the first line isn't part
+    # of the #defines below
     set(LFS_TEST_PROGRAM "
         #include <sys/types.h>
         #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))


### PR DESCRIPTION
Fixes #4626.

Add a linefeed to the beginning of `LFS_TEST_PROGRAM`.

The issue comes a little later down in the diff:

```
    check_c_source_compiles("${LFS_TEST_PROGRAM}" NO_LFS_MACROS_REQUIRED)
    if(NOT NO_LFS_MACROS_REQUIRED)
        if(NOT DEFINED FILE_OFFSET_BITS_LFS_MACRO_REQUIRED)
            check_c_source_compiles("#define _FILE_OFFSET_BITS 64 ${LFS_TEST_PROGRAM}" FILE_OFFSET_BITS_LFS_MACRO_REQUIRED)
            if(NOT FILE_OFFSET_BITS_LFS_MACRO_REQUIRED AND NOT DEFINED LARGE_FILES_LFS_MACRO_REQUIRED)
                check_c_source_compiles("#define _LARGE_FILES 1 ${LFS_TEST_PROGRAM}" LARGE_FILES_LFS_MACRO_REQUIRED)
            endif()
        endif()
```

Note that `${LFS_TEST_PROGRAM}` comes on the same line as the `#define`, so the line `#include <sys/types.h>` was being included as part of the `#define` macro which made the second and third calls to `check_c_source_compiles()` to fail, meaning that `-D_FILE_OFFSET_BITS` and `-D_LARGE_FILES` never got used from this file.

Looks like https://github.com/transmission/transmission/pull/4507 broke this for `4.0.0-beta.3`