### PR TITLE
fix(remote): Crash caused by typo when displaying tracker info

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1602,7 +1602,7 @@ static void printTrackersImpl(tr_variant* trackerStats)
                     break;
 
                 case TR_TRACKER_WAITING:
-                    fmt::print("  Asking for more peers in {:s)\n", tr_strltime(nextAnnounceTime - now));
+                    fmt::print("  Asking for more peers in {:s}\n", tr_strltime(nextAnnounceTime - now));
                     break;
 
                 case TR_TRACKER_QUEUED:


### PR DESCRIPTION
This caused a crash when running `transmission-remote -t1 -it`