### PR TITLE
fix: announcer not updated after torrent announce list edited

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1102,6 +1102,7 @@ char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
     }
 
     tor->announceList().save(tor->torrentFile());
+    tor->on_announce_list_changed();
 
     return nullptr;
 }
@@ -1128,6 +1129,7 @@ char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
     }
 
     tor->announceList().save(tor->torrentFile());
+    tor->on_announce_list_changed();
 
     return nullptr;
 }
@@ -1154,6 +1156,7 @@ char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
     }
 
     tor->announceList().save(tor->torrentFile());
+    tor->on_announce_list_changed();
 
     return nullptr;
 }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -845,7 +845,10 @@ public:
 
     void fetch(tr_web::FetchOptions&& options) const
     {
-        web_->fetch(std::move(options));
+        if (web_)
+        {
+            web_->fetch(std::move(options));
+        }
     }
 
     [[nodiscard]] constexpr auto const& bandwidthGroups() const noexcept

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2189,8 +2189,7 @@ bool tr_torrent::setTrackerList(std::string_view text)
         }
     }
 
-    /* tell the announcer to reload this torrent's tracker list */
-    this->session->announcer_->resetTorrent(this);
+    on_announce_list_changed();
 
     return true;
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -788,6 +788,13 @@ public:
         return announce_key_;
     }
 
+    // should be called when done modifying the torrent's announce list.
+    void on_announce_list_changed()
+    {
+        markEdited();
+        session->announcer_->resetTorrent(this);
+    }
+
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;


### PR DESCRIPTION
Fixes #4632.

Notes: Fixed `4.0.0-beta.1` regression that did not update the UI when a user removed a tracker from the announce list.