### PR TITLE
chore: pin brew libpsl to 0.21.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -180,7 +180,7 @@ jobs:
           echo '${{ toJSON(runner) }}'
           sw_vers
       - name: Get Dependencies
-        run: brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja
+        run: brew install cmake gettext libdeflate libevent libnatpmp libpsl@0.21.1 miniupnpc ninja
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: brew install gtkmm3 libjpeg
@@ -451,7 +451,7 @@ jobs:
           echo '${{ toJSON(runner) }}'
           sw_vers
       - name: Get Dependencies
-        run: brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja
+        run: brew install cmake gettext libdeflate libevent libnatpmp libpsl@0.21.1 miniupnpc ninja
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: brew install gtkmm3 libjpeg


### PR DESCRIPTION
temporary workaround for Homebrew/homebrew-core/issues/121081 since we're still hitting this on fresh install CI boxes.

IDK what the pipeline is for homebrew but presumably this will work itself out; will check back in a week.