### PR TITLE
build: add webapp github actions

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -1,0 +1,147 @@
+name: webapp
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+jobs:
+  decide-what-jobs-to-run:
+    runs-on: ubuntu-22.04
+    outputs:
+      test-style: ${{ steps.check-diffs.outputs.web-changed == '1' }}
+      test-generated-files: ${{ steps.check-diffs.outputs.web-changed == '1' && steps.check-main-push.outputs.is-main-push == '0'}}
+      update-generated-files: ${{ steps.check-diffs.outputs.web-changed == '1' && steps.check-main-push.outputs.is-main-push == '1'}}
+    steps:
+      - name: Show env
+        run: |
+          env | sort
+      - name: Get source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2 # >1 needed for merge base
+      - name: Check push-to-main
+        id: check-main-push
+        run: |
+          set -x # echo all executed commands to the terminal
+          if [ "$GITHUB_EVENT_NAME" = 'push' ] && [ "$GITHUB_REF_NAME" = 'main' ]; then
+            echo is-main-push=1 >> "$GITHUB_OUTPUT"
+          else
+            echo is-main-push=0 >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check for diffs
+        id: check-diffs
+        run: |
+          git --no-pager log -n100
+          set -x # echo all executed commands to the terminal
+          function get_changes() { # name, paths...
+            local name="$1"
+            shift
+            if [ "$GITHUB_EVENT_NAME" = 'push' ] && [ "$GITHUB_REF_NAME" = 'main' ]; then
+              DIFF_TARGET='--name-only HEAD^'
+            else
+              git fetch --depth=1 origin "$GITHUB_BASE_REF"
+              DIFF_TARGET="--merge-base origin/$GITHUB_BASE_REF"
+            fi
+            set +e # do not abort if git --exit-code returns nonzero
+            git diff --exit-code ${DIFF_TARGET} -- "$@"
+            echo "$name-changed=$?" >> "$GITHUB_OUTPUT"
+          }
+          get_changes web CMakeLists.txt web
+
+  code-style:
+    runs-on: ubuntu-latest
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.test-style == 'true' }}
+    steps:
+      - name: Get source
+        uses: actions/checkout@v3
+      - name: Get dependencies
+        run: |
+          set -e # abort if any command fails
+          sudo apt-get install -y npm
+      - name: Check for style diffs
+        id: check-for-diffs
+        run: |
+          set -x # echo all executed commands to the terminal
+          set -e # abort if any command fails
+          npm --prefix web ci
+          npm --prefix web run lint:fix
+          set +e # do not end the script if a cmd returns an exit code
+          git diff --exit-code web > style.diff
+          echo "differs=$?" >> $GITHUB_OUTPUT
+          echo ===
+          cat style.diff
+          echo ===
+          set -e # undo set +e
+      - name: Upload diffs
+        uses: actions/upload-artifact@v3
+        if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
+        with:
+          name: code-style.diff
+          path: 'style.diff'
+      - name: Fail if diffs exist
+        if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
+        run: |
+          echo "code style does not match expected."
+          cat style.diff
+          echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
+          exit 1
+
+  test-generated-files:
+    runs-on: ubuntu-latest
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.test-generated-files == 'true' }}
+    steps:
+      - name: Get source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2 # >1 needed for merge base
+      - name: Check for changes to generated files
+        run: |
+          git fetch --quiet --depth=1 origin "$GITHUB_BASE_REF"
+          set -e # abort if diff --exit-code fails
+          echo
+          echo Hello, code contributor!
+          echo For security reasons, ${GITHUB_REPOSITORY} does not accept PRs that change generated files.
+          echo
+          echo Please undo your changes to these files:
+          git diff --exit-code --name-only --merge-base "origin/$GITHUB_BASE_REF" -- \
+              web/public_html/transmission-app.js \
+              web/public_html/transmission-app.js.map \
+              web/public_html/transmission-app.js.LICENSE.txt
+
+  update-generated-files:
+    runs-on: ubuntu-latest
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.update-generated-files == 'true' }}
+    steps:
+      - name: Show env
+        run: |
+          env | sort
+      - name: Get dependencies
+        run: |
+          set -e # abort if any command fails
+          sudo apt-get install -y npm
+      - name: Get source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2 # >1 needed for merge base
+      - name: Generate webapp files
+        run: |
+          set -x # echo all executed commands to the terminal
+          set -e # abort if any command fails
+          npm --prefix web ci
+          npm --prefix web run build
+          git diff --name-only
+          git add --update web
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: 'chore/update-webapp-files'
+          commit-message: 'chore: update generated transmission-web files'
+          delete-branch: true
+          title: 'chore: update generated transmission-web files'
+          body: Generated from https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -14,9 +14,6 @@ jobs:
       test-generated-files: ${{ steps.check-diffs.outputs.web-changed == '1' && steps.check-main-push.outputs.is-main-push == '0'}}
       update-generated-files: ${{ steps.check-diffs.outputs.web-changed == '1' && steps.check-main-push.outputs.is-main-push == '1'}}
     steps:
-      - name: Show env
-        run: |
-          env | sort
       - name: Get source
         uses: actions/checkout@v3
         with:
@@ -33,7 +30,6 @@ jobs:
       - name: Check for diffs
         id: check-diffs
         run: |
-          git --no-pager log -n100
           set -x # echo all executed commands to the terminal
           function get_changes() { # name, paths...
             local name="$1"


### PR DESCRIPTION
Fixes #4060.
Fixes #4042.
Supersedes #4061.

## Description

Adds GitHub actions to:

- Fail CI if a user-submitted PR changes generated files (e.g. `transmission-app.js`).
- Open a new PR ([sample](https://github.com/ckerr/transmission/pull/10)) that refreshes the generated files when changes to the web app source code are pushed into `main`.
- Lint any changes to the web app's source code.

## Rationale:

- User-submitted changes to generated files are a potential attack vector #4060 or bug vector #4024

- Generating the files at build time on systems without internet access is problematic since `npm install` requires adding an npm cache that's populated from another system. #4042 

- Generating the files at build time on older systems is problematic since their package repositories may not have access to a modern version of Node. We have to choose between supporting old systems **or** supported devDependencies. #4644

- Generating the files at build time can be annoying since many people don't use the web client, but installing Node.js + npm + the devDependencies is quite heavyweight. https://github.com/transmission/transmission/pull/4061#issuecomment-1401313316