### PR TITLE
fix: ensure prefs window is centered the first time shown

### DIFF
--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -398,6 +398,7 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     }
     windowRect.size.width = [sizeString floatValue];
     [self.window setFrame:windowRect display:YES animate:NO];
+    [self.window center];
 }
 
 //for a beta release, always use the beta appcast

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -209,6 +209,8 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     self.window.toolbar = toolbar;
 
     [self setWindowSize];
+    [self.window center];
+
     [self setPrefView:nil];
 
     //set special-handling of magnet link add window checkbox
@@ -398,7 +400,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     }
     windowRect.size.width = [sizeString floatValue];
     [self.window setFrame:windowRect display:YES animate:NO];
-    [self.window center];
 }
 
 //for a beta release, always use the beta appcast


### PR DESCRIPTION
Fixes #4657.

After the first time, subsequent calls are always centered via 
https://github.com/transmission/transmission/blob/096db96bca139bf6623ecc937dca282d183c02ff/macosx/Controller.mm#L2219 .