### PR TITLE
fix: omit curlopt options if curl is old

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -516,8 +516,10 @@ public:
 
         if (!curl_ssl_verify)
         {
+#if LIBCURL_VERSION_NUM >= 0x073400 /* 7.52.0 */
             (void)curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
             (void)curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
+#endif
         }
         else if (!std::empty(curl_ca_bundle))
         {
@@ -539,7 +541,9 @@ public:
         }
         else if (!std::empty(curl_ca_bundle))
         {
+#if LIBCURL_VERSION_NUM >= 0x073400 /* 7.52.0 */
             (void)curl_easy_setopt(e, CURLOPT_PROXY_CAINFO, curl_ca_bundle.c_str());
+#endif
         }
 
         if (auto const& ua = user_agent; !std::empty(ua))


### PR DESCRIPTION
Fixes #4674.

Notes: Fixed 4.0.0-beta.1 FTBFS error on CentOS 7.