### PR TITLE
refactor: tidy libtransmission symbol visibility

### DIFF
--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -229,6 +229,16 @@ public:
         return this->band_[direction].honor_parent_limits_;
     }
 
+    [[nodiscard]] tr_bandwidth_limits getLimits() const;
+
+    void setLimits(tr_bandwidth_limits const* limits);
+
+    [[nodiscard]] constexpr auto* parent() noexcept
+    {
+        return parent_;
+    }
+
+private:
     struct RateControl
     {
         std::array<uint64_t, HistorySize> date_;
@@ -248,16 +258,6 @@ public:
         bool honor_parent_limits_ = true;
     };
 
-    [[nodiscard]] tr_bandwidth_limits getLimits() const;
-
-    void setLimits(tr_bandwidth_limits const* limits);
-
-    [[nodiscard]] constexpr auto* parent() noexcept
-    {
-        return parent_;
-    }
-
-private:
     static tr_bytes_per_second_t getSpeedBytesPerSecond(RateControl& r, unsigned int interval_msec, uint64_t now);
 
     static void notifyBandwidthConsumedBytes(uint64_t now, RateControl* r, size_t size);

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -119,8 +119,6 @@ public:
 
     void setParent(tr_bandwidth* new_parent);
 
-    void deparent() noexcept;
-
     [[nodiscard]] constexpr tr_priority_t getPriority() const noexcept
     {
         return this->priority_;
@@ -233,11 +231,6 @@ public:
 
     void setLimits(tr_bandwidth_limits const* limits);
 
-    [[nodiscard]] constexpr auto* parent() noexcept
-    {
-        return parent_;
-    }
-
 private:
     struct RateControl
     {
@@ -259,6 +252,13 @@ private:
     };
 
     static tr_bytes_per_second_t getSpeedBytesPerSecond(RateControl& r, unsigned int interval_msec, uint64_t now);
+
+    [[nodiscard]] constexpr auto* parent() noexcept
+    {
+        return parent_;
+    }
+
+    void deparent() noexcept;
 
     static void notifyBandwidthConsumedBytes(uint64_t now, RateControl* r, size_t size);
 

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -138,7 +138,7 @@ public:
     }
 
     /** @brief Get the raw total of bytes read or sent by this bandwidth subtree. */
-    [[nodiscard]] tr_bytes_per_second_t getRawSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
+    [[nodiscard]] auto getRawSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
     {
         TR_ASSERT(tr_isDirection(dir));
 
@@ -146,7 +146,7 @@ public:
     }
 
     /** @brief Get the number of piece data bytes read or sent by this bandwidth subtree. */
-    [[nodiscard]] tr_bytes_per_second_t getPieceSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
+    [[nodiscard]] auto getPieceSpeedBytesPerSecond(uint64_t const now, tr_direction const dir) const
     {
         TR_ASSERT(tr_isDirection(dir));
 
@@ -166,6 +166,15 @@ public:
         return did_change;
     }
 
+    /**
+     * @brief Get the desired speed for the bandwidth subtree.
+     * @see `tr_bandwidth::setDesiredSpeed`
+     */
+    [[nodiscard]] constexpr auto getDesiredSpeedBytesPerSecond(tr_direction dir) const
+    {
+        return this->band_[dir].desired_speed_bps_;
+    }
+
     [[nodiscard]] bool is_maxed_out(tr_direction dir, uint64_t now_msec) const noexcept
     {
         if (!isLimited(dir))
@@ -176,15 +185,6 @@ public:
         auto const got = getPieceSpeedBytesPerSecond(now_msec, dir);
         auto const want = getDesiredSpeedBytesPerSecond(dir);
         return got >= want;
-    }
-
-    /**
-     * @brief Get the desired speed for the bandwidth subtree.
-     * @see `tr_bandwidth::setDesiredSpeed`
-     */
-    [[nodiscard]] constexpr tr_bytes_per_second_t getDesiredSpeedBytesPerSecond(tr_direction dir) const
-    {
-        return this->band_[dir].desired_speed_bps_;
     }
 
     /**

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -228,11 +228,6 @@ bool tr_bitfield::ensureNthBitAlloced(size_t nth)
     return true;
 }
 
-void tr_bitfield::freeArray() noexcept
-{
-    flags_ = std::vector<uint8_t>{};
-}
-
 void tr_bitfield::setTrueCount(size_t n) noexcept
 {
     TR_ASSERT(bit_count_ == 0 || n <= bit_count_);
@@ -247,11 +242,6 @@ void tr_bitfield::setTrueCount(size_t n) noexcept
     }
 
     TR_ASSERT(isValid());
-}
-
-void tr_bitfield::rebuildTrueCount() noexcept
-{
-    setTrueCount(countFlags());
 }
 
 void tr_bitfield::incrementTrueCount(size_t inc) noexcept

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -132,12 +132,20 @@ private:
 
     void ensureBitsAlloced(size_t n);
     [[nodiscard]] bool ensureNthBitAlloced(size_t nth);
-    void freeArray() noexcept;
 
-    void setTrueCount(size_t n) noexcept;
-    void rebuildTrueCount() noexcept;
+    void freeArray() noexcept
+    {
+        // move-assign to ensure the reserve memory is cleared
+        flags_ = std::vector<uint8_t>{};
+    }
+
     void incrementTrueCount(size_t inc) noexcept;
     void decrementTrueCount(size_t dec) noexcept;
+    void setTrueCount(size_t n) noexcept;
+    void rebuildTrueCount() noexcept
+    {
+        setTrueCount(countFlags());
+    }
 
     std::vector<uint8_t> flags_;
 

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -94,17 +94,6 @@ void tr_completion::amountDone(float* tab, size_t n_tabs) const
     }
 }
 
-size_t tr_completion::countMissingBlocksInPiece(tr_piece_index_t piece) const
-{
-    auto const [begin, end] = block_info_->blockSpanForPiece(piece);
-    return (end - begin) - blocks_.count(begin, end);
-}
-
-size_t tr_completion::countMissingBytesInPiece(tr_piece_index_t piece) const
-{
-    return block_info_->pieceSize(piece) - countHasBytesInPiece(piece);
-}
-
 std::vector<uint8_t> tr_completion::createPieceBitfield() const
 {
     size_t const n = block_info_->pieceCount();

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -118,8 +118,16 @@ struct tr_completion
 
     [[nodiscard]] std::vector<uint8_t> createPieceBitfield() const;
 
-    [[nodiscard]] size_t countMissingBlocksInPiece(tr_piece_index_t) const;
-    [[nodiscard]] size_t countMissingBytesInPiece(tr_piece_index_t) const;
+    [[nodiscard]] size_t countMissingBlocksInPiece(tr_piece_index_t piece) const
+    {
+        auto const [begin, end] = block_info_->blockSpanForPiece(piece);
+        return (end - begin) - blocks_.count(begin, end);
+    }
+
+    [[nodiscard]] size_t countMissingBytesInPiece(tr_piece_index_t piece) const
+    {
+        return block_info_->pieceSize(piece) - countHasBytesInPiece(piece);
+    }
 
     void amountDone(float* tab, size_t n_tabs) const;
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -694,21 +694,16 @@ std::pair<sockaddr_storage, socklen_t> tr_address::to_sockaddr(tr_port port) con
     return { ss, sizeof(sockaddr_in6) };
 }
 
-static int tr_address_compare(tr_address const* a, tr_address const* b) noexcept // <=>
-{
-    // IPv6 addresses are always "greater than" IPv4
-    if (a->type != b->type)
-    {
-        return a->is_ipv4() ? 1 : -1;
-    }
-
-    return a->is_ipv4() ? memcmp(&a->addr.addr4, &b->addr.addr4, sizeof(a->addr.addr4)) :
-                          memcmp(&a->addr.addr6.s6_addr, &b->addr.addr6.s6_addr, sizeof(a->addr.addr6.s6_addr));
-}
-
 int tr_address::compare(tr_address const& that) const noexcept // <=>
 {
-    return tr_address_compare(this, &that);
+    // IPv6 addresses are always "greater than" IPv4
+    if (this->type != that.type)
+    {
+        return this->is_ipv4() ? 1 : -1;
+    }
+
+    return this->is_ipv4() ? memcmp(&this->addr.addr4, &that.addr.addr4, sizeof(this->addr.addr4)) :
+                             memcmp(&this->addr.addr6.s6_addr, &that.addr.addr6.s6_addr, sizeof(this->addr.addr6.s6_addr));
 }
 
 // https://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -417,6 +417,8 @@ void tr_net_close_socket(tr_socket_t sockfd)
     evutil_closesocket(sockfd);
 }
 
+namespace
+{
 // code in global_ipv6_herlpers is written by Juliusz Chroboczek
 // and is covered under the same license as dht.cc.
 // Please feel free to copy them into your software if it can help
@@ -482,6 +484,7 @@ namespace global_ipv6_helpers
 }
 
 } // namespace global_ipv6_helpers
+} // namespace
 
 /* Return our global IPv6 address, with caching. */
 std::optional<tr_address> tr_globalIPv6()
@@ -503,6 +506,8 @@ std::optional<tr_address> tr_globalIPv6()
 
 // ---
 
+namespace
+{
 namespace is_valid_for_peers_helpers
 {
 
@@ -543,6 +548,7 @@ namespace is_valid_for_peers_helpers
 }
 
 } // namespace is_valid_for_peers_helpers
+} // namespace
 
 bool tr_address::is_valid_for_peers(tr_port port) const noexcept
 {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1233,6 +1233,8 @@ void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t piece_index)
     tr_announcerAddBytes(tor, TR_ANN_CORRUPT, byte_count);
 }
 
+namespace
+{
 namespace get_peers_helpers
 {
 
@@ -1296,6 +1298,7 @@ struct CompareAtomsByUsefulness
 }
 
 } // namespace get_peers_helpers
+} // namespace
 
 std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t address_type, uint8_t list_mode, size_t max_peer_count)
 {
@@ -1533,6 +1536,8 @@ tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i)
     return i >= n ? tr_webseed_view{} : tr_webseedView(tor->swarm->webseeds[i].get());
 }
 
+namespace
+{
 namespace peer_stat_helpers
 {
 
@@ -1634,6 +1639,7 @@ namespace peer_stat_helpers
 }
 
 } // namespace peer_stat_helpers
+} // namespace
 
 tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, size_t* setme_count)
 {
@@ -1666,11 +1672,10 @@ void tr_peerMgrClearInterest(tr_torrent* tor)
     std::for_each(std::begin(peers), std::end(peers), [](auto* const peer) { peer->set_interested(false); });
 }
 
-namespace rechoke_downloads_helpers
-{
 namespace
 {
-
+namespace rechoke_downloads_helpers
+{
 /* does this peer have any pieces that we want? */
 [[nodiscard]] bool isPeerInteresting(
     tr_torrent const* const tor,
@@ -1737,8 +1742,6 @@ struct tr_rechoke_info
     int rechoke_state;
     uint8_t salt;
 };
-
-} // namespace
 
 /* determines who we send "interested" messages to */
 void rechokeDownloads(tr_swarm* s)
@@ -1896,16 +1899,15 @@ void rechokeDownloads(tr_swarm* s)
         rechoke[i].peer->set_interested(i < s->interested_count);
     }
 }
-
 } // namespace rechoke_downloads_helpers
+} // namespace
 
 // ---
 
-namespace rechoke_uploads_helpers
-{
 namespace
 {
-
+namespace rechoke_uploads_helpers
+{
 struct ChokeData
 {
     ChokeData(tr_peerMsgs* msgs_in, int rate_in, uint8_t salt_in, bool is_interested_in, bool was_choked_in, bool is_choked_in)
@@ -1974,8 +1976,6 @@ struct ChokeData
 // an optimistically unchoked peer is immune from rechoking
 // for this many calls to rechokeUploads().
 auto constexpr OptimisticUnchokeMultiplier = uint8_t{ 4 };
-
-} // namespace
 
 void rechokeUploads(tr_swarm* s, uint64_t const now)
 {
@@ -2090,8 +2090,8 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
         item.msgs->set_choke(item.is_choked);
     }
 }
-
 } // namespace rechoke_uploads_helpers
+} // namespace
 
 void tr_peerMgr::rechokePulse() const
 {
@@ -2122,9 +2122,9 @@ void tr_peerMgr::rechokePulse() const
 
 // --- Life and Death
 
-namespace disconnect_helpers
-{
 namespace
+{
+namespace disconnect_helpers
 {
 // when many peers are available, keep idle ones this long
 auto constexpr MinUploadIdleSecs = time_t{ 60 };
@@ -2248,8 +2248,6 @@ struct ComparePeerByActivity
     return peers_to_close;
 }
 
-} // namespace
-
 void closeBadPeers(tr_swarm* s, time_t const now_sec)
 {
     for (auto* peer : getPeersToClose(s, now_sec))
@@ -2296,8 +2294,8 @@ void enforceSessionPeerLimit(tr_session* session)
         std::for_each(std::begin(peers) + max, std::end(peers), closePeer);
     }
 }
-
 } // namespace disconnect_helpers
+} // namespace
 
 void tr_peerMgr::reconnectPulse()
 {
@@ -2340,6 +2338,8 @@ void tr_peerMgr::reconnectPulse()
 
 // --- Bandwidth Allocation
 
+namespace
+{
 namespace bandwidth_helpers
 {
 
@@ -2373,6 +2373,7 @@ void queuePulse(tr_session* session, tr_direction dir)
 }
 
 } // namespace bandwidth_helpers
+} // namespace
 
 void tr_peerMgr::bandwidthPulse()
 {
@@ -2405,11 +2406,10 @@ bool tr_swarm::peer_is_in_use(peer_atom const& atom) const
         manager->incoming_handshakes.count(atom.addr) != 0U;
 }
 
-namespace connect_helpers
-{
 namespace
 {
-
+namespace connect_helpers
+{
 /* is this atom someone that we'd want to initiate a connection to? */
 [[nodiscard]] bool isPeerCandidate(tr_torrent const* tor, peer_atom const& atom, time_t const now)
 {
@@ -2529,8 +2529,6 @@ struct peer_candidate
 
     return score;
 }
-
-} // namespace
 
 /** @return an array of all the atoms we might want to connect to */
 [[nodiscard]] std::vector<peer_candidate> getPeerCandidates(tr_session* session, size_t max)
@@ -2655,8 +2653,8 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     atom.lastConnectionAttemptAt = now;
     atom.time = now;
 }
-
 } // namespace connect_helpers
+} // namespace
 
 void tr_peerMgr::makeNewPeerConnections(size_t max)
 {

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -16,6 +16,8 @@
 
 using namespace std::literals;
 
+namespace
+{
 namespace wi
 {
 using key_t = math::wide_integer::uintwide_t<
@@ -61,6 +63,7 @@ auto WIDE_INTEGER_CONSTEXPR const prime = wi::key_t{
 // NOLINTEND(readability-identifier-naming)
 
 } // namespace wi
+} // namespace
 
 namespace tr_message_stream_encryption
 {

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -23,12 +23,15 @@
 
 using namespace std::literals;
 
+namespace
+{
 struct optional_args
 {
     std::optional<bool> paused;
     std::optional<uint16_t> peer_limit;
     std::string download_dir;
 };
+} // namespace
 
 /** Opaque class used when instantiating torrents.
  * @ingroup tr_ctor */

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -28,11 +28,14 @@
 #include "utils.h"
 #include "variant.h"
 
+namespace
+{
 struct metadata_node
 {
     time_t requested_at = 0U;
     int piece = 0;
 };
+} // namespace
 
 struct tr_incomplete_metadata
 {

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -53,12 +53,15 @@ std::string tr_torrent_metainfo::fixWebseedUrl(tr_torrent_metainfo const& tm, st
     return std::string{ url };
 }
 
-static auto constexpr MaxBencDepth = 32;
+namespace
+{
+auto constexpr MaxBencDepth = 32;
 
 bool tr_error_is_set(tr_error const* const* error)
 {
     return (error != nullptr) && (*error != nullptr);
 }
+} // namespace
 
 struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDepth>
 {

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -631,11 +631,6 @@ bool tr_torrent_metainfo::parseTorrentFile(std::string_view filename, std::vecto
     return tr_loadFile(filename, *contents, error) && parseBenc({ std::data(*contents), std::size(*contents) }, error);
 }
 
-tr_sha1_digest_t const& tr_torrent_metainfo::pieceHash(tr_piece_index_t piece) const
-{
-    return this->pieces_[piece];
-}
-
 tr_pathbuf tr_torrent_metainfo::makeFilename(
     std::string_view dirname,
     std::string_view name,

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -128,7 +128,10 @@ public:
         return is_private_;
     }
 
-    [[nodiscard]] tr_sha1_digest_t const& pieceHash(tr_piece_index_t piece) const;
+    [[nodiscard]] TR_CONSTEXPR20 tr_sha1_digest_t const& pieceHash(tr_piece_index_t piece) const
+    {
+        return pieces_[piece];
+    }
 
     [[nodiscard]] TR_CONSTEXPR20 bool hasV1Metadata() const noexcept
     {

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -25,8 +25,6 @@ namespace libtransmission
 class Buffer
 {
 public:
-    using Iovec = evbuffer_iovec;
-
     class Iterator
     {
     public:
@@ -132,7 +130,7 @@ public:
 
         evbuffer* buf_;
         evbuffer_ptr ptr_ = {};
-        Iovec iov_ = {};
+        evbuffer_iovec iov_ = {};
         size_t iov_offset_ = 0;
     };
 
@@ -247,21 +245,9 @@ public:
         return 0;
     }
 
-    [[nodiscard]] Iovec alloc(size_t n_bytes)
-    {
-        auto iov = Iovec{};
-        evbuffer_reserve_space(buf_.get(), static_cast<ev_ssize_t>(n_bytes), &iov, 1);
-        return iov;
-    }
-
     [[nodiscard]] std::pair<std::byte*, size_t> pullup()
     {
         return { reinterpret_cast<std::byte*>(evbuffer_pullup(buf_.get(), -1)), size() };
-    }
-
-    void commit(Iovec iov)
-    {
-        evbuffer_commit_space(buf_.get(), &iov, 1);
     }
 
     void reserve(size_t n_bytes)

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -204,7 +204,7 @@ constexpr std::string_view getPortForScheme(std::string_view scheme)
     return "-1"sv;
 }
 
-bool urlCharsAreValid(std::string_view url)
+TR_CONSTEXPR20 bool urlCharsAreValid(std::string_view url)
 {
     // rfc2396
     auto constexpr ValidChars = std::string_view{

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -43,6 +43,8 @@ using namespace std::literals;
 
 // ---
 
+namespace
+{
 namespace curl_helpers
 {
 
@@ -92,6 +94,7 @@ struct EasyDeleter
 using easy_unique_ptr = std::unique_ptr<CURL, EasyDeleter>;
 
 } // namespace curl_helpers
+} // namespace
 
 #ifdef _WIN32
 static CURLcode ssl_context_func(CURL* /*curl*/, void* ssl_ctx, void* /*user_data*/)


### PR DESCRIPTION
No functional changes.

- Ensure that helper functions are hidden in unnamed namespaces
- Make some class members private
- Remove some unused class methods