### PR TITLE
Fix webui filter selection on mobile

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -290,7 +290,7 @@ $toolbar-height: $toolbar-height-number * 1px;
   @include for-phone-only {
     padding: 5px 10px;
 
-    :not(select):not(input) {
+    :not(select):not(input):not(option) {
       display: none;
     }
 


### PR DESCRIPTION
On my phone screen, the two filter selections become empty lists.

Fix this by preventing display:none on option tags.