### PR TITLE
fix: clang-tidy header warnings

### DIFF
--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -157,7 +157,7 @@ public:
         return *this != std::string_view{ that != nullptr ? that : "" };
     }
 
-    constexpr operator std::string_view() const noexcept
+    [[nodiscard]] constexpr operator std::string_view() const noexcept
     {
         return sv();
     }

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -24,14 +24,14 @@ class Wishlist
 public:
     struct Mediator
     {
-        virtual bool clientCanRequestBlock(tr_block_index_t block) const = 0;
-        virtual bool clientCanRequestPiece(tr_piece_index_t piece) const = 0;
-        virtual bool isEndgame() const = 0;
-        virtual size_t countActiveRequests(tr_block_index_t block) const = 0;
-        virtual size_t countMissingBlocks(tr_piece_index_t piece) const = 0;
-        virtual tr_block_span_t blockSpan(tr_piece_index_t) const = 0;
-        virtual tr_piece_index_t countAllPieces() const = 0;
-        virtual tr_priority_t priority(tr_piece_index_t) const = 0;
+        [[nodiscard]] virtual bool clientCanRequestBlock(tr_block_index_t block) const = 0;
+        [[nodiscard]] virtual bool clientCanRequestPiece(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual bool isEndgame() const = 0;
+        [[nodiscard]] virtual size_t countActiveRequests(tr_block_index_t block) const = 0;
+        [[nodiscard]] virtual size_t countMissingBlocks(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual tr_block_span_t blockSpan(tr_piece_index_t) const = 0;
+        [[nodiscard]] virtual tr_piece_index_t countAllPieces() const = 0;
+        [[nodiscard]] virtual tr_priority_t priority(tr_piece_index_t) const = 0;
         virtual ~Mediator() = default;
     };
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -58,7 +58,7 @@ struct tr_pex
     tr_pex() = default;
 
     tr_pex(tr_address addr_in, tr_port port_in, uint8_t flags_in = {})
-        : addr{ std::move(addr_in) }
+        : addr{ addr_in }
         , port{ port_in }
         , flags{ flags_in }
     {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2291,7 +2291,7 @@ void tr_peerMsgsImpl::sendPex()
 
 tr_peerMsgs::~tr_peerMsgs()
 {
-    [[maybe_unused]] auto const n_prev = n_peers_--;
+    [[maybe_unused]] auto const n_prev = n_peers--;
     TR_ASSERT(n_prev > 0U);
 }
 

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -36,14 +36,14 @@ public:
         : tr_peer{ tor, atom_in }
         , have_{ tor->pieceCount() }
     {
-        ++n_peers_;
+        ++n_peers;
     }
 
     virtual ~tr_peerMsgs() override;
 
     [[nodiscard]] static size_t size() noexcept
     {
-        return n_peers_.load();
+        return n_peers.load();
     }
 
     [[nodiscard]] virtual bool is_peer_choked() const noexcept = 0;
@@ -78,7 +78,7 @@ protected:
     tr_bitfield have_;
 
 private:
-    static inline auto n_peers_ = std::atomic<size_t>{};
+    static inline auto n_peers = std::atomic<size_t>{};
 };
 
 tr_peerMsgs* tr_peerMsgsNew(

--- a/libtransmission/port-forwarding-upnp.h
+++ b/libtransmission/port-forwarding-upnp.h
@@ -22,10 +22,10 @@
 
 struct tr_upnp;
 
-tr_upnp* tr_upnpInit(void);
+tr_upnp* tr_upnpInit();
 
-void tr_upnpClose(tr_upnp*);
+void tr_upnpClose(tr_upnp* handle);
 
-tr_port_forwarding_state tr_upnpPulse(tr_upnp*, tr_port port, bool is_enabled, bool do_port_check, std::string);
+tr_port_forwarding_state tr_upnpPulse(tr_upnp*, tr_port port, bool is_enabled, bool do_port_check, std::string bindaddr);
 
 /* @} */

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -445,4 +445,4 @@ enum
  * exists for that string, it is returned so that no duplicates are
  * created.
  */
-[[nodiscard]] tr_quark tr_quark_new(std::string_view);
+[[nodiscard]] tr_quark tr_quark_new(std::string_view str);

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -65,7 +65,7 @@ public:
         return port_;
     }
 
-    void setPort(tr_port) noexcept;
+    void setPort(tr_port port) noexcept;
 
     [[nodiscard]] constexpr auto isEnabled() const noexcept
     {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -86,7 +86,7 @@ private:
     {
     public:
         using IncomingCallback = void (*)(tr_socket_t, void*);
-        BoundSocket(struct event_base*, tr_address const& addr, tr_port port, IncomingCallback cb, void* cb_data);
+        BoundSocket(struct event_base* base, tr_address const& addr, tr_port port, IncomingCallback cb, void* cb_data);
         BoundSocket(BoundSocket&&) = delete;
         BoundSocket(BoundSocket const&) = delete;
         BoundSocket operator=(BoundSocket&&) = delete;
@@ -281,7 +281,7 @@ private:
         tr_udp_core(tr_session& session, tr_port udp_port);
         ~tr_udp_core();
 
-        void sendto(void const* buf, size_t buflen, struct sockaddr const* to, socklen_t const tolen) const;
+        void sendto(void const* buf, size_t buflen, struct sockaddr const* to, socklen_t tolen) const;
 
         [[nodiscard]] constexpr auto socket4() const noexcept
         {

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -112,7 +112,7 @@ bool isJunkFile(std::string_view filename)
 
 std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     tr_file_index_t file_index,
-    std::string_view const* search_paths,
+    std::string_view const* paths,
     size_t n_paths) const
 {
     auto filename = tr_pathbuf{};
@@ -120,7 +120,7 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
 
     for (size_t path_idx = 0; path_idx < n_paths; ++path_idx)
     {
-        auto const base = search_paths[path_idx];
+        auto const base = paths[path_idx];
 
         filename.assign(base, '/', subpath);
         if (auto const info = tr_sys_path_get_info(filename); info)
@@ -138,11 +138,11 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     return {};
 }
 
-bool tr_torrent_files::hasAnyLocalData(std::string_view const* search_paths, size_t n_paths) const
+bool tr_torrent_files::hasAnyLocalData(std::string_view const* paths, size_t n_paths) const
 {
     for (tr_file_index_t i = 0, n = fileCount(); i < n; ++i)
     {
-        if (find(i, search_paths, n_paths))
+        if (find(i, paths, n_paths))
         {
             return true;
         }
@@ -179,7 +179,7 @@ bool tr_torrent_files::move(
         return false;
     }
 
-    auto const search_paths = std::array<std::string_view, 1>{ old_parent.sv() };
+    auto const paths = std::array<std::string_view, 1>{ old_parent.sv() };
 
     auto const total_size = totalSize();
     auto err = bool{};
@@ -187,7 +187,7 @@ bool tr_torrent_files::move(
 
     for (tr_file_index_t i = 0, n = fileCount(); i < n; ++i)
     {
-        auto const found = find(i, std::data(search_paths), std::size(search_paths));
+        auto const found = find(i, std::data(paths), std::size(paths));
         if (!found)
         {
             continue;
@@ -259,10 +259,10 @@ void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdi
     tr_sys_dir_create_temp(std::data(tmpdir));
 
     // move the local data to the tmpdir
-    auto const search_paths = std::array<std::string_view, 1>{ parent.sv() };
+    auto const paths = std::array<std::string_view, 1>{ parent.sv() };
     for (tr_file_index_t idx = 0, n_files = fileCount(); idx < n_files; ++idx)
     {
-        if (auto const found = find(idx, std::data(search_paths), std::size(search_paths)); found)
+        if (auto const found = find(idx, std::data(paths), std::size(paths)); found)
         {
             tr_moveFile(found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() });
         }

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -86,7 +86,7 @@ public:
         total_size_ = uint64_t{};
     }
 
-    auto sortedByPath() const
+    [[nodiscard]] auto sortedByPath() const
     {
         auto ret = std::vector<std::pair<std::string /*path*/, uint64_t /*size*/>>{};
         ret.reserve(std::size(files_));
@@ -152,8 +152,8 @@ public:
         size_t base_len_;
     };
 
-    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t, std::string_view const* search_paths, size_t n_paths) const;
-    [[nodiscard]] bool hasAnyLocalData(std::string_view const* search_paths, size_t n_paths) const;
+    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file, std::string_view const* paths, size_t n_paths) const;
+    [[nodiscard]] bool hasAnyLocalData(std::string_view const* paths, size_t n_paths) const;
 
     static void makeSubpathPortable(std::string_view path, tr_pathbuf& append_me);
 

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -216,7 +216,7 @@ private:
         BasenameFormat format,
         std::string_view suffix);
 
-    auto makeFilename(std::string_view dirname, BasenameFormat format, std::string_view suffix) const
+    [[nodiscard]] auto makeFilename(std::string_view dirname, BasenameFormat format, std::string_view suffix) const
     {
         return makeFilename(dirname, name(), infoHashString(), format, suffix);
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -52,7 +52,7 @@ bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_erro
 
 tr_session* tr_ctorGetSession(tr_ctor const* ctor);
 
-bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setmeIncompleteDir);
+bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setme_incomplete_dir);
 
 // ---
 
@@ -344,9 +344,9 @@ public:
         return file_priorities_.piecePriority(piece);
     }
 
-    void setFilePriorities(tr_file_index_t const* files, tr_file_index_t fileCount, tr_priority_t priority)
+    void setFilePriorities(tr_file_index_t const* files, tr_file_index_t file_count, tr_priority_t priority)
     {
-        file_priorities_.set(files, fileCount, priority);
+        file_priorities_.set(files, file_count, priority);
         setDirty();
     }
 
@@ -826,7 +826,7 @@ public:
      * peer_id that was registered by the peer. The peer_id from the tracker
      * and in the handshake are expected to match.
      */
-    tr_peer_id_t peer_id_;
+    tr_peer_id_t peer_id_ = {};
 
     tr_session* session = nullptr;
 
@@ -961,7 +961,7 @@ constexpr bool tr_isTorrent(tr_torrent const* tor)
 /**
  * Tell the `tr_torrent` that it's gotten a block
  */
-void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t blockIndex);
+void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
 
 tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -62,7 +62,7 @@ public:
         return get(key) != nullptr;
     }
 
-    [[nodiscard]] std::vector<tr_torrent_id_t> removedSince(time_t) const;
+    [[nodiscard]] std::vector<tr_torrent_id_t> removedSince(time_t timestamp) const;
 
     [[nodiscard]] TR_CONSTEXPR20 auto cbegin() const noexcept
     {

--- a/libtransmission/tr-arc4.h
+++ b/libtransmission/tr-arc4.h
@@ -51,7 +51,7 @@ public:
     {
         for (size_t i = 0; i < data_length; ++i)
         {
-            ((uint8_t*)dst_data)[i] = ((uint8_t const*)src_data)[i] ^ arc4_next();
+            static_cast<uint8_t*>(dst_data)[i] = static_cast<uint8_t const*>(src_data)[i] ^ arc4_next();
         }
     }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -583,7 +583,7 @@ uint64_t tr_htonll(uint64_t hostlonglong)
 {
 #ifdef HAVE_HTONLL
 
-    return htonll(x);
+    return htonll(hostlonglong);
 
 #else
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -579,7 +579,7 @@ bool tr_moveFile(std::string_view oldpath_in, std::string_view newpath_in, tr_er
 
 // ---
 
-uint64_t tr_htonll(uint64_t x)
+uint64_t tr_htonll(uint64_t hostlonglong)
 {
 #ifdef HAVE_HTONLL
 
@@ -593,18 +593,18 @@ uint64_t tr_htonll(uint64_t x)
         std::array<uint32_t, 2> lx;
         uint64_t llx;
     } u = {};
-    u.lx[0] = htonl(x >> 32);
-    u.lx[1] = htonl(x & 0xFFFFFFFFULL);
+    u.lx[0] = htonl(hostlonglong >> 32);
+    u.lx[1] = htonl(hostlonglong & 0xFFFFFFFFULL);
     return u.llx;
 
 #endif
 }
 
-uint64_t tr_ntohll(uint64_t x)
+uint64_t tr_ntohll(uint64_t netlonglong)
 {
 #ifdef HAVE_NTOHLL
 
-    return ntohll(x);
+    return ntohll(netlonglong);
 
 #else
 
@@ -614,7 +614,7 @@ uint64_t tr_ntohll(uint64_t x)
         std::array<uint32_t, 2> lx;
         uint64_t llx;
     } u = {};
-    u.llx = x;
+    u.llx = netlonglong;
     return ((uint64_t)ntohl(u.lx[0]) << 32) | (uint64_t)ntohl(u.lx[1]);
 
 #endif

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -155,7 +155,7 @@ template<typename T>
 template<typename T>
 [[nodiscard]] constexpr bool tr_strvContains(std::string_view sv, T key) noexcept // c++23
 {
-    return sv.find(key) != sv.npos;
+    return sv.find(key) != std::string_view::npos;
 }
 
 [[nodiscard]] constexpr bool tr_strvStartsWith(std::string_view sv, char key) // c++20
@@ -290,10 +290,10 @@ constexpr void tr_timeUpdate(time_t now) noexcept
 }
 
 /** @brief Portability wrapper for `htonll()` that uses the system implementation if available */
-[[nodiscard]] uint64_t tr_htonll(uint64_t);
+[[nodiscard]] uint64_t tr_htonll(uint64_t hostlonglong);
 
 /** @brief Portability wrapper for `ntohll()` that uses the system implementation if available */
-[[nodiscard]] uint64_t tr_ntohll(uint64_t);
+[[nodiscard]] uint64_t tr_ntohll(uint64_t netlonglong);
 
 // ---
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -75,7 +75,7 @@ constexpr char const* tr_variant_string_get_string(struct tr_variant_string cons
     }
 }
 
-void tr_variant_string_set_quark(struct tr_variant_string* str, tr_quark const quark)
+void tr_variant_string_set_quark(struct tr_variant_string* str, tr_quark quark)
 {
     tr_variant_string_clear(str);
 
@@ -123,7 +123,7 @@ constexpr char const* getStr(tr_variant const* v)
     return tr_variant_string_get_string(&v->val.s);
 }
 
-constexpr int dictIndexOf(tr_variant const* dict, tr_quark const key)
+constexpr int dictIndexOf(tr_variant const* dict, tr_quark key)
 {
     if (tr_variantIsDict(dict))
     {
@@ -139,7 +139,7 @@ constexpr int dictIndexOf(tr_variant const* dict, tr_quark const key)
     return -1;
 }
 
-bool dictFindType(tr_variant* dict, tr_quark const key, int type, tr_variant** setme)
+bool dictFindType(tr_variant* dict, tr_quark key, int type, tr_variant** setme)
 {
     *setme = tr_variantDictFind(dict, key);
     return tr_variantIsType(*setme, type);
@@ -169,7 +169,7 @@ tr_variant* containerReserve(tr_variant* v, size_t count)
     return v->val.l.vals + v->val.l.count;
 }
 
-tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark const key, int type)
+tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, int type)
 {
     /* see if it already exists, and if so, try to reuse it */
     tr_variant* child = tr_variantDictFind(dict, key);
@@ -197,7 +197,7 @@ tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark const key, int type)
 
 } // namespace
 
-tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark const key)
+tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark key)
 {
     auto const i = dictIndexOf(dict, key);
 
@@ -361,47 +361,47 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
     return success;
 }
 
-bool tr_variantDictFindInt(tr_variant* dict, tr_quark const key, int64_t* setme)
+bool tr_variantDictFindInt(tr_variant* dict, tr_quark key, int64_t* setme)
 {
     tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetInt(child, setme);
 }
 
-bool tr_variantDictFindBool(tr_variant* dict, tr_quark const key, bool* setme)
+bool tr_variantDictFindBool(tr_variant* dict, tr_quark key, bool* setme)
 {
     tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetBool(child, setme);
 }
 
-bool tr_variantDictFindReal(tr_variant* dict, tr_quark const key, double* setme)
+bool tr_variantDictFindReal(tr_variant* dict, tr_quark key, double* setme)
 {
     tr_variant const* child = tr_variantDictFind(dict, key);
     return tr_variantGetReal(child, setme);
 }
 
-bool tr_variantDictFindStrView(tr_variant* dict, tr_quark const key, std::string_view* setme)
+bool tr_variantDictFindStrView(tr_variant* dict, tr_quark key, std::string_view* setme)
 {
     tr_variant const* const child = tr_variantDictFind(dict, key);
     return tr_variantGetStrView(child, setme);
 }
 
-bool tr_variantDictFindList(tr_variant* dict, tr_quark const key, tr_variant** setme)
+bool tr_variantDictFindList(tr_variant* dict, tr_quark key, tr_variant** setme)
 {
     return dictFindType(dict, key, TR_VARIANT_TYPE_LIST, setme);
 }
 
-bool tr_variantDictFindDict(tr_variant* dict, tr_quark const key, tr_variant** setme)
+bool tr_variantDictFindDict(tr_variant* dict, tr_quark key, tr_variant** setme)
 {
     return dictFindType(dict, key, TR_VARIANT_TYPE_DICT, setme);
 }
 
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const** setme_raw, size_t* setme_len)
+bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, uint8_t const** setme_raw, size_t* setme_len)
 {
     auto const* child = tr_variantDictFind(dict, key);
     return tr_variantGetRaw(child, setme_raw, setme_len);
 }
 
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, std::byte const** setme_raw, size_t* setme_len)
+bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** setme_raw, size_t* setme_len)
 {
     auto const* child = tr_variantDictFind(dict, key);
     return tr_variantGetRaw(child, setme_raw, setme_len);
@@ -409,22 +409,22 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, std::byte const
 
 // ---
 
-void tr_variantInitRaw(tr_variant* initme, void const* raw, size_t raw_len)
+void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
 {
     tr_variantInit(initme, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string(&initme->val.s, { static_cast<char const*>(raw), raw_len });
+    tr_variant_string_set_string(&initme->val.s, { static_cast<char const*>(value), value_len });
 }
 
-void tr_variantInitQuark(tr_variant* initme, tr_quark const q)
+void tr_variantInitQuark(tr_variant* initme, tr_quark value)
 {
     tr_variantInit(initme, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_quark(&initme->val.s, q);
+    tr_variant_string_set_quark(&initme->val.s, value);
 }
 
-void tr_variantInitStr(tr_variant* initme, std::string_view str)
+void tr_variantInitStr(tr_variant* initme, std::string_view value)
 {
     tr_variantInit(initme, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string(&initme->val.s, str);
+    tr_variant_string_set_string(&initme->val.s, value);
 }
 
 void tr_variantInitList(tr_variant* initme, size_t reserve_count)
@@ -500,7 +500,7 @@ tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value)
     return child;
 }
 
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const value)
+tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark value)
 {
     tr_variant* child = tr_variantListAdd(list);
     tr_variantInitQuark(child, value);
@@ -528,7 +528,7 @@ tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count)
     return child;
 }
 
-tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark const key)
+tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark key)
 {
     TR_ASSERT(tr_variantIsDict(dict));
 
@@ -540,70 +540,70 @@ tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark const key)
     return val;
 }
 
-tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark const key, int64_t val)
+tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark key, int64_t val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_INT);
     tr_variantInitInt(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark const key, bool val)
+tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark key, bool val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_BOOL);
     tr_variantInitBool(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark const key, double val)
+tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark key, double val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_REAL);
     tr_variantInitReal(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark const key, tr_quark const val)
+tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark key, tr_quark const val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
     tr_variantInitQuark(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark const key, std::string_view str)
+tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark key, std::string_view val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
-    tr_variantInitStr(child, str);
+    tr_variantInitStr(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark const key, std::string_view str)
+tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark key, std::string_view val)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
-    tr_variantInitStrView(child, str);
+    tr_variantInitStrView(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark const key, void const* value, size_t len)
+tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark key, void const* value, size_t len)
 {
     tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
     tr_variantInitRaw(child, value, len);
     return child;
 }
 
-tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark const key, size_t reserve_count)
+tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark key, size_t reserve_count)
 {
     tr_variant* child = tr_variantDictAdd(dict, key);
     tr_variantInitList(child, reserve_count);
     return child;
 }
 
-tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark const key, size_t reserve_count)
+tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark key, size_t reserve_count)
 {
     tr_variant* child = tr_variantDictAdd(dict, key);
     tr_variantInitDict(child, reserve_count);
     return child;
 }
 
-tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark const key, tr_variant* value)
+tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark key, tr_variant* value)
 {
     tr_variant* child = tr_variantDictAdd(dict, key);
     *child = *value;
@@ -612,7 +612,7 @@ tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark const key, tr_variant
     return child;
 }
 
-bool tr_variantDictRemove(tr_variant* dict, tr_quark const key)
+bool tr_variantDictRemove(tr_variant* dict, tr_quark key)
 {
     bool removed = false;
 
@@ -896,16 +896,16 @@ VariantWalkFuncs constexpr FreeWalkFuncs = {
 } // namespace clear_helpers
 } // namespace
 
-void tr_variantClear(tr_variant* v)
+void tr_variantClear(tr_variant* clearme)
 {
     using namespace clear_helpers;
 
-    if (!tr_variantIsEmpty(v))
+    if (!tr_variantIsEmpty(clearme))
     {
-        tr_variantWalk(v, &FreeWalkFuncs, nullptr, false);
+        tr_variantWalk(clearme, &FreeWalkFuncs, nullptr, false);
     }
 
-    *v = {};
+    *clearme = {};
 }
 
 // ---

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -97,7 +97,7 @@ struct tr_variant
  * The variant itself is not freed, but any memory used by
  * its *value* -- e.g. a string or child variants -- is freed.
  */
-void tr_variantClear(tr_variant*);
+void tr_variantClear(tr_variant* clearme);
 
 // --- Serialization / Deserialization
 
@@ -167,9 +167,9 @@ bool tr_variantFromBuf(
 
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
-void tr_variantInitStr(tr_variant* initme, std::string_view);
-void tr_variantInitQuark(tr_variant* initme, tr_quark const quark);
-void tr_variantInitRaw(tr_variant* initme, void const* raw, size_t raw_len);
+void tr_variantInitStr(tr_variant* initme, std::string_view value);
+void tr_variantInitQuark(tr_variant* initme, tr_quark value);
+void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len);
 
 constexpr void tr_variantInit(tr_variant* initme, char type)
 {
@@ -249,7 +249,7 @@ tr_variant* tr_variantListAddInt(tr_variant* list, int64_t value);
 tr_variant* tr_variantListAddReal(tr_variant* list, double value);
 tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view value);
 tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value);
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark const value);
+tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark value);
 tr_variant* tr_variantListAddRaw(tr_variant* list, void const* value, size_t value_len);
 tr_variant* tr_variantListAddList(tr_variant* list, size_t reserve_count);
 tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count);
@@ -271,30 +271,30 @@ bool tr_variantListRemove(tr_variant* list, size_t pos);
 
 void tr_variantInitDict(tr_variant* initme, size_t reserve_count);
 void tr_variantDictReserve(tr_variant* dict, size_t reserve_count);
-bool tr_variantDictRemove(tr_variant* dict, tr_quark const key);
+bool tr_variantDictRemove(tr_variant* dict, tr_quark key);
 
-tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark const key);
-tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark const key, double value);
-tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark const key, int64_t value);
-tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark const key, bool value);
-tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark const key, std::string_view);
-tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark const key, std::string_view);
-tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark const key, tr_quark const val);
-tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark const key, size_t reserve_count);
-tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark const key, size_t reserve_count);
-tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark const key, tr_variant* value);
-tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark const key, void const* value, size_t len);
+tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark key);
+tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark key, double value);
+tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark key, int64_t value);
+tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark key, bool value);
+tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark key, std::string_view value);
+tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark key, std::string_view value);
+tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark key, tr_quark val);
+tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark key, size_t reserve_count);
+tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark key, size_t reserve_count);
+tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark key, tr_variant* value);
+tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark key, void const* value, size_t len);
 
 bool tr_variantDictChild(tr_variant* dict, size_t pos, tr_quark* setme_key, tr_variant** setme_value);
-tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark const key);
-bool tr_variantDictFindList(tr_variant* dict, tr_quark const key, tr_variant** setme);
-bool tr_variantDictFindDict(tr_variant* dict, tr_quark const key, tr_variant** setme_value);
-bool tr_variantDictFindInt(tr_variant* dict, tr_quark const key, int64_t* setme);
-bool tr_variantDictFindReal(tr_variant* dict, tr_quark const key, double* setme);
-bool tr_variantDictFindBool(tr_variant* dict, tr_quark const key, bool* setme);
-bool tr_variantDictFindStrView(tr_variant* dict, tr_quark const key, std::string_view* setme);
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, uint8_t const** setme_raw, size_t* setme_len);
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark const key, std::byte const** setme_raw, size_t* setme_len);
+tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark key);
+bool tr_variantDictFindList(tr_variant* dict, tr_quark key, tr_variant** setme);
+bool tr_variantDictFindDict(tr_variant* dict, tr_quark key, tr_variant** setme_value);
+bool tr_variantDictFindInt(tr_variant* dict, tr_quark key, int64_t* setme);
+bool tr_variantDictFindReal(tr_variant* dict, tr_quark key, double* setme);
+bool tr_variantDictFindBool(tr_variant* dict, tr_quark key, bool* setme);
+bool tr_variantDictFindStrView(tr_variant* dict, tr_quark key, std::string_view* setme);
+bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, uint8_t const** setme_raw, size_t* setme_len);
+bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** setme_raw, size_t* setme_len);
 
 /* this is only quasi-supported. don't rely on it too heavily outside of libT */
 void tr_variantMergeDicts(tr_variant* dict_target, tr_variant const* dict_source);

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -62,7 +62,7 @@ struct tr_url_query_view
     struct iterator
     {
         std::pair<std::string_view, std::string_view> keyval = std::make_pair(std::string_view{ "" }, std::string_view{ "" });
-        std::string_view remain = std::string_view{ "" };
+        std::string_view remain = "";
 
         iterator& operator++();
 
@@ -98,13 +98,13 @@ struct tr_url_query_view
 template<typename BackInsertIter>
 constexpr void tr_urlPercentEncode(BackInsertIter out, std::string_view input, bool escape_reserved = true)
 {
-    auto constexpr is_unreserved = [](unsigned char ch)
+    auto constexpr IsUnreserved = [](unsigned char ch)
     {
         return ('0' <= ch && ch <= '9') || ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ch == '-' || ch == '_' ||
             ch == '.' || ch == '~';
     };
 
-    auto constexpr is_reserved = [](unsigned char ch)
+    auto constexpr IsReserved = [](unsigned char ch)
     {
         return ch == '!' || ch == '*' || ch == '(' || ch == ')' || ch == ';' || ch == ':' || ch == '@' || ch == '&' ||
             ch == '=' || ch == '+' || ch == '$' || ch == ',' || ch == '/' || ch == '?' || ch == '%' || ch == '#' || ch == '[' ||
@@ -113,7 +113,7 @@ constexpr void tr_urlPercentEncode(BackInsertIter out, std::string_view input, b
 
     for (unsigned char ch : input)
     {
-        if (is_unreserved(ch) || (!escape_reserved && is_reserved(ch)))
+        if (IsUnreserved(ch) || (!escape_reserved && IsReserved(ch)))
         {
             out = ch;
         }
@@ -132,4 +132,4 @@ constexpr void tr_urlPercentEncode(BackInsertIter out, tr_sha1_digest_t const& d
 
 [[nodiscard]] char const* tr_webGetResponseStr(long response_code);
 
-[[nodiscard]] std::string tr_urlPercentDecode(std::string_view);
+[[nodiscard]] std::string tr_urlPercentDecode(std::string_view /*url*/);

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -97,7 +97,7 @@ public:
     // Notify tr_web that it's going to be destroyed soon.
     // New fetch() tasks will be rejected, but already-running tasks
     // are left alone so that they can finish.
-    void startShutdown(std::chrono::milliseconds);
+    void startShutdown(std::chrono::milliseconds /*deadline*/);
 
     // If you want to give running tasks a chance to finish, call closeSoon()
     // before destroying the tr_web object. Deleting the object will cancel


### PR DESCRIPTION
No functional changes.

Still enabling + cleaning up some more clang-tidy warnings in libtransmission.