### PR TITLE
fix: coverity warnings

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -447,6 +447,7 @@ namespace global_ipv6_helpers
             {
                 if (auto const addrport = tr_address::from_sockaddr(reinterpret_cast<sockaddr*>(&src_ss)); addrport)
                 {
+                    evutil_closesocket(sock);
                     errno = save;
                     return addrport->first;
                 }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -225,7 +225,7 @@ TEST_F(FileTest, getInfo)
     // Can't get info of non-existent file/directory
     tr_error* err = nullptr;
     auto info = tr_sys_path_get_info(path1, 0, &err);
-    ASSERT_FALSE(info.has_value());
+    EXPECT_FALSE(info.has_value());
     EXPECT_NE(nullptr, err);
     tr_error_clear(&err);
 


### PR DESCRIPTION
Fix a couple of warnings reported by Coverity.

- The one in tests/ is just a make-the-linter-happy change.
- The one in libtransmission/ fixes a recent regression that could leak one socket per half hour. This may help a tiny bit with https://github.com/transmission/transmission/issues/3677.