### PR TITLE
#warning in header file should start with capital letter

### DIFF
--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -46,7 +46,7 @@
 // - Callbacks are only on the main thread.
 // - Unmaintained as a standalone project.
 
-#warning adopt an alternative to VDKQueue (UKFSEventsWatcher, EonilFSEvents, FileWatcher, DTFolderMonitor or SFSMonitor)
+#warning Adopt an alternative to VDKQueue (UKFSEventsWatcher, EonilFSEvents, FileWatcher, DTFolderMonitor or SFSMonitor)
 // ALTERNATIVES (from archaic to modern)
 //
 //  - FreeBSD 4.1: Kernel Queue API (kevent and kqueue)


### PR DESCRIPTION
Issue specific to .h files (not .m files): `#warning` should be capitalized, otherwise it will duplicate the warning depending on the context where it is imported.

![Capture d’écran 2023-01-29 à 15 55 40](https://user-images.githubusercontent.com/839992/215336334-a7c9486f-6145-4465-8d20-7997543cc4f2.png)
