### PR TITLE
fix: remove abort() call from tr_assert_message()

### DIFF
--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -5,8 +5,6 @@
 
 #import <Foundation/Foundation.h>
 
-#include <cstdlib> // for abort()
-
 #include <fmt/format.h>
 
 #include "tr-assert.h"
@@ -20,10 +18,6 @@
 {
     auto const full_text = fmt::format(FMT_STRING("assertion failed: {:s} ({:s}:{:d})"), message, file, line);
     [NSException raise:NSInternalInconsistencyException format:@"%s", full_text.c_str()];
-
-    // We should not reach this anyway, but it helps mark the function as property noreturn
-    // (the Objective-C NSException method does not).
-    abort();
 }
 
 #endif


### PR DESCRIPTION
I *think* this is aborting the application before it has a chance for the uncaught exception handler to be reached, which is why crashes reports that people include in bug reports never include the assertion failure message.

Example: the crash report shown in  https://github.com/transmission/transmission/issues/4695 has the process ending in the `abort()` that's removed from here, so we never see what the assertion message is.

Marking as `needs code review` because I'd like a second opinion on this theory