### PR TITLE
fix: Add precheck for tar archive test.

### DIFF
--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -210,6 +210,29 @@ BlocklistDownloader* fBLDownloader = nil;
 
 - (BOOL)untarFrom:(NSURL*)file to:(NSURL*)destination
 {
+    // We need to check validity of archive before listing or unpacking.
+    NSTask* tarListCheck = [[NSTask alloc] init];
+
+    tarListCheck.launchPath = @"/usr/bin/tar";
+    tarListCheck.arguments = @[ @"--list", @"--file", file.path ];
+    tarListCheck.standardOutput = nil;
+    tarListCheck.standardError = nil;
+
+    @try
+    {
+        [tarListCheck launch];
+        [tarListCheck waitUntilExit];
+
+        if (tarListCheck.terminationStatus != 0)
+        {
+            return NO;
+        }
+    }
+    @catch (NSException* exception)
+    {
+        return NO;
+    }
+
     NSTask* tarList = [[NSTask alloc] init];
 
     tarList.launchPath = @"/usr/bin/tar";


### PR DESCRIPTION
Recently we discovered we do not properly handle broken tar archives.

The problem is running tar (in linting mode) on invalid archive and piping stdout to NSPipe introduces a hang as NSPipe cannot process such huge data amounts.

Fixing this problem by adding a precheck with tar (listing mode) with piping stdout to /dev/null.

Fixes: #4702