### PR TITLE
Workaround for CoreAutoLayout hang during runCustomizationPalette on macOS 13.2

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4358,9 +4358,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
             ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause.circle.fill" withFallback:@"ToolbarPauseAllTemplate"];
             ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise.circle.fill"
                                                           withFallback:@"ToolbarResumeAllTemplate"];
-            // on macOS 13.2, in French, the palette autolayout will hang unless the title length is at least 12 spaces long
-            ((NSButton*)itemPause.view).title = @"            ";
-            ((NSButton*)itemResume.view).title = @"            ";
+            // On macOS 13.2, the palette autolayout will hang unless the title length is at least 14 spaces long in Russian (12 spaces long or less in French and other languages).
+            ((NSButton*)itemPause.view).title = @"              ";
+            ((NSButton*)itemResume.view).title = @"              ";
         }
         groupItem.target = self;
         groupItem.action = @selector(allToolbarClicked:);
@@ -4419,9 +4419,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         {
             ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause" withFallback:@"ToolbarPauseSelectedTemplate"];
             ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise" withFallback:@"ToolbarResumeSelectedTemplate"];
-            // on macOS 13.2, in French, the palette autolayout will hang unless the title length is at least 12 spaces long
-            ((NSButton*)itemPause.view).title = @"            ";
-            ((NSButton*)itemResume.view).title = @"            ";
+            // On macOS 13.2, the palette autolayout will hang unless the title length is at least 14 spaces long in Russian (12 spaces long or less in French and other languages).
+            ((NSButton*)itemPause.view).title = @"              ";
+            ((NSButton*)itemResume.view).title = @"              ";
         }
         groupItem.target = self;
         groupItem.action = @selector(selectedToolbarClicked:);

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4344,7 +4344,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                         forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
                           forSegment:TOOLBAR_RESUME_TAG];
-        if (![toolbar isKindOfClass:Toolbar.class] || ((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
         {
             // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
             [segmentedControl setWidth:64 forSegment:TOOLBAR_PAUSE_TAG];
@@ -4400,7 +4400,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                         forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
                           forSegment:TOOLBAR_RESUME_TAG];
-        if (![toolbar isKindOfClass:Toolbar.class] || ((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
         {
             // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
             [segmentedControl setWidth:64 forSegment:TOOLBAR_PAUSE_TAG];

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4344,24 +4344,18 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                         forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
                           forSegment:TOOLBAR_RESUME_TAG];
+        if (![toolbar isKindOfClass:Toolbar.class] || ((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        {
+            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
+            [segmentedControl setWidth:64 forSegment:TOOLBAR_PAUSE_TAG];
+            [segmentedControl setWidth:64 forSegment:TOOLBAR_RESUME_TAG];
+        }
 
         groupItem.label = NSLocalizedString(@"Apply All", "All toolbar item -> label");
         groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
         groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
         groupItem.subitems = @[ itemPause, itemResume ];
-        if ([toolbar isKindOfClass:Toolbar.class] && !((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
-        {
-            groupItem.view = segmentedControl;
-        }
-        else
-        {
-            ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause.circle.fill" withFallback:@"ToolbarPauseAllTemplate"];
-            ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise.circle.fill"
-                                                          withFallback:@"ToolbarResumeAllTemplate"];
-            // On macOS 13.2, the palette autolayout will hang unless the title length is at least 14 spaces long in Russian (12 spaces long or less in French and other languages).
-            ((NSButton*)itemPause.view).title = @"              ";
-            ((NSButton*)itemResume.view).title = @"              ";
-        }
+        groupItem.view = segmentedControl;
         groupItem.target = self;
         groupItem.action = @selector(allToolbarClicked:);
 
@@ -4406,23 +4400,18 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                         forSegment:TOOLBAR_RESUME_TAG];
         [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
                           forSegment:TOOLBAR_RESUME_TAG];
+        if (![toolbar isKindOfClass:Toolbar.class] || ((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        {
+            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
+            [segmentedControl setWidth:64 forSegment:TOOLBAR_PAUSE_TAG];
+            [segmentedControl setWidth:64 forSegment:TOOLBAR_RESUME_TAG];
+        }
 
         groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
         groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
         groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
         groupItem.subitems = @[ itemPause, itemResume ];
-        if ([toolbar isKindOfClass:Toolbar.class] && !((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
-        {
-            groupItem.view = segmentedControl;
-        }
-        else
-        {
-            ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause" withFallback:@"ToolbarPauseSelectedTemplate"];
-            ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise" withFallback:@"ToolbarResumeSelectedTemplate"];
-            // On macOS 13.2, the palette autolayout will hang unless the title length is at least 14 spaces long in Russian (12 spaces long or less in French and other languages).
-            ((NSButton*)itemPause.view).title = @"              ";
-            ((NSButton*)itemResume.view).title = @"              ";
-        }
+        groupItem.view = segmentedControl;
         groupItem.target = self;
         groupItem.action = @selector(selectedToolbarClicked:);
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -4225,7 +4225,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     return [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ButtonToolbarItem class]];
 }
 
-- (id)toolbarButtonWithIdentifier:(NSString*)ident forToolbarButtonClass:(Class)klass
+- (__kindof ButtonToolbarItem*)toolbarButtonWithIdentifier:(NSString*)ident forToolbarButtonClass:(Class)klass
 {
     ButtonToolbarItem* item = [[klass alloc] initWithItemIdentifier:ident];
 
@@ -4349,7 +4349,19 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
         groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
         groupItem.subitems = @[ itemPause, itemResume ];
-        groupItem.view = segmentedControl;
+        if ([toolbar isKindOfClass:Toolbar.class] && !((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        {
+            groupItem.view = segmentedControl;
+        }
+        else
+        {
+            ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause.circle.fill" withFallback:@"ToolbarPauseAllTemplate"];
+            ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise.circle.fill"
+                                                          withFallback:@"ToolbarResumeAllTemplate"];
+            // on macOS 13.2, in French, the palette autolayout will hang unless the title length is at least 12 spaces long
+            ((NSButton*)itemPause.view).title = @"            ";
+            ((NSButton*)itemResume.view).title = @"            ";
+        }
         groupItem.target = self;
         groupItem.action = @selector(allToolbarClicked:);
 
@@ -4395,12 +4407,22 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
                           forSegment:TOOLBAR_RESUME_TAG];
 
-        groupItem.view = segmentedControl;
         groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
         groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
         groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
         groupItem.subitems = @[ itemPause, itemResume ];
-        groupItem.view = segmentedControl;
+        if ([toolbar isKindOfClass:Toolbar.class] && !((Toolbar*)toolbar).customizationPaletteIsRunning_fixed)
+        {
+            groupItem.view = segmentedControl;
+        }
+        else
+        {
+            ((NSButton*)itemPause.view).image = [NSImage systemSymbol:@"pause" withFallback:@"ToolbarPauseSelectedTemplate"];
+            ((NSButton*)itemResume.view).image = [NSImage systemSymbol:@"arrow.clockwise" withFallback:@"ToolbarResumeSelectedTemplate"];
+            // on macOS 13.2, in French, the palette autolayout will hang unless the title length is at least 12 spaces long
+            ((NSButton*)itemPause.view).title = @"            ";
+            ((NSButton*)itemResume.view).title = @"            ";
+        }
         groupItem.target = self;
         groupItem.action = @selector(selectedToolbarClicked:);
 

--- a/macosx/Toolbar.h
+++ b/macosx/Toolbar.h
@@ -6,4 +6,6 @@
 
 @interface Toolbar : NSToolbar
 
+@property(readonly) BOOL customizationPaletteIsRunning_fixed;
+
 @end

--- a/macosx/Toolbar.h
+++ b/macosx/Toolbar.h
@@ -6,6 +6,6 @@
 
 @interface Toolbar : NSToolbar
 
-@property(readonly) BOOL customizationPaletteIsRunning_fixed;
+@property(readonly) BOOL isRunningCustomizationPalette;
 
 @end

--- a/macosx/Toolbar.mm
+++ b/macosx/Toolbar.mm
@@ -5,7 +5,7 @@
 #import "Toolbar.h"
 
 @interface Toolbar ()
-@property(nonatomic) BOOL customizationPaletteIsRunning_fixed;
+@property(nonatomic) BOOL isRunningCustomizationPalette;
 @end
 
 @implementation Toolbar
@@ -21,9 +21,9 @@
 
 - (void)runCustomizationPalette:(nullable id)sender
 {
-    _customizationPaletteIsRunning_fixed = YES;
+    _isRunningCustomizationPalette = YES;
     [super runCustomizationPalette:sender];
-    _customizationPaletteIsRunning_fixed = NO;
+    _isRunningCustomizationPalette = NO;
 }
 
 @end

--- a/macosx/Toolbar.mm
+++ b/macosx/Toolbar.mm
@@ -4,6 +4,10 @@
 
 #import "Toolbar.h"
 
+@interface Toolbar ()
+@property(nonatomic) BOOL customizationPaletteIsRunning_fixed;
+@end
+
 @implementation Toolbar
 
 - (void)setVisible:(BOOL)visible
@@ -13,6 +17,13 @@
     [NSNotificationCenter.defaultCenter postNotificationName:@"ToolbarDidChange" object:nil];
 
     super.visible = visible;
+}
+
+- (void)runCustomizationPalette:(nullable id)sender
+{
+    _customizationPaletteIsRunning_fixed = YES;
+    [super runCustomizationPalette:sender];
+    _customizationPaletteIsRunning_fixed = NO;
 }
 
 @end


### PR DESCRIPTION
Fix #4604

Apparently, on the customization palette (right-click on Toolbar > Customize), if the label is larger than a groupItem, then Apple's autolayout on macOS 13.2 will enter into some infinite loop with increasing memory usage, causing the app to hang then crash.

My workaround: enlarge artificially each groupItem in the palette so that they are larger than their label.

Tested in all locales.