### PR TITLE
fix: ensure ipv4 for udp announces.

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -409,7 +409,7 @@ private:
         *fmt::format_to(std::data(szport), FMT_STRING("{:d}"), port.host()) = '\0';
 
         auto hints = addrinfo{};
-        hints.ai_family = AF_UNSPEC;
+        hints.ai_family = AF_INET; // https://github.com/transmission/transmission/issues/4719
         hints.ai_protocol = IPPROTO_UDP;
         hints.ai_socktype = SOCK_DGRAM;
 


### PR DESCRIPTION
This is an interim fix to unblock 4.0.0. See ticket 4719 for details.

Fixes #4719.