### PR TITLE
tests: expose libtransmission gtests to ctest

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Make
         run: cmake --build obj --config Debug --target libtransmission-test transmission-show
       - name: Test with sanitizers
-        run: cmake -E chdir obj ctest --build-config Debug --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
 
   macos-11:
     runs-on: macos-11
@@ -225,7 +225,7 @@ jobs:
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         env:
           TMPDIR: /private/tmp
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v3
@@ -301,7 +301,7 @@ jobs:
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         env:
           TMPDIR: /private/tmp
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v3
@@ -394,7 +394,7 @@ jobs:
           cmake --build obj --config RelWithDebInfo
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure --timeout 600
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure --timeout 600
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install
       - name: Package
@@ -501,7 +501,7 @@ jobs:
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         env:
           TMPDIR: /private/tmp
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v3
@@ -578,7 +578,7 @@ jobs:
         run: cmake --build obj --config RelWithDebInfo
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v3
@@ -654,7 +654,7 @@ jobs:
         run: cmake --build obj --config RelWithDebInfo
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-        run: cmake -E chdir obj ctest --build-config RelWithDebInfo --output-on-failure
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v3

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GoogleTest)
+
 add_executable(libtransmission-test)
 
 target_sources(libtransmission-test
@@ -75,9 +77,9 @@ target_link_libraries(libtransmission-test
         libevent::event
         WideInteger::WideInteger)
 
-add_test(
-    NAME libtransmission-test
-    COMMAND libtransmission-test)
+gtest_discover_tests(libtransmission-test
+    TEST_PREFIX "LT."
+)
 
 add_custom_command(
     TARGET libtransmission-test

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -339,19 +339,6 @@ TEST_F(FileTest, readFile)
     EXPECT_EQ(nullptr, err) << *err;
 
     tr_sys_file_close(fd);
-
-    // read from closed file
-    n_read = 0;
-    EXPECT_FALSE(tr_sys_file_read(fd, std::data(buf), std::size(buf), &n_read, &err)); // coverity[USE_AFTER_FREE]
-    EXPECT_EQ(0, n_read);
-    EXPECT_NE(nullptr, err);
-    tr_error_clear(&err);
-
-    // read_at from closed file
-    EXPECT_FALSE(tr_sys_file_read_at(fd, std::data(buf), std::size(buf), offset, &n_read, &err)); // coverity[USE_AFTER_FREE]
-    EXPECT_EQ(0, n_read);
-    EXPECT_NE(nullptr, err);
-    tr_error_clear(&err);
 }
 
 TEST_F(FileTest, pathExists)

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -75,6 +75,8 @@ TEST_F(PlatformTest, defaultConfigDirXdgConfig)
 
 TEST_F(PlatformTest, defaultConfigDirXdgConfigHome)
 {
+    unsetenv("TRANSMISSION_HOME");
+    unsetenv("XDG_CONFIG_HOME");
     auto const home = tr_pathbuf{ sandboxDir(), "/home/user" };
     setenv("HOME", home, 1);
 


### PR DESCRIPTION
By using gtest_discover_tests() each testcase is exposed to ctest as a single test.
This allows more fine-grained reporting and also parallel execution of testcases.