### PR TITLE
Include libb64 and libutp as subprojects

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,8 +64,8 @@ jobs:
     - name: Build Dependencies
       if: ${{ matrix.language == 'cpp' }}
       run: |
-        ninja -C _build -t targets |
-            grep -E 'third-party/.*-build:' |
+        ninja -C _build -t targets all |
+            grep -E 'third-party/.*-build:|third-party/.*/all:' |
             cut -d: -f1 |
             xargs -L1 ninja -C _build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,11 +496,12 @@ tr_add_external_auto_library(PSL libpsl psl
 
 if(ENABLE_UTP)
     tr_add_external_auto_library(UTP libutp utp
-        TARGET libutp::libutp
-        CMAKE_ARGS -DLIBUTP_BUILD_PROGRAMS=OFF)
+        SUBPROJECT
+        TARGET libutp::libutp)
 endif()
 
 tr_add_external_auto_library(B64 libb64 b64
+    SUBPROJECT
     TARGET libb64::libb64)
 
 if(NOT ${REBUILD_WEB} STREQUAL "OFF")

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -129,7 +129,7 @@ function(tr_process_list_conditions VAR_PREFIX)
 endfunction()
 
 macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
-    cmake_parse_arguments(_TAEAL_ARG "" "TARGET" "CMAKE_ARGS" ${ARGN})
+    cmake_parse_arguments(_TAEAL_ARG "SUBPROJECT" "TARGET" "CMAKE_ARGS" ${ARGN})
 
     if(USE_SYSTEM_${ID})
         tr_get_required_flag(USE_SYSTEM_${ID} SYSTEM_${ID}_IS_REQUIRED)
@@ -139,6 +139,8 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
 
     if(USE_SYSTEM_${ID})
         unset(${ID}_UPSTREAM_TARGET)
+    elseif(_TAEAL_ARG_SUBPROJECT)
+        add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/${DIRNAME}" "${CMAKE_BINARY_DIR}/third-party/${DIRNAME}")
     else()
         set(${ID}_UPSTREAM_TARGET ${LIBNAME})
         set(${ID}_PREFIX "${CMAKE_BINARY_DIR}/third-party/${${ID}_UPSTREAM_TARGET}")
@@ -185,7 +187,7 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
         file(MAKE_DIRECTORY ${${ID}_INCLUDE_DIRS})
     endif()
 
-    if(_TAEAL_ARG_TARGET)
+    if(_TAEAL_ARG_TARGET AND (USE_SYSTEM_${ID} OR NOT _TAEAL_ARG_SUBPROJECT))
         add_library(${_TAEAL_ARG_TARGET} INTERFACE IMPORTED)
 
         target_include_directories(${_TAEAL_ARG_TARGET}
@@ -199,6 +201,10 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
         if(${ID}_UPSTREAM_TARGET)
             add_dependencies(${_TAEAL_ARG_TARGET} ${${ID}_UPSTREAM_TARGET})
         endif()
+    endif()
+
+    if(_TAEAL_ARG_TARGET AND NOT TARGET ${_TAEAL_ARG_TARGET})
+        message(FATAL_ERROR "Build system is misconfigured, this shouldn't happen! Can't find target '${_TAEAL_ARG_TARGET}'")
     endif()
 endmacro()
 


### PR DESCRIPTION
Fixes: #4752

Notes: Fixed `4.0.0` regression of mistakenly treating warnings as errors when building bundled libb64 and libutp.