### PR TITLE
Imply port 443 for https scheme

### DIFF
--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -192,7 +192,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
     // hostname
     str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
     auto const url = QUrl(inf.st.announce);
-    str += QStringLiteral("%1:%2").arg(url.host()).arg(url.port(80));
+    str += QStringLiteral("%1:%2").arg(url.host()).arg(url.port(url.scheme == "https" ? 443 : 80));
 
     str += inf.st.is_backup ? QStringLiteral("</i>") : QStringLiteral("</b>");
 


### PR DESCRIPTION
Attempt to fix transmission/transmission#4782
I'm not set up to compile the project, so this is edited "in the blind".

It also feels wrong to assume HTTP, but I can't figure what other schemes would end up here -- udp:// doesn't have a sane default port.