### PR TITLE
added padding to widgets in macOS client to avoid being hidden below scroller

### DIFF
--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -772,7 +772,8 @@ static NSInteger const kMaxPieces = 18 * 18;
     result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle + kPaddingBetweenTitleAndProgress + kHeightStatus +
         kPaddingBetweenProgressAndBar;
 
-    result.size.width = floor(NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal - 2.0 * (kPaddingBetweenButtons + kNormalButtonWidth + kPaddingEdgeMax));
+    result.size.width = floor(
+        NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal - 2.0 * (kPaddingBetweenButtons + kNormalButtonWidth + kPaddingEdgeMax));
 
     return result;
 }

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -31,6 +31,7 @@ static CGFloat const kHeightTitle = 16.0;
 static CGFloat const kHeightStatus = 12.0;
 
 static CGFloat const kPaddingHorizontal = 5.0;
+static CGFloat const kPaddingEdgeMax = 12.0;
 static CGFloat const kPaddingBetweenButtons = 3.0;
 static CGFloat const kPaddingBetweenImageAndTitle = kPaddingHorizontal + 1.0;
 static CGFloat const kPaddingBetweenImageAndBar = kPaddingHorizontal;
@@ -701,7 +702,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     NSRect result;
     result.size = [string size];
 
-    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + NSWidth(result));
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + NSWidth(result) + kPaddingEdgeMax);
     result.origin.y = ceil(NSMidY(bounds) - NSHeight(result) * 0.5);
 
     return result;
@@ -726,7 +727,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     {
         result.origin.x += kGroupPaddingRegular;
         result.origin.y = NSMinY(bounds) + kPaddingAboveTitle;
-        result.size.width = rightBound - NSMinX(result) - kPaddingHorizontal;
+        result.size.width = rightBound - NSMinX(result) - kPaddingHorizontal - kPaddingEdgeMax;
     }
 
     if (((Torrent*)self.representedObject).priority != TR_PRI_NORMAL)
@@ -771,7 +772,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     result.origin.y = NSMinY(bounds) + kPaddingAboveTitle + kHeightTitle + kPaddingBetweenTitleAndProgress + kHeightStatus +
         kPaddingBetweenProgressAndBar;
 
-    result.size.width = floor(NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal - 2.0 * (kPaddingBetweenButtons + kNormalButtonWidth));
+    result.size.width = floor(NSMaxX(bounds) - NSMinX(result) - kPaddingHorizontal - 2.0 * (kPaddingBetweenButtons + kNormalButtonWidth + kPaddingEdgeMax));
 
     return result;
 }
@@ -782,7 +783,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     result.origin.x = NSMinX(bounds) + kPaddingHorizontal + kImageSizeMin + kGroupPaddingMin + kPaddingBetweenImageAndBar;
     result.origin.y = NSMinY(bounds) + kPaddingBetweenBarAndEdgeMin;
     result.size.height = NSHeight(bounds) - 2.0 * kPaddingBetweenBarAndEdgeMin;
-    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingBetweenBarAndEdgeMin;
+    result.size.width = NSMaxX(bounds) - NSMinX(result) - kPaddingBetweenBarAndEdgeMin - kPaddingEdgeMax;
 
     return result;
 }
@@ -792,7 +793,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     NSRect result;
     result.size.height = kNormalButtonWidth;
     result.size.width = kNormalButtonWidth;
-    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth + kPaddingBetweenButtons + kNormalButtonWidth);
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth + kPaddingBetweenButtons + kNormalButtonWidth + kPaddingEdgeMax);
 
     if (![self.fDefaults boolForKey:@"SmallView"])
     {
@@ -812,7 +813,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     NSRect result;
     result.size.height = kNormalButtonWidth;
     result.size.width = kNormalButtonWidth;
-    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth);
+    result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + kNormalButtonWidth + kPaddingEdgeMax);
 
     if (![self.fDefaults boolForKey:@"SmallView"])
     {


### PR DESCRIPTION
The scroller on macOS covers parts of the UI. This PR addresses that.
Fixes: #261

**Before:**
![before_no_scroll](https://user-images.githubusercontent.com/7323792/217983062-b08b1b8a-26c8-463a-8cb3-80797a884c08.png)
![before](https://user-images.githubusercontent.com/7323792/217982489-3434b1b9-7f43-4766-b27e-edc240e010df.png)
![compact_before](https://user-images.githubusercontent.com/7323792/217982525-570ff72d-b8de-4020-aab4-f8c2a1f623a1.png)

**After:**
![after_no_scroll](https://user-images.githubusercontent.com/7323792/217983098-18701e83-a67f-4886-b78e-6945fe855ba6.png)
![after](https://user-images.githubusercontent.com/7323792/217982550-b7472aa9-6f17-4d90-9393-80ac3a8fed44.png)
![compact_after](https://user-images.githubusercontent.com/7323792/217982570-0ed7e758-ac4b-42fa-8dcc-0b9187961ff1.png)
