### PR TITLE
Fix: Prevent lengthy compilation workflows to run needlessly

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,14 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
   schedule:
     - cron: '29 14 * * 1'
 

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
   pull_request:
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
 jobs:
   decide-what-jobs-to-run:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I noticed #4803 triggered runs involving compiling the source code while it was merely suggesting a change to the documentation.
I suppose this PR wil lalso trigger them.

This proposal aims at reducing the cost of PRs merely addressing docs or pipelines definitions.