### PR TITLE
cmake: pass --no-warn-unused-cli to child cmake process

### DIFF
--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -173,6 +173,7 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
             PREFIX "${${ID}_PREFIX}"
             CMAKE_ARGS
                 -Wno-dev # We don't want to be warned over unused variables
+                --no-warn-unused-cli
                 "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}"
                 "-DCMAKE_USER_MAKE_RULES_OVERRIDE=${CMAKE_USER_MAKE_RULES_OVERRIDE}"
                 "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"


### PR DESCRIPTION
Hides a warning when building the dht library.
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_FLAGS
    CMAKE_INSTALL_LIBDIR
```