### PR TITLE
chore: disable flaky unit tests

### DIFF
--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -101,7 +101,7 @@ TEST_F(LpdTest, HelloWorld)
     EXPECT_EQ(0U, std::size(mediator.found_));
 }
 
-TEST_F(LpdTest, CanAnnounceAndRead)
+TEST_F(LpdTest, DISABLED_CanAnnounceAndRead)
 {
     auto mediator_a = MyMediator{ *session_ };
     auto lpd_a = tr_lpd::create(mediator_a, session_->eventBase());
@@ -123,7 +123,7 @@ TEST_F(LpdTest, CanAnnounceAndRead)
     EXPECT_EQ(0U, mediator_b.found_.count(info_hash_str));
 }
 
-TEST_F(LpdTest, canMultiAnnounce)
+TEST_F(LpdTest, DISABLED_canMultiAnnounce)
 {
     auto mediator_a = MyMediator{ *session_ };
     auto lpd_a = tr_lpd::create(mediator_a, session_->eventBase());
@@ -159,7 +159,7 @@ TEST_F(LpdTest, canMultiAnnounce)
     }
 }
 
-TEST_F(LpdTest, DoesNotReannounceTooSoon)
+TEST_F(LpdTest, DISABLED_DoesNotReannounceTooSoon)
 {
     auto mediator_a = MyMediator{ *session_ };
     auto lpd_a = tr_lpd::create(mediator_a, session_->eventBase());

--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -203,7 +203,7 @@ TEST_F(TimerTest, restartWithDifferentInterval)
     test(200ms);
 }
 
-TEST_F(TimerTest, restartWithSameInterval)
+TEST_F(TimerTest, DISABLED_restartWithSameInterval)
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();
@@ -232,7 +232,7 @@ TEST_F(TimerTest, restartWithSameInterval)
     test(timer->interval());
 }
 
-TEST_F(TimerTest, repeatingThenSingleShot)
+TEST_F(TimerTest, DISABLED_repeatingThenSingleShot)
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();
@@ -274,7 +274,7 @@ TEST_F(TimerTest, repeatingThenSingleShot)
     EXPECT_EQ(baseline + 1, n_calls);
 }
 
-TEST_F(TimerTest, singleShotStop)
+TEST_F(TimerTest, DISABLED_singleShotStop)
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -215,7 +215,7 @@ TEST_P(WatchDirTest, watch)
     EXPECT_TRUE(std::empty(names));
 }
 
-TEST_P(WatchDirTest, retry)
+TEST_P(WatchDirTest, DISABLED_retry)
 {
     auto const path = sandboxDir();
 


### PR DESCRIPTION
This shouldn't be a long-term fix -- each of these tests should be fixed instead of disabled -- but they are causing so much noise in CI that I'm disabling them for now and then they can be re-enabled when fixed.

Closes #4747.