### PR TITLE
Fix: Put "private" and "source" inside the metadata "info" key

### DIFF
--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -340,16 +340,6 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
 
     tr_variantDictAddStrView(&top, TR_KEY_encoding, "UTF-8");
 
-    if (is_private_)
-    {
-        tr_variantDictAddInt(&top, TR_KEY_private, 1);
-    }
-
-    if (!std::empty(source))
-    {
-        tr_variantDictAddStr(&top, TR_KEY_source, source_);
-    }
-
     auto* const info_dict = tr_variantDictAddDict(&top, TR_KEY_info, 5);
     auto const base = tr_sys_path_basename(top_);
 
@@ -392,6 +382,17 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
 
     tr_variantDictAddInt(info_dict, TR_KEY_piece_length, pieceSize());
     tr_variantDictAddRaw(info_dict, TR_KEY_pieces, std::data(piece_hashes_), std::size(piece_hashes_));
+
+    if (is_private_)
+    {
+        tr_variantDictAddInt(info_dict, TR_KEY_private, 1);
+    }
+
+    if (!std::empty(source))
+    {
+        tr_variantDictAddStr(info_dict, TR_KEY_source, source_);
+    }
+
     auto ret = tr_variantToStr(&top, TR_VARIANT_FMT_BENC);
     tr_variantClear(&top);
     return ret;

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -216,4 +216,24 @@ TEST_F(MakemetaTest, singleFile)
     testBuilder(builder);
 }
 
+TEST_F(MakemetaTest, privateAndSourceHasDifferentInfoHash)
+{
+    auto const files = makeRandomFiles(sandboxDir(), 1);
+    auto const [filename, payload] = files.front();
+    auto builder = tr_metainfo_builder{ filename };
+    auto trackers = tr_announce_list{};
+    trackers.add("udp://tracker.openbittorrent.com:80"sv, trackers.nextTier());
+    builder.setAnnounceList(std::move(trackers));
+    auto baseMetainfo = testBuilder(builder);
+
+    builder.setPrivate(true);
+    auto privateMetainfo = testBuilder(builder);
+    EXPECT_NE(baseMetainfo.infoHash(), privateMetainfo.infoHash());
+
+    builder.setSource("FOO");
+    auto privateSourceMetainfo = testBuilder(builder);
+    EXPECT_NE(baseMetainfo.infoHash(), privateSourceMetainfo.infoHash());
+    EXPECT_NE(privateMetainfo.infoHash(), privateSourceMetainfo.infoHash());
+}
+
 } // namespace libtransmission::test


### PR DESCRIPTION
Fixes #4771 .

Also add a test to ensure that the info-hashes generated for torrents with "private" and/or "source" flags are different to the same torrent without them set.