### PR TITLE
fix: sometimes fails to detect when a uTP socket isn't writable & doesn't connect

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -130,7 +130,15 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
 
     auto peer_io = tr_peerIo::create(session, parent, &info_hash, false, is_seed);
 
+    // try a TCP socket
+    if (auto sock = tr_netOpenPeerSocket(session, addr, port, is_seed); sock.is_valid())
+    {
+        peer_io->set_socket(std::move(sock));
+        return peer_io;
+    }
+
 #ifdef WITH_UTP
+    // try a UTP socket
     if (utp)
     {
         auto* const sock = utp_create_socket(session->utp_context);
@@ -144,15 +152,6 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
         }
     }
 #endif
-
-    if (!peer_io->socket_.is_valid())
-    {
-        if (auto sock = tr_netOpenPeerSocket(session, addr, port, is_seed); sock.is_valid())
-        {
-            peer_io->set_socket(std::move(sock));
-            return peer_io;
-        }
-    }
 
     return {};
 }


### PR DESCRIPTION
Fixes a long-standing bug (affects 4.0.0, 3.00, and apparently earlier) where Transmission initiates connection to a BitTorrent peer via uTP and just doesn't realize that the connection is not happening. Ideally we'd fail out of this and retry the connection via TCP.

A less intrusive "quick fix" that's more appropriate for a patch release is to just swap the TCP / uTP order to try TCP first, since we know whether the TCP socket is connected as soon as we call `connect()`.

This gets the job done but I'd like to revisit this to ensure uTP connection failure is detected properly even when we try it as the fallback option.

Notes: Fixed issue that prevented connecting to some BitTorrent peers.