### PR TITLE
Fix: announcer: Add nullptr dereference safeguards

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -871,6 +871,11 @@ void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e)
 
     /* switch to the next tracker */
     current_tracker = tier->useNextTracker();
+    TR_ASSERT(current_tracker != nullptr);
+    if (current_tracker == nullptr)
+    {
+        return;
+    }
 
     if (isUnregistered(err))
     {
@@ -1243,6 +1248,11 @@ void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char const* e
 
     // switch to the next tracker
     current_tracker = tier->useNextTracker();
+    TR_ASSERT(current_tracker != nullptr);
+    if (current_tracker == nullptr)
+    {
+        return;
+    }
 
     // schedule a rescrape
     auto const interval = current_tracker->getRetryInterval();


### PR DESCRIPTION
This PR adds to the work started in #4805.

Attempts to fix the current compilation warning:
<details>
<summary>Compilation warning</summary>

```cpp
/tmp/transmission/libtransmission/announcer.cc: In function ‘void {anonymous}::on_scrape_done_helpers::on_scrape_error(const tr_session*, tr_tier*, const char*)’:
/tmp/transmission/libtransmission/announcer.cc:357:20: warning: potential null pointer dereference [-Wnull-dereference]
  357 |             return nullptr;
      |                    ^~~~~~~
```
</details>

I am very wary of my proposed changes, as whole blocks of code are being bypassed.
However, the main effect has been achieved (no more warning), showing it is indeed on those locations that something needs to be done.