### PR TITLE
fix: tr_swarm order of destruction

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -644,7 +644,12 @@ public:
 
     tr_torrent* const tor;
 
+    ActiveRequests active_requests;
+
+    // depends-on: active_requests
     std::vector<std::unique_ptr<tr_peer>> webseeds;
+
+    // depends-on: active_requests
     std::vector<tr_peerMsgs*> peers;
 
     // tr_peers hold pointers to the items in this container,
@@ -655,8 +660,6 @@ public:
     tr_peerMsgs* optimistic = nullptr; /* the optimistic peer, or nullptr if none */
 
     time_t lastCancel = 0;
-
-    ActiveRequests active_requests;
 
 private:
     static void maybeSendCancelRequest(tr_peer* peer, tr_block_index_t block, tr_peer const* muted)


### PR DESCRIPTION
Fixes #4844.

Notes: Fixed `4.0.0` crash that occurred when removing a webseed torrent while downloading.