### PR TITLE
fix: magnet links paused when added

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -43,6 +43,7 @@
 #include "session.h"
 #include "timer.h"
 #include "torrent.h"
+#include "torrent-magnet.h"
 #include "tr-assert.h"
 #include "tr-utp.h"
 #include "utils.h"
@@ -2391,8 +2392,11 @@ void tr_peerMgr::bandwidthPulse()
     session->top_bandwidth_.allocate(Msec);
 
     // torrent upkeep
-    auto& torrents = session->torrents();
-    std::for_each(std::begin(torrents), std::end(torrents), [](auto* tor) { tor->do_idle_work(); });
+    for (auto* const tor : session->torrents())
+    {
+        tor->do_idle_work();
+        tr_torrentMagnetDoIdleWork(tor);
+    }
 
     /* pump the queues */
     queuePulse(session, TR_UP);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -712,7 +712,7 @@ auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bool* did
 
     if (auto val = bool{}; (fields_to_load & tr_resume::Run) != 0 && tr_variantDictFindBool(&top, TR_KEY_paused, &val))
     {
-        tor->isRunning = !val;
+        tor->start_when_stable = !val;
         fields_loaded |= tr_resume::Run;
     }
 
@@ -831,7 +831,7 @@ auto setFromCtor(tr_torrent* tor, tr_resume::fields_t fields, tr_ctor const* cto
     {
         if (auto is_paused = bool{}; tr_ctorGetPaused(ctor, mode, &is_paused))
         {
-            tor->isRunning = !is_paused;
+            tor->start_when_stable = !is_paused;
             ret |= tr_resume::Run;
         }
     }
@@ -907,7 +907,7 @@ void save(tr_torrent* tor)
     tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->uploadedPrev + tor->uploadedCur);
     tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->peerLimit());
     tr_variantDictAddInt(&top, TR_KEY_bandwidth_priority, tor->getPriority());
-    tr_variantDictAddBool(&top, TR_KEY_paused, !tor->isRunning && !tor->isQueued());
+    tr_variantDictAddBool(&top, TR_KEY_paused, !tor->start_when_stable);
     savePeers(&top, tor);
 
     if (tor->hasMetainfo())

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -326,6 +326,19 @@ void on_have_all_metainfo(tr_torrent* tor, tr_incomplete_metadata* m)
 } // namespace set_metadata_piece_helpers
 } // namespace
 
+void tr_torrentMagnetDoIdleWork(tr_torrent* const tor)
+{
+    using namespace set_metadata_piece_helpers;
+
+    TR_ASSERT(tr_isTorrent(tor));
+
+    if (auto* const m = tor->incompleteMetadata; m != nullptr && std::empty(m->pieces_needed))
+    {
+        tr_logAddDebugTor(tor, fmt::format("we now have all the metainfo!"));
+        on_have_all_metainfo(tor, m);
+    }
+}
+
 void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, size_t len)
 {
     using namespace set_metadata_piece_helpers;
@@ -370,13 +383,6 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, si
 
     needed.erase(iter);
     tr_logAddDebugTor(tor, fmt::format("saving metainfo piece {}... {} remain", piece, std::size(needed)));
-
-    // are we done?
-    if (std::empty(needed))
-    {
-        tr_logAddDebugTor(tor, fmt::format("metainfo piece {} was the last one", piece));
-        on_have_all_metainfo(tor, m);
-    }
 }
 
 // ---

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -176,13 +176,6 @@ bool tr_torrentUseMetainfoFromFile(
         delete tor->incompleteMetadata;
         tor->incompleteMetadata = nullptr;
     }
-    tor->isStopping = true;
-    tor->magnetVerify = true;
-    if (tor->session->shouldPauseAddedTorrents())
-    {
-        tor->startAfterVerify = false;
-    }
-    tor->markEdited();
 
     return true;
 }
@@ -310,13 +303,6 @@ void on_have_all_metainfo(tr_torrent* tor, tr_incomplete_metadata* m)
     {
         delete tor->incompleteMetadata;
         tor->incompleteMetadata = nullptr;
-        tor->isStopping = true;
-        tor->magnetVerify = true;
-        if (tor->session->shouldPauseAddedTorrents() && !tor->magnetStartAfterVerify)
-        {
-            tor->startAfterVerify = false;
-        }
-        tor->markEdited();
     }
     else /* drat. */
     {

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -33,6 +33,8 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 
+void tr_torrentMagnetDoIdleWork(tr_torrent* tor);
+
 bool tr_torrentUseMetainfoFromFile(
     tr_torrent* tor,
     tr_torrent_metainfo const* metainfo,

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1045,6 +1045,10 @@ void on_metainfo_completed(tr_torrent* tor)
         {
             torrentStart(tor);
         }
+        else if (tor->isRunning)
+        {
+            tr_torrentStop(tor);
+        }
     }
 }
 
@@ -1815,6 +1819,11 @@ void torrentVerifyImpl(tr_torrent* const tor)
 
     // if the torrent's already being verified, stop it
     tor->session->verifyRemove(tor);
+
+    if (!tor->hasMetainfo())
+    {
+        return;
+    }
 
     if (tor->isRunning)
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1191,7 +1191,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     {
         on_metainfo_completed(tor);
     }
-    else if (tor->start_when_stable || !has_metainfo)
+    else if (tor->start_when_stable)
     {
         auto opts = torrent_start_opts{};
         opts.bypass_queue = !has_metainfo; // to fetch metainfo from peers

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1191,7 +1191,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     {
         on_metainfo_completed(tor);
     }
-    else if (tor->start_when_stable)
+    else if (tor->start_when_stable || !has_metainfo)
     {
         auto opts = torrent_start_opts{};
         opts.bypass_queue = !has_metainfo; // to fetch metainfo from peers

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -109,7 +109,8 @@ public:
     // but more refactoring is needed before that can happen
     // because much of tr_torrent's impl is in the non-member C bindings
 
-    void setMetainfo(tr_torrent_metainfo const& tm);
+    // Used to add metainfo to a magnet torrent.
+    void setMetainfo(tr_torrent_metainfo tm);
 
     [[nodiscard]] auto unique_lock() const
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -904,10 +904,10 @@ public:
     bool is_queued = false;
     bool isRunning = false;
     bool isStopping = false;
-    bool startAfterVerify = false;
-    bool magnetStartAfterVerify = false;
 
-    bool magnetVerify = false;
+    // start the torrent after all the startup scaffolding is done,
+    // e.g. fetching metadata from peers and/or verifying the torrent
+    bool start_when_stable = false;
 
 private:
     [[nodiscard]] constexpr bool isPieceTransferAllowed(tr_direction direction) const noexcept

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -601,7 +601,7 @@ void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool enabled);
 /** @brief Like `tr_torrentStart()`, but resumes right away regardless of the queues. */
 void tr_torrentStartNow(tr_torrent* tor);
 
-/** @brief Like tr_torrentStart(), but sets magnetStartAfterVerify to true. */
+/** @brief DEPRECATED. Equivalent to tr_torrentStart(). Use that instead. */
 void tr_torrentStartMagnet(tr_torrent*);
 
 /** @brief Return the queued torrent's position in the queue it's in. [0...n) */

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -280,7 +280,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
 {
     if ([self alertForRemainingDiskSpace])
     {
-        tr_torrentStartMagnet(self.fHandle);
+        tr_torrentStart(self.fHandle);
         [self update];
 
         //capture, specifically, stop-seeding settings changing to unlimited


### PR DESCRIPTION
Fixes #4740.

This is working for me but I'd appreciate testers give it a spin because ... there are so many options & factors that it's complicated :sweat_smile: CI will build executables that you can try while this is still an unmerged PR -- just click to the latest Sanity actions page https://github.com/transmission/transmission/actions/runs/4160296004 scroll to the 'Artifacts' section, and the executables should be there when they finish building.

I'd welcome testers to try this out & test that the right thing happens when you:

 - [ ] add a non-paused magnet and it turns out you had those files & it is a seed
 - [ ] add a non-paused magnet and you do not have the files
 - [ ] add a non-paused torrent and it turns out you had those files & it is a seed
 - [ ] add a non-paused torrent and you do not have the files
 - [ ] add a paused magnet and it turns out you had those files & it is a seed
 - [ ] add a paused magnet and you do not have the files
 - [ ] add a paused torrent and it turns out you had those files & it is a seed
 - [ ] add a paused torrent and you do not have the files
 - [ ] restart. Are previously-paused torrents still paused?
 - [ ] restart. Are previously-running torrents still running?

CC @Coeur and @sweetppro as collaborators & potential testers, and everyone in 4856 who would like to test
