### PR TITLE
fix: assertion failed leftUntilDone <= sizeWhenDone

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -156,13 +156,28 @@ void tr_completion::addPiece(tr_piece_index_t piece)
     }
 }
 
+void tr_completion::removeBlock(tr_block_index_t block)
+{
+    if (!hasBlock(block))
+    {
+        return; // already didn't have it
+    }
+
+    blocks_.unset(block);
+    size_now_ -= block_info_->blockSize(block);
+
+    size_when_done_.reset();
+    has_valid_.reset();
+}
+
 void tr_completion::removePiece(tr_piece_index_t piece)
 {
     auto const [begin, end] = block_info_->blockSpanForPiece(piece);
-    size_now_ -= countHasBytesInPiece(piece);
-    size_when_done_.reset();
-    has_valid_.reset();
-    blocks_.unsetSpan(begin, end);
+
+    for (auto block = begin; block < end; ++block)
+    {
+        removeBlock(block);
+    }
 }
 
 uint64_t tr_completion::countHasBytesInSpan(tr_byte_span_t span) const

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -172,6 +172,8 @@ private:
         return countHasBytesInSpan(block_info_->byteSpanForPiece(piece));
     }
 
+    void removeBlock(tr_block_index_t block);
+
     torrent_view const* tor_;
     tr_block_info const* block_info_;
 


### PR DESCRIPTION
Fixes #4695.

Notes: Fixed assertion failure in `tr_torrentStat()`.

The bug was in the implementation of `tr_completion::removePiece()`, which would throw off the bookkeeping with pieces that didn't align cleanly on block boundaries.