### PR TITLE
macOS autolayout fixes in info activity view

### DIFF
--- a/macosx/Base.lproj/InfoActivityView.xib
+++ b/macosx/Base.lproj/InfoActivityView.xib
@@ -32,13 +32,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Activity">
-            <rect key="frame" x="0.0" y="0.0" width="389" height="358"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="358"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2aX-cc-oXC">
-                    <rect key="frame" x="12" y="12" width="357" height="334"/>
+                    <rect key="frame" x="12" y="12" width="334" height="334"/>
                     <subviews>
                         <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Vhd-qH-kFK">
-                            <rect key="frame" x="0.0" y="136" width="357" height="198"/>
+                            <rect key="frame" x="0.0" y="136" width="334" height="198"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="28" customClass="InfoTextField">
                                     <rect key="frame" x="75" y="120" width="23" height="14"/>
@@ -113,7 +113,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <imageView verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="19" customClass="PiecesView">
-                                    <rect key="frame" x="264" y="89" width="93" height="93"/>
+                                    <rect key="frame" x="241" y="89" width="93" height="93"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="93" id="bsS-qa-kx6"/>
                                         <constraint firstAttribute="width" constant="93" id="euA-Qi-kqQ"/>
@@ -132,7 +132,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <segmentedControl verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                                    <rect key="frame" x="262" y="71" width="97" height="16"/>
+                                    <rect key="frame" x="239" y="71" width="97" height="16"/>
                                     <segmentedCell key="cell" controlSize="mini" borderStyle="border" alignment="left" style="rounded" trackingMode="selectAny" id="54">
                                         <font key="font" metaFont="miniSystem"/>
                                         <segments>
@@ -160,7 +160,7 @@
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="22" customClass="InfoTextField">
+                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="22" customClass="InfoTextField">
                                     <rect key="frame" x="75" y="136" width="23" height="14"/>
                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" placeholderString="N/A" usesSingleLineMode="YES" id="37">
                                         <font key="font" metaFont="smallSystem"/>
@@ -193,17 +193,17 @@
                                     </textFieldCell>
                                 </textField>
                                 <scrollView horizontalHuggingPriority="249" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3">
-                                    <rect key="frame" x="77" y="12" width="280" height="58"/>
+                                    <rect key="frame" x="77" y="12" width="257" height="58"/>
                                     <clipView key="contentView" drawsBackground="NO" id="5oS-8e-S2G">
-                                        <rect key="frame" x="1" y="1" width="278" height="56"/>
+                                        <rect key="frame" x="1" y="1" width="255" height="56"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <textView editable="NO" importsGraphics="NO" richText="NO" horizontallyResizable="YES" verticallyResizable="YES" usesFontPanel="YES" usesRuler="YES" linkDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="61">
-                                                <rect key="frame" x="0.0" y="0.0" width="278" height="56"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="255" height="56"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                <size key="minSize" width="278" height="56"/>
+                                                <size key="minSize" width="255" height="56"/>
                                                 <size key="maxSize" width="517" height="10000000"/>
                                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             </textView>
@@ -218,13 +218,13 @@
                                         <autoresizingMask key="autoresizingMask"/>
                                     </scroller>
                                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" controlSize="small" horizontal="NO" id="60">
-                                        <rect key="frame" x="265" y="1" width="14" height="56"/>
+                                        <rect key="frame" x="242" y="1" width="14" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                     </scroller>
                                 </scrollView>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="19" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="22" secondAttribute="trailing" constant="8" symbolic="YES" id="0TW-Bs-Akm"/>
+                                <constraint firstItem="19" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="22" secondAttribute="trailing" priority="250" constant="8" symbolic="YES" id="0TW-Bs-Akm"/>
                                 <constraint firstItem="7" firstAttribute="trailing" secondItem="21" secondAttribute="trailing" id="0ot-I1-ZUY"/>
                                 <constraint firstItem="3" firstAttribute="top" secondItem="18" secondAttribute="top" id="1aS-5E-rJb"/>
                                 <constraint firstItem="25" firstAttribute="trailing" secondItem="21" secondAttribute="trailing" id="2Nt-SL-6xH"/>
@@ -429,8 +429,8 @@
                         </customView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="WMr-Dh-mdg" secondAttribute="trailing" priority="250" constant="218" id="BL5-hI-Rcy"/>
-                        <constraint firstAttribute="width" priority="250" constant="330" id="zSb-K0-Tyg"/>
+                        <constraint firstAttribute="trailing" secondItem="WMr-Dh-mdg" secondAttribute="trailing" priority="250" constant="199" id="BL5-hI-Rcy"/>
+                        <constraint firstAttribute="width" priority="250" constant="237" id="zSb-K0-Tyg"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
@@ -444,7 +444,7 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="2aX-cc-oXC" secondAttribute="bottom" constant="12" placeholder="YES" id="J07-OR-G1K"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2aX-cc-oXC" secondAttribute="trailing" constant="12" id="OdA-Cy-muk"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2aX-cc-oXC" secondAttribute="trailing" constant="12" id="N5S-Jb-63i"/>
                 <constraint firstItem="2aX-cc-oXC" firstAttribute="top" secondItem="2" secondAttribute="top" constant="12" id="eYs-tj-l9N"/>
                 <constraint firstItem="2aX-cc-oXC" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="12" id="jV3-g1-mGq"/>
             </constraints>


### PR DESCRIPTION
fix an issue where the pieces view can jump around:
https://user-images.githubusercontent.com/7323792/218632047-994e6ce4-18db-45f0-b968-cdf0d10a5292.mov

Notes: Fixed `4.0.0` layout issue in the pieces view