### PR TITLE
Don't autofetch metainfo at startup and new torrents.

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1191,7 +1191,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     {
         on_metainfo_completed(tor);
     }
-    else if (tor->start_when_stable || !has_metainfo)
+    else if (tor->start_when_stable)
     {
         auto opts = torrent_start_opts{};
         opts.bypass_queue = !has_metainfo; // to fetch metainfo from peers

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -601,8 +601,8 @@ void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool enabled);
 /** @brief Like `tr_torrentStart()`, but resumes right away regardless of the queues. */
 void tr_torrentStartNow(tr_torrent* tor);
 
-/** @brief DEPRECATED. Equivalent to tr_torrentStart(). Use that instead. */
-void tr_torrentStartMagnet(tr_torrent*);
+/** @brief DEPRECATED. Equivalent to `tr_torrentStart()`. Use that instead. */
+void tr_torrentStartMagnet(tr_torrent* tor);
 
 /** @brief Return the queued torrent's position in the queue it's in. [0...n) */
 size_t tr_torrentGetQueuePosition(tr_torrent const* tor);


### PR DESCRIPTION
This is a temporary measure to avoid a regression in Transmission 4.0.1.
Fetching metainfo early will be postponed to #4874 in 4.1.0.