### PR TITLE
macOS fix selected Group text color

### DIFF
--- a/macosx/GroupTextCell.h
+++ b/macosx/GroupTextCell.h
@@ -6,4 +6,6 @@
 
 @interface GroupTextCell : NSTextFieldCell
 
+@property(nonatomic) BOOL selected;
+
 @end

--- a/macosx/GroupTextCell.mm
+++ b/macosx/GroupTextCell.mm
@@ -24,8 +24,8 @@
     NSRect titleRect = [self titleRectForBounds:cellFrame];
     NSMutableAttributedString* string = [[self attributedStringValue] mutableCopy];
     NSDictionary* attributes = @{
-        NSFontAttributeName: [NSFont boldSystemFontOfSize:11.0],
-        NSForegroundColorAttributeName: self.selected ? [NSColor labelColor] : [NSColor secondaryLabelColor]
+        NSFontAttributeName : [NSFont boldSystemFontOfSize:11.0],
+        NSForegroundColorAttributeName : self.selected ? [NSColor labelColor] : [NSColor secondaryLabelColor]
     };
 
     [string addAttributes:attributes range:NSMakeRange(0, string.length)];

--- a/macosx/GroupTextCell.mm
+++ b/macosx/GroupTextCell.mm
@@ -23,14 +23,10 @@
     //set font size and color
     NSRect titleRect = [self titleRectForBounds:cellFrame];
     NSMutableAttributedString* string = [[self attributedStringValue] mutableCopy];
-    NSMutableDictionary* attributes = [NSMutableDictionary
-        dictionaryWithObjects:@[ [NSFont boldSystemFontOfSize:11.0], [NSColor secondaryLabelColor] ]
-                      forKeys:@[ NSFontAttributeName, NSForegroundColorAttributeName ]];
-
-    if (self.selected)
-    {
-        [attributes setObject:[NSColor labelColor] forKey:NSForegroundColorAttributeName];
-    }
+    NSDictionary* attributes = @{
+        NSFontAttributeName: [NSFont boldSystemFontOfSize:11.0],
+        NSForegroundColorAttributeName: self.selected ? [NSColor labelColor] : [NSColor secondaryLabelColor]
+    };
 
     [string addAttributes:attributes range:NSMakeRange(0, string.length)];
     [string drawInRect:titleRect];

--- a/macosx/GroupTextCell.mm
+++ b/macosx/GroupTextCell.mm
@@ -4,6 +4,7 @@
 
 #import "GroupTextCell.h"
 #import "TorrentGroup.h"
+#import "TorrentTableView.h"
 
 @implementation GroupTextCell
 
@@ -22,9 +23,15 @@
     //set font size and color
     NSRect titleRect = [self titleRectForBounds:cellFrame];
     NSMutableAttributedString* string = [[self attributedStringValue] mutableCopy];
-    NSDictionary* attributes = [NSDictionary
+    NSMutableDictionary* attributes = [NSMutableDictionary
         dictionaryWithObjects:@[ [NSFont boldSystemFontOfSize:11.0], [NSColor secondaryLabelColor] ]
                       forKeys:@[ NSFontAttributeName, NSForegroundColorAttributeName ]];
+
+    if (self.selected)
+    {
+        [attributes setObject:[NSColor labelColor] forKey:NSForegroundColorAttributeName];
+    }
+
     [string addAttributes:attributes range:NSMakeRange(0, string.length)];
     [string drawInRect:titleRect];
 }

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -221,6 +221,22 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             }
         }
     }
+    else
+    {
+        if ([cell isKindOfClass:[GroupTextCell class]])
+        {
+            GroupTextCell* groupCell = cell;
+            groupCell.selected = NO;
+
+            // if cell is selected, set selected flag so we can style the title in GroupTextCell drawInteriorWithFrame
+            NSInteger const row = [self rowForItem:item];
+            NSIndexSet* selectedRowIndexes = self.selectedRowIndexes;
+            if ([selectedRowIndexes containsIndex:row])
+            {
+                groupCell.selected = YES;
+            }
+        }
+    }
 }
 
 //we override row highlighting because we are custom drawing the group rows

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -226,15 +226,11 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         if ([cell isKindOfClass:[GroupTextCell class]])
         {
             GroupTextCell* groupCell = cell;
-            groupCell.selected = NO;
 
             // if cell is selected, set selected flag so we can style the title in GroupTextCell drawInteriorWithFrame
             NSInteger const row = [self rowForItem:item];
             NSIndexSet* selectedRowIndexes = self.selectedRowIndexes;
-            if ([selectedRowIndexes containsIndex:row])
-            {
-                groupCell.selected = YES;
-            }
+            groupCell.selected = [selectedRowIndexes containsIndex:row];
         }
     }
 }


### PR DESCRIPTION
Fixes: #4806

Notes: Fixed `4.0.0` bug that didn't highlight the current selection in `View > Use Groups`.