### PR TITLE
fix: try utp connection first; fix utp timeout issues.

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -792,6 +792,7 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
             handshake->have_sent_bittorrent_handshake_ = true;
             handshake->set_state(State::AwaitingHandshake);
             io->write_bytes(std::data(msg), std::size(msg), false);
+            return;
         }
     }
 
@@ -807,12 +808,11 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
         handshake->have_sent_bittorrent_handshake_ = true;
         handshake->set_state(State::AwaitingHandshake);
         io->write_bytes(std::data(msg), std::size(msg), false);
+        return;
     }
-    else
-    {
-        tr_logAddTraceHand(handshake, fmt::format("handshake socket err: {:s} ({:d})", error.message, error.code));
-        handshake->done(false);
-    }
+
+    tr_logAddTraceHand(handshake, fmt::format("handshake socket err: {:s} ({:d})", error.message, error.code));
+    handshake->done(false);
 }
 
 bool tr_handshake::fire_done(bool is_connected)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -130,15 +130,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
 
     auto peer_io = tr_peerIo::create(session, parent, &info_hash, false, is_seed);
 
-    // try a TCP socket
-    if (auto sock = tr_netOpenPeerSocket(session, addr, port, is_seed); sock.is_valid())
-    {
-        peer_io->set_socket(std::move(sock));
-        return peer_io;
-    }
-
 #ifdef WITH_UTP
-    // try a UTP socket
     if (utp)
     {
         auto* const sock = utp_create_socket(session->utp_context);
@@ -152,6 +144,15 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
         }
     }
 #endif
+
+    if (!peer_io->socket_.is_valid())
+    {
+        if (auto sock = tr_netOpenPeerSocket(session, addr, port, is_seed); sock.is_valid())
+        {
+            peer_io->set_socket(std::move(sock));
+            return peer_io;
+        }
+    }
 
     return {};
 }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -686,17 +686,17 @@ void tr_peerIo::on_utp_error(int errcode)
     tr_error* error = nullptr;
     switch (errcode)
     {
-        case UTP_ECONNREFUSED:
-            tr_error_set_from_errno(&error, ECONNREFUSED);
-            break;
-        case UTP_ECONNRESET:
-            tr_error_set_from_errno(&error, ECONNRESET);
-            break;
-        case UTP_ETIMEDOUT:
-            tr_error_set_from_errno(&error, ETIMEDOUT);
-            break;
-        default:
-            tr_error_set(&error, errcode, utp_error_code_names[errcode]);
+    case UTP_ECONNREFUSED:
+        tr_error_set_from_errno(&error, ECONNREFUSED);
+        break;
+    case UTP_ECONNRESET:
+        tr_error_set_from_errno(&error, ECONNRESET);
+        break;
+    case UTP_ETIMEDOUT:
+        tr_error_set_from_errno(&error, ETIMEDOUT);
+        break;
+    default:
+        tr_error_set(&error, errcode, utp_error_code_names[errcode]);
     }
     call_error_callback(*error);
     tr_error_clear(&error);


### PR DESCRIPTION
A followup to #4826 which correctly diagnosed a problem (utp connections did not timeout correctly) but had a suboptimal solution. **Big** thanks to @reardonia for the review and analysis of both Tr3 and Tr4.

This PR:

- Reverts 4826 to restore the behavior of trying a uTP peer connection before TCP.
- Fixes a Tr3 and Tr4 bug that did not start the uTP upkeep timer until there was uTP peer data received. This meant that in the edge case of starting a new Transmission session with a new torrent whose peers were TCP-only, those uTP connection attempts would never timeout because the "check timeouts" timer had never been started :dizzy: 
- Fixes a Tr4 bug that did not handle uTP errors correctly in `handshake.cc`, preventing a TCP retry from occurring.

@reardonia code review welcomed :heart: 

Notes: Fixed `4.0.0` bug that failed to retry to connect to peers with TCP if UTP failed first.