### PR TITLE
fix: awkward grammar in details dialog running-time display

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -809,7 +809,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
         }
         else
         {
-            str = tr_format_time_relative(now, baseline);
+            str = tr_format_time(now - baseline);
         }
     }
 


### PR DESCRIPTION
Fixes #4883.

Notes: Fixed awkward grammar in the Details Dialog's running-time row. 