### PR TITLE
feat: add stats for known peers, not just connected ones

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -263,8 +263,12 @@ struct tr_swarm_stats
 {
     std::array<uint16_t, 2> active_peer_count;
     uint16_t active_webseed_count;
+    // connected peers
     uint16_t peer_count;
+    // connected peers
     std::array<uint16_t, TR_PEER_FROM__MAX> peer_from_count;
+    // known peers
+    std::array<uint16_t, TR_PEER_FROM__MAX> known_peer_from_count;
 };
 
 tr_swarm_stats tr_swarmGetStats(tr_swarm const* swarm);

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -265,9 +265,9 @@ struct tr_swarm_stats
     uint16_t active_webseed_count;
     // connected peers
     uint16_t peer_count;
-    // connected peers
+    // connected peers by peer source
     std::array<uint16_t, TR_PEER_FROM__MAX> peer_from_count;
-    // known peers
+    // known peers by peer source
     std::array<uint16_t, TR_PEER_FROM__MAX> known_peer_from_count;
 };
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -455,6 +455,12 @@ public:
             peer_info.found_at(from);
             peer_info.set_pex_flags(flags);
         }
+        else if (is_connectable)
+        {
+            // TODO: decrement count on `connectable_pool.extract` and `connectable_pool.erase`
+            // TODO: increment count on `connectable_pool.insert`
+            ++stats.known_peer_from_count[from];
+        }
 
         mark_all_seeds_flag_dirty();
 
@@ -1334,8 +1340,6 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, tr_pex const* pex, s
             ++n_used;
         }
     }
-    // best estimate: we can't tell for sure if they are the same peers
-    s->stats.known_peer_from_count[from] = std::max(s->stats.known_peer_from_count[from], (uint16_t)n_used);
 
     return n_used;
 }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1334,6 +1334,8 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, tr_pex const* pex, s
             ++n_used;
         }
     }
+    // best estimate: we can't tell for sure if they are the same peers
+    s->stats.known_peer_from_count[from] = std::max(s->stats.known_peer_from_count[from], (uint16_t)n_used);
 
     return n_used;
 }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -336,7 +336,7 @@ public:
             auto& [socket_address, peer_info] = *iter;
             if (peer_info.is_inactive(now))
             {
-                --stats.known_peer_from_count[iter->second.from_first()];
+                --stats.known_peer_from_count[peer_info.from_first()];
                 iter = connectable_pool.erase(iter);
             }
             else
@@ -822,7 +822,8 @@ private:
             }
 
             info_this.merge(info_that);
-            stats.known_peer_from_count[info_that.from_first()] -= connectable_pool.erase(info_that.listen_socket_address());
+            auto from = info_that.from_first();
+            stats.known_peer_from_count[from] -= connectable_pool.erase(info_that.listen_socket_address());
         }
         else if (!was_connectable)
         {
@@ -838,7 +839,7 @@ private:
         }
         else
         {
-            ++stats.known_peer_from_count[info_this.from_first()];
+            ++stats.known_peer_from_count[nh.mapped().from_first()];
             TR_ASSERT(nh.key().address() == nh.mapped().listen_address());
         }
         nh.key().port_ = event.port;
@@ -865,8 +866,8 @@ private:
             TR_ASSERT(it != std::end(peers));
             (*it)->do_purge = true;
 
-            // Note that it_that is invalid after this point
             --stats.known_peer_from_count[info_that.from_first()];
+            // Note that it_that is invalid after this point
             graveyard_pool.insert(connectable_pool.extract(it_that));
 
             return false;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1357,6 +1357,7 @@ tr_stat tr_torrent::stats() const
     for (int i = 0; i < TR_PEER_FROM__MAX; i++)
     {
         stats.peersFrom[i] = swarm_stats.peer_from_count[i];
+        stats.knownPeersFrom[i] = swarm_stats.known_peer_from_count[i];
     }
 
     auto const piece_upload_speed_byps = this->bandwidth_.get_piece_speed_bytes_per_second(now_msec, TR_UP);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1574,9 +1574,13 @@ struct tr_stat
     /** Number of peers that we're connected to */
     uint16_t peersConnected;
 
-    /** How many peers we found out about from the tracker, or from pex,
+    /** How many connected peers we found out about from the tracker, or from pex,
         or from incoming connections, or from our resume file. */
     uint16_t peersFrom[TR_PEER_FROM__MAX];
+
+    /** How many known peers we found out about from the tracker, or from pex,
+        or from incoming connections, or from our resume file. */
+    uint16_t knownPeersFrom[TR_PEER_FROM__MAX];
 
     /** Number of peers that are sending data to us. */
     uint16_t peersSendingToUs;

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -141,6 +141,13 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
     NSUInteger ltep = 0;
     NSUInteger toUs = 0;
     NSUInteger fromUs = 0;
+    NSUInteger knownTracker = 0;
+    NSUInteger knownIncoming = 0;
+    NSUInteger knownCache = 0;
+    NSUInteger knownLpd = 0;
+    NSUInteger knownPex = 0;
+    NSUInteger knownDht = 0;
+    NSUInteger knownLtep = 0;
     BOOL anyActive = false;
     for (Torrent* torrent in self.fTorrents)
     {
@@ -170,6 +177,13 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
                 fromUs += torrent.peersGettingFromUs;
             }
         }
+        knownTracker += torrent.totalKnownPeersTracker;
+        knownIncoming += torrent.totalKnownPeersIncoming;
+        knownCache += torrent.totalKnownPeersCache;
+        knownLpd += torrent.totalKnownPeersLocal;
+        knownPex += torrent.totalKnownPeersPex;
+        knownDht += torrent.totalKnownPeersDHT;
+        knownLtep += torrent.totalKnownPeersLTEP;
     }
 
     [self.fPeers sortUsingDescriptors:self.peerSortDescriptors];
@@ -210,45 +224,13 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
                 connectedText = [connectedText stringByAppendingFormat:@": %@", [upDownComponents componentsJoinedByString:@", "]];
             }
 
-            NSMutableArray* fromComponents = [NSMutableArray arrayWithCapacity:7];
-            if (tracker > 0)
-            {
-                [fromComponents addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu tracker", "Inspector -> Peers tab -> peers"),
-                                                                              tracker]];
-            }
-            if (incoming > 0)
-            {
-                [fromComponents addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu incoming", "Inspector -> Peers tab -> peers"),
-                                                                              incoming]];
-            }
-            if (cache > 0)
-            {
-                [fromComponents
-                    addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu cache", "Inspector -> Peers tab -> peers"), cache]];
-            }
-            if (lpd > 0)
-            {
-                [fromComponents addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu local discovery", "Inspector -> Peers tab -> peers"),
-                                                                              lpd]];
-            }
-            if (pex > 0)
-            {
-                [fromComponents
-                    addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu PEX", "Inspector -> Peers tab -> peers"), pex]];
-            }
-            if (dht > 0)
-            {
-                [fromComponents
-                    addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu DHT", "Inspector -> Peers tab -> peers"), dht]];
-            }
-            if (ltep > 0)
-            {
-                [fromComponents
-                    addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu LTEP", "Inspector -> Peers tab -> peers"), ltep]];
-            }
-
-            connectedText = [connectedText stringByAppendingFormat:@"\n%@", [fromComponents componentsJoinedByString:@", "]];
+            connectedText = [connectedText
+                stringByAppendingFormat:@"\n%@", [self connectedTextFrom:tracker:incoming:cache:lpd:pex:dht:ltep]];
         }
+
+        connectedText = [[connectedText stringByAppendingString:@"\n"]
+            stringByAppendingFormat:NSLocalizedString(@"(known: %@)", "Inspector -> Peers tab -> peers"),
+                                    [self connectedTextFrom:knownTracker:knownIncoming:knownCache:knownLpd:knownPex:knownDht:knownLtep]];
 
         self.fConnectedPeersField.stringValue = connectedText;
     }
@@ -264,8 +246,60 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
             notActiveString = NSLocalizedString(@"Transfers Not Active", "Inspector -> Peers tab -> peers");
         }
 
+        notActiveString = [[notActiveString stringByAppendingString:@"\n"]
+            stringByAppendingFormat:NSLocalizedString(@"(known: %@)", "Inspector -> Peers tab -> peers"),
+                                    [self connectedTextFrom:knownTracker:knownIncoming:knownCache:knownLpd:knownPex:knownDht:knownLtep]];
+
         self.fConnectedPeersField.stringValue = notActiveString;
     }
+}
+
+- (NSString*)connectedTextFrom:(NSUInteger)
+                       tracker:(NSUInteger)incoming
+                              :(NSUInteger)cache
+                              :(NSUInteger)lpd
+                              :(NSUInteger)pex
+                              :(NSUInteger)dht
+                              :(NSUInteger)ltep
+{
+    NSMutableArray* fromComponents = [NSMutableArray arrayWithCapacity:7];
+    if (tracker > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu tracker", "Inspector -> Peers tab -> peers"), tracker]];
+    }
+    if (incoming > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu incoming", "Inspector -> Peers tab -> peers"), incoming]];
+    }
+    if (cache > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu cache", "Inspector -> Peers tab -> peers"), cache]];
+    }
+    if (lpd > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu local discovery", "Inspector -> Peers tab -> peers"), lpd]];
+    }
+    if (pex > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu PEX", "Inspector -> Peers tab -> peers"), pex]];
+    }
+    if (dht > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu DHT", "Inspector -> Peers tab -> peers"), dht]];
+    }
+    if (ltep > 0)
+    {
+        [fromComponents
+            addObject:[NSString localizedStringWithFormat:NSLocalizedString(@"%lu LTEP", "Inspector -> Peers tab -> peers"), ltep]];
+    }
+
+    return [fromComponents componentsJoinedByString:@", "];
 }
 
 - (void)saveViewSize

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -228,10 +228,6 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
                 stringByAppendingFormat:@"\n%@", [self connectedTextFrom:tracker:incoming:cache:lpd:pex:dht:ltep]];
         }
 
-        connectedText = [[connectedText stringByAppendingString:@"\n"]
-            stringByAppendingFormat:NSLocalizedString(@"(known: %@)", "Inspector -> Peers tab -> peers"),
-                                    [self connectedTextFrom:knownTracker:knownIncoming:knownCache:knownLpd:knownPex:knownDht:knownLtep]];
-
         self.fConnectedPeersField.stringValue = connectedText;
     }
     else
@@ -246,16 +242,25 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
             notActiveString = NSLocalizedString(@"Transfers Not Active", "Inspector -> Peers tab -> peers");
         }
 
-        notActiveString = [[notActiveString stringByAppendingString:@"\n"]
-            stringByAppendingFormat:NSLocalizedString(@"(known: %@)", "Inspector -> Peers tab -> peers"),
-                                    [self connectedTextFrom:knownTracker:knownIncoming:knownCache:knownLpd:knownPex:knownDht:knownLtep]];
-
         self.fConnectedPeersField.stringValue = notActiveString;
+    }
+    auto totalKnown = knownTracker + knownIncoming + knownCache + knownLpd + knownPex + knownDht + knownLtep;
+    NSString* knownText = [self connectedTextFrom:knownTracker:knownIncoming:knownCache:knownLpd:knownPex:knownDht:knownLtep];
+    if (totalKnown <= 1)
+    {
+        self.fConnectedPeersField.toolTip = [NSLocalizedString(@"Known:", "Inspector -> Peers tab -> peers")
+            stringByAppendingFormat:@" %@", totalKnown > 0 ? knownText : @"0"];
+    }
+    else
+    {
+        self.fConnectedPeersField.toolTip = [[NSString
+            localizedStringWithFormat:NSLocalizedString(@"%lu Known:", "Inspector -> Peers tab -> peers"), totalKnown]
+            stringByAppendingFormat:@" %@", knownText];
     }
 }
 
-- (NSString*)connectedTextFrom:(NSUInteger)
-                       tracker:(NSUInteger)incoming
+- (NSString*)connectedTextFrom:(NSUInteger)tracker //
+                              :(NSUInteger)incoming
                               :(NSUInteger)cache
                               :(NSUInteger)lpd
                               :(NSUInteger)pex

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -160,6 +160,14 @@ extern NSString* const kTorrentDidChangeGroupNotification;
 @property(nonatomic, readonly) NSUInteger totalPeersLocal;
 @property(nonatomic, readonly) NSUInteger totalPeersLTEP;
 
+@property(nonatomic, readonly) NSUInteger totalKnownPeersTracker;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersIncoming;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersCache;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersPex;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersDHT;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersLocal;
+@property(nonatomic, readonly) NSUInteger totalKnownPeersLTEP;
+
 @property(nonatomic, readonly) NSUInteger peersSendingToUs;
 @property(nonatomic, readonly) NSUInteger peersGettingFromUs;
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1352,6 +1352,41 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     return self.fStat->peersFrom[TR_PEER_FROM_LTEP];
 }
 
+- (NSUInteger)totalKnownPeersTracker
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_TRACKER];
+}
+
+- (NSUInteger)totalKnownPeersIncoming
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_INCOMING];
+}
+
+- (NSUInteger)totalKnownPeersCache
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_RESUME];
+}
+
+- (NSUInteger)totalKnownPeersPex
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_PEX];
+}
+
+- (NSUInteger)totalKnownPeersDHT
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_DHT];
+}
+
+- (NSUInteger)totalKnownPeersLocal
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_LPD];
+}
+
+- (NSUInteger)totalKnownPeersLTEP
+{
+    return self.fStat->knownPeersFrom[TR_PEER_FROM_LTEP];
+}
+
 - (NSUInteger)peersSendingToUs
 {
     return self.fStat->peersSendingToUs;


### PR DESCRIPTION
New feature: display stats for known peers (instead of just stats for connected peers).

Some other torrent clients already have this feature, and I feel this is kind of a must-have for Transmission, especially in light of all the connection issues that we could be facing.

Screenshots: check the last line where it's written "known".
![Capture d’écran 2023-02-15 à 16 01 00](https://user-images.githubusercontent.com/839992/218970010-0ec84591-7ae7-436a-bca4-adfa6ef2a096.png)
![Capture d’écran 2023-02-15 à 16 06 36](https://user-images.githubusercontent.com/839992/218970025-6380dec6-d7a2-439a-8af0-8b78bbaa5d86.png)

Fixes #1054.