### PR TITLE
fix: progressbar percentage in gtk client

### DIFF
--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -226,7 +226,7 @@ Torrent::ChangeFlags Torrent::Impl::update_cache()
             stats->activity == TR_STATUS_SEED && has_seed_ratio ? stats->seedRatioPercentDone : stats->percentDone,
             0.0F,
             1.0F),
-        0.01F,
+        0.0001F,
         result,
         ChangeFlag::PERCENT_DONE);
     update_cache_value(cache_.finished, stats->finished, result, ChangeFlag::FINISHED);


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/4891 but see the discussion in 4891's description.

Notes: Fixed `4.0.0` rounding error in the progressbar's percentage display.