### PR TITLE
build: Use CXX symbol checking to verify system libutp

### DIFF
--- a/cmake/FindUTP.cmake
+++ b/cmake/FindUTP.cmake
@@ -20,7 +20,7 @@ find_library(UTP_LIBRARY
     HINTS ${_UTP_LIBDIR})
 
 if(UTP_INCLUDE_DIR AND UTP_LIBRARY)
-    include(CheckSymbolExists)
+    include(CheckCXXSymbolExists)
 
     set(_UTP_FUNCS
         utp_check_timeouts
@@ -53,7 +53,7 @@ if(UTP_INCLUDE_DIR AND UTP_LIBRARY)
     foreach(_UTP_FUNC IN LISTS _UTP_FUNCS)
         string(MAKE_C_IDENTIFIER "HAVE_${_UTP_FUNC}" _UTP_FUNC_VAR)
         string(TOUPPER "${_UTP_FUNC_VAR}" _UTP_FUNC_VAR)
-        check_symbol_exists(${_UTP_FUNC} libutp/utp.h ${_UTP_FUNC_VAR})
+        check_cxx_symbol_exists(${_UTP_FUNC} libutp/utp.h ${_UTP_FUNC_VAR})
         if(NOT ${_UTP_FUNC_VAR})
             unset(UTP_INCLUDE_DIR CACHE)
             unset(UTP_LIBRARY CACHE)


### PR DESCRIPTION
Configuring yielded:

      Could NOT find UTP (missing: UTP_LIBRARY UTP_INCLUDE_DIR)
    Call Stack (most recent call first):
      /very/long/path/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
      cmake/FindUTP.cmake:74 (find_package_handle_standard_args)
      cmake/TrMacros.cmake:136 (find_package)
      CMakeLists.txt:503 (tr_add_external_auto_library)

    -- Configuring incomplete, errors occurred!
    See also "/home/user/dev/torrents/transmission/build/CMakeFiles/CMakeOutput.log".
    See also "/home/user/dev/torrents/transmission/build/CMakeFiles/CMakeError.log".

The error logs included this bit:

    /very/long/path/bin/ld: /very/long/path/lib/libutp.a(utp_internal.cpp.o): in function `UTP_FreeAll(UTPSocketHT*)':
    (.text+0xc15): undefined reference to `operator delete(void*)'

After changing the check method to use `check_cxx_symbol_exists` instead, configuring yielded:

    -- Found UTP: /very/long/path/lib/libutp.a


Closes https://github.com/transmission/transmission/issues/4910