### PR TITLE
fix: Implicit conversion loses integer precision

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -203,7 +203,7 @@ static void removeKeRangerRansomware()
             pid_t const krProcessId = [line substringFromIndex:1].intValue;
             if (kill(krProcessId, SIGKILL) == -1)
             {
-                NSLog(@"Unable to forcibly terminate ransomware process (kernel_service, pid %d), please do so manually", (int)krProcessId);
+                NSLog(@"Unable to forcibly terminate ransomware process (kernel_service, pid %d), please do so manually", krProcessId);
             }
         }
     }

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -151,7 +151,7 @@ typedef struct PieceInfo
 
     // get the current state
     BOOL const showAvailability = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
-    NSInteger const numCells = MIN(_torrent.pieceCount, kMaxCells);
+    int const numCells = static_cast<int>(MIN(_torrent.pieceCount, kMaxCells));
     PieceInfo info;
     [self.torrent getAvailability:info.available size:numCells];
     [self.torrent getAmountFinished:info.complete size:numCells];

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -157,7 +157,7 @@ typedef struct PieceInfo
     [self.torrent getAmountFinished:info.complete size:numCells];
 
     // compute bounds and color of each cell
-    int const across = (int)ceil(sqrt(numCells));
+    int const across = static_cast<int>(ceil(sqrt(numCells)));
     CGFloat const fullWidth = self.bounds.size.width;
     NSInteger const cellWidth = (NSInteger)((fullWidth - (across + 1) * kBetweenPadding) / across);
     NSInteger const extraBorder = (NSInteger)((fullWidth - ((cellWidth + kBetweenPadding) * across + kBetweenPadding)) / 2);

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -157,16 +157,16 @@ typedef struct PieceInfo
     [self.torrent getAmountFinished:info.complete size:numCells];
 
     // compute bounds and color of each cell
-    NSInteger const across = (NSInteger)ceil(sqrt(numCells));
+    int const across = (int)ceil(sqrt(numCells));
     CGFloat const fullWidth = self.bounds.size.width;
     NSInteger const cellWidth = (NSInteger)((fullWidth - (across + 1) * kBetweenPadding) / across);
     NSInteger const extraBorder = (NSInteger)((fullWidth - ((cellWidth + kBetweenPadding) * across + kBetweenPadding)) / 2);
     NSMutableArray<NSValue*>* cellBounds = [NSMutableArray arrayWithCapacity:numCells];
     NSMutableArray<NSColor*>* cellColors = [NSMutableArray arrayWithCapacity:numCells];
-    for (NSInteger index = 0; index < numCells; index++)
+    for (int index = 0; index < numCells; index++)
     {
-        NSInteger const row = index / across;
-        NSInteger const col = index % across;
+        int const row = index / across;
+        int const col = index % across;
 
         cellBounds[index] = [NSValue valueWithRect:NSMakeRect(
                                                        col * (cellWidth + kBetweenPadding) + kBetweenPadding + extraBorder,
@@ -184,12 +184,12 @@ typedef struct PieceInfo
     {
         self.image = [NSImage imageWithSize:self.bounds.size flipped:NO drawingHandler:^BOOL(NSRect /*dstRect*/) {
             NSRect cFillRects[numCells];
-            for (NSInteger i = 0; i < numCells; ++i)
+            for (int i = 0; i < numCells; ++i)
             {
                 cFillRects[i] = cellBounds[i].rectValue;
             }
             NSColor* cFillColors[numCells];
-            for (NSInteger i = 0; i < numCells; ++i)
+            for (int i = 0; i < numCells; ++i)
             {
                 cFillColors[i] = cellColors[i];
             }

--- a/macosx/ProgressBarView.mm
+++ b/macosx/ProgressBarView.mm
@@ -166,7 +166,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     NSIndexSet* previousFinishedIndexes = torrent.previousFinishedPieces;
     NSMutableIndexSet* finishedIndexes = [NSMutableIndexSet indexSet];
 
-    for (NSInteger i = 0; i < pieceCount; i++)
+    for (int i = 0; i < pieceCount; i++)
     {
         NSColor* pieceColor;
         if (piecesPercent[i] == 1.0f)

--- a/macosx/ProgressBarView.mm
+++ b/macosx/ProgressBarView.mm
@@ -150,7 +150,7 @@ static NSInteger const kMaxPieces = 18 * 18;
         return;
     }
 
-    NSInteger pieceCount = MIN(torrent.pieceCount, kMaxPieces);
+    int const pieceCount = static_cast<int>(MIN(torrent.pieceCount, kMaxPieces));
     float* piecesPercent = static_cast<float*>(malloc(pieceCount * sizeof(float)));
     [torrent getAmountFinished:piecesPercent size:pieceCount];
 

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -31,8 +31,8 @@ extern NSString* const kTorrentDidChangeGroupNotification;
 
 @property(nonatomic, readonly) NSString* currentDirectory;
 
-- (void)getAvailability:(int8_t*)tab size:(NSInteger)size;
-- (void)getAmountFinished:(float*)tab size:(NSInteger)size;
+- (void)getAvailability:(int8_t*)tab size:(int)size;
+- (void)getAmountFinished:(float*)tab size:(int)size;
 @property(nonatomic) NSIndexSet* previousFinishedPieces;
 
 - (void)update;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -201,12 +201,12 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     return @(tr_torrentGetCurrentDir(self.fHandle));
 }
 
-- (void)getAvailability:(int8_t*)tab size:(NSInteger)size
+- (void)getAvailability:(int8_t*)tab size:(int)size
 {
     tr_torrentAvailability(self.fHandle, tab, size);
 }
 
-- (void)getAmountFinished:(float*)tab size:(NSInteger)size
+- (void)getAmountFinished:(float*)tab size:(int)size
 {
     tr_torrentAmountFinished(self.fHandle, tab, size);
 }


### PR DESCRIPTION
A minor warning fix:
>Implicit conversion loses integer precision: 'NSInteger' (aka 'long') to 'int'