### PR TITLE
Allow searching labels with spaces and hyphens

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -940,7 +940,7 @@ TODO: fix this when notifications get fixed
 
     let filter_text = null;
     let labels = null;
-    const m = /^labels:([\w,]*)(.*)$/.exec(this.filterText);
+    const m = /^labels:([\w,-\s]*)(.*)$/.exec(this.filterText);
     if (m) {
       filter_text = m[2].trim();
       labels = m[1].split(',');


### PR DESCRIPTION
Right now the `labels:` filter does not allow searching labels containing spaces or hyphens, this minor change fixes it.