### PR TITLE
fix: revert tr_torrentStat() acquires a session thread lock (#4571

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1476,7 +1476,6 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     using namespace stat_helpers;
 
     TR_ASSERT(tr_isTorrent(tor));
-    auto const lock = tor->unique_lock();
 
     auto const now = tr_time_msec();
     auto const now_sec = tr_time();


### PR DESCRIPTION
This reverts commit e4b480ecd45f79ff302a60ad2347a10e8dd7d4db.

This fix is too burdensome; it causes a lot of thread contention. I need to find a different solution.

Reopening https://github.com/transmission/transmission/issues/3811.