### PR TITLE
build: do not test utils if not building utils

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(gtest)
 add_subdirectory(libtransmission)
-add_subdirectory(utils)
+if(ENABLE_UTILS)
+    add_subdirectory(utils)
+endif()


### PR DESCRIPTION
Setting `-DENABLE_UTILS=0 -DENABLE_TESTS=1` causes CMake errors due to tests/utils/CMakeLists.txt referencing `$<TARGET_FILE:transmission-show>` which is undefined.  Fixed by including the tests/utils/ directory only if `ENABLE_UTILS` is true.