### PR TITLE
Support in-source builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -53,18 +53,18 @@ jobs:
             git diff --exit-code "$MERGE_BASE" -- "$@"
             echo "$name-changed=$?" >> "$GITHUB_OUTPUT"
           }
-          get_changes cli      CMakeLists.txt Transmission.xcodeproj third-party libtransmission cli
-          get_changes any-code CMakeLists.txt Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web third-party
-          get_changes our-code CMakeLists.txt Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web
-          get_changes daemon   CMakeLists.txt Transmission.xcodeproj third-party libtransmission daemon
+          get_changes cli      CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission cli
+          get_changes any-code CMakeLists.txt cmake Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web third-party
+          get_changes our-code CMakeLists.txt cmake Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web
+          get_changes daemon   CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission daemon
           get_changes dist     dist
           get_changes docs     docs
-          get_changes gtk      CMakeLists.txt third-party libtransmission gtk
-          get_changes mac      CMakeLists.txt Transmission.xcodeproj third-party libtransmission macosx Transmission.xcodeproj
-          get_changes qt       CMakeLists.txt third-party libtransmission qt
-          get_changes tests    CMakeLists.txt third-party libtransmission utils tests
-          get_changes utils    CMakeLists.txt third-party libtransmission utils
-          get_changes web      CMakeLists.txt third-party libtransmission web
+          get_changes gtk      CMakeLists.txt cmake third-party libtransmission gtk
+          get_changes mac      CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission macosx Transmission.xcodeproj
+          get_changes qt       CMakeLists.txt cmake third-party libtransmission qt
+          get_changes tests    CMakeLists.txt cmake third-party libtransmission utils tests
+          get_changes utils    CMakeLists.txt cmake third-party libtransmission utils
+          get_changes web      CMakeLists.txt cmake third-party libtransmission web
 
   code-style:
     runs-on: ubuntu-22.04

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -145,10 +145,10 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
                 set(${CMAKE_MATCH_1} ${CMAKE_MATCH_3} CACHE INTERNAL "")
             endif()
         endforeach()
-        add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/${DIRNAME}" "${CMAKE_BINARY_DIR}/third-party/${DIRNAME}")
+        add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/${DIRNAME}" "${CMAKE_BINARY_DIR}/third-party/${DIRNAME}.bld")
     else()
         set(${ID}_UPSTREAM_TARGET ${LIBNAME})
-        set(${ID}_PREFIX "${CMAKE_BINARY_DIR}/third-party/${${ID}_UPSTREAM_TARGET}")
+        set(${ID}_PREFIX "${CMAKE_BINARY_DIR}/third-party/${DIRNAME}.bld/pfx")
 
         set(${ID}_INCLUDE_DIR "${${ID}_PREFIX}/include"
             CACHE INTERNAL "")
@@ -169,8 +169,9 @@ macro(tr_add_external_auto_library ID DIRNAME LIBNAME)
 
         ExternalProject_Add(
             ${${ID}_UPSTREAM_TARGET}
-            URL "${CMAKE_SOURCE_DIR}/third-party/${DIRNAME}"
-            PREFIX "${${ID}_PREFIX}"
+            PREFIX "${CMAKE_BINARY_DIR}/third-party/${DIRNAME}.bld"
+            SOURCE_DIR "${CMAKE_SOURCE_DIR}/third-party/${DIRNAME}"
+            INSTALL_DIR "${${ID}_PREFIX}"
             CMAKE_ARGS
                 -Wno-dev # We don't want to be warned over unused variables
                 --no-warn-unused-cli


### PR DESCRIPTION
Don't copy third-party directories into themselves (actually, don't copy them at all) by switching from `URL` to `SOURCE_DIR`. Separate build, source, and install directories for third-party libraries.

Despite out-of-source builds being "strongly encauraged"[^1], people unfamiliar with CMake keep doing the opposite (see #1264, #2997, #3062, #3479, #4945). I first considered erroring out when in-source build is attempted, but this would've led to us still needing to educate people on what building out-of-source means, which is not something I want to spend my time on.

[^1]: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Getting%20Started.html