### PR TITLE
docs: document new settings

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -34,8 +34,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
 ### Options
 #### IP Announce
 
- * **announce-ip:** String (default = "") Alternative IP address to announce to tracker.
- * **announce-ip-enabled:** Boolean (default = false) When enabled **announce-ip** value is used instead of client's address visible to tracker for announcement requests.
+ * **announce-ip:** String (default = "") Alternative IP address to announce to the tracker.
+ * **announce-ip-enabled:** Boolean (default = false) When enabled **announce-ip** value is used instead of the client's address visible to the tracker for announcement requests.
 
 #### Bandwidth
 
@@ -62,19 +62,21 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **preallocation:** Number (0 = Off, 1 = Fast, 2 = Full (slower but reduces disk fragmentation), default = 1)
  * **rename-partial-files:** Boolean (default = true) Postfix partially downloaded files with ".part".
  * **start-added-torrents:** Boolean (default = true) Start torrents as soon as they are added.
+ * **trash-can-enabled:** Boolean (default = true) Whether to move the torrents to the system's trashcan or unlink them right away upon deletion from Transmission.
  * **trash-original-torrent-files:** Boolean (default = false) Delete torrents added from the watch directory.
- * **umask:** String (default = "022") Sets Transmission's file mode creation mask. See [the umask(2) manpage](https://developer.apple.com/documentation/Darwin/Reference/ManPages/man2/umask.2.html) for more information. Users who want their saved torrents to be world-writable may want to set this value to "0".
+ * **umask:** String (default = "022") Sets Transmission's file mode creation mask. See [the umask(2) manpage](https://man7.org/linux/man-pages/man2/umask.2.html) for more information.
  * **watch-dir:** String
- * **watch-dir-enabled:** Boolean (default = false) Watch a directory for torrent files and add them to transmission.
+ * **watch-dir-enabled:** Boolean (default = false) Watch a directory for torrent files and add them to Transmission.
    _Note: When **watch-dir-enabled** is true, only the transmission-daemon, transmission-gtk, and transmission-qt applications will monitor **watch-dir** for new .torrent files and automatically load them._
 
 #### Misc
- * **cache-size-mb:** Size (default = 4), in megabytes, to allocate for Transmission's memory cache. The cache is used to help batch disk IO together, so increasing the cache size can be used to reduce the number of disk reads and writes.
+ * **cache-size-mb:** Number (default = 4), in megabytes, to allocate for Transmission's memory cache. The cache is used to help batch disk IO together, so increasing the cache size can be used to reduce the number of disk reads and writes. The value is the total available to the Transmission instance.
+ * **default-trackers:** String (default = "") A list of double-newline separated tracker announce URLs. These are used for all torrents in addition to the per torrent trackers specified in the torrent file. If a tracker is only meant to be a backup, it should be separated from its main tracker by a single newline character. If a tracker should be used additionally to another tracker it should be separated by two newlines. (e.g. "udp://tracker.example.invalid:1337/announce\n\nudp://tracker.another-example.invalid:6969/announce\nhttps://backup-tracker.another-example.invalid:443/announce\n\nudp://tracker.yet-another-example.invalid:1337/announce", in this case tracker.example.invalid, tracker.another-example.invalid and tracker.yet-another-example.invalid would be used as trackers and backup-tracker.another-example.invalid as backup in case tracker.another-example.invalid is unreachable.
  * **dht-enabled:** Boolean (default = true) Enable [Distributed Hash Table (DHT)](https://wiki.theory.org/BitTorrentSpecification#Distributed_Hash_Table).
  * **encryption:** Number (0 = Prefer unencrypted connections, 1 = Prefer encrypted connections, 2 = Require encrypted connections; default = 1) [Encryption](https://wiki.vuze.com/w/Message_Stream_Encryption) preference. Encryption may help get around some ISP filtering, but at the cost of slightly higher CPU use.
  * **lazy-bitfield-enabled:** Boolean (default = true) May help get around some ISP filtering. [Vuze specification](https://wiki.vuze.com/w/Commandline_options#Network_Options).
  * **lpd-enabled:** Boolean (default = false) Enable [Local Peer Discovery (LPD)](https://en.wikipedia.org/wiki/Local_Peer_Discovery).
- * **message-level:** Number (0 = None, 1 = Error, 2 = Info, 3 = Debug, default = 2) Set verbosity of transmission messages.
+ * **message-level:** Number (0 = None, 1 = Error, 2 = Info, 3 = Debug, default = 2) Set verbosity of Transmission's log messages.
  * **pex-enabled:** Boolean (default =  true) Enable [https://en.wikipedia.org/wiki/Peer_exchange Peer Exchange (PEX)].
  * **pidfile:** String Path to file in which daemon PID will be stored (transmission-daemon only)
  * **prefetch-enabled:** Boolean (default = true). When enabled, Transmission will hint to the OS which piece data it's about to read from disk in order to satisfy requests from peers. On Linux, this is done by passing `POSIX_FADV_WILLNEED` to [posix_fadvise()](https://www.kernel.org/doc/man-pages/online/pages/man2/posix_fadvise.2.html). On macOS, this is done by passing `F_RDADVISE` to [fcntl()](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html).
@@ -85,6 +87,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **script-torrent-done-filename:** String (default = "") Path to script.
  * **script-torrent-done-seeding-enabled:** Boolean (default = false) Run a script when a torrent is done seeding. Environmental variables are passed in as detailed on the [Scripts](./Scripts.md) page
  * **script-torrent-done-seeding-filename:** String (default = "") Path to script.
+ * **tcp-enabled:** Boolean (default = true) Optionally disable TCP connection to other peers. Never disable TCP when you also disable UTP, because then your client would not be able to communicate. Disabling TCP might also break webseeds. Unless you have a good reason, you should not set this to false.
  * **torrent-added-verify-mode:** String ("fast", "full", default: "fast") Whether newly-added torrents' local data should be fully verified when added, or wait and verify them on-demand later. See [#2626](https://github.com/transmission/transmission/pull/2626) for more discussion.
  * **utp-enabled:** Boolean (default = true) Enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
 
@@ -113,6 +116,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **seed-queue-size:** Number (default = 10) See seed-queue-enabled.
 
 #### [RPC](rpc-spec.md)
+ * **anti-brute-force-enabled:**: Boolean (default = false) Enable a very basic brute force protection for the RPC server. See "anti-brute-force-threshold" below.
+ * **anti-brute-force-threshold:**: Number (default = 100) After this amount of failed authentication attempts is surpassed, the RPC server will deny any further authentication attempts until it is restarted. This is not tracked per IP but in total.
  * **rpc-authentication-required:** Boolean (default = false)
  * **rpc-bind-address:** String (default = "0.0.0.0") Where to listen for RPC connections
  * **rpc-enabled:** Boolean (default = true)

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -10,10 +10,10 @@ If `transmission-remote` is called with a `--debug` argument, its RPC traffic to
 
 If `transmission-qt` is run with an environment variable `TR_RPC_VERBOSE` set, it too will dump the RPC requests and responses to the terminal for inspection.
 
-Lastly, using devtools in the Transmission web client is always an option.
+Lastly, using the browser's developer tools in the Transmission web client is always an option.
 
 ### 1.3 Libraries of ready-made wrappers
-Some people outside of the Transmission project have written libraries that wrap this RPC API. These aren't supported by the Transmission project, but are listed herer in the hope that they may be useful:
+Some people outside of the Transmission project have written libraries that wrap this RPC API. These aren't supported by the Transmission project, but are listed here in the hope that they may be useful:
 
 | Language | Link
 |:---|:---
@@ -264,7 +264,7 @@ The 'source' column here corresponds to the data structure there.
 | `secondsDownloading`| number| tr_stat
 | `secondsSeeding`| number| tr_stat
 | `seedIdleLimit`| number| tr_torrent
-| `seedIdleMode`| number| tr_inactvelimit
+| `seedIdleMode`| number| tr_inactivelimit
 | `seedRatioLimit`| double| tr_torrent
 | `seedRatioMode`| number| tr_ratiolimit
 | `sizeWhenDone`| number| tr_stat
@@ -396,7 +396,7 @@ The 'source' column here corresponds to the data structure there.
 | `tier`                    | number     | tr_tracker_view
 
 
-`wanted`: An array of `tr_torrentFileCount()` booleans true if the corresponding file is to be downloaded. (Source: `tr_file_view`)
+`wanted`: An array of `tr_torrentFileCount()` Booleans true if the corresponding file is to be downloaded. (Source: `tr_file_view`)
 
 
 Example:
@@ -505,7 +505,7 @@ Request arguments:
 
 | Key | Value Type | Description
 |:--|:--|:--
-| `ids` | array | the torrent torrent list, as described in 3.1 (must only be 1 torrent)
+| `ids` | array | the torrent list, as described in 3.1 (must only be 1 torrent)
 | `path` | string | the path to the file or folder that will be renamed
 | `name` | string | the file or folder's new name
 
@@ -528,7 +528,7 @@ Response arguments: `path`, `name`, and `id`, holding the torrent ID integer
 | `cache-size-mb` | number | maximum size of the disk cache (MB)
 | `config-dir` | string | location of transmission's configuration directory
 | `default-trackers` | list of default trackers to use on public torrents
-| `dht-enabled` | boolean | true means allow dht in public torrents
+| `dht-enabled` | boolean | true means allow DHT in public torrents
 | `download-dir` | string | default path to download torrents
 | `download-dir-free-space` | number |  **DEPRECATED** Use the `free-space` method instead.
 | `download-queue-enabled` | boolean | if true, limit how many torrents can be downloaded at once
@@ -543,7 +543,7 @@ Response arguments: `path`, `name`, and `id`, holding the torrent ID integer
 | `peer-limit-per-torrent` | number | maximum global number of peers
 | `peer-port-random-on-start` | boolean | true means pick a random peer port on launch
 | `peer-port` | number | port number
-| `pex-enabled` | boolean | true means allow pex in public torrents
+| `pex-enabled` | boolean | true means allow PEX in public torrents
 | `port-forwarding-enabled` | boolean | true means ask upstream router to forward the configured peer port to transmission using UPnP or NAT-PMP
 | `queue-stalled-enabled` | boolean | whether or not to consider idle torrents as stalled
 | `queue-stalled-minutes` | number | torrents that are idle for N minuets aren't counted toward seed-queue-size or download-queue-size
@@ -568,7 +568,7 @@ Response arguments: `path`, `name`, and `id`, holding the torrent ID integer
 | `start-added-torrents` | boolean | true means added torrents will be started right away
 | `trash-original-torrent-files` | boolean | true means the .torrent file of added torrents will be deleted
 | `units` | object | see below
-| `utp-enabled` | boolean | true means allow utp
+| `utp-enabled` | boolean | true means allow UTP
 | `version` | string | long version string `$version ($revision)`
 
 
@@ -657,7 +657,7 @@ Method name: `port-test`
 
 Request arguments: none
 
-Response arguments: a bool, `port-is-open`
+Response arguments: a Boolean, `port-is-open`
 
 ### 4.5 Session shutdown
 This method tells the transmission session to shut down.


### PR DESCRIPTION
When bringing my `transmission-daemon` settings up to version 4.0, I had to search through the commit history to find out what some of the new settings do. I documented all those settings based on what I found and tested.
I'm not entirely certain if I missed something for `enable-tcp`, e. g. I'm not sure whether it influences the connection to the tracker.

I also fixed some minor typos.
I could not find ` tr_inactvelimit`, `tr_inactivelimit` or spelling variations thereof in the source code, so I'm also not sure whether it should even still be there.