### PR TITLE
fix: cannot build with clang on Windows

### DIFF
--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -25,7 +25,7 @@
 namespace
 {
 
-[[nodiscard]] auto constexpr isOpen(tr_sys_file_t fd) noexcept
+[[nodiscard]] auto isOpen(tr_sys_file_t fd) noexcept
 {
     return fd != TR_BAD_SYS_FILE;
 }


### PR DESCRIPTION
Fixes #4977.

Notes: Fixed `4.0.0` build failure when compiling with Clang on Windows.

Thanks to @fghzxm for realizing the problem