### PR TITLE
fix: make context menu highlighted row readable in dark mode

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -23,7 +23,7 @@ $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
 $nice-grey: #666666;
-$nice-grey-darker: #616161;
+$nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;
 $default-accent-color: #fff8c5;
 $default-accent-color-dark: #2e2e2e;

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -23,7 +23,7 @@ $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
 $nice-grey: #666666;
-$nice-grey-darker: #f0f0f0;
+$nice-grey-darker: #616161;
 $dark-mode-black: #121212;
 $default-accent-color: #fff8c5;
 $default-accent-color-dark: #2e2e2e;

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -120,7 +120,7 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
     --color-default-border: #{$default-border-dark};
   }
   @media (prefers-color-scheme: light) {
-    --color-bg-hover: #{$grey-40};
+    --color-bg-hover: #{$nice-grey};
     --color-fg-primary: #404040;
     --color-bg-primary: #fff;
     --color-bg-even: #{$white};

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -11,7 +11,6 @@ $green-200: #bef5cb;
 $green-300: #85e89d;
 $green-500: #28a745;
 $green-700: #176f2c;
-$grey-40: #666666;
 $grey-500: #828282;
 $grey-700: #373737;
 $grey-800: #292929;
@@ -23,6 +22,7 @@ $white: #fff;
 $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
+$grey-40: #666666;
 $nice-grey: #f8f8f8;
 $nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;
@@ -120,7 +120,7 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
     --color-default-border: #{$default-border-dark};
   }
   @media (prefers-color-scheme: light) {
-    --color-bg-hover: #{$nice-grey};
+    --color-bg-hover: #{$grey-40};
     --color-fg-primary: #404040;
     --color-bg-primary: #fff;
     --color-bg-even: #{$white};

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -11,6 +11,7 @@ $green-200: #bef5cb;
 $green-300: #85e89d;
 $green-500: #28a745;
 $green-700: #176f2c;
+$grey-40: #666666;
 $grey-500: #828282;
 $grey-700: #373737;
 $grey-800: #292929;
@@ -22,7 +23,7 @@ $white: #fff;
 $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
-$nice-grey: #666666;
+$nice-grey: #f8f8f8;
 $nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;
 $default-accent-color: #fff8c5;
@@ -95,7 +96,7 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
   --color-progressbar-seed-2: #{$green-700};
   color-scheme: light dark;
   @media (prefers-color-scheme: dark) {
-    --color-bg-hover: #{$nice-grey};
+    --color-bg-hover: #{$grey-40};
     --color-fg-primary: #fff;
     --color-bg-primary: #{$grey-800};
     --color-bg-odd: #{$grey-900};

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -22,7 +22,7 @@ $white: #fff;
 $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
-$grey-40: #666666;
+$grey-40: #666;
 $nice-grey: #f8f8f8;
 $nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -22,7 +22,7 @@ $white: #fff;
 $yellow-300: #ffea7f;
 $yellow-700: #dbab09;
 
-$nice-grey: #f8f8f8;
+$nice-grey: #666666;
 $nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;
 $default-accent-color: #fff8c5;


### PR DESCRIPTION
Mostly fixes #4983

(images from @rcunov)

Before:

![Before](https://user-images.githubusercontent.com/61329286/220487798-1602af9b-9947-4afb-8777-1879b8f333c5.gif)

After:

![After](https://user-images.githubusercontent.com/61329286/220489681-7d0ddaa8-7c84-4bbe-8bd7-a1bae23358d0.png)