### PR TITLE
fix: TR_TIME_LOCALTIME contained garbage when calling a script

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -475,10 +475,11 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
     auto const labels_str = buildLabelsString(tor);
     auto const trackers_str = buildTrackersString(tor);
     auto const bytes_downloaded_str = std::to_string(tor->downloadedCur + tor->downloadedPrev);
+    auto const localtime_str = fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time()));
 
     auto const env = std::map<std::string_view, std::string_view>{
         { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
-        { "TR_TIME_LOCALTIME"sv, fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time())) },
+        { "TR_TIME_LOCALTIME"sv, localtime_str },
         { "TR_TORRENT_BYTES_DOWNLOADED"sv, bytes_downloaded_str },
         { "TR_TORRENT_DIR"sv, torrent_dir.c_str() },
         { "TR_TORRENT_HASH"sv, tor->infoHashString() },


### PR DESCRIPTION
At least on my Linux box, a script doing `export | grep TR_` showed weird results like:

`declare -x TR_TIME_LOCALTIME="TR_APP_VERSION=4.0.0-dev"`

or

`declare -x TR_TIME_LOCALTIME="TR_TIME_LOCALTIME"`

This patch fixes it, since the formatted time string is now kept on the stack.

Notes: fix the value of TR_TIME_LOCALTIME passed to scripts