### PR TITLE
feat: Use updated minimal NSColorWell style for Groups.

### DIFF
--- a/macosx/CocoaCompatibility.h
+++ b/macosx/CocoaCompatibility.h
@@ -37,4 +37,17 @@ typedef NS_ENUM(NSInteger, NSTableViewStyle) {
 
 #endif
 
+// Compatibility declarations to build `@available(macOS 13.0, *)` code with older Xcode 11.3.1 (the last 32-bit OS compatible Xcode)
+#ifndef __MAC_13_0
+
+typedef NS_ENUM(NSInteger, NSColorWellStyle) {
+    NSColorWellStyleMinimal = 1,
+} API_AVAILABLE(macos(13.0));
+
+@interface NSColorWell ()
+@property(assign) NSColorWellStyle colorWellStyle API_AVAILABLE(macos(13.0));
+@end
+
+#endif
+
 NS_ASSUME_NONNULL_END

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -41,6 +41,11 @@ typedef NS_ENUM(NSInteger, SegmentTag) {
 
     [self.fSelectedColorView addObserver:self forKeyPath:@"color" options:0 context:NULL];
 
+    if (@available(macOS 13.0, *))
+    {
+        self.fSelectedColorView.colorWellStyle = NSColorWellStyleMinimal;
+    }
+
     [self updateSelectedGroup];
 }
 

--- a/macosx/GroupsPrefsController.mm
+++ b/macosx/GroupsPrefsController.mm
@@ -2,6 +2,8 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#import "CocoaCompatibility.h"
+
 #import "GroupsPrefsController.h"
 #import "GroupsController.h"
 #import "ExpandedPathToPathTransformer.h"


### PR DESCRIPTION
Only on macOS Ventura (13.0+), as AppKit changes were introduced here.

Somewhat fixes #5011

<details>
<summary>Comparison</summary>

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="752" alt="Screenshot 2023-02-24 at 01 20 12" src="https://user-images.githubusercontent.com/8330119/221043652-1b4df3d0-2068-4172-be3e-695231d99a9b.png">
	<td><img width="752" alt="Screenshot 2023-02-24 at 01 18 13" src="https://user-images.githubusercontent.com/8330119/221043678-19da1f18-ce33-4c4d-87a2-77f90e32852d.png">

</table>

</details>