### PR TITLE
fix: Use bounds for relative NSPopover positioning.

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3390,7 +3390,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else
     {
-        [popover showRelativeToRect:senderView.frame ofView:senderView preferredEdge:NSMaxYEdge];
+        [popover showRelativeToRect:senderView.bounds ofView:senderView preferredEdge:NSMaxYEdge];
     }
 }
 


### PR DESCRIPTION
Fixes #5013

<details>
<summary>After:</summary>

<img width="950" alt="image" src="https://user-images.githubusercontent.com/8330119/221049860-734731c1-a7ee-476e-8ed6-e70e96e34498.png">

</details>