### PR TITLE
Limit in-kernel file copying to 2 GiB blocks at a time

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -379,7 +379,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
 
     while (file_size > 0U)
     {
-        size_t const chunk_size = std::min(file_size, uint64_t{ SSIZE_MAX });
+        size_t const chunk_size = std::min({ file_size, uint64_t{ SSIZE_MAX }, uint64_t{ INT32_MAX } });
         auto const copied = copy_file_range(in, nullptr, out, nullptr, chunk_size, 0);
 
         TR_ASSERT(copied == -1 || copied >= 0); /* -1 for error; some non-negative value otherwise. */
@@ -432,7 +432,7 @@ bool tr_sys_path_copy(char const* src_path, char const* dst_path, tr_error** err
         {
             while (file_size > 0U)
             {
-                size_t const chunk_size = std::min(file_size, uint64_t{ SSIZE_MAX });
+                size_t const chunk_size = std::min({ file_size, uint64_t{ SSIZE_MAX }, uint64_t{ INT32_MAX } });
                 auto const copied = sendfile64(out, in, nullptr, chunk_size);
                 TR_ASSERT(copied == -1 || copied >= 0); /* -1 for error; some non-negative value otherwise. */
 


### PR DESCRIPTION
This reportedly helps with copying to cifs target where `copy_file_range()` would sometimes return `EINVAL` for no apparent reason when copying large files. Extending the limit to `sendfile64()` to avoid similar issue there, if it exists.

Overall, copying at most 2 GiB at a time will result in more syscalls but shouldn't affect the performance gain in any noticeable way.

Notes: Limited in-kernel file copying to 2 GiB blocks at a time to avoid potential issues with CIFS mounts.