### PR TITLE
Web: Increase font weight of  progress details

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -589,6 +589,7 @@ $video-image: '../img/film.svg';
   .torrent-peer-details {
     font-size: x-small;
     font-weight: bold;
+    
     &:not(.paused) {
       color: var(--color-fg-primary);
     }

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -590,6 +590,7 @@ $video-image: '../img/film.svg';
     font-size: x-small;
     font-weight: bold;
     
+    
     &:not(.paused) {
       color: var(--color-fg-primary);
     }

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -587,8 +587,12 @@ $video-image: '../img/film.svg';
 
   .torrent-progress-details,
   .torrent-peer-details {
-    color: var(--color-fg-primary);
     font-size: x-small;
+    font-weight: bold;
+    
+    &:not(.paused) {
+      color: var(--color-fg-primary);
+    }
   }
 
   .torrent-progress-bar {

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -589,8 +589,6 @@ $video-image: '../img/film.svg';
   .torrent-peer-details {
     font-size: x-small;
     font-weight: bold;
-    
-    
     &:not(.paused) {
       color: var(--color-fg-primary);
     }


### PR DESCRIPTION
I thought the visibility of the text for the peers and progress information in the main window was quite low and experimented with an increase in size which seemed too much and settled on bolding.

Additionally, i've started work on trying to apply the changing of the font colour for this info when a torrent is paused. It was always there for the title of the torrent, but was never there for the progress/peers text. I haven't been able to get this working properly if someone can advise (@dareiff?), it seems i just can't see the obvious today (lines 593 and 594).

Current:

![peers2](https://user-images.githubusercontent.com/69029666/221332328-77186c62-c895-4686-ad14-5dedf8938f9c.png)

Proposed:

![peers](https://user-images.githubusercontent.com/69029666/221332318-a4bbd7b8-62f2-4df5-9d07-a11799158123.png)