### PR TITLE
docs: warn users about bannable actions in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -6,9 +6,9 @@ body:
     attributes:
       label: What is the issue?
       description: |
-       For UI, attach a screenshot.
+       For UI, attach a screenshot that <b>does not incude</b> unlicensed content.
        For crashes, attach a crash log.
-       For specific issues, attach a torrent or provide a magnet, with public domain content only.
+       For specific issues, attach a torrent or provide a magnet, with public domain content <b>only</b>.
   - type: dropdown
     id: client
     attributes:

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -6,9 +6,10 @@ body:
     attributes:
       label: What is the issue?
       description: |
-       For UI, attach a screenshot that **does not incude** unlicensed content.
+       **Users who include information about pirated material will be banned**
+       For UI, attach a screenshot.
        For crashes, attach a crash log.
-       For specific issues, attach a torrent or provide a magnet, with public domain content **only**.
+       For specific issues, attach a torrent or provide a magnet, with public domain content only.
   - type: dropdown
     id: client
     attributes:
@@ -18,6 +19,7 @@ body:
         - GTK+ app on Linux, BSD, etc.
         - Qt app on Linux, BSD, etc.
         - Qt app on Windows
+        - Qt app on macOS
         - Web client
         - transmission-daemon
         - transmission-remote

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -6,9 +6,9 @@ body:
     attributes:
       label: What is the issue?
       description: |
-       For UI, attach a screenshot that <b>does not incude</b> unlicensed content.
+       For UI, attach a screenshot that **does not incude** unlicensed content.
        For crashes, attach a crash log.
-       For specific issues, attach a torrent or provide a magnet, with public domain content <b>only</b>.
+       For specific issues, attach a torrent or provide a magnet, with public domain content **only**.
   - type: dropdown
     id: client
     attributes:

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -6,10 +6,10 @@ body:
     attributes:
       label: What is the issue?
       description: |
-       **Users who include information about pirated material will be banned**
        For UI, attach a screenshot.
        For crashes, attach a crash log.
        For specific issues, attach a torrent or provide a magnet, with public domain content only.
+       **YOU WILL BE BANNED** if you include information about pirated torrents.
   - type: dropdown
     id: client
     attributes:

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yml
@@ -19,7 +19,6 @@ body:
         - GTK+ app on Linux, BSD, etc.
         - Qt app on Linux, BSD, etc.
         - Qt app on Windows
-        - Qt app on macOS
         - Web client
         - transmission-daemon
         - transmission-remote


### PR DESCRIPTION
There has been a wealth of users over-sharing their unlicensed or illegal content during the 4.0 release process when they file issues, and i thought it might be worthwhile to make it explicit that it's not wanted. I usualy ask people to obscure it, but some think this is a suggestion.