### PR TITLE
refactor: use idiomatic enum names & types in objc

### DIFF
--- a/macosx/BlocklistDownloader.h
+++ b/macosx/BlocklistDownloader.h
@@ -6,10 +6,10 @@
 
 @class BlocklistDownloaderViewController;
 
-typedef NS_ENUM(unsigned int, blocklistDownloadState) { //
-    BLOCKLIST_DL_START,
-    BLOCKLIST_DL_DOWNLOADING,
-    BLOCKLIST_DL_PROCESSING
+typedef NS_ENUM(NSUInteger, BlocklistDownloadState) { //
+    BlocklistDownloadStateStart,
+    BlocklistDownloadStateDownloading,
+    BlocklistDownloadStateProcessing
 };
 
 @interface BlocklistDownloader : NSObject<NSURLSessionDownloadDelegate>

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -12,7 +12,7 @@
 @property(nonatomic) NSURLSession* fSession;
 @property(nonatomic) NSUInteger fCurrentSize;
 @property(nonatomic) long long fExpectedSize;
-@property(nonatomic) blocklistDownloadState fState;
+@property(nonatomic) BlocklistDownloadState fState;
 
 @end
 
@@ -43,13 +43,13 @@ BlocklistDownloader* fBLDownloader = nil;
     {
         switch (self.fState)
         {
-        case BLOCKLIST_DL_START:
+        case BlocklistDownloadStateStart:
             [_viewController setStatusStarting];
             break;
-        case BLOCKLIST_DL_DOWNLOADING:
+        case BlocklistDownloadStateDownloading:
             [_viewController setStatusProgressForCurrentSize:self.fCurrentSize expectedSize:self.fExpectedSize];
             break;
-        case BLOCKLIST_DL_PROCESSING:
+        case BlocklistDownloadStateProcessing:
             [_viewController setStatusProcessing];
             break;
         }
@@ -74,7 +74,7 @@ BlocklistDownloader* fBLDownloader = nil;
     totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.fState = BLOCKLIST_DL_DOWNLOADING;
+        self.fState = BlocklistDownloadStateDownloading;
 
         self.fCurrentSize = totalBytesWritten;
         self.fExpectedSize = totalBytesExpectedToWrite;
@@ -103,7 +103,7 @@ BlocklistDownloader* fBLDownloader = nil;
                  downloadTask:(NSURLSessionDownloadTask*)downloadTask
     didFinishDownloadingToURL:(NSURL*)location
 {
-    self.fState = BLOCKLIST_DL_PROCESSING;
+    self.fState = BlocklistDownloadStateProcessing;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.viewController setStatusProcessing];
@@ -163,7 +163,7 @@ BlocklistDownloader* fBLDownloader = nil;
 
 - (void)startDownload
 {
-    self.fState = BLOCKLIST_DL_START;
+    self.fState = BlocklistDownloadStateStart;
 
     self.fSession = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.ephemeralSessionConfiguration delegate:self
                                              delegateQueue:nil];

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -17,18 +17,18 @@
 @class PrefsController;
 @class Torrent;
 
-typedef NS_ENUM(unsigned int, addType) { //
-    ADD_MANUAL,
-    ADD_AUTO,
-    ADD_SHOW_OPTIONS,
-    ADD_URL,
-    ADD_CREATED
+typedef NS_ENUM(NSUInteger, AddType) { //
+    AddTypeManual,
+    AddTypeAuto,
+    AddTypeShowOptions,
+    AddTypeURL,
+    AddTypeCreated
 };
 
 @interface Controller
     : NSObject<NSApplicationDelegate, NSPopoverDelegate, NSSharingServiceDelegate, NSSharingServicePickerDelegate, NSSoundDelegate, NSToolbarDelegate, NSWindowDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate, VDKQueueDelegate, SUUpdaterDelegate>
 
-- (void)openFiles:(NSArray<NSString*>*)filenames addType:(addType)type forcePath:(NSString*)path;
+- (void)openFiles:(NSArray<NSString*>*)filenames addType:(AddType)type forcePath:(NSString*)path;
 
 - (void)askOpenConfirmed:(AddWindowController*)addController add:(BOOL)add;
 - (void)openCreatedFile:(NSNotification*)notification;

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -13,15 +13,15 @@
 
 static CGFloat const kRowSmallHeight = 18.0;
 
-typedef NS_ENUM(unsigned int, fileCheckMenuTag) { //
-    FILE_CHECK_TAG,
-    FILE_UNCHECK_TAG
+typedef NS_ENUM(NSUInteger, FileCheckMenuTag) { //
+    FileCheckMenuTagCheck,
+    FileCheckMenuTagUncheck
 };
 
-typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
-    FILE_PRIORITY_HIGH_TAG,
-    FILE_PRIORITY_NORMAL_TAG,
-    FILE_PRIORITY_LOW_TAG
+typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
+    FilePriorityMenuTagHigh,
+    FilePriorityMenuTagNormal,
+    FilePriorityMenuTagLow
 };
 
 @interface FileOutlineController ()
@@ -353,7 +353,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
 
 - (void)setCheck:(id)sender
 {
-    NSInteger state = [sender tag] == FILE_UNCHECK_TAG ? NSControlStateValueOff : NSControlStateValueOn;
+    NSInteger state = [sender tag] == FileCheckMenuTagUncheck ? NSControlStateValueOff : NSControlStateValueOn;
 
     NSIndexSet* indexSet = self.fOutline.selectedRowIndexes;
     NSMutableIndexSet* itemIndexes = [NSMutableIndexSet indexSet];
@@ -405,13 +405,13 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
     tr_priority_t priority;
     switch ([sender tag])
     {
-    case FILE_PRIORITY_HIGH_TAG:
+    case FilePriorityMenuTagHigh:
         priority = TR_PRI_HIGH;
         break;
-    case FILE_PRIORITY_NORMAL_TAG:
+    case FilePriorityMenuTagNormal:
         priority = TR_PRI_NORMAL;
         break;
-    case FILE_PRIORITY_LOW_TAG:
+    case FilePriorityMenuTagLow:
         priority = TR_PRI_LOW;
         break;
     default:
@@ -517,7 +517,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
             [itemIndexes addIndexes:node.indexes];
         }
 
-        NSInteger state = (menuItem.tag == FILE_CHECK_TAG) ? NSControlStateValueOn : NSControlStateValueOff;
+        NSInteger state = (menuItem.tag == FileCheckMenuTagCheck) ? NSControlStateValueOn : NSControlStateValueOff;
         return [self.torrent checkForFiles:itemIndexes] != state && [self.torrent canChangeDownloadCheckForFiles:itemIndexes];
     }
 
@@ -552,13 +552,13 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
         tr_priority_t priority;
         switch (menuItem.tag)
         {
-        case FILE_PRIORITY_HIGH_TAG:
+        case FilePriorityMenuTagHigh:
             priority = TR_PRI_HIGH;
             break;
-        case FILE_PRIORITY_NORMAL_TAG:
+        case FilePriorityMenuTagNormal:
             priority = TR_PRI_NORMAL;
             break;
-        case FILE_PRIORITY_LOW_TAG:
+        case FilePriorityMenuTagLow:
             priority = TR_PRI_LOW;
             break;
         default:
@@ -607,14 +607,14 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
                                                   action:@selector(setCheck:)
                                            keyEquivalent:@""];
     item.target = self;
-    item.tag = FILE_CHECK_TAG;
+    item.tag = FileCheckMenuTagCheck;
     [menu addItem:item];
 
     item = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Uncheck Selected", "File Outline -> Menu")
                                       action:@selector(setCheck:)
                                keyEquivalent:@""];
     item.target = self;
-    item.tag = FILE_UNCHECK_TAG;
+    item.tag = FileCheckMenuTagUncheck;
     [menu addItem:item];
 
     //only check selected
@@ -636,7 +636,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
                                       action:@selector(setPriority:)
                                keyEquivalent:@""];
     item.target = self;
-    item.tag = FILE_PRIORITY_HIGH_TAG;
+    item.tag = FilePriorityMenuTagHigh;
     item.image = [NSImage imageNamed:@"PriorityHighTemplate"];
     [priorityMenu addItem:item];
 
@@ -644,7 +644,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
                                       action:@selector(setPriority:)
                                keyEquivalent:@""];
     item.target = self;
-    item.tag = FILE_PRIORITY_NORMAL_TAG;
+    item.tag = FilePriorityMenuTagNormal;
     item.image = [NSImage imageNamed:@"PriorityNormalTemplate"];
     [priorityMenu addItem:item];
 
@@ -652,7 +652,7 @@ typedef NS_ENUM(unsigned int, filePriorityMenuTag) { //
                                       action:@selector(setPriority:)
                                keyEquivalent:@""];
     item.target = self;
-    item.tag = FILE_PRIORITY_LOW_TAG;
+    item.tag = FilePriorityMenuTagLow;
     item.image = [NSImage imageNamed:@"PriorityLowTemplate"];
     [priorityMenu addItem:item];
 

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -27,13 +27,13 @@ static CGFloat const kTabMinHeight = 250;
 
 static NSInteger const kInvalidTag = -99;
 
-typedef NS_ENUM(unsigned int, tabTag) {
-    TAB_GENERAL_TAG = 0,
-    TAB_ACTIVITY_TAG = 1,
-    TAB_TRACKERS_TAG = 2,
-    TAB_PEERS_TAG = 3,
-    TAB_FILE_TAG = 4,
-    TAB_OPTIONS_TAG = 5
+typedef NS_ENUM(NSUInteger, TabTag) {
+    TabTagGeneral = 0,
+    TabTagActivity = 1,
+    TabTagTrackers = 2,
+    TabTagPeers = 3,
+    TabTagFile = 4,
+    TabTagOptions = 5
 };
 
 @interface InfoWindowController ()
@@ -103,21 +103,21 @@ typedef NS_ENUM(unsigned int, tabTag) {
     setImageAndToolTipForSegment(
         [NSImage systemSymbol:@"info.circle" withFallback:@"InfoGeneral"],
         NSLocalizedString(@"General Info", "Inspector -> tab"),
-        TAB_GENERAL_TAG);
+        TabTagGeneral);
     setImageAndToolTipForSegment(
         [NSImage systemSymbol:@"square.grid.3x3.fill.square" withFallback:@"InfoActivity"],
         NSLocalizedString(@"Activity", "Inspector -> tab"),
-        TAB_ACTIVITY_TAG);
+        TabTagActivity);
     setImageAndToolTipForSegment(
         [NSImage systemSymbol:@"antenna.radiowaves.left.and.right" withFallback:@"InfoTracker"],
         NSLocalizedString(@"Trackers", "Inspector -> tab"),
-        TAB_TRACKERS_TAG);
-    setImageAndToolTipForSegment([NSImage systemSymbol:@"person.2" withFallback:@"InfoPeers"], NSLocalizedString(@"Peers", "Inspector -> tab"), TAB_PEERS_TAG);
-    setImageAndToolTipForSegment([NSImage systemSymbol:@"doc.on.doc" withFallback:@"InfoFiles"], NSLocalizedString(@"Files", "Inspector -> tab"), TAB_FILE_TAG);
+        TabTagTrackers);
+    setImageAndToolTipForSegment([NSImage systemSymbol:@"person.2" withFallback:@"InfoPeers"], NSLocalizedString(@"Peers", "Inspector -> tab"), TabTagPeers);
+    setImageAndToolTipForSegment([NSImage systemSymbol:@"doc.on.doc" withFallback:@"InfoFiles"], NSLocalizedString(@"Files", "Inspector -> tab"), TabTagFile);
     setImageAndToolTipForSegment(
         [NSImage systemSymbol:@"gearshape" withFallback:@"InfoOptions"],
         NSLocalizedString(@"Options", "Inspector -> tab"),
-        TAB_OPTIONS_TAG);
+        TabTagOptions);
 
     //set selected tab
     self.fCurrentTabTag = kInvalidTag;
@@ -125,32 +125,32 @@ typedef NS_ENUM(unsigned int, tabTag) {
     NSInteger tag;
     if ([identifier isEqualToString:TabIdentifierInfo])
     {
-        tag = TAB_GENERAL_TAG;
+        tag = TabTagGeneral;
     }
     else if ([identifier isEqualToString:TabIdentifierActivity])
     {
-        tag = TAB_ACTIVITY_TAG;
+        tag = TabTagActivity;
     }
     else if ([identifier isEqualToString:TabIdentifierTracker])
     {
-        tag = TAB_TRACKERS_TAG;
+        tag = TabTagTrackers;
     }
     else if ([identifier isEqualToString:TabIdentifierPeers])
     {
-        tag = TAB_PEERS_TAG;
+        tag = TabTagPeers;
     }
     else if ([identifier isEqualToString:TabIdentifierFiles])
     {
-        tag = TAB_FILE_TAG;
+        tag = TabTagFile;
     }
     else if ([identifier isEqualToString:TabIdentifierOptions])
     {
-        tag = TAB_OPTIONS_TAG;
+        tag = TabTagOptions;
     }
     else //safety
     {
         [NSUserDefaults.standardUserDefaults setObject:TabIdentifierInfo forKey:@"InspectorSelected"];
-        tag = TAB_GENERAL_TAG;
+        tag = TabTagGeneral;
     }
 
     self.fTabs.selectedSegment = tag;
@@ -212,7 +212,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
 
 - (void)windowWillClose:(NSNotification*)notification
 {
-    if (self.fCurrentTabTag == TAB_FILE_TAG && ([QLPreviewPanel sharedPreviewPanelExists] && [QLPreviewPanel sharedPreviewPanel].visible))
+    if (self.fCurrentTabTag == TabTagFile && ([QLPreviewPanel sharedPreviewPanelExists] && [QLPreviewPanel sharedPreviewPanel].visible))
     {
         [[QLPreviewPanel sharedPreviewPanel] reloadData];
     }
@@ -255,7 +255,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
     TabIdentifier identifier;
     switch (self.fCurrentTabTag)
     {
-    case TAB_GENERAL_TAG:
+    case TabTagGeneral:
         if (!self.fGeneralViewController)
         {
             self.fGeneralViewController = [[InfoGeneralViewController alloc] init];
@@ -265,7 +265,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         self.fViewController = self.fGeneralViewController;
         identifier = TabIdentifierInfo;
         break;
-    case TAB_ACTIVITY_TAG:
+    case TabTagActivity:
         if (!self.fActivityViewController)
         {
             self.fActivityViewController = [[InfoActivityViewController alloc] init];
@@ -275,7 +275,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         self.fViewController = self.fActivityViewController;
         identifier = TabIdentifierActivity;
         break;
-    case TAB_TRACKERS_TAG:
+    case TabTagTrackers:
         if (!self.fTrackersViewController)
         {
             self.fTrackersViewController = [[InfoTrackersViewController alloc] init];
@@ -285,7 +285,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         self.fViewController = self.fTrackersViewController;
         identifier = TabIdentifierTracker;
         break;
-    case TAB_PEERS_TAG:
+    case TabTagPeers:
         if (!self.fPeersViewController)
         {
             self.fPeersViewController = [[InfoPeersViewController alloc] init];
@@ -295,7 +295,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         self.fViewController = self.fPeersViewController;
         identifier = TabIdentifierPeers;
         break;
-    case TAB_FILE_TAG:
+    case TabTagFile:
         if (!self.fFileViewController)
         {
             self.fFileViewController = [[InfoFileViewController alloc] init];
@@ -305,7 +305,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         self.fViewController = self.fFileViewController;
         identifier = TabIdentifierFiles;
         break;
-    case TAB_OPTIONS_TAG:
+    case TabTagOptions:
         if (!self.fOptionsViewController)
         {
             self.fOptionsViewController = [[InfoOptionsViewController alloc] init];
@@ -415,7 +415,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
         addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[tabs]-0-[view]-0-|" options:0 metrics:nil
                                                                  views:@{ @"tabs" : self.fTabs, @"view" : view }]];
 
-    if ((self.fCurrentTabTag == TAB_FILE_TAG || oldTabTag == TAB_FILE_TAG) &&
+    if ((self.fCurrentTabTag == TabTagFile || oldTabTag == TabTagFile) &&
         ([QLPreviewPanel sharedPreviewPanelExists] && [QLPreviewPanel sharedPreviewPanel].visible))
     {
         [[QLPreviewPanel sharedPreviewPanel] reloadData];
@@ -482,7 +482,7 @@ typedef NS_ENUM(unsigned int, tabTag) {
 
 - (BOOL)canQuickLook
 {
-    if (self.fCurrentTabTag != TAB_FILE_TAG || !self.window.visible)
+    if (self.fCurrentTabTag != TabTagFile || !self.window.visible)
     {
         return NO;
     }

--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -6,18 +6,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(unsigned int, port_status_t) { //
-    PORT_STATUS_CHECKING,
-    PORT_STATUS_OPEN,
-    PORT_STATUS_CLOSED,
-    PORT_STATUS_ERROR
+typedef NS_ENUM(NSUInteger, PortStatus) { //
+    PortStatusChecking,
+    PortStatusOpen,
+    PortStatusClosed,
+    PortStatusError
 };
 
 @protocol PortCheckerDelegate;
 
 @interface PortChecker : NSObject
 
-@property(nonatomic, readonly) port_status_t status;
+@property(nonatomic, readonly) PortStatus status;
 
 - (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(NSObject<PortCheckerDelegate>*)delegate;
 - (void)cancelProbe;

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -9,7 +9,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 @interface PortChecker ()
 
 @property(nonatomic, weak) NSObject<PortCheckerDelegate>* fDelegate;
-@property(nonatomic) port_status_t fStatus;
+@property(nonatomic) PortStatus fStatus;
 
 @property(nonatomic) NSURLSession* fSession;
 @property(nonatomic) NSURLSessionDataTask* fTask;
@@ -28,7 +28,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
                                              delegateQueue:nil];
         _fDelegate = delegate;
 
-        _fStatus = PORT_STATUS_CHECKING;
+        _fStatus = PortStatusChecking;
 
         _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval target:self selector:@selector(startProbe:)
                                                  userInfo:@(portNumber)
@@ -47,7 +47,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
     [self cancelProbe];
 }
 
-- (port_status_t)status
+- (PortStatus)status
 {
     return self.fStatus;
 }
@@ -76,33 +76,33 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
                               if (error)
                               {
                                   NSLog(@"Unable to get port status: connection failed (%@)", error.localizedDescription);
-                                  [self callBackWithStatus:PORT_STATUS_ERROR];
+                                  [self callBackWithStatus:PortStatusError];
                                   return;
                               }
                               NSString* probeString = [[NSString alloc] initWithData:data ?: NSData.data encoding:NSUTF8StringEncoding];
                               if (!probeString)
                               {
                                   NSLog(@"Unable to get port status: invalid data received");
-                                  [self callBackWithStatus:PORT_STATUS_ERROR];
+                                  [self callBackWithStatus:PortStatusError];
                               }
                               else if ([probeString isEqualToString:@"1"])
                               {
-                                  [self callBackWithStatus:PORT_STATUS_OPEN];
+                                  [self callBackWithStatus:PortStatusOpen];
                               }
                               else if ([probeString isEqualToString:@"0"])
                               {
-                                  [self callBackWithStatus:PORT_STATUS_CLOSED];
+                                  [self callBackWithStatus:PortStatusClosed];
                               }
                               else
                               {
                                   NSLog(@"Unable to get port status: invalid response (%@)", probeString);
-                                  [self callBackWithStatus:PORT_STATUS_ERROR];
+                                  [self callBackWithStatus:PortStatusError];
                               }
                           }];
     [_fTask resume];
 }
 
-- (void)callBackWithStatus:(port_status_t)status
+- (void)callBackWithStatus:(PortStatus)status
 {
     self.fStatus = status;
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -476,19 +476,19 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self.fPortStatusProgress stopAnimation:self];
     switch (self.fPortChecker.status)
     {
-    case PORT_STATUS_OPEN:
+    case PortStatusOpen:
         self.fPortStatusField.stringValue = NSLocalizedString(@"Port is open", "Preferences -> Network -> port status");
         self.fPortStatusImage.image = [NSImage imageNamed:NSImageNameStatusAvailable];
         break;
-    case PORT_STATUS_CLOSED:
+    case PortStatusClosed:
         self.fPortStatusField.stringValue = NSLocalizedString(@"Port is closed", "Preferences -> Network -> port status");
         self.fPortStatusImage.image = [NSImage imageNamed:NSImageNameStatusUnavailable];
         break;
-    case PORT_STATUS_ERROR:
+    case PortStatusError:
         self.fPortStatusField.stringValue = NSLocalizedString(@"Port check site is down", "Preferences -> Network -> port status");
         self.fPortStatusImage.image = [NSImage imageNamed:NSImageNameStatusPartiallyAvailable];
         break;
-    case PORT_STATUS_CHECKING:
+    case PortStatusChecking:
         break;
     default:
         NSAssert(NO, @"Port checker returned invalid status: %d", self.fPortChecker.status);

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -15,11 +15,11 @@ typedef NSString* StatusTransferType NS_TYPED_EXTENSIBLE_ENUM;
 static StatusTransferType const StatusTransferTypeTotal = @"TransferTotal";
 static StatusTransferType const StatusTransferTypeSession = @"TransferSession";
 
-typedef NS_ENUM(unsigned int, statusTag) {
-    STATUS_RATIO_TOTAL_TAG = 0,
-    STATUS_RATIO_SESSION_TAG = 1,
-    STATUS_TRANSFER_TOTAL_TAG = 2,
-    STATUS_TRANSFER_SESSION_TAG = 3
+typedef NS_ENUM(NSUInteger, StatusTag) {
+    StatusTagTotalRatio = 0,
+    StatusTagSessionRatio = 1,
+    StatusTagTotalTransfer = 2,
+    StatusTagSessionTransfer = 3
 };
 
 @interface StatusBarController ()
@@ -55,10 +55,10 @@ typedef NS_ENUM(unsigned int, statusTag) {
 - (void)awakeFromNib
 {
     //localize menu items
-    [self.fStatusButton.menu itemWithTag:STATUS_RATIO_TOTAL_TAG].title = NSLocalizedString(@"Total Ratio", "Status Bar -> status menu");
-    [self.fStatusButton.menu itemWithTag:STATUS_RATIO_SESSION_TAG].title = NSLocalizedString(@"Session Ratio", "Status Bar -> status menu");
-    [self.fStatusButton.menu itemWithTag:STATUS_TRANSFER_TOTAL_TAG].title = NSLocalizedString(@"Total Transfer", "Status Bar -> status menu");
-    [self.fStatusButton.menu itemWithTag:STATUS_TRANSFER_SESSION_TAG].title = NSLocalizedString(@"Session Transfer", "Status Bar -> status menu");
+    [self.fStatusButton.menu itemWithTag:StatusTagTotalRatio].title = NSLocalizedString(@"Total Ratio", "Status Bar -> status menu");
+    [self.fStatusButton.menu itemWithTag:StatusTagSessionRatio].title = NSLocalizedString(@"Session Ratio", "Status Bar -> status menu");
+    [self.fStatusButton.menu itemWithTag:StatusTagTotalTransfer].title = NSLocalizedString(@"Total Transfer", "Status Bar -> status menu");
+    [self.fStatusButton.menu itemWithTag:StatusTagSessionTransfer].title = NSLocalizedString(@"Session Transfer", "Status Bar -> status menu");
 
     self.fStatusButton.cell.backgroundStyle = NSBackgroundStyleRaised;
     self.fTotalDLField.cell.backgroundStyle = NSBackgroundStyleRaised;
@@ -127,16 +127,16 @@ typedef NS_ENUM(unsigned int, statusTag) {
     NSString* statusLabel;
     switch ([sender tag])
     {
-    case STATUS_RATIO_TOTAL_TAG:
+    case StatusTagTotalRatio:
         statusLabel = StatusRatioTypeTotal;
         break;
-    case STATUS_RATIO_SESSION_TAG:
+    case StatusTagSessionRatio:
         statusLabel = StatusRatioTypeSession;
         break;
-    case STATUS_TRANSFER_TOTAL_TAG:
+    case StatusTagTotalTransfer:
         statusLabel = StatusTransferTypeTotal;
         break;
-    case STATUS_TRANSFER_SESSION_TAG:
+    case StatusTagSessionTransfer:
         statusLabel = StatusTransferTypeSession;
         break;
     default:
@@ -202,16 +202,16 @@ typedef NS_ENUM(unsigned int, statusTag) {
         NSString* statusLabel;
         switch (menuItem.tag)
         {
-        case STATUS_RATIO_TOTAL_TAG:
+        case StatusTagTotalRatio:
             statusLabel = StatusRatioTypeTotal;
             break;
-        case STATUS_RATIO_SESSION_TAG:
+        case StatusTagSessionRatio:
             statusLabel = StatusRatioTypeSession;
             break;
-        case STATUS_TRANSFER_TOTAL_TAG:
+        case StatusTagTotalTransfer:
             statusLabel = StatusTransferTypeTotal;
             break;
-        case STATUS_TRANSFER_SESSION_TAG:
+        case StatusTagSessionTransfer:
             statusLabel = StatusTransferTypeSession;
             break;
         default:

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -9,10 +9,7 @@
 
 @class FileListNode;
 
-typedef NS_ENUM(unsigned int, TorrentDeterminationType) {
-    TorrentDeterminationAutomatic = 0,
-    TorrentDeterminationUserSpecified
-};
+typedef NS_ENUM(NSUInteger, TorrentDeterminationType) { TorrentDeterminationAutomatic = 0, TorrentDeterminationUserSpecified };
 
 extern NSString* const kTorrentDidChangeGroupNotification;
 


### PR DESCRIPTION
Continuing the work from https://github.com/transmission/transmission/pull/3974, this PR updates the remaining enums defined in objc code to use idiomatic types (NSUInteger as opposed to unsigned int) and names (port_status_t -> PortStatus).

The advantages are the following:

- It's easier to differentiate from types defined in C/C++ (e.g. libtransmission types)
- It unifies the naming & typing with Apple-defined enums, and most other objc enums in the project
- It facilitates the potential usage of these enums from Swift