### PR TITLE
fix: 4.0.0 bookkeeping of protocol overhead when receiving peer messages

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -373,7 +373,7 @@ void tr_peerIo::can_read_wrapper()
 
         if (overhead > 0)
         {
-            bandwidth().notifyBandwidthConsumed(TR_UP, overhead, false, now);
+            bandwidth().notifyBandwidthConsumed(TR_DOWN, overhead, false, now);
         }
 
         switch (read_state)


### PR DESCRIPTION
Fixes #5057.

@GaryElshaw there are always going to be second-to-second discrepancies -- particularly in the qt client because its UI is intentionally designed to "lazy-update" so that the same code that runs for a local session can play nice with a remote session that may involve a lot of lag -- but there was a bookkeeping error here that could throw off instantaneous counts. Thanks for reporting this!