### PR TITLE
feat: Badge with arrow

### DIFF
--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         } while (badgeSize.width < stringSize.width + 2 * arrowHeight * arrowWidthHeightRatio +
                      arrowHeight); // text is centered + surrounded by the size of two arrows + arrow spacing (" ▼ 888.8 K ▽ ")
 
-        kArrowInset = { badgeSize.height * 0.15, badgeSize.height * 0.1 };
+        kArrowInset = { badgeSize.height * 0.2, badgeSize.height * 0.1 };
         kArrowSize = { arrowHeight * arrowWidthHeightRatio, arrowHeight };
     }
     return self;

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -4,8 +4,11 @@
 
 #import "BadgeView.h"
 #import "NSStringAdditions.h"
+#import "NSImageAdditions.h"
 
 static CGFloat const kBetweenPadding = 2.0;
+static NSImage* whiteUpArrow = [[NSImage imageNamed:@"UpArrowTemplate"] imageWithColor:NSColor.whiteColor];
+static NSImage* whiteDownArrow = [[NSImage imageNamed:@"DownArrowTemplate"] imageWithColor:NSColor.whiteColor];
 
 @interface BadgeView ()
 
@@ -24,6 +27,14 @@ static CGFloat const kBetweenPadding = 2.0;
     {
         _fDownloadRate = 0.0;
         _fUploadRate = 0.0;
+
+        NSShadow* stringShadow = [[NSShadow alloc] init];
+        stringShadow.shadowOffset = NSMakeSize(2.0, -2.0);
+        stringShadow.shadowBlurRadius = 4.0;
+
+        _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
+        _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
+        _fAttributes[NSShadowAttributeName] = stringShadow;
     }
     return self;
 }
@@ -51,7 +62,7 @@ static CGFloat const kBetweenPadding = 2.0;
     if (download)
     {
         NSImage* downloadBadge = [NSImage imageNamed:@"DownloadBadge"];
-        [self badge:downloadBadge string:[NSString stringForSpeedAbbrev:self.fDownloadRate] atHeight:bottom];
+        [self badge:downloadBadge arrow:whiteDownArrow string:[NSString stringForSpeedAbbrev:self.fDownloadRate] atHeight:bottom];
 
         if (upload)
         {
@@ -60,29 +71,21 @@ static CGFloat const kBetweenPadding = 2.0;
     }
     if (upload)
     {
-        [self badge:[NSImage imageNamed:@"UploadBadge"] string:[NSString stringForSpeedAbbrev:self.fUploadRate] atHeight:bottom];
+        [self badge:[NSImage imageNamed:@"UploadBadge"] arrow:whiteUpArrow
+              string:[NSString stringForSpeedAbbrev:self.fUploadRate]
+            atHeight:bottom];
     }
 }
 
-- (void)badge:(NSImage*)badge string:(NSString*)string atHeight:(CGFloat)height
+- (void)badge:(NSImage*)badge arrow:(NSImage*)arrow string:(NSString*)string atHeight:(CGFloat)height
 {
-    if (!self.fAttributes)
-    {
-        NSShadow* stringShadow = [[NSShadow alloc] init];
-        stringShadow.shadowOffset = NSMakeSize(2.0, -2.0);
-        stringShadow.shadowBlurRadius = 4.0;
-
-        self.fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
-        self.fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
-        self.fAttributes[NSShadowAttributeName] = stringShadow;
-    }
-
-    NSRect badgeRect;
-    badgeRect.size = badge.size;
-    badgeRect.origin.x = 0.0;
-    badgeRect.origin.y = height;
-
+    NSRect badgeRect = { { 0.0, height }, badge.size };
     [badge drawInRect:badgeRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
+
+    CGFloat arrowInset = badge.size.height * 0.1;
+    CGFloat arrowRatio = arrow.size.width / arrow.size.height;
+    NSRect arrowRect = { { arrowInset, height + arrowInset }, { badge.size.height * 0.8 * arrowRatio, badge.size.height * 0.8 } };
+    [arrow drawInRect:arrowRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
 
     //make sure text fits on the badge
     CGFloat fontSize = 26.0;
@@ -92,7 +95,7 @@ static CGFloat const kBetweenPadding = 2.0;
         self.fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:fontSize];
         stringSize = [string sizeWithAttributes:self.fAttributes];
         fontSize -= 1.0;
-    } while (NSWidth(badgeRect) < stringSize.width);
+    } while (NSWidth(badgeRect) - 2 * NSWidth(arrowRect) - 2 * arrowInset < stringSize.width);
 
     //string is in center of image
     NSRect stringRect;


### PR DESCRIPTION
Fix #5072

The adopted approach is with the existing images UpArrowTemplate and DownArrowTemplate, at a fixed position and size for the arrow, and a fixed font size for the text.

Rendering after second commit:
![Capture d’écran 2023-03-01 à 19 51 06](https://user-images.githubusercontent.com/839992/222134056-bfb847fc-6341-4173-a8e3-ae68f7ca4d1f.png)

Rendering after third commit:
![Capture d’écran 2023-03-02 à 00 30 27](https://user-images.githubusercontent.com/839992/222202659-c36f00c4-ede7-4cee-82e6-d7b3e0f0f24b.png)

This needs UI review from multiple reviewers, regarding:
a. is that image usage desirable (it matches the other displays of speed in the app), or would we want to change it to a new glyph, like ▲ and ▼?
b. do we want the arrow at a fixed horizontal position, or left-attached to the text?
c. do we want the arrow at a fixed size, or variable size matching the text height?
d. do we want to keep the text in the center, or do we want to left or right-align the text now?