### PR TITLE
fix: escaped representation of non-BMP characters when generating JSON

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -132,7 +132,7 @@ void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsons
 }
 
 /* like sscanf(in+2, "%4x", &val) but less slow */
-[[nodiscard]] constexpr bool decode_hex_string(char const* in, unsigned int* setme)
+[[nodiscard]] constexpr bool decode_hex_string(char const* in, std::uint16_t& setme)
 {
     TR_ASSERT(in != nullptr);
 
@@ -165,8 +165,48 @@ void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsons
         }
     } while (++in != end);
 
-    *setme = val;
+    setme = val;
     return true;
+}
+
+template<typename Iter>
+void decode_single_uchar(char const*& in, char const* const in_end, Iter& buf16_out_it)
+{
+    constexpr unsigned escaped_uchar_length = 6;
+    if (in_end - in >= escaped_uchar_length && decode_hex_string(in, *buf16_out_it))
+    {
+        in += escaped_uchar_length;
+        ++buf16_out_it;
+    }
+}
+
+[[nodiscard]] bool decode_escaped_uchar_sequence(char const*& in, char const* const in_end, std::string& buf)
+{
+    auto buf16 = std::array<std::uint16_t, 2>{};
+    auto buf16_out_it = std::begin(buf16);
+
+    decode_single_uchar(in, in_end, buf16_out_it);
+    if (in[0] == '\\' && in[1] == 'u')
+    {
+        decode_single_uchar(in, in_end, buf16_out_it);
+    }
+
+    if (buf16_out_it != std::begin(buf16))
+    {
+        try
+        {
+            utf8::utf16to8(std::begin(buf16), buf16_out_it, std::back_inserter(buf));
+        }
+        catch (utf8::exception const&) // invalid codepoint
+        {
+            buf.push_back('?');
+        }
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 [[nodiscard]] std::string_view extract_escaped_string(char const* in, size_t in_len, std::string& buf)
@@ -232,26 +272,10 @@ void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsons
                 break;
 
             case 'u':
-                if (in_end - in >= 6)
+                if (decode_escaped_uchar_sequence(in, in_end, buf))
                 {
-                    unsigned int val = 0;
-
-                    if (decode_hex_string(in, &val))
-                    {
-                        try
-                        {
-                            auto buf8 = std::array<char, 8>{};
-                            auto const it = utf8::append(val, std::data(buf8));
-                            buf.append(std::data(buf8), it - std::data(buf8));
-                        }
-                        catch (utf8::exception const&) // invalid codepoint
-                        {
-                            buf.push_back('?');
-                        }
-                        unescaped = true;
-                        in += 6;
-                        break;
-                    }
+                    unescaped = true;
+                    break;
                 }
             }
         }
@@ -541,6 +565,26 @@ void jsonRealFunc(tr_variant const* val, void* vdata)
     jsonChildFunc(data);
 }
 
+void write_escaped_char(Buffer& out, std::string_view& sv)
+{
+    auto u16buf = std::array<std::uint16_t, 2>{};
+
+    auto const* const begin8 = std::data(sv);
+    auto const* const end8 = begin8 + std::size(sv);
+    auto const* walk8 = begin8;
+    utf8::next(walk8, end8);
+    auto const end16 = utf8::utf8to16(begin8, walk8, std::begin(u16buf));
+
+    for (auto it = std::cbegin(u16buf); it != end16; ++it)
+    {
+        auto arr = std::array<char, 16>{};
+        auto const result = fmt::format_to_n(std::data(arr), std::size(arr), FMT_COMPILE("\\u{:04x}"), *it);
+        out.add(std::data(arr), result.size);
+    }
+
+    sv.remove_prefix(walk8 - begin8 - 1);
+}
+
 void jsonStringFunc(tr_variant const* val, void* vdata)
 {
     auto* data = static_cast<struct JsonWalk*>(vdata);
@@ -593,14 +637,7 @@ void jsonStringFunc(tr_variant const* val, void* vdata)
             {
                 try
                 {
-                    auto arr = std::array<char, 16>{};
-                    auto const* const begin8 = std::data(sv);
-                    auto const* const end8 = begin8 + std::size(sv);
-                    auto const* walk8 = begin8;
-                    auto const uch32 = utf8::next(walk8, end8);
-                    auto const result = fmt::format_to_n(std::data(arr), std::size(arr), FMT_COMPILE("\\u{:04x}"), uch32);
-                    out.add(std::data(arr), result.size);
-                    sv.remove_prefix(walk8 - begin8 - 1);
+                    write_escaped_char(out, sv);
                 }
                 catch (utf8::exception const&)
                 {

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -133,6 +133,7 @@ TEST_P(JSONTest, testUtf16Surrogates)
         R"({"key":"\ud83e\udd14"})"
         "\n"sv,
         json);
+    tr_variantClear(&top);
 
     tr_variant parsed;
     EXPECT_TRUE(tr_variantFromBuf(&parsed, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, json));
@@ -140,6 +141,7 @@ TEST_P(JSONTest, testUtf16Surrogates)
     std::string_view value;
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
     EXPECT_EQ(thinking_face_emoji_utf8, value);
+    tr_variantClear(&parsed);
 }
 
 TEST_P(JSONTest, test1)

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -129,8 +129,8 @@ TEST_P(JSONTest, testUtf16Surrogates)
     tr_quark const key = tr_quark_new("key"sv);
     tr_variantDictAddStr(&top, key, thinking_face_emoji_utf8);
     auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
-    EXPECT_NE(std::string::npos, json.find("\\ud83e"));
-    EXPECT_NE(std::string::npos, json.find("\\udd14"));
+    EXPECT_NE(std::string::npos, json.find("ud83e"));
+    EXPECT_NE(std::string::npos, json.find("udd14"));
     tr_variantClear(&top);
 
     tr_variant parsed;

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -129,10 +129,8 @@ TEST_P(JSONTest, testUtf16Surrogates)
     tr_quark const key = tr_quark_new("key"sv);
     tr_variantDictAddStr(&top, key, thinking_face_emoji_utf8);
     auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
-    EXPECT_EQ(
-        R"({"key":"\ud83e\udd14"})"
-        "\n"sv,
-        json);
+    EXPECT_NE(std::string::npos, json.find("\\ud83e"));
+    EXPECT_NE(std::string::npos, json.find("\\udd14"));
     tr_variantClear(&top);
 
     tr_variant parsed;

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -123,22 +123,22 @@ TEST_P(JSONTest, testUtf8)
 
 TEST_P(JSONTest, testUtf16Surrogates)
 {
-    constexpr auto thinking_face_emoji_utf8 = "\xf0\x9f\xa4\x94"sv;
-    tr_variant top;
+    static auto constexpr ThinkingFaceEmojiUtf8 = "\xf0\x9f\xa4\x94"sv;
+    auto top = tr_variant{};
     tr_variantInitDict(&top, 1);
-    tr_quark const key = tr_quark_new("key"sv);
-    tr_variantDictAddStr(&top, key, thinking_face_emoji_utf8);
-    auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
+    auto const key = tr_quark_new("key"sv);
+    tr_variantDictAddStr(&top, key, ThinkingFaceEmojiUtf8);
+    auto const json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
     EXPECT_NE(std::string::npos, json.find("ud83e"));
     EXPECT_NE(std::string::npos, json.find("udd14"));
     tr_variantClear(&top);
 
-    tr_variant parsed;
+    auto parsed = tr_variant{};
     EXPECT_TRUE(tr_variantFromBuf(&parsed, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, json));
     EXPECT_TRUE(tr_variantIsDict(&parsed));
-    std::string_view value;
+    auto value = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
-    EXPECT_EQ(thinking_face_emoji_utf8, value);
+    EXPECT_EQ(ThinkingFaceEmojiUtf8, value);
     tr_variantClear(&parsed);
 }
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -121,6 +121,27 @@ TEST_P(JSONTest, testUtf8)
     tr_variantClear(&top);
 }
 
+TEST_P(JSONTest, testUtf16Surrogates)
+{
+    constexpr auto thinking_face_emoji_utf8 = "\xf0\x9f\xa4\x94"sv;
+    tr_variant top;
+    tr_variantInitDict(&top, 1);
+    tr_quark const key = tr_quark_new("key"sv);
+    tr_variantDictAddStr(&top, key, thinking_face_emoji_utf8);
+    auto json = tr_variantToStr(&top, TR_VARIANT_FMT_JSON_LEAN);
+    EXPECT_EQ(
+        R"({"key":"\ud83e\udd14"})"
+        "\n"sv,
+        json);
+
+    tr_variant parsed;
+    EXPECT_TRUE(tr_variantFromBuf(&parsed, TR_VARIANT_PARSE_JSON | TR_VARIANT_PARSE_INPLACE, json));
+    EXPECT_TRUE(tr_variantIsDict(&parsed));
+    std::string_view value;
+    EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
+    EXPECT_EQ(thinking_face_emoji_utf8, value);
+}
+
 TEST_P(JSONTest, test1)
 {
     auto const in = std::string{


### PR DESCRIPTION
Fixes #1718.

According to [ECMA 404](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) : 

> To escape a code point that is not in the Basic Multilingual Plane, the character may be represented as a twelve-character sequence, encoding the UTF-16 surrogate pair corresponding to the code point. So for example, a string containing only the G clef character (U+1D11E) may be represented as "\uD834\uDD1E".

This currently doesn't work correctly in Transmission, as it converts the internal UTF-8 representation of its strings to UTF-32 and appends the absolute code point value as the escaped `\u` token. This is incorrect, since the UTF-16 encoding is not equal to UTF-32 for characters outside the BMP due to UTF-16's usage of high and low surrogates to represent those.

All the necessary plumbing is already done by `utf8.h`, so the only changes necessary need to be made in `variant-json.cc` to make sure that two UTF-16 code units are output when producing JSON if necessary, and similarly that two UTF-16 code units are read when parsing.