### PR TITLE
Replace mac app default BindPort with a random port

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -510,6 +510,17 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         tr_variantDictAddInt(&settings, TR_KEY_peer_limit_global, [_fDefaults integerForKey:@"PeersTotal"]);
         tr_variantDictAddInt(&settings, TR_KEY_peer_limit_per_torrent, [_fDefaults integerForKey:@"PeersTorrent"]);
 
+        NSInteger bindPort = [_fDefaults integerForKey:@"BindPort"];
+        if (bindPort <= 0 || bindPort > 65535)
+        {
+            // First launch, we avoid a default port to be less likely blocked on such port and to have more chances of success when connecting to swarms.
+            // Ideally, we should be setting port 0, then reading the port number assigned by the system and save that value. But that would be best handled by libtransmission itself.
+            // For now, we randomize the port as a Dynamic/Private/Ephemeral Port from 49152–65535
+            // https://datatracker.ietf.org/doc/html/rfc6335#section-6
+            uint16_t defaultPort = 49152 + arc4random_uniform(65536 - 49152);
+            [_fDefaults setInteger:defaultPort forKey:@"BindPort"];
+        }
+
         BOOL const randomPort = [_fDefaults boolForKey:@"RandomPort"];
         tr_variantDictAddBool(&settings, TR_KEY_peer_port_random_on_start, randomPort);
         if (!randomPort)

--- a/macosx/Defaults.plist
+++ b/macosx/Defaults.plist
@@ -14,8 +14,6 @@
 	<true/>
 	<key>BadgeUploadRate</key>
 	<true/>
-	<key>BindPort</key>
-	<integer>51413</integer>
 	<key>BlocklistAutoUpdate</key>
 	<false/>
 	<key>BlocklistNew</key>


### PR DESCRIPTION
This is a partial enhancement toward #4917:
- it's only for the mac app, not QT/GTK/daemon/...
- it's a random default port, but not one assigned by the system. In order to get a random port assigned by the system, we would need to start with port 0, then read the port number assigned by the system and save that value. That would be best handled by libtransmission itself, hence why I'm not doing it as part of this PR.