### PR TITLE
Align tr_formatter_speed_KBps with `stringForSpeed: kb: mb: gb:`

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -755,7 +755,7 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
 
     auto speed = kilo_per_second;
 
-    if (speed < 999.95) // 0.0 KB to 999.9 KB
+    if (speed < 999.95) // 0.0 KB to 999.9 KB (0.0 KiB to 999.9 KiB)
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
     }
@@ -767,7 +767,7 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
     {
         return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
-    if (speed < 999.95) // 100.0 MB to 999.9 MB
+    if (speed < 999.95) // 100.0 MB to 999.9 MB (100.0 MiB to 999.9 MiB)
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
@@ -778,7 +778,7 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
     {
         return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
     }
-    // 100.0 GB and above
+    // 100.0 GB and above (100.0 GiB and above)
     return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
 }
 
@@ -788,11 +788,11 @@ std::string tr_formatter_speed_compact_KBps(double kilo_per_second)
 
     auto speed = kilo_per_second;
 
-    if (speed < 99.95) // 0.0 KB to 99.9 KB
+    if (speed < 99.95) // 0.0 KB to 99.9 KB (0.0 KiB to 99.9 KiB)
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
     }
-    if (speed < 999.5) // 100 KB to 999 KB
+    if (speed < 999.5) // 100 KB to 999 KB (100 KiB to 999 KiB)
     {
         return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
     }
@@ -804,11 +804,11 @@ std::string tr_formatter_speed_compact_KBps(double kilo_per_second)
     {
         return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
-    if (speed < 99.95) // 10.0 MB to 99.9 MB
+    if (speed < 99.95) // 10.0 MB to 99.9 MB (10.0 MiB to 99.9 MiB)
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
-    if (speed < 999.5) // 100 MB to 999 MB
+    if (speed < 999.5) // 100 MB to 999 MB (100 MiB to 999 MiB)
     {
         return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
@@ -819,11 +819,11 @@ std::string tr_formatter_speed_compact_KBps(double kilo_per_second)
     {
         return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
     }
-    if (speed < 99.95) // 10.0 GB to 99.9 GB
+    if (speed < 99.95) // 10.0 GB to 99.9 GB (10.0 GiB to 99.9 GiB)
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
     }
-    // 100 GB and above
+    // 100 GB and above (100 GiB and above)
     return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -755,25 +755,76 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
 
     auto speed = kilo_per_second;
 
-    if (speed <= 999.95) // 0.0 KB to 999.9 KB
+    if (speed < 999.95) // 0.0 KB to 999.9 KB
     {
-        return fmt::format("{:Ld} {:s}", int(speed), std::data(speed_units[TR_FMT_KB].name));
+        return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
     }
 
     double const kilo = speed_units[TR_FMT_KB].value;
     speed /= kilo;
 
-    if (speed <= 99.995) // 0.98 MB to 99.99 MB
+    if (speed < 99.995) // 0.98 MB to 99.99 MB (1.00 MiB to 99.99 MiB)
     {
         return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
-
-    if (speed <= 999.95) // 100.0 MB to 999.9 MB
+    if (speed < 999.95) // 100.0 MB to 999.9 MB
     {
         return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
 
-    return fmt::format("{:.1Lf} {:s}", speed / kilo, std::data(speed_units[TR_FMT_GB].name));
+    speed /= kilo;
+
+    if (speed < 99.995) // 0.98 GB to 99.99 GB (1.00 GiB to 99.99 GiB)
+    {
+        return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
+    }
+    // 100.0 GB and above
+    return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
+}
+
+std::string tr_formatter_speed_compact_KBps(double kilo_per_second)
+{
+    using namespace formatter_impl;
+
+    auto speed = kilo_per_second;
+
+    if (speed < 99.95) // 0.0 KB to 99.9 KB
+    {
+        return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
+    }
+    if (speed < 999.5) // 100 KB to 999 KB
+    {
+        return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_KB].name));
+    }
+
+    double const kilo = speed_units[TR_FMT_KB].value;
+    speed /= kilo;
+
+    if (speed < 9.995) // 0.98 MB to 9.99 MB (1.00 MiB to 9.99 MiB)
+    {
+        return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
+    }
+    if (speed < 99.95) // 10.0 MB to 99.9 MB
+    {
+        return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
+    }
+    if (speed < 999.5) // 100 MB to 999 MB
+    {
+        return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
+    }
+
+    speed /= kilo;
+
+    if (speed < 9.995) // 0.98 GB to 9.99 GB (1.00 GiB to 9.99 GiB)
+    {
+        return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
+    }
+    if (speed < 99.95) // 10.0 GB to 99.9 GB
+    {
+        return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
+    }
+    // 100 GB and above
+    return fmt::format("{:.0Lf} {:s}", speed, std::data(speed_units[TR_FMT_GB].name));
 }
 
 size_t tr_mem_K = 0;

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -311,8 +311,10 @@ extern size_t tr_speed_K;
 extern size_t tr_mem_K;
 extern uint64_t tr_size_K; /* unused? */
 
-/* format a speed from KBps into a user-readable string. */
+/* format a speed from KBps into a 4 significant digits user-readable string. */
 [[nodiscard]] std::string tr_formatter_speed_KBps(double kilo_per_second);
+/* format a speed from KBps into a 3 significant digits user-readable string. */
+[[nodiscard]] std::string tr_formatter_speed_compact_KBps(double kilo_per_second);
 
 /* format a memory size from bytes into a user-readable string. */
 [[nodiscard]] std::string tr_formatter_mem_B(size_t bytes);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -311,21 +311,21 @@ extern size_t tr_speed_K;
 extern size_t tr_mem_K;
 extern uint64_t tr_size_K; /* unused? */
 
-/* format a speed from KBps into a 4 significant digits user-readable string. */
+/** @brief Format a speed from KBps into a user-readable string of at most 4 significant digits. */
 [[nodiscard]] std::string tr_formatter_speed_KBps(double kilo_per_second);
-/* format a speed from KBps into a 3 significant digits user-readable string. */
+/** @brief Format a speed from KBps into a user-readable string of at most 3 significant digits. */
 [[nodiscard]] std::string tr_formatter_speed_compact_KBps(double kilo_per_second);
 
-/* format a memory size from bytes into a user-readable string. */
+/** @brief Format a memory size from bytes into a user-readable string. */
 [[nodiscard]] std::string tr_formatter_mem_B(size_t bytes);
 
-/* format a memory size from MB into a user-readable string. */
+/** @brief Format a memory size from MB into a user-readable string. */
 [[nodiscard]] static inline std::string tr_formatter_mem_MB(double MBps)
 {
     return tr_formatter_mem_B((size_t)(MBps * tr_mem_K * tr_mem_K));
 }
 
-/* format a file size from bytes into a user-readable string. */
+/** @brief Format a file size from bytes into a user-readable string. */
 [[nodiscard]] std::string tr_formatter_size_B(uint64_t bytes);
 
 void tr_formatter_get_units(void* dict);


### PR DESCRIPTION
Three changes:

1. This change re-adds 1 digit after the dot/comma for small values, in order to align with macOS string display (partial revert of efc306a8d34eab842b296e4833cf7fafe8e3bb80)
2. This change increases digits precision for large values, in order to align with macOS string display.
3. Edge cases significants (same as #5100):
- A speed of 999.95 should display as "0.98 M" or "1.00 M", not "1000.0 K" (only affects after adding 1 digit after the dot)
- A speed of 99995 should display as "100.0 M", not "100.00 M" (only affects when kilo is 1000)
- A speed of 999950 should display as "1.00 G", not "1000.0 M" (only affects when kilo is 1000)