### PR TITLE
fix: 5053 old torrent files keep appearing

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -621,22 +621,14 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
 
 // ---
 
-auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load, bool* did_migrate_filename)
+auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load)
 {
     auto fields_loaded = tr_resume::fields_t{};
 
     TR_ASSERT(tr_isTorrent(tor));
     auto const was_dirty = tor->isDirty;
 
-    auto const migrated = tr_torrent_metainfo::migrateFile(
-        tor->session->resumeDir(),
-        tor->name(),
-        tor->infoHashString(),
-        ".resume"sv);
-    if (did_migrate_filename != nullptr)
-    {
-        *did_migrate_filename = migrated;
-    }
+    tr_torrent_metainfo::migrateFile(tor->session->resumeDir(), tor->name(), tor->infoHashString(), ".resume"sv);
 
     auto const filename = tor->resumeFile();
     if (!tr_sys_path_exists(filename))
@@ -865,7 +857,7 @@ auto useFallbackFields(tr_torrent* tor, tr_resume::fields_t fields, tr_ctor cons
 }
 } // namespace
 
-fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor, bool* did_rename_to_hash_only_name)
+fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
@@ -873,7 +865,7 @@ fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor, boo
 
     ret |= useMandatoryFields(tor, fields_to_load, ctor);
     fields_to_load &= ~ret;
-    ret |= loadFromFile(tor, fields_to_load, did_rename_to_hash_only_name);
+    ret |= loadFromFile(tor, fields_to_load);
     fields_to_load &= ~ret;
     ret |= useFallbackFields(tor, fields_to_load, ctor);
 

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -46,7 +46,7 @@ auto inline constexpr Group = fields_t{ 1 << 23 };
 
 auto inline constexpr All = ~fields_t{ 0 };
 
-fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor, bool* did_rename_to_hash_only_name);
+fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor);
 
 void save(tr_torrent* tor);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1105,15 +1105,9 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         // the same ones that would be saved back again, so don't let them
         // affect the 'is dirty' flag.
         auto const was_dirty = tor->isDirty;
-
-        bool resume_file_was_migrated = false;
-        loaded = tr_resume::load(tor, tr_resume::All, ctor, &resume_file_was_migrated);
+        loaded = tr_resume::load(tor, tr_resume::All, ctor);
         tor->isDirty = was_dirty;
-
-        if (resume_file_was_migrated)
-        {
-            tr_torrent_metainfo::migrateFile(session->torrentDir(), tor->name(), tor->infoHashString(), ".torrent"sv);
-        }
+        tr_torrent_metainfo::migrateFile(session->torrentDir(), tor->name(), tor->infoHashString(), ".torrent"sv);
     }
 
     tor->completeness = tor->completion.status();

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -192,7 +192,7 @@ TEST_F(RenameTest, singleFilenameTorrent)
     // (while it's renamed: confirm that the .resume file remembers the changes)
     tr_resume::save(tor);
     sync();
-    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor, nullptr);
+    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor);
     EXPECT_STREQ("foobar", tr_torrentName(tor));
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Name));
 
@@ -303,7 +303,7 @@ TEST_F(RenameTest, multifileTorrent)
     tr_resume::save(tor);
     // this is a bit dodgy code-wise, but let's make sure the .resume file got the name
     tor->setFileSubpath(1, "gabba gabba hey"sv);
-    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor, nullptr);
+    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
     EXPECT_EQ(ExpectedFiles[0], tr_torrentFile(tor, 0).name);
     EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", tr_torrentFile(tor, 1).name);


### PR DESCRIPTION
Fixes #5053.

Old torrent files will still reappear once since they are sitting around in the `torrents/` directory from years before. But the worse issue was about how they would keep coming back again and again after being removed.

This PR should fix that by ensuring that any files using the old `${name}.${infohash.substr(0, 16)}.torrent` naming scheme will be migrated to the new `${infohash}.torrent` naming scheme.

Notes: Fixed `4.0.0` bug where macOS users could see some of their old torrents reappear after removing & restarting.