### PR TITLE
refactor: remove unnecessary NSNotificationCenter observer removals

### DIFF
--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -106,11 +106,6 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
     }
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (void)setDestination:(id)sender
 {
     NSOpenPanel* panel = [NSOpenPanel openPanel];

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -176,8 +176,6 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-
     [_fTimer invalidate];
 }
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1028,9 +1028,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         [[BlocklistDownloader downloader] cancelDownload];
     }
 
-    //stop timers and notification checking
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-
+    //stop timers
     [self.fTimer invalidate];
 
     if (self.fAutoImportTimer)

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1028,7 +1028,9 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         [[BlocklistDownloader downloader] cancelDownload];
     }
 
-    //stop timers
+    //stop timers and notification checking
+    [NSNotificationCenter.defaultCenter removeObserver:self];
+
     [self.fTimer invalidate];
 
     if (self.fAutoImportTimer)

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -50,11 +50,6 @@
     return self;
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (void)setTorrents:(NSArray<NSString*>*)files
 {
     uint64_t size = 0;

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -140,11 +140,6 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
     self.fSearchField.delegate = self;
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (void)setFilter:(id)sender
 {
     NSString* oldFilterType = [NSUserDefaults.standardUserDefaults stringForKey:@"Filter"];

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -69,11 +69,6 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
     [self checkWindowSize];
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (CGFloat)fHorizLayoutHeight
 {
     return NSHeight(self.fTransferView.frame) + 2 * kStackViewInset;

--- a/macosx/InfoOptionsViewController.mm
+++ b/macosx/InfoOptionsViewController.mm
@@ -84,11 +84,6 @@ static CGFloat const kStackViewSpacing = 8.0;
                                              object:nil];
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (CGFloat)fHorizLayoutHeight
 {
     return NSHeight(self.fPriorityView.frame) + 2 * kStackViewInset;

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -171,8 +171,6 @@ typedef NS_ENUM(NSUInteger, TabTag) {
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-
     if ([_fViewController respondsToSelector:@selector(saveViewSize)])
     {
         [_fViewController saveViewSize];

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -141,7 +141,6 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self];
     [_fTimer invalidate];
 }
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -188,8 +188,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-
     [_fPortStatusTimer invalidate];
     if (_fPortChecker)
     {

--- a/macosx/StatusBarController.mm
+++ b/macosx/StatusBarController.mm
@@ -73,11 +73,6 @@ typedef NS_ENUM(NSUInteger, StatusTag) {
                                              object:nil];
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (void)updateWithDownload:(CGFloat)dlRate upload:(CGFloat)ulRate
 {
     //set rates

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -168,11 +168,6 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     };
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (NSString*)description
 {
     return [@"Torrent: " stringByAppendingString:self.name];

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -112,11 +112,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     return self;
 }
 
-- (void)dealloc
-{
-    [NSNotificationCenter.defaultCenter removeObserver:self];
-}
-
 - (void)awakeFromNib
 {
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(refreshTorrentTable) name:@"RefreshTorrentTable"


### PR DESCRIPTION
According to the docs, targeting macOS 10.11+ allows us to remove the code that manually deregisters NSObjects from receiving NSNotificationCenter notifications. This PR does just that. 
In a few cases, this code did nothing as no notifications were sent in the first place.