### PR TITLE
Add more complex formatting to a spinbox

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1311,10 +1311,9 @@ void DetailsDialog::onIdleModeChanged(int index)
 void DetailsDialog::onIdleLimitChanged()
 {
     //: Spin box format, "Stop seeding if idle for: [ 5 minutes ]"
-    QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleSpin->value());
-
+    auto const units_format = QT_TRANSLATE_N_NOOP("DetailsDialog", "%1 minute(s)");
     auto const placeholder = QStringLiteral("%1");
-    Utils::updateSpinBoxFormat(ui_.idleSpin, units_format, placeholder);
+    Utils::updateSpinBoxFormat(ui_.idleSpin, "DetailsDialog", units_format, placeholder);
 }
 
 void DetailsDialog::onRatioModeChanged(int index)

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1314,23 +1314,7 @@ void DetailsDialog::onIdleLimitChanged()
     QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleSpin->value());
 
     auto const placeholder = QStringLiteral("%1");
-    auto const placeholder_pos = units_format.indexOf(placeholder);
-    if (placeholder_pos == -1)
-    {
-        return;
-    }
-
-    auto const units_prefix = units_format.left(placeholder_pos);
-    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
-
-    if (ui_.idleSpin->prefix() != units_prefix)
-    {
-        ui_.idleSpin->setPrefix(units_prefix);
-    }
-    if (ui_.idleSpin->suffix() != units_suffix)
-    {
-        ui_.idleSpin->setSuffix(units_suffix);
-    }
+    Utils::updateSpinBoxFormat(ui_.idleSpin, units_format, placeholder);
 }
 
 void DetailsDialog::onRatioModeChanged(int index)

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1310,9 +1310,23 @@ void DetailsDialog::onIdleModeChanged(int index)
 
 void DetailsDialog::onIdleLimitChanged()
 {
-    //: Spin box suffix, "Stop seeding if idle for: [ 5 minutes ]" (includes leading space after the number, if needed)
-    QString const units_suffix = tr(" minute(s)", nullptr, ui_.idleSpin->value());
+    //: Spin box format, "Stop seeding if idle for: [ 5 minutes ]"
+    QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleSpin->value());
 
+    auto const placeholder = QStringLiteral("%1");
+    auto const placeholder_pos = units_format.indexOf(placeholder);
+    if (placeholder_pos == -1)
+    {
+        return;
+    }
+
+    auto const units_prefix = units_format.left(placeholder_pos);
+    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
+
+    if (ui_.idleSpin->prefix() != units_prefix)
+    {
+        ui_.idleSpin->setPrefix(units_prefix);
+    }
     if (ui_.idleSpin->suffix() != units_suffix)
     {
         ui_.idleSpin->setSuffix(units_suffix);

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -551,25 +551,8 @@ void PrefsDialog::onIdleLimitChanged()
 {
     //: Spin box format, "Stop seeding if idle for: [ 5 minutes ]"
     QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleLimitSpin->value());
-
     auto const placeholder = QStringLiteral("%1");
-    auto const placeholder_pos = units_format.indexOf(placeholder);
-    if (placeholder_pos == -1)
-    {
-        return;
-    }
-
-    auto const units_prefix = units_format.left(placeholder_pos);
-    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
-
-    if (ui_.idleLimitSpin->prefix() != units_prefix)
-    {
-        ui_.idleLimitSpin->setPrefix(units_prefix);
-    }
-    if (ui_.idleLimitSpin->suffix() != units_suffix)
-    {
-        ui_.idleLimitSpin->setSuffix(units_suffix);
-    }
+    Utils::updateSpinBoxFormat(ui_.idleLimitSpin, units_format, placeholder);
 }
 
 void PrefsDialog::initSeedingTab()
@@ -594,25 +577,8 @@ void PrefsDialog::onQueueStalledMinutesChanged()
 {
     //: Spin box format, "Download is inactive if data sharing stopped: [ 5 minutes ago ]"
     QString const units_format = tr("%1 minute(s) ago", nullptr, ui_.queueStalledMinutesSpin->value());
-
     auto const placeholder = QStringLiteral("%1");
-    auto const placeholder_pos = units_format.indexOf(placeholder);
-    if (placeholder_pos == -1)
-    {
-        return;
-    }
-
-    auto const units_prefix = units_format.left(placeholder_pos);
-    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
-
-    if (ui_.queueStalledMinutesSpin->prefix() != units_prefix)
-    {
-        ui_.queueStalledMinutesSpin->setPrefix(units_prefix);
-    }
-    if (ui_.queueStalledMinutesSpin->suffix() != units_suffix)
-    {
-        ui_.queueStalledMinutesSpin->setSuffix(units_suffix);
-    }
+    Utils::updateSpinBoxFormat(ui_.queueStalledMinutesSpin, units_format, placeholder);
 }
 
 void PrefsDialog::initDownloadingTab()

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -578,9 +578,16 @@ void PrefsDialog::initSeedingTab()
 
 void PrefsDialog::onQueueStalledMinutesChanged()
 {
-    //: Spin box suffix, "Download is inactive if data sharing stopped: [ 5 minutes ago ]" (includes leading space after the number, if needed)
-    QString const units_suffix = tr(" minute(s) ago", nullptr, ui_.queueStalledMinutesSpin->value());
+    //: Spin box format, "Download is inactive if data sharing stopped: [ 5 minutes ago ]" (includes leading space after the number, if needed)
+    QString const units_format = tr("%1 minute(s) ago", nullptr, ui_.queueStalledMinutesSpin->value());
 
+    QString const units_prefix = units_format.section(QStringLiteral("%1"), -2, -2);
+    QString const units_suffix = units_format.section(QStringLiteral("%1"), -1);
+
+    if (ui_.queueStalledMinutesSpin->prefix() != units_prefix)
+    {
+        ui_.queueStalledMinutesSpin->setPrefix(units_prefix);
+    }
     if (ui_.queueStalledMinutesSpin->suffix() != units_suffix)
     {
         ui_.queueStalledMinutesSpin->setSuffix(units_suffix);

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -578,11 +578,18 @@ void PrefsDialog::initSeedingTab()
 
 void PrefsDialog::onQueueStalledMinutesChanged()
 {
-    //: Spin box format, "Download is inactive if data sharing stopped: [ 5 minutes ago ]" (includes leading space after the number, if needed)
+    //: Spin box format, "Download is inactive if data sharing stopped: [ 5 minutes ago ]"
     QString const units_format = tr("%1 minute(s) ago", nullptr, ui_.queueStalledMinutesSpin->value());
 
-    QString const units_prefix = units_format.section(QStringLiteral("%1"), -2, -2);
-    QString const units_suffix = units_format.section(QStringLiteral("%1"), -1);
+    auto const placeholder = QStringLiteral("%1");
+    auto const placeholder_pos = units_format.indexOf(placeholder);
+    if (placeholder_pos == -1)
+    {
+        return;
+    }
+
+    auto const units_prefix = units_format.left(placeholder_pos);
+    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
 
     if (ui_.queueStalledMinutesSpin->prefix() != units_prefix)
     {

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -549,9 +549,23 @@ void PrefsDialog::initPrivacyTab()
 
 void PrefsDialog::onIdleLimitChanged()
 {
-    //: Spin box suffix, "Stop seeding if idle for: [ 5 minutes ]" (includes leading space after the number, if needed)
-    QString const units_suffix = tr(" minute(s)", nullptr, ui_.idleLimitSpin->value());
+    //: Spin box format, "Stop seeding if idle for: [ 5 minutes ]"
+    QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleLimitSpin->value());
 
+    auto const placeholder = QStringLiteral("%1");
+    auto const placeholder_pos = units_format.indexOf(placeholder);
+    if (placeholder_pos == -1)
+    {
+        return;
+    }
+
+    auto const units_prefix = units_format.left(placeholder_pos);
+    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
+
+    if (ui_.idleLimitSpin->prefix() != units_prefix)
+    {
+        ui_.idleLimitSpin->setPrefix(units_prefix);
+    }
     if (ui_.idleLimitSpin->suffix() != units_suffix)
     {
         ui_.idleLimitSpin->setSuffix(units_suffix);

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -550,9 +550,9 @@ void PrefsDialog::initPrivacyTab()
 void PrefsDialog::onIdleLimitChanged()
 {
     //: Spin box format, "Stop seeding if idle for: [ 5 minutes ]"
-    QString const units_format = tr("%1 minute(s)", nullptr, ui_.idleLimitSpin->value());
+    auto const units_format = QT_TRANSLATE_N_NOOP("PrefsDialog", "%1 minute(s)");
     auto const placeholder = QStringLiteral("%1");
-    Utils::updateSpinBoxFormat(ui_.idleLimitSpin, units_format, placeholder);
+    Utils::updateSpinBoxFormat(ui_.idleLimitSpin, "PrefsDialog", units_format, placeholder);
 }
 
 void PrefsDialog::initSeedingTab()
@@ -576,9 +576,9 @@ void PrefsDialog::initSeedingTab()
 void PrefsDialog::onQueueStalledMinutesChanged()
 {
     //: Spin box format, "Download is inactive if data sharing stopped: [ 5 minutes ago ]"
-    QString const units_format = tr("%1 minute(s) ago", nullptr, ui_.queueStalledMinutesSpin->value());
+    auto const units_format = QT_TRANSLATE_N_NOOP("PrefsDialog", "%1 minute(s) ago");
     auto const placeholder = QStringLiteral("%1");
-    Utils::updateSpinBoxFormat(ui_.queueStalledMinutesSpin, units_format, placeholder);
+    Utils::updateSpinBoxFormat(ui_.queueStalledMinutesSpin, "PrefsDialog", units_format, placeholder);
 }
 
 void PrefsDialog::initDownloadingTab()

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -6,6 +6,7 @@
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QColor>
+#include <QCoreApplication>
 #include <QDataStream>
 #include <QFile>
 #include <QFileIconProvider>
@@ -102,16 +103,17 @@ QColor Utils::getFadedColor(QColor const& color)
     return faded_color;
 }
 
-void Utils::updateSpinBoxFormat(QSpinBox* spinBox, QString const& format, QString const& placeholder)
+void Utils::updateSpinBoxFormat(QSpinBox* spinBox, char const* context, char const* format, QString const& placeholder)
 {
-    auto const placeholder_pos = format.indexOf(placeholder);
+    QString const units_format = QCoreApplication::translate(context, format, nullptr, spinBox->value());
+    auto const placeholder_pos = units_format.indexOf(placeholder);
     if (placeholder_pos == -1)
     {
         return;
     }
 
-    auto const units_prefix = format.left(placeholder_pos);
-    auto const units_suffix = format.mid(placeholder_pos + placeholder.size());
+    auto const units_prefix = units_format.left(placeholder_pos);
+    auto const units_suffix = units_format.mid(placeholder_pos + placeholder.size());
 
     if (spinBox->prefix() != units_prefix)
     {

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -101,3 +101,24 @@ QColor Utils::getFadedColor(QColor const& color)
     faded_color.setAlpha(128);
     return faded_color;
 }
+
+void Utils::updateSpinBoxFormat(QSpinBox* spinBox, QString const& format, QString const& placeholder)
+{
+    auto const placeholder_pos = format.indexOf(placeholder);
+    if (placeholder_pos == -1)
+    {
+        return;
+    }
+
+    auto const units_prefix = format.left(placeholder_pos);
+    auto const units_suffix = format.mid(placeholder_pos + placeholder.size());
+
+    if (spinBox->prefix() != units_prefix)
+    {
+        spinBox->setPrefix(units_prefix);
+    }
+    if (spinBox->suffix() != units_suffix)
+    {
+        spinBox->setSuffix(units_suffix);
+    }
+}

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -11,6 +11,7 @@
 #include <QHash>
 #include <QPointer>
 #include <QRect>
+#include <QSpinBox>
 #include <QString>
 
 class QAbstractItemView;
@@ -74,4 +75,6 @@ public:
             dialog->activateWindow();
         }
     }
+
+    static void updateSpinBoxFormat(QSpinBox* spinBox, QString const& format, QString const& placeholder);
 };

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -76,5 +76,5 @@ public:
         }
     }
 
-    static void updateSpinBoxFormat(QSpinBox* spinBox, QString const& format, QString const& placeholder);
+    static void updateSpinBoxFormat(QSpinBox* spinBox, char const* context, char const* format, QString const& placeholder);
 };

--- a/qt/translations/transmission_sl.ts
+++ b/qt/translations/transmission_sl.ts
@@ -1815,14 +1815,14 @@ Za dodajanje nadaljnjega glavnega URL, ga dodajte za prazno vrstico.</translatio
         <translation>Izberi skripto za zaključek sejanja torrenta</translation>
     </message>
     <message numerus="yes">
-        <location line="+19"/>
-        <source> minute(s) ago</source>
+        <location filename="PrefsDialog.cc" line="582"/>
+        <source>%1 minute(s) ago</source>
         <extracomment>Spin box suffix, &quot;Download is inactive if data sharing stopped: [ 5 minutes ago ]&quot; (includes leading space after the number, if needed)</extracomment>
         <translation>
-            <numerusform>minuto nazaj</numerusform>
-            <numerusform>minutama nazaj</numerusform>
-            <numerusform>minutami nazaj</numerusform>
-            <numerusform>minutami nazaj</numerusform>
+            <numerusform>pred %1 minuto</numerusform>
+            <numerusform>pred %1 minutama</numerusform>
+            <numerusform>pred %1 minutami</numerusform>
+            <numerusform>pred %1 minutami</numerusform>
         </translation>
     </message>
     <message>

--- a/qt/translations/transmission_sl.ts
+++ b/qt/translations/transmission_sl.ts
@@ -1815,14 +1815,14 @@ Za dodajanje nadaljnjega glavnega URL, ga dodajte za prazno vrstico.</translatio
         <translation>Izberi skripto za zaključek sejanja torrenta</translation>
     </message>
     <message numerus="yes">
-        <location filename="PrefsDialog.cc" line="582"/>
-        <source>%1 minute(s) ago</source>
+        <location line="+19"/>
+        <source> minute(s) ago</source>
         <extracomment>Spin box suffix, &quot;Download is inactive if data sharing stopped: [ 5 minutes ago ]&quot; (includes leading space after the number, if needed)</extracomment>
         <translation>
-            <numerusform>pred %1 minuto</numerusform>
-            <numerusform>pred %1 minutama</numerusform>
-            <numerusform>pred %1 minutami</numerusform>
-            <numerusform>pred %1 minutami</numerusform>
+            <numerusform>minuto nazaj</numerusform>
+            <numerusform>minutama nazaj</numerusform>
+            <numerusform>minutami nazaj</numerusform>
+            <numerusform>minutami nazaj</numerusform>
         </translation>
     </message>
     <message>


### PR DESCRIPTION
As mentioned in #5111, thanks for the feedback.
If `%1` is omitted, the behaviour stays the same as before (the string is used as suffix only).

How would integration with transifex work, if this code is merged? Also, would it be better to change all spinboxes to this format, or should it be done on case-by-case basis?