### PR TITLE
Use bundled deps for GHA build from tarball on Mac

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -190,7 +190,7 @@ jobs:
           brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3 libjpeg
+        run: brew install gtkmm3
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
         run: brew install qt@5
@@ -462,10 +462,10 @@ jobs:
       - name: Get Dependencies
         run: |
           brew update
-          brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja node pkg-config
+          brew install cmake gettext ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3 libjpeg
+        run: brew install gtkmm3
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
         run: brew install qt@5
@@ -494,7 +494,15 @@ jobs:
             -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_WERROR=ON \
-            -DRUN_CLANG_TIDY=OFF
+            -DRUN_CLANG_TIDY=OFF \
+            -DUSE_SYSTEM_EVENT2=OFF \
+            -DUSE_SYSTEM_DEFLATE=OFF \
+            -DUSE_SYSTEM_DHT=OFF \
+            -DUSE_SYSTEM_MINIUPNPC=OFF \
+            -DUSE_SYSTEM_NATPMP=OFF \
+            -DUSE_SYSTEM_UTP=OFF \
+            -DUSE_SYSTEM_B64=OFF \
+            -DUSE_SYSTEM_PSL=OFF
       - name: Make
         run: cmake --build obj --config RelWithDebInfo
       - name: Test


### PR DESCRIPTION
Homebrew libraries aren't meant for redistribution so don't use them for one of the two Mac builds to make it suitable for testing. Making Transmission binary inside the bundle executable is still necessary, but that's minor. Build time seems to be about the same.

Related to the discussion in #5079.