### PR TITLE
docs: add libssl-dev to Ubuntu dependencies

### DIFF
--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -63,7 +63,7 @@ Then you can begin [building.](#building-transmission-from-git-first-time)
 On Ubuntu, you can install the required development tools for GTK with this command:
 
 ```console
-$ sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libevent-dev libminiupnpc-dev libgtk-3-dev libappindicator3-dev
+$ sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libevent-dev libminiupnpc-dev libgtk-3-dev libappindicator3-dev libmbedtls-dev
 ```
 
 Then you can begin [building.](#building-transmission-from-git-first-time)

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -63,7 +63,7 @@ Then you can begin [building.](#building-transmission-from-git-first-time)
 On Ubuntu, you can install the required development tools for GTK with this command:
 
 ```console
-$ sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libevent-dev libminiupnpc-dev libgtk-3-dev libappindicator3-dev libmbedtls-dev
+$ sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libevent-dev libminiupnpc-dev libgtk-3-dev libappindicator3-dev libssl-dev
 ```
 
 Then you can begin [building.](#building-transmission-from-git-first-time)


### PR DESCRIPTION
Just adding this because I had to install `libmbedtls-dev` in addition to the packages already listed in `Building-Transmission.md` for Ubuntu, in order for CMake to configure properly.

I am on Ubuntu 22.04 LTS.