### PR TITLE
fix: selected torrent row color in dark mode

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -23,7 +23,7 @@ $nice-grey: #f8f8f8;
 $nice-grey-darker: #f0f0f0;
 $dark-mode-black: #121212;
 $default-accent-color: #fff8c5;
-$default-accent-color-dark: #2e2e2e;
+$default-accent-color-dark: #0c2d6b;
 $default-border-dark: #575757;
 $default-border-light: #aeaeae;
 


### PR DESCRIPTION
Current selected color `#2e2e2e` is indistinguishable from unselected even row `#292929`. Make it bluish `#0c2d6b`. It's copied from github's dark mode `--color-scale-blue-8`. I'm open to any other values though.

Before:
![2023-03-06-001847_945x212_scrot](https://user-images.githubusercontent.com/7259503/222973562-ad9fa28c-a6e6-4be5-a8df-aabebeffc403.png)

After:
![2023-03-06-002129_904x213_scrot](https://user-images.githubusercontent.com/7259503/222973565-d0535d45-4734-4bb9-8cfb-2ab87c206bb5.png)
