### PR TITLE
feat: Add libtransmission::BufferWriter class

### DIFF
--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -61,3 +61,37 @@ TEST_F(BufferTest, startsWithInMultiSegment)
     EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World!"sv));
 }
+
+TEST_F(BufferTest, NonBufferWriter)
+{
+    auto constexpr Hello = "Hello, "sv;
+    auto constexpr World = "World"sv;
+    auto constexpr Bang = "!"sv;
+
+    auto out1 = Buffer{};
+
+    auto out2_vec = std::vector<std::byte>{};
+    auto out2 = libtransmission::BufferWriter<std::vector<std::byte>, std::byte>{ &out2_vec };
+
+    out1.add_uint8(1);
+    out2.add_uint8(1);
+
+    out1.add_uint16(1);
+    out2.add_uint16(1);
+
+    out1.add_uint32(1);
+    out2.add_uint32(1);
+
+    out1.add(Hello);
+    out2.add(Hello);
+
+    out1.add(World);
+    out2.add(World);
+
+    out1.add(Bang);
+    out2.add(Bang);
+
+    auto const result1 = out1.pullup_sv();
+    auto const result2 = std::string_view{ reinterpret_cast<char const*>(std::data(out2_vec)), std::size(out2_vec) };
+    EXPECT_EQ(result1, result2);
+}


### PR DESCRIPTION
This is a prerequisite step for decoupling message-building from Buffer.

For example, it would be nice to use a stack-allocated container from [sfl-library](https://github.com/slavenf/sfl-library) instead of requiring heap memory via `evbuffer` or `std::vector`.