### PR TITLE
Only publish 'leechers' if it was actually returned during the announce

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1099,7 +1099,11 @@ void tr_announcer_impl::onAnnounceDone(
             publishPeersPex(tier, seeders, leechers, response.pex6);
         }
 
-        publishPeerCounts(tier, seeders, leechers);
+        /* Only publish leechers if it was actually returned during the announce */
+        if (response.leechers >= 0)
+        {
+            publishPeerCounts(tier, seeders, leechers);
+        }
 
         tier->isRunning = is_running_on_success;
 


### PR DESCRIPTION
This is a quick solution to #2932 which "does no harm". But it really deserves a more complete refactor.

To restate the problem: if the announcer never saw a "leechers" key in the response from the tracker, then the response.leechers value remains unset.  publishPeerCounts() actually ignores "seeders" value but does use the leechers value to set the SwarmIsAllSeeds flag, which in turn determines whether outbound connections are made.  The way the code is structured, the local-scope leechers value is set to {0} while the response.leechers value remains at {-1}, but the former is sent to publishPeerCount(). So most torrents end-up in a ping-pong between the announce&scrape, where SwarmIsAllSeeds is set/unset incorrectly.

Note that out of 12 private trackers I tested, only 1 was returning "leechers" as part of the announce; the rest return it during scrape.

A better version of this would redo publishPeerCounts() and publishPeersPex(), make clear that "-1" means "no update", and would add "downloads" to the tr_tracker_event object.