### PR TITLE
fix: increase priority of first and last piece of each file

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -141,12 +141,11 @@ tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
     }
 
     // check the priorities of the files that touch this piece
-    if (!std::empty(priorities_))
+    if (end_file <= std::size(priorities_))
     {
         auto const begin = std::begin(priorities_) + begin_file;
         auto const end = std::begin(priorities_) + end_file;
-        auto const it = std::max_element(begin, end);
-        if (it != end)
+        if (auto const it = std::max_element(begin, end); it != end)
         {
             return *it;
         }

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -129,9 +129,9 @@ tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
         return TR_PRI_NORMAL;
     }
 
-    // increase priority if a file begins or ends in this piece.
-    // Xref: f2daeb242dab1a9586651e6e80124792a9f05d26
-    // Xref: https://forum.transmissionbt.com/viewtopic.php?t=10473
+    // increase priority if a file begins or ends in this piece
+    // because that makes life easier for code/users using at incomplete files.
+    // Xrefs: f2daeb242, https://forum.transmissionbt.com/viewtopic.php?t=10473
     auto const [begin_file, end_file] = fpm_->fileSpan(piece);
     if ((begin_file + 1 != end_file) // at least one file ends in this piece
         || (piece == fpm_->pieceSpan(begin_file).begin) // piece's first file starts in this piece

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -16,6 +16,7 @@
 #include "transmission.h"
 
 #include "bitfield.h"
+#include "block-info.h"
 
 struct tr_block_info;
 struct tr_torrent_metainfo;
@@ -62,6 +63,11 @@ public:
         return std::size(file_pieces_);
     }
 
+    [[nodiscard]] TR_CONSTEXPR20 bool empty() const noexcept
+    {
+        return std::empty(file_pieces_);
+    }
+
     // TODO(ckerr) minor wart here, two identical span types
     [[nodiscard]] tr_byte_span_t byteSpan(tr_file_index_t file) const
     {
@@ -69,7 +75,14 @@ public:
         return tr_byte_span_t{ span.begin, span.end };
     }
 
+    [[nodiscard]] constexpr auto const& blockInfo() const noexcept
+    {
+        return block_info_;
+    }
+
 private:
+    tr_block_info block_info_;
+
     using byte_span_t = index_span_t<uint64_t>;
     std::vector<byte_span_t> file_bytes_;
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -16,7 +16,6 @@
 #include "transmission.h"
 
 #include "bitfield.h"
-#include "block-info.h"
 
 struct tr_block_info;
 struct tr_torrent_metainfo;
@@ -79,14 +78,7 @@ public:
         return tr_byte_span_t{ span.begin, span.end };
     }
 
-    [[nodiscard]] constexpr auto const& blockInfo() const noexcept
-    {
-        return block_info_;
-    }
-
 private:
-    tr_block_info block_info_;
-
     using byte_span_t = index_span_t<uint64_t>;
     std::vector<byte_span_t> file_bytes_;
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -52,7 +52,7 @@ public:
     void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
     void reset(tr_torrent_metainfo const& tm);
 
-    [[nodiscard]] constexpr auto pieceSpan(tr_file_index_t file) const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 piece_span_t pieceSpan(tr_file_index_t file) const noexcept
     {
         return file_pieces_[file];
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -53,7 +53,11 @@ public:
     void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
     void reset(tr_torrent_metainfo const& tm);
 
-    [[nodiscard]] piece_span_t pieceSpan(tr_file_index_t file) const;
+    [[nodiscard]] constexpr auto pieceSpan(tr_file_index_t file) const noexcept
+    {
+        return file_pieces_[file];
+    }
+
     [[nodiscard]] file_span_t fileSpan(tr_piece_index_t piece) const;
 
     [[nodiscard]] file_offset_t fileOffset(uint64_t offset) const;

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -139,15 +139,33 @@ TEST_F(FilePieceMapTest, priorities)
     {
         for (tr_file_index_t i = 0; i < n_files; ++i)
         {
-            EXPECT_EQ(int(expected_file_priorities[i]), int(file_priorities.filePriority(i)));
+            auto const expected = static_cast<int>(expected_file_priorities[i]);
+            auto const actual = static_cast<int>(file_priorities.filePriority(i));
+            EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
         for (tr_piece_index_t i = 0; i < block_info_.pieceCount(); ++i)
         {
-            EXPECT_EQ(int(expected_piece_priorities[i]), int(file_priorities.piecePriority(i)));
+            auto const expected = static_cast<int>(expected_piece_priorities[i]);
+            auto const actual = static_cast<int>(file_priorities.piecePriority(i));
+            EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
+        }
+    };
+
+    auto const mark_file_endpoints_as_high_priority = [&]()
+    {
+        for (tr_file_index_t i = 0; i < n_files; ++i)
+        {
+            auto const [begin_piece, end_piece] = fpm.pieceSpan(i);
+            expected_piece_priorities[begin_piece] = TR_PRI_HIGH;
+            if (end_piece > begin_piece)
+            {
+                expected_piece_priorities[end_piece - 1] = TR_PRI_HIGH;
+            }
         }
     };
 
     // check default priority is normal
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // set the first file as high priority.
@@ -160,6 +178,7 @@ TEST_F(FilePieceMapTest, priorities)
     {
         expected_piece_priorities[i] = pri;
     }
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // This file shares a piece with another file.
@@ -172,17 +191,20 @@ TEST_F(FilePieceMapTest, priorities)
     file_priorities.set(5, pri);
     expected_file_priorities[5] = pri;
     expected_piece_priorities[5] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // ...and that shared piece should still be the same when both are high...
     file_priorities.set(6, pri);
     expected_file_priorities[6] = pri;
     expected_piece_priorities[5] = pri;
     expected_piece_priorities[6] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // ...and that shared piece should still be the same when only 6 is high...
     pri = TR_PRI_NORMAL;
     file_priorities.set(5, pri);
     expected_file_priorities[5] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // setup for the next test: set all files to low priority
@@ -193,6 +215,7 @@ TEST_F(FilePieceMapTest, priorities)
     }
     std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
     std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // Raise the priority of a small 1-piece file.
@@ -202,6 +225,7 @@ TEST_F(FilePieceMapTest, priorities)
     file_priorities.set(8, pri);
     expected_file_priorities[8] = pri;
     expected_piece_priorities[6] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Raise the priority of another small 1-piece file in the same piece.
     // Since _it_ now has the highest priority in the piece, piecePriority should return _its_ value.
@@ -210,6 +234,7 @@ TEST_F(FilePieceMapTest, priorities)
     file_priorities.set(9, pri);
     expected_file_priorities[9] = pri;
     expected_piece_priorities[6] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // Prep for the next test: set all files to normal priority
@@ -220,6 +245,7 @@ TEST_F(FilePieceMapTest, priorities)
     }
     std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
     std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // *Sigh* OK what happens to piece priorities if you set the priority
@@ -234,12 +260,14 @@ TEST_F(FilePieceMapTest, priorities)
     file_priorities.set(1, pri);
     expected_file_priorities[1] = pri;
     expected_piece_priorities[5] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's priority.
     // file #16 byte [1001, 1001) piece [10, 11)
     file_priorities.set(16, pri);
     expected_file_priorities[16] = pri;
     expected_piece_priorities[10] = pri;
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // test the batch API
@@ -249,11 +277,13 @@ TEST_F(FilePieceMapTest, priorities)
     file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
     std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
     std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
     pri = TR_PRI_LOW;
     file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
     std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
     std::fill(std::begin(expected_piece_priorities), std::end(expected_piece_priorities), pri);
+    mark_file_endpoints_as_high_priority();
     compare_to_expected();
 }
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -139,14 +139,14 @@ TEST_F(FilePieceMapTest, priorities)
     {
         for (tr_file_index_t i = 0; i < n_files; ++i)
         {
-            auto const expected = static_cast<int>(expected_file_priorities[i]);
-            auto const actual = static_cast<int>(file_priorities.filePriority(i));
+            auto const expected = int{ expected_file_priorities[i] };
+            auto const actual = int{ file_priorities.filePriority(i) };
             EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
         for (tr_piece_index_t i = 0; i < block_info_.pieceCount(); ++i)
         {
-            auto const expected = static_cast<int>(expected_piece_priorities[i]);
-            auto const actual = static_cast<int>(file_priorities.piecePriority(i));
+            auto const expected = int{ expected_piece_priorities[i] };
+            auto const actual = int{ file_priorities.piecePriority(i) };
             EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
     };


### PR DESCRIPTION
Discussion @ https://github.com/transmission/transmission/pull/4795#issuecomment-1455131323

First & last prioritization was the correct behavior in 3.00 and earlier but that logic got lost in 4.0.0. This PR restores it.

Notes: Fixed `4.0.0` regression that stopped increasing the download priority of files' first and last pieces. These pieces are important for making incomplete downloads previewable / playable while still being downloaded.

CC @pldubouilh