### PR TITLE
Hardcoding BadgeView fontSize

### DIFF
--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
         _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
         _fAttributes[NSShadowAttributeName] = stringShadow;
-        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:22.0];
+        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:23.0];
 
         // DownloadBadge and UploadBadge should have the same size
         NSSize badgeSize = [NSImage imageNamed:@"DownloadBadge"].size;

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -42,27 +42,15 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
         _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
         _fAttributes[NSShadowAttributeName] = stringShadow;
+        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:22.0];
 
         // DownloadBadge and UploadBadge should have the same size
         NSSize badgeSize = [NSImage imageNamed:@"DownloadBadge"].size;
         // DownArrowTemplate and UpArrowTemplate should have the same size
         CGFloat arrowWidthHeightRatio = kWhiteDownArrow.size.width / kWhiteDownArrow.size.height;
 
-        // Make sure text fits on the badge.
-        // In macOS Ventura, this will end up calculating a boldSystemFontOfSize of 21.
-        NSString* maxString = [NSString stringForSpeedAbbrev:888.8]; // "888.8 K" localized
-        CGFloat fontSize = 26.0;
-        NSSize stringSize;
-        CGFloat arrowHeight;
-        do
-        {
-            fontSize -= 1.0;
-            _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:fontSize];
-            stringSize = [maxString sizeWithAttributes:_fAttributes];
-            // arrow height equal to font capital letter height + shadow
-            arrowHeight = [_fAttributes[NSFontAttributeName] capHeight] + 4;
-        } while (badgeSize.width < stringSize.width + 2 * arrowHeight * arrowWidthHeightRatio +
-                     arrowHeight); // text is centered + surrounded by the size of two arrows + arrow spacing (" ▼ 888.8 K ▽ ")
+        // arrow height equal to font capital letter height + shadow
+        CGFloat arrowHeight = [_fAttributes[NSFontAttributeName] capHeight] + 4;
 
         kArrowInset = { badgeSize.height * 0.2, badgeSize.height * 0.1 };
         kArrowSize = { arrowHeight * arrowWidthHeightRatio, arrowHeight };

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -175,9 +175,16 @@
     {
         return [NSString localizedStringWithFormat:@"%.1f %@", speed, mb];
     }
+
+    speed /= 1000.0;
+
+    if (speed < 99.995) // 1.00 GB/s to 99.99 GB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.2f %@", speed, gb];
+    }
     else // insane speeds
     {
-        return [NSString localizedStringWithFormat:@"%.2f %@", speed / 1000.0, gb];
+        return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
     }
 }
 


### PR DESCRIPTION
Increasing fontSize by 2 (from 21 to 23), based on feedback from @ilikepeaches on #5095. The fontSize of 21 was a visual regression caused by me preserving too much space for the arrow in previous PR.

![Capture d’écran 2023-03-07 à 08 06 37](https://user-images.githubusercontent.com/839992/223284820-7d93a7b0-a9af-472a-8f0f-05e56001a546.png)
