### PR TITLE
Revert "wanted" RPC field to integer, not bool

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -299,7 +299,7 @@ The 'source' column here corresponds to the data structure there.
 | Key | Value Type | transmission.h source
 |:--|:--|:--
 | `bytesCompleted` | number | tr_file_view
-| `wanted` | boolean | tr_file_view
+| `wanted` | number | tr_file_view (0,1 as boolean)
 | `priority` | number | tr_file_view
 
 `peers`: an array of objects, each containing:
@@ -1000,4 +1000,4 @@ Transmission 4.0.0 (`rpc-version-semver` 5.3.0, `rpc-version`: 17)
 | `torrent-set` | :warning: **DEPRECATED** `trackerReplace`. Use `trackerList` instead.
 | `group-set` | new method
 | `group-get` | new method
-
+| `wanted` | warning: previously documented as an array of booleans; prior to 4.0.0, it was serialized as an array of 0 or 1. only 4.0.0 and 4.0.1 serialize as bool

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -1000,4 +1000,4 @@ Transmission 4.0.0 (`rpc-version-semver` 5.3.0, `rpc-version`: 17)
 | `torrent-set` | :warning: **DEPRECATED** `trackerReplace`. Use `trackerList` instead.
 | `group-set` | new method
 | `group-get` | new method
-| `wanted` | warning: previously documented as an array of booleans; prior to 4.0.0, it was serialized as an array of 0 or 1. only 4.0.0 and 4.0.1 serialize as bool
+| `wanted` | :warning: Transmission 3.00 and earlier sent this as an array of `0` or `1` despite being documented as an array of booleans. Transmission 4.0.0 and 4.0.1 "fixed" this by returning an array of booleans, but as a practical matter this caused an unannounced breaking change for 3rd party code that expects `0` or `1`. For this reason, 4.0.2 restores the 3.00 behavior and updates this spec to match the code.

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -299,7 +299,7 @@ The 'source' column here corresponds to the data structure there.
 | Key | Value Type | transmission.h source
 |:--|:--|:--
 | `bytesCompleted` | number | tr_file_view
-| `wanted` | number | tr_file_view (0,1 as boolean)
+| `wanted` | number | tr_file_view (**Note:** For backwards compatibility, this is serialized as an array of `0` or `1` that should be treated as booleans)
 | `priority` | number | tr_file_view
 
 `peers`: an array of objects, each containing:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -317,7 +317,7 @@ void addFileStats(tr_torrent const* tor, tr_variant* list)
         tr_variant* d = tr_variantListAddDict(list, 3);
         tr_variantDictAddInt(d, TR_KEY_bytesCompleted, file.have);
         tr_variantDictAddInt(d, TR_KEY_priority, file.priority);
-        tr_variantDictAddInt(d, TR_KEY_wanted, file.wanted);
+        tr_variantDictAddBool(d, TR_KEY_wanted, file.wanted);
     }
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -317,7 +317,7 @@ void addFileStats(tr_torrent const* tor, tr_variant* list)
         tr_variant* d = tr_variantListAddDict(list, 3);
         tr_variantDictAddInt(d, TR_KEY_bytesCompleted, file.have);
         tr_variantDictAddInt(d, TR_KEY_priority, file.priority);
-        tr_variantDictAddBool(d, TR_KEY_wanted, file.wanted);
+        tr_variantDictAddInt(d, TR_KEY_wanted, file.wanted);
     }
 }
 
@@ -853,7 +853,7 @@ void initField(tr_torrent const* const tor, tr_stat const* const st, tr_variant*
             tr_variantInitList(initme, n);
             for (tr_file_index_t i = 0; i < n; ++i)
             {
-                tr_variantListAddBool(initme, tr_torrentFile(tor, i).wanted);
+                tr_variantListAddInt(initme, tr_torrentFile(tor, i).wanted);
             }
         }
         break;


### PR DESCRIPTION
This patch forces the "wanted" RPC field as an integer-proxy for bool during JSON serialization.

Ok, this will probably raise a few eyebrows, but offering this to fix a Tr3 compat problem:

Tr3 and earlier serialize the "wanted" RPC field as a 0/1 integer, not a "true/false" bool. During the Tr4 refactor (git@ecef0feb0c) a change was made for the output serialization from Int() -> Bool() so that it would match the input serialization, but unfortunately this breaks backward compat.

Older code (and many older JSON libraries) may not be particularly resilient to the use of "true/false" vs "0/1".  In particular, the popular _Transmission Remote GTK_ tool wants this to be a 0/1 integer or fails to recognize the do-not-download state (DND in <=Tr3) of individual files.

Recommend keeping the Tr3 behavior for max compat. This patch changes both the input and output serialization to Int() but if we want to just preserve Tr3 behavior then only the output serialization should change.