### PR TITLE
perf: reducing the usage of is_looping_mutex_

### DIFF
--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -230,10 +230,7 @@ private:
         constexpr auto ToggleLooping = [](evutil_socket_t, short /*evtype*/, void* vself)
         {
             auto* const self = static_cast<tr_session_thread_impl*>(vself);
-            self->is_looping_mutex_.lock();
-            self->is_looping_ = !self->is_looping_;
-            self->is_looping_mutex_.unlock();
-
+            self->is_looping_ ^= 1;
             self->is_looping_cv_.notify_one();
         };
 
@@ -287,7 +284,7 @@ private:
 
     std::mutex is_looping_mutex_;
     std::condition_variable is_looping_cv_;
-    std::atomic<bool> is_looping_ = false;
+    std::atomic<int> is_looping_ = 0;
 
     std::atomic<bool> is_shutting_down_ = false;
     static constexpr std::chrono::seconds Deadline = 5s;


### PR DESCRIPTION
Inspired by the spinning logs of https://github.com/transmission/transmission/issues/5160, I looked at those lines:
```
    +         ! : 1 (anonymous namespace)::tr_evthread_init_helpers::lock_lock(unsigned int, void*)  (in Transmission) + 20  [0x100b721d0]
    +         ! : | 1 DYLD-STUB$$std::recursive_mutex::lock()  (in Transmission) + 0  [0x100c2c1ac]
```

It's not much, but I found that we can avoid one lock on `is_looping_mutex_` by applying the technique from https://stackoverflow.com/questions/9806200/how-to-atomically-negate-an-stdatomic-bool

[edit]
Although, I'm not a C++ locks specialist, so I may be doing it wrong? In which case, feel free to close my PR.