### PR TITLE
Split current and initially requested minimized state

### DIFF
--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -18,7 +18,7 @@
 class Application : public Gtk::Application
 {
 public:
-    Application(std::string const& config_dir, bool start_paused, bool is_iconified);
+    Application(std::string const& config_dir, bool start_paused, bool start_iconified);
     ~Application() override;
 
     TR_DISABLE_COPY_MOVE(Application)

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
     std::string config_dir;
     bool show_version = false;
     bool start_paused = false;
-    bool is_iconified = false;
+    bool start_iconified = false;
 
     /* parse the command line */
     auto const config_dir_option = create_option_entry("config-dir", 'g', _("Where to look for configuration files"));
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
     Glib::OptionGroup main_group({}, {});
     main_group.add_entry_filename(config_dir_option, config_dir);
     main_group.add_entry(paused_option, start_paused);
-    main_group.add_entry(minimized_option, is_iconified);
+    main_group.add_entry(minimized_option, start_iconified);
     main_group.add_entry(version_option, show_version);
 
     Glib::OptionContext option_context(_("[torrent files or urls]"));
@@ -134,5 +134,5 @@ int main(int argc, char** argv)
     gtr_notify_init();
 
     /* init the application for the specified config dir */
-    return Application(config_dir, start_paused, is_iconified).run(argc, argv);
+    return Application(config_dir, start_paused, start_iconified).run(argc, argv);
 }


### PR DESCRIPTION
Fixes: #5094

Notes: Fixed `4.0.0` ignoring `-m`/`--minimized` command line option.