### PR TITLE
fix: possible fix for fmt crash in get_long_status_text()

### DIFF
--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -447,7 +447,8 @@ Glib::ustring Torrent::Impl::get_long_status_text() const
     default:
         if (auto const buf = get_short_transfer_text(); !std::empty(buf))
         {
-            status_str += fmt::format(FMT_STRING(" - {:s}"), buf);
+            status_str += " - ";
+            status_str += buf;
         }
     }
 


### PR DESCRIPTION
Possible fix for https://retrace.fedoraproject.org/faf/problems/bthash/?bth=5e5ac793986f7c00a4e49af443fe2e8dc42692e9&bth=6050117c6d5c1a7bc20c972474f956a1eb203a1f&bth=d88f238a2c3ab0e95917abe7d95fff5f7bcdf137&bth=3e3950db30e25f47ca4c4fabce8ab0c66bd3896d&bth=5ea606869e112165944584f4935c1b354937a913 which is one of the most frequent 4.0.x crashers.

- It's crashing in the one `fmt::format()` call in Torrent's `get_long_status_text()`.
- I'm not able to reproduce the crash
- It's possible that it's triggered by some combo locale setting + passing a `Glib::ustring` to `fmt::format()`
- But `fmt::format()`'s use in that function is overkill so we can replace it with `Glib::ustring::operator +=` without losing anything

This above is mostly guesswork so CC @mikedld for a 2nd opinion