### PR TITLE
fix: change badge font size, position and precision

### DIFF
--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
         _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
         _fAttributes[NSShadowAttributeName] = stringShadow;
-        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:23.0];
+        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:22.0];
 
         // DownloadBadge and UploadBadge should have the same size
         NSSize badgeSize = [NSImage imageNamed:@"DownloadBadge"].size;

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
         _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
         _fAttributes[NSShadowAttributeName] = stringShadow;
-        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:22.0];
+        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:24.0];
 
         // DownloadBadge and UploadBadge should have the same size
         NSSize badgeSize = [NSImage imageNamed:@"DownloadBadge"].size;
@@ -105,8 +105,8 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
     //string is in center of image
     NSSize stringSize = [string sizeWithAttributes:self.fAttributes];
     NSRect stringRect;
-    stringRect.origin.x = NSMidX(badgeRect) - stringSize.width * 0.5;
-    stringRect.origin.y = NSMidY(badgeRect) - stringSize.height * 0.5 + 1.0; //adjust for shadow
+    stringRect.origin.x = NSMidX(badgeRect) - stringSize.width * 0.5 + kArrowInset.width; // adjust for arrow
+    stringRect.origin.y = NSMidY(badgeRect) - stringSize.height * 0.5 + 1.0; // adjust for shadow
     stringRect.size = stringSize;
     [string drawInRect:stringRect withAttributes:self.fAttributes];
 

--- a/macosx/BadgeView.mm
+++ b/macosx/BadgeView.mm
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
         _fAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
         _fAttributes[NSForegroundColorAttributeName] = NSColor.whiteColor;
         _fAttributes[NSShadowAttributeName] = stringShadow;
-        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:24.0];
+        _fAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:26.0];
 
         // DownloadBadge and UploadBadge should have the same size
         NSSize badgeSize = [NSImage imageNamed:@"DownloadBadge"].size;
@@ -81,7 +81,8 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
     if (download)
     {
         NSImage* downloadBadge = [NSImage imageNamed:@"DownloadBadge"];
-        [self badge:downloadBadge arrow:ArrowDirectionDown string:[NSString stringForSpeedAbbrev:self.fDownloadRate] atHeight:bottom];
+        [self badge:downloadBadge arrow:ArrowDirectionDown string:[NSString stringForSpeedAbbrevCompact:self.fDownloadRate]
+            atHeight:bottom];
 
         if (upload)
         {
@@ -91,7 +92,7 @@ typedef NS_ENUM(NSInteger, ArrowDirection) {
     if (upload)
     {
         [self badge:[NSImage imageNamed:@"UploadBadge"] arrow:ArrowDirectionUp
-              string:[NSString stringForSpeedAbbrev:self.fUploadRate]
+              string:[NSString stringForSpeedAbbrevCompact:self.fUploadRate]
             atHeight:bottom];
     }
 }

--- a/macosx/NSStringAdditions.h
+++ b/macosx/NSStringAdditions.h
@@ -12,8 +12,12 @@
 + (NSString*)stringForFileSize:(uint64_t)size;
 + (NSString*)stringForFilePartialSize:(uint64_t)partialSize fullSize:(uint64_t)fullSize;
 
+// 4 significant digits
 + (NSString*)stringForSpeed:(CGFloat)speed;
+// 4 significant digits
 + (NSString*)stringForSpeedAbbrev:(CGFloat)speed;
+// 3 significant digits
++ (NSString*)stringForSpeedAbbrevCompact:(CGFloat)speed;
 + (NSString*)stringForRatio:(CGFloat)ratio;
 
 + (NSString*)percentString:(CGFloat)progress longDecimals:(BOOL)longDecimals;

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -11,6 +11,7 @@
 @interface NSString (Private)
 
 + (NSString*)stringForSpeed:(CGFloat)speed kb:(NSString*)kb mb:(NSString*)mb gb:(NSString*)gb;
++ (NSString*)stringForSpeedCompact:(CGFloat)speed kb:(NSString*)kb mb:(NSString*)mb gb:(NSString*)gb;
 
 @end
 
@@ -71,6 +72,11 @@
 + (NSString*)stringForSpeedAbbrev:(CGFloat)speed
 {
     return [self stringForSpeed:speed kb:@"K" mb:@"M" gb:@"G"];
+}
+
++ (NSString*)stringForSpeedAbbrevCompact:(CGFloat)speed
+{
+    return [self stringForSpeedCompact:speed kb:@"K" mb:@"M" gb:@"G"];
 }
 
 + (NSString*)stringForRatio:(CGFloat)ratio
@@ -185,6 +191,48 @@
     else // insane speeds
     {
         return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
+    }
+}
+
++ (NSString*)stringForSpeedCompact:(CGFloat)speed kb:(NSString*)kb mb:(NSString*)mb gb:(NSString*)gb
+{
+    if (speed < 99.95) // 0.0 KB/s to 99.9 KB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.1f %@", speed, kb];
+    }
+    if (speed < 999.95) // 100 KB/s to 999 KB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, kb];
+    }
+
+    speed /= 1000.0;
+
+    if (speed < 9.95) // 1.00 MB/s to 9.99 MB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.2f %@", speed, mb];
+    }
+    if (speed < 99.95) // 10.0 MB/s to 99.9 MB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.1f %@", speed, mb];
+    }
+    if (speed < 999.95) // 100 MB/s to 999 MB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, mb];
+    }
+
+    speed /= 1000.0;
+
+    if (speed < 9.95) // 1.00 GB/s to 9.99 GB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.2f %@", speed, gb];
+    }
+    if (speed < 99.95) // 10.0 GB/s to 99.9 GB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
+    }
+    else // insane speeds
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, gb];
     }
 }
 


### PR DESCRIPTION
So... historically
1. I didn't choose whether adding a UI element was a "patch" or a "minor" change. I had no particular opinion, positive not negative. But I'm happy with the result ([thank you ckerr](https://github.com/transmission/transmission/pull/5095#issuecomment-1450545388)).
2. I wrongly assumed that the longest string would be "987,6 K". Actually, "64,40 M" is the longest one in system font.
3. I originally had a left margin of `badgeSize.height * 0.15`, but I followed code review recommendations to increase it to `badgeSize.height * 0.2` (and this was a good change: it looks better, [thank you nevack](https://github.com/transmission/transmission/pull/5095#issuecomment-1452253094)).
4. When I made calculations for ideal font size (21), it got considered too small ([thanks for noticing ilikepeaches](https://github.com/transmission/transmission/pull/5095#issuecomment-1456483307)), so I increased it to 23.
5. When I changed it to 23, it was found to overlap for high speed downloads ([thanks for noticing ilikepeaches](https://github.com/transmission/transmission/pull/5095#issuecomment-1460814987)). On my defence, I never saw a download speed of 10 MB/s on my Wi-Fi ^^.

So this PR, after code review:
A. adopts the off-center / visual-center proposal from nevack
B. adopts the significant digits reduction proposal from ilikepeaches
C. font size is back to Transmission 3 font size

Screenshots with the longest length speed.

BEFORE the arrow (Transmission 4.0.1):
![Capture d’écran 2023-03-10 à 01 35 48](https://user-images.githubusercontent.com/839992/224109738-43788a7e-530e-420b-be5f-5d85fd6fca1c.png)

BEFORE this PR (main branch):
![Capture d’écran 2023-03-10 à 01 18 42](https://user-images.githubusercontent.com/839992/224105648-d02b9b21-5092-4360-ad1a-9b45b0971fc8.png)

AFTER this PR (second commit, using the same font size as system apps on macOS when they show a badge):
![Capture d’écran 2023-03-10 à 01 11 19](https://user-images.githubusercontent.com/839992/224104081-3aa35a81-3fd0-4687-8da7-41221c49e4d7.png)

FINAL AFTER this PR (third commit, decreasing number of significant digits):
![Capture d’écran 2023-03-10 à 12 50 58](https://user-images.githubusercontent.com/839992/224226541-b346034b-91d7-4d39-b75e-7d4942260731.png)

And we are all aware hopefully that the arrows never made it to a single release yet, so it was all just in development builds?