### PR TITLE
fix: recent clang-tidy regressions in the nightlies

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -853,7 +853,7 @@ void initField(tr_torrent const* const tor, tr_stat const* const st, tr_variant*
             tr_variantInitList(initme, n);
             for (tr_file_index_t i = 0; i < n; ++i)
             {
-                tr_variantListAddInt(initme, tr_torrentFile(tor, i).wanted);
+                tr_variantListAddInt(initme, tr_torrentFile(tor, i).wanted ? 1 : 0);
             }
         }
         break;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2429,14 +2429,14 @@ size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, 
     return tr_strvToBuf(tr_torrentFindFile(tor, file_num), buf, buflen);
 }
 
-void tr_torrent::setDownloadDir(std::string_view path, bool isNewTorrent)
+void tr_torrent::setDownloadDir(std::string_view path, bool is_new_torrent)
 {
     download_dir = path;
     markEdited();
     setDirty();
     refreshCurrentDir();
 
-    if (isNewTorrent)
+    if (is_new_torrent)
     {
         if (session->shouldFullyVerifyAddedTorrents() || !torrent_init_helpers::isNewTorrentASeed(this))
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -582,7 +582,7 @@ public:
         this->error_string = errmsg;
     }
 
-    void setDownloadDir(std::string_view path, bool isNewTorrent = false);
+    void setDownloadDir(std::string_view path, bool is_new_torrent = false);
 
     void refreshCurrentDir();
 


### PR DESCRIPTION
No functional changes; just fixing some warnings that showed up over the last week or so.