### PR TITLE
ci: check for clang tidy errors in libtransmission

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -174,6 +174,57 @@ jobs:
       - name: Test with sanitizers
         run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
 
+  clang-tidy-libtransmission:
+    runs-on: ubuntu-22.04
+    needs: [ what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-style == 'true' }}
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          cat /etc/os-release
+      - name: Get Dependencies
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates \
+            clang \
+            clang-tidy \
+            cmake \
+            gettext \
+            libcurl4-openssl-dev \
+            libdeflate-dev \
+            libevent-dev \
+            libfmt-dev \
+            libminiupnpc-dev \
+            libnatpmp-dev \
+            libpsl-dev \
+            libssl-dev \
+            ninja-build \
+            npm
+      - name: Get Source
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          path: src
+      - name: Configure
+        run: |
+          cmake \
+            -S src \
+            -B obj \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER='clang++' \
+            -DCMAKE_C_COMPILER='clang' \
+            -DCMAKE_INSTALL_PREFIX=pfx \
+            -DRUN_CLANG_TIDY=ON
+      - name: Make
+        run: cmake --build obj --config Debug --target libtransmission.a 2>&1 | tee makelog
+      - name: Test for warnings
+        run: ! grep 'warning:' makelog
+
   macos-11:
     runs-on: macos-11
     needs: [ what-to-make ]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -177,7 +177,7 @@ jobs:
   clang-tidy-libtransmission:
     runs-on: ubuntu-22.04
     needs: [ what-to-make ]
-    if: ${{ needs.what-to-make.outputs.make-style == 'true' }}
+    if: ${{ needs.what-to-make.outputs.test-style == 'true' }}
     steps:
       - name: Show Configuration
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -224,7 +224,8 @@ jobs:
       - name: Make
         run: cmake --build obj --config Debug --target libtransmission.a 2>&1 | tee makelog
       - name: Test for warnings
-        run: ! grep 'warning:' makelog
+        run: |
+          if grep 'warning:' makelog; then exit 1; fi
 
   macos-11:
     runs-on: macos-11

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -65,6 +65,7 @@ jobs:
           get_changes tests    CMakeLists.txt cmake third-party libtransmission utils tests
           get_changes utils    CMakeLists.txt cmake third-party libtransmission utils
           get_changes web      CMakeLists.txt cmake third-party libtransmission web
+          cat "$GITHUB_OUTPUT"
 
   code-style:
     runs-on: ubuntu-22.04

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
       - '.github/**'
 jobs:
-  decide-web-jobs-to-run:
+  decide-what-jobs-to-run:
     runs-on: ubuntu-22.04
     outputs:
       test-style: ${{ steps.check-diffs.outputs.web-changed == '1' }}
@@ -52,10 +52,10 @@ jobs:
           }
           get_changes web CMakeLists.txt web
 
-  web-code-style:
+  code-style:
     runs-on: ubuntu-latest
-    needs: [ decide-web-jobs-to-run ]
-    if: ${{ needs.decide-web-jobs-to-run.outputs.test-style == 'true' }}
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.test-style == 'true' }}
     steps:
       - name: Get source
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
           npm --prefix web ci
           npm --prefix web run lint:fix
           set +e # do not end the script if a cmd returns an exit code
-          git diff --exit-code web > web-style.diff
+          git diff --exit-code web > style.diff
           echo "differs=$?" >> $GITHUB_OUTPUT
           echo ===
           cat style.diff
@@ -81,20 +81,20 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
         with:
-          name: web-code-style.diff
-          path: 'web-style.diff'
+          name: code-style.diff
+          path: 'style.diff'
       - name: Fail if diffs exist
         if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
         run: |
           echo "code style does not match expected."
           cat style.diff
-          echo "When CI is done, the above patch will be uploaded as 'web-code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
+          echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
           exit 1
 
   test-generated-files:
     runs-on: ubuntu-latest
-    needs: [ decide-web-jobs-to-run ]
-    if: ${{ needs.decide-web-jobs-to-run.outputs.test-generated-files == 'true' }}
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.test-generated-files == 'true' }}
     steps:
       - name: Get source
         uses: actions/checkout@v3
@@ -116,8 +116,8 @@ jobs:
 
   update-generated-files:
     runs-on: ubuntu-latest
-    needs: [ decide-web-jobs-to-run ]
-    if: ${{ needs.decide-web-jobs-to-run.outputs.update-generated-files == 'true' }}
+    needs: [ decide-what-jobs-to-run ]
+    if: ${{ needs.decide-what-jobs-to-run.outputs.update-generated-files == 'true' }}
     steps:
       - name: Show env
         run: |

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
       - '.github/**'
 jobs:
-  decide-what-jobs-to-run:
+  decide-what-web-jobs-to-run:
     runs-on: ubuntu-22.04
     outputs:
       test-style: ${{ steps.check-diffs.outputs.web-changed == '1' }}
@@ -52,7 +52,7 @@ jobs:
           }
           get_changes web CMakeLists.txt web
 
-  code-style:
+  web-code-style:
     runs-on: ubuntu-latest
     needs: [ decide-what-jobs-to-run ]
     if: ${{ needs.decide-what-jobs-to-run.outputs.test-style == 'true' }}

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/**'
       - '.github/**'
 jobs:
-  decide-what-web-jobs-to-run:
+  decide-web-jobs-to-run:
     runs-on: ubuntu-22.04
     outputs:
       test-style: ${{ steps.check-diffs.outputs.web-changed == '1' }}
@@ -54,8 +54,8 @@ jobs:
 
   web-code-style:
     runs-on: ubuntu-latest
-    needs: [ decide-what-jobs-to-run ]
-    if: ${{ needs.decide-what-jobs-to-run.outputs.test-style == 'true' }}
+    needs: [ decide-web-jobs-to-run ]
+    if: ${{ needs.decide-web-jobs-to-run.outputs.test-style == 'true' }}
     steps:
       - name: Get source
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
           npm --prefix web ci
           npm --prefix web run lint:fix
           set +e # do not end the script if a cmd returns an exit code
-          git diff --exit-code web > style.diff
+          git diff --exit-code web > web-style.diff
           echo "differs=$?" >> $GITHUB_OUTPUT
           echo ===
           cat style.diff
@@ -81,20 +81,20 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
         with:
-          name: code-style.diff
-          path: 'style.diff'
+          name: web-code-style.diff
+          path: 'web-style.diff'
       - name: Fail if diffs exist
         if: ${{ steps.check-for-diffs.outputs.differs == '1' }}
         run: |
           echo "code style does not match expected."
           cat style.diff
-          echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
+          echo "When CI is done, the above patch will be uploaded as 'web-code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
           exit 1
 
   test-generated-files:
     runs-on: ubuntu-latest
-    needs: [ decide-what-jobs-to-run ]
-    if: ${{ needs.decide-what-jobs-to-run.outputs.test-generated-files == 'true' }}
+    needs: [ decide-web-jobs-to-run ]
+    if: ${{ needs.decide-web-jobs-to-run.outputs.test-generated-files == 'true' }}
     steps:
       - name: Get source
         uses: actions/checkout@v3
@@ -116,8 +116,8 @@ jobs:
 
   update-generated-files:
     runs-on: ubuntu-latest
-    needs: [ decide-what-jobs-to-run ]
-    if: ${{ needs.decide-what-jobs-to-run.outputs.update-generated-files == 'true' }}
+    needs: [ decide-web-jobs-to-run ]
+    if: ${{ needs.decide-web-jobs-to-run.outputs.update-generated-files == 'true' }}
     steps:
       - name: Show env
         run: |

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -853,7 +853,7 @@ void initField(tr_torrent const* const tor, tr_stat const* const st, tr_variant*
             tr_variantInitList(initme, n);
             for (tr_file_index_t i = 0; i < n; ++i)
             {
-                tr_variantListAddInt(initme, tr_torrentFile(tor, i).wanted);
+                tr_variantListAddInt(initme, tr_torrentFile(tor, i).wanted ? 1 : 0);
             }
         }
         break;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2429,14 +2429,14 @@ size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, 
     return tr_strvToBuf(tr_torrentFindFile(tor, file_num), buf, buflen);
 }
 
-void tr_torrent::setDownloadDir(std::string_view path, bool isNewTorrent)
+void tr_torrent::setDownloadDir(std::string_view path, bool is_new_torrent)
 {
     download_dir = path;
     markEdited();
     setDirty();
     refreshCurrentDir();
 
-    if (isNewTorrent)
+    if (is_new_torrent)
     {
         if (session->shouldFullyVerifyAddedTorrents() || !torrent_init_helpers::isNewTorrentASeed(this))
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -582,7 +582,7 @@ public:
         this->error_string = errmsg;
     }
 
-    void setDownloadDir(std::string_view path, bool isNewTorrent = false);
+    void setDownloadDir(std::string_view path, bool is_new_torrent = false);
 
     void refreshCurrentDir();
 


### PR DESCRIPTION
Fix a couple of clang-tidy warnings introduced in recent commits.

Add CI check to ensure clang-tidy libtransmission passes.

No behavioral changes.