### PR TITLE
fix: update Torrent::ratio() to match #2770

### DIFF
--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -300,10 +300,9 @@ public:
 
     [[nodiscard]] constexpr auto ratio() const noexcept
     {
-        auto const u = uploadedEver();
-        auto const d = downloadedEver();
-        auto const t = totalSize();
-        return double(u) / (d ? d : t);
+        auto const numerator = static_cast<double>(uploadedEver());
+        auto const denominator = sizeWhenDone();
+        return denominator > 0U ? numerator / denominator : double{};
     }
 
     [[nodiscard]] constexpr double percentComplete() const noexcept


### PR DESCRIPTION
Fixes #4708 by updating `Torrent::ratio()` to match #2770.

Notes: Fixed per-torrent ratio display in main window.