### PR TITLE
Don't discover tests when cross-compiling w/o an emulator

### DIFF
--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -77,9 +77,14 @@ target_link_libraries(libtransmission-test
         libevent::event
         WideInteger::WideInteger)
 
-gtest_discover_tests(libtransmission-test
-    TEST_PREFIX "LT."
-)
+if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+    gtest_discover_tests(libtransmission-test
+        TEST_PREFIX "LT.")
+else()
+    add_test(
+        NAME libtransmission-test
+        COMMAND libtransmission-test)
+endif()
 
 add_custom_command(
     TARGET libtransmission-test


### PR DESCRIPTION
Based on discussion in SynoCommunity/spksrc#5616 and [cmake/cmake#18840](https://gitlab.kitware.com/cmake/cmake/-/issues/18840).

Notes: Fixed `4.0.1` failure to discover tests when cross-compiling without an emulator.