### PR TITLE
fix: check tr_ctorSetFoo() return values before adding torrent via RPC

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1695,10 +1695,13 @@ char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_variant* /*a
             auto const metainfo = tr_base64_decode(metainfo_base64);
             ok = tr_ctorSetMetainfo(ctor, std::data(metainfo), std::size(metainfo), nullptr);
         }
+        else if (tr_sys_path_exists(tr_pathbuf{ filename }))
+        {
+            ok = tr_ctorSetMetainfoFromFile(ctor, filename);
+        }
         else
         {
-            ok = tr_sys_path_exists(tr_pathbuf{ filename }) ? tr_ctorSetMetainfoFromFile(ctor, filename) :
-                                                              tr_ctorSetMetainfoFromMagnetLink(ctor, filename);
+            ok = tr_ctorSetMetainfoFromMagnetLink(ctor, filename);
         }
 
         if (!ok)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1688,21 +1688,22 @@ char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_variant* /*a
     }
     else
     {
+        auto ok = false;
+
         if (std::empty(filename))
         {
             auto const metainfo = tr_base64_decode(metainfo_base64);
-            tr_ctorSetMetainfo(ctor, std::data(metainfo), std::size(metainfo), nullptr);
+            ok = tr_ctorSetMetainfo(ctor, std::data(metainfo), std::size(metainfo), nullptr);
         }
         else
         {
-            if (tr_sys_path_exists(tr_pathbuf{ filename }))
-            {
-                tr_ctorSetMetainfoFromFile(ctor, filename);
-            }
-            else
-            {
-                tr_ctorSetMetainfoFromMagnetLink(ctor, filename);
-            }
+            ok = tr_sys_path_exists(tr_pathbuf{ filename }) ? tr_ctorSetMetainfoFromFile(ctor, filename) :
+                                                              tr_ctorSetMetainfoFromMagnetLink(ctor, filename);
+        }
+
+        if (!ok)
+        {
+            return "unrecognized info";
         }
 
         addTorrentImpl(idle_data, ctor);


### PR DESCRIPTION
Fixes #5201.

Notes: Fixed `4.0.0` error that did insufficient sanity checking of unsupported magnet links added via RPC.