### PR TITLE
fix: std::clamp() assertion failure in maxAvailableReqs()

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -619,7 +619,11 @@ private:
         size_t constexpr Seconds = RequestBufSecs;
         size_t const estimated_blocks_in_period = (rate_bytes_per_second * Seconds) / tr_block_info::BlockSize;
         size_t const ceil = reqq ? *reqq : 250;
-        return std::clamp(estimated_blocks_in_period, Floor, ceil);
+
+        auto max_reqs = estimated_blocks_in_period;
+        max_reqs = std::min(max_reqs, ceil);
+        max_reqs = std::max(max_reqs, Floor);
+        return max_reqs;
     }
 
     void protocolSendRequest(struct peer_request const& req)


### PR DESCRIPTION
Fixes https://retrace.fedoraproject.org/faf/reports/631667/ .

The issue was a call to `std::clamp(val, lo, hi)` where we passed a `hi` that was less than `lo`.

similar fix in peer-mgr.cc: ac319321b #5080

Notes: Fixed `std::clamp()` assertion failures.