### PR TITLE
quicklook: alternate row background color

### DIFF
--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -149,7 +149,7 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
 
         for (size_t i = 0; i < n_webseeds; ++i)
         {
-            [listSection appendFormat:@"<tr><td>%s<td></tr>", metainfo.webseed(i).c_str()];
+            [listSection appendFormat:@"<tr><td>%s</td></tr>", metainfo.webseed(i).c_str()];
         }
 
         [listSection appendString:@"</table>"];
@@ -169,10 +169,10 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
             [NSString localizedStringWithFormat:NSLocalizedStringFromTableInBundle(@"%lu Trackers", nil, bundle, "quicklook tracker header"), n];
         [listSection appendFormat:@"<tr><th>%@</th></tr>", headerTitleString];
 
-#warning handle tiers?
+        // TODO: handle tiers?
         for (auto const& tracker : announce_list)
         {
-            [listSection appendFormat:@"<tr><td>%s<td></tr>", tracker.announce.c_str()];
+            [listSection appendFormat:@"<tr><td>%s</td></tr>", tracker.announce.c_str()];
         }
 
         [listSection appendString:@"</table>"];
@@ -196,15 +196,15 @@ OSStatus GeneratePreviewForURL(void* thisInterface, QLPreviewRequestRef preview,
             NSCAssert([fullFilePath hasPrefix:[name stringByAppendingString:@"/"]], @"Expected file path %@ to begin with %@/", fullFilePath, name);
 
             NSString* shortenedFilePath = [fullFilePath substringFromIndex:name.length + 1];
-            NSString* shortenedFilePathAndSize = [NSString
-                stringWithFormat:@"%@ - %@", shortenedFilePath, [NSString stringForFileSize:size]];
+            NSString* fileSize = [NSString stringForFileSize:size];
 
             NSUInteger const width = 16;
-            [listSection appendFormat:@"<tr><td><img class=\"icon\" src=\"%@\" width=\"%ld\" height=\"%ld\" />%@<td></tr>",
+            [listSection appendFormat:@"<tr><td><img class=\"icon\" src=\"%@\" width=\"%ld\" height=\"%ld\" />%@</td><td class=\"grey\">%@</td></tr>",
                                       generateIconData(shortenedFilePath.pathExtension, width, allImgProps),
                                       width,
                                       width,
-                                      shortenedFilePathAndSize];
+                                      shortenedFilePath,
+                                      fileSize];
         }
 
         [listSection appendString:@"</table>"];

--- a/macosx/QuickLookPlugin/style.css
+++ b/macosx/QuickLookPlugin/style.css
@@ -4,15 +4,35 @@ html {
   text-align: left;
 }
 
+table {
+  width: 100%;
+  border-spacing: 0;
+}
+
 th {
   color: rgb(50,50,50);
   font-weight: bold;
   text-align: left;
 }
 
+tr:nth-child(even) {
+  background: rgb(244,245,245);
+}
+tr:nth-child(even) td:first-child {
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+}
+tr:nth-child(even) td:last-child {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+}
+
 td {
   color: rgb(80,80,80);
   text-align: left;
+}
+td.grey {
+  color: rgb(133,133,133);
 }
 
 img.icon {


### PR DESCRIPTION
Adopts more Finder style for QuickLook plugin:
1. A grey background with round corner for one row out of two.
2. File size in grey font.

This is inspired by #1739, although I didn't change the font size, which was the primary request of the originator.

### Before
![Capture d’écran 2023-03-14 à 02 52 33](https://user-images.githubusercontent.com/839992/224801408-4fd79397-31e5-495f-8b45-469a7d83e629.png)
### After
![Capture d’écran 2023-03-14 à 02 50 37](https://user-images.githubusercontent.com/839992/224801425-07fcdbc1-1128-4e7d-aeb5-82fdad83dea2.png)
