### PR TITLE
refactor: replace NSMutableDictionary with constant attributes

### DIFF
--- a/macosx/FileNameCell.h
+++ b/macosx/FileNameCell.h
@@ -4,6 +4,12 @@
 
 #import <AppKit/AppKit.h>
 
+typedef NS_ENUM(NSInteger, AttributesStyle) {
+    AttributesStyleNormal,
+    AttributesStyleEmphasized,
+    AttributesStyleDisabled,
+};
+
 @interface FileNameCell : NSActionCell
 
 - (NSRect)imageRectForBounds:(NSRect)bounds;

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -20,45 +20,51 @@ static CGFloat const kPaddingBelowStatusFile = 2.0;
 static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 static CGFloat const kPaddingExpansionFrame = 2.0;
 
-@interface FileNameCell ()
+static NSParagraphStyle* kParagraphStyle()
+{
+    NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    return paragraphStyle;
+}
+static NSParagraphStyle* kStatusParagraphStyle()
+{
+    NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+    return paragraphStyle;
+}
 
-@property(nonatomic, readonly) NSAttributedString* attributedTitle;
-@property(nonatomic, readonly) NSAttributedString* attributedStatus;
-@property(nonatomic, readonly) NSMutableDictionary* fTitleAttributes;
-@property(nonatomic, readonly) NSMutableDictionary* fStatusAttributes;
-
-@end
+static NSDictionary<NSAttributedStringKey, id>* const kTitleAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:12.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.controlTextColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kStatusAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:9.0],
+    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.secondaryLabelColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kTitleEmphasizedAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:12.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.whiteColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kStatusEmphasizedAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:9.0],
+    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.whiteColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kTitleDisabledAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:12.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.disabledControlTextColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kStatusDisabledAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:9.0],
+    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.disabledControlTextColor
+};
 
 @implementation FileNameCell
-
-- (instancetype)init
-{
-    if ((self = [super init]))
-    {
-        NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
-        paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
-
-        _fTitleAttributes = [[NSMutableDictionary alloc]
-            initWithObjectsAndKeys:[NSFont messageFontOfSize:12.0], NSFontAttributeName, paragraphStyle, NSParagraphStyleAttributeName, nil];
-
-        NSMutableParagraphStyle* statusParagraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
-        statusParagraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
-
-        _fStatusAttributes = [[NSMutableDictionary alloc]
-            initWithObjectsAndKeys:[NSFont messageFontOfSize:9.0], NSFontAttributeName, statusParagraphStyle, NSParagraphStyleAttributeName, nil];
-    }
-    return self;
-}
-
-- (id)copyWithZone:(NSZone*)zone
-{
-    FileNameCell* copy = [super copyWithZone:zone];
-
-    copy->_fTitleAttributes = _fTitleAttributes;
-    copy->_fStatusAttributes = _fStatusAttributes;
-
-    return copy;
-}
 
 - (NSImage*)image
 {
@@ -87,40 +93,36 @@ static CGFloat const kPaddingExpansionFrame = 2.0;
             respectFlipped:YES
                      hints:nil];
 
-    NSColor *titleColor, *statusColor;
     FileListNode* node = self.objectValue;
+    AttributesStyle style;
     if (self.backgroundStyle == NSBackgroundStyleEmphasized)
     {
-        titleColor = statusColor = NSColor.whiteColor;
+        style = AttributesStyleEmphasized;
     }
     else if ([node.torrent checkForFiles:node.indexes] == NSControlStateValueOff)
     {
-        titleColor = statusColor = NSColor.disabledControlTextColor;
+        style = AttributesStyleDisabled;
     }
     else
     {
-        titleColor = NSColor.controlTextColor;
-        statusColor = NSColor.secondaryLabelColor;
+        style = AttributesStyleNormal;
     }
 
-    self.fTitleAttributes[NSForegroundColorAttributeName] = titleColor;
-    self.fStatusAttributes[NSForegroundColorAttributeName] = statusColor;
-
     //title
-    NSAttributedString* titleString = self.attributedTitle;
-    NSRect titleRect = [self rectForTitleWithString:titleString inBounds:cellFrame];
+    NSAttributedString* titleString = [self attributedTitleWithStyle:style];
+    NSRect titleRect = [self rectForTitleWithStringSize:[titleString size] inBounds:cellFrame];
     [titleString drawInRect:titleRect];
 
     //status
-    NSAttributedString* statusString = self.attributedStatus;
+    NSAttributedString* statusString = [self attributedStatusWithStyle:style];
     NSRect statusRect = [self rectForStatusWithString:statusString withTitleRect:titleRect inBounds:cellFrame];
     [statusString drawInRect:statusRect];
 }
 
 - (NSRect)expansionFrameWithFrame:(NSRect)cellFrame inView:(NSView*)view
 {
-    NSAttributedString* titleString = self.attributedTitle;
-    NSRect realRect = [self rectForTitleWithString:titleString inBounds:cellFrame];
+    NSAttributedString* titleString = [self attributedTitleWithStyle:AttributesStyleNormal];
+    NSRect realRect = [self rectForTitleWithStringSize:[titleString size] inBounds:cellFrame];
 
     if ([titleString size].width > NSWidth(realRect) &&
         NSMouseInRect([view convertPoint:view.window.mouseLocationOutsideOfEventStream fromView:nil], realRect, view.flipped))
@@ -137,16 +139,15 @@ static CGFloat const kPaddingExpansionFrame = 2.0;
     cellFrame.origin.x += kPaddingExpansionFrame;
     cellFrame.origin.y += kPaddingExpansionFrame;
 
-    self.fTitleAttributes[NSForegroundColorAttributeName] = NSColor.controlTextColor;
-    NSAttributedString* titleString = self.attributedTitle;
+    NSAttributedString* titleString = [self attributedTitleWithStyle:AttributesStyleNormal];
     [titleString drawInRect:cellFrame];
 }
 
 #pragma mark - Private
 
-- (NSRect)rectForTitleWithString:(NSAttributedString*)string inBounds:(NSRect)bounds
+- (NSRect)rectForTitleWithStringSize:(NSSize)stringSize inBounds:(NSRect)bounds
 {
-    NSSize const titleSize = [string size];
+    NSSize const titleSize = stringSize;
 
     //no right padding, so that there's not too much space between this and the priority image
     NSRect result;
@@ -189,13 +190,15 @@ static CGFloat const kPaddingExpansionFrame = 2.0;
     return result;
 }
 
-- (NSAttributedString*)attributedTitle
+- (NSAttributedString*)attributedTitleWithStyle:(AttributesStyle)style
 {
     NSString* title = ((FileListNode*)self.objectValue).name;
-    return [[NSAttributedString alloc] initWithString:title attributes:self.fTitleAttributes];
+    return [[NSAttributedString alloc] initWithString:title attributes:style == AttributesStyleEmphasized ? kTitleEmphasizedAttributes :
+                                                                style == AttributesStyleDisabled ? kTitleDisabledAttributes :
+                                                                                                   kTitleAttributes];
 }
 
-- (NSAttributedString*)attributedStatus
+- (NSAttributedString*)attributedStatusWithStyle:(AttributesStyle)style
 {
     FileListNode* node = (FileListNode*)self.objectValue;
     Torrent* torrent = node.torrent;
@@ -207,7 +210,9 @@ static CGFloat const kPaddingExpansionFrame = 2.0;
                                                   percentString,
                                                   [NSString stringForFileSize:node.size]];
 
-    return [[NSAttributedString alloc] initWithString:status attributes:self.fStatusAttributes];
+    return [[NSAttributedString alloc] initWithString:status attributes:style == AttributesStyleEmphasized ? kStatusEmphasizedAttributes :
+                                                                 style == AttributesStyleDisabled ? kStatusDisabledAttributes :
+                                                                                                    kStatusAttributes];
 }
 
 @end

--- a/macosx/FileNameCell.mm
+++ b/macosx/FileNameCell.mm
@@ -20,13 +20,13 @@ static CGFloat const kPaddingBelowStatusFile = 2.0;
 static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 static CGFloat const kPaddingExpansionFrame = 2.0;
 
-static NSParagraphStyle* kParagraphStyle()
+static NSMutableParagraphStyle* sParagraphStyle()
 {
     NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
     paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
     return paragraphStyle;
 }
-static NSParagraphStyle* kStatusParagraphStyle()
+static NSMutableParagraphStyle* sStatusParagraphStyle()
 {
     NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
     paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
@@ -35,32 +35,32 @@ static NSParagraphStyle* kStatusParagraphStyle()
 
 static NSDictionary<NSAttributedStringKey, id>* const kTitleAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:12.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.controlTextColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kStatusAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:9.0],
-    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSParagraphStyleAttributeName : sStatusParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.secondaryLabelColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kTitleEmphasizedAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:12.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.whiteColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kStatusEmphasizedAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:9.0],
-    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSParagraphStyleAttributeName : sStatusParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.whiteColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kTitleDisabledAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:12.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.disabledControlTextColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kStatusDisabledAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:9.0],
-    NSParagraphStyleAttributeName : kStatusParagraphStyle(),
+    NSParagraphStyleAttributeName : sStatusParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.disabledControlTextColor
 };
 

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -49,7 +49,7 @@ static CGFloat const kPiecesTotalPercent = 0.6;
 
 static NSInteger const kMaxPieces = 18 * 18;
 
-static NSParagraphStyle* kParagraphStyle()
+static NSMutableParagraphStyle* sParagraphStyle()
 {
     NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
     paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
@@ -57,22 +57,22 @@ static NSParagraphStyle* kParagraphStyle()
 }
 static NSDictionary<NSAttributedStringKey, id>* const kTitleAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:12.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.labelColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kStatusAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:10.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.secondaryLabelColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kTitleEmphasizedAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:12.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.whiteColor
 };
 static NSDictionary<NSAttributedStringKey, id>* const kStatusEmphasizedAttributes = @{
     NSFontAttributeName : [NSFont messageFontOfSize:10.0],
-    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSParagraphStyleAttributeName : sParagraphStyle(),
     NSForegroundColorAttributeName : NSColor.whiteColor
 };
 

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -3,6 +3,7 @@
 // License text can be found in the licenses/ folder.
 
 #import "TorrentCell.h"
+#import "FileNameCell.h"
 #import "GroupsController.h"
 #import "NSImageAdditions.h"
 #import "NSStringAdditions.h"
@@ -48,12 +49,34 @@ static CGFloat const kPiecesTotalPercent = 0.6;
 
 static NSInteger const kMaxPieces = 18 * 18;
 
+static NSParagraphStyle* kParagraphStyle()
+{
+    NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    return paragraphStyle;
+}
+static NSDictionary<NSAttributedStringKey, id>* const kTitleAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:12.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.labelColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kStatusAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:10.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.secondaryLabelColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kTitleEmphasizedAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:12.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.whiteColor
+};
+static NSDictionary<NSAttributedStringKey, id>* const kStatusEmphasizedAttributes = @{
+    NSFontAttributeName : [NSFont messageFontOfSize:10.0],
+    NSParagraphStyleAttributeName : kParagraphStyle(),
+    NSForegroundColorAttributeName : NSColor.whiteColor
+};
+
 @interface TorrentCell ()
-
-@property(nonatomic, readonly) NSUserDefaults* fDefaults;
-
-@property(nonatomic, readonly) NSMutableDictionary* fTitleAttributes;
-@property(nonatomic, readonly) NSMutableDictionary* fStatusAttributes;
 
 @property(nonatomic) BOOL fTracking;
 @property(nonatomic) BOOL fMouseDownControlButton;
@@ -62,13 +85,6 @@ static NSInteger const kMaxPieces = 18 * 18;
 @property(nonatomic, readonly) NSColor* fBarBorderColor;
 @property(nonatomic, readonly) NSColor* fBluePieceColor;
 @property(nonatomic, readonly) NSColor* fBarMinimalBorderColor;
-
-@property(nonatomic, readonly) NSAttributedString* attributedTitle;
-- (NSAttributedString*)attributedStatusString:(NSString*)string;
-
-@property(nonatomic, readonly) NSString* buttonString;
-@property(nonatomic, readonly) NSString* statusString;
-@property(nonatomic, readonly) NSString* minimalStatusString;
 
 @end
 
@@ -79,17 +95,6 @@ static NSInteger const kMaxPieces = 18 * 18;
 {
     if ((self = [super init]))
     {
-        NSMutableParagraphStyle* paragraphStyle = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
-        paragraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
-
-        _fTitleAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
-        _fTitleAttributes[NSFontAttributeName] = [NSFont messageFontOfSize:12.0];
-        _fTitleAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
-
-        _fStatusAttributes = [[NSMutableDictionary alloc] initWithCapacity:3];
-        _fStatusAttributes[NSFontAttributeName] = [NSFont messageFontOfSize:10.0];
-        _fStatusAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
-
         _fBluePieceColor = [NSColor colorWithCalibratedRed:0.0 green:0.4 blue:0.8 alpha:1.0];
         _fBarBorderColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.2];
         _fBarMinimalBorderColor = [NSColor colorWithCalibratedWhite:0.0 alpha:0.015];
@@ -100,8 +105,6 @@ static NSInteger const kMaxPieces = 18 * 18;
 - (id)copyWithZone:(NSZone*)zone
 {
     TorrentCell* copy = [super copyWithZone:zone];
-    copy->_fTitleAttributes = [_fTitleAttributes mutableCopyWithZone:zone];
-    copy->_fStatusAttributes = [_fStatusAttributes mutableCopyWithZone:zone];
     copy->_fBluePieceColor = _fBluePieceColor;
     copy->_fBarBorderColor = _fBarBorderColor;
     copy->_fBarMinimalBorderColor = _fBarMinimalBorderColor;
@@ -333,27 +336,14 @@ static NSInteger const kMaxPieces = 18 * 18;
                          hints:nil];
     }
 
-    //text color
-    NSColor *titleColor, *statusColor;
-    if (self.backgroundStyle == NSBackgroundStyleEmphasized)
-    {
-        titleColor = statusColor = NSColor.whiteColor;
-    }
-    else
-    {
-        titleColor = NSColor.labelColor;
-        statusColor = NSColor.secondaryLabelColor;
-    }
-
-    self.fTitleAttributes[NSForegroundColorAttributeName] = titleColor;
-    self.fStatusAttributes[NSForegroundColorAttributeName] = statusColor;
+    AttributesStyle style = self.backgroundStyle == NSBackgroundStyleEmphasized ? AttributesStyleEmphasized : AttributesStyleNormal;
 
     CGFloat titleRightBound;
     //minimal status
     if (minimal)
     {
-        NSAttributedString* minimalString = [self attributedStatusString:self.minimalStatusString];
-        NSRect minimalStatusRect = [self rectForMinimalStatusWithString:minimalString inBounds:cellFrame];
+        NSAttributedString* minimalString = [self attributedStatusString:self.minimalStatusString style:style];
+        NSRect minimalStatusRect = [self rectForMinimalStatusWithStringSize:[minimalString size] inBounds:cellFrame];
 
         if (!self.hover)
         {
@@ -365,7 +355,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     //progress
     else
     {
-        NSAttributedString* progressString = [self attributedStatusString:torrent.progressString];
+        NSAttributedString* progressString = [self attributedStatusString:torrent.progressString style:style];
         NSRect progressRect = [self rectForProgressWithStringInBounds:cellFrame];
 
         [progressString drawInRect:progressRect];
@@ -455,8 +445,9 @@ static NSInteger const kMaxPieces = 18 * 18;
     }
 
     //title
-    NSAttributedString* titleString = self.attributedTitle;
-    NSRect titleRect = [self rectForTitleWithString:titleString withRightBound:titleRightBound inBounds:cellFrame minimal:minimal];
+    NSAttributedString* titleString = [self attributedTitleWithStyle:style];
+    NSRect titleRect = [self rectForTitleWithStringSize:[titleString size] withRightBound:titleRightBound inBounds:cellFrame
+                                                minimal:minimal];
     [titleString drawInRect:titleRect];
 
     //priority icon
@@ -480,7 +471,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     //status
     if (!minimal)
     {
-        NSAttributedString* statusString = [self attributedStatusString:self.statusString];
+        NSAttributedString* statusString = [self attributedStatusString:self.statusString style:style];
         [statusString drawInRect:[self rectForStatusWithStringInBounds:cellFrame]];
     }
 }
@@ -493,8 +484,8 @@ static NSInteger const kMaxPieces = 18 * 18;
     CGFloat titleRightBound;
     if (minimal)
     {
-        NSAttributedString* minimalString = [self attributedStatusString:self.minimalStatusString];
-        NSRect minimalStatusRect = [self rectForMinimalStatusWithString:minimalString inBounds:cellFrame];
+        NSAttributedString* minimalString = [self attributedStatusString:self.minimalStatusString style:AttributesStyleNormal];
+        NSRect minimalStatusRect = [self rectForMinimalStatusWithStringSize:[minimalString size] inBounds:cellFrame];
 
         titleRightBound = NSMinX(minimalStatusRect);
 
@@ -509,15 +500,17 @@ static NSInteger const kMaxPieces = 18 * 18;
         titleRightBound = NSMaxX(cellFrame);
     }
 
-    NSAttributedString* titleString = self.attributedTitle;
-    NSRect realRect = [self rectForTitleWithString:titleString withRightBound:titleRightBound inBounds:cellFrame minimal:minimal];
+    NSAttributedString* titleString = [self attributedTitleWithStyle:AttributesStyleNormal];
+    NSSize titleStringSize = [titleString size];
+    NSRect realRect = [self rectForTitleWithStringSize:titleStringSize withRightBound:titleRightBound inBounds:cellFrame
+                                               minimal:minimal];
 
-    NSAssert([titleString size].width >= NSWidth(realRect), @"Full rect width should not be less than the used title rect width!");
+    NSAssert(titleStringSize.width >= NSWidth(realRect), @"Full rect width should not be less than the used title rect width!");
 
-    if ([titleString size].width > NSWidth(realRect) &&
+    if (titleStringSize.width > NSWidth(realRect) &&
         NSMouseInRect([view convertPoint:view.window.mouseLocationOutsideOfEventStream fromView:nil], realRect, view.flipped))
     {
-        realRect.size.width = [titleString size].width;
+        realRect.size.width = titleStringSize.width;
         return NSInsetRect(realRect, -kPaddingExpansionFrame, -kPaddingExpansionFrame);
     }
 
@@ -529,8 +522,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     cellFrame.origin.x += kPaddingExpansionFrame;
     cellFrame.origin.y += kPaddingExpansionFrame;
 
-    self.fTitleAttributes[NSForegroundColorAttributeName] = NSColor.labelColor;
-    NSAttributedString* titleString = self.attributedTitle;
+    NSAttributedString* titleString = [self attributedTitleWithStyle:AttributesStyleNormal];
     [titleString drawInRect:cellFrame];
 }
 
@@ -711,10 +703,10 @@ static NSInteger const kMaxPieces = 18 * 18;
                  hints:nil];
 }
 
-- (NSRect)rectForMinimalStatusWithString:(NSAttributedString*)string inBounds:(NSRect)bounds
+- (NSRect)rectForMinimalStatusWithStringSize:(NSSize)stringSize inBounds:(NSRect)bounds
 {
     NSRect result;
-    result.size = [string size];
+    result.size = stringSize;
 
     result.origin.x = NSMaxX(bounds) - (kPaddingHorizontal + NSWidth(result) + kPaddingEdgeMax);
     result.origin.y = ceil(NSMidY(bounds) - NSHeight(result) * 0.5);
@@ -722,10 +714,10 @@ static NSInteger const kMaxPieces = 18 * 18;
     return result;
 }
 
-- (NSRect)rectForTitleWithString:(NSAttributedString*)string
-                  withRightBound:(CGFloat)rightBound
-                        inBounds:(NSRect)bounds
-                         minimal:(BOOL)minimal
+- (NSRect)rectForTitleWithStringSize:(NSSize)stringSize
+                      withRightBound:(CGFloat)rightBound
+                            inBounds:(NSRect)bounds
+                             minimal:(BOOL)minimal
 {
     NSRect result;
     result.origin.x = NSMinX(bounds) + kPaddingHorizontal + (minimal ? kImageSizeMin : kImageSizeRegular) + kPaddingBetweenImageAndTitle;
@@ -748,7 +740,7 @@ static NSInteger const kMaxPieces = 18 * 18;
     {
         result.size.width -= kPriorityIconSize + kPaddingBetweenTitleAndPriority;
     }
-    result.size.width = MIN(NSWidth(result), [string size].width);
+    result.size.width = MIN(NSWidth(result), stringSize.width);
 
     return result;
 }
@@ -857,15 +849,17 @@ static NSInteger const kMaxPieces = 18 * 18;
     return NSMakeRect(NSMinX(bounds) - padding * 0.5, NSMidY(bounds) - imageSize * 0.5, imageSize, imageSize);
 }
 
-- (NSAttributedString*)attributedTitle
+- (NSAttributedString*)attributedTitleWithStyle:(AttributesStyle)style
 {
     NSString* title = ((Torrent*)self.representedObject).name;
-    return [[NSAttributedString alloc] initWithString:title attributes:self.fTitleAttributes];
+    return [[NSAttributedString alloc] initWithString:title
+                                           attributes:style == AttributesStyleEmphasized ? kTitleEmphasizedAttributes : kTitleAttributes];
 }
 
-- (NSAttributedString*)attributedStatusString:(NSString*)string
+- (NSAttributedString*)attributedStatusString:(NSString*)string style:(AttributesStyle)style
 {
-    return [[NSAttributedString alloc] initWithString:string attributes:self.fStatusAttributes];
+    return [[NSAttributedString alloc] initWithString:string
+                                           attributes:style == AttributesStyleEmphasized ? kStatusEmphasizedAttributes : kStatusAttributes];
 }
 
 - (NSString*)buttonString


### PR DESCRIPTION
(Previously: <s>`attempt to fix #5212`</s>)

This is a small performance refactor.
I'm replacing NSMutableDictionary with non-mutable static attributes.
So now there are only a total of 4-6 non-mutable static attribute dictionaries instead of 2 mutable instance copies for each torrent.