### PR TITLE
Remove empty line in manpage

### DIFF
--- a/cli/transmission-cli.1
+++ b/cli/transmission-cli.1
@@ -103,7 +103,6 @@ value 0-255, or any of these DSCP strings:
 .Dq cs7 ,
 .Dq ef ,
 .Dq le
-
 These ToS keys are deprecated and will be removed in the future:
 .Dq default ,
 .Dq lowcost ,


### PR DESCRIPTION
I saw a patch in[ debian repository](https://salsa.debian.org/debian/transmission/-/blob/2bc995ee96301ac8d1797475384919eb6100b23b/debian/patches/0002-fix-remove-empty-line-in-manpage.patch) made by Leo and figured it might as well be in the main repository to make their future packaging job cleaner.