### PR TITLE
fix: generate peer-id on launch

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -95,7 +95,6 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections.
  * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections.
  * **peer-congestion-algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
- * **peer-id-ttl-hours:** Number (default = 6) Recycle the peer id used for public torrents after N hours of use.
  * **peer-limit-global:** Number (default = 240)
  * **peer-limit-per-torrent:** Number (default =  60)
  * **peer-socket-tos:** String (default = "default") Set the [Type-Of-Service (TOS)](https://en.wikipedia.org/wiki/Type_of_Service) parameter for outgoing TCP packets. Possible values are "default", "lowcost", "throughput", "lowdelay" and "reliability". The value "lowcost" is recommended if you're using a smart router, and shouldn't harm in any case.

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -910,7 +910,7 @@ void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e)
     req.announce_url = current_tracker->announce_url;
     req.tracker_id = current_tracker->tracker_id;
     req.info_hash = tor->infoHash();
-    req.peer_id = tr_torrentGetPeerId(tor);
+    req.peer_id = tor->peer_id();
     req.up = tier->byteCounts[TR_ANN_UP];
     req.down = tier->byteCounts[TR_ANN_DOWN];
     req.corrupt = tier->byteCounts[TR_ANN_CORRUPT];

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -75,7 +75,7 @@ private:
 
         auto info = TorrentInfo{};
         info.info_hash = tor->infoHash();
-        info.client_peer_id = tr_torrentGetPeerId(tor);
+        info.client_peer_id = tor->peer_id();
         info.id = tor->id();
         info.is_done = tor->isDone();
         return info;

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr MyStatic = std::array<std::string_view, 402>{ ""sv,
+auto constexpr MyStatic = std::array<std::string_view, 401>{ ""sv,
                                                              "activeTorrentCount"sv,
                                                              "activity-date"sv,
                                                              "activityDate"sv,
@@ -217,7 +217,6 @@ auto constexpr MyStatic = std::array<std::string_view, 402>{ ""sv,
                                                              "paused"sv,
                                                              "pausedTorrentCount"sv,
                                                              "peer-congestion-algorithm"sv,
-                                                             "peer-id-ttl-hours"sv,
                                                              "peer-limit"sv,
                                                              "peer-limit-global"sv,
                                                              "peer-limit-per-torrent"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -220,7 +220,6 @@ enum
     TR_KEY_paused,
     TR_KEY_pausedTorrentCount,
     TR_KEY_peer_congestion_algorithm,
-    TR_KEY_peer_id_ttl_hours,
     TR_KEY_peer_limit,
     TR_KEY_peer_limit_global,
     TR_KEY_peer_limit_per_torrent,

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -37,7 +37,6 @@ struct tr_variant;
     V(TR_KEY_lpd_enabled, lpd_enabled, bool, true, "") \
     V(TR_KEY_message_level, log_level, tr_log_level, TR_LOG_INFO, "") \
     V(TR_KEY_peer_congestion_algorithm, peer_congestion_algorithm, std::string, "", "") \
-    V(TR_KEY_peer_id_ttl_hours, peer_id_ttl_hours, size_t, 6U, "") \
     V(TR_KEY_peer_limit_global, peer_limit_global, size_t, TR_DEFAULT_PEER_LIMIT_GLOBAL, "") \
     V(TR_KEY_peer_limit_per_torrent, peer_limit_per_torrent, size_t, TR_DEFAULT_PEER_LIMIT_TORRENT, "") \
     V(TR_KEY_peer_port, peer_port, tr_port, tr_port::fromHost(TR_DEFAULT_PEER_PORT), "The local machine's incoming peer port") \

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -822,11 +822,6 @@ public:
         return settings_.ratio_limit;
     }
 
-    [[nodiscard]] constexpr auto peerIdTTLHours() const noexcept
-    {
-        return settings_.peer_id_ttl_hours;
-    }
-
     void verifyRemove(tr_torrent* tor)
     {
         if (verifier_)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -779,6 +779,11 @@ public:
         return announce_key_;
     }
 
+    [[nodiscard]] constexpr tr_peer_id_t const& peer_id() const noexcept
+    {
+        return peer_id_;
+    }
+
     // should be called when done modifying the torrent's announce list.
     void on_announce_list_changed()
     {
@@ -814,15 +819,6 @@ public:
 
     tr_sha1_digest_t obfuscated_hash = {};
 
-    /* If the initiator of the connection receives a handshake in which the
-     * peer_id does not match the expected peerid, then the initiator is
-     * expected to drop the connection. Note that the initiator presumably
-     * received the peer information from the tracker, which includes the
-     * peer_id that was registered by the peer. The peer_id from the tracker
-     * and in the handshake are expected to match.
-     */
-    tr_peer_id_t peer_id_ = {};
-
     tr_session* session = nullptr;
 
     tr_torrent_announcer* torrent_announcer = nullptr;
@@ -833,8 +829,6 @@ public:
      * and we're in the process of downloading the metainfo from
      * other peers */
     struct tr_incomplete_metadata* incompleteMetadata = nullptr;
-
-    time_t peer_id_creation_time_ = 0;
 
     time_t lpdAnnounceAt = 0;
 
@@ -936,6 +930,15 @@ private:
         }
     }
 
+    /* If the initiator of the connection receives a handshake in which the
+     * peer_id does not match the expected peerid, then the initiator is
+     * expected to drop the connection. Note that the initiator presumably
+     * received the peer information from the tracker, which includes the
+     * peer_id that was registered by the peer. The peer_id from the tracker
+     * and in the handshake are expected to match.
+     */
+    tr_peer_id_t peer_id_ = tr_peerIdInit();
+
     tr_verify_state verify_state_ = TR_VERIFY_NONE;
 
     float verify_progress_ = -1;
@@ -958,8 +961,6 @@ constexpr bool tr_isTorrent(tr_torrent const* tor)
  * Tell the `tr_torrent` that it's gotten a block
  */
 void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
-
-tr_peer_id_t const& tr_torrentGetPeerId(tr_torrent* tor);
 
 tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 


### PR DESCRIPTION
Fixes #5232.

Notes: Updated Peer ID generation to happen once per session.