### PR TITLE
Fix Potential leak of an object of type 'NSString * _Nullable'

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3717,7 +3717,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
@@ -3961,7 +3960,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
@@ -4277,7 +4275,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -12,10 +12,7 @@ check_symbol_exists(SO_REUSEPORT "sys/types.h;sys/socket.h" HAVE_SO_REUSEPORT)
 
 add_compile_options(
     # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES for this directory
-    $<$<AND:$<BOOL:${APPLE}>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-arc>
-
-    # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES for this directory
-    $<$<AND:$<BOOL:${APPLE}>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-weak>)
+    $<$<AND:$<BOOL:${APPLE}>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-arc>)
 
 add_library(${TR_NAME} STATIC)
 

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -10,6 +10,13 @@ endif()
 
 check_symbol_exists(SO_REUSEPORT "sys/types.h;sys/socket.h" HAVE_SO_REUSEPORT)
 
+add_compile_options(
+    # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES for this directory
+    $<$<AND:$<BOOL:${APPLE}>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-arc>
+
+    # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES for this directory
+    $<$<AND:$<BOOL:${APPLE}>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-weak>)
+
 add_library(${TR_NAME} STATIC)
 
 target_sources(${TR_NAME}

--- a/libtransmission/utils.mm
+++ b/libtransmission/utils.mm
@@ -15,35 +15,40 @@
 
 std::string tr_strv_convert_utf8(std::string_view sv)
 {
-    // UTF-8 encoding
-    char const* validUTF8 = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding].UTF8String;
-    if (validUTF8)
+    // local pool for non-app tools like transmission-daemon, transmission-remote, transmission-create, ...
+    @autoreleasepool
     {
-        return std::string(validUTF8);
-    }
-
-    // autodetection of the encoding (#3434)
-    NSString* convertedString;
-    NSStringEncoding stringEncoding = [NSString
-        stringEncodingForData:[NSData dataWithBytes:std::data(sv) length:std::size(sv)]
-              encodingOptions:@{
-                  // We disallow lossy conversion, and will leave it to `utf8::unchecked::replace_invalid`.
-                  NSStringEncodingDetectionAllowLossyKey : @NO,
-                  // We only set the likely language.
-                  // If we were to set suggested encodings, then whatever is listed first would take precedence on all others, making for instance kCFStringEncodingDOSJapanese (cp932) and kCFStringEncodingDOSRussian (cp866) taking priority on each other.
-                  NSStringEncodingDetectionLikelyLanguageKey : NSLocale.currentLocale.languageCode
-              }
-              convertedString:&convertedString
-          usedLossyConversion:nil];
-    if (stringEncoding)
-    {
-        validUTF8 = convertedString.UTF8String;
+        // UTF-8 encoding
+        char const* validUTF8 = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding]
+                                    .UTF8String;
         if (validUTF8)
         {
             return std::string(validUTF8);
         }
-    }
 
-    // invalid encoding
-    return tr_strv_replace_invalid(sv);
+        // autodetection of the encoding (#3434)
+        NSString* convertedString;
+        NSStringEncoding stringEncoding = [NSString
+            stringEncodingForData:[NSData dataWithBytes:std::data(sv) length:std::size(sv)]
+                  encodingOptions:@{
+                      // We disallow lossy conversion, and will leave it to `utf8::unchecked::replace_invalid`.
+                      NSStringEncodingDetectionAllowLossyKey : @NO,
+                      // We only set the likely language.
+                      // If we were to set suggested encodings, then whatever is listed first would take precedence on all others, making for instance kCFStringEncodingDOSJapanese (cp932) and kCFStringEncodingDOSRussian (cp866) taking priority on each other.
+                      NSStringEncodingDetectionLikelyLanguageKey : NSLocale.currentLocale.languageCode
+                  }
+                  convertedString:&convertedString
+              usedLossyConversion:nil];
+        if (stringEncoding)
+        {
+            validUTF8 = convertedString.UTF8String;
+            if (validUTF8)
+            {
+                return std::string(validUTF8);
+            }
+        }
+
+        // invalid encoding
+        return tr_strv_replace_invalid(sv);
+    }
 }

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -1,20 +1,32 @@
+# minimum macOS target support
 if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS MACOS_SUPPORT_MINIMUM)
     message(FATAL_ERROR "Targeting macOS versions before ${MACOS_SUPPORT_MINIMUM} is not supported for the macOS project, please adjust CMAKE_OSX_DEPLOYMENT_TARGET (${CMAKE_OSX_DEPLOYMENT_TARGET})")
 endif()
 
+find_program(ACTOOL_EXECUTABLE actool REQUIRED)
+find_program(CODESIGN_EXECUTABLE codesign REQUIRED)
+
 set(MAC_BUNDLE_NAME Transmission)
 
 add_compile_options(
-    -fcxx-modules
-    -fmodules
-    -fobjc-arc
-    # #warnings are good practice in development
-    "-Wno-#warnings"
-    # GNU extensions are good practice in Objective-C
-    -Wno-gnu)
+    $<$<COMPILE_LANGUAGE:C,CXX>:-fmodules>
+    $<$<COMPILE_LANGUAGE:C,CXX>:-fcxx-modules>
 
-find_program(ACTOOL_EXECUTABLE actool REQUIRED)
-find_program(CODESIGN_EXECUTABLE codesign REQUIRED)
+    # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES for this directory
+    $<$<COMPILE_LANGUAGE:C,CXX>:-fobjc-arc>
+
+    # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES for this directory
+    $<$<COMPILE_LANGUAGE:C,CXX>:-fobjc-weak>
+
+    # GNU extensions are good practice in Objective-C
+    $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-gnu>
+
+    # Our #warnings are good practice in IDE development, not in command-line compilation
+    $<$<AND:$<NOT:$<BOOL:${XCODE}>>,$<COMPILE_LANGUAGE:C,CXX>>:-Wno-\#warnings>)
+
+add_link_options(
+    # equivalent of XCODE_ATTRIBUTE_DEAD_CODE_STRIPPING YES for this directory
+    $<$<LINK_LANGUAGE:C,CXX>:-dead_strip>)
 
 add_subdirectory(QuickLookPlugin)
 add_subdirectory(VDKQueue)
@@ -411,10 +423,10 @@ endif()
 set_target_properties(
     ${TR_NAME}-mac
     PROPERTIES
-        OUTPUT_NAME ${MAC_BUNDLE_NAME}
+        INSTALL_RPATH "@executable_path;@executable_path/../Frameworks"
         MACOSX_BUNDLE_GUI_IDENTIFIER "org.m0k.transmission"
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in
-        INSTALL_RPATH "@executable_path;@executable_path/../Frameworks")
+        OUTPUT_NAME ${MAC_BUNDLE_NAME})
 
 install(
     TARGETS ${TR_NAME}-mac

--- a/macosx/QuickLookPlugin/CMakeLists.txt
+++ b/macosx/QuickLookPlugin/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MAC_QL_BUNDLE_NAME QuickLookPlugin)
+
 add_library(${TR_NAME}-mac-ql MODULE)
 
 target_sources(${TR_NAME}-mac-ql
@@ -61,17 +63,15 @@ target_sources(${TR_NAME}-mac-ql
     PRIVATE
         ${RESOURCES})
 
-set(MAC_QL_BUNDLE_NAME QuickLookPlugin)
-
 set_target_properties(
     ${TR_NAME}-mac-ql
     PROPERTIES
-        OUTPUT_NAME ${MAC_QL_BUNDLE_NAME}
-        MACOSX_BUNDLE ON
         BUNDLE ON
         BUNDLE_EXTENSION qlgenerator
+        INSTALL_RPATH "@loader_path/../../../../../MacOS;@loader_path/../../../../../Frameworks"
+        MACOSX_BUNDLE ON
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
-        INSTALL_RPATH "@loader_path/../../../../../MacOS;@loader_path/../../../../../Frameworks")
+        OUTPUT_NAME ${MAC_QL_BUNDLE_NAME})
 
 target_include_directories(${TR_NAME}-mac-ql
     PRIVATE


### PR DESCRIPTION
Fix #5212.
Followup of #5244 for compilation flags when using cmake.
![Capture d’écran 2023-03-21 à 02 41 06](https://user-images.githubusercontent.com/839992/226440932-90c4e1ec-41d3-4a87-9a59-e715ef57842e.png)

I cherry picked #4931 because really that one should have been a patch, otherwise building with Xcode and cmake are using different compilation flags and that causes unexpected behaviors depending on which tool is used for a release.