### PR TITLE
fix: 4.0.2 wishlist CPU perf regression pt. 1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -738,11 +738,11 @@ jobs:
           set -ex
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            apptream \
             ca-certificates \
             clang \
             cmake \
             gettext \
+            intltool \
             libcurl4-openssl-dev \
             libdeflate-dev \
             libevent-dev \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -738,11 +738,11 @@ jobs:
           set -ex
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            appstream \
             ca-certificates \
             clang \
             cmake \
             gettext \
-            intltool \
             libcurl4-openssl-dev \
             libdeflate-dev \
             libevent-dev \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -738,6 +738,7 @@ jobs:
           set -ex
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            apptream \
             ca-certificates \
             clang \
             cmake \

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -65,7 +65,7 @@ tr_file_piece_map::file_span_t tr_file_piece_map::fileSpan(tr_piece_index_t piec
     constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
     auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
-    return { tr_piece_index_t(std::distance(begin, equal_begin)), tr_piece_index_t(std::distance(begin, equal_end)) };
+    return { tr_piece_index_t(equal_begin - begin), tr_piece_index_t(equal_end - begin) };
 }
 
 tr_file_piece_map::file_offset_t tr_file_piece_map::fileOffset(uint64_t offset) const
@@ -124,11 +124,6 @@ tr_priority_t tr_file_priorities::filePriority(tr_file_index_t file) const
 
 tr_priority_t tr_file_priorities::piecePriority(tr_piece_index_t piece) const
 {
-    if (std::empty(*fpm_)) // not initialized yet
-    {
-        return TR_PRI_NORMAL;
-    }
-
     // increase priority if a file begins or ends in this piece
     // because that makes life easier for code/users using at incomplete files.
     // Xrefs: f2daeb242, https://forum.transmissionbt.com/viewtopic.php?t=10473

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -62,17 +62,17 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
 
 tr_file_piece_map::file_span_t tr_file_piece_map::fileSpan(tr_piece_index_t piece) const
 {
-    auto compare = CompareToSpan<tr_piece_index_t>{};
+    constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
-    auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, compare);
+    auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
     return { tr_piece_index_t(std::distance(begin, equal_begin)), tr_piece_index_t(std::distance(begin, equal_end)) };
 }
 
 tr_file_piece_map::file_offset_t tr_file_piece_map::fileOffset(uint64_t offset) const
 {
-    auto compare = CompareToSpan<uint64_t>{};
+    constexpr auto Compare = CompareToSpan<uint64_t>{};
     auto const begin = std::begin(file_bytes_);
-    auto const it = std::lower_bound(begin, std::end(file_bytes_), offset, compare);
+    auto const it = std::lower_bound(begin, std::end(file_bytes_), offset, Compare);
     tr_file_index_t const file_index = std::distance(begin, it);
     auto const file_offset = offset - it->begin;
     return file_offset_t{ file_index, file_offset };

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -89,7 +89,7 @@ private:
     {
         using span_t = index_span_t<T>;
 
-        int compare(T item, span_t span) const // <=>
+        [[nodiscard]] constexpr int compare(T item, span_t span) const // <=>
         {
             if (item < span.begin)
             {
@@ -104,17 +104,17 @@ private:
             return 0;
         }
 
-        bool operator()(T item, span_t span) const // <
+        [[nodiscard]] constexpr bool operator()(T item, span_t span) const // <
         {
             return compare(item, span) < 0;
         }
 
-        int compare(span_t span, T item) const // <=>
+        [[nodiscard]] constexpr int compare(span_t span, T item) const // <=>
         {
             return -compare(item, span);
         }
 
-        bool operator()(span_t span, T item) const // <
+        [[nodiscard]] constexpr bool operator()(span_t span, T item) const // <
         {
             return compare(span, item) < 0;
         }


### PR DESCRIPTION
Figuring out which blocks to ask for next got more expensive in terms of CPU in #5167 due to the extra logic in that function. The code isn't that complicated, but it's called so many times that it adds up quite a bit.

This PR is a minimal do-no-harm refactor to add `constexpr` and avoid an unnecessary test. This doesn't entirely fix the CPU regression (which is why this is pt. 1) but it does help and is a minimal change.

Notes: Fixed CPU load regression that #5167 introduced in 4.0.2.