### PR TITLE
fix: GTK client prefs window too large for small displays

### DIFF
--- a/gtk/ui/gtk3/PrefsDialog.ui
+++ b/gtk/ui/gtk3/PrefsDialog.ui
@@ -56,6 +56,7 @@
         </child>
         <child>
           <object class="GtkNotebook" id="dialog_pages">
+            <property name="height-request">-1</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <child>
@@ -1153,6 +1154,7 @@
             </child>
             <child>
               <object class="GtkBox" id="network_page_layout">
+                <property name="height-request">-1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="border-width">12</property>
@@ -1545,11 +1547,12 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-start">18</property>
+                    <property name="vexpand">True</property>
                     <property name="row-spacing">6</property>
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkScrolledWindow" id="default_trackers_scroll">
-                        <property name="height-request">166</property>
+                        <property name="height-request">100</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
@@ -1563,6 +1566,7 @@
 
 To add a backup URL, add it on the next line after a primary URL.
 To add a new primary URL, add it after a blank line.</property>
+                            <property name="vexpand">True</property>
                           </object>
                         </child>
                       </object>

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -12,6 +12,7 @@
         <property name="vexpand">1</property>
         <child>
           <object class="GtkNotebook" id="dialog_pages">
+            <property name="height-request">-1</property>
             <property name="vexpand">1</property>
             <property name="focusable">1</property>
             <child>
@@ -798,6 +799,7 @@
                 <property name="position">4</property>
                 <property name="child">
                   <object class="GtkBox" id="network_page_layout">
+                    <property name="height-request">-1</property>
                     <property name="css-classes">tr-pad-large</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
@@ -1070,9 +1072,10 @@
                         <property name="margin-start">18</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">12</property>
+                        <property name="vexpand">True</property>
                         <child>
                           <object class="GtkScrolledWindow" id="default_trackers_scroll">
-                            <property name="height-request">166</property>
+                            <property name="height-request">100</property>
                             <property name="focusable">1</property>
                             <property name="hexpand">1</property>
                             <property name="vexpand">1</property>
@@ -1085,6 +1088,7 @@
 
 To add a backup URL, add it on the next line after a primary URL.
 To add a new primary URL, add it after a blank line.</property>
+                                <property name="vexpand">True</property>
                               </object>
                             </property>
                             <layout>


### PR DESCRIPTION
Fixes #5257.

Notes: Fixed preferences dialog being too large for small displays.