### PR TITLE
fix crash on launch from tapping on a notification

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -884,10 +884,24 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
                                                         andEventID:kAEOpenContents];
 
     //if we were opened from a user notification, do the corresponding action
-    NSUserNotification* launchNotification = notification.userInfo[NSApplicationLaunchUserNotificationKey];
-    if (launchNotification)
+    if (@available(macOS 10.14, *))
     {
-        [self userNotificationCenter:NSUserNotificationCenter.defaultUserNotificationCenter didActivateNotification:launchNotification];
+        UNNotificationResponse* launchNotification = notification.userInfo[NSApplicationLaunchUserNotificationKey];
+        if (launchNotification)
+        {
+            [self userNotificationCenter:UNUserNotificationCenter.currentNotificationCenter
+                didReceiveNotificationResponse:launchNotification withCompletionHandler:^{
+                }];
+        }
+    }
+    else
+    {
+        NSUserNotification* launchNotification = notification.userInfo[NSApplicationLaunchUserNotificationKey];
+        if (launchNotification)
+        {
+            [self userNotificationCenter:NSUserNotificationCenter.defaultUserNotificationCenter
+                 didActivateNotification:launchNotification];
+        }
     }
 
     //auto importing
@@ -2385,6 +2399,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 {
     if (!response.notification.request.content.userInfo.count)
     {
+        completionHandler();
         return;
     }
 
@@ -2396,6 +2411,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     {
         [self didActivateNotificationByActionShowWithUserInfo:response.notification.request.content.userInfo];
     }
+    completionHandler();
 }
 
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center didActivateNotification:(NSUserNotification*)notification


### PR DESCRIPTION
Problem: while [`NSApplicationLaunchUserNotificationKey` is documented as returning an `NSUserNotification`](https://developer.apple.com/documentation/appkit/nsapplicationlaunchusernotificationkey?language=objc), it is actually an `UNNotificationResponse` in reality. So when you tap on a notification button "Show", Transmission may crash on launch. This is a regression introduced with #3040.

Solution: adopt the correct handler for macOS 10.14 and newer.

Tested: on macOS 10.14.6 and macOS 13.3.