### PR TITLE
fix: The right operand of '<' is a garbage value

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -172,9 +172,7 @@ void tr_completion::removeBlock(tr_block_index_t block)
 
 void tr_completion::removePiece(tr_piece_index_t piece)
 {
-    auto const [begin, end] = block_info_->blockSpanForPiece(piece);
-
-    for (auto block = begin; block < end; ++block)
+    for (auto [block, end] = block_info_->blockSpanForPiece(piece); block < end; ++block)
     {
         removeBlock(block);
     }


### PR DESCRIPTION
Might be a bogus analyzer warning from Xcode 14.3 (released two days ago), but now it's going to always show for months if we don't workaround it.
![Capture d’écran 2023-03-23 à 22 32 47](https://user-images.githubusercontent.com/839992/227237296-2b9770a9-53ba-4876-a277-caf25d621b36.png)
