### PR TITLE
docs: update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@ The Transmission Project
 https://transmissionbt.com/
 
 Maintainers
-  Charles Kerr (@ckerr) (libtransmission, Qt client)
+  Charles Kerr (@ckerr) (libtransmission, Qt client, utils)
   Mike Gelfand (@mikedld) (GTK client, scripts & tooling)
   Mitchell Livingston (@livings124) (macOS client)
 
@@ -17,7 +17,11 @@ Contributor Team
 Hall of Fame
   Eric Petit (@titer) (Project originator)
   Josh Elsasser (Daemon, Backend, GTK client)
+  Juliusz Chroboczek (DHT, network code)
   Bryan Varner (BeOS client)
+  Malcolm Jarvis (Web client)
+  Kendall Hopkins <SoftwareElves@gmail.com> (Web client)
+  Kevin Glowacz <kjg@transmissionbt.com> (Web client)
 
 Starting with Transmission 4.0.0, contributors are credited in each
 release's notes so that repeat contributions receive repeat shout-outs.
@@ -38,23 +42,23 @@ These people contributed to the project before Transmission 4:
   Greg Hazel, Guido Cella, Guido Vranken, Hakjoon Sim, Han Shen,
   Herman Semenov, Hugo van Heuven, Ilkka Kallioniemi, Ilya Chirkov,
   Isabella Skořepová, Jakub Steiner, James "Kibo" Parry, Jan Weiß,
-  Jelle van der Waa, John Clay, Jonas Malaco, Jonas Rask, Jordan Lee,
-  Josh Elsasser, Juliusz Chroboczek, Kendall Hopkins, Kevin Glowacz,
-  Kevin Stubbings, Kirill Ovchinnikov, Lucas Clemente Vella, Luukas Pörtfors,
+  Jelle van der Waa, John Clay, Jonas Malaco, Jonas Rask, Josh Elsasser,
+  Juliusz Chroboczek, Kendall Hopkins, Kevin Glowacz, Kevin Stubbings,
+  Kirill Ovchinnikov, Lucas Clemente Vella, Luukas Pörtfors,
   Maarten Van Coile, Maciej Wolny, Malcolm Jarvis, Mark Deepwell,
   Markus Amalthea Magnuson, Matan Ziv-Av, Matt Joiner, Max Zettlmeißl,
   Michael Lopez, Michael Skree, Michal Kubiak, Mike Gelfand, Mike Gilbert,
-  Mingye Wang, Mitchell Livingston, Mitch Livingston, Mukund Sivaraman,
-  Nathan Benichou, Nicholas Guriev, Niklas Haas, Norbert Papke, Oleg Chashko,
-  Pavel Borzenkov, Pavel Shlyak, Pedro Scarapicchia Junior, Peter Bailey,
-  Peter Dave Hello, Pierre Carru, Piotr Drąg, Rahim Nathwani, Rashid Eissing,
-  Reed Morrison, Rick Patrick, Robert Palmer, Robert Vehse, Robin Seth Ekman,
-  Rodger Werner, Rosen Penev, Sam Marcus, Sam Thursfield, Sander van Kasteel,
+  Mingye Wang, Mitch Livingston, Mukund Sivaraman, Nathan Benichou,
+  Nicholas Guriev, Niklas Haas, Norbert Papke, Oleg Chashko, Pavel Borzenkov,
+  Pavel Shlyak, Pedro Scarapicchia Junior, Peter Bailey, Peter Dave Hello,
+  Pierre Carru, Piotr Drąg, Rahim Nathwani, Rashid Eissing, Reed Morrison,
+  Rick Patrick, Robert Palmer, Robert Vehse, Robin Seth Ekman, Rodger Werner,
+  Rosen Penev, Sam Marcus, Sam Thursfield, Sander van Kasteel,
   Sebastiaan Lokhorst, Sebastian Andrzej Siewior, Sebastian Jensen,
   Sergey Fedoseev, Simon Wells, Stefan Talpalaru, Ștefan Talpalaru,
   Sven Depondt, Szepesi Tibor, Tavis Ormandy, Thomas Hines, Tomas Carnecky,
-  Tomáš Kelemen, Tom Forbes, Tom Richards, Viacheslav Chimishuk, Vincent Vinel,
-  Vitaly Potyarkin, Waldemar Brodkorb, Will Thompson, Yaron Shahrabani,
-  Yuze Jiang, and Zachary J. Slater.
+  Tomáš Kelemen, Tom Forbes, Tom Richards, Viacheslav Chimishuk,
+  Vincent Vinel, Vitaly Potyarkin, Waldemar Brodkorb, Will Thompson,
+  Yaron Shahrabani, Yuze Jiang, and Zachary J. Slater.
 
 If anyone is missing from this list, please let us know!

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,59 +1,60 @@
 The Transmission Project
 https://transmissionbt.com/
 
-Lead Developers <dev@transmissionbt.com>
-  Charles Kerr, Mnemosyne LLC <charles@charleskerr.com> (Daemon, Backend, GTK+, QT clients)
-  Mitchell Livingston, Digital Ignition LLC <livings124@transmissionbt.com> (macOS client)
-  Mike Gelfand <mike@transmissionbt.com>
+Maintainers
+  Charles Kerr (@ckerr) (libtransmission, Qt client)
+  Mike Gelfand (@mikedld) (GTK client, scripts & tooling)
+  Mitchell Livingston (@livings124) (macOS client)
 
-Project Contributors
-  John Clay <john@transmissionbt.com> (Website maintenance and troubleshooting, macOS help documentation)
-  Hugo van Heuven, madebysofa (Main icon design)
-  Andreas Nilsson (GNOME adaptation of main icon)
-  Rodger Werner ("Big Sur" adaptation of main icon)
-  Bruno Bierbaumer (Web client patches)
-  Juliusz Chroboczek (DHT, network code, BitTorrent code improvements)
-  Daniel Lee (Patches)
-  Tomas Carnecky (Profiling, patches, and detection of sneaky bugs)
-  Diego Jiménez (Patches)
-  Kendall Hopkins <SoftwareElves@gmail.com> (Web client)
-  Malcolm Jarvis <mjarvis@transmissionbt.com> (Web client)
-  Kevin Glowacz <kjg@transmissionbt.com> (Web client)
-  Rashid Eissing (macOS Transfers preferences icon)
-  Dean Ostetto
-  Rick Patrick (macOS images)
-  Jonas Rask (macOS Globe icon)
-  Erick Turnquist (IPv6 code, support)
-  Maarten Van Coile (Wiki Wrangler, troubleshooting, support)
-  James "Kibo" Parry (Updated Mac Retina images)
-  Max Zettlmeißl <max@zettlmeissl.de>
+Previous Maintainers
+  Eric Petit (@titer) (Project originator)
+  Josh Elsasser (Daemon, Backend, GTK client)
+  Bryan Varner (BeOS client)
 
-Previous Developers
-  Eric Petit <eric@lapsus.org> (Project originator)
-  Josh Elsasser <josh@elsasser.org> (Daemon, Backend, GTK+ client)
-  Bryan Varner <bryan@varnernet.com> (BeOS client)
+Contributor Team
+  Derek Reiff (@dareiff) (Web client)
+  Dmitry Serov (@DevilDimon) (macOS client)
+  Dzmitry Neviadomski (@nevack) (macOS client)
+  FX Coudert (@fxcoudert) (macOS client)
+  John Clay (@JohnClay)
+  SweetP Pro (@sweetppro) (macOS client)
 
-macOS Translators, current release:
-  Jorge Carrasco (Spanish)
-  Etienne Samson (French)
-  Marco Cavazzuti (Italian)
-  Anton Sotkov (Russian)
-  Alexander Bykov (Russian)
-  Maarten Van Coile (Dutch)
-  Guilherme Fernandes (Brazilian Portuguese)
-  Sven-S. Porst (German)
-  Tianhao He (Simplified Chinese)
-  Sérgio Miranda (European Portuguese)
-  Daniel Østergaard Nielsen (Danish)
-  Emir SARI (Turkish)
+Starting with Transmission 4.0.0, contributors are credited in each
+release's notes so that repeat contributions receive repeat shout-outs.
+Please see news/ for these credits!
 
-GTK+ Translators:
-  Hundreds of people in an ever-changing list.
-  See the po files and the translation website (https://www.transifex.com/transmissionbt/teams/) for a full list.
+These people contributed to the project before Transmission 4:
 
-Third-Party Resources:
-  Nick Mathewson and Niels Provos for libevent. <http://monkey.org/~provos/libevent/>
-  Greg Hazel of BitTorrent Inc. for libutp. <https://github.com/bittorrent/libutp>
-  Thomas Bernard for MiniUPnP and libnatpmp. <https://miniupnp.tuxfamily.org/>
-  Andy Matuschak for Sparkle. <http://sparkle.andymatuschak.org/>
-  Bryan D K Jones for VDKQueue. <https://github.com/bdkjones/VDKQueue>
+  Aleksej Lebedev, Alexander Futekov, Alexandre Jouandin, Andreas Nilsson,
+  Balázs Meskó, Bernard Spil, Bogdan Vasiliev, Bruno Bierbaumer,
+  Bryan Varner, Carles Pastor Badosa, Carl Michael Skog, Charles Kerr,
+  Christian Muehlhaeuser, Chris Young, Chuan Zhang, Clément Fauchereau,
+  Cœur, Colin B, Craig Andrews, C.W. Betts, Daniel Kamil Kozar, Daniel Lee,
+  Daniil Subbotin, Dan Walters, David Beinder, David Miguel Susano Pinto,
+  Dean Ostetto, Derek Reiff, Dhiru Kholia, Diego Jiménez, Dinesh Manajipet,
+  Dmitry Antipov, Dmitry Serov, Dmytro Lytovchenko, Duncan Beevers,
+  Dzmitry Neviadomski, Edward Betts, Erick Turnquist, Eric Petit, Esa Varemo,
+  Federico Bond, Federico Scodelaro, Frank Aurich, FX Coudert, Gary Elshaw,
+  Greg Hazel, Guido Cella, Guido Vranken, Hakjoon Sim, Han Shen,
+  Herman Semenov, Hugo van Heuven, Ilkka Kallioniemi, Ilya Chirkov,
+  Isabella Skořepová, Jakub Steiner, James "Kibo" Parry, Jan Weiß,
+  Jelle van der Waa, John Clay, Jonas Malaco, Jonas Rask, Jordan Lee,
+  Josh Elsasser, Juliusz Chroboczek, Kendall Hopkins, Kevin Glowacz,
+  Kevin Stubbings, Kirill Ovchinnikov, Lucas Clemente Vella, Luukas Pörtfors,
+  Maarten Van Coile, Maciej Wolny, Malcolm Jarvis, Mark Deepwell,
+  Markus Amalthea Magnuson, Matan Ziv-Av, Matt Joiner, Max Zettlmeißl,
+  Michael Lopez, Michael Skree, Michal Kubiak, Mike Gelfand, Mike Gilbert,
+  Mingye Wang, Mitchell Livingston, Mitch Livingston, Mukund Sivaraman,
+  Nathan Benichou, Nicholas Guriev, Niklas Haas, Norbert Papke, Oleg Chashko,
+  Pavel Borzenkov, Pavel Shlyak, Pedro Scarapicchia Junior, Peter Bailey,
+  Peter Dave Hello, Pierre Carru, Piotr Drąg, Rahim Nathwani, Rashid Eissing,
+  Reed Morrison, Rick Patrick, Robert Palmer, Robert Vehse, Robin Seth Ekman,
+  Rodger Werner, Rosen Penev, Sam Marcus, Sam Thursfield, Sander van Kasteel,
+  Sebastiaan Lokhorst, Sebastian Andrzej Siewior, Sebastian Jensen,
+  Sergey Fedoseev, Simon Wells, Stefan Talpalaru, Ștefan Talpalaru,
+  Sven Depondt, Szepesi Tibor, Tavis Ormandy, Thomas Hines, Tomas Carnecky,
+  Tomáš Kelemen, Tom Forbes, Tom Richards, Viacheslav Chimishuk, Vincent Vinel,
+  Vitaly Potyarkin, Waldemar Brodkorb, Will Thompson, Yaron Shahrabani,
+  Yuze Jiang, and Zachary J. Slater.
+
+If anyone is missing from this list, please let us know!

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,11 +6,6 @@ Maintainers
   Mike Gelfand (@mikedld) (GTK client, scripts & tooling)
   Mitchell Livingston (@livings124) (macOS client)
 
-Previous Maintainers
-  Eric Petit (@titer) (Project originator)
-  Josh Elsasser (Daemon, Backend, GTK client)
-  Bryan Varner (BeOS client)
-
 Contributor Team
   Derek Reiff (@dareiff) (Web client)
   Dmitry Serov (@DevilDimon) (macOS client)
@@ -18,6 +13,11 @@ Contributor Team
   FX Coudert (@fxcoudert) (macOS client)
   John Clay (@JohnClay)
   SweetP Pro (@sweetppro) (macOS client)
+
+Hall of Fame
+  Eric Petit (@titer) (Project originator)
+  Josh Elsasser (Daemon, Backend, GTK client)
+  Bryan Varner (BeOS client)
 
 Starting with Transmission 4.0.0, contributors are credited in each
 release's notes so that repeat contributions receive repeat shout-outs.

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Contributor Team
   Dmitry Serov (@DevilDimon) (macOS client)
   Dzmitry Neviadomski (@nevack) (macOS client)
   FX Coudert (@fxcoudert) (macOS client)
+  Gary Elshaw (@GaryElshaw)
   John Clay (@JohnClay)
   SweetP Pro (@sweetppro) (macOS client)
 


### PR DESCRIPTION
Update the `AUTHORS` file, as inspired by [this discussion](https://github.com/transmission/transmission/discussions/4736#discussioncomment-5357038) about giving people credit where it's due.

CC @transmission/contributors for review

Goals:

- Elevate @transmission/contributors to give them their due credit
- Remove email addresses
- Make explicit that individual contributions are now credited in release notes so that extra contributions get extra shout-outs. No need to update `AUTHORS` when someone new lands a PR.

Questions

- Gary's not on here. I could've sworn he was in `@transmission/contributors` but apparently not? I don't remember what's going on here so thought I'd ask. I don't want to omit anyone who wants credit.
- One other active contributor :heart:  is omitted here. I did that intentionally since I think they do not want to be listed. Please LMK if this is wrong.
- Translation credit is TBD. The list in the old `AUTHORS` file is _really_ old so I've removed it, but IDK how to coax an up-to-date list out of Transifex.

