### PR TITLE
Use locale-dependent decimal separators for user-visible numbers

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -494,7 +494,7 @@ std::vector<int> tr_parseNumberRange(std::string_view str)
 double tr_truncd(double x, int decimal_places)
 {
     auto buf = std::array<char, 128>{};
-    auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, "{:.{}f}", x, DBL_DIG);
+    auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, "{:.{}Lf}", x, DBL_DIG);
     *out = '\0';
 
     if (auto* const pt = strstr(std::data(buf), localeconv()->decimal_point); pt != nullptr)
@@ -509,15 +509,15 @@ std::string tr_strpercent(double x)
 {
     if (x < 5.0)
     {
-        return fmt::format("{:.2f}", tr_truncd(x, 2));
+        return fmt::format("{:.2Lf}", tr_truncd(x, 2));
     }
 
     if (x < 100.0)
     {
-        return fmt::format("{:.1f}", tr_truncd(x, 1));
+        return fmt::format("{:.1Lf}", tr_truncd(x, 1));
     }
 
-    return fmt::format("{:.0f}", x);
+    return fmt::format("{:.0Lf}", x);
 }
 
 std::string tr_strratio(double ratio, char const* infinity)
@@ -715,7 +715,7 @@ char* formatter_get_size_str(formatter_units const& u, char* buf, uint64_t bytes
         precision = 1;
     }
 
-    auto const [out, len] = fmt::format_to_n(buf, buflen - 1, "{:.{}f} {:s}", value, precision, units);
+    auto const [out, len] = fmt::format_to_n(buf, buflen - 1, "{:.{}Lf} {:s}", value, precision, units);
     *out = '\0';
     return buf;
 }
@@ -757,7 +757,7 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
 
     if (speed <= 999.95) // 0.0 KB to 999.9 KB
     {
-        return fmt::format("{:d} {:s}", int(speed), std::data(speed_units[TR_FMT_KB].name));
+        return fmt::format("{:Ld} {:s}", int(speed), std::data(speed_units[TR_FMT_KB].name));
     }
 
     double const kilo = speed_units[TR_FMT_KB].value;
@@ -765,15 +765,15 @@ std::string tr_formatter_speed_KBps(double kilo_per_second)
 
     if (speed <= 99.995) // 0.98 MB to 99.99 MB
     {
-        return fmt::format("{:.2f} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
+        return fmt::format("{:.2Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
 
     if (speed <= 999.95) // 100.0 MB to 999.9 MB
     {
-        return fmt::format("{:.1f} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
+        return fmt::format("{:.1Lf} {:s}", speed, std::data(speed_units[TR_FMT_MB].name));
     }
 
-    return fmt::format("{:.1f} {:s}", speed / kilo, std::data(speed_units[TR_FMT_GB].name));
+    return fmt::format("{:.1Lf} {:s}", speed / kilo, std::data(speed_units[TR_FMT_GB].name));
 }
 
 size_t tr_mem_K = 0;


### PR DESCRIPTION
This includes percents, ratios, sizes, speeds, etc. coming from shared formatting helpers. Previously based on sprintf-like functions using locale, now using libfmt which doesn't use locale by default and needs to be instructed to do it explicitly.

Fixes: #5284