### PR TITLE
Intermediate fix for HTTP announce behaviour affected by `bind-address-ipv*`

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -92,8 +92,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **utp-enabled:** Boolean (default = true) Enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
 
 #### Peers
- * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections.
- * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections.
+ * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections. Invalid IP addresses will be treated as "0.0.0.0".
+ * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections. Invalid IP addresses will be treated as "::".
  * **peer-congestion-algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
  * **peer-limit-global:** Number (default = 240)
  * **peer-limit-per-torrent:** Number (default =  60)

--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -92,8 +92,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **utp-enabled:** Boolean (default = true) Enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
 
 #### Peers
- * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections. Invalid IP addresses will be treated as "0.0.0.0".
- * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections. Invalid IP addresses will be treated as "::".
+ * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections. When no valid IPv4 address is provided, Transmission will default to "0.0.0.0".
+ * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections. When no valid IPv6 address is provided, Transmission will determine your default public IPv6 address and use it.
  * **peer-congestion-algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
  * **peer-limit-global:** Number (default = 240)
  * **peer-limit-per-torrent:** Number (default =  60)

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -267,11 +267,8 @@ void tr_tracker_http_announce(
        public address they want to use.
 
        We should ensure that we send the announce both via IPv6 and IPv4,
-       and to be safe we also add the "ipv6=" and "ipv4=" parameters, if
-       we already have them. Our global IPv6 address is computed for the
-       LTEP handshake, so this comes for free. Our public IPv4 address
-       may have been returned from a previous announce and stored in the
-       session.
+       but no longer use the "ipv4=" and "ipv6=" parameters. So, we no
+       longer need to compute the global IPv4 and IPv6 addresses.
      */
     auto url = tr_urlbuf{};
     announce_url_new(url, session, request);
@@ -286,8 +283,6 @@ void tr_tracker_http_announce(
         session->fetch(std::move(opt));
     };
 
-    auto const [ipv6, ipv6_is_any] = session->publicAddress(TR_AF_INET6);
-
     /*
      * Before Curl 7.77.0, if we explicitly choose the IP version we want
      * to use, it is still possible that the wrong one is used. The workaround
@@ -295,7 +290,7 @@ void tr_tracker_http_announce(
      * a request that we don't know if will go through IPv6 or IPv4.
      */
     static auto const use_curl_workaround = curl_version_info(CURLVERSION_NOW)->version_num < 0x074D00 /* 7.77.0 */;
-    if (use_curl_workaround)
+    if (use_curl_workaround || session->useAnnounceIP())
     {
         if (session->useAnnounceIP())
         {
@@ -307,28 +302,16 @@ void tr_tracker_http_announce(
     }
     else
     {
-        if (session->useAnnounceIP() || ipv6_is_any)
-        {
-            if (session->useAnnounceIP())
-            {
-                options.url += format_ip_arg(session->announceIP());
-            }
-            d->requests_sent_count = 1;
-            do_make_request(""sv, std::move(options));
-        }
-        else
-        {
-            d->requests_sent_count = 2;
+        d->requests_sent_count = 2;
 
-            // First try to send the announce via IPv4:
-            auto ipv4_options = options;
-            ipv4_options.ip_proto = tr_web::FetchOptions::IPProtocol::V4;
-            do_make_request("IPv4"sv, std::move(ipv4_options));
+        // First try to send the announce via IPv4:
+        auto ipv4_options = options;
+        ipv4_options.ip_proto = tr_web::FetchOptions::IPProtocol::V4;
+        do_make_request("IPv4"sv, std::move(ipv4_options));
 
-            // Then try to send via IPv6:
-            options.ip_proto = tr_web::FetchOptions::IPProtocol::V6;
-            do_make_request("IPv6"sv, std::move(options));
-        }
+        // Then try to send via IPv6:
+        options.ip_proto = tr_web::FetchOptions::IPProtocol::V6;
+        do_make_request("IPv6"sv, std::move(options));
     }
 }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -581,13 +581,15 @@ std::optional<tr_address> tr_address::from_string(std::string_view address_sv)
 
     auto addr = tr_address{};
 
-    if (evutil_inet_pton(AF_INET, address_sz, &addr.addr) == 1)
+    addr.addr.addr4 = {};
+    if (evutil_inet_pton(AF_INET, address_sz, &addr.addr.addr4) == 1)
     {
         addr.type = TR_AF_INET;
         return addr;
     }
 
-    if (evutil_inet_pton(AF_INET6, address_sz, &addr.addr) == 1)
+    addr.addr.addr6 = {};
+    if (evutil_inet_pton(AF_INET6, address_sz, &addr.addr.addr6) == 1)
     {
         addr.type = TR_AF_INET6;
         return addr;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -300,6 +300,21 @@ struct tr_address
         return tr_address{ TR_AF_INET6, { IN6ADDR_ANY_INIT } };
     }
 
+    [[nodiscard]] auto constexpr is_any4() const noexcept
+    {
+        return *this == any_ipv4();
+    }
+
+    [[nodiscard]] auto constexpr is_any6() const noexcept
+    {
+        return *this == any_ipv6();
+    }
+
+    [[nodiscard]] auto constexpr is_any() const noexcept
+    {
+        return is_any4() || is_any6();
+    }
+
     [[nodiscard]] constexpr auto is_valid() const noexcept
     {
         return type == TR_AF_INET || type == TR_AF_INET6;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -300,21 +300,6 @@ struct tr_address
         return tr_address{ TR_AF_INET6, { IN6ADDR_ANY_INIT } };
     }
 
-    [[nodiscard]] auto is_any4() const noexcept
-    {
-        return *this == any_ipv4();
-    }
-
-    [[nodiscard]] auto is_any6() const noexcept
-    {
-        return *this == any_ipv6();
-    }
-
-    [[nodiscard]] auto is_any() const noexcept
-    {
-        return is_any4() || is_any6();
-    }
-
     [[nodiscard]] constexpr auto is_valid() const noexcept
     {
         return type == TR_AF_INET || type == TR_AF_INET6;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -300,17 +300,17 @@ struct tr_address
         return tr_address{ TR_AF_INET6, { IN6ADDR_ANY_INIT } };
     }
 
-    [[nodiscard]] auto constexpr is_any4() const noexcept
+    [[nodiscard]] auto is_any4() const noexcept
     {
         return *this == any_ipv4();
     }
 
-    [[nodiscard]] auto constexpr is_any6() const noexcept
+    [[nodiscard]] auto is_any6() const noexcept
     {
         return *this == any_ipv6();
     }
 
-    [[nodiscard]] auto constexpr is_any() const noexcept
+    [[nodiscard]] auto is_any() const noexcept
     {
         return is_any4() || is_any6();
     }


### PR DESCRIPTION
Closes #5206.

Added more details to the docs that describe the behaviour of the `bind-address-ipv*` settings. You may notice that IPv4 and IPv6 behaviour are not entirely the same. ~I intend to align `bind-address-ipv6` behaviour with `bind-address-ipv4` after this PR, hence "intermediate fix"~.

Edit: I now see that the reason for the IPv6 behaviour is for efficient DHT, and the reason why IPv4 is not like IPv6 is because of the existence of NAT. I won't align the behaviour.

For the very least, setting `"bind-address-ipv6": "::"` and `"bind-address-ipv4": "0.0.0.0"` now gives the behaviour you would expect.

## What's Changed

`main` branch before this PR:
- **If libcurl version < 7.77.0, and/or `announce-ip-enabled: true`, and/or `bind-address-ipv6: "::"`:**
  Transmission will announce once without explicitly specifying the IP protocol to use.

- **Otherwise:**
  Transmission will try to announce once with IPv4 and once with IPv6.

After merging this PR:
- **If libcurl version is lower than 7.77.0, and/or `announce-ip-enabled` is `true`:**
  Transmission will announce once without explicitly specifying the IP protocol to use.

- **Otherwise:**
  Transmission will try to announce once with IPv4 and once with IPv6.

## Test Results

Test method is same as #5206.

### `"bind-address-ipv6": "::"` and `"bind-address-ipv4": "0.0.0.0"`

<details>
<summary>Click to expand/hide</summary>

#### On torrent start

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
19:37:50.970533 IP REDACTED.58160 > 130.239.18.158.6969: Flags [S], seq 1355800952, win 2920, options [mss 1460,sackOK,TS val 2774742310 ecr 0,nop,wscale 0], length 0
E..<J5@.@..yt........0.9P..x.......h.;.........
.c5&........
19:37:50.970641 IP6 2a01:REDACTED.59176 > 2001:6b0:e:2018::158.6969: Flags [S], seq 928084569, win 2880, options [mss 1440,sackOK,TS val 2660477005 ecr 0,nop,wscale 0], length 0
`..].(.@*....ANJ........ ..... ........X.(.97QrY.......@...........
...M........
19:37:51.006738 IP6 2a01:REDACTED.59176 > 2001:6b0:e:2018::158.6969: Flags [.], ack 1739662399, win 2880, options [nop,nop,TS val 2660477041 ecr 733136876], length 0
`..]. .@*....ANJ........ ..... ........X.(.97QrZg.$?...@.......
...q+...
19:37:51.006828 IP REDACTED.58160 > 130.239.18.158.6969: Flags [.], ack 2422392795, win 2920, options [nop,nop,TS val 2774742346 ecr 688193309], length 0
E..4J6@.@...t........0.9P..y.b.....h.3.....
.c5J)...
19:37:51.006852 IP6 2a01:REDACTED.59176 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:347, ack 1, win 2880, options [nop,nop,TS val 2660477041 ecr 733136876], length 347
`..].{.@*....ANJ........ ..... ........X.(.97QrZg.$?...@.6.....
...q+...GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=1096707450&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


19:37:51.006931 IP REDACTED.58160 > 130.239.18.158.6969: Flags [P.], seq 0:347, ack 1, win 2920, options [nop,nop,TS val 2774742346 ecr 688193309], length 347
E...J7@.@..$t........0.9P..y.b.....h.......
.c5J)...GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=1096707450&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


19:37:51.042119 IP6 2a01:REDACTED.59176 > 2001:6b0:e:2018::158.6969: Flags [.], ack 874, win 2619, options [nop,nop,TS val 2660477076 ecr 733136940], length 0
`..]. .@*....ANJ........ ..... ........X.(.97Qs.g.'...
;.......
....+..,
19:37:51.042249 IP6 2a01:REDACTED.59176 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 347, ack 875, win 2619, options [nop,nop,TS val 2660477077 ecr 733136940], length 0
`..]. .@*....ANJ........ ..... ........X.(.97Qs.g.'...
;.......
....+..,
19:37:51.043389 IP REDACTED.58160 > 130.239.18.158.6969: Flags [.], ack 620, win 2476, options [nop,nop,TS val 2774742383 ecr 688193373], length 0
E..4J8@.@..~t........0.9P....b.F..      ..3.....
.c5o)..]
19:37:51.043512 IP REDACTED.58160 > 130.239.18.158.6969: Flags [F.], seq 347, ack 621, win 2476, options [nop,nop,TS val 2774742383 ecr 688193373], length 0
E..4J9@.@..}t........0.9P....b.G..      ..3.....
.c5o)..]
^C
10 packets captured
125 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'started' (announcer.cc:805)
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:started] (announcer.cc:774)
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Announcing to tracker (announcer.cc:1592)
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=1096707450&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
[2023-03-25 19:37:50.955] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=1096707450&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
```

#### On exit:

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
19:38:30.798409 IP REDACTED.45664 > 130.239.18.158.6969: Flags [S], seq 740465858, win 2920, options [mss 1460,sackOK,TS val 2774782138 ecr 0,nop,wscale 0], length 0
E..<0.@.@...t........`.9,".........h.;.........
.c..........
19:38:30.798557 IP6 2a01:REDACTED.59930 > 2001:6b0:e:2018::158.6969: Flags [S], seq 2576676522, win 2880, options [mss 1440,sackOK,TS val 2660516833 ecr 0,nop,wscale 0], length 0
`.O..(.@*....ANJ........ ..... ........X...9...........@...........
..C.........
19:38:30.833728 IP REDACTED.45664 > 130.239.18.158.6969: Flags [.], ack 1917381792, win 2920, options [nop,nop,TS val 2774782173 ecr 688233117], length 0
E..40.@.@...t........`.9,"..rH.....h.3.....
.c..)...
19:38:30.833832 IP REDACTED.45664 > 130.239.18.158.6969: Flags [P.], seq 0:352, ack 1, win 2920, options [nop,nop,TS val 2774782173 ecr 688233117], length 352
E...0.@.@...t........`.9,"..rH.....h.......
.c..)...GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=5242880&left=3507240960&numwant=0&key=1096707450&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


19:38:30.835217 IP6 2a01:REDACTED.59930 > 2001:6b0:e:2018::158.6969: Flags [.], ack 1626444395, win 2880, options [nop,nop,TS val 2660516870 ecr 733176684], length 0
`.O.. .@*....ANJ........ ..... ........X...9....`..k...@.......
..D.+.cl
19:38:30.835309 IP6 2a01:REDACTED.59930 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:352, ack 1, win 2880, options [nop,nop,TS val 2660516870 ecr 733176684], length 352
`.O....@*....ANJ........ ..... ........X...9....`..k...@.;.....
..D.+.clGET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=5242880&left=3507240960&numwant=0&key=1096707450&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


19:38:30.869377 IP REDACTED.45664 > 130.239.18.158.6969: Flags [.], ack 137, win 2784, options [nop,nop,TS val 2774782209 ecr 688233200], length 0
E..40.@.@...t........`.9,".#rH.(..
..3.....
.c..)...
19:38:30.869505 IP REDACTED.45664 > 130.239.18.158.6969: Flags [F.], seq 352, ack 138, win 2784, options [nop,nop,TS val 2774782209 ecr 688233200], length 0
E..40.@.@...t........`.9,".#rH.)..
..3.....
.c..)...
19:38:30.870970 IP6 2a01:REDACTED.59930 > 2001:6b0:e:2018::158.6969: Flags [.], ack 137, win 2744, options [nop,nop,TS val 2660516905 ecr 733176769], length 0
`.O.. .@*....ANJ........ ..... ........X...9....`.....
........
..D)+.c.
19:38:30.871067 IP6 2a01:REDACTED.59930 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 352, ack 138, win 2744, options [nop,nop,TS val 2660516905 ecr 733176769], length 0
`.O.. .@*....ANJ........ ..... ........X...9....`.....
........
..D)+.c.
^C
10 packets captured
1803 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:] (announcer.cc:774)
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'stopped' (announcer.cc:805)
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:stopped] (announcer.cc:774)
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=5242880&left=3507240960&numwant=0&key=1096707450&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
[2023-03-25 19:38:31.149] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-q0gsnig40puu&port=51413&uploaded=0&downloaded=5242880&left=3507240960&numwant=0&key=1096707450&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
```

</details>

### `"bind-address-ipv6": ""` and `"bind-address-ipv4": "0.0.0.0"`

<details>
<summary>Click to expand/hide</summary>

#### On torrent start

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:10:38.843194 IP REDACTED.33038 > 130.239.18.158.6969: Flags [S], seq 819629393, win 2920, options [mss 1460,sackOK,TS val 2780310182 ecr 0,nop,wscale 0], length 0
E..<G,@.@...t..........90..Q.......h.;.........
..*.........
21:10:38.843658 IP6 2a01:REDACTED.52538 > 2001:6b0:e:2018::158.6969: Flags [S], seq 2405156750, win 2880, options [mss 1440,sackOK,TS val 2666044878 ecr 0,nop,wscale 0], length 0
`.#..(.@*....ANJ........ ..... ........X.:.9.[.........@...........
............
21:10:38.878506 IP REDACTED.33038 > 130.239.18.158.6969: Flags [.], ack 581926239, win 2920, options [nop,nop,TS val 2780310218 ecr 693761181], length 0
E..4G-@.@...t..........90..R".}_...h.3.....
..*.)Y..
21:10:38.878595 IP REDACTED.33038 > 130.239.18.158.6969: Flags [P.], seq 0:347, ack 1, win 2920, options [nop,nop,TS val 2780310218 ecr 693761181], length 347
E...G.@.@..-t..........90..R".}_...h.......
..*.)Y..GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=2876526270&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:10:38.879822 IP6 2a01:REDACTED.52538 > 2001:6b0:e:2018::158.6969: Flags [.], ack 3495200912, win 2880, options [nop,nop,TS val 2666044914 ecr 738704748], length 0
`.#.. .@*....ANJ........ ..... ........X.:.9.[...T.....@.......
....,..l
21:10:38.879892 IP6 2a01:REDACTED.52538 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:347, ack 1, win 2880, options [nop,nop,TS val 2666044914 ecr 738704748], length 347
`.#..{.@*....ANJ........ ..... ........X.:.9.[...T.....@.6.....
....,..lGET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=2876526270&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:10:38.914233 IP REDACTED.33038 > 130.239.18.158.6969: Flags [.], ack 620, win 2476, options [nop,nop,TS val 2780310254 ecr 693761244], length 0
E..4G/@.@...t..........90...".....      ..3.....
..*.)Y..

...hide scrape request to save space...

^C
17 packets captured
555 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'started' (announcer.cc:805)
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:started] (announcer.cc:774)
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Announcing to tracker (announcer.cc:1592)
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=2876526270&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
[2023-03-25 21:10:38.883] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=2876526270&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
```

#### On exit

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:11:04.689535 IP REDACTED.33366 > 130.239.18.158.6969: Flags [S], seq 1251506776, win 2920, options [mss 1460,sackOK,TS val 2780336029 ecr 0,nop,wscale 0], length 0
E..<T'@.@...t........V.9J.zX.......h.;.........
............
21:11:04.689938 IP6 2a01:REDACTED.48188 > 2001:6b0:e:2018::158.6969: Flags [S], seq 779395024, win 2880, options [mss 1440,sackOK,TS val 2666070724 ecr 0,nop,wscale 0], length 0
`.dl.(.@*....ANJ........ ..... ........X.<.9.t.........@...........
............
21:11:04.726235 IP6 2a01:REDACTED.48188 > 2001:6b0:e:2018::158.6969: Flags [.], ack 1037942833, win 2880, options [nop,nop,TS val 2666070761 ecr 738730604], length 0
`.dl. .@*....ANJ........ ..... ........X.<.9.t..=..1...@.......
....,."l
21:11:04.726334 IP6 2a01:REDACTED.48188 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:353, ack 1, win 2880, options [nop,nop,TS val 2666070761 ecr 738730604], length 353
`.dl...@*....ANJ........ ..... ........X.<.9.t..=..1...@.<.....
....,."lGET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=14417920&left=3763470336&numwant=0&key=2876526270&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:11:04.726475 IP REDACTED.33366 > 130.239.18.158.6969: Flags [.], ack 3010211611, win 2920, options [nop,nop,TS val 2780336066 ecr 693787037], length 0
E..4T(@.@...t........V.9J.zY.l/....h.3.....
....)ZY.
21:11:04.726560 IP REDACTED.33366 > 130.239.18.158.6969: Flags [P.], seq 0:353, ack 1, win 2920, options [nop,nop,TS val 2780336066 ecr 693787037], length 353
E...T)@.@..,t........V.9J.zY.l/....h.......
....)ZY.GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=14417920&left=3763470336&numwant=0&key=2876526270&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:11:04.761626 IP6 2a01:REDACTED.48188 > 2001:6b0:e:2018::158.6969: Flags [.], ack 137, win 2744, options [nop,nop,TS val 2666070796 ecr 738730659], length 0
`.dl. .@*....ANJ........ ..... ........X.<.9.t.2=.....
........
....,.".
21:11:04.761741 IP6 2a01:REDACTED.48188 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 353, ack 138, win 2744, options [nop,nop,TS val 2666070796 ecr 738730659], length 0
`.dl. .@*....ANJ........ ..... ........X.<.9.t.2=.....
........
....,.".
21:11:04.763480 IP REDACTED.33366 > 130.239.18.158.6969: Flags [.], ack 137, win 2784, options [nop,nop,TS val 2780336103 ecr 693787093], length 0
E..4T*@.@...t........V.9J.{..l/...
..3.....
....)ZY.
21:11:04.763540 IP REDACTED.33366 > 130.239.18.158.6969: Flags [F.], seq 353, ack 138, win 2784, options [nop,nop,TS val 2780336103 ecr 693787093], length 0
E..4T+@.@...t........V.9J.{..l/...
..3.....
....)ZY.
21:11:27.068563 IP REDACTED.63676 > 130.239.18.158.8561: UDP, length 115
E...#X..@.`.t.........!q.{..d1:ad2:id20:<e...>.j.`.x...!.1..9:info_hash20:.:./. ZJ...w\......Z6:noseedi1ee1:q9:get_peers1:t2:..1:v4:LT..1:y1:qe
^C
11 packets captured
86 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:] (announcer.cc:774)
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'stopped' (announcer.cc:805)
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:stopped] (announcer.cc:774)
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=14417920&left=3763470336&numwant=0&key=2876526270&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
[2023-03-25 21:11:05.070] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-8deehl6eh32f&port=51413&uploaded=0&downloaded=14417920&left=3763470336&numwant=0&key=2876526270&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
```

</details>

### `"bind-address-ipv6": ""` and `"bind-address-ipv4": ""`

<details>
<summary>Click to expand/hide</summary>

#### On torrent start

`tcpdump`:
```
dropped privs to tcpdump
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:41:28.112074 IP REDACTED.35330 > 130.239.18.158.6969: Flags [S], seq 3635482442, win 2920, options [mss 1460,sackOK,TS val 2782159451 ecr 0,nop,wscale 0], length 0
E..<..@.@.\+t..........9...J.......h.;.........
..b[........
21:41:28.112441 IP6 2a01:REDACTED.50378 > 2001:6b0:e:2018::158.6969: Flags [S], seq 2879704662, win 2880, options [mss 1440,sackOK,TS val 2667894147 ecr 0,nop,wscale 0], length 0
`       ...(.@*....ANJ........ ..... ........X...9...V.......@...........
............
21:41:28.148795 IP REDACTED.35330 > 130.239.18.158.6969: Flags [.], ack 305354442, win 2920, options [nop,nop,TS val 2782159488 ecr 695610478], length 0
E..4..@.@.\2t..........9...K.3V....h.3.....
..b.)v,n
21:41:28.148855 IP6 2a01:REDACTED.50378 > 2001:6b0:e:2018::158.6969: Flags [.], ack 3313820841, win 2880, options [nop,nop,TS val 2667894183 ecr 740554028], length 0
`       ... .@*....ANJ........ ..... ........X...9...W.......@.......
....,#.,
21:41:28.148892 IP REDACTED.35330 > 130.239.18.158.6969: Flags [P.], seq 0:347, ack 1, win 2920, options [nop,nop,TS val 2782159488 ecr 695610478], length 347
E.....@.@.Z.t..........9...K.3V....h.......
..b.)v,nGET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=4288128172&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:41:28.148951 IP6 2a01:REDACTED.50378 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:347, ack 1, win 2880, options [nop,nop,TS val 2667894183 ecr 740554028], length 347
`       ...{.@*....ANJ........ ..... ........X...9...W.......@.6.....
....,#.,GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=4288128172&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:41:28.185449 IP6 2a01:REDACTED.50378 > 2001:6b0:e:2018::158.6969: Flags [.], ack 862, win 2583, options [nop,nop,TS val 2667894220 ecr 740554082], length 0
`       ... .@*....ANJ........ ..... ........X...9..........
........
....,#.b
21:41:28.185626 IP6 2a01:REDACTED.50378 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 347, ack 863, win 2583, options [nop,nop,TS val 2667894220 ecr 740554082], length 0
`       ... .@*....ANJ........ ..... ........X...9..........
........
....,#.b
21:41:28.185737 IP REDACTED.35330 > 130.239.18.158.6969: Flags [.], ack 620, win 2476, options [nop,nop,TS val 2782159525 ecr 695610515], length 0
E..4..@.@.\0t..........9.....3Y5..      ..3.....
..b.)v,.
21:41:28.185837 IP REDACTED.35330 > 130.239.18.158.6969: Flags [F.], seq 347, ack 621, win 2476, options [nop,nop,TS val 2782159525 ecr 695610515], length 0
E..4..@.@.\/t..........9.....3Y6..      ..3.....
..b.)v,.
^C
10 packets captured
2733 packets received by filter
101 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:41:28.395] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'started' (announcer.cc:805)
[2023-03-25 21:41:28.395] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:started] (announcer.cc:774)
[2023-03-25 21:41:28.395] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:41:28.396] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Announcing to tracker (announcer.cc:1592)
[2023-03-25 21:41:28.396] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=4288128172&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
[2023-03-25 21:41:28.396] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=4288128172&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
```

#### On exit

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:41:38.778042 IP REDACTED.49962 > 130.239.18.158.6969: Flags [S], seq 4001606163, win 2920, options [mss 1460,sackOK,TS val 2782170117 ecr 0,nop,wscale 0], length 0
E..<mV@.@..Xt........*.9...........h.;.........
............
21:41:38.778405 IP6 2a01:REDACTED.49028 > 2001:6b0:e:2018::158.6969: Flags [S], seq 1327327940, win 2880, options [mss 1440,sackOK,TS val 2667904813 ecr 0,nop,wscale 0], length 0
`.+".(.@*....ANJ........ ..... ........X...9O.j........@...........
...-........
21:41:38.813546 IP6 2a01:REDACTED.49028 > 2001:6b0:e:2018::158.6969: Flags [.], ack 3025697178, win 2880, options [nop,nop,TS val 2667904848 ecr 740564652], length 0
`.+". .@*....ANJ........ ..... ........X...9O.j..Xy....@.......
...P,$..
21:41:38.814391 IP REDACTED.49962 > 130.239.18.158.6969: Flags [.], ack 3783514063, win 2920, options [nop,nop,TS val 2782170154 ecr 695621085], length 0
E..4mW@.@.._t........*.9...........h.3.....
...*)vU.
21:41:38.903253 IP REDACTED.49962 > 130.239.18.158.6969: Flags [P.], seq 0:346, ack 1, win 2920, options [nop,nop,TS val 2782170243 ecr 695621085], length 346
E...mX@.@...t........*.9...........h.......
....)vU.GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3865509888&numwant=0&key=4288128172&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:41:38.903312 IP6 2a01:REDACTED.49028 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:346, ack 1, win 2880, options [nop,nop,TS val 2667904938 ecr 740564652], length 346
`.+".z.@*....ANJ........ ..... ........X...9O.j..Xy....@.5.....
....,$..GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3865509888&numwant=0&key=4288128172&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:41:38.939602 IP6 2a01:REDACTED.49028 > 2001:6b0:e:2018::158.6969: Flags [.], ack 137, win 2744, options [nop,nop,TS val 2667904974 ecr 740564836], length 0
`.+". .@*....ANJ........ ..... ........X...9O.l..Xz"..
........
....,$.d
21:41:38.939748 IP6 2a01:REDACTED.49028 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 346, ack 138, win 2744, options [nop,nop,TS val 2667904974 ecr 740564836], length 0
`.+". .@*....ANJ........ ..... ........X...9O.l..Xz#..
........
....,$.d
21:41:38.939767 IP REDACTED.49962 > 130.239.18.158.6969: Flags [.], ack 137, win 2784, options [nop,nop,TS val 2782170279 ecr 695621269], length 0
E..4mY@.@..]t........*.9...n...W..
..3.....
....)vV.
21:41:38.939972 IP REDACTED.49962 > 130.239.18.158.6969: Flags [F.], seq 346, ack 138, win 2784, options [nop,nop,TS val 2782170279 ecr 695621269], length 0
E..4mZ@.@..\t........*.9...n...X..
..3.....
....)vV.
21:42:52.382392 IP REDACTED.63676 > 130.239.18.158.8561: UDP, length 115
E...Sh..@.0.t.........!q.{..d1:ad2:id20:<e...>.j.`.x...!.1..9:info_hash20:.:./. ZJ...w\......Z6:noseedi1ee1:q9:get_peers1:t2:
W1:v4:LT..1:y1:qe
^C
11 packets captured
628 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:] (announcer.cc:774)
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'stopped' (announcer.cc:805)
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:stopped] (announcer.cc:774)
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3865509888&numwant=0&key=4288128172&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
[2023-03-25 21:41:39.080] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-f8a7aw6yk14x&port=51413&uploaded=0&downloaded=0&left=3865509888&numwant=0&key=4288128172&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
```

</details>

### `"bind-address-ipv6": "::"` and `"bind-address-ipv4": ""`

<details>
<summary>Click to expand/hide</summary>

#### On torrent start

`tcpdump`:
```
dropped privs to tcpdump
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:53:30.279847 IP REDACTED.40086 > 130.239.18.158.6969: Flags [S], seq 3009749805, win 2920, options [mss 1460,sackOK,TS val 2782881619 ecr 0,nop,wscale 0], length 0
E..<..@.@.7.t..........9.e#-.......h.;.........
..gS........
21:53:30.279975 IP6 2a01:REDACTED.39364 > 2001:6b0:e:2018::158.6969: Flags [S], seq 1471819594, win 2880, options [mss 1440,sackOK,TS val 2668616314 ecr 0,nop,wscale 0], length 0
`..=.(.@*....ANJ........ ..... ........X...9W./J.......@...........
...z........
21:53:30.315370 IP6 2a01:REDACTED.39364 > 2001:6b0:e:2018::158.6969: Flags [.], ack 1261710501, win 2880, options [nop,nop,TS val 2668616350 ecr 741276204], length 0
`..=. .@*....ANJ........ ..... ........X...9W./KK4,....@.......
....,..,
21:53:30.315473 IP6 2a01:REDACTED.39364 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:347, ack 1, win 2880, options [nop,nop,TS val 2668616350 ecr 741276204], length 347
`..=.{.@*....ANJ........ ..... ........X...9W./KK4,....@.6.....
....,..,GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=3190198377&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:53:30.316232 IP REDACTED.40086 > 130.239.18.158.6969: Flags [.], ack 56555413, win 2920, options [nop,nop,TS val 2782881656 ecr 696332637], length 0
E..4..@.@.8.t..........9.e#..^.....h.3.....
..gx).1]
21:53:30.316291 IP REDACTED.40086 > 130.239.18.158.6969: Flags [P.], seq 0:347, ack 1, win 2920, options [nop,nop,TS val 2782881656 ecr 696332637], length 347
E.....@.@.6.t..........9.e#..^.....h.......
..gx).1]GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=3190198377&compact=1&supportcrypto=1&event=started HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:53:30.351098 IP6 2a01:REDACTED.39364 > 2001:6b0:e:2018::158.6969: Flags [.], ack 766, win 2295, options [nop,nop,TS val 2668616385 ecr 741276248], length 0
`..=. .@*....ANJ........ ..... ........X...9W.0.K4/............
....,..X
21:53:30.352718 IP REDACTED.40086 > 130.239.18.158.6969: Flags [.], ack 620, win 2476, options [nop,nop,TS val 2782881692 ecr 696332682], length 0
E..4..@.@.8.t..........9.e$..^....      ..3.....
..g.).1.

...Hide scrape request to save space...

^C
17 packets captured
234 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'started' (announcer.cc:805)
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:started] (announcer.cc:774)
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Announcing to tracker (announcer.cc:1592)
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=3190198377&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
[2023-03-25 21:53:30.029] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=0&left=3909091328&numwant=80&key=3190198377&compact=1&supportcrypto=1&event=started' (announcer-http.cc:282)
```

#### On exit

`tcpdump`:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eno1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:53:42.610649 IP REDACTED.56898 > 130.239.18.158.6969: Flags [S], seq 608987061, win 2920, options [mss 1460,sackOK,TS val 2782893950 ecr 0,nop,wscale 0], length 0
E..<Xt@.@..:t........B.9$Lg........h.;.........
...~........
21:53:42.647381 IP REDACTED.56898 > 130.239.18.158.6969: Flags [.], ack 2255675889, win 2920, options [nop,nop,TS val 2782893987 ecr 696344925], length 0
E..4Xu@.@..At........B.9$Lg..r.....h.3.....
....).a]
21:53:42.647397 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [S], seq 3497716323, win 2880, options [mss 1440,sackOK,TS val 2668628682 ecr 0,nop,wscale 0], length 0
`       ...(.@*....ANJ........ ..... ........X.F.9.z.c.......@...........
..
.........
21:53:42.647537 IP REDACTED.56898 > 130.239.18.158.6969: Flags [P.], seq 0:351, ack 1, win 2920, options [nop,nop,TS val 2782893987 ecr 696344925], length 351
E...Xv@.@...t........B.9$Lg..r.....h.......
....).a]GET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=786432&left=3846684672&numwant=0&key=3190198377&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:53:42.682431 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [.], ack 271193223, win 2880, options [nop,nop,TS val 2668628717 ecr 741288556], length 0
`       ... .@*....ANJ........ ..... ........X.F.9.z.d.*.....@.......
..
.,/*l
21:53:42.682550 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [P.], seq 0:351, ack 1, win 2880, options [nop,nop,TS val 2668628717 ecr 741288556], length 351
`       .....@*....ANJ........ ..... ........X.F.9.z.d.*.....@.:.....
..
.,/*lGET /announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=786432&left=3846684672&numwant=0&key=3190198377&compact=1&supportcrypto=1&event=stopped HTTP/1.1
Host: bttracker.debian.org:6969
User-Agent: Transmission/4.0.2-dev
Accept: */*
Accept-Encoding: deflate, gzip, br


21:53:42.684350 IP REDACTED.56898 > 130.239.18.158.6969: Flags [.], ack 137, win 2784, options [nop,nop,TS val 2782894024 ecr 696345013], length 0
E..4Xw@.@..?t........B.9$Li..r.y..
..3.....
....).a.
21:53:42.717709 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [.], ack 137, win 2744, options [nop,nop,TS val 2668628752 ecr 741288615], length 0
`       ... .@*....ANJ........ ..... ........X.F.9.z...*....
........
....,/*.
21:53:42.725892 IP REDACTED.56898 > 130.239.18.158.6969: Flags [.], ack 138, win 2784, options [nop,nop,TS val 2782894065 ecr 696345013], length 0
E..4Xx@.@..>t........B.9$Li..r.z..
..3.....
....).a.
21:53:42.757895 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [.], ack 138, win 2744, options [nop,nop,TS val 2668628792 ecr 741288615], length 0
`       ... .@*....ANJ........ ..... ........X.F.9.z...*....
........
...8,/*.
21:53:42.776998 IP REDACTED.56898 > 130.239.18.158.6969: Flags [F.], seq 351, ack 138, win 2784, options [nop,nop,TS val 2782894116 ecr 696345013], length 0
E..4Xy@.@..=t........B.9$Li..r.z..
..3.....
...$).a.
21:53:42.777058 IP6 2a01:REDACTED.42054 > 2001:6b0:e:2018::158.6969: Flags [F.], seq 351, ack 138, win 2744, options [nop,nop,TS val 2668628811 ecr 741288615], length 0
`       ... .@*....ANJ........ ..... ........X.F.9.z...*....
........
...K,/*.
^C
12 packets captured
58 packets received by filter
0 packets dropped by kernel
```

Transmission log:
```
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:] (announcer.cc:774)
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 queued 'stopped' (announcer.cc:805)
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 [0:stopped] (announcer.cc:774)
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 announcing in 0 seconds (announcer.cc:835)
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv4 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=786432&left=3846684672&numwant=0&key=3190198377&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
[2023-03-25 21:53:42.988] trc debian-11.6.0-amd64-DVD-1.iso at bttracker.debian.org:6969 Sending IPv6 announce to libcurl: 'http://bttracker.debian.org:6969/announce?info_hash=%07c%B7W4%19V%B9%BFY%94%E4%A9%92%C3do%9F%19%BD&peer_id=-TR402Z-wwx868z2rc9c&port=51413&uploaded=0&downloaded=786432&left=3846684672&numwant=0&key=3190198377&compact=1&supportcrypto=1&event=stopped' (announcer-http.cc:282)
```
