### PR TITLE
Fix tr_net_hasIPv6()

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -368,7 +368,7 @@ bool tr_net_hasIPv6(tr_port port)
     if (!already_done)
     {
         int err = 0;
-        auto const fd = tr_netBindTCPImpl(tr_address::any_ipv4(), port, true, &err);
+        auto const fd = tr_netBindTCPImpl(tr_address::any_ipv6(), port, true, &err);
 
         if (fd != TR_BAD_SOCKET || err != EAFNOSUPPORT) /* we support ipv6 */
         {


### PR DESCRIPTION
```
commit 36edd516aa550c8b08f0b18fd9cc3e51b843e3f4
Author: Charles Kerr <charles@charleskerr.com>
Date:   Sun Nov 6 10:35:48 2022 -0600

    refactor: replace tr_boundinfo with tr_session::BoundSocket (#4103)

diff --git a/libtransmission/net.cc b/libtransmission/net.cc
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -500,1 +496,1 @@
-        auto const fd = tr_netBindTCPImpl(&tr_in6addr_any, port, true, &err);
+        auto const fd = tr_netBindTCPImpl(tr_address::AnyIPv4(), port, true, &err);
```