### PR TITLE
Reduce GTK Prefs.ui size to 90

### DIFF
--- a/gtk/ui/gtk3/PrefsDialog.ui
+++ b/gtk/ui/gtk3/PrefsDialog.ui
@@ -1552,7 +1552,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkScrolledWindow" id="default_trackers_scroll">
-                        <property name="height-request">100</property>
+                        <property name="height-request">90</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="hexpand">True</property>

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -1075,7 +1075,7 @@
                         <property name="vexpand">True</property>
                         <child>
                           <object class="GtkScrolledWindow" id="default_trackers_scroll">
-                            <property name="height-request">100</property>
+                            <property name="height-request">90</property>
                             <property name="focusable">1</property>
                             <property name="hexpand">1</property>
                             <property name="vexpand">1</property>


### PR DESCRIPTION
A follow-up to #5276 that hopefully resolves user feedback. https://github.com/transmission/transmission/pull/5276#issuecomment-1500055454

Notes: Fixed preferences dialog being too large for small displays.