### PR TITLE
fix: silence torrent-metainfo warnings for cross_seed_entry, uid

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -408,6 +408,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
+            pathIs(InfoKey, CrossSeedEntryKey) || //
             pathIs(InfoKey, Ed2kKey) || //
             pathIs(InfoKey, EntropyKey) || //
             pathIs(InfoKey, Md5sumKey) || //
@@ -421,6 +422,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             pathIs(PublisherUrlKey) || //
             pathIs(PublisherUrlUtf8Key) || //
             pathIs(TitleKey) || //
+            pathIs(UidKey) || //
             pathStartsWith(AzureusPrivatePropertiesKey) || //
             pathStartsWith(AzureusPropertiesKey) || //
             pathStartsWith(InfoKey, CollectionsKey) || //
@@ -578,6 +580,7 @@ private:
     static constexpr std::string_view CreatedByKey = "created by"sv;
     static constexpr std::string_view CreatedByUtf8Key = "created by.utf-8"sv;
     static constexpr std::string_view CreationDateKey = "creation date"sv;
+    static constexpr std::string_view CrossSeedEntryKey = "cross_seed_entry"sv;
     static constexpr std::string_view DisplayNameKey = "display-name"sv;
     static constexpr std::string_view DurationKey = "duration"sv;
     static constexpr std::string_view Ed2kKey = "ed2k"sv;
@@ -621,6 +624,7 @@ private:
     static constexpr std::string_view Sha1Key = "sha1"sv;
     static constexpr std::string_view SourceKey = "source"sv;
     static constexpr std::string_view TitleKey = "title"sv;
+    static constexpr std::string_view UidKey = "uid"sv;
     static constexpr std::string_view UniqueKey = "unique"sv;
     static constexpr std::string_view UrlListKey = "url-list"sv;
     static constexpr std::string_view VcodecKey = "vcodec"sv;


### PR DESCRIPTION
Fixes #5354.

Notes: Fixed minor warnings for `cross_seed_entry` and `uid` entries in torrent files.