### PR TITLE
fix: return success on RPC add-torrent duplicate

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1508,7 +1508,7 @@ void addTorrentImpl(struct tr_rpc_idle_data* data, tr_ctor* ctor)
             tr_variantDictAdd(data->args_out, TR_KEY_torrent_duplicate),
             std::data(Fields),
             std::size(Fields));
-        tr_idle_function_done(data, "duplicate torrent"sv);
+        tr_idle_function_done(data, SuccessResult);
         return;
     }
 


### PR DESCRIPTION
Same behavior as Transmission 3 to avoid unnannounced API change.

Fixes #5355.