### PR TITLE
ci: fix Sanity/Windows GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -385,8 +385,6 @@ jobs:
             jom `
             nasm `
             nodejs
-          choco uninstall `
-            openssl.light
           (Join-Path $Env:ProgramFiles NASM) | Out-File $Env:GITHUB_PATH -Append
           (Join-Path ${Env:ProgramFiles(x86)} 'WiX Toolset v3.11' bin) | Out-File $Env:GITHUB_PATH -Append
 


### PR DESCRIPTION
Fixes `Sanity / Windows` GitHub Actions CI failure:

```
Uninstalling the following packages:
openssl.light
openssl.light is not installed. Cannot uninstall a non-existent package.

Chocolatey uninstalled 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - openssl.light - openssl.light is not installed. Cannot uninstall a non-existent package.

If a package uninstall is failing and/or you've already uninstalled the
 software outside of Chocolatey, you can attempt to run the command
 with `-n` to skip running a chocolateyUninstall script, additionally
 adding `--skip-autouninstaller` to skip an attempt to automatically
 remove system-installed software. Only the packaging files are removed
 and not things like software installed to Programs and Features.
```