### PR TITLE
fix: restore accidentally-deleted copyright notice (GTK)

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -99,9 +99,10 @@ namespace
 auto const AppIconName = "transmission"sv; // TODO(C++20): Use ""s
 
 char const* const LICENSE =
-    "Copyright 2005-2022. All code is copyrighted by the respective authors.\n"
+    "Copyright 2005-2023. All code is copyrighted by the respective authors.\n"
     "\n"
     "Transmission can be redistributed and/or modified under the terms of the "
+    "GNU GPL, versions 2 or 3, or by any future license endorsed by Mnemosyne LLC."
     "\n"
     "In addition, linking to and/or using OpenSSL is allowed.\n"
     "\n"


### PR DESCRIPTION
It looks like this line was deleted in https://github.com/transmission/transmission/commit/df1cca9b573789634b182a5b98a8cc6382314643, leaving the copyright notice incomplete:

![Screenshot_20230412_141423](https://user-images.githubusercontent.com/19615999/231468966-46548692-0051-40de-90c5-5c0896dd3196.png)

This commit rectifies the problem, as well as updating the stated copyright year.