### PR TITLE
fix: only torrent metainfo display-name as a fallback

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -390,7 +390,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         {
             tm_.addWebseed(value);
         }
-        else if (pathIs(MagnetInfoKey, DisplayNameKey))
+        else if (pathIs(MagnetInfoKey, DisplayNameKey) && std::empty(tm_.name()))
         {
             // compatibility with Transmission <= 3.0
             tm_.setName(value);


### PR DESCRIPTION
Fixes #5347.

Notes: Fixed use of metainfo display-name as a fallback name.