### PR TITLE
Copyright updates

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -70,7 +70,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
+++ b/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
@@ -49,7 +49,7 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>QLNeedsToBeRunInMainThread</key>
 	<false/>
 	<key>QLPreviewHeight</key>

--- a/macosx/da.lproj/InfoPlist.strings
+++ b/macosx/da.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/de.lproj/InfoPlist.strings
+++ b/macosx/de.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/en.lproj/InfoPlist.strings
+++ b/macosx/en.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/es.lproj/InfoPlist.strings
+++ b/macosx/es.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/fr.lproj/InfoPlist.strings
+++ b/macosx/fr.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/it.lproj/InfoPlist.strings
+++ b/macosx/it.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/nl.lproj/InfoPlist.strings
+++ b/macosx/nl.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/pt_PT.lproj/InfoPlist.strings
+++ b/macosx/pt_PT.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/ru.lproj/InfoPlist.strings
+++ b/macosx/ru.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/macosx/tr.lproj/InfoPlist.strings
+++ b/macosx/tr.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";


### PR DESCRIPTION
This covers the About box and the localizations, 2022 -> 2023.

No functionality.  Just the one byte change in each file. :)

@CKerr I finally figured it out. :)