### PR TITLE
try reconnecting to peers more frequently; increase default reqq for both peer and client

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -255,7 +255,7 @@ struct peer_atom
         return std::nullopt;
     }
 
-    constexpr void incrementFailCount(void) noexcept {
+    constexpr void incrementFailCount() noexcept {
         if (this->num_fails != ~0) {
             ++this->num_fails;
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -256,7 +256,8 @@ struct peer_atom
     }
 
     constexpr void incrementFailCount() noexcept {
-        if (this->num_fails != ~0) {
+        static auto constexpr Max = std::numeric_limits<decltype(num_fails)>::max();
+        if (this->num_fails != Max) {
             ++this->num_fails;
         }
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -164,7 +164,11 @@ auto constexpr KeepaliveIntervalSecs = int{ 100 };
 
 auto constexpr MetadataReqQ = int{ 64 };
 
-auto constexpr ReqQ = int{ 512 };
+// libtorrent-rasterbar defaults to 2000
+auto constexpr ReqQ = int{ 2000 };
+
+// libtorrent-rasterbar defaults to 500
+auto constexpr ReqC = int{ 500 };
 
 // used in lowering the outMessages queue period
 
@@ -557,7 +561,7 @@ private:
         size_t constexpr Floor = 32;
         size_t constexpr Seconds = RequestBufSecs;
         size_t const estimated_blocks_in_period = (rate_bytes_per_second * Seconds) / tr_block_info::BlockSize;
-        size_t const ceil = reqq ? *reqq : 250;
+        size_t const ceil = reqq ? *reqq : ReqC;
 
         auto max_reqs = estimated_blocks_in_period;
         max_reqs = std::min(max_reqs, ceil);
@@ -647,6 +651,7 @@ public:
     /* if the peer supports the Extension Protocol in BEP 10 and
        supplied a reqq argument, it's stored here. */
     std::optional<size_t> reqq;
+    int reqc;
 
     std::unique_ptr<libtransmission::Timer> pex_timer_;
 
@@ -961,7 +966,7 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     // http://bittorrent.org/beps/bep_0010.html
     // An integer, the number of outstanding request messages this
     // client supports without dropping any. The default in in
-    // libtorrent is 250.
+    // libtorrent is 2000.
     tr_variantDictAddInt(&val, TR_KEY_reqq, ReqQ);
 
     // https://www.bittorrent.org/beps/bep_0010.html

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -18,7 +18,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr MyStatic = std::array<std::string_view, 402>{ ""sv,
+auto constexpr MyStatic = std::array<std::string_view, 403>{ ""sv,
                                                              "activeTorrentCount"sv,
                                                              "activity-date"sv,
                                                              "activityDate"sv,
@@ -290,6 +290,7 @@ auto constexpr MyStatic = std::array<std::string_view, 402>{ ""sv,
                                                              "remote-session-username"sv,
                                                              "removed"sv,
                                                              "rename-partial-files"sv,
+                                                             "reqc"sv,
                                                              "reqq"sv,
                                                              "result"sv,
                                                              "rpc-authentication-required"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -293,6 +293,7 @@ enum
     TR_KEY_remote_session_username,
     TR_KEY_removed,
     TR_KEY_rename_partial_files,
+    TR_KEY_reqc,
     TR_KEY_reqq,
     TR_KEY_result,
     TR_KEY_rpc_authentication_required,

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -52,6 +52,8 @@ struct tr_variant;
     V(TR_KEY_queue_stalled_minutes, queue_stalled_minutes, size_t, 30U, "") \
     V(TR_KEY_ratio_limit, ratio_limit, double, 2.0, "") \
     V(TR_KEY_ratio_limit_enabled, ratio_limit_enabled, bool, false, "") \
+    V(TR_KEY_reqc, reqc, size_t, 500, "") \
+    V(TR_KEY_reqq, reqq, size_t, 2000, "") \
     V(TR_KEY_rename_partial_files, is_incomplete_file_naming_enabled, bool, false, "") \
     V(TR_KEY_scrape_paused_torrents_enabled, should_scrape_paused_torrents, bool, true, "") \
     V(TR_KEY_script_torrent_added_enabled, script_torrent_added_enabled, bool, false, "") \


### PR DESCRIPTION
Transmission has been a very... reclusive player in swarms. I've done a couple of syncs with another library, libtorrent-rasterbar (lt), to bring some of the hard coded defines up to the "desktop" level that the rasterbar documentation defaults to.

lt has 3 presets, with all values being "tweakable". right now transmission seems is somewhere between min_memory_usage and desktop, which is not ideal for the ecosystem outside of embedded.

```
	// The default values of the session settings are set for a regular
	// bittorrent client running on a desktop system. There are functions that
	// can set the session settings to pre set settings for other environments.
	// These can be used for the basis, and should be tweaked to fit your needs
	// better.
	//
	// ``min_memory_usage`` returns settings that will use the minimal amount of
	// RAM, at the potential expense of upload and download performance. It
	// adjusts the socket buffer sizes, disables the disk cache, lowers the send
	// buffer watermarks so that each connection only has at most one block in
	// use at any one time. It lowers the outstanding blocks send to the disk
	// I/O thread so that connections only have one block waiting to be flushed
	// to disk at any given time. It lowers the max number of peers in the peer
	// list for torrents. It performs multiple smaller reads when it hashes
	// pieces, instead of reading it all into memory before hashing.
	//
	// This configuration is intended to be the starting point for embedded
	// devices. It will significantly reduce memory usage.
	//
	// ``high_performance_seed`` returns settings optimized for a seed box,
	// serving many peers and that doesn't do any downloading. It has a 128 MB
	// disk cache and has a limit of 400 files in its file pool. It support fast
	// upload rates by allowing large send buffers.
```

It should be noted that even high_performance_seed isn't good enough for some swarms, which brings people to configuring the settings_pack to better fit their environment.

Where this sits right now is how should this be implemented. There's 20~ more "options" that need to be updated / added, I've picked some small samples that should net large (and basic) wins. I put in 2 place holders in session-settings.h but there's no clear way to bring that into the fold as each "frontend" does it differently.