### PR TITLE
chore: prefer fmt/core.h over fmt/format.h

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -10,7 +10,7 @@
 
 #include <signal.h>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 

--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -17,7 +17,7 @@
 
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "daemon.h"
 

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -8,7 +8,7 @@
 
 #include <algorithm> /* std::max() */
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "daemon.h"
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -49,7 +49,6 @@
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include <algorithm>
 #include <array>

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -23,7 +23,6 @@
 #include <gtkmm/window.h>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include <cstddef>
 #include <ctime>

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -21,7 +21,6 @@
 #endif
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -20,7 +20,7 @@ extern "C"
 #include <b64/cencode.h>
 }
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -49,7 +49,7 @@
 #define USE_COPY_FILE_RANGE
 #endif /* __linux__ */
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -15,7 +15,7 @@
 #include <shlobj.h> /* SHCreateDirectoryEx() */
 #include <winioctl.h> /* FSCTL_SET_SPARSE */
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -10,7 +10,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -7,7 +7,7 @@
 
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "quark.h"
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -18,7 +18,7 @@
 #endif
 
 #include <fmt/chrono.h>
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -10,7 +10,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -15,7 +15,7 @@
 
 #include <libutp/utp.h>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #define LIBTRANSMISSION_PEER_MODULE
 #include "libtransmission/transmission.h"

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libutp/utp.h>
 

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -32,7 +32,7 @@
 #include <FindDirectory.h>
 #endif
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -13,7 +13,6 @@
 #include <utility>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #ifdef SYSTEM_MINIUPNP
 #include <miniupnpc/miniupnpc.h>

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
 #include <fmt/format.h> // fmt::ptr
 
 #include "libtransmission/transmission.h"

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -11,7 +11,7 @@
 #include <sys/stat.h>
 #endif
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/session-settings.cc
+++ b/libtransmission/session-settings.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -29,7 +29,6 @@
 #include <event2/event.h>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
 #include <fmt/format.h> // fmt::ptr
 
 #include "libtransmission/transmission.h"

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -14,7 +14,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -12,7 +12,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <fmt/xchar.h> // for wchar_t support
 
 #include <windows.h>

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -13,7 +13,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-assert.mm
+++ b/libtransmission/tr-assert.mm
@@ -7,7 +7,7 @@
 
 #include <cstdlib> // for abort()
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "tr-assert.h"
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -30,7 +30,7 @@
 #include <netinet/in.h> /* sockaddr_in */
 #endif
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -8,7 +8,7 @@
 #include <cstring>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -20,7 +20,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -9,7 +9,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 /**
  * A memory buffer which uses a builtin array of N bytes, using heap

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -6,7 +6,6 @@
 #include <chrono>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include <libutp/utp.h>
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -35,7 +35,7 @@
 #define UTF_CPP_CPLUSPLUS 201703L
 #include <utf8.h>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <fast_float/fast_float.h>
 #include <wildmat.h>

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -9,8 +9,8 @@
 #include <string_view>
 #include <optional>
 
+#include <fmt/core.h>
 #include <fmt/compile.h>
-#include <fmt/format.h>
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 

--- a/libtransmission/variant-converters.cc
+++ b/libtransmission/variant-converters.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -17,8 +17,9 @@
 #define UTF_CPP_CPLUSPLUS 201703L
 #include <utf8.h>
 
+#include <fmt/core.h>
 #include <fmt/compile.h>
-#include <fmt/format.h>
+
 #include <jsonsl.h>
 
 #define LIBTRANSMISSION_VARIANT_MODULE

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -14,7 +14,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #define PSL_STATIC
 #include <libpsl.h>

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -11,7 +11,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "tr-macros.h" // tr_sha1_digest_t
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -24,7 +24,6 @@
 #include <curl/curl.h>
 
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "libtransmission/transmission.h"
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -5,7 +5,7 @@
 
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "RpcClient.h"
 

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 

--- a/tests/libtransmission/benc-test.cc
+++ b/tests/libtransmission/benc-test.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -11,7 +11,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -9,7 +9,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -21,7 +21,7 @@
 #include <event2/buffer.h>
 
 #include <fmt/chrono.h>
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/crypto-utils.h>

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -14,7 +14,6 @@
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
-#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 


### PR DESCRIPTION
fmtlib/fmt/issues/1755 explains:

> If you need any of "compile-time format string checks, output iterator and user-defined type support" then use fmt/format.h, otherwise use fmt/core.h.