### PR TITLE
GTK: Improve appstream metainfo

### DIFF
--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -38,4 +38,11 @@ Copyright 2017 Endless Mobile, Inc.
   <content_rating type="oars-1.1">
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
+  <releases>
+    <release date="2023-04-14" version="4.0.3" />
+    <release date="2023-03-16" version="4.0.2" />
+    <release date="2023-02-23" version="4.0.1" />
+    <release date="2023-02-08" version="4.0.0" />
+    <release date="2020-05-03" version="3.00" />
+  </releases>
 </component>

--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -29,6 +29,14 @@ Copyright 2017 Endless Mobile, Inc.
     </p>
   </description>
   <url type="homepage">https://transmissionbt.com/</url>
+  <url type="bugtracker">https://github.com/transmission/transmission/issues</url>
+  <url type="faq">https://transmissionbt.com/help/gtk/latest/html/FAQ.html</url>
+  <url type="help">https://transmissionbt.com/help/gtk/latest/index.html</url>
+  <url type="donation">https://transmissionbt.com/donate</url>
+  <url type="translate">https://explore.transifex.com/transmissionbt/transmissionbt/</url>
+  <url type="contact">https://github.com/transmission/transmission/discussions</url>
+  <url type="vcs-browser">https://github.com/transmission/transmission</url>
+  <url type="contribute">https://github.com/transmission/transmission/blob/main/CONTRIBUTING.md</url>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/transmission/transmission/main/gtk/screenshots/a.png</image>

--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -53,4 +53,5 @@ Copyright 2017 Endless Mobile, Inc.
     <release date="2023-02-08" version="4.0.0" />
     <release date="2020-05-03" version="3.00" />
   </releases>
+  <translation type="gettext">transmission-gtk</translation>
 </component>


### PR DESCRIPTION
The first patch is derived from a patch that has been included in the Flathub version for 5+ years. The others are improvements I added while I was here.