### PR TITLE
refactor: add tr_sys_dir_get_files()

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -294,25 +294,12 @@ auto parseFile(std::string_view filename)
 
 auto getFilenamesInDir(std::string_view folder)
 {
-    auto files = std::vector<std::string>{};
-
-    if (auto const odir = tr_sys_dir_open(folder); odir != TR_BAD_SYS_DIR)
+    auto const prefix = std::string{ folder } + '/';
+    auto files = tr_sys_dir_get_files(folder, tr_strvIsNotDotFile);
+    for (auto& file : files)
     {
-        char const* name = nullptr;
-        auto const prefix = std::string{ folder } + '/';
-        while ((name = tr_sys_dir_read_name(odir)) != nullptr)
-        {
-            if (name[0] == '.') // ignore dotfiles
-            {
-                continue;
-            }
-
-            files.emplace_back(prefix + name);
-        }
-
-        tr_sys_dir_close(odir);
+        file.insert(0, prefix);
     }
-
     return files;
 }
 

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -8,9 +8,11 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint64_t
 #include <ctime> // time_t
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -611,6 +613,13 @@ char const* tr_sys_dir_read_name(tr_sys_dir_t handle, struct tr_error** error = 
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
 bool tr_sys_dir_close(tr_sys_dir_t handle, struct tr_error** error = nullptr);
+
+[[nodiscard]] std::vector<std::string> tr_sys_dir_get_files(std::string_view folder, tr_error** error = nullptr);
+
+[[nodiscard]] std::vector<std::string> tr_sys_dir_get_files(
+    std::string_view folder,
+    std::function<bool(std::string_view name)> const& test,
+    tr_error** error = nullptr);
 
 /** @} */
 /** @} */

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -86,33 +86,16 @@ void walkTree(std::string_view const top, std::string_view const subpath, std::s
     switch (info->type)
     {
     case TR_SYS_PATH_IS_DIRECTORY:
-        if (tr_sys_dir_t odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR)
+        for (auto const& name : tr_sys_dir_get_files(path, tr_strvIsNotDotFile))
         {
-            for (;;)
+            if (!std::empty(subpath))
             {
-                char const* const name = tr_sys_dir_read_name(odir);
-
-                if (name == nullptr)
-                {
-                    break;
-                }
-
-                if (name[0] == '.') // skip dotfiles
-                {
-                    continue;
-                }
-
-                if (!std::empty(subpath))
-                {
-                    walkTree(top, tr_pathbuf{ subpath, '/', name }, files);
-                }
-                else
-                {
-                    walkTree(top, name, files);
-                }
+                walkTree(top, tr_pathbuf{ subpath, '/', name }, files);
             }
-
-            tr_sys_dir_close(odir);
+            else
+            {
+                walkTree(top, name, files);
+            }
         }
         break;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1341,7 +1341,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     auto n_torrents = size_t{};
     auto const& folder = session->torrentDir();
 
-    for (auto const& name : tr_sys_dir_get_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".torrent"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strvEndsWith(name, ".torrent"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 
@@ -1352,7 +1352,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     }
 
     auto buf = std::vector<char>{};
-    for (auto const& name : tr_sys_dir_get_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".magnet"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strvEndsWith(name, ".magnet"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1336,45 +1336,12 @@ namespace
 {
 namespace load_torrents_helpers
 {
-[[nodiscard]] std::vector<std::string> get_matching_files(
-    std::string const& folder,
-    std::function<bool(std::string_view)> const& test)
-{
-    if (auto const info = tr_sys_path_get_info(folder); !info || !info->isFolder())
-    {
-        return {};
-    }
-
-    auto const odir = tr_sys_dir_open(folder);
-    if (odir == TR_BAD_SYS_DIR)
-    {
-        return {};
-    }
-
-    auto filenames = std::vector<std::string>{};
-    for (;;)
-    {
-        char const* const name = tr_sys_dir_read_name(odir);
-
-        if (name == nullptr)
-        {
-            tr_sys_dir_close(odir);
-            return filenames;
-        }
-
-        if (test(name))
-        {
-            filenames.emplace_back(name);
-        }
-    }
-}
-
 void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size_t>* loaded_promise)
 {
     auto n_torrents = size_t{};
     auto const& folder = session->torrentDir();
 
-    for (auto const& name : get_matching_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".torrent"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".torrent"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 
@@ -1385,7 +1352,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     }
 
     auto buf = std::vector<char>{};
-    for (auto const& name : get_matching_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".magnet"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto const& name) { return tr_strvEndsWith(name, ".magnet"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -183,6 +183,11 @@ template<typename T>
     return !std::empty(sv) && sv.back() == key;
 }
 
+[[nodiscard]] constexpr bool tr_strvIsNotDotFile(std::string_view sv)
+{
+    return !tr_strvStartsWith(sv, '.');
+}
+
 constexpr std::string_view tr_strvSep(std::string_view* sv, char delim)
 {
     auto pos = sv->find(delim);

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -110,32 +110,10 @@ void BaseWatchdir::processFile(std::string_view basename)
 void BaseWatchdir::scan()
 {
     tr_error* error = nullptr;
-    auto const dir = tr_sys_dir_open(dirname_, &error);
-    if (dir == TR_BAD_SYS_DIR)
+
+    for (auto const& file : tr_sys_dir_get_files(dirname_, tr_strvIsNotDotFile, &error))
     {
-        tr_logAddWarn(fmt::format(
-            _("Couldn't read '{path}': {error} ({error_code})"),
-            fmt::arg("path", dirname()),
-            fmt::arg("error", error->message),
-            fmt::arg("error_code", error->code)));
-        tr_error_free(error);
-        return;
-    }
-
-    for (;;)
-    {
-        char const* const name = tr_sys_dir_read_name(dir, &error);
-        if (name == nullptr)
-        {
-            break;
-        }
-
-        if ("."sv == name || ".."sv == name)
-        {
-            continue;
-        }
-
-        processFile(name);
+        processFile(file);
     }
 
     if (error != nullptr)
@@ -147,8 +125,6 @@ void BaseWatchdir::scan()
             fmt::arg("error_code", error->code)));
         tr_error_free(error);
     }
-
-    tr_sys_dir_close(dir);
 }
 
 } // namespace impl


### PR DESCRIPTION
This is a small helper function to get a list of files from directory X which pass some filter test.

It simplifies some libtransmission code that walks through a directory.