### PR TITLE
fix: no such file or directory warning in transmission-cli

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -259,7 +259,8 @@ int tr_main(int argc, char* argv[])
 
     tr_ctorSetPaused(ctor, TR_FORCE, false);
 
-    if (tr_ctorSetMetainfoFromFile(ctor, torrentPath, nullptr) || tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath, nullptr))
+    if (tr_sys_path_exists(torrentPath) ? tr_ctorSetMetainfoFromFile(ctor, torrentPath, nullptr) :
+                                          tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath, nullptr))
     {
         // all good
     }


### PR DESCRIPTION
Fixes #5424.

Notes: Fixed "no such file or directory" warning when adding a magnet link.