### PR TITLE
fix: Buffer::Buffer(Buffer&&) bug 

### DIFF
--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -259,7 +259,6 @@ public:
 
     Buffer(Buffer const&) = delete;
     Buffer& operator=(Buffer const&) = delete;
-    ~Buffer() = default;
 
     template<typename T>
     explicit Buffer(T const& data)

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -112,7 +112,7 @@ public:
         using reference = value_type&;
         using iterator_category = std::random_access_iterator_tag;
 
-        constexpr Iterator(evbuffer* buf, size_t offset)
+        constexpr Iterator(evbuffer* const buf, size_t offset)
             : buf_{ buf }
             , buf_offset_{ offset }
         {
@@ -240,15 +240,26 @@ public:
         size_t buf_offset_ = 0;
     };
 
-    Buffer(Buffer&&) = default;
-    Buffer(Buffer const&) = delete;
-    Buffer& operator=(Buffer const&) = delete;
-    Buffer& operator=(Buffer&&) = default;
-
     Buffer()
         : BufferWriter<Buffer, std::byte>{ this }
     {
     }
+
+    Buffer(Buffer&& that)
+        : BufferWriter<Buffer, std::byte>(this)
+        , buf_{ std::move(that.buf_) }
+    {
+    }
+
+    Buffer& operator=(Buffer&& that)
+    {
+        buf_ = std::move(that.buf_);
+        return *this;
+    }
+
+    Buffer(Buffer const&) = delete;
+    Buffer& operator=(Buffer const&) = delete;
+    ~Buffer() = default;
 
     template<typename T>
     explicit Buffer(T const& data)

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -62,6 +62,52 @@ TEST_F(BufferTest, startsWithInMultiSegment)
     EXPECT_TRUE(buf->starts_with("Hello, World!"sv));
 }
 
+TEST_F(BufferTest, Move)
+{
+    auto constexpr TwoChars = "12"sv;
+    auto constexpr SixChars = "123456"sv;
+    auto constexpr TenChars = "1234567890"sv;
+
+    auto a = Buffer{ TwoChars };
+    auto b = Buffer{ SixChars };
+    auto c = Buffer{ TenChars };
+
+    auto lens = std::array<size_t, 3>{ std::size(TwoChars), std::size(SixChars), std::size(TenChars) };
+
+    EXPECT_EQ(lens[0], std::size(a));
+    EXPECT_EQ(lens[1], std::size(b));
+    EXPECT_EQ(lens[2], std::size(c));
+
+    std::swap(a, b);
+    EXPECT_EQ(lens[0], std::size(b));
+    EXPECT_EQ(lens[1], std::size(a));
+    EXPECT_EQ(lens[2], std::size(c));
+
+    std::swap(a, c);
+    EXPECT_EQ(lens[0], std::size(b));
+    EXPECT_EQ(lens[1], std::size(c));
+    EXPECT_EQ(lens[2], std::size(a));
+
+    std::swap(b, c);
+    EXPECT_EQ(lens[0], std::size(c));
+    EXPECT_EQ(lens[1], std::size(b));
+    EXPECT_EQ(lens[2], std::size(a));
+
+    a.add(std::data(TwoChars), std::size(TwoChars));
+
+    {
+        auto constexpr OneChar = "1"sv;
+        auto d = Buffer{ OneChar };
+
+        std::swap(a, d);
+        EXPECT_EQ(1U, std::size(a));
+    }
+
+    EXPECT_EQ(1U, std::size(a));
+    a.add(std::data(TwoChars), std::size(TwoChars));
+    EXPECT_EQ(3U, std::size(a));
+}
+
 TEST_F(BufferTest, NonBufferWriter)
 {
     auto constexpr Hello = "Hello, "sv;


### PR DESCRIPTION
fixup unreleased Buffer bug introduced by the BufferWriter refactor in ed4919a4f49343d2e73559e6758bd1462838b930. The problem was that the move operator should not change the parent BufferWriter's pointer field.

Fixes #5422.

Does not affect 4.0.x branch since `BufferWriter` is new in 4.1.0-dev