### PR TITLE
fixup! feat: Add BufferWriter class (#5154)

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -581,6 +581,7 @@ void tr_peerIo::write(libtransmission::Buffer& buf, bool is_piece_data)
     encrypt(len, bytes);
     outbuf_info_.emplace_back(std::size(buf), is_piece_data);
     outbuf_.add(buf);
+    buf.clear();
 }
 
 void tr_peerIo::write_bytes(void const* bytes, size_t n_bytes, bool is_piece_data)


### PR DESCRIPTION
fix `tr_peerIo::write(Buffer&)`, which broke as a side-effect of the 4.1.0-dev BufferWriter refactor. 4.0.x is unaffected.

The issue is that `tr_peerIo::write(Buffer&)` still needs to consume the buffer contents.

Fixes #5423.