### PR TITLE
fix: bug that prevented providing the final metadata piece

### DIFF
--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -65,6 +65,12 @@ auto create_all_needed(int n_pieces)
 
     return ret;
 }
+
+[[nodiscard]] int div_ceil(int numerator, int denominator)
+{
+    auto const [quot, rem] = std::div(numerator, denominator);
+    return quot + (rem == 0 ? 0 : 1);
+}
 } // namespace
 
 bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
@@ -79,12 +85,8 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
         return false;
     }
 
-    int const n = (size <= 0 || size > INT_MAX) ?
-        -1 :
-        static_cast<int>(size / METADATA_PIECE_SIZE + (size % METADATA_PIECE_SIZE != 0 ? 1 : 0));
-
+    int const n = (size <= 0 || size > INT_MAX) ? -1 : div_ceil(size, METADATA_PIECE_SIZE);
     tr_logAddDebugTor(tor, fmt::format("metadata is {} bytes in {} pieces", size, n));
-
     if (n <= 0)
     {
         return false;
@@ -121,7 +123,7 @@ std::optional<std::vector<std::byte>> tr_torrentGetMetadataPiece(tr_torrent cons
         return {};
     }
 
-    auto const n_pieces = std::max(1, static_cast<int>(tor->info_dict_size() / METADATA_PIECE_SIZE));
+    auto const n_pieces = std::max(1, div_ceil(tor->info_dict_size(), METADATA_PIECE_SIZE));
     if (piece < 0 || piece >= n_pieces)
     {
         return {};


### PR DESCRIPTION
Fixes off-by-one bug in [BEP 9](https://www.bittorrent.org/beps/bep_0009.html) implementation that prevented the final piece of metadata from being sent.

Affects `4.0.0` through `4.0.3`.

Notes: Fixed bug in sending metadata files to peers.