### PR TITLE
ci: do not install homebrew libnatpmp on macos 11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Get Dependencies
         run: |
           brew update
-          brew install cmake gettext libdeflate libevent libnatpmp libpsl miniupnpc ninja node pkg-config
+          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: brew install gtkmm3


### PR DESCRIPTION
Temporary workaround for what appears to be an upstream issue from https://github.com/Homebrew/homebrew-core/pull/129122 -- that landed at the same time that this breakage was introduced.

I haven't opened an upstream issue yet since I haven't tested firsthand on a macOS box.

The breakage is:

> In file included from /Users/runner/work/transmission/transmission/src/libtransmission/port-forwarding-natpmp.cc:16: /usr/local/include/natpmp.h:52:10: fatal error: 'natpmp_declspec.h' file not found
> 1 error generated.
