### PR TITLE
Typos in libtransmission tests

### DIFF
--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -429,7 +429,7 @@ TEST_F(AnnouncerUdpTest, canMultiScrape)
 
 TEST_F(AnnouncerUdpTest, canHandleScrapeError)
 {
-    // build the expected reponse
+    // build the expected response
     auto expected_response = tr_scrape_response{};
     expected_response.did_connect = true;
     expected_response.did_timeout = false;
@@ -598,7 +598,7 @@ TEST_F(AnnouncerUdpTest, canAnnounce)
     expected_response.min_interval = 0; // not specified in UDP announce
     expected_response.seeders = Seeders;
     expected_response.leechers = Leechers;
-    expected_response.downloads = -1; // not specified in UDP anounce
+    expected_response.downloads = -1; // not specified in UDP announce
     expected_response.pex = std::vector<tr_pex>{ tr_pex{ addresses[0].first, addresses[0].second },
                                                  tr_pex{ addresses[1].first, addresses[1].second },
                                                  tr_pex{ addresses[2].first, addresses[2].second } };

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -49,7 +49,7 @@ TEST_F(BufferTest, startsWithInMultiSegment)
 
     buf->add(Buffer{ World });
     EXPECT_TRUE(buf->starts_with(Hello));
-    EXPECT_TRUE(buf->starts_with("Hello, World"sv));
+    EXPECT_TRUE(buf->starts_with("Hello, Worl"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_FALSE(buf->starts_with("Hello, World!"sv));
     EXPECT_FALSE(buf->starts_with("Hello!"sv));

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -25,7 +25,7 @@ TEST_F(BufferTest, startsWithInSingleSegment)
 
     buf.add(World);
     EXPECT_TRUE(buf.starts_with(Hello));
-    EXPECT_TRUE(buf.starts_with("Hello, World"sv));
+    EXPECT_TRUE(buf.starts_with("Hello, Worl"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_FALSE(buf.starts_with("Hello, World!"sv));
     EXPECT_FALSE(buf.starts_with("Hello!"sv));

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -25,7 +25,7 @@ TEST_F(BufferTest, startsWithInSingleSegment)
 
     buf.add(World);
     EXPECT_TRUE(buf.starts_with(Hello));
-    EXPECT_TRUE(buf.starts_with("Hello, Worl"sv));
+    EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_FALSE(buf.starts_with("Hello, World!"sv));
     EXPECT_FALSE(buf.starts_with("Hello!"sv));
@@ -33,7 +33,7 @@ TEST_F(BufferTest, startsWithInSingleSegment)
     buf.add(Bang);
     EXPECT_FALSE(buf.starts_with("Hello!"));
     EXPECT_TRUE(buf.starts_with(Hello));
-    EXPECT_TRUE(buf.starts_with("Hello, Worl"sv));
+    EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World!"sv));
 }
@@ -49,7 +49,7 @@ TEST_F(BufferTest, startsWithInMultiSegment)
 
     buf->add(Buffer{ World });
     EXPECT_TRUE(buf->starts_with(Hello));
-    EXPECT_TRUE(buf->starts_with("Hello, Worl"sv));
+    EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_FALSE(buf->starts_with("Hello, World!"sv));
     EXPECT_FALSE(buf->starts_with("Hello!"sv));
@@ -57,7 +57,7 @@ TEST_F(BufferTest, startsWithInMultiSegment)
     buf->add(Buffer{ Bang });
     EXPECT_FALSE(buf->starts_with("Hello!"));
     EXPECT_TRUE(buf->starts_with(Hello));
-    EXPECT_TRUE(buf->starts_with("Hello, Worl"sv));
+    EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World!"sv));
 }

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -57,7 +57,7 @@ TEST_F(BufferTest, startsWithInMultiSegment)
     buf->add(Buffer{ Bang });
     EXPECT_FALSE(buf->starts_with("Hello!"));
     EXPECT_TRUE(buf->starts_with(Hello));
-    EXPECT_TRUE(buf->starts_with("Hello, World"sv));
+    EXPECT_TRUE(buf->starts_with("Hello, Worl"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World"sv));
     EXPECT_TRUE(buf->starts_with("Hello, World!"sv));
 }

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -33,7 +33,7 @@ TEST_F(BufferTest, startsWithInSingleSegment)
     buf.add(Bang);
     EXPECT_FALSE(buf.starts_with("Hello!"));
     EXPECT_TRUE(buf.starts_with(Hello));
-    EXPECT_TRUE(buf.starts_with("Hello, World"sv));
+    EXPECT_TRUE(buf.starts_with("Hello, Worl"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World"sv));
     EXPECT_TRUE(buf.starts_with("Hello, World!"sv));
 }

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -497,7 +497,7 @@ TEST_F(DhtTest, stopsBootstrappingWhenSwarmHealthIsGoodEnough)
     waitFor(event_base_, MockTimerInterval * 10);
 
     // Confirm that the number of nodes pinged is unchanged,
-    // indicating that boostrapping is done
+    // indicating that bootsrapping is done
     EXPECT_EQ(TurnGoodAfterNthPing, std::size(mock_dht.pinged_));
 }
 

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -497,7 +497,7 @@ TEST_F(DhtTest, stopsBootstrappingWhenSwarmHealthIsGoodEnough)
     waitFor(event_base_, MockTimerInterval * 10);
 
     // Confirm that the number of nodes pinged is unchanged,
-    // indicating that bootsrapping is done
+    // indicating that bootstrapping is done
     EXPECT_EQ(TurnGoodAfterNthPing, std::size(mock_dht.pinged_));
 }
 

--- a/tests/libtransmission/session-alt-speeds-test.cc
+++ b/tests/libtransmission/session-alt-speeds-test.cc
@@ -125,7 +125,7 @@ TEST_F(SessionAltSpeedsTest, canSchedule)
     alt_speeds.checkScheduler();
     EXPECT_EQ(n_changes, std::size(mediator.changelog_));
 
-    // Confirm that crossin the threshold does enable
+    // Confirm that crossing the threshold does enable
     now += std::chrono::duration_cast<std::chrono::seconds>(1min).count();
     mediator.current_time_ = now;
     alt_speeds.checkScheduler();
@@ -141,7 +141,7 @@ TEST_F(SessionAltSpeedsTest, canSchedule)
     alt_speeds.checkScheduler();
     EXPECT_EQ(n_changes, std::size(mediator.changelog_));
 
-    // Confirm that crossin the threshold does disable
+    // Confirm that crossing the threshold does disable
     now += std::chrono::duration_cast<std::chrono::seconds>(1min).count();
     mediator.current_time_ = now;
     alt_speeds.checkScheduler();

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -232,7 +232,7 @@ TEST_F(UtilsTest, trStrlcpy)
         "a",
         "",
         "12345678901234567890",
-        "This, very useful string contains a total of 104 characters not counting null. Almost like an easter egg!"
+        "This, very useful string contains a total of 105 characters not counting null. Almost like an easter egg!"
     };
 
     for (auto const& test : tests)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -43,7 +43,7 @@ TEST_F(UtilsTest, trStrvContains)
     EXPECT_TRUE(tr_strvContains("test "sv, "test"sv));
     EXPECT_TRUE(tr_strvContains("test"sv, ""sv));
     EXPECT_TRUE(tr_strvContains("test"sv, "t"sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, "test"sv));
+    EXPECT_TRUE(tr_strvContains("test"sv, "te"sv));
     EXPECT_TRUE(tr_strvContains("test"sv, "test"sv));
     EXPECT_TRUE(tr_strvContains("this is a test"sv, "test"sv));
     EXPECT_TRUE(tr_strvContains(""sv, ""sv));

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -43,7 +43,7 @@ TEST_F(UtilsTest, trStrvContains)
     EXPECT_TRUE(tr_strvContains("test "sv, "test"sv));
     EXPECT_TRUE(tr_strvContains("test"sv, ""sv));
     EXPECT_TRUE(tr_strvContains("test"sv, "t"sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, "te"sv));
+    EXPECT_TRUE(tr_strvContains("test"sv, "test"sv));
     EXPECT_TRUE(tr_strvContains("test"sv, "test"sv));
     EXPECT_TRUE(tr_strvContains("this is a test"sv, "test"sv));
     EXPECT_TRUE(tr_strvContains(""sv, ""sv));
@@ -232,7 +232,7 @@ TEST_F(UtilsTest, trStrlcpy)
         "a",
         "",
         "12345678901234567890",
-        "This, very usefull string contains total of 104 characters not counting null. Almost like an easter egg!"
+        "This, very useful string contains a total of 104 characters not counting null. Almost like an easter egg!"
     };
 
     for (auto const& test : tests)


### PR DESCRIPTION
Minor typo fixes,

Hmmm a few things there i can see i've mistakenly 'corrected'. The changes that look good are:

- tests/libtransmission/announcer-udp-test.cc
- tests/libtransmission/dht-test.cc
- tests/libtransmission/session-alt-speeds-test.cc
- tests/libtransmission/utils-test.cc
