### PR TITLE
Follow-up and clean-up of `tr_global_ip_cache` PR

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -360,32 +360,6 @@ tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_ms
     return tr_netBindTCPImpl(addr, port, suppress_msgs, &unused);
 }
 
-bool tr_net_hasIPv6(tr_port port)
-{
-    static bool result = false;
-    static bool already_done = false;
-
-    if (!already_done)
-    {
-        int err = 0;
-        auto const fd = tr_netBindTCPImpl(tr_address::any_ipv6(), port, true, &err);
-
-        if (fd != TR_BAD_SOCKET || err != EAFNOSUPPORT) /* we support ipv6 */
-        {
-            result = true;
-        }
-
-        if (fd != TR_BAD_SOCKET)
-        {
-            tr_net_close_socket(fd);
-        }
-
-        already_done = true;
-    }
-
-    return result;
-}
-
 std::optional<std::tuple<tr_address, tr_port, tr_socket_t>> tr_netAccept(tr_session* session, tr_socket_t listening_sockfd)
 {
     TR_ASSERT(session != nullptr);

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -327,8 +327,6 @@ void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm);
 
 void tr_net_close_socket(tr_socket_t fd);
 
-[[nodiscard]] bool tr_net_hasIPv6(tr_port);
-
 // --- TOS / DSCP
 
 /**

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2052,22 +2052,6 @@ void tr_session::closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noe
 
 // ---
 
-std::string tr_session::bindAddress(tr_address_type type) const noexcept
-{
-    switch (type)
-    {
-    case TR_AF_INET:
-        return settings_.bind_address_ipv4;
-    case TR_AF_INET6:
-        return settings_.bind_address_ipv6;
-    default:
-        TR_ASSERT_MSG(false, "invalid type");
-        return {};
-    }
-}
-
-// ---
-
 void tr_sessionSetQueueStartCallback(tr_session* session, void (*callback)(tr_session*, tr_torrent*, void*), void* user_data)
 {
     session->setQueueStartCallback(callback, user_data);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -429,7 +429,7 @@ tr_address tr_session::publicAddress(tr_address_type type) const noexcept
     if (type == TR_AF_INET6)
     {
         // if user provided an address, use it.
-        // otherwise, if we can determine which one to use via globalSourceIPv6 magic, use it.
+        // otherwise, if we can determine which one to use via global_source_address(ipv6) magic, use it.
         // otherwise, use any_ipv6 (::).
         auto const source_addr = global_source_address(type);
         return source_addr && source_addr->is_global_unicast_address() ? *source_addr : global_ip_cache_->bind_addr(type);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -506,10 +506,6 @@ public:
     void closeTorrentFiles(tr_torrent* tor) noexcept;
     void closeTorrentFile(tr_torrent* tor, tr_file_index_t file_num) noexcept;
 
-    // bind address
-
-    [[nodiscard]] std::string bindAddress(tr_address_type type) const noexcept;
-
     // announce ip
 
     [[nodiscard]] constexpr std::string const& announceIP() const noexcept

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -175,7 +175,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         }
     }
 
-    if (!tr_net_hasIPv6(udp_port_))
+    if (!session.has_ip_protocol(TR_AF_INET6))
     {
         // no IPv6; do nothing
     }


### PR DESCRIPTION
Follow up of #5329.

1. Removed `tr_session::bindAddress()`. It was added for `tr_global_ip_cache` to get the `bind-address-ipv*` parameters, but it is no longer used.
2. Replaced `tr_net_hasIPv6()` usages with `tr_session::has_ip_protocol()`.