### PR TITLE
refactor: rename tr_tracker_view.host to .host_and_port for clarity

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1964,7 +1964,8 @@ void buildTrackerSummary(
     // hostname
     gstr << text_dir_mark.at(static_cast<int>(direction));
     gstr << (tracker.isBackup ? "<i>" : "<b>");
-    gstr << Glib::Markup::escape_text(!key.empty() ? fmt::format(FMT_STRING("{:s} - {:s}"), tracker.host, key) : tracker.host);
+    gstr << Glib::Markup::escape_text(
+        !key.empty() ? fmt::format(FMT_STRING("{:s} - {:s}"), tracker.host_and_port, key) : tracker.host_and_port);
     gstr << (tracker.isBackup ? "</i>" : "</b>");
 
     if (!tracker.isBackup)

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -218,7 +218,7 @@ bool FilterBar::Impl::tracker_filter_model_update()
         for (size_t j = 0, n = tr_torrentTrackerCount(&raw_torrent); j < n; ++j)
         {
             auto const view = tr_torrentTracker(&raw_torrent, j);
-            site_to_host_and_announce.try_emplace(std::data(view.sitename), view.host, view.announce);
+            site_to_host_and_announce.try_emplace(std::data(view.sitename), view.host_and_port, view.announce);
         }
 
         for (auto const& [sitename, host_and_announce] : site_to_host_and_announce)

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -84,7 +84,7 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
     tracker.announce = announce_url_sv;
     tracker.tier = get_tier(tier, *announce);
     tracker.id = next_unique_id();
-    tracker.host = fmt::format(FMT_STRING("{:s}:{:d}"), announce->host, announce->port);
+    tracker.host_and_port = fmt::format(FMT_STRING("{:s}:{:d}"), announce->host, announce->port);
     tracker.sitename = announce->sitename;
 
     if (auto const scrape_str = announce_to_scrape(announce_url_sv); scrape_str)

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -26,7 +26,7 @@ public:
     {
         tr_interned_string announce;
         tr_interned_string scrape;
-        tr_interned_string host; // 'example.org:80'
+        tr_interned_string host_and_port; // 'example.org:80'
         tr_interned_string sitename; // 'example'
         tr_tracker_tier_t tier = 0;
         tr_tracker_id_t id = 0;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -362,7 +362,7 @@ void addTrackerStats(tr_tracker_view const& tracker, tr_variant* list)
     tr_variantDictAddInt(d, TR_KEY_downloadCount, tracker.downloadCount);
     tr_variantDictAddBool(d, TR_KEY_hasAnnounced, tracker.hasAnnounced);
     tr_variantDictAddBool(d, TR_KEY_hasScraped, tracker.hasScraped);
-    tr_variantDictAddStr(d, TR_KEY_host, tracker.host);
+    tr_variantDictAddStr(d, TR_KEY_host, tracker.host_and_port);
     tr_variantDictAddStr(d, TR_KEY_sitename, tracker.sitename);
     tr_variantDictAddInt(d, TR_KEY_id, tracker.id);
     tr_variantDictAddBool(d, TR_KEY_isBackup, tracker.isBackup);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -418,7 +418,7 @@ namespace script_helpers
 
     for (size_t i = 0, n = tr_torrentTrackerCount(tor); i < n; ++i)
     {
-        buf << tr_torrentTracker(tor, i).host;
+        buf << tr_torrentTracker(tor, i).host_and_port;
 
         if (++i < n)
         {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1274,7 +1274,7 @@ struct tr_tracker_view
 {
     char const* announce; // full announce URL
     char const* scrape; // full scrape URL
-    char const* host; // uniquely-identifying tracker name (`${host}:${port}`)
+    char const* host_and_port; // uniquely-identifying tracker name (`${host}:${port}`)
 
     // The tracker site's name. Uses the first label before the public suffix
     // (https://publicsuffix.org/) in the announce URL's host.

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1684,10 +1684,10 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     {
         auto const tracker = tr_torrentTracker(self.fHandle, i);
 
-        NSString* host = @(tracker.host);
-        if (!best || [host localizedCaseInsensitiveCompare:best] == NSOrderedAscending)
+        NSString* host_and_port = @(tracker.host_and_port);
+        if (!best || [host_and_port localizedCaseInsensitiveCompare:best] == NSOrderedAscending)
         {
-            best = host;
+            best = host_and_port;
         }
     }
 

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -58,7 +58,7 @@
 
 - (NSString*)host
 {
-    return @(self.fStat.host);
+    return @(self.fStat.host_and_port);
 }
 
 - (NSString*)fullAnnounceAddress

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -35,7 +35,7 @@ TEST_F(AnnounceListTest, canAdd)
     EXPECT_EQ(Announce, tracker.announce.sv());
     EXPECT_EQ("https://example.org/scrape"sv, tracker.scrape.sv());
     EXPECT_EQ(Tier, tracker.tier);
-    EXPECT_EQ("example.org:443"sv, tracker.host.sv());
+    EXPECT_EQ("example.org:443"sv, tracker.host_and_port.sv());
 }
 
 TEST_F(AnnounceListTest, groupsSiblingsIntoSameTier)
@@ -59,9 +59,9 @@ TEST_F(AnnounceListTest, groupsSiblingsIntoSameTier)
     EXPECT_EQ(Announce1, announce_list.at(0).announce.sv());
     EXPECT_EQ(Announce2, announce_list.at(1).announce.sv());
     EXPECT_EQ(Announce3, announce_list.at(2).announce.sv());
-    EXPECT_EQ("example.org:443"sv, announce_list.at(0).host.sv());
-    EXPECT_EQ("example.org:80"sv, announce_list.at(1).host.sv());
-    EXPECT_EQ("example.org:999"sv, announce_list.at(2).host.sv());
+    EXPECT_EQ("example.org:443"sv, announce_list.at(0).host_and_port.sv());
+    EXPECT_EQ("example.org:80"sv, announce_list.at(1).host_and_port.sv());
+    EXPECT_EQ("example.org:999"sv, announce_list.at(2).host_and_port.sv());
 }
 
 TEST_F(AnnounceListTest, canAddWithoutScrape)


### PR DESCRIPTION
No functional changes.

Having port information in a "host" field is non-intuitive and potentially bugprone if someone uses the host field as a host.