### PR TITLE
Enable global IP query and fixes/refactorings

### DIFF
--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -168,6 +168,7 @@ bool tr_global_ip_cache::try_shutdown() noexcept
     return true;
 }
 
+// (Almost) always a good idea to call update_addr() after calling this function
 void tr_global_ip_cache::set_settings_bind_addr(tr_address_type type, std::string_view bind_address) noexcept
 {
     settings_bind_addr_[type] = tr_address::from_string(bind_address);

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -33,6 +33,13 @@ static_assert(TR_AF_INET6 == 1);
 
 auto constexpr protocol_str(tr_address_type type) noexcept
 {
+    /* TODO: very slight performance nit
+     * - If upgrading to C++20, change Map to a consteval lambda:
+     *   auto map = []() consteval { return std::array{ "IPv4"sv, "IPv6"sv }; };
+     * - If upgrading to C++23, change Map to static constexpr
+     *
+     * Ref: https://wg21.link/p2647r1
+     */
     auto constexpr Map = std::array{ "IPv4"sv, "IPv6"sv };
     return Map[type];
 }

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -212,7 +212,6 @@ void tr_global_ip_cache::update_addr(tr_address_type type) noexcept
 void tr_global_ip_cache::update_global_addr(tr_address_type type) noexcept
 {
     TR_ASSERT(has_ip_protocol_[type]);
-    TR_ASSERT(global_source_addr(type));
     TR_ASSERT(ix_service_[type] < std::size(IPQueryServices[type]));
 
     if (ix_service_[type] == 0U && !set_is_updating(type))

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -36,11 +36,11 @@ auto constexpr RetryUpkeepInterval = 30s;
 
 namespace
 {
-// Functions contained in external_source_ip_helpers are modified from code
+// Functions contained in global_source_ip_helpers are modified from code
 // by Juliusz Chroboczek and is covered under the same license as dht.cc.
 // Please feel free to copy them into your software if it can help
 // unbreaking the double-stack Internet.
-namespace external_source_ip_helpers
+namespace global_source_ip_helpers
 {
 
 // Get the source address used for a given destination address.
@@ -109,7 +109,7 @@ namespace external_source_ip_helpers
     return {};
 }
 
-} // namespace external_source_ip_helpers
+} // namespace global_source_ip_helpers
 } // namespace
 
 tr_global_ip_cache::tr_global_ip_cache(tr_web& web_in, libtransmission::TimerMaker& timer_maker_in)
@@ -281,7 +281,7 @@ void tr_global_ip_cache::update_global_addr(tr_address_type type) noexcept
 
 void tr_global_ip_cache::update_source_addr(tr_address_type type) noexcept
 {
-    using namespace external_source_ip_helpers;
+    using namespace global_source_ip_helpers;
 
     TR_ASSERT(has_ip_protocol_[type]);
 

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -177,8 +177,7 @@ tr_address tr_global_ip_cache::bind_addr(tr_address_type type) const noexcept
 {
     if (type == TR_AF_INET || type == TR_AF_INET6)
     {
-        auto const addr = tr_address::from_string(mediator_.settings_bind_addr(type));
-        if (addr && type == addr->type)
+        if (auto const addr = tr_address::from_string(mediator_.settings_bind_addr(type)); addr && type == addr->type)
         {
             return *addr;
         }
@@ -246,7 +245,7 @@ void tr_global_ip_cache::update_source_addr(tr_address_type type) noexcept
 
     auto const protocol = type == TR_AF_INET ? "IPv4"sv : "IPv6"sv;
 
-    auto err = int{};
+    auto err = int{ 0 };
     auto const& source_addr = get_global_source_address(bind_addr(type), err);
     if (source_addr)
     {

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -279,7 +279,7 @@ void tr_global_ip_cache::on_response_ip_query(tr_address_type type, tr_web::Fetc
     TR_ASSERT(ix_service_[type] < std::size(IPQueryServices[type]));
 
     auto const protocol = type == TR_AF_INET ? "IPv4"sv : "IPv6"sv;
-    auto success = bool{ false };
+    auto success = false;
 
     if (response.status == 200 /* HTTP_OK */)
     {

--- a/libtransmission/global-ip-cache.h
+++ b/libtransmission/global-ip-cache.h
@@ -11,7 +11,6 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
-#include <string>
 #include <string_view>
 
 #include "libtransmission/net.h"

--- a/libtransmission/global-ip-cache.h
+++ b/libtransmission/global-ip-cache.h
@@ -33,7 +33,7 @@
  *
  * The idea is, if this class successfully cached a source address, that means
  * you have connectivity to the public internet. And if the global address is
- * the same with the source address, then you are not behind an NAT.
+ * the same as the source address, then you are not behind a NAT.
  *
  */
 class tr_global_ip_cache

--- a/libtransmission/global-ip-cache.h
+++ b/libtransmission/global-ip-cache.h
@@ -65,8 +65,14 @@ public:
     void set_settings_bind_addr(tr_address_type type, std::string_view bind_address) noexcept;
     [[nodiscard]] tr_address bind_addr(tr_address_type type) const noexcept;
 
-    void update_addr(tr_address_type type) noexcept;
     bool set_global_addr(tr_address_type type, tr_address const& addr) noexcept;
+
+    void update_addr(tr_address_type type) noexcept;
+    void update_global_addr(tr_address_type type) noexcept;
+    void update_source_addr(tr_address_type type) noexcept;
+
+    // Only use as a callback for web_->fetch()
+    void on_response_ip_query(tr_address_type type, tr_web::FetchResponse const& response) noexcept;
 
     [[nodiscard]] constexpr auto has_ip_protocol(tr_address_type type) const noexcept
     {
@@ -93,12 +99,6 @@ private:
 
     [[nodiscard]] bool set_is_updating(tr_address_type type) noexcept;
     void unset_is_updating(tr_address_type type) noexcept;
-
-    void update_global_addr(tr_address_type type) noexcept;
-    void update_source_addr(tr_address_type type) noexcept;
-
-    // Only use as a callback for web_->fetch()
-    void on_response_ip_query(tr_address_type type, tr_web::FetchResponse const& response) noexcept;
 
     tr_web& web_;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -641,8 +641,6 @@ void tr_session::initImpl(init_data& data)
 
     this->blocklists_ = libtransmission::Blocklist::loadBlocklists(blocklist_dir_, useBlocklist());
 
-    this->global_ip_cache_ = std::make_unique<tr_global_ip_cache>(*web_, timerMaker());
-
     tr_logAddInfo(fmt::format(_("Transmission version {version} starting"), fmt::arg("version", LONG_VERSION_STRING)));
 
     setSettings(client_settings, true);
@@ -703,12 +701,10 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
 
     if (auto const& val = new_settings.bind_address_ipv4; force || val != old_settings.bind_address_ipv4)
     {
-        global_ip_cache_->set_settings_bind_addr(TR_AF_INET, val);
         global_ip_cache_->update_addr(TR_AF_INET);
     }
     if (auto const& val = new_settings.bind_address_ipv6; force || val != old_settings.bind_address_ipv6)
     {
-        global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, val);
         global_ip_cache_->update_addr(TR_AF_INET6);
     }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -432,7 +432,9 @@ tr_address tr_session::publicAddress(tr_address_type type) const noexcept
         // otherwise, if we can determine which one to use via global_source_address(ipv6) magic, use it.
         // otherwise, use any_ipv6 (::).
         auto const source_addr = global_source_address(type);
-        return source_addr && source_addr->is_global_unicast_address() ? *source_addr : global_ip_cache_->bind_addr(type);
+        auto const default_addr = source_addr && source_addr->is_global_unicast_address() ? *source_addr :
+                                                                                            tr_address::any_ipv6();
+        return tr_address::from_string(settings_.bind_address_ipv6).value_or(default_addr);
     }
 
     TR_ASSERT_MSG(false, "invalid type");

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -702,10 +702,12 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
     if (auto const& val = new_settings.bind_address_ipv4; force || val != old_settings.bind_address_ipv4)
     {
         global_ip_cache_->set_settings_bind_addr(TR_AF_INET, val);
+        global_ip_cache_->update_addr(TR_AF_INET);
     }
     if (auto const& val = new_settings.bind_address_ipv6; force || val != old_settings.bind_address_ipv6)
     {
         global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, val);
+        global_ip_cache_->update_addr(TR_AF_INET6);
     }
 
     if (auto const& val = new_settings.default_trackers_str; force || val != old_settings.default_trackers_str)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -701,11 +701,11 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
 
     if (auto const& val = new_settings.bind_address_ipv4; force || val != old_settings.bind_address_ipv4)
     {
-        global_ip_cache_->set_settings_bind_addr(TR_AF_INET, new_settings.bind_address_ipv4);
+        global_ip_cache_->set_settings_bind_addr(TR_AF_INET, val);
     }
     if (auto const& val = new_settings.bind_address_ipv6; force || val != old_settings.bind_address_ipv6)
     {
-        global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, new_settings.bind_address_ipv6);
+        global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, val);
     }
 
     if (auto const& val = new_settings.default_trackers_str; force || val != old_settings.default_trackers_str)

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -263,7 +263,7 @@ TEST_F(GlobalIPCacheTest, onResponseIPQuery)
                 global_ip_cache_->update_global_addr(type);
 
                 auto const global_addr = global_ip_cache_->global_addr(type);
-                EXPECT_EQ(static_cast<bool>(global_addr), j == 200 /* HTTP_OK */ && AddrTests[i][k]);
+                EXPECT_EQ(!!global_addr, j == 200 /* HTTP_OK */ && AddrTests[i][k]);
                 if (global_addr)
                 {
                     EXPECT_EQ(global_addr->display_name(), AddrStr[k]);

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -96,7 +96,7 @@ TEST_F(GlobalIPCacheTest, bindAddr)
         std::array<std::pair<std::string_view, std::string_view>, 4>{ { { "8.8.8.8"sv, "8.8.8.8"sv },
                                                                         { "192.168.133.133"sv, "192.168.133.133"sv },
                                                                         { "2001:1890:1112:1::20"sv, "0.0.0.0"sv },
-                                                                        { "asdasd"sv, "0.0.0.0"sv } } }, /* IPv4 */
+                                                                        { "asdasd"sv, "0.0.0.0"sv } } } /* IPv4 */,
         std::array<std::pair<std::string_view, std::string_view>, 4>{ { { "fd12:3456:789a:1::1"sv, "fd12:3456:789a:1::1"sv },
                                                                         { "192.168.133.133"sv, "::"sv },
                                                                         { "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv },
@@ -214,7 +214,6 @@ TEST_F(GlobalIPCacheTest, globalSourceIPv6)
 
 TEST_F(GlobalIPCacheTest, onResponseIPQuery)
 {
-
     static auto constexpr AddrStr = std::array{
         "8.8.8.8"sv,      "192.168.133.133"sv,     "172.16.241.133"sv, "2001:1890:1112:1::20"sv, "fd12:3456:789a:1::1"sv,
         "91.121.74.28"sv, "2001:1890:1112:1::20"sv

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -168,7 +168,7 @@ TEST_F(GlobalIPCacheTest, setGlobalAddr)
 
 TEST_F(GlobalIPCacheTest, globalSourceIPv4)
 {
-    global_ip_cache_->set_settings_bind_addr(TR_AF_INET, "0.0.0.0"s);
+    global_ip_cache_->set_settings_bind_addr(TR_AF_INET, "0.0.0.0"sv);
     global_ip_cache_->update_source_addr(TR_AF_INET);
     auto const addr = global_ip_cache_->global_source_addr(TR_AF_INET);
     if (!addr)
@@ -183,7 +183,7 @@ TEST_F(GlobalIPCacheTest, globalSourceIPv4)
 
 TEST_F(GlobalIPCacheTest, globalSourceIPv6)
 {
-    global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, "::"s);
+    global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, "::"sv);
     global_ip_cache_->update_source_addr(TR_AF_INET6);
     auto const addr = global_ip_cache_->global_source_addr(TR_AF_INET6);
     if (!addr)

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <chrono>
-#include <ctime>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -169,6 +169,7 @@ TEST_F(GlobalIPCacheTest, setGlobalAddr)
 TEST_F(GlobalIPCacheTest, globalSourceIPv4)
 {
     global_ip_cache_->set_settings_bind_addr(TR_AF_INET, "0.0.0.0"s);
+    global_ip_cache_->update_source_addr(TR_AF_INET);
     auto const addr = global_ip_cache_->global_source_addr(TR_AF_INET);
     if (!addr)
     {
@@ -183,6 +184,7 @@ TEST_F(GlobalIPCacheTest, globalSourceIPv4)
 TEST_F(GlobalIPCacheTest, globalSourceIPv6)
 {
     global_ip_cache_->set_settings_bind_addr(TR_AF_INET6, "::"s);
+    global_ip_cache_->update_source_addr(TR_AF_INET6);
     auto const addr = global_ip_cache_->global_source_addr(TR_AF_INET6);
     if (!addr)
     {

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -79,11 +79,11 @@ protected:
 
     void TearDown() override
     {
-        ::testing::Test::TearDown();
         if (global_ip_cache_)
         {
             global_ip_cache_->try_shutdown();
         }
+        ::testing::Test::TearDown();
     }
 
     // To be created within the test body


### PR DESCRIPTION
1. Enable global IP query, thanks to the new endpoints on transmissionbt.com. https://github.com/transmission/transmission/pull/5329#discussion_r1189389905
2. Fix unintended behavioural change in `tr_address::publicAddress()` for IPv6.
3. Added a new test for the callback of the global IP query feature.
4. Refactor `tr_global_ip_cache` to use a mediator, so that more tests are possible.

Fixes #5554.