### PR TITLE
Only format JS if files in web/ change

### DIFF
--- a/code_style.sh
+++ b/code_style.sh
@@ -76,6 +76,8 @@ if [ -n "$fix" ]; then
 fi
 
 # format JS
+# but only if js has changed
+git diff --cached --quiet -- "web/**" && exit $exitcode
 cd "${root}/web" || exit 1
 npm_lint_args="$([ -n "$fix" ] && echo 'lint:fix' || echo 'lint')"
 if ! npm ci --no-audit --no-fund --no-progress &>/dev/null; then


### PR DESCRIPTION
In many cases the webui code is not updated for core libtransmission changes and changes in the utils/clients. Therefore, check to see if any web changes are made before running npm linting.