### PR TITLE
perf: avoid extra work in read_vc()

### DIFF
--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -249,6 +249,11 @@ private:
     using vc_t = std::array<std::byte, 8>;
     static auto constexpr VC = vc_t{};
 
+    // Used when resynchronizing in read_vc(). This value is cached to avoid
+    // the cost of recomputing it. MSE spec: "Since the length of [PadB is]
+    // unknown, A will be able to resynchronize on ENCRYPT(VC)".
+    std::optional<vc_t> encrypted_vc_;
+
     ///
 
     static constexpr auto DhPoolMaxSize = size_t{ 32 };


### PR DESCRIPTION
Cache the value of `ENCRYPT(VC)` instead of recomputing it every time `read_vc()` is called.

Notes: Avoid unnecessary heap memory allocations.