### PR TITLE
Moving trash setting to libtransmission.

### DIFF
--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -129,7 +129,7 @@ void OptionsDialog::Impl::addResponseCB(int response)
 
             if (trash_check_->get_active())
             {
-                gtr_file_trash_or_remove(filename_, nullptr);
+                core_->file_trash_or_remove(filename_, nullptr);
             }
 
             gtr_save_recent_dir("download", core_, downloadDir_);

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -59,7 +59,6 @@ static void tr_prefs_init_defaults(tr_variant* d)
     tr_variantDictAddBool(d, TR_KEY_show_toolbar, true);
     tr_variantDictAddBool(d, TR_KEY_show_filterbar, true);
     tr_variantDictAddBool(d, TR_KEY_show_statusbar, true);
-    tr_variantDictAddBool(d, TR_KEY_trash_can_enabled, true);
     tr_variantDictAddBool(d, TR_KEY_show_notification_area_icon, false);
     tr_variantDictAddBool(d, TR_KEY_show_tracker_scrapes, false);
     tr_variantDictAddBool(d, TR_KEY_show_extra_peer_details, false);

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -135,6 +135,8 @@ public:
 
     void open_folder(tr_torrent_id_t torrent_id) const;
 
+    bool file_trash_or_remove(std::string const& filename, tr_error** error) const;
+
     sigc::signal<void(ErrorCode, Glib::ustring const&)>& signal_add_error();
     sigc::signal<void(tr_ctor*)>& signal_add_prompt();
     sigc::signal<void(bool)>& signal_blocklist_updated();

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -408,52 +408,25 @@ void setup_tree_view_button_event_handling(
 #endif
 }
 
-bool gtr_file_trash_or_remove(std::string const& filename, tr_error** error)
+bool gtr_file_trash(std::string const& filename, tr_error** error)
 {
-    bool trashed = false;
-    bool result = true;
-
-    g_return_val_if_fail(!filename.empty(), false);
-
     auto const file = Gio::File::create_for_path(filename);
 
-    if (gtr_pref_flag_get(TR_KEY_trash_can_enabled))
+    try
     {
-        try
-        {
-            trashed = file->trash();
-        }
-        catch (Glib::Error const& e)
-        {
-            gtr_message(fmt::format(
-                _("Couldn't move '{path}' to trash: {error} ({error_code})"),
-                fmt::arg("path", filename),
-                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-                fmt::arg("error_code", e.code())));
-            tr_error_set(error, e.code(), TR_GLIB_EXCEPTION_WHAT(e));
-        }
+        return file->trash();
     }
-
-    if (!trashed)
+    catch (Glib::Error const& e)
     {
-        try
-        {
-            file->remove();
-        }
-        catch (Glib::Error const& e)
-        {
-            gtr_message(fmt::format(
-                _("Couldn't remove '{path}': {error} ({error_code})"),
-                fmt::arg("path", filename),
-                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-                fmt::arg("error_code", e.code())));
-            tr_error_clear(error);
-            tr_error_set(error, e.code(), TR_GLIB_EXCEPTION_WHAT(e));
-            result = false;
-        }
-    }
+        gtr_message(fmt::format(
+            _("Couldn't move '{path}' to trash: {error} ({error_code})"),
+            fmt::arg("path", filename),
+            fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
+            fmt::arg("error_code", e.code())));
+        tr_error_set(error, e.code(), TR_GLIB_EXCEPTION_WHAT(e));
 
-    return result;
+        return false;
+    }
 }
 
 namespace

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -154,8 +154,8 @@ void setup_tree_view_button_event_handling(
     std::function<bool(guint, TrGdkModifierType, double, double, bool)> const& press_callback,
     std::function<bool(double, double)> const& release_callback);
 
-/* move a file to the trashcan if GIO is available; otherwise, delete it */
-bool gtr_file_trash_or_remove(std::string const& filename, tr_error** error);
+/* move a file to the trashcan if GIO is available; fail otherwise */
+bool gtr_file_trash(std::string const& filename, tr_error** error);
 
 void gtr_paste_clipboard_url_into_entry(Gtk::Entry& entry);
 

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -68,6 +68,11 @@ struct tr_variant;
     V(TR_KEY_speed_limit_up_enabled, speed_limit_up_enabled, bool, false, "") \
     V(TR_KEY_start_added_torrents, should_start_added_torrents, bool, true, "") \
     V(TR_KEY_tcp_enabled, tcp_enabled, bool, true, "") \
+    V(TR_KEY_trash_can_enabled, \
+      should_move_files_to_trash, \
+      bool, \
+      false, \
+      "Files should be moved to trash can instead of immediately deleted") \
     V(TR_KEY_trash_original_torrent_files, should_delete_source_torrents, bool, false, "") \
     V(TR_KEY_umask, umask, tr_mode_t, 022, "") \
     V(TR_KEY_upload_slots_per_torrent, upload_slots_per_torrent, size_t, 8U, "") \

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1235,6 +1235,13 @@ bool tr_sessionGetPaused(tr_session const* session)
     return session->shouldPauseAddedTorrents();
 }
 
+bool tr_sessionGetTrashFiles(tr_session* session)
+{
+    TR_ASSERT(session != nullptr);
+
+    return session->shouldTrashFiles();
+}
+
 void tr_sessionSetDeleteSource(tr_session* session, bool delete_source)
 {
     TR_ASSERT(session != nullptr);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -703,6 +703,11 @@ public:
         return !settings_.should_start_added_torrents;
     }
 
+    [[nodiscard]] constexpr auto shouldTrashFiles() const noexcept
+    {
+        return settings_.should_move_files_to_trash;
+    }
+
     [[nodiscard]] constexpr auto shouldFullyVerifyAddedTorrents() const noexcept
     {
         return settings_.torrent_added_verify_mode == TR_VERIFY_ADDED_FULL;

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -116,8 +116,10 @@ public:
         std::string_view parent_name = "",
         tr_error** error = nullptr) const;
 
-    using FileFunc = std::function<void(char const* filename)>;
-    void remove(std::string_view parent_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
+    using FileFunc = std::function<void(char const* filename, struct tr_error** error)>;
+    void trash(std::string_view parent_in, std::string_view tmpdir_prefix, FileFunc const& func) const;
+
+    void remove(std::string_view root) const;
 
     struct FoundFile : public tr_sys_path_info
     {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -568,6 +568,8 @@ void tr_sessionSetPeerLimitPerTorrent(tr_session* session, uint16_t max_peers);
 bool tr_sessionGetPaused(tr_session const* session);
 void tr_sessionSetPaused(tr_session* session, bool is_paused);
 
+bool tr_sessionGetTrashFiles(tr_session* session);
+
 void tr_sessionSetDeleteSource(tr_session* session, bool delete_source);
 
 tr_priority_t tr_torrentGetPriority(tr_torrent const* tor);
@@ -854,7 +856,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
 using tr_fileFunc = bool (*)(char const* filename, void* user_data, struct tr_error** error);
 
 /** @brief Removes our torrent and .resume files for this torrent */
-void tr_torrentRemove(tr_torrent* torrent, bool delete_flag, tr_fileFunc delete_func, void* user_data);
+void tr_torrentRemove(tr_torrent* torrent, bool delete_flag, tr_fileFunc trash_func, void* user_data);
 
 /** @brief Start a torrent */
 void tr_torrentStart(tr_torrent* torrent);

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(libtransmission-test
         torrent-magnet-test.cc
         torrent-metainfo-test.cc
         torrents-test.cc
+        trash-test.cc
         utils-test.cc
         variant-test.cc
         watchdir-test.cc


### PR DESCRIPTION
Now libtransmission decides whether to use the platform specific move to trash function or delete the files outright, based on a new setting ported from Gtk interface.

This partially solves #5361. Specifically, should solve the problem for users of transmission-daemon or others who choose not to use trash/recycle bin by setting `"trash-can-enabled"`, which is now known by libtransmission.

This is not ideal, but to fix the other half of the issue, where errors in moving files are not reported to the user, I would need to change the libtransmission API to raise torrent removal errors to the user interface, which I can't because I don't have a mac to make/build/test the necessary changes in macOS interface.

EDIT: Considering that it is unavoidable to move files around if we must preserve the directory structure but avoid deleting files that are not part of the torrent, this will invariably subject the operation to filesystem errors when it is full, and I find it sensible my solution in this PR to have a switch for users who don't want to be subject to such problems. 