### PR TITLE
fix: Qt 6.5 deprecation warning

### DIFF
--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1110,7 +1110,11 @@ void MainWindow::toggleWindows(bool do_show)
         }
 
         raise();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+        this->activateWindow();
+#else
         QApplication::setActiveWindow(this);
+#endif
     }
 }
 


### PR DESCRIPTION
This is intended to fix the following deprecation warning observed when building against `qt-6.5.0`:
```
qt/MainWindow.cc: In member function ‘void MainWindow::toggleWindows(bool)’:
qt/MainWindow.cc:1113:38: warning: ‘static void QApplication::setActiveWindow(QWidget*)’ is deprecated: Use QWidget::activateWindow() instead. [-Wdeprecated-declarations]
 1113 |         QApplication::setActiveWindow(this);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from /usr/include/qt6/QtWidgets/QApplication:1,
                 from qt/transmission-qt_autogen/include/ui_AboutDialog.h:14,
                 from qt/AboutDialog.h:13,
                 from qt/MainWindow.cc:23:
/usr/include/qt6/QtWidgets/qapplication.h:84:17: note: declared here
   84 |     static void setActiveWindow(QWidget* act);
      |                 ^~~~~~~~~~~~~~~
```