### PR TITLE
fix: return error when renaming into existing file

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2447,24 +2447,19 @@ namespace
 {
 namespace rename_helpers
 {
-bool renameArgsAreValid(std::string_view oldpath, std::string_view newname)
+bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
 {
-    return !std::empty(oldpath) && !std::empty(newname) && newname != "."sv && newname != ".."sv &&
-        !tr_strvContains(newname, TR_PATH_DELIMITER);
-}
+    if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv ||
+        tr_strvContains(newname, TR_PATH_DELIMITER))
+    {
+        return false;
+    }
 
-bool renameNoCollision(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
-{
-    std::string newpath{};
-    if (tr_strvContains(oldpath, TR_PATH_DELIMITER))
-    {
-        newpath = fmt::format(FMT_STRING("{:s}/{:s}"sv), tr_sys_path_dirname(oldpath), newname);
-    }
-    else
-    {
-        newpath = newname;
-    }
-    if (newpath == oldpath)
+    auto const newpath = tr_strvContains(oldpath, TR_PATH_DELIMITER) ?
+        tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
+        tr_pathbuf{ newname };
+
+    if (oldpath == newpath)
     {
         return true;
     }
@@ -2474,7 +2469,7 @@ bool renameNoCollision(tr_torrent const* tor, std::string_view oldpath, std::str
 
     for (tr_file_index_t i = 0; i < n_files; ++i)
     {
-        auto const& name = tor->file_subpath(i);
+        std::string_view name = tor->file_subpath(i);
         if (name == newpath || tr_strvStartsWith(name, newpath_as_dir))
         {
             return false;
@@ -2598,11 +2593,7 @@ void torrentRenamePath(
 
     int error = 0;
 
-    if (!renameArgsAreValid(oldpath, newname))
-    {
-        error = EINVAL;
-    }
-    else if (!renameNoCollision(tor, oldpath, newname))
+    if (!renameArgsAreValid(tor, oldpath, newname))
     {
         error = EINVAL;
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2459,7 +2459,7 @@ bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::st
         tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
         tr_pathbuf{ newname };
 
-    if (oldpath == newpath)
+    if (newpath == oldpath)
     {
         return true;
     }
@@ -2469,8 +2469,8 @@ bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::st
 
     for (tr_file_index_t i = 0; i < n_files; ++i)
     {
-        std::string_view name = tor->file_subpath(i);
-        if (name == newpath || tr_strvStartsWith(name, newpath_as_dir))
+        auto const& name = tor->file_subpath(i);
+        if (newpath == name || tr_strvStartsWith(name, newpath_as_dir))
         {
             return false;
         }

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -414,6 +414,9 @@ TEST_F(RenameTest, multifileTorrent)
     EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "Felidae/FelinaeX", "Genus Felinae"));
     EXPECT_STREQ("Felidae", tr_torrentName(tor));
 
+    // rename filename collision
+    EXPECT_EQ(EINVAL, torrentRenameAndWait(tor, "Felidae/Felinae/Felis/catus/Kyphi", "Saffron"));
+    EXPECT_STREQ("Felidae", tr_torrentName(tor));
     /***
     ****
     ***/


### PR DESCRIPTION
My attempt at resolving [this issue](https://github.com/transmission/transmission/issues/5555#issue-1723972944).

 *edit by @ckerr:* @basilefff use the phrase "Fixes #DDDD" so GitHub will understand and link the issue and PR together :tada:

Fixes #5555.