### PR TITLE
handle IPv6 NAT during LTEP handshake

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -958,7 +958,7 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
-    if (auto const addr = msgs->session->publicAddress(TR_AF_INET6); !addr.is_any())
+    if (auto const addr = msgs->session->global_address(TR_AF_INET6); !addr.is_any())
     {
         TR_ASSERT(addr.is_ipv6());
         tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr.addr.addr6, sizeof(addr.addr.addr6));

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -958,14 +958,15 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
-    // If we have a preferred IPv6 interface (i.e. !msgs->session->publicAddress(TR_AF_INET6).is_any()),
-    // then suggest our IPv6 address to the peer.
-    if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET6) :
-                                                                            msgs->session->global_source_address(TR_AF_INET6);
-        !msgs->session->publicAddress(TR_AF_INET6).is_any() && addr)
+    // If connecting to global peer, then use global address
+    // Otherwise we are connecting to local peer, use bind address directly
+    if (auto const addr = msgs->io->address().is_global_unicast_address() ?
+            msgs->session->global_address(TR_AF_INET6).value_or(tr_address::any_ipv6()) :
+            msgs->session->publicAddress(TR_AF_INET6);
+        !addr.is_any())
     {
-        TR_ASSERT(addr->is_ipv6());
-        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr->addr.addr6, sizeof(addr->addr.addr6));
+        TR_ASSERT(addr.is_ipv6());
+        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr.addr.addr6, sizeof(addr.addr.addr6));
     }
 
     // http://bittorrent.org/beps/bep_0009.html

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -960,13 +960,12 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
     // If connecting to global peer, then use global address
     // Otherwise we are connecting to local peer, use bind address directly
-    if (auto const addr = msgs->io->address().is_global_unicast_address() ?
-            msgs->session->global_address(TR_AF_INET6).value_or(tr_address::any_ipv6()) :
-            msgs->session->publicAddress(TR_AF_INET6);
-        !addr.is_any())
+    if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET6) :
+                                                                            msgs->session->publicAddress(TR_AF_INET6);
+        addr && !addr->is_any())
     {
-        TR_ASSERT(addr.is_ipv6());
-        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr.addr.addr6, sizeof(addr.addr.addr6));
+        TR_ASSERT(addr->is_ipv6());
+        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr->addr.addr6, sizeof(addr->addr.addr6));
     }
 
     // http://bittorrent.org/beps/bep_0009.html

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -958,10 +958,12 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
-    if (auto const addr = msgs->session->global_address(TR_AF_INET6); !addr.is_any())
+    if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET6) :
+                                                                            msgs->session->global_source_address(TR_AF_INET6);
+        addr && !addr->is_any())
     {
-        TR_ASSERT(addr.is_ipv6());
-        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr.addr.addr6, sizeof(addr.addr.addr6));
+        TR_ASSERT(addr->is_ipv6());
+        tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr->addr.addr6, sizeof(addr->addr.addr6));
     }
 
     // http://bittorrent.org/beps/bep_0009.html

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -958,9 +958,11 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     tr_variantInitDict(&val, 8);
     tr_variantDictAddBool(&val, TR_KEY_e, msgs->session->encryptionMode() != TR_CLEAR_PREFERRED);
 
+    // If we have a preferred IPv6 interface (i.e. !msgs->session->publicAddress(TR_AF_INET6).is_any()),
+    // then suggest our IPv6 address to the peer.
     if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET6) :
                                                                             msgs->session->global_source_address(TR_AF_INET6);
-        addr && !addr->is_any())
+        !msgs->session->publicAddress(TR_AF_INET6).is_any() && addr)
     {
         TR_ASSERT(addr->is_ipv6());
         tr_variantDictAddRaw(&val, TR_KEY_ipv6, &addr->addr.addr6, sizeof(addr->addr.addr6));


### PR DESCRIPTION
https://github.com/transmission/transmission/issues/5542#issuecomment-1556710922

The original LTEP handshake code assumes that we are not behind an IPv6 NAT. This PR removes that assumption.
