### PR TITLE
fix: apply i18n to percentage values

### DIFF
--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -108,17 +108,28 @@
 
 + (NSString*)percentString:(CGFloat)progress longDecimals:(BOOL)longDecimals
 {
+    static NSNumberFormatter* longFormatter;
+    static NSNumberFormatter* shortFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        longFormatter = [[NSNumberFormatter alloc] init];
+        longFormatter.numberStyle = NSNumberFormatterPercentStyle;
+        longFormatter.maximumFractionDigits = 2;
+        shortFormatter = [[NSNumberFormatter alloc] init];
+        shortFormatter.numberStyle = NSNumberFormatterPercentStyle;
+        shortFormatter.maximumFractionDigits = 1;
+    });
     if (progress >= 1.0)
     {
-        return [NSString localizedStringWithFormat:@"%d%%", 100];
+        return [shortFormatter stringFromNumber:@(1)];
     }
     else if (longDecimals)
     {
-        return [NSString localizedStringWithFormat:@"%.2f%%", tr_truncd(progress * 100.0, 2)];
+        return [longFormatter stringFromNumber:@(MIN(progress, 0.9999))];
     }
     else
     {
-        return [NSString localizedStringWithFormat:@"%.1f%%", tr_truncd(progress * 100.0, 1)];
+        return [shortFormatter stringFromNumber:@(MIN(progress, 0.999))];
     }
 }
 


### PR DESCRIPTION
Some languages use different percentage formatting style other than 100% (e.g. Turkish and French, %100-100 %). This commit enables the use of NSNumberFormatter(), in order to provide localized formatting.