### PR TITLE
Avoid locale use in `tr_truncd()`

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -9,7 +9,6 @@
 #include <cerrno>
 #include <cfloat> // DBL_DIG
 #include <chrono>
-#include <clocale> // localeconv()
 #include <cstdint> // SIZE_MAX
 #include <cstdlib> // getenv()
 #include <cstring> /* strerror() */
@@ -514,10 +513,10 @@ std::vector<int> tr_parseNumberRange(std::string_view str)
 double tr_truncd(double x, int decimal_places)
 {
     auto buf = std::array<char, 128>{};
-    auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, "{:.{}Lf}", x, DBL_DIG);
+    auto const [out, len] = fmt::format_to_n(std::data(buf), std::size(buf) - 1, "{:.{}f}", x, DBL_DIG);
     *out = '\0';
 
-    if (auto* const pt = strstr(std::data(buf), localeconv()->decimal_point); pt != nullptr)
+    if (auto* const pt = strchr(std::data(buf), '.'); pt != nullptr)
     {
         pt[decimal_places != 0 ? decimal_places + 1 : 0] = '\0';
     }


### PR DESCRIPTION
`tr_parseNum<>()` is implemented with `fast_float::from_chars()`, and the latter is documented as "expecting a locale-indepent format equivalent to what is used by std::strtod in the default ("C") locale". To accomodate locale independent number parsing, switch back to locale-independent number formatting in `tr_truncd()` by both removing a `L` format specifier from `fmt::format_to_n()` call and using a fixed "." decimal separator when truncating the value.

Broken-by: #5288, #3748, #2872
Fixes: #5503
