### PR TITLE
ci: add "brew upgrade" step

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -239,8 +239,6 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew update
-          brew upgrade
           brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
@@ -514,8 +512,6 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew update
-          brew upgrade
           brew install cmake gettext ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -240,6 +240,7 @@ jobs:
       - name: Get Dependencies
         run: |
           brew update
+          brew upgrade
           brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
@@ -514,6 +515,7 @@ jobs:
       - name: Get Dependencies
         run: |
           brew update
+          brew upgrade
           brew install cmake gettext ninja node pkg-config
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -45,6 +45,10 @@
 
 using namespace std::literals;
 
+// FIXME(ckerr) do not merge these three lines.
+// This comment is to make CI think libtransmission has
+// changed so that it will run the libtransmission CI tests
+
 namespace
 {
 #ifdef _WIN32


### PR DESCRIPTION
experimental change to possibly fix https://github.com/transmission/transmission/actions/runs/5237106884/jobs/9455075792?pr=5510.

Appears to be new with the Python 3.11.4 bump, that landed about 5 hours ago at https://github.com/Homebrew/homebrew-core/pull/133015. That's consistent with CI being red now but was working last night. That doesn't prove whose bug it is :smile: I haven't done enough investigation to know whether it's Transmission or homebrew-core