### PR TITLE
add small-0.1.2 to third-party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "third-party/wide-integer"]
 	path = third-party/wide-integer
 	url = https://github.com/transmission/wide-integer
+[submodule "third-party/small"]
+	path = third-party/small
+	url = https://github.com/transmission/small.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,11 +204,12 @@ if(WIN32)
 endif()
 
 set(CMAKE_FOLDER "third-party")
-
-find_package(Fmt)
-find_package(WideInteger)
 find_package(FastFloat)
+find_package(Fmt)
+find_package(Small)
 find_package(UtfCpp)
+find_package(WideInteger)
+
 find_package(Threads)
 find_package(PkgConfig QUIET)
 

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3753,6 +3753,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -3798,6 +3799,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -3819,6 +3821,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3844,6 +3847,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3865,6 +3869,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4007,6 +4012,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4042,6 +4048,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4073,6 +4080,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4274,6 +4282,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4295,6 +4304,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4333,6 +4343,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4372,6 +4383,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4393,6 +4405,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4472,6 +4485,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4501,6 +4515,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4530,6 +4545,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4599,6 +4615,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4620,6 +4637,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4812,6 +4830,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4833,6 +4852,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4854,6 +4874,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4875,6 +4896,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4896,6 +4918,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4917,6 +4940,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4938,6 +4962,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4959,6 +4984,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4980,6 +5006,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};

--- a/cmake/FindSmall.cmake
+++ b/cmake/FindSmall.cmake
@@ -1,0 +1,5 @@
+add_library(small::small INTERFACE IMPORTED)
+
+target_include_directories(small::small
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/../third-party/small/include)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -297,7 +297,8 @@ target_link_libraries(${TR_NAME}
         "$<$<BOOL:${APPLE}>:-framework Foundation>"
     PUBLIC
         fmt::fmt-header-only
-        libevent::event)
+        libevent::event
+        small::small)
 
 if(INSTALL_LIB)
     install(

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -102,18 +102,18 @@ auto loadLabels(tr_variant* dict, tr_torrent* tor)
     }
 
     auto const n = tr_variantListSize(list);
-    auto labels = std::vector<tr_quark>{};
+    auto labels = tr_torrent::labels_t{};
     labels.reserve(n);
     for (size_t i = 0; i < n; ++i)
     {
         auto sv = std::string_view{};
         if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv))
         {
-            labels.emplace_back(tr_quark_new(sv));
+            labels.emplace(tr_quark_new(sv));
         }
     }
 
-    tor->setLabels(labels);
+    tor->set_labels(std::move(labels));
     return tr_resume::Labels;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -968,9 +968,9 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
 
 // ---
 
-[[nodiscard]] std::pair<std::vector<tr_quark>, char const* /*errmsg*/> makeLabels(tr_variant* list)
+[[nodiscard]] std::pair<tr_torrent::labels_t, char const* /*errmsg*/> makeLabels(tr_variant* list)
 {
-    auto labels = std::vector<tr_quark>{};
+    auto labels = tr_torrent::labels_t{};
     size_t const n = tr_variantListSize(list);
     labels.reserve(n);
 
@@ -993,7 +993,7 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
             return { {}, "labels cannot contain comma (,) character" };
         }
 
-        labels.emplace_back(tr_quark_new(label));
+        labels.emplace(tr_quark_new(label));
     }
 
     return { labels, nullptr };
@@ -1008,7 +1008,7 @@ char const* setLabels(tr_torrent* tor, tr_variant* list)
         return errmsg;
     }
 
-    tor->setLabels(labels);
+    tor->set_labels(std::move(labels));
     return nullptr;
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1049,8 +1049,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     tor->error = TR_STAT_OK;
     tor->finished_seeding_by_idle_ = false;
 
-    auto const& labels = tr_ctorGetLabels(ctor);
-    tor->setLabels(labels);
+    tor->set_labels(tr_ctorGetLabels(ctor));
 
     session->addTorrent(tor);
 
@@ -1948,24 +1947,6 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->set_files_wanted(files, n_files, wanted);
-}
-
-// ---
-
-void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
-{
-    auto const lock = unique_lock();
-    this->labels.clear();
-
-    for (auto label : new_labels)
-    {
-        if (std::find(std::begin(this->labels), std::end(this->labels), label) == std::end(this->labels))
-        {
-            this->labels.push_back(label);
-        }
-    }
-    this->labels.shrink_to_fit();
-    this->set_dirty();
 }
 
 // ---


### PR DESCRIPTION
Fixes #5598.

Adding [small](https://github.com/alandefreitas/small) as a third-party dependency is part of a larger project to avoid short-term heap allocations, but 5598 is a much smaller scope and so introducing it here makes for a nice, small PR :smile_cat: 

CC @rsekman, @xavery, reviews welcomed 