### PR TITLE
fix 'setNeedsDisplay' is deprecated: first deprecated in macOS 10.14

### DIFF
--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -129,7 +129,7 @@ typedef struct PieceInfo
     self.image = [[NSImage alloc] initWithSize:self.bounds.size];
 
     [self clearView];
-    [self setNeedsDisplay];
+    self.needsDisplay = YES;
 }
 
 - (void)clearView
@@ -196,7 +196,7 @@ typedef struct PieceInfo
             NSRectFillListWithColors(cFillRects, cFillColors, numCells);
             return YES;
         }];
-        [self setNeedsDisplay];
+        self.needsDisplay = YES;
     }
 
     // save the current state so we can compare it later

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -126,7 +126,13 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     //disable highlight color and set manually in drawRow
     [self setSelectionHighlightStyle:NSTableViewSelectionHighlightStyleNone];
 
-    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(setNeedsDisplay) name:@"RefreshTorrentTable" object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(refreshTorrentTable) name:@"RefreshTorrentTable"
+                                             object:nil];
+}
+
+- (void)refreshTorrentTable
+{
+    self.needsDisplay = YES;
 }
 
 - (BOOL)isGroupCollapsed:(NSInteger)value


### PR DESCRIPTION
<img width="757" alt="Capture d’écran 2023-06-18 à 02 54 42" src="https://github.com/transmission/transmission/assets/839992/e5b9767b-5b72-4b3f-80e3-6b75798d6f13">
