### PR TITLE
Add support for sending the `ipv4` parameter during ltep handshake

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -217,7 +217,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr,
     auto const [sock, addrlen] = addr.to_sockaddr(port);
 
     // set source address
-    auto const source_addr = session->publicAddress(addr.type);
+    auto const source_addr = session->bind_address(addr.type);
     auto const [source_sock, sourcelen] = source_addr.to_sockaddr({});
 
     if (bind(s, reinterpret_cast<sockaddr const*>(&source_sock), sourcelen) == -1)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -351,7 +351,7 @@ public:
         if (session->allowsDHT() && io->supports_dht())
         {
             // only send PORT over IPv6 iff IPv6 DHT is running (BEP-32).
-            if (auto const addr = session->publicAddress(TR_AF_INET6); !addr.is_any())
+            if (auto const addr = session->bind_address(TR_AF_INET6); !addr.is_any())
             {
                 protocolSendPort(this, session->udpPort());
             }
@@ -961,8 +961,15 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
     // If connecting to global peer, then use global address
     // Otherwise we are connecting to local peer, use bind address directly
+    if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET) :
+                                                                            msgs->session->bind_address(TR_AF_INET);
+        addr && !addr->is_any())
+    {
+        TR_ASSERT(addr->is_ipv4());
+        tr_variantDictAddRaw(&val, TR_KEY_ipv4, &addr->addr.addr4, sizeof(addr->addr.addr4));
+    }
     if (auto const addr = msgs->io->address().is_global_unicast_address() ? msgs->session->global_address(TR_AF_INET6) :
-                                                                            msgs->session->publicAddress(TR_AF_INET6);
+                                                                            msgs->session->bind_address(TR_AF_INET6);
         addr && !addr->is_any())
     {
         TR_ASSERT(addr->is_ipv6());

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -303,7 +303,7 @@ std::optional<std::string_view> tr_session::WebMediator::userAgent() const
 
 std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
 {
-    if (auto const addr = session_->publicAddress(TR_AF_INET); !addr.is_any())
+    if (auto const addr = session_->bind_address(TR_AF_INET); !addr.is_any())
     {
         return addr.display_name();
     }
@@ -313,7 +313,7 @@ std::optional<std::string> tr_session::WebMediator::publicAddressV4() const
 
 std::optional<std::string> tr_session::WebMediator::publicAddressV6() const
 {
-    if (auto const addr = session_->publicAddress(TR_AF_INET6); !addr.is_any())
+    if (auto const addr = session_->bind_address(TR_AF_INET6); !addr.is_any())
     {
         return addr.display_name();
     }
@@ -417,7 +417,7 @@ tr_session::BoundSocket::~BoundSocket()
     }
 }
 
-tr_address tr_session::publicAddress(tr_address_type type) const noexcept
+tr_address tr_session::bind_address(tr_address_type type) const noexcept
 {
     if (type == TR_AF_INET)
     {
@@ -734,14 +734,14 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
     {
         if (auto const& val = new_settings.bind_address_ipv4; force || port_changed || val != old_settings.bind_address_ipv4)
         {
-            auto const addr = publicAddress(TR_AF_INET);
+            auto const addr = bind_address(TR_AF_INET);
             bound_ipv4_.emplace(event_base(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this);
             addr_changed = true;
         }
 
         if (auto const& val = new_settings.bind_address_ipv6; force || port_changed || val != old_settings.bind_address_ipv6)
         {
-            auto const addr = publicAddress(TR_AF_INET6);
+            auto const addr = bind_address(TR_AF_INET6);
             bound_ipv6_.emplace(event_base(), addr, local_peer_port_, &tr_session::onIncomingPeerConnection, this);
             addr_changed = true;
         }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -194,7 +194,7 @@ private:
 
         [[nodiscard]] tr_address incoming_peer_address() const override
         {
-            return session_.publicAddress(TR_AF_INET);
+            return session_.bind_address(TR_AF_INET);
         }
 
         [[nodiscard]] tr_port local_peer_port() const override
@@ -815,7 +815,7 @@ public:
         return global_ip_cache_->has_ip_protocol(type);
     }
 
-    [[nodiscard]] tr_address publicAddress(tr_address_type type) const noexcept;
+    [[nodiscard]] tr_address bind_address(tr_address_type type) const noexcept;
 
     [[nodiscard]] std::optional<tr_address> global_address(tr_address_type type) const noexcept
     {
@@ -1113,10 +1113,10 @@ private:
 
     /// other fields
 
-    // depends-on: session_thread_, settings_.bind_address_ipv4, local_peer_port_, global_ip_cache (via tr_session::publicAddress())
+    // depends-on: session_thread_, settings_.bind_address_ipv4, local_peer_port_, global_ip_cache (via tr_session::bind_address())
     std::optional<BoundSocket> bound_ipv4_;
 
-    // depends-on: session_thread_, settings_.bind_address_ipv6, local_peer_port_, global_ip_cache (via tr_session::publicAddress())
+    // depends-on: session_thread_, settings_.bind_address_ipv6, local_peer_port_, global_ip_cache (via tr_session::bind_address())
     std::optional<BoundSocket> bound_ipv6_;
 
 public:
@@ -1151,7 +1151,7 @@ private:
     GlobalIPCacheMediator global_ip_cache_mediator_{ *this };
     std::unique_ptr<tr_global_ip_cache> global_ip_cache_ = tr_global_ip_cache::create(global_ip_cache_mediator_);
 
-    // depends-on: settings_, session_thread_, torrents_, global_ip_cache (via tr_session::publicAddress())
+    // depends-on: settings_, session_thread_, torrents_, global_ip_cache (via tr_session::bind_address())
     WebMediator web_mediator_{ this };
     std::unique_ptr<tr_web> web_ = tr_web::create(this->web_mediator_);
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -150,7 +150,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         auto optval = int{ 1 };
         setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
 
-        auto const addr = session_.publicAddress(TR_AF_INET);
+        auto const addr = session_.bind_address(TR_AF_INET);
         auto const [ss, sslen] = addr.to_sockaddr(udp_port_);
 
         if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)
@@ -184,7 +184,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         auto optval = int{ 1 };
         setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
 
-        auto const addr = session_.publicAddress(TR_AF_INET6);
+        auto const addr = session_.bind_address(TR_AF_INET6);
         auto const [ss, sslen] = addr.to_sockaddr(udp_port_);
 
         if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)


### PR DESCRIPTION
Following up on https://github.com/transmission/transmission/pull/5565#issuecomment-1577875205 to add the ability to include the `ipv4` parameter during LTEP handshake as well. [BEP-10](https://www.bittorrent.org/beps/bep_0010.html)

Also renamed `tr_session::publicAddress()` to `tr_session::bind_address()` as a follow up of https://github.com/transmission/transmission/pull/5565#issuecomment-1596255260.