### PR TITLE
Use a map container to store peers in `tr_swarm`

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -521,9 +521,8 @@ ReadState tr_handshake::read_crypto_provide(tr_peerIo* peer_io)
 
     if (auto const info = mediator_->torrent_from_obfuscated(obfuscated_hash); info)
     {
-        auto const& [addr, port] = peer_io->socket_address();
         bool const client_is_seed = info->is_done;
-        bool const peer_is_seed = mediator_->is_peer_known_seed(info->id, addr, port);
+        bool const peer_is_seed = mediator_->is_peer_known_seed(info->id, peer_io->socket_address());
         tr_logAddTraceHand(this, fmt::format("got INCOMING connection's encrypted handshake for torrent [{}]", info->id));
         peer_io->set_torrent_hash(info->info_hash);
 
@@ -789,8 +788,7 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
         /* Don't mark a peer as non-µTP unless it's really a connect failure. */
         if ((error.code == ETIMEDOUT || error.code == ECONNREFUSED) && info)
         {
-            auto const& [addr, port] = io->socket_address();
-            handshake->mediator_->set_utp_failed(info_hash, addr, port);
+            handshake->mediator_->set_utp_failed(info_hash, io->socket_address());
         }
 
         if (handshake->mediator_->allows_tcp() && io->reconnect())

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -61,15 +61,18 @@ public:
         [[nodiscard]] virtual libtransmission::TimerMaker& timer_maker() = 0;
         [[nodiscard]] virtual bool allows_dht() const = 0;
         [[nodiscard]] virtual bool allows_tcp() const = 0;
-        [[nodiscard]] virtual bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_address const& addr, tr_port const& port)
-            const = 0;
+        [[nodiscard]] virtual bool is_peer_known_seed(
+            tr_torrent_id_t tor_id,
+            std::pair<tr_address, tr_port> const& socket_address) const = 0;
         [[nodiscard]] virtual size_t pad(void* setme, size_t max_bytes) const = 0;
         [[nodiscard]] virtual DH::private_key_bigend_t private_key() const
         {
             return DH::randomPrivateKey();
         }
 
-        virtual void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_address const&, tr_port const&) = 0;
+        virtual void set_utp_failed(
+            tr_sha1_digest_t const& info_hash,
+            std::pair<tr_address, tr_port> const& socket_address) = 0;
     };
 
     tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -479,7 +479,7 @@ public:
 
     [[nodiscard]] peer_atom* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) noexcept
     {
-        auto it = pool.find(socket_address);
+        auto&& it = pool.find(socket_address);
         return it != pool.end() ? &it->second : nullptr;
     }
 
@@ -1010,7 +1010,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, str
 
     auto* const s = manager->get_existing_swarm(result.io->torrent_hash());
 
-    auto const socket_address = result.io->socket_address();
+    auto const& socket_address = result.io->socket_address();
 
     if (result.io->is_incoming())
     {
@@ -1121,9 +1121,9 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
     }
     else /* we don't have a connection to them yet... */
     {
-        auto const& socket_address = socket.socketAddress();
+        auto&& socket_address = socket.socketAddress();
         manager->incoming_handshakes.try_emplace(
-            socket_address,
+            std::move(socket_address),
             &manager->handshake_mediator_,
             tr_peerIo::new_incoming(session, &session->top_bandwidth_, std::move(socket)),
             session->encryptionMode(),

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -300,7 +300,7 @@ private:
     static auto inline n_atoms = std::atomic<size_t>{};
 };
 
-using Handshakes = std::map<tr_address, tr_handshake>;
+using Handshakes = std::map<std::pair<tr_address, tr_port>, tr_handshake>;
 
 #define tr_logAddDebugSwarm(swarm, msg) tr_logAddDebugTor((swarm)->tor, msg)
 #define tr_logAddTraceSwarm(swarm, msg) tr_logAddTraceTor((swarm)->tor, msg)
@@ -1011,11 +1011,11 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, str
 
     if (result.io->is_incoming())
     {
-        manager->incoming_handshakes.erase(addr);
+        manager->incoming_handshakes.erase(std::make_pair(addr, port));
     }
     else if (s != nullptr)
     {
-        s->outgoing_handshakes.erase(addr);
+        s->outgoing_handshakes.erase(std::make_pair(addr, port));
     }
 
     auto const lock = manager->unique_lock();
@@ -1112,15 +1112,14 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
         tr_logAddTrace(fmt::format("Banned IP address '{}' tried to connect to us", socket.display_name()));
         socket.close();
     }
-    else if (manager->incoming_handshakes.count(socket.address()) != 0U)
+    else if (manager->incoming_handshakes.count(socket.socketAddress()) != 0U)
     {
         socket.close();
     }
     else /* we don't have a connection to them yet... */
     {
-        auto address = socket.address();
         manager->incoming_handshakes.try_emplace(
-            address,
+            socket.socketAddress(),
             &manager->handshake_mediator_,
             tr_peerIo::new_incoming(session, &session->top_bandwidth_, std::move(socket)),
             session->encryptionMode(),
@@ -2225,8 +2224,8 @@ void tr_peerMgr::bandwidthPulse()
 
 bool tr_swarm::peer_is_in_use(peer_atom const& atom) const
 {
-    return atom.is_connected || outgoing_handshakes.count(atom.addr) != 0U ||
-        manager->incoming_handshakes.count(atom.addr) != 0U;
+    return atom.is_connected || outgoing_handshakes.count(std::make_pair(atom.addr, atom.port)) != 0U ||
+        manager->incoming_handshakes.count(std::make_pair(atom.addr, atom.port)) != 0U;
 }
 
 namespace
@@ -2466,7 +2465,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     else
     {
         s->outgoing_handshakes.try_emplace(
-            atom.addr,
+            std::make_pair(atom.addr, atom.port),
             &mgr->handshake_mediator_,
             peer_io,
             session->encryptionMode(),

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -479,12 +479,14 @@ public:
 
     [[nodiscard]] peer_atom* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) noexcept
     {
-        return pool.count(socket_address) != 0U ? &pool.at(socket_address) : nullptr;
+        auto it = pool.find(socket_address);
+        return it != pool.end() ? &it->second : nullptr;
     }
 
     [[nodiscard]] peer_atom const* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) const noexcept
     {
-        return pool.count(socket_address) != 0U ? &pool.at(socket_address) : nullptr;
+        auto const& it = pool.find(socket_address);
+        return it != pool.cend() ? &it->second : nullptr;
     }
 
     [[nodiscard]] bool peer_is_a_seed(std::pair<tr_address, tr_port> const& socket_address) const noexcept

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -107,15 +107,16 @@ public:
         return session_.allowsTCP();
     }
 
-    void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_address const& addr, tr_port const& port) override
+    void set_utp_failed(tr_sha1_digest_t const& info_hash, std::pair<tr_address, tr_port> const& socket_address) override
     {
         if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
         {
-            tr_peerMgrSetUtpFailed(tor, addr, port, true);
+            tr_peerMgrSetUtpFailed(tor, socket_address, true);
         }
     }
 
-    [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_address const& addr, tr_port const& port) const override;
+    [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t tor_id, std::pair<tr_address, tr_port> const& socket_address)
+        const override;
 
     [[nodiscard]] libtransmission::TimerMaker& timer_maker() override
     {
@@ -462,7 +463,10 @@ public:
     {
         if (!pool_is_all_seeds_)
         {
-            pool_is_all_seeds_ = std::all_of(std::begin(pool), std::end(pool), [](auto const& atom) { return atom.isSeed(); });
+            pool_is_all_seeds_ = std::all_of(
+                std::begin(pool),
+                std::end(pool),
+                [](auto const& key_val) { return key_val.second.isSeed(); });
         }
 
         return *pool_is_all_seeds_;
@@ -473,40 +477,38 @@ public:
         pool_is_all_seeds_.reset();
     }
 
-    [[nodiscard]] peer_atom* get_existing_atom(tr_address const& addr, tr_port const& port) noexcept
+    [[nodiscard]] peer_atom* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) noexcept
     {
-        auto const iter = std::find_if(
-            std::begin(pool),
-            std::end(pool),
-            [&addr, &port](auto const& atom) { return atom.addr == addr && atom.port == port; });
-        return iter != std::end(pool) ? &*iter : nullptr;
+        return pool.count(socket_address) != 0U ? &pool.at(socket_address) : nullptr;
     }
 
-    [[nodiscard]] peer_atom const* get_existing_atom(tr_address const& addr, tr_port const& port) const noexcept
+    [[nodiscard]] peer_atom const* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) const noexcept
     {
-        auto const iter = std::find_if(
-            std::begin(pool),
-            std::end(pool),
-            [&addr, &port](auto const& atom) { return atom.addr == addr && atom.port == port; });
-        return iter != std::end(pool) ? &*iter : nullptr;
+        return pool.count(socket_address) != 0U ? &pool.at(socket_address) : nullptr;
     }
 
-    [[nodiscard]] bool peer_is_a_seed(tr_address const& addr, tr_port const& port) const noexcept
+    [[nodiscard]] bool peer_is_a_seed(std::pair<tr_address, tr_port> const& socket_address) const noexcept
     {
-        auto const* const atom = get_existing_atom(addr, port);
+        auto const* const atom = get_existing_atom(socket_address);
         return atom != nullptr && atom->isSeed();
     }
 
-    peer_atom* ensure_atom_exists(tr_address const& addr, tr_port const& port, uint8_t const flags, uint8_t const from)
+    peer_atom* ensure_atom_exists(std::pair<tr_address, tr_port> const& socket_address, uint8_t const flags, uint8_t const from)
     {
+        auto const& [addr, port] = socket_address;
+
         TR_ASSERT(addr.is_valid());
         TR_ASSERT(from < TR_PEER_FROM__MAX);
 
-        peer_atom* atom = get_existing_atom(addr, port);
+        peer_atom* atom = get_existing_atom(socket_address);
 
         if (atom == nullptr)
         {
-            atom = &pool.emplace_back(addr, port, flags, from);
+            atom = &pool.emplace(
+                            std::piecewise_construct,
+                            std::forward_as_tuple(socket_address),
+                            std::forward_as_tuple(addr, port, flags, from))
+                        .first->second;
         }
         else
         {
@@ -651,9 +653,8 @@ public:
     std::vector<tr_peerMsgs*> peers;
 
     // tr_peers hold pointers to the items in this container,
-    // so use a deque instead of vector to prevent insertion from
-    // invalidating those pointers
-    std::deque<peer_atom> pool;
+    // therefore references to elements within cannot invalidate
+    std::map<std::pair<tr_address, tr_port>, peer_atom> pool;
 
     tr_peerMsgs* optimistic = nullptr; /* the optimistic peer, or nullptr if none */
 
@@ -799,7 +800,7 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
        since the blocklist has changed, erase that cached value */
     for (auto* const tor : mgr->session->torrents())
     {
-        for (auto& atom : tor->swarm->pool)
+        for (auto& [socket_address, atom] : tor->swarm->pool)
         {
             atom.setBlocklistedDirty();
         }
@@ -808,17 +809,17 @@ void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr)
 
 // ---
 
-void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr, tr_port const& port)
+void tr_peerMgrSetUtpSupported(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address)
 {
-    if (auto* const atom = tor->swarm->get_existing_atom(addr, port); atom != nullptr)
+    if (auto* const atom = tor->swarm->get_existing_atom(socket_address); atom != nullptr)
     {
         atom->flags |= ADDED_F_UTP_FLAGS;
     }
 }
 
-void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const& addr, tr_port const& port, bool failed)
+void tr_peerMgrSetUtpFailed(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address, bool failed)
 {
-    if (auto* const atom = tor->swarm->get_existing_atom(addr, port); atom != nullptr)
+    if (auto* const atom = tor->swarm->get_existing_atom(socket_address); atom != nullptr)
     {
         atom->utp_failed = failed;
     }
@@ -1007,15 +1008,15 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, str
 
     auto* const s = manager->get_existing_swarm(result.io->torrent_hash());
 
-    auto const [addr, port] = result.io->socket_address();
+    auto const socket_address = result.io->socket_address();
 
     if (result.io->is_incoming())
     {
-        manager->incoming_handshakes.erase(std::make_pair(addr, port));
+        manager->incoming_handshakes.erase(socket_address);
     }
     else if (s != nullptr)
     {
-        s->outgoing_handshakes.erase(std::make_pair(addr, port));
+        s->outgoing_handshakes.erase(socket_address);
     }
 
     auto const lock = manager->unique_lock();
@@ -1024,7 +1025,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, str
     {
         if (s != nullptr)
         {
-            struct peer_atom* atom = s->get_existing_atom(addr, port);
+            struct peer_atom* atom = s->get_existing_atom(socket_address);
 
             if (atom != nullptr)
             {
@@ -1045,7 +1046,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, str
     }
     else /* looking good */
     {
-        struct peer_atom* atom = s->ensure_atom_exists(addr, port, 0, TR_PEER_FROM_INCOMING);
+        struct peer_atom* atom = s->ensure_atom_exists(socket_address, 0, TR_PEER_FROM_INCOMING);
 
         atom->time = tr_time();
         atom->piece_data_time = 0;
@@ -1134,7 +1135,7 @@ void tr_peerMgrSetSwarmIsAllSeeds(tr_torrent* tor)
 
     auto* const swarm = tor->swarm;
 
-    for (auto& atom : swarm->pool)
+    for (auto& [socket_address, atom] : swarm->pool)
     {
         swarm->mark_atom_as_seed(atom);
     }
@@ -1153,7 +1154,7 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t
         if (tr_isPex(pex) && /* safeguard against corrupt data */
             !s->manager->session->addressIsBlocked(pex->addr) && pex->is_valid_for_peers())
         {
-            s->ensure_atom_exists(pex->addr, pex->port, pex->flags, from);
+            s->ensure_atom_exists(std::make_pair(pex->addr, pex->port), pex->flags, from);
             ++n_used;
         }
     }
@@ -1328,7 +1329,7 @@ std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t address_ty
     }
     else /* TR_PEERS_INTERESTING */
     {
-        for (auto const& atom : s->pool)
+        for (auto const& [socket_address, atom] : s->pool)
         {
             if (isAtomInteresting(tor, atom))
             {
@@ -2399,7 +2400,7 @@ struct peer_candidate
             continue;
         }
 
-        for (auto& atom : swarm->pool)
+        for (auto& [socket_address, atom] : swarm->pool)
         {
             if (isPeerCandidate(tor, atom, now))
             {
@@ -2493,8 +2494,8 @@ void tr_peerMgr::makeNewPeerConnections(size_t max)
 
 // ---
 
-bool HandshakeMediator::is_peer_known_seed(tr_torrent_id_t tor_id, tr_address const& addr, tr_port const& port) const
+bool HandshakeMediator::is_peer_known_seed(tr_torrent_id_t tor_id, std::pair<tr_address, tr_port> const& socket_address) const
 {
     auto const* const tor = session_.torrents().get(tor_id);
-    return tor != nullptr && tor->swarm != nullptr && tor->swarm->peer_is_a_seed(addr, port);
+    return tor != nullptr && tor->swarm != nullptr && tor->swarm->peer_is_a_seed(socket_address);
 }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1118,8 +1118,9 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
     }
     else /* we don't have a connection to them yet... */
     {
+        auto const& socket_address = socket.socketAddress();
         manager->incoming_handshakes.try_emplace(
-            socket.socketAddress(),
+            socket_address,
             &manager->handshake_mediator_,
             tr_peerIo::new_incoming(session, &session->top_bandwidth_, std::move(socket)),
             session->encryptionMode(),

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -502,17 +502,9 @@ public:
         TR_ASSERT(addr.is_valid());
         TR_ASSERT(from < TR_PEER_FROM__MAX);
 
-        peer_atom* atom = get_existing_atom(socket_address);
-
-        if (atom == nullptr)
-        {
-            atom = &pool.emplace(
-                            std::piecewise_construct,
-                            std::forward_as_tuple(socket_address),
-                            std::forward_as_tuple(addr, port, flags, from))
-                        .first->second;
-        }
-        else
+        auto&& [atom_it, is_new] = pool.try_emplace(socket_address, addr, port, flags, from);
+        peer_atom* atom = &atom_it->second;
+        if (!is_new)
         {
             atom->fromBest = std::min(atom->fromBest, from);
             atom->flags |= flags;

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -163,9 +163,9 @@ constexpr bool tr_isPex(tr_pex const* pex)
 
 void tr_peerMgrFree(tr_peerMgr* manager);
 
-void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_address const& addr, tr_port const& port);
+void tr_peerMgrSetUtpSupported(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address);
 
-void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_address const& addr, tr_port const& port, bool failed);
+void tr_peerMgrSetUtpFailed(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address, bool failed);
 
 [[nodiscard]] std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_peer const* peer, size_t numwant);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -336,9 +336,8 @@ public:
 
         if (io->supports_utp())
         {
-            auto const& [addr, port] = socketAddress();
-            tr_peerMgrSetUtpSupported(torrent, addr, port);
-            tr_peerMgrSetUtpFailed(torrent, addr, port, false);
+            tr_peerMgrSetUtpSupported(torrent, socketAddress());
+            tr_peerMgrSetUtpFailed(torrent, socketAddress(), false);
         }
 
         if (io->supports_ltep())
@@ -1091,8 +1090,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
         {
             /* Mysterious µTorrent extension that we don't grok.  However,
                it implies support for µTP, so use it to indicate that. */
-            auto const& [addr, port] = msgs->socketAddress();
-            tr_peerMgrSetUtpFailed(msgs->torrent, addr, port, false);
+            tr_peerMgrSetUtpFailed(msgs->torrent, msgs->socketAddress(), false);
         }
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -336,8 +336,9 @@ public:
 
         if (io->supports_utp())
         {
-            tr_peerMgrSetUtpSupported(torrent, socketAddress());
-            tr_peerMgrSetUtpFailed(torrent, socketAddress(), false);
+            auto const& socket_address = socketAddress();
+            tr_peerMgrSetUtpSupported(torrent, socket_address);
+            tr_peerMgrSetUtpFailed(torrent, socket_address, false);
         }
 
         if (io->supports_ltep())

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -81,8 +81,9 @@ public:
             return true;
         }
 
-        [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t, std::pair<tr_address, tr_port> const& socket_address)
-            const override
+        [[nodiscard]] bool is_peer_known_seed(
+            tr_torrent_id_t /*tor_id*/,
+            std::pair<tr_address, tr_port> const& /*socket_address*/) const override
         {
             return false;
         }
@@ -100,7 +101,8 @@ public:
             return private_key_;
         }
 
-        void set_utp_failed(tr_sha1_digest_t const&, std::pair<tr_address, tr_port> const& socket_address) override
+        void set_utp_failed(tr_sha1_digest_t const& /*info_hash*/, std::pair<tr_address, tr_port> const& /*socket_address*/)
+            override
         {
         }
 

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -81,7 +81,7 @@ public:
             return true;
         }
 
-        [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t /*tor_id*/, tr_address const& /*addr*/, tr_port const& /*port*/)
+        [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t, std::pair<tr_address, tr_port> const& socket_address)
             const override
         {
             return false;
@@ -100,7 +100,7 @@ public:
             return private_key_;
         }
 
-        void set_utp_failed(tr_sha1_digest_t const& /*info_hash*/, tr_address const& /*addr*/, tr_port const& /*port*/) override
+        void set_utp_failed(tr_sha1_digest_t const&, std::pair<tr_address, tr_port> const& socket_address) override
         {
         }
 


### PR DESCRIPTION
(Partially? Hopefully?) fixes #5610.

1. To address the high CPU usage of `tr_swarm::get_existing_atom()`, the member `pool` of `tr_swarm` was changed from a dequeue to a map.
2. Refactored related functions to streamline function calls.

Notes: Made internal peer bookkeeping more efficient.