### PR TITLE
refactor: add libsmall dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "third-party/wide-integer"]
 	path = third-party/wide-integer
 	url = https://github.com/transmission/wide-integer
+[submodule "third-party/small"]
+	path = third-party/small
+	url = https://github.com/transmission/small.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,11 +204,12 @@ if(WIN32)
 endif()
 
 set(CMAKE_FOLDER "third-party")
-
-find_package(Fmt)
-find_package(WideInteger)
 find_package(FastFloat)
+find_package(Fmt)
+find_package(Small)
 find_package(UtfCpp)
+find_package(WideInteger)
+
 find_package(Threads)
 find_package(PkgConfig QUIET)
 

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3753,6 +3753,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -3798,6 +3799,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -3819,6 +3821,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3844,6 +3847,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3865,6 +3869,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4007,6 +4012,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4042,6 +4048,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4073,6 +4080,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4274,6 +4282,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4295,6 +4304,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4333,6 +4343,7 @@
 					"third-party/dht",
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4372,6 +4383,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4393,6 +4405,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4472,6 +4485,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4501,6 +4515,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4530,6 +4545,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4599,6 +4615,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4620,6 +4637,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4812,6 +4830,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4833,6 +4852,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4854,6 +4874,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4875,6 +4896,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4896,6 +4918,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4917,6 +4940,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4938,6 +4962,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4959,6 +4984,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4980,6 +5006,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/fmt/include",
+					"third-party/small/include",
 					"third-party/libevent/include",
 				);
 			};

--- a/cmake/FindSmall.cmake
+++ b/cmake/FindSmall.cmake
@@ -3,3 +3,9 @@ add_library(small::small INTERFACE IMPORTED)
 target_include_directories(small::small
     INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../third-party/small/include)
+
+
+target_compile_definitions(fmt::fmt-header-only
+    INTERFACE
+        SMALL_DISABLE_EXCEPTIONS=1)
+

--- a/cmake/FindSmall.cmake
+++ b/cmake/FindSmall.cmake
@@ -1,0 +1,5 @@
+add_library(small::small INTERFACE IMPORTED)
+
+target_include_directories(small::small
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/../third-party/small/include)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -297,6 +297,7 @@ target_link_libraries(${TR_NAME}
         "$<$<BOOL:${APPLE}>:-framework Foundation>"
     PUBLIC
         fmt::fmt-header-only
+        small::small
         libevent::event)
 
 if(INSTALL_LIB)

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -9,7 +9,7 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <cstdint> // for size_t
+#include <cstddef> // for size_t
 #include <cstdint> // for intX_t, uintX_t
 #include <ctime>
 #include <memory> // for std::unique_ptr

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -16,6 +16,8 @@
 #include <utility> // for std::pair
 #include <vector>
 
+#include <small/vector.hpp>
+
 #include "transmission.h"
 
 #include "block-info.h"
@@ -26,43 +28,7 @@ struct tr_torrent;
 class Cache
 {
 public:
-    class BlockData
-    {
-    public:
-        BlockData(size_t size)
-            : size_{ size }
-        {
-        }
-
-        [[nodiscard]] constexpr auto size() const noexcept
-        {
-            return size_;
-        }
-
-        [[nodiscard]] constexpr auto* data() noexcept
-        {
-            return std::data(data_);
-        }
-
-        [[nodiscard]] constexpr const auto* data() const noexcept
-        {
-            return std::data(data_);
-        }
-
-        [[nodiscard]] constexpr auto* begin() const noexcept
-        {
-            return data();
-        }
-
-        [[nodiscard]] constexpr auto* end() const noexcept
-        {
-            return begin() + size();
-        }
-
-    private:
-        std::array<uint8_t, tr_block_info::BlockSize> data_;
-        size_t const size_;
-    };
+    using BlockData = small::max_size_vector<uint8_t, tr_block_info::BlockSize>;
 
     Cache(tr_torrents& torrents, int64_t max_bytes);
 

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -9,14 +9,13 @@
 #include <utility>
 #include <vector>
 
-#include <small/set.hpp>
-
 #define LIBTRANSMISSION_PEER_MODULE
 
 #include "libtransmission/transmission.h"
 
 #include "libtransmission/crypto-utils.h" // for tr_salt_shaker
 #include "libtransmission/peer-mgr-wishlist.h"
+#include "libtransmission/tr-assert.h"
 
 namespace
 {
@@ -103,7 +102,7 @@ std::vector<Candidate> getCandidates(Wishlist::Mediator const& mediator)
     return candidates;
 }
 
-std::vector<tr_block_span_t> makeSpans(tr_block_index_t const* const sorted_blocks, size_t n_blocks)
+std::vector<tr_block_span_t> makeSpans(tr_block_index_t const* sorted_blocks, size_t n_blocks)
 {
     if (n_blocks == 0)
     {
@@ -146,9 +145,7 @@ std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
     auto const middle = std::min(std::size(candidates), MaxSortedPieces);
     std::partial_sort(std::begin(candidates), std::begin(candidates) + middle, std::end(candidates));
 
-    static auto constexpr StaticSize = 4096U;
-    auto blocks = small::set<tr_block_index_t, StaticSize>{};
-    blocks.reserve(n_wanted_blocks);
+    auto blocks = std::set<tr_block_index_t>{};
     for (auto const& candidate : candidates)
     {
         // do we have enough?
@@ -169,7 +166,7 @@ std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
 
             // don't request from too many peers
             size_t const n_peers = mediator_.countActiveRequests(block);
-            if (size_t const max_peers = mediator_.isEndgame() ? EndgameMaxPeers : 1; n_peers >= max_peers)
+            if (size_t const max_peers = mediator_.isEndgame() ? 2 : 1; n_peers >= max_peers)
             {
                 continue;
             }
@@ -178,5 +175,6 @@ std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
         }
     }
 
-    return makeSpans(std::data(blocks), std::size(blocks));
+    auto const blocks_v = std::vector<tr_block_index_t>{ std::begin(blocks), std::end(blocks) };
+    return makeSpans(std::data(blocks_v), std::size(blocks_v));
 }

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -22,6 +22,8 @@
 class Wishlist
 {
 public:
+    static auto constexpr EndgameMaxPeers = size_t{ 2U };
+
     struct Mediator
     {
         [[nodiscard]] virtual bool clientCanRequestBlock(tr_block_index_t block) const = 0;

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -22,8 +22,6 @@
 class Wishlist
 {
 public:
-    static auto constexpr EndgameMaxPeers = size_t{ 2U };
-
     struct Mediator
     {
         [[nodiscard]] virtual bool clientCanRequestBlock(tr_block_index_t block) const = 0;

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -19,6 +19,9 @@
 #include <process.h> /* _beginthreadex(), _endthreadex() */
 #include <windows.h>
 #include <shlobj.h> /* SHGetKnownFolderPath(), FOLDERID_... */
+#ifdef small // workaround name collision between libsmall and rpcndr.h
+#undef small
+#endif
 #else
 #include <pwd.h>
 #include <unistd.h> /* getuid() */

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -17,6 +17,8 @@
 
 #include <fmt/core.h>
 
+#include <small/vector.hpp>
+
 #define LIBTRANSMISSION_VARIANT_MODULE
 
 #include "libtransmission/transmission.h"
@@ -640,6 +642,8 @@ bool tr_variantDictRemove(tr_variant* dict, tr_quark key)
 class WalkNode
 {
 public:
+    WalkNode() = default;
+
     explicit WalkNode(tr_variant const* v_in)
     {
         assign(v_in);
@@ -683,7 +687,8 @@ protected:
         size_t idx = {};
     };
 
-    void sort(std::vector<ByKey>& sortbuf)
+    template<typename Container>
+    void sort(Container& sortbuf)
     {
         if (!tr_variantIsDict(&v))
         {
@@ -763,8 +768,10 @@ public:
 
 private:
     size_t size = 0;
-    std::vector<WalkNode> stack;
-    std::vector<WalkNode::ByKey> sortbuf;
+
+    static auto constexpr InitialCapacity = size_t{ 32U };
+    small::vector<WalkNode, InitialCapacity> stack;
+    small::vector<WalkNode::ByKey, InitialCapacity> sortbuf;
 };
 
 /**


### PR DESCRIPTION
Add header-only library https://github.com/alandefreitas/small for use in libtransmission. Part 1 of N.

- add scaffolding for using small
 - in cache, replace the bespoke `BlockData` struct with a `small::max_size_vector`
 - in variant's WalkNode helper, use `small::vector<>` for the stack
 
Notes: Use [libsmall](https://github.com/alandefreitas/small) to avoid some unnecessary  heap allocations.

ObPedant: the name is `small` not `libsmall` but saying something like "add small dependency" or "add dependency of small header library" is just too confusing :smile_cat: 