### PR TITLE
perf: use small in libtransmission

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -50,6 +50,7 @@ using tau_connection_t = uint64_t;
 using tau_transaction_t = uint32_t;
 
 using InBuf = libtransmission::BufferReader<std::byte>;
+using PayloadBuffer = libtransmission::SmallBuffer<4096, std::byte>;
 
 constexpr auto TauConnectionTtlSecs = time_t{ 45 };
 
@@ -85,7 +86,7 @@ struct tau_scrape_request
         }
 
         // build the payload
-        auto buf = libtransmission::Buffer{};
+        auto buf = PayloadBuffer{};
         buf.add_uint32(TAU_ACTION_SCRAPE);
         buf.add_uint32(transaction_id);
         for (int i = 0; i < in.info_hash_count; ++i)
@@ -179,7 +180,7 @@ struct tau_announce_request
         response.info_hash = in.info_hash;
 
         // build the payload
-        auto buf = libtransmission::Buffer{};
+        auto buf = PayloadBuffer{};
         buf.add_uint32(TAU_ACTION_ANNOUNCE);
         buf.add_uint32(transaction_id);
         buf.add(in.info_hash);
@@ -374,7 +375,7 @@ struct tau_tracker
             this->connection_transaction_id = tau_transaction_new();
             logtrace(this->key, fmt::format("Trying to connect. Transaction ID is {}", this->connection_transaction_id));
 
-            auto buf = libtransmission::Buffer{};
+            auto buf = PayloadBuffer{};
             buf.add_uint64(0x41727101980LL);
             buf.add_uint32(TAU_ACTION_CONNECT);
             buf.add_uint32(this->connection_transaction_id);
@@ -462,7 +463,7 @@ private:
     {
         if (this->connecting_at != 0 && this->connecting_at + ConnectionRequestTtl < now)
         {
-            auto empty_buf = libtransmission::Buffer{};
+            auto empty_buf = PayloadBuffer{};
             on_connection_response(TAU_ACTION_ERROR, empty_buf);
         }
 
@@ -535,7 +536,7 @@ private:
     {
         logdbg(this->key, fmt::format("sending request w/connection id {}", this->connection_id));
 
-        auto buf = libtransmission::Buffer{};
+        auto buf = PayloadBuffer{};
         buf.add_uint64(this->connection_id);
         buf.add(payload, payload_len);
 
@@ -622,7 +623,7 @@ public:
         }
 
         // extract the action_id and see if it makes sense
-        auto buf = libtransmission::Buffer{};
+        auto buf = PayloadBuffer{};
         buf.add(msg, msglen);
         auto const action_id = static_cast<tau_action_t>(buf.to_uint32());
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -185,7 +185,7 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
 
     /* now send these: HASH('req1', S), HASH('req2', SKEY) xor HASH('req3', S),
      * ENCRYPT(VC, crypto_provide, len(PadC), PadC, len(IA)), ENCRYPT(IA) */
-    auto outbuf = libtransmission::Buffer{};
+    auto outbuf = libtransmission::SmallBuffer<4096>{};
 
     /* HASH('req1', S) */
     outbuf.add(tr_sha1::digest("req1"sv, dh_.secret()));
@@ -601,7 +601,7 @@ ReadState tr_handshake::read_ia(tr_peerIo* peer_io)
     auto const& info_hash = peer_io->torrent_hash();
     TR_ASSERT_MSG(info_hash != tr_sha1_digest_t{}, "readIA requires an info_hash");
     peer_io->encrypt_init(peer_io->is_incoming(), dh_, info_hash);
-    auto outbuf = libtransmission::Buffer{};
+    auto outbuf = libtransmission::SmallBuffer<4096>{};
 
     // send VC
     tr_logAddTraceHand(this, "sending vc");

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -15,6 +15,8 @@
 #include <memory>
 #include <utility> // std::pair
 
+#include <event2/util.h> // for evutil_socket_t
+
 #include "transmission.h"
 
 #include "bandwidth.h"

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -47,7 +47,10 @@
 #endif
 
 using namespace std::literals;
-using MessageBuffer = libtransmission::Buffer;
+
+// sized to hold a piece message
+using MessageBuffer = libtransmission::
+    SmallBuffer<sizeof(uint8_t) + sizeof(uint32_t) * 2U + tr_block_info::BlockSize, std::byte>;
 using MessageReader = libtransmission::BufferReader<std::byte>;
 using MessageWriter = libtransmission::BufferWriter<std::byte>;
 
@@ -1385,9 +1388,9 @@ ReadResult read_piece_data(tr_peerMsgsImpl* msgs, MessageReader& payload)
         return { READ_ERR, len };
     }
 
-    msgs->publish(tr_peer_event::GotPieceData(len));
+    logtrace(msgs, fmt::format("got {:d} bytes for req {:d}:{:d}->{:d}", len, piece, offset, len));
 
-    if (loc.block_offset == 0U && len == block_size) // simple case: one message has entire block
+    if (loc.block_offset == 0U && len == block_size) // simple case: got the full block in one message
     {
         auto buf = std::make_unique<Cache::BlockData>(block_size);
         payload.to_buf(std::data(*buf), len);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1804,8 +1804,7 @@ ReadState canRead(tr_peerIo* io, void* vmsgs, size_t* piece)
     current_message_len.reset();
     auto const message_type = *current_message_type;
     current_message_type.reset();
-    auto payload = MessageBuffer{};
-    std::swap(payload, current_payload);
+    auto payload = MessageBuffer{ std::data(current_payload), std::size(current_payload) };
 
     auto const [read_state, n_piece_bytes_read] = process_peer_message(msgs, message_type, payload);
     *piece = n_piece_bytes_read;

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -123,6 +123,11 @@ public:
         tr_error_set(error, err, tr_net_strerror(err));
         return {};
     }
+
+    void clear()
+    {
+        drain(size());
+    }
 };
 
 template<typename value_type>
@@ -235,15 +240,20 @@ class SmallBuffer final
 {
 public:
     SmallBuffer() = default;
-    SmallBuffer(SmallBuffer&&) = default;
-    SmallBuffer& operator=(SmallBuffer&&) = default;
+    SmallBuffer(SmallBuffer&&) = delete;
+    SmallBuffer& operator=(SmallBuffer&&) = delete;
     SmallBuffer(SmallBuffer const&) = delete;
     SmallBuffer& operator=(SmallBuffer const&) = delete;
 
+    explicit SmallBuffer(void const* const data, size_t n_bytes)
+    {
+        BufferWriter<value_type>::add(data, n_bytes);
+    }
+
     template<typename ContiguousContainer>
     explicit SmallBuffer(ContiguousContainer const& data)
+        : SmallBuffer{ std::data(data), std::size(data) }
     {
-        BufferWriter<value_type>::add(data);
     }
 
     [[nodiscard]] size_t size() const noexcept override

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -277,7 +277,7 @@ namespace
 {
 namespace to_string_helpers
 {
-using OutBuf = libtransmission::Buffer;
+using OutBuf = libtransmission::SmallBuffer<1024 * 16, std::byte>;
 
 void saveIntFunc(tr_variant const* val, void* vout)
 {

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -442,7 +442,7 @@ struct JsonWalk
     }
 
     std::deque<ParentState> parents;
-    libtransmission::Buffer out;
+    libtransmission::SmallBuffer<1024 * 16> out;
     bool doIndent;
 };
 

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <utility>
 
+#include <event2/buffer.h>
+
 struct evbuffer;
 
 class tr_web

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -62,52 +62,6 @@ TEST_F(BufferTest, startsWithInMultiSegment)
     EXPECT_TRUE(buf->starts_with("Hello, World!"sv));
 }
 
-TEST_F(BufferTest, Move)
-{
-    auto constexpr TwoChars = "12"sv;
-    auto constexpr SixChars = "123456"sv;
-    auto constexpr TenChars = "1234567890"sv;
-
-    auto a = Buffer{ TwoChars };
-    auto b = Buffer{ SixChars };
-    auto c = Buffer{ TenChars };
-
-    auto lens = std::array<size_t, 3>{ std::size(TwoChars), std::size(SixChars), std::size(TenChars) };
-
-    EXPECT_EQ(lens[0], std::size(a));
-    EXPECT_EQ(lens[1], std::size(b));
-    EXPECT_EQ(lens[2], std::size(c));
-
-    std::swap(a, b);
-    EXPECT_EQ(lens[0], std::size(b));
-    EXPECT_EQ(lens[1], std::size(a));
-    EXPECT_EQ(lens[2], std::size(c));
-
-    std::swap(a, c);
-    EXPECT_EQ(lens[0], std::size(b));
-    EXPECT_EQ(lens[1], std::size(c));
-    EXPECT_EQ(lens[2], std::size(a));
-
-    std::swap(b, c);
-    EXPECT_EQ(lens[0], std::size(c));
-    EXPECT_EQ(lens[1], std::size(b));
-    EXPECT_EQ(lens[2], std::size(a));
-
-    a.add(std::data(TwoChars), std::size(TwoChars));
-
-    {
-        auto constexpr OneChar = "1"sv;
-        auto d = Buffer{ OneChar };
-
-        std::swap(a, d);
-        EXPECT_EQ(1U, std::size(a));
-    }
-
-    EXPECT_EQ(1U, std::size(a));
-    a.add(std::data(TwoChars), std::size(TwoChars));
-    EXPECT_EQ(3U, std::size(a));
-}
-
 TEST_F(BufferTest, Numbers)
 {
     for (auto i = 0; i < 100; ++i)


### PR DESCRIPTION
Start using https://github.com/alandefreitas/small in libtransmission,  e.g. to avoid heap allocations for short-term buffers that only need to exist on the stack.

Part 2 of N; first in the series is #5649.

- refactor: migrate `libtransmission::Buffer` from `evbuffer` to `small::vector`
- perf: use stack-based buffers in announcer-udp, variant-json, variant-benc, handshake, and peer-msgs.

Notes: Use [libsmall](https://github.com/alandefreitas/small) to avoid some unnecessary  heap allocations.