### PR TITLE
refactor: replace some C idioms with C++ ones 

### DIFF
--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -3,15 +3,15 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include <pthread.h>
 #ifdef HAVE_SYS_SIGNALFD_H
 #include <sys/signalfd.h>
 #endif /* signalfd API */
 #include <event2/event.h>
-#include <signal.h>
-#include <stdlib.h> /* abort(), daemon(), exit() */
+#include <csignal>
+#include <cstdlib> /* abort(), daemon(), exit() */
 #include <fcntl.h> /* open() */
 #include <unistd.h> /* fork(), setsid(), chdir(), dup2(), close(), pipe() */
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -695,7 +695,7 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
     /* setup event state */
     ev_base_ = event_base_new();
 
-    if (ev_base_ == nullptr || setup_signals() == false)
+    if (ev_base_ == nullptr || !setup_signals())
     {
         auto const error_code = errno;
         auto const errmsg = fmt::format(

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -39,15 +39,9 @@
 
 #else
 
-static void sd_notify(int /*status*/, char const* /*str*/)
-{
-    // no-op
-}
-
-static void sd_notifyf(int /*status*/, char const* /*fmt*/, ...)
-{
-    // no-op
-}
+// no-op
+#define sd_notify(status, str)
+#define sd_notifyf(status, fmt, ...)
 
 #endif
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -584,8 +584,8 @@ void Application::Impl::on_startup()
         css_provider,
         GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-    std::ignore = FilterBar();
-    std::ignore = PathButton();
+    FilterBar();
+    PathButton();
 
     tr_session* session = nullptr;
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -82,8 +82,8 @@ enum tr_encryption_mode
     TR_ENCRYPTION_REQUIRED
 };
 
-#define TR_RATIO_NA -1
-#define TR_RATIO_INF -2
+#define TR_RATIO_NA (-1)
+#define TR_RATIO_INF (-2)
 
 // --- Startup & Shutdown
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -257,8 +257,8 @@ uint64_t tr_time_msec()
  */
 size_t tr_strlcpy(void* vdst, void const* vsrc, size_t siz)
 {
-    auto* dst = reinterpret_cast<char*>(vdst);
-    auto const* const src = reinterpret_cast<char const*>(vsrc);
+    auto* dst = static_cast<char*>(vdst);
+    auto const* const src = static_cast<char const*>(vsrc);
 
     TR_ASSERT(dst != nullptr);
     TR_ASSERT(src != nullptr);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -257,8 +257,8 @@ uint64_t tr_time_msec()
  */
 size_t tr_strlcpy(void* vdst, void const* vsrc, size_t siz)
 {
-    auto* dst = static_cast<char*>(vdst);
-    auto const* const src = static_cast<char const*>(vsrc);
+    auto* dst = reinterpret_cast<char*>(vdst);
+    auto const* const src = reinterpret_cast<char const*>(vsrc);
 
     TR_ASSERT(dst != nullptr);
     TR_ASSERT(src != nullptr);
@@ -274,7 +274,7 @@ double tr_getRatio(uint64_t numerator, uint64_t denominator)
 {
     if (denominator > 0)
     {
-        return numerator / (double)denominator;
+        return numerator / static_cast<double>(denominator);
     }
 
     if (numerator > 0)
@@ -717,7 +717,7 @@ char* formatter_get_size_str(formatter_units const& u, char* buf, uint64_t bytes
         unit = &u[3];
     }
 
-    double const value = double(bytes) / unit->value;
+    double const value = static_cast<double>(bytes) / unit->value;
     auto const* const units = std::data(unit->name);
 
     auto precision = int{};

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -66,10 +66,10 @@ void tr_locale_set_global(char const* locale_name) noexcept
 {
     try
     {
-        std::ignore = std::locale::global(std::locale{ locale_name });
+        std::locale::global(std::locale{ locale_name });
 
-        std::ignore = std::cout.imbue(std::locale{});
-        std::ignore = std::cerr.imbue(std::locale{});
+        std::cout.imbue(std::locale{});
+        std::cerr.imbue(std::locale{});
     }
     catch (std::exception const&)
     {

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -39,7 +39,7 @@ protected:
     {
         if (old_locale_)
         {
-            std::ignore = std::locale::global(*old_locale_);
+            std::locale::global(*old_locale_);
         }
     }
 


### PR DESCRIPTION
No functional changes intended.

1. Changed C-style `<???.h>` standard headers to `<c???>`.
2. Replaced C-style casts with C++ casts.
3. Removed undefined-usages of `std::ignore`. Its behaviour is only formally defined when used in conjunction with `std::tie`.
4. Avoid descending an extra level in `transmission-daemon` when not compiled with systemd support.

Nitpicking, I know. 🤣 