### PR TITLE
refactor: change `static_cast` to `reinterpret_cast` for pointers

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -403,7 +403,7 @@ void tr_daemon::periodic_update(void)
 
 static void periodic_update(evutil_socket_t /*fd*/, short /*what*/, void* arg)
 {
-    static_cast<tr_daemon*>(arg)->periodic_update();
+    reinterpret_cast<tr_daemon*>(arg)->periodic_update();
 }
 
 static tr_rpc_callback_status on_rpc_callback(
@@ -414,7 +414,7 @@ static tr_rpc_callback_status on_rpc_callback(
 {
     if (type == TR_RPC_SESSION_CLOSE)
     {
-        static_cast<tr_daemon*>(arg)->stop();
+        reinterpret_cast<tr_daemon*>(arg)->stop();
     }
     return TR_RPC_OK;
 }

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -116,7 +116,7 @@ public:
     void add(void const* data, size_t data_length) override
     {
         static auto constexpr Max = static_cast<size_t>(std::numeric_limits<CC_LONG>::max());
-        auto const* sha_data = static_cast<uint8_t const*>(data);
+        auto const* sha_data = reinterpret_cast<uint8_t const*>(data);
         while (data_length > 0)
         {
             auto const n_bytes = static_cast<CC_LONG>(std::min(data_length, Max));

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -263,5 +263,5 @@ bool tr_rand_buffer_crypto(void* buffer, size_t length)
 
     TR_ASSERT(buffer != nullptr);
 
-    return check_result(RAND_bytes(static_cast<unsigned char*>(buffer), (int)length));
+    return check_result(RAND_bytes(reinterpret_cast<unsigned char*>(buffer), (int)length));
 }

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -681,7 +681,7 @@ ReadState tr_handshake::read_payload_stream(tr_peerIo* peer_io)
 
 ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* piece)
 {
-    auto* handshake = static_cast<tr_handshake*>(vhandshake);
+    auto* handshake = reinterpret_cast<tr_handshake*>(vhandshake);
 
     bool ready_for_more = true;
 
@@ -777,7 +777,7 @@ ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* p
 
 void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandshake)
 {
-    auto* handshake = static_cast<tr_handshake*>(vhandshake);
+    auto* handshake = reinterpret_cast<tr_handshake*>(vhandshake);
 
     if (io->is_utp() && !io->is_incoming() && handshake->is_state(State::AwaitingYb))
     {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -320,7 +320,7 @@ size_t tr_peerIo::try_write(size_t max)
 
 void tr_peerIo::event_write_cb([[maybe_unused]] evutil_socket_t fd, short /*event*/, void* vio)
 {
-    auto* const io = static_cast<tr_peerIo*>(vio);
+    auto* const io = reinterpret_cast<tr_peerIo*>(vio);
     tr_logAddTraceIo(io, "libevent says this peer socket is ready for writing");
 
     TR_ASSERT(io->socket_.is_tcp());
@@ -444,7 +444,7 @@ void tr_peerIo::event_read_cb([[maybe_unused]] evutil_socket_t fd, short /*event
 {
     static auto constexpr MaxLen = RcvBuf;
 
-    auto* const io = static_cast<tr_peerIo*>(vio);
+    auto* const io = reinterpret_cast<tr_peerIo*>(vio);
     tr_logAddTraceIo(io, "libevent says this peer socket is ready for reading");
 
     TR_ASSERT(io->socket_.is_tcp());
@@ -683,7 +683,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
         UTP_ON_READ,
         [](utp_callback_arguments* args) -> uint64
         {
-            if (auto* const io = static_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
+            if (auto* const io = reinterpret_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
             {
                 io->inbuf_.add(args->buf, args->len);
                 io->set_enabled(TR_DOWN, true);
@@ -697,7 +697,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
         UTP_GET_READ_BUFFER_SIZE,
         [](utp_callback_arguments* args) -> uint64
         {
-            if (auto const* const io = static_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
+            if (auto const* const io = reinterpret_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
             {
                 // We use this callback to enforce speed limits by telling
                 // libutp to read no more than `target_dl_bytes` bytes.
@@ -718,7 +718,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
         UTP_ON_ERROR,
         [](utp_callback_arguments* args) -> uint64
         {
-            if (auto* const io = static_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
+            if (auto* const io = reinterpret_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
             {
                 io->on_utp_error(args->error_code);
             }
@@ -730,7 +730,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
         UTP_ON_OVERHEAD_STATISTICS,
         [](utp_callback_arguments* args) -> uint64
         {
-            if (auto* const io = static_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
+            if (auto* const io = reinterpret_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
             {
                 tr_logAddTraceIo(io, fmt::format("{:d} overhead bytes via utp", args->len));
                 io->bandwidth().notify_bandwidth_consumed(args->send != 0 ? TR_UP : TR_DOWN, args->len, false, tr_time_msec());
@@ -743,7 +743,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
         UTP_ON_STATE_CHANGE,
         [](utp_callback_arguments* args) -> uint64
         {
-            if (auto* const io = static_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
+            if (auto* const io = reinterpret_cast<tr_peerIo*>(utp_get_userdata(args->socket)); io != nullptr)
             {
                 io->on_utp_state_change(args->state);
             }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1345,7 +1345,7 @@ char const* torrentSetLocation(
 
 void torrentRenamePathDone(tr_torrent* tor, char const* oldpath, char const* newname, int error, void* user_data)
 {
-    auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
+    auto* data = reinterpret_cast<struct tr_rpc_idle_data*>(user_data);
 
     tr_variantDictAddInt(data->args_out, TR_KEY_id, tr_torrentId(tor));
     tr_variantDictAddStr(data->args_out, TR_KEY_path, oldpath);
@@ -1385,7 +1385,7 @@ char const* torrentRenamePath(
 void onPortTested(tr_web::FetchResponse const& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, user_data] = web_response;
-    auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
+    auto* data = reinterpret_cast<struct tr_rpc_idle_data*>(user_data);
 
     if (status != 200)
     {
@@ -1417,7 +1417,7 @@ char const* portTest(tr_session* session, tr_variant* /*args_in*/, tr_variant* /
 void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, user_data] = web_response;
-    auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
+    auto* data = reinterpret_cast<struct tr_rpc_idle_data*>(user_data);
     auto* const session = data->session;
 
     if (status != 200)
@@ -1542,7 +1542,7 @@ struct add_torrent_idle_data
 void onMetadataFetched(tr_web::FetchResponse const& web_response)
 {
     auto const& [status, body, did_connect, did_timeout, user_data] = web_response;
-    auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
+    auto* data = reinterpret_cast<struct add_torrent_idle_data*>(user_data);
 
     tr_logAddTrace(fmt::format(
         "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -73,11 +73,11 @@ extern "C"
         int len3)
     {
         auto* setme = reinterpret_cast<std::byte*>(hash_return);
-        std::fill_n(static_cast<char*>(hash_return), hash_size, '\0');
+        std::fill_n(reinterpret_cast<char*>(hash_return), hash_size, '\0');
 
-        auto const sv1 = std::string_view{ static_cast<char const*>(v1), size_t(len1) };
-        auto const sv2 = std::string_view{ static_cast<char const*>(v2), size_t(len2) };
-        auto const sv3 = std::string_view{ static_cast<char const*>(v3), size_t(len3) };
+        auto const sv1 = std::string_view{ reinterpret_cast<char const*>(v1), size_t(len1) };
+        auto const sv2 = std::string_view{ reinterpret_cast<char const*>(v2), size_t(len2) };
+        auto const sv3 = std::string_view{ reinterpret_cast<char const*>(v3), size_t(len3) };
         auto const digest = tr_sha1::digest(sv1, sv2, sv3);
         std::copy_n(std::data(digest), std::min(size_t(hash_size), std::size(digest)), setme);
     }
@@ -90,7 +90,7 @@ extern "C"
 
     int dht_sendto(int sockfd, void const* buf, int len, int flags, struct sockaddr const* to, int tolen)
     {
-        return static_cast<int>(sendto(sockfd, static_cast<char const*>(buf), len, flags, to, tolen));
+        return static_cast<int>(sendto(sockfd, reinterpret_cast<char const*>(buf), len, flags, to, tolen));
     }
 
 #if defined(_WIN32) && !defined(__MINGW32__)

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -394,7 +394,7 @@ private:
     {
         if ((type & EV_READ) != 0)
         {
-            static_cast<tr_lpd_impl*>(vself)->onCanRead();
+            reinterpret_cast<tr_lpd_impl*>(vself)->onCanRead();
         }
     }
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -108,7 +108,7 @@ void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsessi
          is between 0 and 3
        - the above cannot be µTP packets, since these start with a 4-bit
          version number (1). */
-    auto* const session = static_cast<tr_session*>(vsession);
+    auto* const session = reinterpret_cast<tr_session*>(vsession);
     if (buf[0] == 'd')
     {
         if (session->dht_)
@@ -255,7 +255,7 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
         // don't try to connect to a global address if we don't have connectivity to public internet
         return;
     }
-    else if (::sendto(sock, static_cast<char const*>(buf), buflen, 0, to, tolen) != -1)
+    else if (::sendto(sock, reinterpret_cast<char const*>(buf), buflen, 0, to, tolen) != -1)
     {
         return;
     }

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -115,7 +115,7 @@ void utp_send_to(
 
 uint64 utp_callback(utp_callback_arguments* args)
 {
-    auto* const session = static_cast<tr_session*>(utp_context_get_userdata(args->context));
+    auto* const session = reinterpret_cast<tr_session*>(utp_context_get_userdata(args->context));
 
     TR_ASSERT(session != nullptr);
     TR_ASSERT(session->utp_context == args->context);
@@ -170,7 +170,7 @@ void restart_timer(tr_session* session)
 
 void timer_callback(void* vsession)
 {
-    auto* session = static_cast<tr_session*>(vsession);
+    auto* session = reinterpret_cast<tr_session*>(vsession);
 
     /* utp_internal.cpp says "Should be called each time the UDP socket is drained" but it's tricky with libevent */
     utp_issue_deferred_acks(session->utp_context);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -868,7 +868,7 @@ void tr_formatter_get_units(void* vdict)
 {
     using namespace formatter_impl;
 
-    auto* dict = static_cast<tr_variant*>(vdict);
+    auto* dict = reinterpret_cast<tr_variant*>(vdict);
 
     tr_variantDictReserve(dict, 6);
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -281,7 +281,7 @@ using OutBuf = libtransmission::SmallBuffer<1024 * 16, std::byte>;
 
 void saveIntFunc(tr_variant const* val, void* vout)
 {
-    auto out = static_cast<OutBuf*>(vout);
+    auto out = reinterpret_cast<OutBuf*>(vout);
 
     auto const [buf, buflen] = out->reserve_space(64U);
     auto* walk = reinterpret_cast<char*>(buf);
@@ -292,7 +292,7 @@ void saveIntFunc(tr_variant const* val, void* vout)
 
 void saveBoolFunc(tr_variant const* val, void* vout)
 {
-    static_cast<OutBuf*>(vout)->add(val->val.b ? "i1e"sv : "i0e"sv);
+    reinterpret_cast<OutBuf*>(vout)->add(val->val.b ? "i1e"sv : "i0e"sv);
 }
 
 void saveStringImpl(OutBuf* out, std::string_view sv)
@@ -310,7 +310,7 @@ void saveStringFunc(tr_variant const* v, void* vout)
 {
     auto sv = std::string_view{};
     (void)!tr_variantGetStrView(v, &sv);
-    saveStringImpl(static_cast<OutBuf*>(vout), sv);
+    saveStringImpl(reinterpret_cast<OutBuf*>(vout), sv);
 }
 
 void saveRealFunc(tr_variant const* val, void* vout)
@@ -319,22 +319,22 @@ void saveRealFunc(tr_variant const* val, void* vout)
 
     auto buf = std::array<char, 64>{};
     auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:f}"), val->val.d);
-    saveStringImpl(static_cast<OutBuf*>(vout), { std::data(buf), static_cast<size_t>(out - std::data(buf)) });
+    saveStringImpl(reinterpret_cast<OutBuf*>(vout), { std::data(buf), static_cast<size_t>(out - std::data(buf)) });
 }
 
 void saveDictBeginFunc(tr_variant const* /*val*/, void* vbuf)
 {
-    static_cast<OutBuf*>(vbuf)->push_back('d');
+    reinterpret_cast<OutBuf*>(vbuf)->push_back('d');
 }
 
 void saveListBeginFunc(tr_variant const* /*val*/, void* vbuf)
 {
-    static_cast<OutBuf*>(vbuf)->push_back('l');
+    reinterpret_cast<OutBuf*>(vbuf)->push_back('l');
 }
 
 void saveContainerEndFunc(tr_variant const* /*val*/, void* vbuf)
 {
-    static_cast<OutBuf*>(vbuf)->push_back('e');
+    reinterpret_cast<OutBuf*>(vbuf)->push_back('e');
 }
 
 struct VariantWalkFuncs const walk_funcs = {

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -65,7 +65,7 @@ struct json_wrapper_data
 
 tr_variant* get_node(struct jsonsl_st* jsn)
 {
-    auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
+    auto* data = reinterpret_cast<struct json_wrapper_data*>(jsn->data);
 
     auto* parent = std::empty(data->stack) ? nullptr : data->stack.back();
 
@@ -89,7 +89,7 @@ tr_variant* get_node(struct jsonsl_st* jsn)
 
 void error_handler(jsonsl_t jsn, jsonsl_error_t error, jsonsl_state_st* /*state*/, jsonsl_char_t const* buf)
 {
-    auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
+    auto* data = reinterpret_cast<struct json_wrapper_data*>(jsn->data);
 
     tr_error_set(
         &data->error,
@@ -110,7 +110,7 @@ int error_callback(jsonsl_t jsn, jsonsl_error_t error, struct jsonsl_state_st* s
 
 void action_callback_PUSH(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsonsl_state_st* state, jsonsl_char_t const* /*buf*/)
 {
-    auto* const data = static_cast<json_wrapper_data*>(jsn->data);
+    auto* const data = reinterpret_cast<json_wrapper_data*>(jsn->data);
 
     if ((state->type == JSONSL_T_LIST) || (state->type == JSONSL_T_OBJECT))
     {
@@ -311,7 +311,7 @@ void decode_single_uchar(char const*& in, char const* const in_end, Iter& buf16_
 
 void action_callback_POP(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsonsl_state_st* state, jsonsl_char_t const* /*buf*/)
 {
-    auto* data = static_cast<struct json_wrapper_data*>(jsn->data);
+    auto* data = reinterpret_cast<struct json_wrapper_data*>(jsn->data);
 
     if (state->type == JSONSL_T_STRING)
     {
@@ -397,7 +397,7 @@ bool tr_variantParseJson(tr_variant& setme, int parse_opts, std::string_view jso
     data.top = &setme;
 
     /* parse it */
-    jsonsl_feed(jsn, static_cast<jsonsl_char_t const*>(std::data(json)), std::size(json));
+    jsonsl_feed(jsn, reinterpret_cast<jsonsl_char_t const*>(std::data(json)), std::size(json));
 
     /* EINVAL if there was no content */
     if (data.error == nullptr && !data.has_content)
@@ -523,14 +523,14 @@ void jsonIntFunc(tr_variant const* val, void* vdata)
 {
     auto buf = std::array<char, 64>{};
     auto const* const out = fmt::format_to(std::data(buf), FMT_COMPILE("{:d}"), val->val.i);
-    auto* const data = static_cast<JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<JsonWalk*>(vdata);
     data->out.add(std::data(buf), static_cast<size_t>(out - std::data(buf)));
     jsonChildFunc(data);
 }
 
 void jsonBoolFunc(tr_variant const* val, void* vdata)
 {
-    auto* data = static_cast<struct JsonWalk*>(vdata);
+    auto* data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     if (val->val.b)
     {
@@ -546,7 +546,7 @@ void jsonBoolFunc(tr_variant const* val, void* vdata)
 
 void jsonRealFunc(tr_variant const* val, void* vdata)
 {
-    auto* const data = static_cast<struct JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     auto const [buf, buflen] = data->out.reserve_space(64);
     auto* walk = reinterpret_cast<char*>(buf);
@@ -587,7 +587,7 @@ void jsonRealFunc(tr_variant const* val, void* vdata)
 
 void jsonStringFunc(tr_variant const* val, void* vdata)
 {
-    auto* const data = static_cast<struct JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     auto sv = std::string_view{};
     (void)!tr_variantGetStrView(val, &sv);
@@ -668,7 +668,7 @@ void jsonStringFunc(tr_variant const* val, void* vdata)
 
 void jsonDictBeginFunc(tr_variant const* val, void* vdata)
 {
-    auto* const data = static_cast<struct JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     jsonPushParent(data, val);
     data->out.push_back('{');
@@ -682,7 +682,7 @@ void jsonDictBeginFunc(tr_variant const* val, void* vdata)
 void jsonListBeginFunc(tr_variant const* val, void* vdata)
 {
     size_t const n_children = tr_variantListSize(val);
-    auto* const data = static_cast<struct JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     jsonPushParent(data, val);
     data->out.push_back('[');
@@ -695,7 +695,7 @@ void jsonListBeginFunc(tr_variant const* val, void* vdata)
 
 void jsonContainerEndFunc(tr_variant const* val, void* vdata)
 {
-    auto* const data = static_cast<struct JsonWalk*>(vdata);
+    auto* const data = reinterpret_cast<struct JsonWalk*>(vdata);
 
     jsonPopParent(data);
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -414,7 +414,7 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** set
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
 {
     tr_variantInit(initme, TR_VARIANT_TYPE_STR);
-    tr_variant_string_set_string(&initme->val.s, { static_cast<char const*>(value), value_len });
+    tr_variant_string_set_string(&initme->val.s, { reinterpret_cast<char const*>(value), value_len });
 }
 
 void tr_variantInitQuark(tr_variant* initme, tr_quark value)

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -115,7 +115,7 @@ private:
 
     static void onInotifyEvent(struct bufferevent* event, void* vself)
     {
-        static_cast<INotifyWatchdir*>(vself)->handleInotifyEvent(event);
+        reinterpret_cast<INotifyWatchdir*>(vself)->handleInotifyEvent(event);
     }
 
     void handleInotifyEvent(struct bufferevent* event)

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -133,7 +133,7 @@ private:
 
     static void onKqueueEvent(evutil_socket_t /*fd*/, short /*type*/, void* vself)
     {
-        static_cast<KQueueWatchdir*>(vself)->handleKqueueEvent();
+        reinterpret_cast<KQueueWatchdir*>(vself)->handleKqueueEvent();
     }
 
     void handleKqueueEvent()

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -200,7 +200,7 @@ private:
 
     static unsigned int __stdcall staticThreadFunc(void* vself)
     {
-        return static_cast<Win32Watchdir*>(vself)->threadFunc();
+        return reinterpret_cast<Win32Watchdir*>(vself)->threadFunc();
     }
 
     unsigned int threadFunc()
@@ -237,12 +237,12 @@ private:
 
     static void onFirstScan(evutil_socket_t /*unused*/, short /*unused*/, void* vself)
     {
-        static_cast<Win32Watchdir*>(vself)->scan();
+        reinterpret_cast<Win32Watchdir*>(vself)->scan();
     }
 
     static void onBufferEvent(struct bufferevent* event, void* vself)
     {
-        static_cast<Win32Watchdir*>(vself)->processBufferEvent(event);
+        reinterpret_cast<Win32Watchdir*>(vself)->processBufferEvent(event);
     }
 
     void processBufferEvent(struct bufferevent* event)

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -412,7 +412,7 @@ void useFetchedBlocks(tr_webseed_task* task)
 void onBufferGotData(evbuffer* /*buf*/, evbuffer_cb_info const* info, void* vtask)
 {
     size_t const n_added = info->n_added;
-    auto* const task = static_cast<tr_webseed_task*>(vtask);
+    auto* const task = reinterpret_cast<tr_webseed_task*>(vtask);
     if (n_added == 0 || task->dead)
     {
         return;
@@ -446,7 +446,7 @@ void onPartialDataFetched(tr_web::FetchResponse const& web_response)
     auto const& [status, body, did_connect, did_timeout, vtask] = web_response;
     bool const success = status == 206;
 
-    auto* const task = static_cast<tr_webseed_task*>(vtask);
+    auto* const task = reinterpret_cast<tr_webseed_task*>(vtask);
 
     if (task->dead)
     {

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -51,7 +51,7 @@ protected:
         {
             auto target = tr_address::from_sockaddr(sa);
             ASSERT_TRUE(target);
-            sent_.emplace_back(static_cast<char const*>(buf), buflen, sa, salen);
+            sent_.emplace_back(reinterpret_cast<char const*>(buf), buflen, sa, salen);
         }
 
         [[nodiscard]] auto* eventBase()

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -71,7 +71,7 @@ TEST_F(RpcTest, sessionGet)
 {
     auto const rpc_response_func = [](tr_session* /*session*/, tr_variant* response, void* setme) noexcept
     {
-        *static_cast<tr_variant*>(setme) = *response;
+        *reinterpret_cast<tr_variant*>(setme) = *response;
         tr_variantInitBool(response, false);
     };
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -799,7 +799,7 @@ static auto constexpr ListKeys = std::array<tr_quark, 14>{
 
 static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vbuf)
 {
-    auto* const buf = static_cast<evbuffer*>(vbuf);
+    auto* const buf = reinterpret_cast<evbuffer*>(vbuf);
     size_t const byteCount = size * nmemb;
     evbuffer_add(buf, ptr, byteCount);
     return byteCount;
@@ -808,8 +808,8 @@ static size_t writeFunc(void* ptr, size_t size, size_t nmemb, void* vbuf)
 /* look for a session id in the header in case the server gives back a 409 */
 static size_t parseResponseHeader(void* ptr, size_t size, size_t nmemb, void* vconfig)
 {
-    auto& config = *static_cast<Config*>(vconfig);
-    auto const* const line = static_cast<char const*>(ptr);
+    auto& config = *reinterpret_cast<Config*>(vconfig);
+    auto const* const line = reinterpret_cast<char const*>(ptr);
     size_t const line_len = size * nmemb;
     char const* key = TR_RPC_SESSION_ID_HEADER ": ";
     size_t const key_len = strlen(key);


### PR DESCRIPTION
Just so we are absolutely clear that no alterations need be made to the underlying value in order to cast from pointer type to pointer type.

No functional changes intended.