### PR TITLE
fix: fix broken unix socket support

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -86,12 +86,12 @@ class tr_unix_addr
 public:
     [[nodiscard]] std::string to_string() const
     {
-        return std::empty(unix_socket_path_) ? unix_socket_path_ : std::string(TrUnixSocketPrefix);
+        return std::empty(unix_socket_path_) ? std::string(TrUnixSocketPrefix) : unix_socket_path_;
     }
 
     [[nodiscard]] bool from_string(std::string_view src)
     {
-        if (!tr_strvStartsWith(TrUnixSocketPrefix, src))
+        if (!tr_strvStartsWith(src, TrUnixSocketPrefix))
         {
             return false;
         }


### PR DESCRIPTION
The changes in #5523 made two errors in the new implementation

1. tr_unix_address::to_string() got the ternary check backwards, leading to always printing an empty string when the address is valid.
2. The inputs to tr_strvStartsWith in tr_unix_address::from_string() were backwards as well, leading to the check failing for valid socket addresses.

@ckerr sorry about that, apparently I didn't test this properly. As a side note, I'm interesting in writing unit tests for this, but I'm not quite sure how to do that for non-exported classes/functions.

This can be tested with
```
curl -X POST --unix-socket /tmp/lol.sock http://localhost/transmission/rpc -d '{"method":"session-stats"}'
```
