### PR TITLE
fix: do not write log if file handler is bad

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -169,7 +169,7 @@ void logAddImpl(
             {
                 return;
             }
-        } 
+        }
 
         auto timestr = std::array<char, 64>{};
         tr_logGetTimeStr(std::data(timestr), std::size(timestr));

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -164,7 +164,12 @@ void logAddImpl(
         if (fp == TR_BAD_SYS_FILE)
         {
             fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
-        }
+            // if fp is still bad, do not write log
+            if (fp == TR_BAD_SYS_FILE)
+            {
+                return;
+            }
+        } 
 
         auto timestr = std::array<char, 64>{};
         tr_logGetTimeStr(std::data(timestr), std::size(timestr));


### PR DESCRIPTION
On Windows, I encountered an issue with an electron application I'm developing. It would crash when launched from the file explorer but worked without any problems when started from the terminal. The application worked fine on Linux.

After several days debugging using `WinDbg`, I discovered that the application was crashing in `logAddImpl`.
On windows, according to the [getstdhandle](https://learn.microsoft.com/en-us/windows/console/getstdhandle) documentation, the function can return NULL if standard handles are not correctly redirected.

To prevent this crash, I implemented the following patch: libtransmission would now ignore writing logs if the file handler equals to `TR_BAD_SYS_FILE`.