### PR TITLE
refactor: share `CompareCacheBlockByKey` by constexpr static member

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -148,7 +148,7 @@ int Cache::write_block(tr_torrent_id_t tor_id, tr_block_index_t block, std::uniq
     }
 
     auto const key = Key{ tor_id, block };
-    auto iter = std::lower_bound(std::begin(blocks_), std::end(blocks_), key, CompareCacheBlockByKey{});
+    auto iter = std::lower_bound(std::begin(blocks_), std::end(blocks_), key, CompareCacheBlockByKey);
     if (iter == std::end(blocks_) || iter->key != key)
     {
         iter = blocks_.emplace(iter);
@@ -169,7 +169,7 @@ Cache::CIter Cache::get_block(tr_torrent const* torrent, tr_block_info::Location
             std::begin(blocks_),
             std::end(blocks_),
             make_key(torrent, loc),
-            CompareCacheBlockByKey{});
+            CompareCacheBlockByKey);
         begin < end)
     {
         return begin;
@@ -221,23 +221,21 @@ int Cache::flush_span(CIter const begin, CIter const end)
 
 int Cache::flush_file(tr_torrent const* torrent, tr_file_index_t file)
 {
-    auto const compare = CompareCacheBlockByKey{};
     auto const tor_id = torrent->id();
     auto const [block_begin, block_end] = tr_torGetFileBlockSpan(torrent, file);
 
     return flush_span(
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_begin), compare),
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_end), compare));
+        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_begin), CompareCacheBlockByKey),
+        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_end), CompareCacheBlockByKey));
 }
 
 int Cache::flush_torrent(tr_torrent const* torrent)
 {
-    auto const compare = CompareCacheBlockByKey{};
     auto const tor_id = torrent->id();
 
     return flush_span(
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, 0), compare),
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id + 1, 0), compare));
+        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, 0), CompareCacheBlockByKey),
+        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id + 1, 0), CompareCacheBlockByKey));
 }
 
 int Cache::flush_biggest()

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -53,18 +53,6 @@ private:
     using Blocks = std::vector<CacheBlock>;
     using CIter = Blocks::const_iterator;
 
-    struct CompareCacheBlockByKey
-    {
-        [[nodiscard]] constexpr bool operator()(Key const& key, CacheBlock const& block)
-        {
-            return key < block.key;
-        }
-        [[nodiscard]] constexpr bool operator()(CacheBlock const& block, Key const& key)
-        {
-            return block.key < key;
-        }
-    };
-
     [[nodiscard]] static Key make_key(tr_torrent const* torrent, tr_block_info::Location loc) noexcept;
 
     [[nodiscard]] static std::pair<CIter, CIter> find_biggest_span(CIter begin, CIter end) noexcept;
@@ -96,4 +84,16 @@ private:
     mutable size_t disk_write_bytes_ = 0;
     mutable size_t cache_writes_ = 0;
     mutable size_t cache_write_bytes_ = 0;
+
+    static constexpr struct
+    {
+        [[nodiscard]] constexpr bool operator()(Key const& key, CacheBlock const& block)
+        {
+            return key < block.key;
+        }
+        [[nodiscard]] constexpr bool operator()(CacheBlock const& block, Key const& key)
+        {
+            return block.key < key;
+        }
+    } CompareCacheBlockByKey{};
 };


### PR DESCRIPTION
Avoid constructing a new compare callable object each time the member functions in `cache.cc` are called.