### PR TITLE
refactor: remove useless TR_DEBUG_FD env var

### DIFF
--- a/docs/Environment-Variables.md
+++ b/docs/Environment-Variables.md
@@ -5,11 +5,6 @@ Users can set environmental variables to override Transmission's default behavio
  * If `TRANSMISSION_WEB_HOME` is set, Transmission will look there for the [Web Interface](Web-Interface.md) files, such as the JavaScript, HTML, and graphics files.
  * If `TR_CURL_SSL_NO_VERIFY` is set, Transmission will not validate SSL certificate for HTTPS connections when talking to trackers. See CURL's documentation ([CURLOPT_SSL_VERIFYHOST](https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html) and [CURLOPT_SSL_VERIFYPEER](https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html)) for more details.
  * If `TR_CURL_VERBOSE` is set, debugging information for libcurl will be enabled.  More information about libcurl's debugging mode [is available here](https://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTVERBOSE).
- * If `TR_DEBUG_FD` is set to an integer, that integer is treated as a [file descriptor](https://en.wikipedia.org/wiki/File_descriptor) and very verbose debugging information is written to it.  For example, here is how to turn on debugging and save it to a file named "runlog" when running Transmission from a bash shell:
-   ```console
-   $ export TR_DEBUG_FD=2
-   $ transmission 2>runlog
-   ```
  * If `TR_DHT_VERBOSE` is set, Transmission will log all of the DHT's activities in excruciating detail to standard error.
 
 ## Standard Variables Used by Transmission

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -57,34 +57,6 @@ auto log_state = tr_log_state{};
 
 // ---
 
-tr_sys_file_t tr_logGetFile()
-{
-    static bool initialized = false;
-    static tr_sys_file_t file = TR_BAD_SYS_FILE;
-
-    if (!initialized)
-    {
-        switch (tr_env_get_int("TR_DEBUG_FD", 0))
-        {
-        case 1:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_OUT);
-            break;
-
-        case 2:
-            file = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
-            break;
-
-        default:
-            file = TR_BAD_SYS_FILE;
-            break;
-        }
-
-        initialized = true;
-    }
-
-    return file;
-}
-
 void logAddImpl(
     [[maybe_unused]] std::string_view file,
     [[maybe_unused]] long line,
@@ -159,16 +131,11 @@ void logAddImpl(
     }
     else
     {
-        tr_sys_file_t fp = tr_logGetFile();
+        static auto const fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
 
         if (fp == TR_BAD_SYS_FILE)
         {
-            fp = tr_sys_file_get_std(TR_STD_SYS_FILE_ERR);
-            // if fp is still bad, do not write log
-            if (fp == TR_BAD_SYS_FILE)
-            {
-                return;
-            }
+            return;
         }
 
         auto timestr = std::array<char, 64>{};


### PR DESCRIPTION
This feature was originally meant to redirect verbose logging to *any* fd, but it now only supports writing to stdout or stderr, and defaults to stderr.

Redirecting to stdout isn't very useful and complicates the code, so just remove it and always use stderr.

Removing a feature is usually a `semver/major` change; but since it's a debug-only feature that's not working correctly anyway, I don't think anyone will miss it and am OK with removing it without a major bump. :man_shrugging: 