### PR TITLE
chore: remove tr_wait(); use std::this_thread::sleep_for() instead

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -7,6 +7,7 @@
 #include <cstdlib> /* atoi () */
 #include <string>
 #include <string_view>
+#include <thread>
 
 #include <signal.h>
 
@@ -17,7 +18,7 @@
 #include <libtransmission/error.h>
 #include <libtransmission/file.h>
 #include <libtransmission/tr-getopt.h>
-#include <libtransmission/utils.h> /* tr_wait() */
+#include <libtransmission/utils.h> // _()
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
 #include <libtransmission/web-utils.h>
@@ -273,7 +274,7 @@ int tr_main(int argc, char* argv[])
         waitingOnWeb = true;
         while (waitingOnWeb)
         {
-            tr_wait(1s);
+            std::this_thread::sleep_for(1s);
         }
     }
     else
@@ -315,7 +316,7 @@ int tr_main(int argc, char* argv[])
             "Error:",
         };
 
-        tr_wait(200ms);
+        std::this_thread::sleep_for(200ms);
 
         if (gotsig)
         {

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -7,14 +7,12 @@
 
 #include <algorithm>
 #include <cctype>
-#include <chrono>
 #include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <cstddef> // size_t
 #include <ctime> // time_t
 #include <optional>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -86,13 +84,6 @@ constexpr auto tr_saveFile(std::string_view filename, ContiguousRange const& x, 
 
 /** @brief return the current date in milliseconds */
 [[nodiscard]] uint64_t tr_time_msec();
-
-/** @brief sleep for the specified duration */
-template<class rep, class period>
-void tr_wait(std::chrono::duration<rep, period> const& delay)
-{
-    std::this_thread::sleep_for(delay);
-}
 
 template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 [[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* setme_remainder = nullptr, int base = 10);

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -21,7 +21,7 @@
 #include "libtransmission/log.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/utils.h" // tr_time(), tr_wait()
+#include "libtransmission/utils.h" // tr_time()
 #include "libtransmission/verify.h"
 
 using namespace std::chrono_literals;
@@ -135,7 +135,7 @@ bool tr_verify_worker::verify_torrent(tr_torrent* tor, std::atomic<bool> const& 
             if (auto const now = tr_time(); last_slept_at != now)
             {
                 last_slept_at = now;
-                tr_wait(SleepPerSecondDuringVerify);
+                std::this_thread::sleep_for(SleepPerSecondDuringVerify);
             }
 
             sha->clear();
@@ -277,6 +277,6 @@ tr_verify_worker::~tr_verify_worker()
 
     while (verify_thread_id_.has_value())
     {
-        tr_wait(20ms);
+        std::this_thread::sleep_for(20ms);
     }
 }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -705,7 +705,7 @@ public:
                 ++repeats;
                 if (repeats > 1U)
                 {
-                    tr_wait(100ms);
+                    std::this_thread::sleep_for(100ms);
                 }
             }
             else

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -89,7 +89,7 @@ inline bool waitFor(std::function<bool()> const& test, std::chrono::milliseconds
             return false;
         }
 
-        tr_wait(10ms);
+        std::this_thread::sleep_for(10ms);
     }
 }
 


### PR DESCRIPTION
`tr_wait()` used to have a bespoke implementation, but now it's just a wrapper around `std::this_thread::sleep_for()`.

This PR removes the wrapper and uses `std::` directly.