### PR TITLE
`--init` added in `Building Transmission from Git (updating)` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you're new to building programs from source code, this is typically easier th
     $ make clean
     $ git submodule foreach --recursive git clean -xfd
     $ git pull --rebase --prune
-    $ git submodule update --recursive
+    $ git submodule update --init --recursive
     # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimzed binary with debug information. (preferred)
     # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
     $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..


### PR DESCRIPTION
Whenever a new `third-party` submodule is being added, without the `--init` sub-command in `git submodule update --recursive`, the user will get bitten by compilation error due to an uninitialized submodule dependency.

Fixes #5674