### PR TITLE
refactor: make tr_logGetQueueEnabled() private

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -105,7 +105,7 @@ void logAddImpl(
 
 #else
 
-    if (tr_logGetQueueEnabled())
+    if (log_state.queue_enabled_)
     {
         auto* const newmsg = new tr_log_message{};
         newmsg->level = level;
@@ -169,11 +169,6 @@ void tr_logSetLevel(tr_log_level level)
 void tr_logSetQueueEnabled(bool is_enabled)
 {
     log_state.queue_enabled_ = is_enabled;
-}
-
-bool tr_logGetQueueEnabled()
-{
-    return log_state.queue_enabled_;
 }
 
 tr_log_message* tr_logGetQueue()

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -69,8 +69,6 @@ struct tr_log_message
 
 #define TR_LOG_MAX_QUEUE_LENGTH 10000
 
-[[nodiscard]] bool tr_logGetQueueEnabled();
-
 void tr_logSetQueueEnabled(bool is_enabled);
 
 [[nodiscard]] tr_log_message* tr_logGetQueue();


### PR DESCRIPTION
it is only used in log.cc, so remove it from the public header