### PR TITLE
fix: memory leak from signal handling event in daemon

### DIFF
--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -52,10 +52,9 @@ static void handle_signals(evutil_socket_t fd, short /*what*/, void* arg)
     }
 }
 
-bool tr_daemon::setup_signals()
+bool tr_daemon::setup_signals(struct event*& sig_ev)
 {
     sigset_t mask = {};
-    struct event* sigev = nullptr;
     struct event_base* base = ev_base_;
 
     sigemptyset(&mask);
@@ -70,24 +69,15 @@ bool tr_daemon::setup_signals()
     if (sigfd_ < 0)
         return false;
 
-    sigev = event_new(base, sigfd_, EV_READ | EV_PERSIST, handle_signals, this);
-    if (sigev == nullptr)
-    {
-        close(sigfd_);
-        return false;
-    }
+    sig_ev = event_new(base, sigfd_, EV_READ | EV_PERSIST, handle_signals, this);
 
-    if (event_add(sigev, nullptr) < 0)
-    {
-        event_del(sigev);
-        close(sigfd_);
-        return false;
-    }
-
-    return true;
+    return sig_ev != nullptr && event_add(sig_ev, nullptr) >= 0;
 }
 
 #else /* no signalfd API, use evsignal */
+
+namespace
+{
 
 static void reconfigureMarshall(evutil_socket_t /*fd*/, short /*events*/, void* arg)
 {
@@ -99,29 +89,44 @@ static void stopMarshall(evutil_socket_t /*fd*/, short /*events*/, void* arg)
     static_cast<tr_daemon*>(arg)->stop();
 }
 
-static bool setup_signal(struct event_base* base, int sig, void (*callback)(evutil_socket_t, short, void*), void* arg)
+static bool setup_signal(
+    struct event_base* base,
+    struct event*& sig_ev,
+    int sig,
+    void (*callback)(evutil_socket_t, short, void*),
+    void* arg)
 {
-    struct event* sigev = evsignal_new(base, sig, callback, arg);
+    sig_ev = evsignal_new(base, sig, callback, arg);
 
-    if (sigev == nullptr)
-        return false;
-
-    if (evsignal_add(sigev, nullptr) < 0)
-    {
-        event_free(sigev);
-        return false;
-    }
-
-    return true;
+    return sig_ev != nullptr && evsignal_add(sig_ev, nullptr) >= 0;
 }
 
-bool tr_daemon::setup_signals()
+} // anonymous namespace
+
+bool tr_daemon::setup_signals(struct event*& sig_ev)
 {
-    return setup_signal(ev_base_, SIGHUP, reconfigureMarshall, this) && setup_signal(ev_base_, SIGINT, stopMarshall, this) &&
-        setup_signal(ev_base_, SIGTERM, stopMarshall, this);
+    return setup_signal(ev_base_, sig_ev, SIGHUP, reconfigureMarshall, this) &&
+        setup_signal(ev_base_, sig_ev, SIGINT, stopMarshall, this) &&
+        setup_signal(ev_base_, sig_ev, SIGTERM, stopMarshall, this);
 }
 
 #endif /* HAVE_SYS_SIGNALFD_H */
+
+void tr_daemon::cleanup_signals(struct event* sig_ev) const
+{
+    if (sig_ev != nullptr)
+    {
+        event_del(sig_ev);
+        event_free(sig_ev);
+    }
+
+#ifdef HAVE_SYS_SIGNALFD_H
+    if (sigfd_ >= 0)
+    {
+        close(sigfd_);
+    }
+#endif /* HAVE_SYS_SIGNALFD_H */
+}
 
 bool tr_daemon::spawn(bool foreground, int* exit_code, tr_error** error)
 {

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -196,9 +196,13 @@ static VOID WINAPI service_main(DWORD /*argc*/, LPWSTR* /*argv*/)
     update_service_status(SERVICE_STOPPED, NO_ERROR, exit_code, 0, 0);
 }
 
-bool tr_daemon::setup_signals()
+bool tr_daemon::setup_signals([[maybe_unused]] struct event*& sig_ev)
 {
     return true;
+}
+
+void tr_daemon::cleanup_signals([[maybe_unused]] struct event* sig_ev) const
+{
 }
 
 bool tr_daemon::spawn(bool foreground, int* exit_code, tr_error** error)

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -57,6 +57,7 @@ private:
 
     bool parse_args(int argc, char const* const* argv, bool* dump_settings, bool* foreground, int* exit_code);
     bool reopen_log_file(char const* filename);
-    bool setup_signals();
+    bool setup_signals(struct event*& sig_ev);
+    void cleanup_signals(struct event* sig_ev) const;
     void report_status();
 };


### PR DESCRIPTION
It shouldn't matter much since there will only ever be one signal handling event struct, but anyway.

```
==245222== 128 bytes in 1 blocks are definitely lost in loss record 106 of 144
==245222==    at 0x484182F: malloc (vg_replace_malloc.c:431)
==245222==    by 0x5CF964: event_mm_malloc_ (event.c:3492)
==245222==    by 0x5CF964: event_new (event.c:2211)
==245222==    by 0x435705: tr_daemon::setup_signals() (daemon-posix.cc:73)
==245222==    by 0x4220D2: tr_daemon::start(bool) (daemon.cc:692)
==245222==    by 0x4386EC: tr_daemon::spawn(bool, int*, tr_error**) (daemon-posix.cc:184)
==245222==    by 0x41CC3F: main (daemon.cc:947)
```