### PR TITLE
refactor: utils naming

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -222,7 +222,7 @@ static auto onFileAdded(tr_session const* session, std::string_view dirname, std
     {
         auto content = std::vector<char>{};
         tr_error* error = nullptr;
-        if (!tr_loadFile(filename, content, &error))
+        if (!tr_file_read(filename, content, &error))
         {
             tr_logAddWarn(fmt::format(
                 _("Couldn't read '{path}': {error} ({error_code})"),

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -198,8 +198,8 @@ static std::string getConfigDir(int argc, char const* const* argv)
 static auto onFileAdded(tr_session const* session, std::string_view dirname, std::string_view basename)
 {
     auto const lowercase = tr_strlower(basename);
-    auto const is_torrent = tr_strvEndsWith(lowercase, ".torrent"sv);
-    auto const is_magnet = tr_strvEndsWith(lowercase, ".magnet"sv);
+    auto const is_torrent = tr_strv_ends_with(lowercase, ".torrent"sv);
+    auto const is_magnet = tr_strv_ends_with(lowercase, ".magnet"sv);
 
     if (!is_torrent && !is_magnet)
     {

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -689,7 +689,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     }
     else
     {
-        auto const creator = tr_strvStrip(infos.front().creator != nullptr ? infos.front().creator : "");
+        auto const creator = tr_strv_strip(infos.front().creator != nullptr ? infos.front().creator : "");
         auto const date = infos.front().date_created;
         auto const datestr = get_date_string(date);
         bool const mixed_creator = std::any_of(

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -552,7 +552,7 @@ void FileList::Impl::set_torrent(tr_torrent_id_t torrent_id)
 
                 auto path = std::string_view{ file.name };
                 auto token = std::string_view{};
-                while (tr_strvSep(&path, &token, '/'))
+                while (tr_strv_sep(&path, &token, '/'))
                 {
                     auto*& node = nodes[std::make_pair(parent, token)];
 

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -777,7 +777,7 @@ void gtr_paste_clipboard_url_into_entry(Gtk::Entry& entry)
 {
     auto const process = [&entry](Glib::ustring const& text)
     {
-        if (auto const sv = tr_strvStrip(text.raw());
+        if (auto const sv = tr_strv_strip(text.raw());
             !sv.empty() && (tr_urlIsValid(sv) || tr_magnet_metainfo{}.parseMagnet(sv)))
         {
             entry.set_text(text);

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -194,7 +194,7 @@ tr_tracker_tier_t tr_announce_list::get_tier(tr_tracker_tier_t tier, tr_url_pars
         auto const tracker_announce = tracker.announce.sv();
 
         // fast test to avoid tr_urlParse()ing most trackers
-        if (!tr_strvContains(tracker_announce, announce.host))
+        if (!tr_strv_contains(tracker_announce, announce.host))
         {
             return false;
         }
@@ -217,7 +217,7 @@ bool tr_announce_list::can_add(tr_url_parsed_t const& announce) const noexcept
         auto const tracker_announce = tracker.announce.sv();
 
         // fast test to avoid tr_urlParse()ing most trackers
-        if (!tr_strvContains(tracker_announce, announce.host))
+        if (!tr_strv_contains(tracker_announce, announce.host))
         {
             return false;
         }

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -292,7 +292,7 @@ bool tr_announce_list::parse(std::string_view text)
             line = line.substr(0, std::size(line) - 1);
         }
 
-        line = tr_strvStrip(line);
+        line = tr_strv_strip(line);
 
         if (std::empty(line))
         {

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -287,7 +287,7 @@ bool tr_announce_list::parse(std::string_view text)
     auto line = std::string_view{};
     while (tr_strvSep(&text, &line, '\n'))
     {
-        if (tr_strvEndsWith(line, '\r'))
+        if (tr_strv_ends_with(line, '\r'))
         {
             line = line.substr(0, std::size(line) - 1);
         }

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -285,7 +285,7 @@ bool tr_announce_list::parse(std::string_view text)
     auto current_tier = tr_tracker_tier_t{ 0 };
     auto current_tier_size = size_t{ 0 };
     auto line = std::string_view{};
-    while (tr_strvSep(&text, &line, '\n'))
+    while (tr_strv_sep(&text, &line, '\n'))
     {
         if (tr_strv_ends_with(line, '\r'))
         {

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -137,7 +137,7 @@ std::optional<std::string> tr_announce_list::announce_to_scrape(std::string_view
     }
 
     // some torrents with UDP announce URLs don't have /announce
-    if (tr_strvStartsWith(announce, "udp:"sv))
+    if (tr_strv_starts_with(announce, "udp:"sv))
     {
         return std::string{ announce };
     }

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -275,7 +275,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
     }
 
     // save it
-    return tr_saveFile(torrent_file, contents, error);
+    return tr_file_save(torrent_file, contents, error);
 }
 
 bool tr_announce_list::parse(std::string_view text)

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -211,7 +211,7 @@ void announce_url_new(tr_urlbuf& url, tr_session const* session, tr_announce_req
         "&compact=1"
         "&supportcrypto=1",
         fmt::arg("url", req.announce_url),
-        fmt::arg("sep", tr_strvContains(req.announce_url.sv(), '?') ? '&' : '?'),
+        fmt::arg("sep", tr_strv_contains(req.announce_url.sv(), '?') ? '&' : '?'),
         fmt::arg("info_hash", std::data(escaped_info_hash)),
         fmt::arg("peer_id", std::string_view{ std::data(req.peer_id), std::size(req.peer_id) }),
         fmt::arg("port", req.port.host()),
@@ -520,7 +520,7 @@ void onScrapeDone(tr_web::FetchResponse const& web_response)
 void scrape_url_new(tr_pathbuf& scrape_url, tr_scrape_request const& req)
 {
     scrape_url = req.scrape_url.sv();
-    char delimiter = tr_strvContains(scrape_url, '?') ? '&' : '?';
+    char delimiter = tr_strv_contains(scrape_url, '?') ? '&' : '?';
 
     for (int i = 0; i < req.info_hash_count; ++i)
     {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -849,7 +849,7 @@ bool isUnregistered(char const* errmsg)
 
     auto constexpr Keys = std::array<std::string_view, 2>{ "unregistered torrent"sv, "torrent not registered"sv };
 
-    return std::any_of(std::begin(Keys), std::end(Keys), [&lower](auto const& key) { return tr_strvContains(lower, key); });
+    return std::any_of(std::begin(Keys), std::end(Keys), [&lower](auto const& key) { return tr_strv_contains(lower, key); });
 }
 
 void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e)
@@ -1230,7 +1230,7 @@ namespace on_scrape_done_helpers
     return std::any_of(
         std::begin(too_long_errors),
         std::end(too_long_errors),
-        [&errmsg](auto const& substr) { return tr_strvContains(errmsg, substr); });
+        [&errmsg](auto const& substr) { return tr_strv_contains(errmsg, substr); });
 }
 
 void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char const* errmsg)

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -178,11 +178,11 @@ public:
         TR_ASSERT(!is_shutting_down_);
 
         if (auto const scrape_sv = request.scrape_url.sv();
-            tr_strvStartsWith(scrape_sv, "http://"sv) || tr_strvStartsWith(scrape_sv, "https://"sv))
+            tr_strv_starts_with(scrape_sv, "http://"sv) || tr_strv_starts_with(scrape_sv, "https://"sv))
         {
             tr_tracker_http_scrape(session, request, std::move(on_response));
         }
-        else if (tr_strvStartsWith(scrape_sv, "udp://"sv))
+        else if (tr_strv_starts_with(scrape_sv, "udp://"sv))
         {
             announcer_udp_.scrape(request, std::move(on_response));
         }
@@ -212,11 +212,11 @@ public:
         }
 
         if (auto const announce_sv = request.announce_url.sv();
-            tr_strvStartsWith(announce_sv, "http://"sv) || tr_strvStartsWith(announce_sv, "https://"sv))
+            tr_strv_starts_with(announce_sv, "http://"sv) || tr_strv_starts_with(announce_sv, "https://"sv))
         {
             tr_tracker_http_announce(session, request, std::move(on_response));
         }
-        else if (tr_strvStartsWith(announce_sv, "udp://"sv))
+        else if (tr_strv_starts_with(announce_sv, "udp://"sv))
         {
             announcer_udp_.announce(request, std::move(on_response));
         }

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -183,7 +183,7 @@ std::optional<address_range_t> parseCidrLine(std::string_view line)
         return {};
     }
 
-    auto const pflen = tr_parseNum<size_t>(line.substr(pos + 1));
+    auto const pflen = tr_num_parse<size_t>(line.substr(pos + 1));
     if (!pflen)
     {
         return {};

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -20,7 +20,7 @@
 #include "libtransmission/net.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
-#include "libtransmission/utils.h" // for _(), tr_strerror(), tr_strvEndsWith()
+#include "libtransmission/utils.h" // for _(), tr_strerror(), tr_strv_ends_with()
 
 using namespace std::literals;
 
@@ -394,7 +394,7 @@ std::vector<Blocklist> Blocklist::loadBlocklists(std::string_view const blocklis
     // check for files that need to be updated
     for (auto const& src_file : getFilenamesInDir(blocklist_dir))
     {
-        if (tr_strvEndsWith(src_file, BinFileSuffix))
+        if (tr_strv_ends_with(src_file, BinFileSuffix))
         {
             continue;
         }
@@ -416,7 +416,7 @@ std::vector<Blocklist> Blocklist::loadBlocklists(std::string_view const blocklis
     auto ret = std::vector<Blocklist>{};
     for (auto const& bin_file : getFilenamesInDir(blocklist_dir))
     {
-        if (tr_strvEndsWith(bin_file, BinFileSuffix))
+        if (tr_strv_ends_with(bin_file, BinFileSuffix))
         {
             ret.emplace_back(bin_file, is_enabled);
         }

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -86,7 +86,7 @@ constexpr std::string_view base62str(uint8_t chr)
 int strint(char const* pch, int span, int base = 10)
 {
     auto sv = std::string_view{ pch, static_cast<size_t>(span) };
-    return tr_parseNum<int>(sv, nullptr, base).value_or(0);
+    return tr_num_parse<int>(sv, nullptr, base).value_or(0);
 }
 
 constexpr std::string_view utSuffix(uint8_t ch)

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -130,7 +130,7 @@ std::string tr_base64_encode(std::string_view input)
         std::data(buf),
         std::data(buf) + len,
         std::back_inserter(str),
-        [](auto ch) { return !tr_strvContains("\r\n"sv, ch); });
+        [](auto ch) { return !tr_strv_contains("\r\n"sv, ch); });
     return str;
 }
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -80,7 +80,7 @@ bool tr_ssha1_test(std::string_view text)
 {
     using namespace ssha1_impl;
 
-    return tr_strvStartsWith(text, SaltedPrefix) && std::size(text) >= std::size(SaltedPrefix) + DigestStringSize;
+    return tr_strv_starts_with(text, SaltedPrefix) && std::size(text) >= std::size(SaltedPrefix) + DigestStringSize;
 }
 
 bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext)

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -229,7 +229,7 @@ private:
             perm = std::move(icon);
 
             // cache it on disk
-            tr_saveFile(fmt::format("{:s}/{:s}", icons_dir_, in_flight->sitename()), contents);
+            tr_file_save(fmt::format("{:s}/{:s}", icons_dir_, in_flight->sitename()), contents);
 
             // notify the user that we got it
             in_flight->invoke_callback(&perm);

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -113,7 +113,7 @@ static auto constexpr Slashes = "\\/"sv;
 
 static constexpr bool is_slash(char c)
 {
-    return tr_strvContains(Slashes, c);
+    return tr_strv_contains(Slashes, c);
 }
 
 static constexpr bool is_unc_path(std::string_view path)

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -212,7 +212,7 @@ static std::string native_path_to_path(std::wstring_view wide_path)
         return {};
     }
 
-    if (tr_strvStartsWith(wide_path, NativeUncPathPrefix))
+    if (tr_strv_starts_with(wide_path, NativeUncPathPrefix))
     {
         wide_path.remove_prefix(std::size(NativeUncPathPrefix));
         auto path = tr_win32_native_to_utf8(wide_path);
@@ -220,7 +220,7 @@ static std::string native_path_to_path(std::wstring_view wide_path)
         return path;
     }
 
-    if (tr_strvStartsWith(wide_path, NativeLocalPathPrefix))
+    if (tr_strv_starts_with(wide_path, NativeLocalPathPrefix))
     {
         wide_path.remove_prefix(std::size(NativeLocalPathPrefix));
         return tr_win32_native_to_utf8(wide_path);
@@ -531,7 +531,7 @@ std::string tr_sys_path_resolve(std::string_view path, tr_error** error)
                 {
                     // `wide_ret_size` includes the terminating '\0'; remove it from `wide_ret`
                     wide_ret.resize(std::size(wide_ret) - 1);
-                    TR_ASSERT(tr_strvStartsWith(wide_ret, NativeLocalPathPrefix));
+                    TR_ASSERT(tr_strv_starts_with(wide_ret, NativeLocalPathPrefix));
                     ret = native_path_to_path(wide_ret);
                 }
             }

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -298,7 +298,7 @@ void tr_global_ip_cache::on_response_ip_query(tr_address_type type, tr_web::Fetc
     if (response.status == 200 /* HTTP_OK */)
     {
         // Update member
-        if (auto const addr = tr_address::from_string(tr_strvStrip(response.body)); addr && set_global_addr(type, *addr))
+        if (auto const addr = tr_address::from_string(tr_strv_strip(response.body)); addr && set_global_addr(type, *addr))
         {
             success = true;
             upkeep_timers_[type]->set_interval(UpkeepInterval);

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -303,7 +303,7 @@ static_assert(keysAreOrdered());
 
 std::optional<tr_log_level> tr_logGetLevelFromKey(std::string_view key_in)
 {
-    auto const key = tr_strlower(tr_strvStrip(key_in));
+    auto const key = tr_strlower(tr_strv_strip(key_in));
 
     for (auto const& [name, level] : LogKeys)
     {

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -211,7 +211,7 @@ void tr_magnet_metainfo::add_webseed(std::string_view webseed)
 
 bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** error)
 {
-    magnet_link = tr_strvStrip(magnet_link);
+    magnet_link = tr_strv_strip(magnet_link);
     if (auto const hash = parseHash(magnet_link); hash)
     {
         return parseMagnet(fmt::format(FMT_STRING("magnet:?xt=urn:btih:{:s}"), tr_sha1_to_string(*hash)));
@@ -239,7 +239,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** er
         else if (key == "ws"sv)
         {
             auto const url = tr_urlPercentDecode(value);
-            auto const url_sv = tr_strvStrip(url);
+            auto const url_sv = tr_strv_strip(url);
             if (tr_urlIsValid(url_sv))
             {
                 this->webseed_urls_.emplace_back(url_sv);

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -231,7 +231,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** er
         {
             this->set_name(tr_urlPercentDecode(value));
         }
-        else if (key == "tr"sv || tr_strvStartsWith(key, "tr."sv))
+        else if (key == "tr"sv || tr_strv_starts_with(key, "tr."sv))
         {
             // "tr." explanation @ https://trac.transmissionbt.com/ticket/3341
             this->announce_list_.add(tr_urlPercentDecode(value));
@@ -245,7 +245,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** er
                 this->webseed_urls_.emplace_back(url_sv);
             }
         }
-        else if (static auto constexpr ValPrefix = "urn:btih:"sv; key == "xt"sv && tr_strvStartsWith(value, ValPrefix))
+        else if (static auto constexpr ValPrefix = "urn:btih:"sv; key == "xt"sv && tr_strv_starts_with(value, ValPrefix))
         {
             // v1 info-hash
             if (auto const hash = parseHash(value.substr(std::size(ValPrefix))); hash)
@@ -254,7 +254,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error** er
                 got_hash = true;
             }
         }
-        else if (static auto constexpr ValPrefix2 = "urn:btmh:1220"sv; key == "xt"sv && tr_strvStartsWith(value, ValPrefix2))
+        else if (static auto constexpr ValPrefix2 = "urn:btmh:1220"sv; key == "xt"sv && tr_strv_starts_with(value, ValPrefix2))
         {
             // v2 info-hash
             // The 1220 tag identifies the hash as sha256, removing tag before sending to parseHash2

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -348,7 +348,7 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
 
             auto* const path_list = tr_variantDictAddList(file_dict, TR_KEY_path, 0);
             auto token = std::string_view{};
-            while (tr_strvSep(&subpath, &token, '/'))
+            while (tr_strv_sep(&subpath, &token, '/'))
             {
                 tr_variantListAddStr(path_list, token);
             }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -326,7 +326,7 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
     // "There is also a key `length` or a key `files`, but not both or neither.
     // If length is present then the download represents a single file,
     // otherwise it represents a set of files which go in a directory structure."
-    if (file_count() == 1U && !tr_strvContains(path(0), '/'))
+    if (file_count() == 1U && !tr_strv_contains(path(0), '/'))
     {
         tr_variantDictAddInt(info_dict, TR_KEY_length, file_size(0));
     }

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -20,7 +20,7 @@
 #include "block-info.h"
 #include "file.h"
 #include "torrent-files.h"
-#include "utils.h" // for tr_saveFile()
+#include "utils.h" // for tr_file_save()
 
 class tr_metainfo_builder
 {
@@ -68,7 +68,7 @@ public:
     // generate the metainfo and save it to a torrent file
     bool save(std::string_view filename, tr_error** error = nullptr) const
     {
-        return tr_saveFile(filename, benc(error), error);
+        return tr_file_save(filename, benc(error), error);
     }
 
     /// setters

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -50,7 +50,7 @@ std::string tr_net_strerror(int err)
 
     auto buf = std::array<char, 512>{};
     (void)FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, err, 0, std::data(buf), std::size(buf), nullptr);
-    return std::string{ tr_strvStrip(std::data(buf)) };
+    return std::string{ tr_strv_strip(std::data(buf)) };
 
 #else
 
@@ -63,7 +63,7 @@ std::string tr_net_strerror(int err)
 
 [[nodiscard]] std::optional<tr_tos_t> tr_tos_t::from_string(std::string_view name)
 {
-    auto const needle = tr_strlower(tr_strvStrip(name));
+    auto const needle = tr_strlower(tr_strv_strip(name));
 
     for (auto const& [value, key] : Names)
     {

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -73,7 +73,7 @@ std::string tr_net_strerror(int err)
         }
     }
 
-    if (auto value = tr_parseNum<int>(needle); value)
+    if (auto value = tr_num_parse<int>(needle); value)
     {
         return tr_tos_t(*value);
     }

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -194,7 +194,7 @@ std::string tr_getDefaultConfigDir(std::string_view appname)
 
 size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_getDefaultConfigDir(appname != nullptr ? appname : ""), buf, buflen);
+    return tr_strv_to_buf(tr_getDefaultConfigDir(appname != nullptr ? appname : ""), buf, buflen);
 }
 
 std::string tr_getDefaultDownloadDir()
@@ -220,7 +220,7 @@ std::string tr_getDefaultDownloadDir()
 
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_getDefaultDownloadDir(), buf, buflen);
+    return tr_strv_to_buf(tr_getDefaultDownloadDir(), buf, buflen);
 }
 
 // ---

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -317,7 +317,7 @@ std::string tr_getWebClientDir([[maybe_unused]] tr_session const* session)
         auto token = std::string_view{};
         while (tr_strv_sep(&sv, &token, ':'))
         {
-            token = tr_strvStrip(token);
+            token = tr_strv_strip(token);
             if (!std::empty(token))
             {
                 candidates.emplace_back(token);

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -117,7 +117,7 @@ std::string getXdgEntryFromUserDirs(std::string_view key)
 {
     auto content = std::vector<char>{};
     if (auto const filename = fmt::format("{:s}/{:s}"sv, xdgConfigHome(), "user-dirs.dirs"sv);
-        !tr_sys_path_exists(filename) || !tr_loadFile(filename, content) || std::empty(content))
+        !tr_sys_path_exists(filename) || !tr_file_read(filename, content) || std::empty(content))
     {
         return {};
     }

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -315,7 +315,7 @@ std::string tr_getWebClientDir([[maybe_unused]] tr_session const* session)
 
         auto sv = std::string_view{ buf };
         auto token = std::string_view{};
-        while (tr_strvSep(&sv, &token, ':'))
+        while (tr_strv_sep(&sv, &token, ':'))
         {
             token = tr_strvStrip(token);
             if (!std::empty(token))

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -359,7 +359,7 @@ auto loadName(tr_variant* dict, tr_torrent* tor)
         return ret;
     }
 
-    name = tr_strvStrip(name);
+    name = tr_strv_strip(name);
     if (std::empty(name))
     {
         return ret;

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -637,7 +637,7 @@ auto loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_load)
     auto buf = std::vector<char>{};
     tr_error* error = nullptr;
     auto top = tr_variant{};
-    if (!tr_loadFile(filename, buf, &error) ||
+    if (!tr_file_read(filename, buf, &error) ||
         !tr_variantFromBuf(&top, TR_VARIANT_PARSE_BENC | TR_VARIANT_PARSE_INPLACE, buf, nullptr, &error))
     {
         tr_logAddDebugTor(tor, fmt::format("Couldn't read '{}': {}", filename, error->message));

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -91,7 +91,7 @@ public:
 
     [[nodiscard]] bool from_string(std::string_view src)
     {
-        if (!tr_strvStartsWith(src, TrUnixSocketPrefix))
+        if (!tr_strv_starts_with(src, TrUnixSocketPrefix))
         {
             return false;
         }
@@ -466,7 +466,7 @@ bool is_authorized(tr_rpc_server const* server, char const* auth_header)
 
     auto constexpr Prefix = "Basic "sv;
     auto auth = std::string_view{ auth_header != nullptr ? auth_header : "" };
-    if (!tr_strvStartsWith(auth, Prefix))
+    if (!tr_strv_starts_with(auth, Prefix))
     {
         return false;
     }
@@ -532,7 +532,7 @@ void handle_request(struct evhttp_request* req, void* arg)
         server->login_attempts_ = 0;
 
         auto uri = std::string_view{ req->uri };
-        auto const location = tr_strvStartsWith(uri, server->url()) ? uri.substr(std::size(server->url())) : ""sv;
+        auto const location = tr_strv_starts_with(uri, server->url()) ? uri.substr(std::size(server->url())) : ""sv;
 
         if (std::empty(location) || location == "web"sv)
         {
@@ -540,7 +540,7 @@ void handle_request(struct evhttp_request* req, void* arg)
             evhttp_add_header(req->output_headers, "Location", new_location.c_str());
             send_simple_response(req, HTTP_MOVEPERM, nullptr);
         }
-        else if (tr_strvStartsWith(location, "web/"sv))
+        else if (tr_strv_starts_with(location, "web/"sv))
         {
             handle_web_client(req, server);
         }
@@ -581,7 +581,7 @@ void handle_request(struct evhttp_request* req, void* arg)
             send_simple_response(req, 409, tmp.c_str());
         }
 #endif
-        else if (tr_strvStartsWith(location, "rpc"sv))
+        else if (tr_strv_starts_with(location, "rpc"sv))
         {
             handle_rpc(req, server);
         }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -209,7 +209,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
 
     for (auto const& [suffix, mime_type] : Types)
     {
-        if (tr_strvEndsWith(path, suffix))
+        if (tr_strv_ends_with(path, suffix))
         {
             return mime_type;
         }
@@ -870,7 +870,7 @@ void tr_rpc_server::load(tr_variant* src)
     RPC_SETTINGS_FIELDS(V)
 #undef V
 
-    if (!tr_strvEndsWith(url_, '/'))
+    if (!tr_strv_ends_with(url_, '/'))
     {
         url_ = fmt::format(FMT_STRING("{:s}/"), url_);
     }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -276,7 +276,7 @@ void serve_file(struct evhttp_request* req, tr_rpc_server const* server, std::st
 
     auto content = std::vector<char>{};
 
-    if (tr_error* error = nullptr; !tr_loadFile(filename, content, &error))
+    if (tr_error* error = nullptr; !tr_file_read(filename, content, &error))
     {
         send_simple_response(req, HTTP_NOTFOUND, fmt::format("{} ({})", filename, error->message).c_str());
         tr_error_free(error);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -225,7 +225,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
     char const* key = "Accept-Encoding";
     char const* encoding = evhttp_find_header(req->input_headers, key);
 
-    if (bool const do_compress = encoding != nullptr && tr_strvContains(encoding, "gzip"sv); !do_compress)
+    if (bool const do_compress = encoding != nullptr && tr_strv_contains(encoding, "gzip"sv); !do_compress)
     {
         evbuffer_add(out, std::data(content), std::size(content));
     }
@@ -328,7 +328,7 @@ void handle_web_client(struct evhttp_request* req, tr_rpc_server const* server)
             subpath = DefaultPage;
         }
 
-        if (tr_strvContains(subpath, ".."sv))
+        if (tr_strv_contains(subpath, ".."sv))
         {
             send_simple_response(req, HTTP_NOTFOUND);
         }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -753,7 +753,7 @@ auto parse_whitelist(std::string_view whitelist)
     while (!std::empty(whitelist))
     {
         auto const pos = whitelist.find_first_of(" ,;"sv);
-        auto const token = tr_strvStrip(whitelist.substr(0, pos));
+        auto const token = tr_strv_strip(whitelist.substr(0, pos));
         list.emplace_back(token);
         tr_logAddInfo(fmt::format(_("Added '{entry}' to host whitelist"), fmt::arg("entry", token)));
         whitelist = pos == std::string_view::npos ? ""sv : whitelist.substr(pos + 1);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -474,7 +474,7 @@ bool is_authorized(tr_rpc_server const* server, char const* auth_header)
     auth.remove_prefix(std::size(Prefix));
     auto const decoded_str = tr_base64_decode(auth);
     auto decoded = std::string_view{ decoded_str };
-    auto const username = tr_strvSep(&decoded, ':');
+    auto const username = tr_strv_sep(&decoded, ':');
     auto const password = decoded;
     return server->username() == username && tr_ssha1_matches(server->salted_password_, password);
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -982,7 +982,7 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
             continue;
         }
 
-        label = tr_strvStrip(label);
+        label = tr_strv_strip(label);
         if (std::empty(label))
         {
             return { {}, "labels cannot be empty" };
@@ -1773,7 +1773,7 @@ char const* groupSet(tr_session* session, tr_variant* args_in, tr_variant* /*arg
 {
     auto name = std::string_view{};
     (void)tr_variantDictFindStrView(args_in, TR_KEY_name, &name);
-    name = tr_strvStrip(name);
+    name = tr_strv_strip(name);
     if (std::empty(name))
     {
         return "No group name given";

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -988,7 +988,7 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
             return { {}, "labels cannot be empty" };
         }
 
-        if (tr_strvContains(label, ','))
+        if (tr_strv_contains(label, ','))
         {
             return { {}, "labels cannot contain comma (,) character" };
         }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1466,7 +1466,7 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
     // tr_blocklistSetContent needs a source file,
     // so save content into a tmpfile
     auto const filename = tr_pathbuf{ session->configDir(), "/blocklist.tmp"sv };
-    if (tr_error* error = nullptr; !tr_saveFile(filename, content, &error))
+    if (tr_error* error = nullptr; !tr_file_save(filename, content, &error))
     {
         tr_idle_function_done(
             data,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1398,7 +1398,7 @@ void onPortTested(tr_web::FetchResponse const& web_response)
     }
     else /* success */
     {
-        bool const is_open = tr_strvStartsWith(body, '1');
+        bool const is_open = tr_strv_starts_with(body, '1');
         tr_variantDictAddBool(data->args_out, TR_KEY_port_is_open, is_open);
         tr_idle_function_done(data, SuccessResult);
     }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2597,7 +2597,7 @@ void tr_rpc_request_exec_json(
  */
 void tr_rpc_parse_list_str(tr_variant* setme, std::string_view str)
 {
-    auto const values = tr_parseNumberRange(str);
+    auto const values = tr_num_parse_range(str);
     auto const value_count = std::size(values);
 
     if (value_count == 0)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1371,7 +1371,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 
-        if (tr_loadFile(path, buf) &&
+        if (tr_file_read(path, buf) &&
             tr_ctorSetMetainfoFromMagnetLink(ctor, std::string_view{ std::data(buf), std::size(buf) }, nullptr) &&
             tr_torrentNew(ctor, nullptr) != nullptr)
         {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1356,7 +1356,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     auto n_torrents = size_t{};
     auto const& folder = session->torrentDir();
 
-    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strvEndsWith(name, ".torrent"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strv_ends_with(name, ".torrent"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 
@@ -1367,7 +1367,7 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
     }
 
     auto buf = std::vector<char>{};
-    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strvEndsWith(name, ".magnet"sv); }))
+    for (auto const& name : tr_sys_dir_get_files(folder, [](auto name) { return tr_strv_ends_with(name, ".magnet"sv); }))
     {
         auto const path = tr_pathbuf{ folder, '/', name };
 

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -205,7 +205,7 @@ auto get_app_type(char const* app)
 {
     auto const lower = tr_strlower(app);
 
-    if (tr_strvEndsWith(lower, ".cmd") || tr_strvEndsWith(lower, ".bat"))
+    if (tr_strv_ends_with(lower, ".cmd") || tr_strv_ends_with(lower, ".bat"))
     {
         return tr_app_type::BATCH;
     }

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -75,7 +75,7 @@ bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_err
         return false;
     }
 
-    if (!tr_loadFile(filename, ctor->contents, error))
+    if (!tr_file_read(filename, ctor->contents, error))
     {
         return false;
     }
@@ -126,7 +126,7 @@ bool tr_ctorSaveContents(tr_ctor const* ctor, std::string_view filename, tr_erro
         return false;
     }
 
-    return tr_saveFile(filename, ctor->contents, error);
+    return tr_file_save(filename, ctor->contents, error);
 }
 
 // ---

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -91,7 +91,7 @@ bool isJunkFile(std::string_view filename)
 
 #ifdef __APPLE__
     // check for resource forks. <http://web.archive.org/web/20101010051608/http://support.apple.com/kb/TA20578>
-    if (tr_strvStartsWith(base, "._"sv))
+    if (tr_strv_starts_with(base, "._"sv))
     {
         return true;
     }
@@ -362,7 +362,7 @@ namespace
     return std::any_of(
         std::begin(ReservedPrefixes),
         std::end(ReservedPrefixes),
-        [in_upper_sv](auto const& prefix) { return tr_strvStartsWith(in_upper_sv, prefix); });
+        [in_upper_sv](auto const& prefix) { return tr_strv_starts_with(in_upper_sv, prefix); });
 }
 
 // https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -417,7 +417,7 @@ void appendSanitizedComponent(std::string_view in, tr_pathbuf& out)
 void tr_torrent_files::makeSubpathPortable(std::string_view path, tr_pathbuf& append_me)
 {
     auto segment = std::string_view{};
-    while (tr_strvSep(&path, &segment, '/'))
+    while (tr_strv_sep(&path, &segment, '/'))
     {
         appendSanitizedComponent(segment, append_me);
         append_me.append('/');

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -203,7 +203,7 @@ bool tr_torrent_files::move(
         }
 
         tr_logAddTrace(fmt::format(FMT_STRING("Moving file #{:d} to '{:s}'"), i, old_path, path), parent_name);
-        if (!tr_moveFile(old_path, path, error))
+        if (!tr_file_move(old_path, path, error))
         {
             err = true;
             break;
@@ -264,7 +264,7 @@ void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdi
     {
         if (auto const found = find(idx, std::data(paths), std::size(paths)); found)
         {
-            tr_moveFile(found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() });
+            tr_file_move(found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() });
         }
     }
 

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -391,7 +391,7 @@ namespace
 void appendSanitizedComponent(std::string_view in, tr_pathbuf& out)
 {
     // remove leading and trailing spaces
-    in = tr_strvStrip(in);
+    in = tr_strv_strip(in);
 
     // remove trailing periods
     while (tr_strv_ends_with(in, '.'))

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -394,7 +394,7 @@ void appendSanitizedComponent(std::string_view in, tr_pathbuf& out)
     in = tr_strvStrip(in);
 
     // remove trailing periods
-    while (tr_strvEndsWith(in, '.'))
+    while (tr_strv_ends_with(in, '.'))
     {
         in.remove_suffix(1);
     }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -284,7 +284,7 @@ bool use_new_metainfo(tr_torrent* tor, tr_incomplete_metadata const* m, tr_error
     }
 
     // save it
-    if (!tr_saveFile(tor->torrent_file(), benc, error))
+    if (!tr_file_save(tor->torrent_file(), benc, error))
     {
         return false;
     }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -431,5 +431,5 @@ std::string tr_torrentGetMagnetLink(tr_torrent const* tor)
 
 size_t tr_torrentGetMagnetLinkToBuf(tr_torrent const* tor, char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_torrentGetMagnetLink(tor), buf, buflen);
+    return tr_strv_to_buf(tr_torrentGetMagnetLink(tor), buf, buflen);
 }

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -672,7 +672,7 @@ bool tr_torrent_metainfo::parse_torrent_file(std::string_view filename, std::vec
         contents = &local_contents;
     }
 
-    return tr_loadFile(filename, *contents, error) && parse_benc({ std::data(*contents), std::size(*contents) }, error);
+    return tr_file_read(filename, *contents, error) && parse_benc({ std::data(*contents), std::size(*contents) }, error);
 }
 
 tr_pathbuf tr_torrent_metainfo::make_filename(

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -41,7 +41,7 @@ using namespace std::literals;
  */
 std::string tr_torrent_metainfo::fix_webseed_url(tr_torrent_metainfo const& tm, std::string_view url)
 {
-    url = tr_strvStrip(url);
+    url = tr_strv_strip(url);
 
     if (tm.file_count() > 1U && !std::empty(url) && url.back() != '/')
     {
@@ -350,7 +350,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         }
         else if (pathIs(EncodingKey))
         {
-            encoding_ = tr_strvStrip(value);
+            encoding_ = tr_strv_strip(value);
         }
         else if (pathIs(UrlListKey))
         {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2470,7 +2470,7 @@ bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::st
     for (tr_file_index_t i = 0; i < n_files; ++i)
     {
         auto const& name = tor->file_subpath(i);
-        if (newpath == name || tr_strvStartsWith(name, newpath_as_dir))
+        if (newpath == name || tr_strv_starts_with(name, newpath_as_dir))
         {
             return false;
         }
@@ -2488,7 +2488,7 @@ auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldpath)
     for (tr_file_index_t i = 0; i < n_files; ++i)
     {
         auto const& name = tor->file_subpath(i);
-        if (name == oldpath || tr_strvStartsWith(name, oldpath_as_dir))
+        if (name == oldpath || tr_strv_starts_with(name, oldpath_as_dir))
         {
             indices.push_back(i);
         }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1130,7 +1130,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
         else // magnet link
         {
             auto const magnet_link = tor->magnet();
-            tr_saveFile(filename, magnet_link, &error);
+            tr_file_save(filename, magnet_link, &error);
         }
 
         if (error != nullptr)
@@ -2123,7 +2123,7 @@ bool tr_torrent::set_tracker_list(std::string_view text)
         auto const magnet_file = this->magnet_file();
         auto const magnet_link = this->magnet();
         tr_error* save_error = nullptr;
-        if (!tr_saveFile(magnet_file, magnet_link, &save_error))
+        if (!tr_file_save(magnet_file, magnet_link, &save_error))
         {
             this->set_local_error(fmt::format(
                 _("Couldn't save '{path}': {error} ({error_code})"),

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1972,7 +1972,7 @@ void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
 
 void tr_torrent::set_bandwidth_group(std::string_view group_name) noexcept
 {
-    group_name = tr_strvStrip(group_name);
+    group_name = tr_strv_strip(group_name);
 
     auto const lock = this->unique_lock();
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -956,7 +956,7 @@ bool isNewTorrentASeed(tr_torrent* tor)
         }
 
         // it's not a new seed if a file is partial
-        if (tr_strvEndsWith(found->filename(), tr_torrent_files::PartialFileSuffix))
+        if (tr_strv_ends_with(found->filename(), tr_torrent_files::PartialFileSuffix))
         {
             return false;
         }
@@ -2513,7 +2513,7 @@ int renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view
     if (tr_sys_path_exists(src))
     {
         auto const parent = tr_sys_path_dirname(src);
-        auto const tgt = tr_strvEndsWith(src, tr_torrent_files::PartialFileSuffix) ?
+        auto const tgt = tr_strv_ends_with(src, tr_torrent_files::PartialFileSuffix) ?
             tr_pathbuf{ parent, '/', newname, tr_torrent_files::PartialFileSuffix } :
             tr_pathbuf{ parent, '/', newname };
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1682,7 +1682,7 @@ std::string tr_torrentFilename(tr_torrent const* tor)
 
 size_t tr_torrentFilenameToBuf(tr_torrent const* tor, char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_torrentFilename(tor), buf, buflen);
+    return tr_strv_to_buf(tr_torrentFilename(tor), buf, buflen);
 }
 
 // ---
@@ -2210,7 +2210,7 @@ std::string tr_torrentGetTrackerList(tr_torrent const* tor)
 
 size_t tr_torrentGetTrackerListToBuf(tr_torrent const* tor, char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_torrentGetTrackerList(tor), buf, buflen);
+    return tr_strv_to_buf(tr_torrentGetTrackerList(tor), buf, buflen);
 }
 
 // ---
@@ -2391,7 +2391,7 @@ std::string tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t file_num)
 
 size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, char* buf, size_t buflen)
 {
-    return tr_strvToBuf(tr_torrentFindFile(tor, file_num), buf, buflen);
+    return tr_strv_to_buf(tr_torrentFindFile(tor, file_num), buf, buflen);
 }
 
 void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1670,7 +1670,7 @@ tr_torrent_view tr_torrentView(tr_torrent const* tor)
     ret.piece_size = tor->piece_size();
     ret.n_pieces = tor->piece_count();
     ret.is_private = tor->is_private();
-    ret.is_folder = tor->file_count() > 1 || (tor->file_count() == 1 && tr_strvContains(tor->file_subpath(0), '/'));
+    ret.is_folder = tor->file_count() > 1 || (tor->file_count() == 1 && tr_strv_contains(tor->file_subpath(0), '/'));
 
     return ret;
 }
@@ -2450,12 +2450,12 @@ namespace rename_helpers
 bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
 {
     if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv ||
-        tr_strvContains(newname, TR_PATH_DELIMITER))
+        tr_strv_contains(newname, TR_PATH_DELIMITER))
     {
         return false;
     }
 
-    auto const newpath = tr_strvContains(oldpath, TR_PATH_DELIMITER) ?
+    auto const newpath = tr_strv_contains(oldpath, TR_PATH_DELIMITER) ?
         tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
         tr_pathbuf{ newname };
 
@@ -2546,7 +2546,7 @@ void renameTorrentFileString(tr_torrent* tor, std::string_view oldpath, std::str
     auto const subpath = std::string_view{ tor->file_subpath(file_index) };
     auto const oldpath_len = std::size(oldpath);
 
-    if (!tr_strvContains(oldpath, TR_PATH_DELIMITER))
+    if (!tr_strv_contains(oldpath, TR_PATH_DELIMITER))
     {
         if (oldpath_len >= std::size(subpath))
         {
@@ -2614,7 +2614,7 @@ void torrentRenamePath(
             }
 
             /* update tr_info.name if user changed the toplevel */
-            if (std::size(file_indices) == tor->file_count() && !tr_strvContains(oldpath, '/'))
+            if (std::size(file_indices) == tor->file_count() && !tr_strv_contains(oldpath, '/'))
             {
                 tor->set_name(newname);
             }

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -72,14 +72,14 @@ void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t sh
     auto len = get_next_line_len(description, d_width);
     fmt::print(FMT_STRING("{:s}\n"), description.substr(0, len));
     description.remove_prefix(len);
-    description = tr_strvStrip(description);
+    description = tr_strv_strip(description);
 
     auto const indent = std::string(d_indent, ' ');
     while ((len = get_next_line_len(description, d_width)) != 0)
     {
         fmt::print(FMT_STRING("{:s}{:s}\n"), indent, description.substr(0, len));
         description.remove_prefix(len);
-        description = tr_strvStrip(description);
+        description = tr_strv_strip(description);
     }
 }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -124,7 +124,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     {
         // parse `${major}.${minor}`
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const major = tr_parseNum<int>(walk, &walk); major && tr_strv_starts_with(walk, '.'))
+        if (auto const major = tr_num_parse<int>(walk, &walk); major && tr_strv_starts_with(walk, '.'))
         {
             ret.major = *major;
         }
@@ -134,7 +134,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
         }
 
         walk.remove_prefix(1); // the '.' between major and minor
-        if (auto const minor = tr_parseNum<int>(walk, &walk); minor && tr_strv_starts_with(walk, CrLf))
+        if (auto const minor = tr_num_parse<int>(walk, &walk); minor && tr_strv_starts_with(walk, CrLf))
         {
             ret.minor = *minor;
         }
@@ -148,7 +148,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     if (auto const pos = announce.find(key); pos != std::string_view::npos)
     {
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const port = tr_parseNum<uint16_t>(walk, &walk); port && tr_strv_starts_with(walk, CrLf))
+        if (auto const port = tr_num_parse<uint16_t>(walk, &walk); port && tr_strv_starts_with(walk, CrLf))
         {
             ret.port = tr_port::fromHost(*port);
         }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -124,7 +124,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     {
         // parse `${major}.${minor}`
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const major = tr_parseNum<int>(walk, &walk); major && tr_strvStartsWith(walk, '.'))
+        if (auto const major = tr_parseNum<int>(walk, &walk); major && tr_strv_starts_with(walk, '.'))
         {
             ret.major = *major;
         }
@@ -134,7 +134,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
         }
 
         walk.remove_prefix(1); // the '.' between major and minor
-        if (auto const minor = tr_parseNum<int>(walk, &walk); minor && tr_strvStartsWith(walk, CrLf))
+        if (auto const minor = tr_parseNum<int>(walk, &walk); minor && tr_strv_starts_with(walk, CrLf))
         {
             ret.minor = *minor;
         }
@@ -148,7 +148,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     if (auto const pos = announce.find(key); pos != std::string_view::npos)
     {
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const port = tr_parseNum<uint16_t>(walk, &walk); port && tr_strvStartsWith(walk, CrLf))
+        if (auto const port = tr_parseNum<uint16_t>(walk, &walk); port && tr_strv_starts_with(walk, CrLf))
         {
             ret.port = tr_port::fromHost(*port);
         }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -113,7 +113,7 @@ enum tr_encryption_mode
 [[nodiscard]] std::string tr_getDefaultConfigDir(std::string_view appname);
 #endif
 
-/** @brief buffer variant of `tr_getDefaultConfigDir()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_getDefaultConfigDir()`. See `tr_strv_to_buf()`. */
 size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen);
 
 /**
@@ -128,7 +128,7 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 [[nodiscard]] std::string tr_getDefaultDownloadDir();
 #endif
 
-/** @brief buffer variant of `tr_getDefaultDownloadDir()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_getDefaultDownloadDir()`. See `tr_strv_to_buf()`. */
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
@@ -981,7 +981,7 @@ uint64_t tr_torrentTotalSize(tr_torrent const* tor);
 [[nodiscard]] std::string tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t file_num);
 #endif
 
-/** @brief buffer variant of `tr_torrentFindFile()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_torrentFindFile()`. See `tr_strv_to_buf()`. */
 size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, char* buf, size_t buflen);
 
 // --- Torrent speed limits
@@ -1086,7 +1086,7 @@ char const* tr_torrentGetCurrentDir(tr_torrent const* tor);
 [[nodiscard]] std::string tr_torrentGetMagnetLink(tr_torrent const* tor);
 #endif
 
-/** @brief buffer variant of `tr_torrentGetMagnetLink()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_torrentGetMagnetLink()`. See `tr_strv_to_buf()`. */
 size_t tr_torrentGetMagnetLinkToBuf(tr_torrent const* tor, char* buf, size_t buflen);
 
 // ---
@@ -1105,7 +1105,7 @@ size_t tr_torrentGetMagnetLinkToBuf(tr_torrent const* tor, char* buf, size_t buf
 [[nodiscard]] std::string tr_torrentGetTrackerList(tr_torrent const* tor);
 #endif
 
-/** @brief buffer variant of `tr_torrentGetTrackerList()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_torrentGetTrackerList()`. See `tr_strv_to_buf()`. */
 size_t tr_torrentGetTrackerListToBuf(tr_torrent const* tor, char* buf, size_t buflen);
 
 /**
@@ -1392,7 +1392,7 @@ struct tr_torrent_view tr_torrentView(tr_torrent const* tor);
 [[nodiscard]] std::string tr_torrentFilename(tr_torrent const* tor);
 #endif
 
-/** @brief buffer variant of `tr_torrentFilename()`. See `tr_strvToBuf()`. */
+/** @brief buffer variant of `tr_torrentFilename()`. See `tr_strv_to_buf()`. */
 size_t tr_torrentFilenameToBuf(tr_torrent const* tor, char* buf, size_t buflen);
 
 /**

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -484,7 +484,7 @@ std::vector<int> tr_parseNumberRange(std::string_view str)
     auto values = std::set<int>{};
     auto token = std::string_view{};
     auto range = number_range{};
-    while (tr_strvSep(&str, &token, ',') && parseNumberSection(token, range))
+    while (tr_strv_sep(&str, &token, ',') && parseNumberSection(token, range))
     {
         for (auto i = range.low; i <= range.high; ++i)
         {

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -452,7 +452,7 @@ bool parseNumberSection(std::string_view str, number_range& range)
         return true;
     }
 
-    if (!tr_strvStartsWith(str, Delimiter))
+    if (!tr_strv_starts_with(str, Delimiter))
     {
         return false;
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -212,7 +212,7 @@ char const* tr_strerror(int errnum)
 
 // ---
 
-std::string_view tr_strvStrip(std::string_view str)
+std::string_view tr_strv_strip(std::string_view str)
 {
     auto constexpr Test = [](auto ch)
     {

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -423,7 +423,7 @@ int tr_main_win32(int argc, char** argv, int (*real_main)(int, char**))
 
 namespace
 {
-namespace tr_parseNumberRange_impl
+namespace tr_num_parse_range_impl
 {
 
 struct number_range
@@ -440,7 +440,7 @@ bool parseNumberSection(std::string_view str, number_range& range)
 {
     auto constexpr Delimiter = "-"sv;
 
-    auto const first = tr_parseNum<int>(str, &str);
+    auto const first = tr_num_parse<int>(str, &str);
     if (!first)
     {
         return false;
@@ -458,7 +458,7 @@ bool parseNumberSection(std::string_view str, number_range& range)
     }
 
     str.remove_prefix(std::size(Delimiter));
-    auto const second = tr_parseNum<int>(str);
+    auto const second = tr_num_parse<int>(str);
     if (!second)
     {
         return false;
@@ -468,7 +468,7 @@ bool parseNumberSection(std::string_view str, number_range& range)
     return true;
 }
 
-} // namespace tr_parseNumberRange_impl
+} // namespace tr_num_parse_range_impl
 } // namespace
 
 /**
@@ -477,9 +477,9 @@ bool parseNumberSection(std::string_view str, number_range& range)
  * For example, "5-8" will return [ 5, 6, 7, 8 ] and setmeCount will be 4.
  * If a fragment of the string can't be parsed, nullptr is returned.
  */
-std::vector<int> tr_parseNumberRange(std::string_view str)
+std::vector<int> tr_num_parse_range(std::string_view str)
 {
-    using namespace tr_parseNumberRange_impl;
+    using namespace tr_num_parse_range_impl;
 
     auto values = std::set<int>{};
     auto token = std::string_view{};
@@ -508,7 +508,7 @@ double tr_truncd(double x, int decimal_places)
         pt[decimal_places != 0 ? decimal_places + 1 : 0] = '\0';
     }
 
-    return tr_parseNum<double>(std::data(buf)).value_or(0.0);
+    return tr_num_parse<double>(std::data(buf)).value_or(0.0);
 }
 
 std::string tr_strpercent(double x)
@@ -978,7 +978,7 @@ std::string_view tr_get_mime_type_for_filename(std::string_view filename)
 #include <sstream>
 
 template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-[[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* remainder, int base)
+[[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder, int base)
 {
     auto val = T{};
     auto const tmpstr = std::string(std::data(str), std::min(std::size(str), size_t{ 64 }));
@@ -1007,7 +1007,7 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 #include <charconv> // std::from_chars()
 
 template<typename T, std::enable_if_t<std::is_integral<T>::value, bool>>
-[[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* remainder, int base)
+[[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder, int base)
 {
     auto val = T{};
     auto const* const begin_ch = std::data(str);
@@ -1030,19 +1030,19 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool>>
 
 #endif // #if defined(__GNUC__) && !__has_include(<charconv>)
 
-template std::optional<long long> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<long> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<int> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<char> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
+template std::optional<long long> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<long> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<int> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<char> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
 
-template std::optional<unsigned long long> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<unsigned long> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<unsigned int> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<unsigned short> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
-template std::optional<unsigned char> tr_parseNum(std::string_view str, std::string_view* remainder, int base);
+template std::optional<unsigned long long> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<unsigned long> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<unsigned int> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<unsigned short> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
+template std::optional<unsigned char> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
 
 template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool>>
-[[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* remainder)
+[[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder)
 {
     auto const* const begin_ch = std::data(str);
     auto const* const end_ch = begin_ch + std::size(str);
@@ -1060,4 +1060,4 @@ template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool>>
     return val;
 }
 
-template std::optional<double> tr_parseNum(std::string_view sv, std::string_view* remainder);
+template std::optional<double> tr_num_parse(std::string_view sv, std::string_view* remainder);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -77,7 +77,7 @@ void tr_locale_set_global(char const* locale_name) noexcept
 
 // ---
 
-bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_error** error)
+bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_error** error)
 {
     auto const szfilename = tr_pathbuf{ filename };
 
@@ -132,13 +132,13 @@ bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_erro
     return true;
 }
 
-bool tr_saveFile(std::string_view filename, std::string_view contents, tr_error** error)
+bool tr_file_save(std::string_view filename, std::string_view contents, tr_error** error)
 {
     // follow symlinks to find the "real" file, to make sure the temporary
     // we build with tr_sys_file_open_temp() is created on the right partition
     if (auto const realname = tr_sys_path_resolve(filename); !std::empty(realname) && realname != filename)
     {
-        return tr_saveFile(realname, contents, error);
+        return tr_file_save(realname, contents, error);
     }
 
     // Write it to a temp file first.
@@ -545,7 +545,7 @@ std::string tr_strratio(double ratio, char const* infinity)
 
 // ---
 
-bool tr_moveFile(std::string_view oldpath_in, std::string_view newpath_in, tr_error** error)
+bool tr_file_move(std::string_view oldpath_in, std::string_view newpath_in, tr_error** error)
 {
     auto const oldpath = tr_pathbuf{ oldpath_in };
     auto const newpath = tr_pathbuf{ newpath_in };

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -175,7 +175,7 @@ bool tr_saveFile(std::string_view filename, std::string_view contents, tr_error*
 
 // ---
 
-size_t tr_strvToBuf(std::string_view src, char* buf, size_t buflen)
+size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen)
 {
     size_t const len = std::size(src);
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -169,7 +169,7 @@ template<typename T>
     return !std::empty(sv) && sv.back() == key;
 }
 
-constexpr std::string_view tr_strvSep(std::string_view* sv, char delim)
+constexpr std::string_view tr_strv_sep(std::string_view* sv, char delim)
 {
     auto pos = sv->find(delim);
     auto const ret = sv->substr(0, pos);
@@ -177,14 +177,14 @@ constexpr std::string_view tr_strvSep(std::string_view* sv, char delim)
     return ret;
 }
 
-constexpr bool tr_strvSep(std::string_view* sv, std::string_view* token, char delim)
+constexpr bool tr_strv_sep(std::string_view* sv, std::string_view* token, char delim)
 {
     if (std::empty(*sv))
     {
         return false;
     }
 
-    *token = tr_strvSep(sv, delim);
+    *token = tr_strv_sep(sv, delim);
     return true;
 }
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -59,12 +59,6 @@ void tr_locale_set_global(char const* locale_name) noexcept;
 
 [[nodiscard]] std::string_view tr_get_mime_type_for_filename(std::string_view filename);
 
-/**
- * @brief Rich Salz's classic implementation of shell-style pattern matching for `?`, `\`, `[]`, and `*` characters.
- * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occurred
- */
-[[nodiscard]] bool tr_wildmat(std::string_view text, std::string_view pattern);
-
 bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_error** error = nullptr);
 
 bool tr_file_move(std::string_view oldpath, std::string_view newpath, struct tr_error** error = nullptr);
@@ -134,6 +128,12 @@ template<typename T>
 
 // --- std::string_view utils
 
+/**
+ * @brief Rich Salz's classic implementation of shell-style pattern matching for `?`, `\`, `[]`, and `*` characters.
+ * @return 1 if the pattern matches, 0 if it doesn't, or -1 if an error occurred
+ */
+[[nodiscard]] bool tr_wildmat(std::string_view text, std::string_view pattern);
+
 template<typename T>
 [[nodiscard]] constexpr bool tr_strv_contains(std::string_view sv, T key) noexcept // c++23
 {
@@ -201,10 +201,6 @@ size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
 
 // ---
 
-/** @brief return `TR_RATIO_NA`, `TR_RATIO_INF`, or a number in [0..1]
-    @return `TR_RATIO_NA`, `TR_RATIO_INF`, or a number in [0..1] */
-[[nodiscard]] double tr_getRatio(uint64_t numerator, uint64_t denominator);
-
 template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* setme_remainder = nullptr, int base = 10);
 
@@ -239,10 +235,12 @@ template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = 
 /* return a percent formatted string of either x.xx, xx.x or xxx */
 [[nodiscard]] std::string tr_strpercent(double x);
 
-/**
- * @param ratio    the ratio to convert to a string
- * @param infinity the string representation of "infinity"
- */
+/** @brief return `TR_RATIO_NA`, `TR_RATIO_INF`, or a number in [0..1]
+    @return `TR_RATIO_NA`, `TR_RATIO_INF`, or a number in [0..1] */
+[[nodiscard]] double tr_getRatio(uint64_t numerator, uint64_t denominator);
+
+/** @param ratio    the ratio to convert to a string
+    @param infinity the string representation of "infinity" */
 [[nodiscard]] std::string tr_strratio(double ratio, char const* infinity);
 
 // ---

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -188,7 +188,7 @@ constexpr bool tr_strv_sep(std::string_view* sv, std::string_view* token, char d
     return true;
 }
 
-[[nodiscard]] std::string_view tr_strvStrip(std::string_view str);
+[[nodiscard]] std::string_view tr_strv_strip(std::string_view str);
 
 [[nodiscard]] std::string tr_strv_convert_utf8(std::string_view sv);
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -65,14 +65,16 @@ void tr_locale_set_global(char const* locale_name) noexcept;
  */
 [[nodiscard]] bool tr_wildmat(std::string_view text, std::string_view pattern);
 
-bool tr_loadFile(std::string_view filename, std::vector<char>& contents, tr_error** error = nullptr);
+bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_error** error = nullptr);
 
-bool tr_saveFile(std::string_view filename, std::string_view contents, tr_error** error = nullptr);
+bool tr_file_move(std::string_view oldpath, std::string_view newpath, struct tr_error** error = nullptr);
+
+bool tr_file_save(std::string_view filename, std::string_view contents, tr_error** error = nullptr);
 
 template<typename ContiguousRange>
-constexpr auto tr_saveFile(std::string_view filename, ContiguousRange const& x, tr_error** error = nullptr)
+constexpr auto tr_file_save(std::string_view filename, ContiguousRange const& x, tr_error** error = nullptr)
 {
-    return tr_saveFile(filename, std::string_view{ std::data(x), std::size(x) }, error);
+    return tr_file_save(filename, std::string_view{ std::data(x), std::size(x) }, error);
 }
 
 /** @brief return the current date in milliseconds */
@@ -242,12 +244,6 @@ size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
  * @param infinity the string representation of "infinity"
  */
 [[nodiscard]] std::string tr_strratio(double ratio, char const* infinity);
-
-/**
- * @brief move a file
- * @return `True` on success, `false` otherwise (with `error` set accordingly).
- */
-bool tr_moveFile(std::string_view oldpath, std::string_view newpath, struct tr_error** error = nullptr);
 
 // ---
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -139,7 +139,7 @@ template<typename T>
 // --- std::string_view utils
 
 template<typename T>
-[[nodiscard]] constexpr bool tr_strvContains(std::string_view sv, T key) noexcept // c++23
+[[nodiscard]] constexpr bool tr_strv_contains(std::string_view sv, T key) noexcept // c++23
 {
     return sv.find(key) != std::string_view::npos;
 }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -80,12 +80,6 @@ constexpr auto tr_file_save(std::string_view filename, ContiguousRange const& x,
 /** @brief return the current date in milliseconds */
 [[nodiscard]] uint64_t tr_time_msec();
 
-template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-[[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* setme_remainder = nullptr, int base = 10);
-
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
-[[nodiscard]] std::optional<T> tr_parseNum(std::string_view str, std::string_view* setme_remainder = nullptr);
-
 #ifdef _WIN32
 
 [[nodiscard]] std::string tr_win32_format_message(uint32_t code);
@@ -211,6 +205,12 @@ size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
     @return `TR_RATIO_NA`, `TR_RATIO_INF`, or a number in [0..1] */
 [[nodiscard]] double tr_getRatio(uint64_t numerator, uint64_t denominator);
 
+template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+[[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* setme_remainder = nullptr, int base = 10);
+
+template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+[[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* setme_remainder = nullptr);
+
 /**
  * @brief Given a string like "1-4" or "1-4,6,9,14-51", this returns a
  *        newly-allocated array of all the integers in the set.
@@ -218,7 +218,7 @@ size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
  *
  * For example, "5-8" will return [ 5, 6, 7, 8 ] and setmeCount will be 4.
  */
-[[nodiscard]] std::vector<int> tr_parseNumberRange(std::string_view str);
+[[nodiscard]] std::vector<int> tr_num_parse_range(std::string_view str);
 
 /**
  * @brief truncate a double value at a given number of decimal places.

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -144,17 +144,17 @@ template<typename T>
     return sv.find(key) != std::string_view::npos;
 }
 
-[[nodiscard]] constexpr bool tr_strvStartsWith(std::string_view sv, char key) // c++20
+[[nodiscard]] constexpr bool tr_strv_starts_with(std::string_view sv, char key) // c++20
 {
     return !std::empty(sv) && sv.front() == key;
 }
 
-[[nodiscard]] constexpr bool tr_strvStartsWith(std::string_view sv, std::string_view key) // c++20
+[[nodiscard]] constexpr bool tr_strv_starts_with(std::string_view sv, std::string_view key) // c++20
 {
     return std::size(key) <= std::size(sv) && sv.substr(0, std::size(key)) == key;
 }
 
-[[nodiscard]] constexpr bool tr_strvStartsWith(std::wstring_view sv, std::wstring_view key) // c++20
+[[nodiscard]] constexpr bool tr_strv_starts_with(std::wstring_view sv, std::wstring_view key) // c++20
 {
     return std::size(key) <= std::size(sv) && sv.substr(0, std::size(key)) == key;
 }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -159,12 +159,12 @@ template<typename T>
     return std::size(key) <= std::size(sv) && sv.substr(0, std::size(key)) == key;
 }
 
-[[nodiscard]] constexpr bool tr_strvEndsWith(std::string_view sv, std::string_view key) // c++20
+[[nodiscard]] constexpr bool tr_strv_ends_with(std::string_view sv, std::string_view key) // c++20
 {
     return std::size(key) <= std::size(sv) && sv.substr(std::size(sv) - std::size(key)) == key;
 }
 
-[[nodiscard]] constexpr bool tr_strvEndsWith(std::string_view sv, char key) // c++20
+[[nodiscard]] constexpr bool tr_strv_ends_with(std::string_view sv, char key) // c++20
 {
     return !std::empty(sv) && sv.back() == key;
 }

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -201,7 +201,7 @@ constexpr bool tr_strv_sep(std::string_view* sv, std::string_view* token, char d
  * - `src` will be copied into `buf` iff `buflen >= std::size(src)`
  * - `buf` will also be zero terminated iff `buflen >= std::size(src) + 1`.
  */
-size_t tr_strvToBuf(std::string_view src, char* buf, size_t buflen);
+size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
 
 // ---
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -70,7 +70,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
     }
 
     // parse the string and make sure the next char is `Suffix`
-    auto const value = tr_parseNum<int64_t>(walk, &walk);
+    auto const value = tr_num_parse<int64_t>(walk, &walk);
     if (!value || !tr_strv_starts_with(walk, Suffix))
     {
         return {};
@@ -103,7 +103,7 @@ std::optional<std::string_view> ParseString(std::string_view* benc)
         return {};
     }
 
-    auto const len = tr_parseNum<size_t>(svtmp, &svtmp);
+    auto const len = tr_num_parse<size_t>(svtmp, &svtmp);
     if (!len || *len >= MaxBencStrLength)
     {
         return {};

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -50,7 +50,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
 
     // find the beginning delimiter
     auto walk = *benc;
-    if (std::size(walk) < 3 || !tr_strvStartsWith(walk, Prefix))
+    if (std::size(walk) < 3 || !tr_strv_starts_with(walk, Prefix))
     {
         return {};
     }
@@ -71,7 +71,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
 
     // parse the string and make sure the next char is `Suffix`
     auto const value = tr_parseNum<int64_t>(walk, &walk);
-    if (!value || !tr_strvStartsWith(walk, Suffix))
+    if (!value || !tr_strv_starts_with(walk, Suffix))
     {
         return {};
     }

--- a/libtransmission/variant-converters.cc
+++ b/libtransmission/variant-converters.cc
@@ -9,7 +9,7 @@
 
 #include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port
-#include "libtransmission/utils.h" // for tr_strvStrip(), tr_strlower()
+#include "libtransmission/utils.h" // for tr_strv_strip(), tr_strlower()
 #include "libtransmission/variant.h"
 
 using namespace std::literals;
@@ -93,7 +93,7 @@ std::optional<tr_encryption_mode> VariantConverter::load<tr_encryption_mode>(tr_
 
     if (auto val = std::string_view{}; tr_variantGetStrView(src, &val))
     {
-        auto const needle = tr_strlower(tr_strvStrip(val));
+        auto const needle = tr_strlower(tr_strv_strip(val));
 
         for (auto const& [key, encryption] : Keys)
         {
@@ -133,7 +133,7 @@ std::optional<tr_log_level> VariantConverter::load<tr_log_level>(tr_variant* src
 
     if (auto val = std::string_view{}; tr_variantGetStrView(src, &val))
     {
-        auto const needle = tr_strlower(tr_strvStrip(val));
+        auto const needle = tr_strlower(tr_strv_strip(val));
 
         for (auto const& [name, log_level] : Keys)
         {
@@ -219,7 +219,7 @@ std::optional<tr_preallocation_mode> VariantConverter::load<tr_preallocation_mod
 
     if (auto val = std::string_view{}; tr_variantGetStrView(src, &val))
     {
-        auto const needle = tr_strlower(tr_strvStrip(val));
+        auto const needle = tr_strlower(tr_strv_strip(val));
 
         for (auto const& [name, value] : Keys)
         {
@@ -321,7 +321,7 @@ std::optional<tr_verify_added_mode> VariantConverter::load<tr_verify_added_mode>
 
     if (auto val = std::string_view{}; tr_variantGetStrView(src, &val))
     {
-        auto const needle = tr_strlower(tr_strvStrip(val));
+        auto const needle = tr_strlower(tr_strv_strip(val));
 
         for (auto const& [name, value] : Keys)
         {

--- a/libtransmission/variant-converters.cc
+++ b/libtransmission/variant-converters.cc
@@ -171,7 +171,7 @@ std::optional<tr_mode_t> VariantConverter::load<tr_mode_t>(tr_variant* src)
 {
     if (auto val = std::string_view{}; tr_variantGetStrView(src, &val))
     {
-        if (auto const mode = tr_parseNum<uint32_t>(val, nullptr, 8); mode)
+        if (auto const mode = tr_num_parse<uint32_t>(val, nullptr, 8); mode)
         {
             return static_cast<tr_mode_t>(*mode);
         }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -347,7 +347,7 @@ void action_callback_POP(jsonsl_t jsn, jsonsl_action_t /*action*/, struct jsonsl
         if ((state->special_flags & JSONSL_SPECIALf_NUMNOINT) != 0)
         {
             auto sv = std::string_view{ jsn->base + state->pos_begin, jsn->pos - state->pos_begin };
-            tr_variantInitReal(get_node(jsn), tr_parseNum<double>(sv).value_or(0.0));
+            tr_variantInitReal(get_node(jsn), tr_num_parse<double>(sv).value_or(0.0));
         }
         else if ((state->special_flags & JSONSL_SPECIALf_NUMERIC) != 0)
         {

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -1099,7 +1099,7 @@ int tr_variantToFile(tr_variant const* v, tr_variant_fmt fmt, std::string_view f
     auto const contents = tr_variantToStr(v, fmt);
 
     tr_error* error = nullptr;
-    tr_saveFile(filename, contents, &error);
+    tr_file_save(filename, contents, &error);
     if (error != nullptr)
     {
         tr_logAddError(fmt::format(
@@ -1139,7 +1139,7 @@ bool tr_variantFromFile(tr_variant* setme, tr_variant_parse_opts opts, std::stri
     // can't do inplace when this function is allocating & freeing the memory...
     TR_ASSERT((opts & TR_VARIANT_PARSE_INPLACE) == 0);
 
-    if (auto buf = std::vector<char>{}; tr_loadFile(filename, buf, error))
+    if (auto buf = std::vector<char>{}; tr_file_read(filename, buf, error))
     {
         return tr_variantFromBuf(setme, opts, buf, nullptr, error);
     }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -352,7 +352,7 @@ bool tr_variantGetReal(tr_variant const* v, double* setme)
     {
         if (auto sv = std::string_view{}; tr_variantGetStrView(v, &sv))
         {
-            if (auto d = tr_parseNum<double>(sv); d)
+            if (auto d = tr_num_parse<double>(sv); d)
             {
                 *setme = *d;
                 success = true;

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -304,7 +304,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     // So many magnet links are malformed, e.g. not escaping text
     // in the display name, that we're better off handling magnets
     // as a special case before even scanning for invalid chars.
-    if (auto constexpr MagnetStart = "magnet:?"sv; tr_strvStartsWith(url, MagnetStart))
+    if (auto constexpr MagnetStart = "magnet:?"sv; tr_strv_starts_with(url, MagnetStart))
     {
         parsed.scheme = "magnet"sv;
         parsed.query = url.substr(std::size(MagnetStart));
@@ -327,7 +327,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     // The authority component is preceded by a double slash ("//") and is
     // terminated by the next slash ("/"), question mark ("?"), or number
     // sign ("#") character, or by the end of the URI.
-    if (auto key = "//"sv; tr_strvStartsWith(url, key))
+    if (auto key = "//"sv; tr_strv_starts_with(url, key))
     {
         url.remove_prefix(std::size(key));
         auto pos = url.find_first_of("/?#");
@@ -339,11 +339,11 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         // within square brackets ("[" and "]").  This is the only place where
         // square bracket characters are allowed in the URI syntax.
         auto remain = parsed.authority;
-        if (tr_strvStartsWith(remain, '['))
+        if (tr_strv_starts_with(remain, '['))
         {
             remain.remove_prefix(1); // '['
             parsed.host = tr_strvSep(&remain, ']');
-            if (tr_strvStartsWith(remain, ':'))
+            if (tr_strv_starts_with(remain, ':'))
             {
                 remain.remove_prefix(1);
             }
@@ -370,7 +370,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     url = pos == std::string_view::npos ? ""sv : url.substr(pos);
 
     // query
-    if (tr_strvStartsWith(url, '?'))
+    if (tr_strv_starts_with(url, '?'))
     {
         url.remove_prefix(1);
         pos = url.find('#');
@@ -379,7 +379,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     }
 
     // fragment
-    if (tr_strvStartsWith(url, '#'))
+    if (tr_strv_starts_with(url, '#'))
     {
         parsed.fragment = url.substr(1);
     }

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -296,7 +296,7 @@ std::string_view getSiteName(std::string_view host)
 
 std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
 {
-    url = tr_strvStrip(url);
+    url = tr_strv_strip(url);
 
     auto parsed = tr_url_parsed_t{};
     parsed.full = url;

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -179,7 +179,7 @@ namespace
 
 auto parsePort(std::string_view port_sv)
 {
-    auto const port = tr_parseNum<int>(port_sv);
+    auto const port = tr_num_parse<int>(port_sv);
 
     using PortLimits = std::numeric_limits<uint16_t>;
     return port && PortLimits::min() <= *port && *port <= PortLimits::max() ? *port : -1;

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -317,7 +317,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     }
 
     // scheme
-    parsed.scheme = tr_strvSep(&url, ':');
+    parsed.scheme = tr_strv_sep(&url, ':');
     if (std::empty(parsed.scheme))
     {
         return std::nullopt;
@@ -342,7 +342,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         if (tr_strv_starts_with(remain, '['))
         {
             remain.remove_prefix(1); // '['
-            parsed.host = tr_strvSep(&remain, ']');
+            parsed.host = tr_strv_sep(&remain, ']');
             if (tr_strv_starts_with(remain, ':'))
             {
                 remain.remove_prefix(1);
@@ -357,7 +357,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         }
         else
         {
-            parsed.host = tr_strvSep(&remain, ':');
+            parsed.host = tr_strv_sep(&remain, ':');
         }
         parsed.sitename = getSiteName(parsed.host);
         parsed.port = parsePort(!std::empty(remain) ? remain : getPortForScheme(parsed.scheme));
@@ -418,8 +418,8 @@ std::string tr_urlTrackerLogName(std::string_view url)
 
 tr_url_query_view::iterator& tr_url_query_view::iterator::operator++()
 {
-    auto pair = tr_strvSep(&remain, '&');
-    keyval.first = tr_strvSep(&pair, '=');
+    auto pair = tr_strv_sep(&remain, '&');
+    keyval.first = tr_strv_sep(&pair, '=');
     keyval.second = pair;
     return *this;
 }

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -220,7 +220,7 @@ TR_CONSTEXPR20 bool urlCharsAreValid(std::string_view url)
     };
 
     return !std::empty(url) &&
-        std::all_of(std::begin(url), std::end(url), [&ValidChars](auto ch) { return tr_strvContains(ValidChars, ch); });
+        std::all_of(std::begin(url), std::end(url), [&ValidChars](auto ch) { return tr_strv_contains(ValidChars, ch); });
 }
 
 bool tr_isValidTrackerScheme(std::string_view scheme)

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -491,7 +491,7 @@ void makeUrl(tr_webseed const* const webseed, std::string_view name, OutputIt ou
 
     out = std::copy(std::begin(url), std::end(url), out);
 
-    if (tr_strvEndsWith(url, "/"sv) && !std::empty(name))
+    if (tr_strv_ends_with(url, "/"sv) && !std::empty(name))
     {
         tr_urlPercentEncode(out, name, false);
     }

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -170,7 +170,7 @@ NSMutableSet* creatorWindowControllerSet = nil;
     self.fNameField.stringValue = name;
     self.fNameField.toolTip = self.fPath.path;
 
-    auto const is_folder = self.fBuilder->file_count() > 1 || tr_strvContains(self.fBuilder->path(0), '/');
+    auto const is_folder = self.fBuilder->file_count() > 1 || tr_strv_contains(self.fBuilder->path(0), '/');
 
     NSImage* icon = [NSWorkspace.sharedWorkspace
         iconForFileType:is_folder ? NSFileTypeForHFSTypeCode(kGenericFolderIcon) : self.fPath.pathExtension];

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -342,9 +342,9 @@ TEST_F(AnnounceListTest, save)
     auto original_content = std::vector<char>{};
     auto const test_file = tr_pathbuf{ ::testing::TempDir(), "transmission-announce-list-test.torrent"sv };
     tr_error* error = nullptr;
-    EXPECT_TRUE(tr_loadFile(OriginalFile, original_content, &error));
+    EXPECT_TRUE(tr_file_read(OriginalFile, original_content, &error));
     EXPECT_EQ(nullptr, error) << *error;
-    EXPECT_TRUE(tr_saveFile(test_file.sv(), original_content, &error));
+    EXPECT_TRUE(tr_file_save(test_file.sv(), original_content, &error));
     EXPECT_EQ(nullptr, error) << *error;
 
     // make an announce_list for it

--- a/tests/libtransmission/copy-test.cc
+++ b/tests/libtransmission/copy-test.cc
@@ -70,7 +70,7 @@ private:
     {
         auto contents1 = std::vector<char>{};
         auto contents2 = std::vector<char>{};
-        return tr_loadFile(filename1, contents1) && tr_loadFile(filename2, contents2) && contents1 == contents2;
+        return tr_file_read(filename1, contents1) && tr_file_read(filename2, contents2) && contents1 == contents2;
     }
 };
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -179,7 +179,7 @@ TEST_F(MakemetaTest, anonymizeFalse)
     auto builder = tr_metainfo_builder{ filename };
     builder.set_anonymize(false);
     auto const metainfo = testBuilder(builder);
-    EXPECT_TRUE(tr_strvContains(metainfo.creator(), TR_NAME)) << metainfo.creator();
+    EXPECT_TRUE(tr_strv_contains(metainfo.creator(), TR_NAME)) << metainfo.creator();
     auto const now = time(nullptr);
     EXPECT_LE(metainfo.date_created(), now);
     EXPECT_LE(now - 60, metainfo.date_created());

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -115,7 +115,7 @@ TEST_F(PlatformTest, webClientDirXdgDataHome)
     auto const expected = tr_pathbuf{ sandboxDir(), "/transmission/public_html"sv };
     auto const index_html = tr_pathbuf{ expected, "/index.html"sv };
     EXPECT_TRUE(tr_sys_dir_create(expected, TR_SYS_DIR_CREATE_PARENTS, 0777));
-    EXPECT_TRUE(tr_saveFile(index_html, "<html></html>"sv));
+    EXPECT_TRUE(tr_file_save(index_html, "<html></html>"sv));
 
     EXPECT_EQ(expected, tr_getWebClientDir(session_));
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -85,7 +85,7 @@ protected:
         {
             EXPECT_TRUE(tr_sys_path_exists(found->filename()));
             auto contents = std::vector<char>{};
-            return tr_loadFile(found->filename(), contents) &&
+            return tr_file_read(found->filename(), contents) &&
                 std::string_view{ std::data(contents), std::size(contents) } == str;
         }
 

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -97,7 +97,7 @@ TEST_P(SubprocessTest, SpawnAsyncMissingExec)
 TEST_P(SubprocessTest, SpawnAsyncArgs)
 {
     auto const result_path = buildSandboxPath("result.txt");
-    bool const allow_batch_metachars = TR_IF_WIN32(false, true) || !tr_strvEndsWith(tr_strlower(self_path_), ".cmd"sv);
+    bool const allow_batch_metachars = TR_IF_WIN32(false, true) || !tr_strv_ends_with(tr_strlower(self_path_), ".cmd"sv);
 
     auto const test_arg1 = std::string{ "arg1 " };
     auto const test_arg2 = std::string{ " arg2" };

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -207,9 +207,9 @@ TEST_F(TorrentMetainfoTest, ctorSaveContents)
 
     // the saved contents should match the source file's contents
     auto src_contents = std::vector<char>{};
-    EXPECT_TRUE(tr_loadFile(src_filename.sv(), src_contents, &error));
+    EXPECT_TRUE(tr_file_read(src_filename.sv(), src_contents, &error));
     auto tgt_contents = std::vector<char>{};
-    EXPECT_TRUE(tr_loadFile(tgt_filename.sv(), tgt_contents, &error));
+    EXPECT_TRUE(tr_file_read(tgt_filename.sv(), tgt_contents, &error));
     EXPECT_EQ(src_contents, tgt_contents);
 
     // cleanup

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -104,13 +104,13 @@ TEST_F(UtilsTest, trStrvSep)
 
 TEST_F(UtilsTest, trStrvStrip)
 {
-    EXPECT_EQ(""sv, tr_strvStrip("              "sv));
-    EXPECT_EQ("test test"sv, tr_strvStrip("    test test     "sv));
-    EXPECT_EQ("test"sv, tr_strvStrip("   test     "sv));
-    EXPECT_EQ("test"sv, tr_strvStrip("   test "sv));
-    EXPECT_EQ("test"sv, tr_strvStrip(" test       "sv));
-    EXPECT_EQ("test"sv, tr_strvStrip(" test "sv));
-    EXPECT_EQ("test"sv, tr_strvStrip("test"sv));
+    EXPECT_EQ(""sv, tr_strv_strip("              "sv));
+    EXPECT_EQ("test test"sv, tr_strv_strip("    test test     "sv));
+    EXPECT_EQ("test"sv, tr_strv_strip("   test     "sv));
+    EXPECT_EQ("test"sv, tr_strv_strip("   test "sv));
+    EXPECT_EQ("test"sv, tr_strv_strip(" test       "sv));
+    EXPECT_EQ("test"sv, tr_strv_strip(" test "sv));
+    EXPECT_EQ("test"sv, tr_strv_strip("test"sv));
 }
 
 TEST_F(UtilsTest, strvReplaceInvalid)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -34,19 +34,19 @@ using namespace std::literals;
 
 TEST_F(UtilsTest, trStrvContains)
 {
-    EXPECT_FALSE(tr_strvContains("a test is this"sv, "TEST"sv));
-    EXPECT_FALSE(tr_strvContains("test"sv, "testt"sv));
-    EXPECT_FALSE(tr_strvContains("test"sv, "this is a test"sv));
-    EXPECT_TRUE(tr_strvContains(" test "sv, "tes"sv));
-    EXPECT_TRUE(tr_strvContains(" test"sv, "test"sv));
-    EXPECT_TRUE(tr_strvContains("a test is this"sv, "test"sv));
-    EXPECT_TRUE(tr_strvContains("test "sv, "test"sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, ""sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, "t"sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, "te"sv));
-    EXPECT_TRUE(tr_strvContains("test"sv, "test"sv));
-    EXPECT_TRUE(tr_strvContains("this is a test"sv, "test"sv));
-    EXPECT_TRUE(tr_strvContains(""sv, ""sv));
+    EXPECT_FALSE(tr_strv_contains("a test is this"sv, "TEST"sv));
+    EXPECT_FALSE(tr_strv_contains("test"sv, "testt"sv));
+    EXPECT_FALSE(tr_strv_contains("test"sv, "this is a test"sv));
+    EXPECT_TRUE(tr_strv_contains(" test "sv, "tes"sv));
+    EXPECT_TRUE(tr_strv_contains(" test"sv, "test"sv));
+    EXPECT_TRUE(tr_strv_contains("a test is this"sv, "test"sv));
+    EXPECT_TRUE(tr_strv_contains("test "sv, "test"sv));
+    EXPECT_TRUE(tr_strv_contains("test"sv, ""sv));
+    EXPECT_TRUE(tr_strv_contains("test"sv, "t"sv));
+    EXPECT_TRUE(tr_strv_contains("test"sv, "te"sv));
+    EXPECT_TRUE(tr_strv_contains("test"sv, "test"sv));
+    EXPECT_TRUE(tr_strv_contains("this is a test"sv, "test"sv));
+    EXPECT_TRUE(tr_strv_contains(""sv, ""sv));
 }
 
 TEST_F(UtilsTest, trStrvStartsWith)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -66,18 +66,18 @@ TEST_F(UtilsTest, trStrvStartsWith)
 
 TEST_F(UtilsTest, trStrvEndsWith)
 {
-    EXPECT_FALSE(tr_strvEndsWith(""sv, "string"sv));
-    EXPECT_FALSE(tr_strvEndsWith("this is a string"sv, "alphabet"sv));
-    EXPECT_FALSE(tr_strvEndsWith("this is a string"sv, "strin"sv));
-    EXPECT_FALSE(tr_strvEndsWith("this is a string"sv, "this is"sv));
-    EXPECT_FALSE(tr_strvEndsWith("this is a string"sv, "this"sv));
-    EXPECT_FALSE(tr_strvEndsWith("tring"sv, "string"sv));
-    EXPECT_TRUE(tr_strvEndsWith(""sv, ""sv));
-    EXPECT_TRUE(tr_strvEndsWith("this is a string"sv, " string"sv));
-    EXPECT_TRUE(tr_strvEndsWith("this is a string"sv, ""sv));
-    EXPECT_TRUE(tr_strvEndsWith("this is a string"sv, "a string"sv));
-    EXPECT_TRUE(tr_strvEndsWith("this is a string"sv, "g"sv));
-    EXPECT_TRUE(tr_strvEndsWith("this is a string"sv, "string"sv));
+    EXPECT_FALSE(tr_strv_ends_with(""sv, "string"sv));
+    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "alphabet"sv));
+    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "strin"sv));
+    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "this is"sv));
+    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "this"sv));
+    EXPECT_FALSE(tr_strv_ends_with("tring"sv, "string"sv));
+    EXPECT_TRUE(tr_strv_ends_with(""sv, ""sv));
+    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, " string"sv));
+    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, ""sv));
+    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "a string"sv));
+    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "g"sv));
+    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "string"sv));
 }
 
 TEST_F(UtilsTest, trStrvSep)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -175,20 +175,20 @@ TEST_F(UtilsTest, trParseNumberRange)
         return ss.str();
     };
 
-    auto numbers = tr_parseNumberRange("1-10,13,16-19"sv);
+    auto numbers = tr_num_parse_range("1-10,13,16-19"sv);
     EXPECT_EQ(std::string("1 2 3 4 5 6 7 8 9 10 13 16 17 18 19 "), tostring(numbers));
 
-    numbers = tr_parseNumberRange("1-5,3-7,2-6"sv);
+    numbers = tr_num_parse_range("1-5,3-7,2-6"sv);
     EXPECT_EQ(std::string("1 2 3 4 5 6 7 "), tostring(numbers));
 
-    numbers = tr_parseNumberRange("1-Hello"sv);
+    numbers = tr_num_parse_range("1-Hello"sv);
     auto const empty_string = std::string{};
     EXPECT_EQ(empty_string, tostring(numbers));
 
-    numbers = tr_parseNumberRange("1-"sv);
+    numbers = tr_num_parse_range("1-"sv);
     EXPECT_EQ(empty_string, tostring(numbers));
 
-    numbers = tr_parseNumberRange("Hello"sv);
+    numbers = tr_num_parse_range("Hello"sv);
     EXPECT_EQ(empty_string, tostring(numbers));
 }
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -316,12 +316,12 @@ TEST_F(UtilsTest, saveFile)
     filename.assign(::testing::TempDir(), "filename.txt"sv);
     auto contents = "these are the contents"sv;
     tr_error* error = nullptr;
-    EXPECT_TRUE(tr_saveFile(filename.sv(), contents, &error));
+    EXPECT_TRUE(tr_file_save(filename.sv(), contents, &error));
     EXPECT_EQ(nullptr, error) << *error;
 
     // now read the file back in and confirm the contents are the same
     auto buf = std::vector<char>{};
-    EXPECT_TRUE(tr_loadFile(filename.sv(), buf, &error));
+    EXPECT_TRUE(tr_file_read(filename.sv(), buf, &error));
     EXPECT_EQ(nullptr, error) << *error;
     auto sv = std::string_view{ std::data(buf), std::size(buf) };
     EXPECT_EQ(contents, sv);
@@ -332,7 +332,7 @@ TEST_F(UtilsTest, saveFile)
 
     // try saving a file to a path that doesn't exist
     filename = "/this/path/does/not/exist/foo.txt";
-    EXPECT_FALSE(tr_saveFile(filename.sv(), contents, &error));
+    EXPECT_FALSE(tr_file_save(filename.sv(), contents, &error));
     ASSERT_NE(nullptr, error);
     EXPECT_NE(0, error->code);
     tr_error_clear(&error);

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -51,17 +51,17 @@ TEST_F(UtilsTest, trStrvContains)
 
 TEST_F(UtilsTest, trStrvStartsWith)
 {
-    EXPECT_FALSE(tr_strvStartsWith(""sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strvStartsWith("this is a strin"sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strvStartsWith("this is a strin"sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strvStartsWith("this is a string"sv, " his is a string"sv));
-    EXPECT_FALSE(tr_strvStartsWith("this is a string"sv, "his is a string"sv));
-    EXPECT_FALSE(tr_strvStartsWith("this is a string"sv, "string"sv));
-    EXPECT_TRUE(tr_strvStartsWith(""sv, ""sv));
-    EXPECT_TRUE(tr_strvStartsWith("this is a string"sv, ""sv));
-    EXPECT_TRUE(tr_strvStartsWith("this is a string"sv, "this "sv));
-    EXPECT_TRUE(tr_strvStartsWith("this is a string"sv, "this is"sv));
-    EXPECT_TRUE(tr_strvStartsWith("this is a string"sv, "this"sv));
+    EXPECT_FALSE(tr_strv_starts_with(""sv, "this is a string"sv));
+    EXPECT_FALSE(tr_strv_starts_with("this is a strin"sv, "this is a string"sv));
+    EXPECT_FALSE(tr_strv_starts_with("this is a strin"sv, "this is a string"sv));
+    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, " his is a string"sv));
+    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, "his is a string"sv));
+    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, "string"sv));
+    EXPECT_TRUE(tr_strv_starts_with(""sv, ""sv));
+    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, ""sv));
+    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this "sv));
+    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this is"sv));
+    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this"sv));
 }
 
 TEST_F(UtilsTest, trStrvEndsWith)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -85,21 +85,21 @@ TEST_F(UtilsTest, trStrvSep)
     auto constexpr Delim = ',';
 
     auto sv = "token1,token2,token3"sv;
-    EXPECT_EQ("token1"sv, tr_strvSep(&sv, Delim));
-    EXPECT_EQ("token2"sv, tr_strvSep(&sv, Delim));
-    EXPECT_EQ("token3"sv, tr_strvSep(&sv, Delim));
-    EXPECT_EQ(""sv, tr_strvSep(&sv, Delim));
+    EXPECT_EQ("token1"sv, tr_strv_sep(&sv, Delim));
+    EXPECT_EQ("token2"sv, tr_strv_sep(&sv, Delim));
+    EXPECT_EQ("token3"sv, tr_strv_sep(&sv, Delim));
+    EXPECT_EQ(""sv, tr_strv_sep(&sv, Delim));
 
     sv = " token1,token2"sv;
-    EXPECT_EQ(" token1"sv, tr_strvSep(&sv, Delim));
-    EXPECT_EQ("token2"sv, tr_strvSep(&sv, Delim));
+    EXPECT_EQ(" token1"sv, tr_strv_sep(&sv, Delim));
+    EXPECT_EQ("token2"sv, tr_strv_sep(&sv, Delim));
 
     sv = "token1;token2"sv;
-    EXPECT_EQ("token1;token2"sv, tr_strvSep(&sv, Delim));
-    EXPECT_EQ(""sv, tr_strvSep(&sv, Delim));
+    EXPECT_EQ("token1;token2"sv, tr_strv_sep(&sv, Delim));
+    EXPECT_EQ(""sv, tr_strv_sep(&sv, Delim));
 
     sv = ""sv;
-    EXPECT_EQ(""sv, tr_strvSep(&sv, Delim));
+    EXPECT_EQ(""sv, tr_strv_sep(&sv, Delim));
 }
 
 TEST_F(UtilsTest, trStrvStrip)

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -189,7 +189,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
     tr_variant* announce_list;
     bool changed = false;
 
-    if (tr_variantDictFindStrView(metainfo, TR_KEY_announce, &sv) && tr_strvContains(sv, oldval))
+    if (tr_variantDictFindStrView(metainfo, TR_KEY_announce, &sv) && tr_strv_contains(sv, oldval))
     {
         auto const newstr = replaceSubstr(sv, oldval, newval);
         fmt::print("\tReplaced in 'announce': '{:s}' --> '{:s}'\n", sv, newstr);
@@ -209,7 +209,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
 
             while ((node = tr_variantListChild(tier, nodeCount)) != nullptr)
             {
-                if (tr_variantGetStrView(node, &sv) && tr_strvContains(sv, oldval))
+                if (tr_variantGetStrView(node, &sv) && tr_strv_contains(sv, oldval))
                 {
                     auto const newstr = replaceSubstr(sv, oldval, newval);
                     fmt::print("\tReplaced in 'announce-list' tier #{:d}: '{:s}' --> '{:s}'\n", tierCount + 1, sv, newstr);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -648,7 +648,7 @@ static void addDays(tr_variant* args, tr_quark const key, char const* arg)
 
     if (arg != nullptr)
     {
-        for (int& day : tr_parseNumberRange(arg))
+        for (int& day : tr_num_parse_range(arg))
         {
             if (day < 0 || day > 7)
             {
@@ -706,7 +706,7 @@ static void addFiles(tr_variant* args, tr_quark const key, char const* arg)
 
     if (strcmp(arg, "all") != 0)
     {
-        for (auto const& idx : tr_parseNumberRange(arg))
+        for (auto const& idx : tr_num_parse_range(arg))
         {
             tr_variantListAddInt(files, idx);
         }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -559,7 +559,7 @@ static int getOptMode(int val)
 
 static std::string getEncodedMetainfo(char const* filename)
 {
-    if (auto contents = std::vector<char>{}; tr_sys_path_exists(filename) && tr_loadFile(filename, contents))
+    if (auto contents = std::vector<char>{}; tr_sys_path_exists(filename) && tr_file_read(filename, contents))
     {
         return tr_base64_encode({ std::data(contents), std::size(contents) });
     }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -683,7 +683,7 @@ static void addLabels(tr_variant* args, std::string_view comma_delimited_labels)
     }
 
     auto label = std::string_view{};
-    while (tr_strvSep(&comma_delimited_labels, &label, ','))
+    while (tr_strv_sep(&comma_delimited_labels, &label, ','))
     {
         tr_variantListAddStr(labels, label);
     }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -324,7 +324,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
         // build the full scrape URL
         auto scrape_url = tr_urlbuf{ tracker.scrape.sv() };
-        auto delimiter = tr_strvContains(scrape_url, '?') ? '&' : '?';
+        auto delimiter = tr_strv_contains(scrape_url, '?') ? '&' : '?';
         scrape_url.append(delimiter, "info_hash=");
         tr_urlPercentEncode(std::back_inserter(scrape_url), metainfo.info_hash());
         fmt::print("{:s} ... ", scrape_url);


### PR DESCRIPTION
Another minor naming consistency refactor. This converts some of the utils.h functions to snake_case.