### PR TITLE
fix: recent build warnings and errors

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -249,7 +249,7 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
     auto& cache = tor->session->cache;
     auto const [begin_byte, end_byte] = tor->block_info().byte_span_for_piece(piece);
     auto const [begin_block, end_block] = tor->block_span_for_piece(piece);
-    auto n_bytes_checked = size_t{};
+    [[maybe_unused]] auto n_bytes_checked = size_t{};
     for (auto block = begin_block; block < end_block; ++block)
     {
         auto const block_loc = tor->block_loc(block);

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -22,7 +22,9 @@ std::unordered_map<QString, int> const& FileTreeItem::getMyChildRows() const
 {
     // ensure that all the rows are hashed
     for (int const n = childCount(); first_unhashed_row_ < n; ++first_unhashed_row_)
+    {
         child_rows_.emplace(children_[first_unhashed_row_]->name(), first_unhashed_row_);
+    }
 
     return child_rows_;
 }

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -269,7 +269,7 @@ void FileTreeView::onlyCheckSelectedItems()
 
     while (!std::empty(parents_queue))
     {
-        auto const parent_index = std::move(parents_queue.front());
+        auto const parent_index = parents_queue.front();
         parents_queue.pop();
 
         if (std::binary_search(wanted_indices.begin(), wanted_indices.end(), parent_index))

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -48,7 +48,7 @@ void RpcQueue::stepFinished()
     else
     {
         assert(!next_error_handler_);
-        assert(queue_.isEmpty());
+        assert(std::empty(queue_));
 
         // one way or another, the last step returned nothing.
         // assume it is OK and ensure that we're not going to give an empty response object to any of the next steps.
@@ -61,7 +61,7 @@ void RpcQueue::stepFinished()
 
 void RpcQueue::runNext(RpcResponseFuture const& response)
 {
-    assert(!queue_.isEmpty());
+    assert(!std::empty(queue_));
 
     auto next = std::move(queue_.front());
     queue_.pop();


### PR DESCRIPTION
Fix #5704 FTBFS regression (when building in Debug mode) reported by @tearfur in https://github.com/transmission/transmission/pull/5704#discussion_r1248617868.

Also fix a couple of recent minor clang-tidy regressions.