### PR TITLE
deps: add span-lite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "third-party/small"]
 	path = third-party/small
 	url = https://github.com/transmission/small.git
+[submodule "third-party/span-lite"]
+	path = third-party/span-lite
+	url = https://github.com/transmission/span-lite.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ set(CMAKE_FOLDER "third-party")
 find_package(FastFloat)
 find_package(Fmt)
 find_package(Small)
+find_package(SpanLite)
 find_package(UtfCpp)
 find_package(WideInteger)
 

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3781,6 +3781,7 @@
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -3827,6 +3828,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -3849,6 +3851,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3875,6 +3878,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -3897,6 +3901,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4040,6 +4045,7 @@
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4076,6 +4082,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4108,6 +4115,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4310,6 +4318,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = app;
 			};
@@ -4332,6 +4341,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4371,6 +4381,7 @@
 					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/jsonsl",
 					"third-party/libb64/include",
 					"third-party/libdeflate",
@@ -4411,6 +4422,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4433,6 +4445,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4513,6 +4526,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4543,6 +4557,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4573,6 +4588,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 				);
 				WRAPPER_EXTENSION = qlgenerator;
 			};
@@ -4643,6 +4659,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4665,6 +4682,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4858,6 +4876,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4880,6 +4899,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4902,6 +4922,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4924,6 +4945,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4946,6 +4968,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4968,6 +4991,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -4990,6 +5014,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -5012,6 +5037,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};
@@ -5034,6 +5060,7 @@
 					"$(inherited)",
 					"third-party/fmt/include",
 					"third-party/small/include",
+					"third-party/span-lite/include",
 					"third-party/libevent/include",
 				);
 			};

--- a/cmake/FindSpanLite.cmake
+++ b/cmake/FindSpanLite.cmake
@@ -1,0 +1,9 @@
+add_library(span-lite::span-lite INTERFACE IMPORTED)
+
+target_include_directories(span-lite::span-lite
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/../third-party/span-lite/include)
+
+target_compile_definitions(span-lite::span-lite
+    INTERFACE
+        span_FEATURE_WITH_CONTAINER=1)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -296,8 +296,9 @@ target_link_libraries(${TR_NAME}
         "$<$<BOOL:${APPLE}>:-framework Foundation>"
     PUBLIC
         fmt::fmt-header-only
+        libevent::event
         small::small
-        libevent::event)
+        span-lite::span-lite)
 
 if(INSTALL_LIB)
     install(

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -168,11 +168,11 @@ void tr_files_wanted::set(tr_file_index_t file, bool wanted)
     wanted_.set(file, wanted);
 }
 
-void tr_files_wanted::set(tr_file_index_t const* files, size_t n, bool wanted)
+void tr_files_wanted::set(nonstd::span<tr_file_index_t const> files, bool wanted)
 {
-    for (size_t i = 0; i < n; ++i)
+    for (auto const& idx : files)
     {
-        set(files[i], wanted);
+        set(idx, wanted);
     }
 }
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -14,6 +14,8 @@
 #include <cstddef> // for size_t
 #include <vector>
 
+#include <nonstd/span.hpp>
+
 #include "transmission.h"
 
 #include "bitfield.h"
@@ -164,7 +166,7 @@ public:
     void reset(tr_file_piece_map const* fpm);
 
     void set(tr_file_index_t file, bool wanted);
-    void set(tr_file_index_t const* files, size_t n, bool wanted);
+    void set(nonstd::span<tr_file_index_t const> files, bool wanted);
 
     [[nodiscard]] TR_CONSTEXPR20 bool file_wanted(tr_file_index_t file) const
     {

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -14,6 +14,8 @@
 #include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <string>
 
+#include <nonstd/span.hpp>
+
 #include "transmission.h"
 
 #include "bitfield.h"
@@ -215,7 +217,7 @@ public:
         return bytes_per_second;
     }
 
-    virtual void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) = 0;
+    virtual void requestBlocks(nonstd::span<tr_block_span_t const> block_spans) = 0;
 
     struct RequestLimit
     {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1147,7 +1147,7 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, nonstd::span<tr_pex const
         if (tr_isPex(&peer) && /* safeguard against corrupt data */
             !s->manager->session->addressIsBlocked(peer.addr) && peer.is_valid_for_peers())
         {
-            s->ensure_atom_exists(std::make_pair(pex->addr, pex->port), pex->flags, from);
+            s->ensure_atom_exists({ peer.addr, peer.port }, peer.flags, from);
             ++n_used;
         }
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1136,16 +1136,16 @@ void tr_peerMgrSetSwarmIsAllSeeds(tr_torrent* tor)
     swarm->markAllSeedsFlagDirty();
 }
 
-size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t n_pex)
+size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, nonstd::span<tr_pex const> pex)
 {
     size_t n_used = 0;
     tr_swarm* s = tor->swarm;
     auto const lock = s->manager->unique_lock();
 
-    for (tr_pex const* const end = pex + n_pex; pex != end; ++pex)
+    for (auto const& peer : pex)
     {
-        if (tr_isPex(pex) && /* safeguard against corrupt data */
-            !s->manager->session->addressIsBlocked(pex->addr) && pex->is_valid_for_peers())
+        if (tr_isPex(&peer) && /* safeguard against corrupt data */
+            !s->manager->session->addressIsBlocked(peer.addr) && peer.is_valid_for_peers())
         {
             s->ensure_atom_exists(std::make_pair(pex->addr, pex->port), pex->flags, from);
             ++n_used;

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -79,21 +79,21 @@ struct tr_pex
     }
 
     template<typename OutputIt>
-    static OutputIt to_compact_ipv4(OutputIt out, tr_pex const* pex, size_t n_pex)
+    static OutputIt to_compact_ipv4(OutputIt out, nonstd::span<tr_pex const> pex)
     {
-        for (size_t i = 0; i < n_pex; ++i)
+        for (auto const& peer : pex)
         {
-            out = pex[i].to_compact_ipv4(out);
+            out = peer.to_compact_ipv4(out);
         }
         return out;
     }
 
     template<typename OutputIt>
-    static OutputIt to_compact_ipv6(OutputIt out, tr_pex const* pex, size_t n_pex)
+    static OutputIt to_compact_ipv6(OutputIt out, nonstd::span<tr_pex const> pex)
     {
-        for (size_t i = 0; i < n_pex; ++i)
+        for (auto const& peer : pex)
         {
-            out = pex[i].to_compact_ipv6(out);
+            out = peer.to_compact_ipv6(out);
         }
         return out;
     }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -19,6 +19,8 @@
 #include <winsock2.h> /* struct in_addr */
 #endif
 
+#include <nonstd/span.hpp>
+
 #include "net.h" /* tr_address */
 #include "peer-common.h"
 #include "peer-socket.h"
@@ -177,7 +179,7 @@ void tr_peerMgrClientSentRequests(tr_torrent* torrent, tr_peer* peer, tr_block_s
 
 void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket);
 
-size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t n_pex);
+size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, nonstd::span<tr_pex const> pex);
 
 void tr_peerMgrSetSwarmIsAllSeeds(tr_torrent* tor);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1134,14 +1134,14 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     {
         pex.addr.type = TR_AF_INET;
         memcpy(&pex.addr.addr.addr4, addr, 4);
-        tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, &pex, 1);
+        tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, { &pex, 1U });
     }
 
     if (msgs->io->is_incoming() && tr_variantDictFindRaw(&val, TR_KEY_ipv6, &addr, &addr_len) && addr_len == 16)
     {
         pex.addr.type = TR_AF_INET6;
         memcpy(&pex.addr.addr.addr6, addr, 16);
-        tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, &pex, 1);
+        tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, { &pex, 1U });
     }
 
     /* get peer's maximum request queue size */
@@ -1234,7 +1234,7 @@ void parseUtPex(tr_peerMsgsImpl* msgs, MessageReader& payload)
 
             auto pex = tr_pex::from_compact_ipv4(added, added_len, added_f, added_f_len);
             pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
-            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex);
         }
 
         if (tr_variantDictFindRaw(&val, TR_KEY_added6, &added, &added_len))
@@ -1249,7 +1249,7 @@ void parseUtPex(tr_peerMsgsImpl* msgs, MessageReader& payload)
 
             auto pex = tr_pex::from_compact_ipv6(added, added_len, added_f, added_f_len);
             pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
-            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+            tr_peerMgrAddPex(tor, TR_PEER_FROM_PEX, pex);
         }
 
         tr_variantClear(&val);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -501,15 +501,15 @@ public:
         return tr_torrentReqIsValid(torrent, req.index, req.offset, req.length);
     }
 
-    void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) override
+    void requestBlocks(nonstd::span<tr_block_span_t const> block_spans) override
     {
         TR_ASSERT(torrent->client_can_download());
         TR_ASSERT(client_is_interested());
         TR_ASSERT(!client_is_choked());
 
-        for (auto const *span = block_spans, *span_end = span + n_spans; span != span_end; ++span)
+        for (auto const& span : block_spans)
         {
-            for (auto [block, block_end] = *span; block < block_end; ++block)
+            for (auto [block, block_end] = span; block < block_end; ++block)
             {
                 // Note that requests can't cross over a piece boundary.
                 // So if a piece isn't evenly divisible by the block size,
@@ -528,7 +528,7 @@ public:
                 }
             }
 
-            tr_peerMgrClientSentRequests(torrent, this, *span);
+            tr_peerMgrClientSentRequests(torrent, this, span);
         }
     }
 
@@ -1858,7 +1858,7 @@ void updateBlockRequests(tr_peerMsgsImpl* msgs)
 
     if (auto const requests = tr_peerMgrGetNextRequests(tor, msgs, n_wanted); !std::empty(requests))
     {
-        msgs->requestBlocks(std::data(requests), std::size(requests));
+        msgs->requestBlocks(requests);
     }
 }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2099,7 +2099,7 @@ void tr_peerMsgsImpl::sendPex()
     {
         // "added"
         tmpbuf.clear();
-        tr_pex::to_compact_ipv4(std::back_inserter(tmpbuf), std::data(added), std::size(added));
+        tr_pex::to_compact_ipv4(std::back_inserter(tmpbuf), added);
         TR_ASSERT(std::size(tmpbuf) == std::size(added) * 6);
         tr_variantDictAddRaw(&val, TR_KEY_added, std::data(tmpbuf), std::size(tmpbuf));
 
@@ -2121,7 +2121,7 @@ void tr_peerMsgsImpl::sendPex()
     {
         // "dropped"
         tmpbuf.clear();
-        tr_pex::to_compact_ipv4(std::back_inserter(tmpbuf), std::data(dropped), std::size(dropped));
+        tr_pex::to_compact_ipv4(std::back_inserter(tmpbuf), dropped);
         TR_ASSERT(std::size(tmpbuf) == std::size(dropped) * 6);
         tr_variantDictAddRaw(&val, TR_KEY_dropped, std::data(tmpbuf), std::size(tmpbuf));
     }
@@ -2129,7 +2129,7 @@ void tr_peerMsgsImpl::sendPex()
     if (!std::empty(added6))
     {
         tmpbuf.clear();
-        tr_pex::to_compact_ipv6(std::back_inserter(tmpbuf), std::data(added6), std::size(added6));
+        tr_pex::to_compact_ipv6(std::back_inserter(tmpbuf), added6);
         TR_ASSERT(std::size(tmpbuf) == std::size(added6) * 18);
         tr_variantDictAddRaw(&val, TR_KEY_added6, std::data(tmpbuf), std::size(tmpbuf));
 
@@ -2151,7 +2151,7 @@ void tr_peerMsgsImpl::sendPex()
     {
         // "dropped6"
         tmpbuf.clear();
-        tr_pex::to_compact_ipv6(std::back_inserter(tmpbuf), std::data(dropped6), std::size(dropped6));
+        tr_pex::to_compact_ipv6(std::back_inserter(tmpbuf), dropped6);
         TR_ASSERT(std::size(tmpbuf) == std::size(dropped6) * 18);
         tr_variantDictAddRaw(&val, TR_KEY_dropped6, std::data(tmpbuf), std::size(tmpbuf));
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -54,7 +54,7 @@ size_t addPeers(tr_torrent* tor, uint8_t const* buf, size_t buflen)
 
     auto pex = std::array<tr_pex, MaxRememberedPeers>{};
     memcpy(std::data(pex), buf, sizeof(tr_pex) * n_pex);
-    return tr_peerMgrAddPex(tor, TR_PEER_FROM_RESUME, std::data(pex), n_pex);
+    return tr_peerMgrAddPex(tor, TR_PEER_FROM_RESUME, { std::data(pex), n_pex });
 }
 
 auto loadPeers(tr_variant* dict, tr_torrent* tor)

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -172,8 +172,8 @@ auto loadDND(tr_variant* dict, tr_torrent* tor)
             }
         }
 
-        tor->init_files_wanted(std::data(unwanted), std::size(unwanted), false);
-        tor->init_files_wanted(std::data(wanted), std::size(wanted), true);
+        tor->init_files_wanted(unwanted, false);
+        tor->init_files_wanted(wanted, true);
 
         ret = tr_resume::Dnd;
     }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1081,7 +1081,7 @@ char const* setFileDLs(tr_torrent* tor, bool wanted, tr_variant* list)
         std::iota(std::begin(files), std::end(files), 0);
     }
 
-    tor->set_files_wanted(std::data(files), std::size(files), wanted);
+    tor->set_files_wanted(files, wanted);
 
     return errmsg;
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -226,7 +226,7 @@ void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, nonstd:
 {
     if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
     {
-        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, std::data(pex), std::size(pex));
+        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex);
     }
 }
 
@@ -248,7 +248,7 @@ bool tr_session::LpdMediator::onPeerFound(std::string_view info_hash_str, tr_add
 
     // we found a suitable peer, add it to the torrent
     auto pex = tr_pex{ address, port };
-    tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, &pex, 1U);
+    tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, { &pex, 1U });
     tr_logAddDebugTor(tor, fmt::format(FMT_STRING("Found a local peer from LPD ({:s})"), address.display_name(port)));
     return true;
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -222,11 +222,11 @@ tr_sha1_digest_t tr_session::DhtMediator::torrent_info_hash(tr_torrent_id_t id) 
     return {};
 }
 
-void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, tr_pex const* pex, size_t n_pex)
+void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, nonstd::span<tr_pex const> pex)
 {
     if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
     {
-        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex, n_pex);
+        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, std::data(pex), std::size(pex));
     }
 }
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -26,6 +26,8 @@
 #include <utility> // for std::pair
 #include <vector>
 
+#include <nonstd/span.hpp>
+
 #include <event2/util.h> // for evutil_socket_t
 
 #include "transmission.h"
@@ -180,7 +182,7 @@ private:
             return session_.timerMaker();
         }
 
-        void add_pex(tr_sha1_digest_t const&, tr_pex const* pex, size_t n_pex) override;
+        void add_pex(tr_sha1_digest_t const&, nonstd::span<tr_pex const> pex) override;
 
     private:
         tr_session& session_;

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -164,8 +164,8 @@ void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* files, tr_file_
 
 void tr_ctorInitTorrentWanted(tr_ctor const* ctor, tr_torrent* tor)
 {
-    tor->init_files_wanted(std::data(ctor->unwanted), std::size(ctor->unwanted), false);
-    tor->init_files_wanted(std::data(ctor->wanted), std::size(ctor->wanted), true);
+    tor->init_files_wanted(ctor->unwanted, false);
+    tor->init_files_wanted(ctor->wanted, true);
 }
 
 // ---

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -16,6 +16,8 @@
 #include <utility>
 #include <vector>
 
+#include <nonstd/span.hpp>
+
 #include "transmission.h"
 
 #include "file.h"
@@ -152,8 +154,8 @@ public:
         size_t base_len_;
     };
 
-    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file, std::string_view const* paths, size_t n_paths) const;
-    [[nodiscard]] bool hasAnyLocalData(std::string_view const* paths, size_t n_paths) const;
+    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file, nonstd::span<std::string_view const> paths) const;
+    [[nodiscard]] bool hasAnyLocalData(nonstd::span<std::string_view const> paths) const;
 
     static void makeSubpathPortable(std::string_view path, tr_pathbuf& append_me);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2161,7 +2161,7 @@ void tr_torrent::on_tracker_response(tr_tracker_event const* event)
     {
     case tr_tracker_event::Type::Peers:
         tr_logAddTraceTor(this, fmt::format("Got {} peers from tracker", std::size(event->pex)));
-        tr_peerMgrAddPex(this, TR_PEER_FROM_TRACKER, std::data(event->pex), std::size(event->pex));
+        tr_peerMgrAddPex(this, TR_PEER_FROM_TRACKER, event->pex);
         break;
 
     case tr_tracker_event::Type::Counts:

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1332,7 +1332,7 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent::find_file(tr_file_index_t
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return metainfo_.files().find(file_index, std::data(paths), n_paths);
+    return metainfo_.files().find(file_index, { std::data(paths), n_paths });
 }
 
 bool tr_torrent::has_any_local_data() const
@@ -1341,7 +1341,7 @@ bool tr_torrent::has_any_local_data() const
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return metainfo_.files().hasAnyLocalData(std::data(paths), n_paths);
+    return metainfo_.files().hasAnyLocalData({ std::data(paths), n_paths });
 }
 
 void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1947,7 +1947,7 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    tor->set_files_wanted(files, n_files, wanted);
+    tor->set_files_wanted({ files, n_files }, wanted);
 }
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include <nonstd/span.hpp>
+
 #include "transmission.h"
 
 #include "announce-list.h"
@@ -326,14 +328,14 @@ public:
         return files_wanted_.file_wanted(file);
     }
 
-    void init_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted)
+    void init_files_wanted(nonstd::span<tr_file_index_t const> files, bool wanted)
     {
-        set_files_wanted(files, n_files, wanted, /*is_bootstrapping*/ true);
+        set_files_wanted(files, wanted, /*is_bootstrapping*/ true);
     }
 
-    void set_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted)
+    void set_files_wanted(nonstd::span<tr_file_index_t const> files, bool wanted)
     {
-        set_files_wanted(files, n_files, wanted, /*is_bootstrapping*/ false);
+        set_files_wanted(files, wanted, /*is_bootstrapping*/ false);
     }
 
     void recheck_completeness(); // TODO(ckerr): should be private
@@ -941,11 +943,11 @@ private:
         return true;
     }
 
-    void set_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted, bool is_bootstrapping)
+    void set_files_wanted(nonstd::span<tr_file_index_t const> files, bool wanted, bool is_bootstrapping)
     {
         auto const lock = unique_lock();
 
-        files_wanted_.set(files, n_files, wanted);
+        files_wanted_.set(files, wanted);
         completion.invalidate_size_when_done();
 
         if (!is_bootstrapping)

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -398,12 +398,12 @@ private:
         if (event == DHT_EVENT_VALUES)
         {
             auto const pex = remove_bad_pex(tr_pex::from_compact_ipv4(data, data_len, nullptr, 0));
-            self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
+            self->mediator_.add_pex(hash, pex);
         }
         else if (event == DHT_EVENT_VALUES6)
         {
             auto const pex = remove_bad_pex(tr_pex::from_compact_ipv6(data, data_len, nullptr, 0));
-            self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
+            self->mediator_.add_pex(hash, pex);
         }
     }
 

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <vector>
 
+#include <nonstd/span.hpp>
+
 #include <dht/dht.h>
 
 #include "transmission.h"
@@ -94,7 +96,7 @@ public:
             return api_;
         }
 
-        virtual void add_pex(tr_sha1_digest_t const&, tr_pex const* pex, size_t n_pex) = 0;
+        virtual void add_pex(tr_sha1_digest_t const&, nonstd::span<tr_pex const> pex) = 0;
 
     private:
         API api_;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -256,7 +256,7 @@ public:
         }
     }
 
-    void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) override
+    void requestBlocks(nonstd::span<tr_block_span_t const> block_spans) override
     {
         auto* const tor = getTorrent();
         if (tor == nullptr || !tor->is_running() || tor->is_done())
@@ -264,14 +264,14 @@ public:
             return;
         }
 
-        for (auto const *span = block_spans, *end = span + n_spans; span != end; ++span)
+        for (auto const& span : block_spans)
         {
-            auto* const task = new tr_webseed_task{ tor, this, *span };
+            auto* const task = new tr_webseed_task{ tor, this, span };
             evbuffer_add_cb(task->content(), onBufferGotData, task);
             tasks.insert(task);
             task_request_next_chunk(task);
 
-            tr_peerMgrClientSentRequests(tor, this, *span);
+            tr_peerMgrClientSentRequests(tor, this, span);
         }
     }
 
@@ -433,7 +433,7 @@ void on_idle(tr_webseed* webseed)
     {
         spans.resize(max_spans);
     }
-    webseed->requestBlocks(std::data(spans), std::size(spans));
+    webseed->requestBlocks(spans);
 }
 
 void onPartialDataFetched(tr_web::FetchResponse const& web_response)

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -343,7 +343,7 @@ protected:
             return mock_dht_;
         }
 
-        void add_pex(tr_sha1_digest_t const& /*info_hash*/, tr_pex const* /*pex*/, size_t /*n_pex*/) override
+        void add_pex(tr_sha1_digest_t const& /*info_hash*/, nonstd::span<tr_pex const> /*pex*/) override
         {
         }
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -393,11 +393,11 @@ TEST_F(FilePieceMapTest, wanted)
     // test the batch API
     auto file_indices = std::vector<tr_file_index_t>(n_files);
     std::iota(std::begin(file_indices), std::end(file_indices), 0);
-    files_wanted.set(std::data(file_indices), std::size(file_indices), true);
+    files_wanted.set(file_indices, true);
     expected_files_wanted.set_has_all();
     expected_pieces_wanted.set_has_all();
     compare_to_expected();
-    files_wanted.set(std::data(file_indices), std::size(file_indices), false);
+    files_wanted.set(file_indices, false);
     expected_files_wanted.set_has_none();
     expected_pieces_wanted.set_has_none();
     compare_to_expected();

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -91,7 +91,7 @@ TEST_F(NetTest, compact4)
     // ...serialize that back again too
     std::fill(std::begin(compact4), std::end(compact4), std::byte{});
     out = std::data(compact4);
-    out = tr_pex::to_compact_ipv4(out, std::data(pex), std::size(pex));
+    out = tr_pex::to_compact_ipv4(out, pex);
     EXPECT_EQ(std::data(compact4) + std::size(compact4), out);
     EXPECT_EQ(Compact4, compact4);
 }
@@ -145,7 +145,7 @@ TEST_F(NetTest, compact6)
     // ...serialize that back again too
     std::fill(std::begin(compact6), std::end(compact6), std::byte{});
     out = std::data(compact6);
-    out = tr_pex::to_compact_ipv6(out, std::data(pex), std::size(pex));
+    out = tr_pex::to_compact_ipv6(out, pex);
     EXPECT_EQ(std::data(compact6) + std::size(compact6), out);
     EXPECT_EQ(Compact6, compact6);
 }

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -82,14 +82,14 @@ TEST_F(TorrentFilesTest, find)
     auto const search_path_2 = tr_pathbuf{ "/tmp"sv };
 
     auto search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    auto found = files.find(file_index, std::data(search_path), std::size(search_path));
+    auto found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(filename, found->filename());
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(filename, found->filename());
@@ -98,21 +98,21 @@ TEST_F(TorrentFilesTest, find)
     auto const partial_filename = tr_pathbuf{ filename, tr_torrent_files::PartialFileSuffix };
     EXPECT_TRUE(tr_sys_path_rename(filename, partial_filename));
     search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(partial_filename, found->filename());
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(partial_filename, found->filename());
 
     // what about if we look for a file that does not exist
     EXPECT_TRUE(tr_sys_path_remove(partial_filename));
-    EXPECT_FALSE(files.find(file_index, std::data(search_path), std::size(search_path)));
+    EXPECT_FALSE(files.find(file_index, search_path));
 }
 
 TEST_F(TorrentFilesTest, hasAnyLocalData)
@@ -127,11 +127,11 @@ TEST_F(TorrentFilesTest, hasAnyLocalData)
     auto const search_path_1 = tr_pathbuf{ sandboxDir() };
     auto const search_path_2 = tr_pathbuf{ "/tmp"sv };
 
-    auto search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    EXPECT_TRUE(files.hasAnyLocalData(std::data(search_path), 2U));
-    EXPECT_TRUE(files.hasAnyLocalData(std::data(search_path), 1U));
-    EXPECT_FALSE(files.hasAnyLocalData(std::data(search_path) + 1, 1U));
-    EXPECT_FALSE(files.hasAnyLocalData(std::data(search_path), 0U));
+    auto search_path = std::array<std::string_view, 2>{ search_path_1.sv(), search_path_2.sv() };
+    EXPECT_TRUE(files.hasAnyLocalData({ std::data(search_path), 2U }));
+    EXPECT_TRUE(files.hasAnyLocalData({ std::data(search_path), 1U }));
+    EXPECT_FALSE(files.hasAnyLocalData({ std::data(search_path) + 1, 1U }));
+    EXPECT_FALSE(files.hasAnyLocalData({ std::data(search_path), 0U }));
 }
 
 TEST_F(TorrentFilesTest, isSubpathPortable)


### PR DESCRIPTION
This is something that's been on the backlog for a loooong time (literally a couple of years, I think) so let's go ahead and do it.

This PR adds a dependency to third-party header-only C++ library [span-lite](https://github.com/martinmoene/span-lite) so that we can pick up `std::span`-like behavior without raising the C++ build dependency to C++20.

It seems to be fairly stable; last release was in Oct 2021 and there have been a steady cadence of commits since then but nothing that seems to be urgent. So it looks like there is an active maintainer and that the Oct 2021 release is stable.

Notes: Added [span-lite](https://github.com/martinmoene/span-lite) dependency to get `std::span` functionality without raising the build dependency to C++20.