### PR TITLE
perf: faster Cache::write_contiguous()

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -74,20 +74,21 @@ int Cache::write_contiguous(CIter const begin, CIter const end) const
 
     if (end - begin > 1)
     {
-        // Yes, there are.
+        // copy blocks into contiguous memory
         auto const buflen = std::accumulate(
             begin,
             end,
             size_t{},
             [](size_t sum, auto const& block) { return sum + std::size(*block.buf); });
-        buf.reserve(buflen);
+        buf.resize(buflen);
+        auto* walk = std::data(buf);
         for (auto iter = begin; iter != end; ++iter)
         {
             TR_ASSERT(begin->key.first == iter->key.first);
             TR_ASSERT(begin->key.second + std::distance(begin, iter) == iter->key.second);
-            buf.insert(std::end(buf), std::begin(*iter->buf), std::end(*iter->buf));
+            walk = std::copy_n(std::data(*iter->buf), std::size(*iter->buf), walk);
         }
-        TR_ASSERT(std::size(buf) == buflen);
+        TR_ASSERT(walk - std::data(buf) == std::size(buf));
         out = std::data(buf);
         outlen = std::size(buf);
     }

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -88,7 +88,7 @@ int Cache::write_contiguous(CIter const begin, CIter const end) const
             TR_ASSERT(begin->key.second + std::distance(begin, iter) == iter->key.second);
             walk = std::copy_n(std::data(*iter->buf), std::size(*iter->buf), walk);
         }
-        TR_ASSERT(walk - std::data(buf) == std::size(buf));
+        TR_ASSERT(std::data(buf) + std::size(buf) == walk);
         out = std::data(buf);
         outlen = std::size(buf);
     }


### PR DESCRIPTION
Use raw pointers instead of iterators for this loop.

In a profile of just downloading a torrent with no other activity, this lowers `write_contiguous()` from 9.8% to 4.5% in my per testing