### PR TITLE
refactor: add lightweight observable / observer for decoupling 

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(${TR_NAME}
         mime-types.h
         net.cc
         net.h
+        observable.h
         open-files.cc
         open-files.h
         peer-common.h

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -15,7 +15,7 @@
 
 #include <small/map.hpp>
 
-#include <libtransmission/tr-assert.h>
+#include "tr-assert.h"
 
 namespace libtransmission
 {

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -20,6 +20,9 @@
 namespace libtransmission
 {
 
+// An RAII-based subscription to an Observable.
+// Returned by SimpleObservable::observe().
+// Let it go out-of-scope to cancel the subscription.
 class ObserverTag
 {
 public:

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -1,0 +1,86 @@
+// This file Copyright © 2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <algorithm> // for std::move
+#include <cstddef> // for size_t
+#include <functional>
+
+#include <small/map.hpp>
+
+#include <libtransmission/tr-assert.h>
+
+namespace libtransmission
+{
+
+// A simple observer/observable implementation.
+// Intentionally avoids edge cases like thread safety and
+// remove-during-emit; this is meant to be as lightweight
+// as possible for very basic use cases.
+template<typename... Args>
+class SimpleObservable
+{
+    using key_t = size_t;
+
+public:
+    class Tag
+    {
+    public:
+        [[nodiscard]] bool operator<(Tag const& that) const
+        {
+            return key_ < that.key_;
+        }
+
+        ~Tag()
+        {
+            TR_ASSERT(observable_->observers_.count(key_) == 1U);
+            observable_->observers_.erase(key_);
+        }
+
+    private:
+        friend class SimpleObservable;
+        Tag(SimpleObservable* observable, key_t key)
+            : observable_{ observable }
+            , key_{ key }
+        {
+        }
+        SimpleObservable* observable_;
+        key_t key_;
+    };
+
+    using observer_t = std::function<void(Args...)>;
+
+    ~SimpleObservable()
+    {
+        TR_ASSERT(std::empty(observers_));
+    }
+
+    Tag observe(observer_t observer)
+    {
+        auto const key = next_key_++;
+        observers_.emplace(key, std::move(observer));
+        return Tag{ this, key };
+    }
+
+    void emit(Args... args) const
+    {
+        for (auto& [tag, observer] : observers_)
+        {
+            observer((args)...);
+        }
+    }
+
+private:
+    friend class Tag;
+    static auto inline next_key_ = key_t{ 1U };
+    small::map<key_t, observer_t, 2> observers_;
+};
+
+} // namespace libtransmission

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -13,6 +13,8 @@
 #include <cstddef> // for size_t
 #include <functional>
 
+#include <fmt/core.h>
+
 #include <small/map.hpp>
 
 #include <libtransmission/tr-assert.h>
@@ -63,7 +65,7 @@ public:
 
     ~SimpleObservable()
     {
-        TR_ASSERT(std::empty(observers_));
+        TR_ASSERT_MSG(std::empty(observers_), fmt::print("observers size {:d}\n", std::size(observers_)));
     }
 
     auto observe(Observer observer)
@@ -88,7 +90,7 @@ private:
     void remove(Key key)
     {
         [[maybe_unused]] auto const n_removed = observers_.erase(key);
-        TR_ASSERT(n_removed == 1U);
+        TR_ASSERT_MSG(n_removed == 1U, fmt::print("n_removed is {:d}\n", n_removed));
     }
 
     static auto inline next_key_ = Key{ 1U };

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -13,8 +13,6 @@
 #include <cstddef> // for size_t
 #include <functional>
 
-#include <fmt/core.h>
-
 #include <small/map.hpp>
 
 #include <libtransmission/tr-assert.h>
@@ -31,8 +29,20 @@ public:
     using Callback = std::function<void()>;
 
     ObserverTag() = default;
-    ObserverTag(ObserverTag&&) = default;
-    ObserverTag& operator=(ObserverTag&&) = default;
+
+    ObserverTag(ObserverTag&& that)
+    {
+        on_destroy_ = std::move(that.on_destroy_);
+        that.on_destroy_ = nullptr;
+    }
+
+    ObserverTag& operator=(ObserverTag&& that)
+    {
+        on_destroy_ = std::move(that.on_destroy_);
+        that.on_destroy_ = nullptr;
+        return *this;
+    }
+
     ObserverTag(ObserverTag const&) = delete;
     ObserverTag& operator=(ObserverTag const&) = delete;
 
@@ -65,7 +75,7 @@ public:
 
     ~SimpleObservable()
     {
-        TR_ASSERT_MSG(std::empty(observers_), fmt::print("observers size {:d}\n", std::size(observers_)));
+        TR_ASSERT(std::empty(observers_));
     }
 
     auto observe(Observer observer)
@@ -90,11 +100,11 @@ private:
     void remove(Key key)
     {
         [[maybe_unused]] auto const n_removed = observers_.erase(key);
-        TR_ASSERT_MSG(n_removed == 1U, fmt::print("n_removed is {:d}\n", n_removed));
+        TR_ASSERT(n_removed == 1U);
     }
 
     static auto inline next_key_ = Key{ 1U };
-    small::map<Key, Observer, 2> observers_;
+    small::map<Key, Observer, 64U> observers_;
 };
 
 } // namespace libtransmission

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -318,14 +318,14 @@ public:
         : manager{ manager_in }
         , tor{ tor_in }
         , tags_{ {
-              tor->done_.observe([this](tr_torrent*, bool) { on_torrent_done(); }),
-              tor->doomed_.observe([this](tr_torrent*) { on_torrent_doomed(); }),
-              tor->got_bad_piece_.observe([this](tr_torrent*, tr_piece_index_t p) { on_got_bad_piece(p); }),
-              tor->got_metainfo_.observe([this](tr_torrent*) { on_got_metainfo(); }),
-              tor->piece_completed_.observe([this](tr_torrent*, tr_piece_index_t p) { on_piece_completed(p); }),
-              tor->started_.observe([this](tr_torrent*) { on_torrent_started(); }),
-              tor->stopped_.observe([this](tr_torrent*) { on_torrent_stopped(); }),
-              tor->swarm_is_all_seeds_.observe([this](tr_torrent* /*tor*/) { on_swarm_is_all_seeds(); }),
+              tor_in->done_.observe([this](tr_torrent*, bool) { on_torrent_done(); }),
+              tor_in->doomed_.observe([this](tr_torrent*) { on_torrent_doomed(); }),
+              tor_in->got_bad_piece_.observe([this](tr_torrent*, tr_piece_index_t p) { on_got_bad_piece(p); }),
+              tor_in->got_metainfo_.observe([this](tr_torrent*) { on_got_metainfo(); }),
+              tor_in->piece_completed_.observe([this](tr_torrent*, tr_piece_index_t p) { on_piece_completed(p); }),
+              tor_in->started_.observe([this](tr_torrent*) { on_torrent_started(); }),
+              tor_in->stopped_.observe([this](tr_torrent*) { on_torrent_stopped(); }),
+              tor_in->swarm_is_all_seeds_.observe([this](tr_torrent* /*tor*/) { on_swarm_is_all_seeds(); }),
           } }
     {
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -179,8 +179,6 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket);
 
 size_t tr_peerMgrAddPex(tr_torrent* tor, uint8_t from, tr_pex const* pex, size_t n_pex);
 
-void tr_peerMgrSetSwarmIsAllSeeds(tr_torrent* tor);
-
 enum
 {
     TR_PEERS_CONNECTED,

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -193,10 +193,6 @@ enum
     uint8_t peer_list_mode,
     size_t max_peer_count);
 
-void tr_peerMgrStartTorrent(tr_torrent* tor);
-
-void tr_peerMgrStopTorrent(tr_torrent* tor);
-
 void tr_peerMgrAddTorrent(tr_peerMgr* manager, struct tr_torrent* tor);
 
 void tr_peerMgrRemoveTorrent(tr_torrent* tor);

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -193,8 +193,6 @@ enum
 
 void tr_peerMgrAddTorrent(tr_peerMgr* manager, struct tr_torrent* tor);
 
-void tr_peerMgrRemoveTorrent(tr_torrent* tor);
-
 // return the number of connected peers that have `piece`, or -1 if we already have it
 [[nodiscard]] int8_t tr_peerMgrPieceAvailability(tr_torrent const* tor, tr_piece_index_t piece);
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -210,15 +210,11 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
 
 void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor);
 
-void tr_peerMgrOnBlocklistChanged(tr_peerMgr* mgr);
-
 [[nodiscard]] struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, size_t* setme_count);
 
 [[nodiscard]] tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);
 
 void tr_peerMgrClearInterest(tr_torrent* tor);
-
-void tr_peerMgrGotBadPiece(tr_torrent* tor, tr_piece_index_t piece_index);
 
 void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t pieceIndex);
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -200,8 +200,6 @@ void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned 
 
 [[nodiscard]] uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor);
 
-void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor);
-
 [[nodiscard]] struct tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, size_t* setme_count);
 
 [[nodiscard]] tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -208,6 +208,4 @@ void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor);
 
 [[nodiscard]] tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);
 
-void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t pieceIndex);
-
 /* @} */

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -208,8 +208,6 @@ void tr_peerMgrOnTorrentGotMetainfo(tr_torrent* tor);
 
 [[nodiscard]] tr_webseed_view tr_peerMgrWebseed(tr_torrent const* tor, size_t i);
 
-void tr_peerMgrClearInterest(tr_torrent* tor);
-
 void tr_peerMgrPieceCompleted(tr_torrent* tor, tr_piece_index_t pieceIndex);
 
 /* @} */

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1617,10 +1617,7 @@ void tr_sessionReloadBlocklists(tr_session* session)
 {
     session->blocklists_ = libtransmission::Blocklist::loadBlocklists(session->blocklist_dir_, session->useBlocklist());
 
-    if (session->peer_mgr_)
-    {
-        tr_peerMgrOnBlocklistChanged(session->peer_mgr_.get());
-    }
+    session->blocklist_changed_.emit();
 }
 
 size_t tr_blocklistGetRuleCount(tr_session const* session)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1114,6 +1114,10 @@ private:
 
     std::vector<libtransmission::Blocklist> blocklists_;
 
+public:
+    libtransmission::SimpleObservable<> blocklist_changed_;
+
+private:
     /// other fields
 
     // depends-on: session_thread_, settings_.bind_address_ipv4, local_peer_port_, global_ip_cache (via tr_session::bind_address())
@@ -1163,7 +1167,7 @@ public:
     std::unique_ptr<Cache> cache = std::make_unique<Cache>(torrents_, 1024 * 1024 * 2);
 
 private:
-    // depends-on: timer_maker_, top_bandwidth_, utp_context, torrents_, web_
+    // depends-on: timer_maker_, top_bandwidth_, utp_context, torrents_, web_, blocklist_changed_
     std::unique_ptr<struct tr_peerMgr, void (*)(struct tr_peerMgr*)> peer_mgr_;
 
     // depends-on: peer_mgr_, advertised_peer_port_, torrents_
@@ -1202,8 +1206,6 @@ private:
 
 public:
     std::unique_ptr<libtransmission::Timer> utp_timer;
-
-    libtransmission::SimpleObservable<> blocklist_changed_;
 };
 
 constexpr bool tr_isPriority(tr_priority_t p)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -38,6 +38,7 @@
 #include "global-ip-cache.h"
 #include "interned-string.h"
 #include "net.h" // tr_socket_t
+#include "observable.h"
 #include "open-files.h"
 #include "port-forwarding.h"
 #include "quark.h"
@@ -1201,6 +1202,8 @@ private:
 
 public:
     std::unique_ptr<libtransmission::Timer> utp_timer;
+
+    libtransmission::SimpleObservable<> blocklist_changed_;
 };
 
 constexpr bool tr_isPriority(tr_priority_t p)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2338,7 +2338,7 @@ void onPieceFailed(tr_torrent* tor, tr_piece_index_t piece)
     auto const n = tor->piece_size(piece);
     tor->corruptCur += n;
     tor->downloadedCur -= std::min(tor->downloadedCur, uint64_t{ n });
-    tr_peerMgrGotBadPiece(tor, piece);
+    tor->got_bad_piece_.emit(tor, piece);
     tor->set_has_piece(piece, false);
 }
 } // namespace got_block_helpers

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1174,7 +1174,7 @@ void tr_torrent::set_metainfo(tr_torrent_metainfo tm)
     metainfo_ = std::move(tm);
 
     torrentInitFromInfoDict(this);
-    tr_peerMgrOnTorrentGotMetainfo(this);
+    got_metainfo_.emit(this);
     session->onMetadataCompleted(this);
     this->set_dirty();
     this->mark_edited();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1911,16 +1911,12 @@ void tr_torrent::recheck_completeness()
                 this->doneDate = tr_time();
             }
 
-            if (was_leeching && was_running)
-            {
-                /* clear interested flag on all peers */
-                tr_peerMgrClearInterest(this);
-            }
-
             if (this->current_dir() == this->incomplete_dir())
             {
                 this->set_location(this->download_dir(), true, nullptr, nullptr);
             }
+
+            done_.emit(this, recent_change);
         }
 
         this->session->onTorrentCompletenessChanged(this, completeness, was_running);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2314,7 +2314,10 @@ void onFileCompleted(tr_torrent* tor, tr_file_index_t i)
 
 void onPieceCompleted(tr_torrent* tor, tr_piece_index_t piece)
 {
-    tr_peerMgrPieceCompleted(tor, piece);
+    tor->piece_completed_.emit(tor, piece);
+
+    // bookkeeping
+    tor->set_needs_completeness_check();
 
     // if this piece completes any file, invoke the fileCompleted func for it
     auto const span = tor->fpm_.file_span(piece);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -720,7 +720,7 @@ void torrentStartImpl(tr_torrent* const tor)
     torrentResetTransferStats(tor);
     tor->session->announcer_->startTorrent(tor);
     tor->lpdAnnounceAt = now;
-    tr_peerMgrStartTorrent(tor);
+    tor->started_.emit(tor);
 }
 
 bool removeTorrentFile(char const* filename, void* /*user_data*/, tr_error** error)
@@ -869,7 +869,7 @@ void torrentStop(tr_torrent* const tor)
 
     tor->session->verifyRemove(tor);
 
-    tr_peerMgrStopTorrent(tor);
+    tor->stopped_.emit(tor);
     tor->session->announcer_->stopTorrent(tor);
 
     tor->session->closeTorrentFiles(tor);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -763,7 +763,7 @@ void freeTorrent(tr_torrent* tor)
 
     tr_session* session = tor->session;
 
-    tr_peerMgrRemoveTorrent(tor);
+    tor->doomed_.emit(tor);
 
     session->announcer_->removeTorrent(tor);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2168,7 +2168,7 @@ void tr_torrent::on_tracker_response(tr_tracker_event const* event)
     case tr_tracker_event::Type::Counts:
         if (is_private() && (event->leechers == 0))
         {
-            tr_peerMgrSetSwarmIsAllSeeds(this);
+            swarm_is_all_seeds_.emit(this);
         }
 
         break;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -27,6 +27,7 @@
 #include "crypto-utils.h"
 #include "file-piece-map.h"
 #include "interned-string.h"
+#include "observable.h"
 #include "log.h"
 #include "session.h"
 #include "torrent-metainfo.h"
@@ -921,6 +922,8 @@ public:
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
+
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -923,6 +923,7 @@ public:
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
 
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*> stopped_;
     libtransmission::SimpleObservable<tr_torrent*> started_;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -927,6 +927,7 @@ public:
     libtransmission::SimpleObservable<tr_torrent*> stopped_;
     libtransmission::SimpleObservable<tr_torrent*> started_;
     libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
+    libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -821,6 +821,15 @@ public:
 
     tr_bandwidth bandwidth_;
 
+    libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
+    libtransmission::SimpleObservable<tr_torrent*> doomed_;
+    libtransmission::SimpleObservable<tr_torrent*> got_metainfo_;
+    libtransmission::SimpleObservable<tr_torrent*> started_;
+    libtransmission::SimpleObservable<tr_torrent*> stopped_;
+    libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
+
     tr_stat stats = {};
 
     // TODO(ckerr): make private once some of torrent.cc's `tr_torrentFoo()` methods are member functions
@@ -922,15 +931,6 @@ public:
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
-
-    libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
-    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
-    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
-    libtransmission::SimpleObservable<tr_torrent*> doomed_;
-    libtransmission::SimpleObservable<tr_torrent*> got_metainfo_;
-    libtransmission::SimpleObservable<tr_torrent*> started_;
-    libtransmission::SimpleObservable<tr_torrent*> stopped_;
-    libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -923,13 +923,14 @@ public:
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
 
-    libtransmission::SimpleObservable<tr_torrent*> doomed_;
-    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
-    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
-    libtransmission::SimpleObservable<tr_torrent*> stopped_;
-    libtransmission::SimpleObservable<tr_torrent*> started_;
-    libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
     libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
+    libtransmission::SimpleObservable<tr_torrent*> doomed_;
+    libtransmission::SimpleObservable<tr_torrent*> got_metainfo_;
+    libtransmission::SimpleObservable<tr_torrent*> started_;
+    libtransmission::SimpleObservable<tr_torrent*> stopped_;
+    libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -926,6 +926,7 @@ public:
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*> stopped_;
     libtransmission::SimpleObservable<tr_torrent*> started_;
+    libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -924,6 +924,8 @@ public:
     bool start_when_stable = false;
 
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
+    libtransmission::SimpleObservable<tr_torrent*> stopped_;
+    libtransmission::SimpleObservable<tr_torrent*> started_;
 
 private:
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -923,6 +923,7 @@ public:
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
 
+    libtransmission::SimpleObservable<tr_torrent*> doomed_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*> stopped_;


### PR DESCRIPTION
There are a lot of places in the codebase where one part of the code directly calls another part because it just knows what's needed, e.g. torrent calling peer-mgr.

This refactor adds a lightweight typesafe observer / observable implementation to help decouple this a little bit.

I *think* this mostly a good tradeoff between reducing coupling and not adding too much overhead, but I'd welcome suggestions both at the code review level & at the idea review level