### PR TITLE
perf: use small:set in tr_file_piece_map::reset()

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -3,8 +3,9 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <set>
 #include <vector>
+
+#include <small/set.hpp>
 
 #include "libtransmission/transmission.h"
 
@@ -21,7 +22,8 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
     file_pieces_.resize(n_files);
     file_pieces_.shrink_to_fit();
 
-    auto edge_pieces = std::set<tr_piece_index_t>{};
+    auto edge_pieces = small::set<tr_piece_index_t, 1024U>{};
+    edge_pieces.reserve(n_files * 2U);
 
     uint64_t offset = 0;
     for (tr_file_index_t i = 0; i < n_files; ++i)


### PR DESCRIPTION
This is a good candidate for replacing a `std::set` with a `small::set`: we know the max size in advance + the items are added in sorted order, so there won't be any moves necessary. TBH we could probably even use a `vector` here, but the `set` interface simplifies the code.

Notes: Use [libsmall](https://github.com/alandefreitas/small) to avoid some unnecessary  heap allocations.

