### PR TITLE
refactor: use `std::pair` to store socket addresses

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -319,7 +319,7 @@ struct tr_session;
 
 tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_msgs);
 
-[[nodiscard]] std::optional<std::tuple<tr_address, tr_port, tr_socket_t>> tr_netAccept(
+[[nodiscard]] std::optional<std::pair<std::pair<tr_address, tr_port>, tr_socket_t>> tr_netAccept(
     tr_session* session,
     tr_socket_t listening_sockfd);
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -62,8 +62,7 @@ public:
     static std::shared_ptr<tr_peerIo> new_outgoing(
         tr_session* session,
         tr_bandwidth* parent,
-        tr_address const& addr,
-        tr_port port,
+        std::pair<tr_address, tr_port> const& socket_address,
         tr_sha1_digest_t const& info_hash,
         bool is_seed,
         bool utp);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -144,8 +144,8 @@ private:
  */
 struct peer_atom
 {
-    peer_atom(std::pair<tr_address, tr_port> const& socket_address_in, uint8_t flags_in, uint8_t from)
-        : socket_address{ socket_address_in }
+    peer_atom(std::pair<tr_address, tr_port> socket_address_in, uint8_t flags_in, uint8_t from)
+        : socket_address{ std::move(socket_address_in) }
         , fromFirst{ from }
         , fromBest{ from }
         , flags{ flags_in }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1352,11 +1352,12 @@ std::vector<tr_pex> tr_peerMgrGetPeers(tr_torrent const* tor, uint8_t address_ty
     for (size_t i = 0; i < std::size(atoms) && std::size(pex) < n; ++i)
     {
         auto const* const atom = atoms[i];
+        auto const& [addr, port] = atom->socket_address;
 
-        if (atom->addr().type == address_type)
+        if (addr.type == address_type)
         {
-            TR_ASSERT(atom->addr().is_valid());
-            pex.emplace_back(atom->addr(), atom->port(), atom->flags);
+            TR_ASSERT(addr.is_valid());
+            pex.emplace_back(addr, port, atom->flags);
         }
     }
 
@@ -2455,8 +2456,7 @@ void initiateConnection(tr_peerMgr* mgr, tr_swarm* s, peer_atom& atom)
     auto peer_io = tr_peerIo::new_outgoing(
         session,
         &session->top_bandwidth_,
-        atom.addr(),
-        atom.port(),
+        atom.socket_address,
         s->tor->info_hash(),
         s->tor->completeness == TR_SEED,
         utp);

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -18,16 +18,18 @@
 #define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
 #define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
-tr_peer_socket::tr_peer_socket(tr_session const* session, tr_address const& address, tr_port port, tr_socket_t sock)
+tr_peer_socket::tr_peer_socket(
+    tr_session const* session,
+    std::pair<tr_address, tr_port> const& socket_address,
+    tr_socket_t sock)
     : handle{ sock }
-    , address_{ address }
-    , port_{ port }
+    , socket_address_{ socket_address }
     , type_{ Type::TCP }
 {
     TR_ASSERT(sock != TR_BAD_SOCKET);
 
     ++n_open_sockets_;
-    session->setSocketTOS(sock, address_.type);
+    session->setSocketTOS(sock, address().type);
 
     if (auto const& algo = session->peerCongestionAlgorithm(); !std::empty(algo))
     {
@@ -37,9 +39,8 @@ tr_peer_socket::tr_peer_socket(tr_session const* session, tr_address const& addr
     tr_logAddTraceIo(this, fmt::format("socket (tcp) is {}", handle.tcp));
 }
 
-tr_peer_socket::tr_peer_socket(tr_address const& address, tr_port port, struct UTPSocket* const sock)
-    : address_{ address }
-    , port_{ port }
+tr_peer_socket::tr_peer_socket(std::pair<tr_address, tr_port> const& socket_address, struct UTPSocket* const sock)
+    : socket_address_{ socket_address }
     , type_{ Type::UTP }
 {
     TR_ASSERT(sock != nullptr);

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -18,12 +18,9 @@
 #define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
 #define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
-tr_peer_socket::tr_peer_socket(
-    tr_session const* session,
-    std::pair<tr_address, tr_port> const& socket_address,
-    tr_socket_t sock)
+tr_peer_socket::tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> socket_address, tr_socket_t sock)
     : handle{ sock }
-    , socket_address_{ socket_address }
+    , socket_address_{ std::move(socket_address) }
     , type_{ Type::TCP }
 {
     TR_ASSERT(sock != TR_BAD_SOCKET);
@@ -39,8 +36,8 @@ tr_peer_socket::tr_peer_socket(
     tr_logAddTraceIo(this, fmt::format("socket (tcp) is {}", handle.tcp));
 }
 
-tr_peer_socket::tr_peer_socket(std::pair<tr_address, tr_port> const& socket_address, struct UTPSocket* const sock)
-    : socket_address_{ socket_address }
+tr_peer_socket::tr_peer_socket(std::pair<tr_address, tr_port> socket_address, struct UTPSocket* const sock)
+    : socket_address_{ std::move(socket_address) }
     , type_{ Type::UTP }
 {
     TR_ASSERT(sock != nullptr);

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -32,8 +32,8 @@ public:
     using OutBuf = libtransmission::BufferReader<std::byte>;
 
     tr_peer_socket() = default;
-    tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> const& socket_address, tr_socket_t sock);
-    tr_peer_socket(std::pair<tr_address, tr_port> const& socket_address, struct UTPSocket* sock);
+    tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> socket_address, tr_socket_t sock);
+    tr_peer_socket(std::pair<tr_address, tr_port> socket_address, struct UTPSocket* sock);
     tr_peer_socket(tr_peer_socket&& s) noexcept
     {
         *this = std::move(s);
@@ -142,7 +142,7 @@ public:
         struct UTPSocket* utp;
     } handle = {};
 
-    [[nodiscard]] static bool limit_reached(tr_session* const session) noexcept;
+    [[nodiscard]] static bool limit_reached(tr_session* session) noexcept;
 
 private:
     enum class Type

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -32,19 +32,18 @@ public:
     using OutBuf = libtransmission::BufferReader<std::byte>;
 
     tr_peer_socket() = default;
-    tr_peer_socket(tr_session const* session, tr_address const& address, tr_port port, tr_socket_t sock);
-    tr_peer_socket(tr_address const& address, tr_port port, struct UTPSocket* const sock);
-    tr_peer_socket(tr_peer_socket&& s)
+    tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> const& socket_address, tr_socket_t sock);
+    tr_peer_socket(std::pair<tr_address, tr_port> const& socket_address, struct UTPSocket* sock);
+    tr_peer_socket(tr_peer_socket&& s) noexcept
     {
         *this = std::move(s);
     }
     tr_peer_socket(tr_peer_socket const&) = delete;
-    tr_peer_socket& operator=(tr_peer_socket&& s)
+    tr_peer_socket& operator=(tr_peer_socket&& s) noexcept
     {
         close();
         handle = s.handle;
-        address_ = s.address_;
-        port_ = s.port_;
+        socket_address_ = s.socket_address_;
         type_ = s.type_;
         // invalidate s.type_, s.handle so s.close() won't break anything
         s.type_ = Type::None;
@@ -63,33 +62,33 @@ public:
 
     [[nodiscard]] constexpr std::pair<tr_address, tr_port> socketAddress() const noexcept
     {
-        return std::make_pair(address_, port_);
+        return socket_address_;
     }
 
     [[nodiscard]] constexpr auto const& address() const noexcept
     {
-        return address_;
+        return socket_address_.first;
     }
 
     [[nodiscard]] constexpr auto const& port() const noexcept
     {
-        return port_;
+        return socket_address_.second;
     }
 
     template<typename OutputIt>
     OutputIt display_name(OutputIt out)
     {
-        return address_.display_name(out, port_);
+        return address().display_name(out, port());
     }
 
     [[nodiscard]] std::string_view display_name(char* out, size_t outlen) const
     {
-        return address_.display_name(out, outlen, port_);
+        return address().display_name(out, outlen, port());
     }
 
     [[nodiscard]] std::string display_name() const
     {
-        return address_.display_name(port_);
+        return address().display_name(port());
     }
 
     [[nodiscard]] constexpr auto is_utp() const noexcept
@@ -153,12 +152,14 @@ private:
         UTP
     };
 
-    tr_address address_;
-    tr_port port_;
+    std::pair<tr_address, tr_port> socket_address_;
 
     enum Type type_ = Type::None;
 
     static inline std::atomic<size_t> n_open_sockets_ = {};
 };
 
-tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_address const& addr, tr_port port, bool client_is_seed);
+tr_peer_socket tr_netOpenPeerSocket(
+    tr_session* session,
+    std::pair<tr_address, tr_port> const& socket_address,
+    bool client_is_seed);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -377,9 +377,10 @@ void tr_session::onIncomingPeerConnection(tr_socket_t fd, void* vsession)
 
     if (auto const incoming_info = tr_netAccept(session, fd); incoming_info)
     {
-        auto const& [addr, port, sock] = *incoming_info;
+        auto const& [socket_address, sock] = *incoming_info;
+        auto const& [addr, port] = socket_address;
         tr_logAddTrace(fmt::format("new incoming connection {} ({})", sock, addr.display_name(port)));
-        session->addIncoming(tr_peer_socket{ session, addr, port, sock });
+        session->addIncoming({ session, socket_address, sock });
     }
 }
 

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -93,8 +93,7 @@ void utp_on_accept(tr_session* const session, UTPSocket* const utp_sock)
 
     if (auto addrport = tr_address::from_sockaddr(reinterpret_cast<struct sockaddr*>(&from_storage)); addrport)
     {
-        auto const& [addr, port] = *addrport;
-        session->addIncoming(tr_peer_socket{ addr, port, utp_sock });
+        session->addIncoming({ *addrport, utp_sock });
     }
     else
     {

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -146,8 +146,8 @@ public:
     static auto constexpr ReservedBytesNoExtensions = std::array<uint8_t, 8>{ 0, 0, 0, 0, 0, 0, 0, 0 };
     static auto constexpr PlaintextProtocolName = "\023BitTorrent protocol"sv;
 
-    tr_address const DefaultPeerAddr = *tr_address::from_string("127.0.0.1"sv);
-    tr_port const DefaultPeerPort = tr_port::fromHost(8080);
+    std::pair<tr_address, tr_port> const DefaultPeerSockAddr{ *tr_address::from_string("127.0.0.1"sv),
+                                                              tr_port::fromHost(8080) };
     tr_handshake::Mediator::TorrentInfo const TorrentWeAreSeeding{ tr_sha1::digest("abcde"sv),
                                                                    tr_peerIdInit(),
                                                                    tr_torrent_id_t{ 100 },
@@ -161,12 +161,10 @@ public:
     {
         auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
-        return std::make_pair(
-            tr_peerIo::new_incoming(
-                session,
-                &session->top_bandwidth_,
-                tr_peer_socket(session, DefaultPeerAddr, DefaultPeerPort, sockpair[0])),
-            sockpair[1]);
+        return std::pair{
+            tr_peerIo::new_incoming(session, &session->top_bandwidth_, { session, DefaultPeerSockAddr, sockpair[0] }),
+            sockpair[1]
+        };
     }
 
     auto createOutgoingIo(tr_session* session, tr_sha1_digest_t const& info_hash)
@@ -174,8 +172,8 @@ public:
         auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         auto peer_io = tr_peerIo::create(session, &session->top_bandwidth_, &info_hash, false /*incoming*/, false /*seed*/);
-        peer_io->set_socket(tr_peer_socket(session, DefaultPeerAddr, DefaultPeerPort, sockpair[0]));
-        return std::make_pair(std::move(peer_io), sockpair[1]);
+        peer_io->set_socket({ session, DefaultPeerSockAddr, sockpair[0] });
+        return std::pair{ std::move(peer_io), sockpair[1] };
     }
 
     static constexpr auto makePeerId(std::string_view sv)

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -161,10 +161,11 @@ public:
     {
         auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
-        return std::pair{
-            tr_peerIo::new_incoming(session, &session->top_bandwidth_, { session, DefaultPeerSockAddr, sockpair[0] }),
-            sockpair[1]
-        };
+        return std::pair{ tr_peerIo::new_incoming(
+                              session,
+                              &session->top_bandwidth_,
+                              tr_peer_socket(session, DefaultPeerSockAddr, sockpair[0])),
+                          sockpair[1] };
     }
 
     auto createOutgoingIo(tr_session* session, tr_sha1_digest_t const& info_hash)
@@ -172,7 +173,7 @@ public:
         auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         auto peer_io = tr_peerIo::create(session, &session->top_bandwidth_, &info_hash, false /*incoming*/, false /*seed*/);
-        peer_io->set_socket({ session, DefaultPeerSockAddr, sockpair[0] });
+        peer_io->set_socket(tr_peer_socket(session, DefaultPeerSockAddr, sockpair[0]));
         return std::pair{ std::move(peer_io), sockpair[1] };
     }
 


### PR DESCRIPTION
For performance benefits from avoid constructing `std::pair`s.