### PR TITLE
perf: use small::string in daemon::printMessage()

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -24,6 +24,8 @@
 
 #include <fmt/core.h>
 
+#include <small/string.hpp>
+
 #include "daemon.h"
 
 #include <libtransmission/timer-ev.h>
@@ -311,14 +313,22 @@ static void printMessage(
     std::string_view filename,
     long line)
 {
-    auto const out = std::empty(name) ? fmt::format(FMT_STRING("{:s} ({:s}:{:d})"), message, filename, line) :
-                                        fmt::format(FMT_STRING("{:s} {:s} ({:s}:{:d})"), name, message, filename, line);
+    auto out = small::basic_string<char, 2048U>{};
+
+    if (std::empty(name))
+    {
+        fmt::format_to(std::back_inserter(out), "{:s} ({:s}:{:d})", message, filename, line);
+    }
+    else
+    {
+        fmt::format_to(std::back_inserter(out), "{:s} {:s} ({:s}:{:d})", name, message, filename, line);
+    }
 
     if (file != TR_BAD_SYS_FILE)
     {
         auto timestr = std::array<char, 64>{};
         tr_logGetTimeStr(std::data(timestr), std::size(timestr));
-        tr_sys_file_write_line(file, fmt::format(FMT_STRING("[{:s}] {:s} {:s}"), std::data(timestr), levelName(level), out));
+        tr_sys_file_write_line(file, fmt::format("[{:s}] {:s} {:s}", std::data(timestr), levelName(level), std::data(out)));
     }
 
 #ifdef HAVE_SYSLOG

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -24,8 +24,6 @@
 
 #include <fmt/core.h>
 
-#include <small/string.hpp>
-
 #include "daemon.h"
 
 #include <libtransmission/timer-ev.h>
@@ -313,7 +311,7 @@ static void printMessage(
     std::string_view filename,
     long line)
 {
-    auto out = small::basic_string<char, 2048U>{};
+    auto out = tr_strbuf<char, 2048U>{};
 
     if (std::empty(name))
     {


### PR DESCRIPTION
Use a stack buffer when building most log messages.

Notes: Use [libsmall](https://github.com/alandefreitas/small) to avoid some unnecessary  heap allocations.
