### PR TITLE
perf: avoid string allocations by using fixed-width hash strings

### DIFF
--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -16,7 +16,9 @@
 #include <string>
 #include <string_view>
 
-#include "transmission.h" // tr_sha1_digest_t
+#include "libtransmission/transmission.h" // tr_sha1_digest_t
+
+#include "libtransmission/tr-strbuf.h"
 
 /**
  * @addtogroup utils Utilities
@@ -133,20 +135,24 @@ T tr_rand_obj()
  */
 [[nodiscard]] std::string tr_base64_decode(std::string_view input);
 
+using tr_sha1_string = tr_strbuf<char, sizeof(tr_sha1_digest_t) * 2U + 1U>;
+
 /**
  * @brief Generate an ascii hex string for a sha1 digest.
  */
-[[nodiscard]] std::string tr_sha1_to_string(tr_sha1_digest_t const&);
+[[nodiscard]] tr_sha1_string tr_sha1_to_string(tr_sha1_digest_t const&);
 
 /**
  * @brief Generate a sha1 digest from a hex string.
  */
 [[nodiscard]] std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex);
 
+using tr_sha256_string = tr_strbuf<char, sizeof(tr_sha256_digest_t) * 2U + 1U>;
+
 /**
  * @brief Generate an ascii hex string for a sha256 digest.
  */
-[[nodiscard]] std::string tr_sha256_to_string(tr_sha256_digest_t const&);
+[[nodiscard]] tr_sha256_string tr_sha256_to_string(tr_sha256_digest_t const&);
 
 /**
  * @brief Generate a sha256 digest from a hex string.

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -13,6 +13,7 @@
 #include "transmission.h"
 
 #include "announce-list.h"
+#include "crypto-utils.h"
 #include "tr-strbuf.h" // tr_urlbuf
 #include "utils.h" // tr_strv_convert_utf8()
 
@@ -58,12 +59,12 @@ public:
         return announce_list_;
     }
 
-    [[nodiscard]] constexpr std::string const& info_hash_string() const noexcept
+    [[nodiscard]] constexpr auto const& info_hash_string() const noexcept
     {
         return info_hash_str_;
     }
 
-    [[nodiscard]] constexpr std::string const& info_hash2_string() const noexcept
+    [[nodiscard]] constexpr auto const& info_hash2_string() const noexcept
     {
         return info_hash2_str_;
     }
@@ -80,7 +81,7 @@ protected:
     std::vector<std::string> webseed_urls_;
     tr_sha1_digest_t info_hash_ = {};
     tr_sha256_digest_t info_hash2_ = {};
-    std::string info_hash_str_;
-    std::string info_hash2_str_;
+    tr_sha1_string info_hash_str_;
+    tr_sha256_string info_hash2_str_;
     std::string name_;
 };

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -33,8 +33,16 @@ public:
         ensure_sz();
     }
 
-    tr_strbuf(tr_strbuf const& other) = delete;
-    tr_strbuf& operator=(tr_strbuf const& other) = delete;
+    tr_strbuf(tr_strbuf const& other)
+    {
+        assign(other.sv());
+    }
+
+    tr_strbuf& operator=(tr_strbuf const& other)
+    {
+        assign(other.sv());
+        return *this;
+    }
 
     tr_strbuf(tr_strbuf&& other)
         : buffer_{ std::move(other.buffer_) }

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -43,7 +43,8 @@ QString getNameFromMagnet(QString const& magnet)
         return QString::fromStdString(tmp.name());
     }
 
-    return QString::fromStdString(tmp.info_hash_string());
+    auto const& hashstr = tmp.info_hash_string();
+    return QString::fromUtf8(std::data(hashstr), std::size(hashstr));
 }
 
 } // namespace

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -105,6 +105,7 @@ class TorrentHash
 {
 private:
     tr_sha1_digest_t data_ = {};
+    QString data_str_;
 
 public:
     TorrentHash() = default;
@@ -119,6 +120,9 @@ public:
         if (auto const hash = tr_sha1_from_string(str != nullptr ? str : ""); hash)
         {
             data_ = *hash;
+
+            auto const tmpstr = tr_sha1_to_string(data_);
+            data_str_ = QString::fromUtf8(std::data(tmpstr), std::size(tmpstr));
         }
     }
 
@@ -127,6 +131,9 @@ public:
         if (auto const hash = tr_sha1_from_string(str.toStdString()); hash)
         {
             data_ = *hash;
+
+            auto const tmpstr = tr_sha1_to_string(data_);
+            data_str_ = QString::fromUtf8(std::data(tmpstr), std::size(tmpstr));
         }
     }
 
@@ -145,9 +152,9 @@ public:
         return data_ < that.data_;
     }
 
-    QString toString() const
+    [[nodiscard]] constexpr auto& toString() const noexcept
     {
-        return QString::fromStdString(tr_sha1_to_string(data_));
+        return data_str_;
     }
 };
 


### PR DESCRIPTION
human-readable sha1 and sha256 hex strings have fixed widths (40 hex chars and 64 hex chars respectively); so when aggregating them in a `tr_magnet_metainfo`, use fixed-width strings instead of `std::string`s.

Notes: When beneficial, use fewer heap allocations.