### PR TITLE
perf: minor cleanups

### DIFF
--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -133,7 +133,7 @@ public:
         return files_.fileSize(i);
     }
 
-    [[nodiscard]] constexpr auto const& is_private() const noexcept
+    [[nodiscard]] constexpr auto is_private() const noexcept
     {
         return is_private_;
     }

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -123,7 +123,7 @@ public:
         return source_;
     }
 
-    [[nodiscard]] constexpr auto const& is_private() const noexcept
+    [[nodiscard]] constexpr auto is_private() const noexcept
     {
         return is_private_;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -609,7 +609,7 @@ public:
         return {};
     }
 
-    [[nodiscard]] constexpr auto const& id() const noexcept
+    [[nodiscard]] constexpr auto id() const noexcept
     {
         return unique_id_;
     }


### PR DESCRIPTION
A handful of minor cleanup tweaks, e.g. returning `bool` instead of `bool const&` since the former is simpler and cheaper.

Arguably a `perf` PR but any perf improvements will be minimal.