### PR TITLE
refactor: add tr_socket_address typedef 

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   cert-*,
   -cert-err58-cpp,
   clang-analyzer-*,
-  cppcoreguidelines-avoid-const-or-ref-data-members,
   cppcoreguidelines-avoid-do-while,
   cppcoreguidelines-avoid-goto,
   cppcoreguidelines-avoid-reference-coroutine-parameters,
@@ -37,7 +36,8 @@ Checks: >
   -readability-qualified-auto,
 
 CheckOptions:
-  - { key: readability-identifier-naming.ParameterCase,            value: lower_case }
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
   - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
+  - { key: readability-identifier-naming.ParameterCase,            value: lower_case }
   - { key: readability-identifier-naming.VariableCase,             value: lower_case }
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -61,18 +61,15 @@ public:
         [[nodiscard]] virtual libtransmission::TimerMaker& timer_maker() = 0;
         [[nodiscard]] virtual bool allows_dht() const = 0;
         [[nodiscard]] virtual bool allows_tcp() const = 0;
-        [[nodiscard]] virtual bool is_peer_known_seed(
-            tr_torrent_id_t tor_id,
-            std::pair<tr_address, tr_port> const& socket_address) const = 0;
+        [[nodiscard]] virtual bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address)
+            const = 0;
         [[nodiscard]] virtual size_t pad(void* setme, size_t max_bytes) const = 0;
         [[nodiscard]] virtual DH::private_key_bigend_t private_key() const
         {
             return DH::randomPrivateKey();
         }
 
-        virtual void set_utp_failed(
-            tr_sha1_digest_t const& info_hash,
-            std::pair<tr_address, tr_port> const& socket_address) = 0;
+        virtual void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_socket_address const& socket_address) = 0;
     };
 
     tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -185,10 +185,7 @@ static tr_socket_t createSocket(int domain, int type)
     return sockfd;
 }
 
-tr_peer_socket tr_netOpenPeerSocket(
-    tr_session* session,
-    std::pair<tr_address, tr_port> const& socket_address,
-    bool client_is_seed)
+tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed)
 {
     auto const& [addr, port] = socket_address;
 
@@ -364,9 +361,7 @@ tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_ms
     return tr_netBindTCPImpl(addr, port, suppress_msgs, &unused);
 }
 
-std::optional<std::pair<std::pair<tr_address, tr_port>, tr_socket_t>> tr_netAccept(
-    tr_session* session,
-    tr_socket_t listening_sockfd)
+std::optional<std::pair<tr_socket_address, tr_socket_t>> tr_netAccept(tr_session* session, tr_socket_t listening_sockfd)
 {
     TR_ASSERT(session != nullptr);
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -313,13 +313,15 @@ struct tr_address
     [[nodiscard]] bool is_valid_for_peers(tr_port port) const noexcept;
 };
 
+using tr_socket_address = std::pair<tr_address, tr_port>;
+
 // --- Sockets
 
 struct tr_session;
 
 tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_msgs);
 
-[[nodiscard]] std::optional<std::pair<std::pair<tr_address, tr_port>, tr_socket_t>> tr_netAccept(
+[[nodiscard]] std::optional<std::pair<tr_socket_address, tr_socket_t>> tr_netAccept(
     tr_session* session,
     tr_socket_t listening_sockfd);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -112,7 +112,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_incoming(tr_session* session, tr_bandw
 std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
     tr_session* session,
     tr_bandwidth* parent,
-    std::pair<tr_address, tr_port> const& socket_address,
+    tr_socket_address const& socket_address,
     tr_sha1_digest_t const& info_hash,
     bool is_seed,
     bool utp)

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -62,7 +62,7 @@ public:
     static std::shared_ptr<tr_peerIo> new_outgoing(
         tr_session* session,
         tr_bandwidth* parent,
-        std::pair<tr_address, tr_port> const& socket_address,
+        tr_socket_address const& socket_address,
         tr_sha1_digest_t const& info_hash,
         bool is_seed,
         bool utp);
@@ -259,7 +259,7 @@ public:
         return socket_.address();
     }
 
-    [[nodiscard]] constexpr auto socket_address() const noexcept
+    [[nodiscard]] constexpr auto const& socket_address() const noexcept
     {
         return socket_.socketAddress();
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1205,9 +1205,8 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
     }
     else /* we don't have a connection to them yet... */
     {
-        auto&& socket_address = socket.socketAddress();
         manager->incoming_handshakes.try_emplace(
-            std::move(socket_address),
+            socket.socketAddress(),
             &manager->handshake_mediator_,
             tr_peerIo::new_incoming(session, &session->top_bandwidth_, std::move(socket)),
             session->encryptionMode(),

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -98,7 +98,7 @@ public:
         return session_.allowsTCP();
     }
 
-    void set_utp_failed(tr_sha1_digest_t const& info_hash, std::pair<tr_address, tr_port> const& socket_address) override
+    void set_utp_failed(tr_sha1_digest_t const& info_hash, tr_socket_address const& socket_address) override
     {
         if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr)
         {
@@ -106,8 +106,7 @@ public:
         }
     }
 
-    [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t tor_id, std::pair<tr_address, tr_port> const& socket_address)
-        const override;
+    [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address) const override;
 
     [[nodiscard]] libtransmission::TimerMaker& timer_maker() override
     {
@@ -136,7 +135,7 @@ private:
  */
 struct peer_atom
 {
-    peer_atom(std::pair<tr_address, tr_port> socket_address_in, uint8_t flags_in, uint8_t from)
+    peer_atom(tr_socket_address socket_address_in, uint8_t flags_in, uint8_t from)
         : socket_address{ std::move(socket_address_in) }
         , fromFirst{ from }
         , fromBest{ from }
@@ -287,7 +286,7 @@ struct peer_atom
         is_banned_ = true;
     }
 
-    std::pair<tr_address, tr_port> socket_address;
+    tr_socket_address socket_address;
 
     uint16_t num_fails = {};
 
@@ -317,7 +316,7 @@ private:
     bool is_unreachable_ = false; // we tried to connect & failed
 };
 
-using Handshakes = std::map<std::pair<tr_address, tr_port>, tr_handshake>;
+using Handshakes = std::map<tr_socket_address, tr_handshake>;
 
 #define tr_logAddDebugSwarm(swarm, msg) tr_logAddDebugTor((swarm)->tor, msg)
 #define tr_logAddTraceSwarm(swarm, msg) tr_logAddTraceTor((swarm)->tor, msg)
@@ -499,25 +498,25 @@ public:
         return *pool_is_all_seeds_;
     }
 
-    [[nodiscard]] peer_atom* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) noexcept
+    [[nodiscard]] peer_atom* get_existing_atom(tr_socket_address const& socket_address) noexcept
     {
         auto&& it = pool.find(socket_address);
         return it != pool.end() ? &it->second : nullptr;
     }
 
-    [[nodiscard]] peer_atom const* get_existing_atom(std::pair<tr_address, tr_port> const& socket_address) const noexcept
+    [[nodiscard]] peer_atom const* get_existing_atom(tr_socket_address const& socket_address) const noexcept
     {
         auto const& it = pool.find(socket_address);
         return it != pool.cend() ? &it->second : nullptr;
     }
 
-    [[nodiscard]] bool peer_is_a_seed(std::pair<tr_address, tr_port> const& socket_address) const noexcept
+    [[nodiscard]] bool peer_is_a_seed(tr_socket_address const& socket_address) const noexcept
     {
         auto const* const atom = get_existing_atom(socket_address);
         return atom != nullptr && atom->isSeed();
     }
 
-    peer_atom* ensure_atom_exists(std::pair<tr_address, tr_port> const& socket_address, uint8_t const flags, uint8_t const from)
+    peer_atom* ensure_atom_exists(tr_socket_address const& socket_address, uint8_t const flags, uint8_t const from)
     {
         TR_ASSERT(socket_address.first.is_valid());
         TR_ASSERT(from < TR_PEER_FROM__MAX);
@@ -668,7 +667,7 @@ public:
 
     // tr_peers hold pointers to the items in this container,
     // therefore references to elements within cannot invalidate
-    std::map<std::pair<tr_address, tr_port>, peer_atom> pool;
+    std::map<tr_socket_address, peer_atom> pool;
 
     tr_peerMsgs* optimistic = nullptr; /* the optimistic peer, or nullptr if none */
 
@@ -920,7 +919,7 @@ void tr_peerMgrFree(tr_peerMgr* manager)
 
 // ---
 
-void tr_peerMgrSetUtpSupported(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address)
+void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_socket_address const& socket_address)
 {
     if (auto* const atom = tor->swarm->get_existing_atom(socket_address); atom != nullptr)
     {
@@ -928,7 +927,7 @@ void tr_peerMgrSetUtpSupported(tr_torrent* tor, std::pair<tr_address, tr_port> c
     }
 }
 
-void tr_peerMgrSetUtpFailed(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address, bool failed)
+void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_socket_address const& socket_address, bool failed)
 {
     if (auto* const atom = tor->swarm->get_existing_atom(socket_address); atom != nullptr)
     {
@@ -2509,7 +2508,7 @@ void tr_peerMgr::makeNewPeerConnections(size_t max)
 
 // ---
 
-bool HandshakeMediator::is_peer_known_seed(tr_torrent_id_t tor_id, std::pair<tr_address, tr_port> const& socket_address) const
+bool HandshakeMediator::is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address) const
 {
     auto const* const tor = session_.torrents().get(tor_id);
     return tor != nullptr && tor->swarm != nullptr && tor->swarm->peer_is_a_seed(socket_address);

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -163,9 +163,9 @@ constexpr bool tr_isPex(tr_pex const* pex)
 
 void tr_peerMgrFree(tr_peerMgr* manager);
 
-void tr_peerMgrSetUtpSupported(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address);
+void tr_peerMgrSetUtpSupported(tr_torrent* tor, tr_socket_address const& socket_address);
 
-void tr_peerMgrSetUtpFailed(tr_torrent* tor, std::pair<tr_address, tr_port> const& socket_address, bool failed);
+void tr_peerMgrSetUtpFailed(tr_torrent* tor, tr_socket_address const& socket_address, bool failed);
 
 [[nodiscard]] std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_peer const* peer, size_t numwant);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -409,7 +409,7 @@ public:
         }
     }
 
-    [[nodiscard]] std::pair<tr_address, tr_port> socketAddress() const override
+    [[nodiscard]] tr_socket_address socketAddress() const override
     {
         return io->socket_address();
     }

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -99,7 +99,7 @@ public:
         return is_active_[direction];
     }
 
-    [[nodiscard]] virtual std::pair<tr_address, tr_port> socketAddress() const = 0;
+    [[nodiscard]] virtual tr_socket_address socketAddress() const = 0;
 
     virtual void cancel_block_request(tr_block_index_t block) = 0;
 

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -18,7 +18,7 @@
 #define tr_logAddDebugIo(io, msg) tr_logAddDebug(msg, (io)->display_name())
 #define tr_logAddTraceIo(io, msg) tr_logAddTrace(msg, (io)->display_name())
 
-tr_peer_socket::tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> socket_address, tr_socket_t sock)
+tr_peer_socket::tr_peer_socket(tr_session const* session, tr_socket_address socket_address, tr_socket_t sock)
     : handle{ sock }
     , socket_address_{ std::move(socket_address) }
     , type_{ Type::TCP }
@@ -36,7 +36,7 @@ tr_peer_socket::tr_peer_socket(tr_session const* session, std::pair<tr_address, 
     tr_logAddTraceIo(this, fmt::format("socket (tcp) is {}", handle.tcp));
 }
 
-tr_peer_socket::tr_peer_socket(std::pair<tr_address, tr_port> socket_address, struct UTPSocket* const sock)
+tr_peer_socket::tr_peer_socket(tr_socket_address socket_address, struct UTPSocket* const sock)
     : socket_address_{ std::move(socket_address) }
     , type_{ Type::UTP }
 {

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -32,8 +32,8 @@ public:
     using OutBuf = libtransmission::BufferReader<std::byte>;
 
     tr_peer_socket() = default;
-    tr_peer_socket(tr_session const* session, std::pair<tr_address, tr_port> socket_address, tr_socket_t sock);
-    tr_peer_socket(std::pair<tr_address, tr_port> socket_address, struct UTPSocket* sock);
+    tr_peer_socket(tr_session const* session, tr_socket_address socket_address, tr_socket_t sock);
+    tr_peer_socket(tr_socket_address socket_address, struct UTPSocket* sock);
     tr_peer_socket(tr_peer_socket&& s) noexcept
     {
         *this = std::move(s);
@@ -60,7 +60,7 @@ public:
     size_t try_read(InBuf& buf, size_t max, bool buf_is_empty, tr_error** error) const;
     size_t try_write(OutBuf& buf, size_t max, tr_error** error) const;
 
-    [[nodiscard]] constexpr std::pair<tr_address, tr_port> socketAddress() const noexcept
+    [[nodiscard]] constexpr auto const& socketAddress() const noexcept
     {
         return socket_address_;
     }
@@ -152,14 +152,11 @@ private:
         UTP
     };
 
-    std::pair<tr_address, tr_port> socket_address_;
+    tr_socket_address socket_address_;
 
     enum Type type_ = Type::None;
 
     static inline std::atomic<size_t> n_open_sockets_ = {};
 };
 
-tr_peer_socket tr_netOpenPeerSocket(
-    tr_session* session,
-    std::pair<tr_address, tr_port> const& socket_address,
-    bool client_is_seed);
+tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -111,7 +111,7 @@ extern "C"
 class tr_dht_impl final : public tr_dht
 {
 private:
-    using Node = std::pair<tr_address, tr_port>;
+    using Node = tr_socket_address;
     using Nodes = std::deque<Node>;
     using Id = std::array<unsigned char, 20>;
 


### PR DESCRIPTION
It's still a `std::pair<tr_address, tr_port>`; it just feels semantically clearer to give it a name.