### PR TITLE
perf: reduce copying in `enforceSwarmPeerLimit()`

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2085,15 +2085,21 @@ void closeBadPeers(tr_swarm* s, time_t const now_sec)
 void enforceSwarmPeerLimit(tr_swarm* swarm, size_t max)
 {
     // do we have too many peers?
-    if (auto const n = swarm->peerCount(); n <= max)
+    auto const n = swarm->peerCount();
+    if (n <= max)
     {
         return;
     }
 
     // close all but the `max` most active
-    auto peers = swarm->peers;
-    std::partial_sort(std::begin(peers), std::begin(peers) + max, std::end(peers), ComparePeerByActivity);
-    std::for_each(std::begin(peers) + max, std::end(peers), closePeer);
+    auto peers = std::vector<tr_peerMsgs*>{ n - max };
+    std::partial_sort_copy(
+        std::begin(swarm->peers),
+        std::end(swarm->peers),
+        std::begin(peers),
+        std::end(peers),
+        [](auto const& a, auto const& b) { return ComparePeerByActivity(b, a); });
+    std::for_each(std::begin(peers), std::end(peers), closePeer);
 }
 
 void enforceSessionPeerLimit(tr_session* session)


### PR DESCRIPTION
A small improvement that should help with #5714.