### PR TITLE
fix: spelling mistake in `net.h` function call

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -223,7 +223,7 @@ struct tr_address
     template<typename OutputIt>
     OutputIt to_compact(OutputIt out, tr_port port)
     {
-        return is_ipv4() ? to_compact_4(out, &this->addr.addr4, port) : to_compact_ipv6(out, &this->addr.addr6, port);
+        return is_ipv4() ? to_compact_ipv4(out, &this->addr.addr4, port) : to_compact_ipv6(out, &this->addr.addr6, port);
     }
 
     // compact sockaddr helpers

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -49,8 +49,8 @@ TEST_F(NetTest, compact4)
 {
     static auto constexpr ExpectedReadable = "10.10.10.5"sv;
     static auto constexpr ExpectedPort = tr_port::fromHost(128);
-    static auto constexpr Compact4 = std::array<std::byte, 6>{ std::byte{ 0x0A }, std::byte{ 0x0A }, std::byte{ 0x0A },
-                                                               std::byte{ 0x05 }, std::byte{ 0x00 }, std::byte{ 0x80 } };
+    static auto constexpr Compact4 = std::array<std::byte, 6U>{ std::byte{ 0x0A }, std::byte{ 0x0A }, std::byte{ 0x0A },
+                                                                std::byte{ 0x05 }, std::byte{ 0x00 }, std::byte{ 0x80 } };
 
     /// compact <--> tr_address, port
 
@@ -65,16 +65,34 @@ TEST_F(NetTest, compact4)
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again
-    auto compact4 = std::array<std::byte, 6>{};
+    auto compact4 = std::array<std::byte, 6U>{};
     auto out = std::data(compact4);
     out = addr.to_compact_ipv4(out, port);
     EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(compact4)));
     EXPECT_EQ(Compact4, compact4);
 
+    // ...serialize it back another way
+    compact4.fill(std::byte{});
+    out = std::data(compact4);
+    out = addr.to_compact(out, port);
+    EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(compact4)));
+    EXPECT_EQ(Compact4, compact4);
+
+    /// tr_address --> compact
+    compact4.fill(std::byte{});
+    out = std::data(compact4);
+    out = addr.to_compact(out);
+    EXPECT_EQ(std::size(Compact4) - 2U, static_cast<size_t>(out - std::data(compact4)));
+    EXPECT_TRUE(std::equal(std::data(Compact4), std::data(Compact4) + std::size(Compact4) - 2U, std::data(compact4)));
+    EXPECT_TRUE(std::all_of(
+        std::begin(compact4) + std::size(Compact4) - 2U,
+        std::end(compact4),
+        [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
+
     /// sockaddr --> compact
 
     auto [ss, sslen] = addr.to_sockaddr(port);
-    std::fill(std::begin(compact4), std::end(compact4), std::byte{});
+    compact4.fill(std::byte{});
     out = std::data(compact4);
     out = tr_address::to_compact(out, &ss);
     EXPECT_EQ(out, std::data(compact4) + std::size(compact4));
@@ -100,7 +118,7 @@ TEST_F(NetTest, compact6)
 {
     static auto constexpr ExpectedReadable = "1002:1035:4527:3546:7854:1237:3247:3217"sv;
     static auto constexpr ExpectedPort = tr_port::fromHost(6881);
-    static auto constexpr Compact6 = std::array<std::byte, 18>{
+    static auto constexpr Compact6 = std::array<std::byte, 18U>{
         std::byte{ 0x10 }, std::byte{ 0x02 }, std::byte{ 0x10 }, std::byte{ 0x35 }, std::byte{ 0x45 }, std::byte{ 0x27 },
         std::byte{ 0x35 }, std::byte{ 0x46 }, std::byte{ 0x78 }, std::byte{ 0x54 }, std::byte{ 0x12 }, std::byte{ 0x37 },
         std::byte{ 0x32 }, std::byte{ 0x47 }, std::byte{ 0x32 }, std::byte{ 0x17 }, std::byte{ 0x1A }, std::byte{ 0xE1 }
@@ -119,16 +137,34 @@ TEST_F(NetTest, compact6)
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again
-    auto compact6 = std::array<std::byte, 18>{};
+    auto compact6 = std::array<std::byte, 18U>{};
     auto out = std::data(compact6);
     out = addr.to_compact_ipv6(out, port);
     EXPECT_EQ(std::size(Compact6), static_cast<size_t>(out - std::data(compact6)));
     EXPECT_EQ(Compact6, compact6);
 
+    // ...serialize it back another way
+    compact6.fill(std::byte{});
+    out = std::data(compact6);
+    out = addr.to_compact(out, port);
+    EXPECT_EQ(std::size(Compact6), static_cast<size_t>(out - std::data(compact6)));
+    EXPECT_EQ(Compact6, compact6);
+
+    /// tr_address --> compact
+    compact6.fill(std::byte{});
+    out = std::data(compact6);
+    out = addr.to_compact(out);
+    EXPECT_EQ(std::size(Compact6) - 2U, static_cast<size_t>(out - std::data(compact6)));
+    EXPECT_TRUE(std::equal(std::data(Compact6), std::data(Compact6) + std::size(Compact6) - 2U, std::data(compact6)));
+    EXPECT_TRUE(std::all_of(
+        std::begin(compact6) + std::size(Compact6) - 2U,
+        std::end(compact6),
+        [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
+
     /// sockaddr --> compact
 
     auto [ss, sslen] = addr.to_sockaddr(port);
-    std::fill(std::begin(compact6), std::end(compact6), std::byte{});
+    compact6.fill(std::byte{});
     out = std::data(compact6);
     out = tr_address::to_compact(out, &ss);
     EXPECT_EQ(out, std::data(compact6) + std::size(compact6));

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -4,11 +4,11 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <algorithm>
+#include <cstddef>
 #include <string_view>
 #include <tuple>
 #include <utility>
-
-#include <libtransmission/transmission.h>
 
 #include <libtransmission/net.h>
 #include <libtransmission/peer-mgr.h>


### PR DESCRIPTION
Somehow Palpatine retu-

No I mean somehow the code compiled.