### PR TITLE
fix: add missing cstdint include

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -3,6 +3,7 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstdint>
 #include <vector>
 
 #include <small/set.hpp>


### PR DESCRIPTION
<vector> does not include <cstdint> at all in some STL versions.

Fixes issue introduced by https://github.com/transmission/transmission/pull/5720

Fixes: https://github.com/transmission/transmission/issues/5727