### PR TITLE
fixup! refactor: remove libtransmission::Buffer (#5676)

### DIFF
--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -270,7 +270,7 @@ public:
             {
                 // move data so that all free space is at the end
                 auto const size = this->size();
-                std::copy_n(data(), n_bytes, std::data(buf_));
+                std::copy_n(data(), size, std::data(buf_));
                 begin_pos_ = 0;
                 end_pos_ = size;
             }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -270,7 +270,7 @@ public:
             {
                 // move data so that all free space is at the end
                 auto const size = this->size();
-                std::copy_n(data(), size, std::data(buf_));
+                std::copy(data(), data() + size, std::data(buf_));
                 begin_pos_ = 0;
                 end_pos_ = size;
             }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -15,8 +15,6 @@
 
 #include <small/vector.hpp>
 
-#include <fmt/core.h>
-
 #include "error.h"
 #include "net.h" // tr_socket_t
 #include "utils.h" // for tr_htonll(), tr_ntohll()

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -7,7 +7,6 @@
 
 #include <algorithm> // for std::copy_n
 #include <cstddef>
-#include <cstring>
 #include <iterator>
 #include <limits>
 #include <string>
@@ -271,7 +270,7 @@ public:
             {
                 // move data so that all free space is at the end
                 auto const size = this->size();
-                std::memmove(std::data(buf_), data(), size);
+                std::copy_n(data(), n_bytes, std::data(buf_));
                 begin_pos_ = 0;
                 end_pos_ = size;
             }


### PR DESCRIPTION
fix: high memory use regression.

Fixes #5735.

I was wary about the cost of this new `memmove()` call, but in local testing it happens far less often than I expected and is not a major factor in my perf tests. So I'm OK with this approach until / unless we see it causing problems.

CC @tearfur since even though you're a member of Transmission org, the GitHub UI won't let me request a review :confused: 