### PR TITLE
feat: do not auto-disconnect when seeding & a known seed handshakes

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -521,16 +521,8 @@ ReadState tr_handshake::read_crypto_provide(tr_peerIo* peer_io)
 
     if (auto const info = mediator_->torrent_from_obfuscated(obfuscated_hash); info)
     {
-        bool const client_is_seed = info->is_done;
-        bool const peer_is_seed = mediator_->is_peer_known_seed(info->id, peer_io->socket_address());
         tr_logAddTraceHand(this, fmt::format("got INCOMING connection's encrypted handshake for torrent [{}]", info->id));
         peer_io->set_torrent_hash(info->info_hash);
-
-        if (client_is_seed && peer_is_seed)
-        {
-            tr_logAddTraceHand(this, "another seed tried to reconnect to us!");
-            return done(false);
-        }
     }
     else
     {

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -65,8 +65,6 @@ public:
         [[nodiscard]] virtual libtransmission::TimerMaker& timer_maker() = 0;
         [[nodiscard]] virtual bool allows_dht() const = 0;
         [[nodiscard]] virtual bool allows_tcp() const = 0;
-        [[nodiscard]] virtual bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address)
-            const = 0;
         [[nodiscard]] virtual size_t pad(void* setme, size_t max_bytes) const = 0;
         [[nodiscard]] virtual DH::private_key_bigend_t private_key() const
         {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -111,8 +111,6 @@ public:
         }
     }
 
-    [[nodiscard]] bool is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address) const override;
-
     [[nodiscard]] libtransmission::TimerMaker& timer_maker() override
     {
         return session_.timerMaker();
@@ -2546,12 +2544,4 @@ void tr_peerMgr::make_new_peer_connections()
 
     // remove the N candidates that we just consumed
     candidates.resize(std::size(candidates) - n_this_pass);
-}
-
-// ---
-
-bool HandshakeMediator::is_peer_known_seed(tr_torrent_id_t tor_id, tr_socket_address const& socket_address) const
-{
-    auto const* const tor = session_.torrents().get(tor_id);
-    return tor != nullptr && tor->swarm != nullptr && tor->swarm->peer_is_a_seed(socket_address);
 }

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -103,13 +103,6 @@ public:
             return true;
         }
 
-        [[nodiscard]] bool is_peer_known_seed(
-            tr_torrent_id_t /*tor_id*/,
-            std::pair<tr_address, tr_port> const& /*socket_address*/) const override
-        {
-            return false;
-        }
-
         [[nodiscard]] size_t pad(void* setme, [[maybe_unused]] size_t maxlen) const override
         {
             TR_ASSERT(maxlen > 10);


### PR DESCRIPTION
These seed-to-seed connections can still be useful for a short time, e.g. for peer exchange, so we shouldn't unconditionally disconnect.