### PR TITLE
fix/cleanups to tr_peerMsgsImpl

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1032,8 +1032,6 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
 
 void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
 {
-    msgs->peerSentLtepHandshake = true;
-
     auto const handshake_sv = payload.to_string_view();
 
     auto val = tr_variant{};

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -625,7 +625,6 @@ public:
     bool peerSupportsPex = false;
     bool peerSupportsMetadataXfer = false;
     bool clientSentLtepHandshake = false;
-    bool peerSentLtepHandshake = false;
 
     size_t desired_request_count = 0;
 
@@ -1068,14 +1067,14 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
         if (tr_variantDictFindInt(sub, TR_KEY_ut_pex, &i))
         {
             msgs->peerSupportsPex = i != 0;
-            msgs->ut_pex_id = (uint8_t)i;
+            msgs->ut_pex_id = static_cast<uint8_t>(i);
             logtrace(msgs, fmt::format(FMT_STRING("msgs->ut_pex is {:d}"), static_cast<int>(msgs->ut_pex_id)));
         }
 
         if (tr_variantDictFindInt(sub, TR_KEY_ut_metadata, &i))
         {
             msgs->peerSupportsMetadataXfer = i != 0;
-            msgs->ut_metadata_id = (uint8_t)i;
+            msgs->ut_metadata_id = static_cast<uint8_t>(i);
             logtrace(msgs, fmt::format(FMT_STRING("msgs->ut_metadata_id is {:d}"), static_cast<int>(msgs->ut_metadata_id)));
         }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -938,19 +938,7 @@ void sendLtepHandshake(tr_peerMsgsImpl* msgs)
     bool const allow_metadata_xfer = msgs->torrent->is_public();
 
     /* decide if we want to advertise pex support */
-    auto allow_pex = bool{};
-    if (!msgs->torrent->allows_pex())
-    {
-        allow_pex = false;
-    }
-    else if (msgs->peerSentLtepHandshake)
-    {
-        allow_pex = msgs->peerSupportsPex;
-    }
-    else
-    {
-        allow_pex = true;
-    }
+    bool const allow_pex = msgs->session->allows_pex() && msgs->torrent->allows_pex();
 
     auto val = tr_variant{};
     tr_variantInitDict(&val, 8);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2215,7 +2215,7 @@ void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
         break;
 
     case TR_KEY_pex_enabled:
-        tr_variantDictAddBool(d, key, s->allowsPEX());
+        tr_variantDictAddBool(d, key, s->allows_pex());
         break;
 
     case TR_KEY_tcp_enabled:

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1432,7 +1432,7 @@ bool tr_sessionIsPexEnabled(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
-    return session->allowsPEX();
+    return session->allows_pex();
 }
 
 bool tr_sessionIsDHTEnabled(tr_session const* session)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -766,7 +766,7 @@ public:
         return settings_.lpd_enabled;
     }
 
-    [[nodiscard]] constexpr auto allowsPEX() const noexcept
+    [[nodiscard]] constexpr auto allows_pex() const noexcept
     {
         return settings_.pex_enabled;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -553,7 +553,7 @@ public:
 
     [[nodiscard]] constexpr auto allows_pex() const noexcept
     {
-        return this->is_public() && this->session->allowsPEX();
+        return this->is_public() && this->session->allows_pex();
     }
 
     [[nodiscard]] constexpr auto allows_dht() const noexcept


### PR DESCRIPTION
This PR fixes a few minor issues with `tr_peerMsgs`.

1. BEP-11: Transmission now will not advertise pex support in ltep handshakes if `pex-enabled` is set to `false`.
2. BEP-11: Transmission now advertises pex support regardless of whether the peer supports it.
3. BEP-9: Transmission now checks if `total_size` in the `data` message received is the same as the `metadata_size` field in the ltep handshake received before.