### PR TITLE
refactor: tr_compare_3way()

### DIFF
--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -763,7 +763,7 @@ void Torrent::get_item_value(Glib::RefPtr<Glib::ObjectBase const> const& item, i
 
 int Torrent::compare_by_id(Glib::RefPtr<Torrent const> const& lhs, Glib::RefPtr<Torrent const> const& rhs)
 {
-    return gtr_compare_generic(lhs->get_id(), rhs->get_id());
+    return tr_compare_3way(lhs->get_id(), rhs->get_id());
 }
 
 bool Torrent::less_by_id(Glib::RefPtr<Torrent const> const& lhs, Glib::RefPtr<Torrent const> const& rhs)

--- a/gtk/TorrentSorter.cc
+++ b/gtk/TorrentSorter.cc
@@ -10,6 +10,7 @@
 #include "Utils.h"
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/utils.h>
 
 #include <algorithm>
 
@@ -44,7 +45,7 @@ constexpr int compare_eta(time_t lhs, time_t rhs)
         return 1;
     }
 
-    return -gtr_compare_generic(lhs, rhs);
+    return -tr_compare_3way(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -65,124 +66,107 @@ constexpr int compare_ratio(double lhs, double rhs)
         return -1;
     }
 
-    return gtr_compare_generic(lhs, rhs);
+    return tr_compare_3way(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_name(Torrent const& lhs, Torrent const& rhs)
 {
-    return lhs.get_name_collated().compare(rhs.get_name_collated());
+    return tr_compare_3way(lhs.get_name_collated(), rhs.get_name_collated());
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_queue(Torrent const& lhs, Torrent const& rhs)
 {
-    return gtr_compare_generic(lhs.get_queue_position(), rhs.get_queue_position());
+    return tr_compare_3way(lhs.get_queue_position(), rhs.get_queue_position());
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_ratio(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -compare_ratio(lhs.get_ratio(), rhs.get_ratio()); // default descending
-
-    if (result == 0)
+    if (auto result = -compare_ratio(lhs.get_ratio(), rhs.get_ratio()); result != 0)
     {
-        result = compare_by_queue(lhs, rhs);
+        return result;
     }
 
-    return result;
+    return compare_by_queue(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_activity(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -gtr_compare_generic(
-        lhs.get_speed_up() + lhs.get_speed_down(),
-        rhs.get_speed_up() + rhs.get_speed_down()); // default descending
-
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_speed_up() + lhs.get_speed_down(), rhs.get_speed_up() + rhs.get_speed_down());
+        val != 0)
     {
-        result = -gtr_compare_generic(lhs.get_active_peer_count(), rhs.get_active_peer_count()); // default descending
+        return val;
     }
 
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_active_peer_count(), rhs.get_active_peer_count()); val != 0)
     {
-        result = compare_by_queue(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_queue(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_age(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -gtr_compare_generic(lhs.get_added_date(), rhs.get_added_date()); // default descending
-
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_added_date(), rhs.get_added_date()); val != 0)
     {
-        result = compare_by_name(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_name(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_size(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -gtr_compare_generic(lhs.get_total_size(), rhs.get_total_size()); // default descending
-
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_total_size(), rhs.get_total_size()); val != 0)
     {
-        result = compare_by_name(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_name(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_progress(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -gtr_compare_generic(lhs.get_percent_complete(), rhs.get_percent_complete()); // default descending
-
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_percent_complete(), rhs.get_percent_complete()); val != 0)
     {
-        result = -gtr_compare_generic(
-            lhs.get_seed_ratio_percent_done(),
-            rhs.get_seed_ratio_percent_done()); // default descending
+        return val;
     }
 
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_seed_ratio_percent_done(), rhs.get_seed_ratio_percent_done()); val != 0)
     {
-        result = compare_by_ratio(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_ratio(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_eta(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = compare_eta(lhs.get_eta(), rhs.get_eta());
-
-    if (result == 0)
+    if (auto val = compare_eta(lhs.get_eta(), rhs.get_eta()); val != 0)
     {
-        result = compare_by_name(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_name(lhs, rhs);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_state(Torrent const& lhs, Torrent const& rhs)
 {
-    auto result = -gtr_compare_generic(lhs.get_activity(), rhs.get_activity());
-
-    if (result == 0)
+    if (auto val = -tr_compare_3way(lhs.get_activity(), rhs.get_activity()); val != 0)
     {
-        result = compare_by_queue(lhs, rhs);
+        return val;
     }
 
-    return result;
+    return compare_by_queue(lhs, rhs);
 }
 
 } // namespace

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -172,25 +172,6 @@ inline T gtr_str_strip(T const& text)
     return new_begin == T::npos ? T() : text.substr(new_begin, new_end == T::npos ? new_end : new_end - new_begin + 1);
 }
 
-template<typename T>
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-constexpr int gtr_compare_generic(T const& lhs, T const& rhs)
-{
-    using std::rel_ops::operator>;
-
-    if (lhs < rhs)
-    {
-        return -1;
-    }
-
-    if (lhs > rhs)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
 std::string gtr_get_full_resource_path(std::string const& rel_path);
 
 /***

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1503,7 +1503,7 @@ int compareAnnounceTiers(tr_tier const* a, tr_tier const* b)
 
     // the tiers are effectively equal priority, but add an arbitrary
     // differentiation because ptrArray sorted mode hates equal items.
-    return a < b ? -1 : 1;
+    return tr_compare_3way(a, b);
 }
 
 void tierAnnounce(tr_announcer_impl* announcer, tr_tier* tier)

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -465,12 +465,7 @@ struct tr_pex
             return i;
         }
 
-        if (port != that.port)
-        {
-            return port < that.port ? -1 : 1;
-        }
-
-        return 0;
+        return tr_compare_3way(port, that.port);
     }
 
     [[nodiscard]] bool operator==(tr_pex const& that) const noexcept

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -425,8 +425,3 @@ QString FileTreeItem::path() const
 
     return item_path;
 }
-
-bool FileTreeItem::isComplete() const
-{
-    return have_size_ == totalSize();
-}

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -82,8 +82,12 @@ public:
         return total_size_;
     }
 
+    [[nodiscard]] constexpr auto isComplete() const noexcept
+    {
+        return have_size_ == totalSize();
+    }
+
     QString path() const;
-    bool isComplete() const;
     int priority() const;
     int isSubtreeWanted() const;
 

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -94,18 +94,7 @@ int Torrent::compareSeedProgress(Torrent const& that) const
 
     double const a_progress = a_ratio / *a_ratio_limit;
     double const b_progress = b_ratio / *b_ratio_limit;
-
-    if (a_progress < b_progress)
-    {
-        return -1;
-    }
-
-    if (a_progress > b_progress)
-    {
-        return 1;
-    }
-
-    return 0;
+    return tr_compare_3way(a_progress, b_progress);
 }
 
 int Torrent::compareRatio(Torrent const& that) const
@@ -128,17 +117,7 @@ int Torrent::compareRatio(Torrent const& that) const
         return -1;
     }
 
-    if (a < b)
-    {
-        return -1;
-    }
-
-    if (a > b)
-    {
-        return 1;
-    }
-
-    return 0;
+    return tr_compare_3way(a, b);
 }
 
 int Torrent::compareETA(Torrent const& that) const

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -6,6 +6,8 @@
 #include <array>
 #include <optional>
 
+#include "libtransmission/utils.h"
+
 #include "Filters.h"
 #include "Prefs.h"
 #include "Torrent.h"
@@ -70,27 +72,6 @@ void TorrentFilter::refilter()
 ****
 ***/
 
-namespace
-{
-
-template<typename T>
-int compare(T const a, T const b)
-{
-    if (a < b)
-    {
-        return -1;
-    }
-
-    if (b < a)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
-} // namespace
-
 bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) const
 {
     int val = 0;
@@ -102,7 +83,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_QUEUE:
         if (val == 0)
         {
-            val = -compare(a->queuePosition(), b->queuePosition());
+            val = -tr_compare_3way(a->queuePosition(), b->queuePosition());
         }
 
         break;
@@ -110,7 +91,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_SIZE:
         if (val == 0)
         {
-            val = compare(a->sizeWhenDone(), b->sizeWhenDone());
+            val = tr_compare_3way(a->sizeWhenDone(), b->sizeWhenDone());
         }
 
         break;
@@ -118,7 +99,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_AGE:
         if (val == 0)
         {
-            val = compare(a->dateAdded(), b->dateAdded());
+            val = tr_compare_3way(a->dateAdded(), b->dateAdded());
         }
 
         break;
@@ -126,7 +107,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_ID:
         if (val == 0)
         {
-            val = compare(a->id(), b->id());
+            val = tr_compare_3way(a->id(), b->id());
         }
 
         break;
@@ -134,12 +115,12 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_ACTIVITY:
         if (val == 0)
         {
-            val = compare(a->downloadSpeed() + a->uploadSpeed(), b->downloadSpeed() + b->uploadSpeed());
+            val = tr_compare_3way(a->downloadSpeed() + a->uploadSpeed(), b->downloadSpeed() + b->uploadSpeed());
         }
 
         if (val == 0)
         {
-            val = compare(
+            val = tr_compare_3way(
                 a->peersWeAreUploadingTo() + a->webseedsWeAreDownloadingFrom(),
                 b->peersWeAreUploadingTo() + b->webseedsWeAreDownloadingFrom());
         }
@@ -149,22 +130,22 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_STATE:
         if (val == 0)
         {
-            val = -compare(a->isPaused(), b->isPaused());
+            val = -tr_compare_3way(a->isPaused(), b->isPaused());
         }
 
         if (val == 0)
         {
-            val = compare(a->getActivity(), b->getActivity());
+            val = tr_compare_3way(a->getActivity(), b->getActivity());
         }
 
         if (val == 0)
         {
-            val = -compare(a->queuePosition(), b->queuePosition());
+            val = -tr_compare_3way(a->queuePosition(), b->queuePosition());
         }
 
         if (val == 0)
         {
-            val = compare(a->hasError(), b->hasError());
+            val = tr_compare_3way(a->hasError(), b->hasError());
         }
 
         [[fallthrough]];
@@ -172,12 +153,12 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
     case SortMode::SORT_BY_PROGRESS:
         if (val == 0)
         {
-            val = compare(a->metadataPercentDone(), b->metadataPercentDone());
+            val = tr_compare_3way(a->metadataPercentDone(), b->metadataPercentDone());
         }
 
         if (val == 0)
         {
-            val = compare(a->percentComplete(), b->percentComplete());
+            val = tr_compare_3way(a->percentComplete(), b->percentComplete());
         }
 
         if (val == 0)
@@ -187,7 +168,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
         if (val == 0)
         {
-            val = -compare(a->queuePosition(), b->queuePosition());
+            val = -tr_compare_3way(a->queuePosition(), b->queuePosition());
         }
 
         [[fallthrough]];
@@ -219,7 +200,7 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
     if (val == 0)
     {
-        val = compare(a->hash(), b->hash());
+        val = tr_compare_3way(a->hash(), b->hash());
     }
 
     return val < 0;


### PR DESCRIPTION
use `tr_compare_3way()` everywhere instead of implementing it again in the `gtk/` and `qt/` clients.