### PR TITLE
refactor: prefer direct-brace-initialization

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -93,10 +93,9 @@ bool loadTranslation(QTranslator& translator, QString const& name, QLocale const
 } // namespace
 
 Application::Application(int& argc, char** argv)
-    : QApplication(argc, argv)
+    : QApplication{ argc, argv }
     , config_name_{ QStringLiteral("transmission") }
     , display_name_{ QStringLiteral("transmission-qt") }
-    , start_now_regex_{ QRegularExpression(QStringLiteral(R"rgx(start-now\((\d+)\))rgx")) }
 {
     setApplicationName(config_name_);
     loadTranslations();
@@ -326,12 +325,11 @@ Application::Application(int& argc, char** argv)
 
     if (!prefs_->getBool(Prefs::USER_HAS_GIVEN_INFORMED_CONSENT))
     {
-        auto* dialog = new QMessageBox(
-            QMessageBox::Information,
-            QString(),
-            tr("<b>Transmission is a file sharing program.</b>"),
-            QMessageBox::Ok | QMessageBox::Cancel,
-            window_.get());
+        auto* dialog = new QMessageBox{ QMessageBox::Information,
+                                        QString{},
+                                        tr("<b>Transmission is a file sharing program.</b>"),
+                                        QMessageBox::Ok | QMessageBox::Cancel,
+                                        window_.get() };
         dialog->setInformativeText(
             tr("When you run a torrent, its data will be made available to others by means of upload. "
                "Any content you share is your sole responsibility."));
@@ -353,8 +351,7 @@ Application::Application(int& argc, char** argv)
     InteropHelper::registerObject(this);
 
 #ifdef QT_DBUS_LIB
-    QDBusConnection bus = QDBusConnection::sessionBus();
-    if (bus.isConnected())
+    if (auto bus = QDBusConnection::sessionBus(); bus.isConnected())
     {
         bus.connect(
             fdo_notifications_service_name_,
@@ -370,7 +367,7 @@ Application::Application(int& argc, char** argv)
 
 void Application::loadTranslations()
 {
-    auto const qt_qm_dirs = QStringList() <<
+    auto const qt_qm_dirs = QStringList{} <<
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         QLibraryInfo::path(QLibraryInfo::TranslationsPath) <<
 #else
@@ -381,7 +378,7 @@ void Application::loadTranslations()
 #endif
         (applicationDirPath() + QStringLiteral("/translations"));
 
-    QStringList const app_qm_dirs = QStringList() <<
+    QStringList const app_qm_dirs = QStringList{} <<
 #ifdef TRANSLATIONS_DIR
         QStringLiteral(TRANSLATIONS_DIR) <<
 #endif
@@ -473,7 +470,7 @@ void Application::onTorrentsNeedInfo(torrent_ids_t const& torrent_ids) const
 void Application::notifyTorrentAdded(Torrent const* tor) const
 {
     QStringList actions;
-    actions << QString(QLatin1String("start-now(%1)")).arg(tor->id()) << QObject::tr("Start Now");
+    actions << QString{ QLatin1String("start-now(%1)") }.arg(tor->id()) << QObject::tr("Start Now");
     notifyApp(tr("Torrent Added"), tor->name(), actions);
 }
 
@@ -592,7 +589,7 @@ void Application::addTorrent(AddData const& addme) const
     }
     else
     {
-        auto* o = new OptionsDialog(*session_, *prefs_, addme, window_.get());
+        auto* o = new OptionsDialog{ *session_, *prefs_, addme, window_.get() };
         o->show();
     }
 

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -118,8 +118,9 @@ private:
     QString const fdo_notifications_service_name_ = QStringLiteral("org.freedesktop.Notifications");
     QString const fdo_notifications_path_ = QStringLiteral("/org/freedesktop/Notifications");
     QString const fdo_notifications_interface_name_ = QStringLiteral("org.freedesktop.Notifications");
-    QRegularExpression const start_now_regex_;
 #endif
+
+    QRegularExpression const start_now_regex_{ QStringLiteral(R"rgx(start-now\((\d+)\))rgx") };
 };
 
 #define trApp dynamic_cast<Application*>(Application::instance())

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -34,7 +34,7 @@ int itemColumnSpan(QGridLayout const* layout, QLayoutItem const* item)
 } // namespace
 
 ColumnResizer::ColumnResizer(QObject* parent)
-    : QObject(parent)
+    : QObject{ parent }
 {
     timer_.setSingleShot(true);
     connect(&timer_, &QTimer::timeout, this, &ColumnResizer::update);

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -242,10 +242,10 @@ private:
 int DetailsDialog::prev_tab_index_ = 0;
 
 DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const& model, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
-    , prefs_(prefs)
-    , model_(model)
+    : BaseDialog{ parent }
+    , session_{ session }
+    , prefs_{ prefs }
+    , model_{ model }
 {
     ui_.setupUi(this);
 
@@ -424,17 +424,16 @@ void setIfIdle(QSpinBox* spin, int value)
 void DetailsDialog::refreshUI()
 {
     bool const single = ids_.size() == 1;
-    QString const blank;
-    QFontMetrics const fm(fontMetrics());
-    QList<Torrent const*> torrents;
-    QString string;
-    QString const none = tr("None");
-    QString const mixed = tr("Mixed");
-    QString const unknown = tr("Unknown");
+    auto const blank = QString{};
+    auto const fm = fontMetrics();
+    auto const none = tr("None");
+    auto const mixed = tr("Mixed");
+    auto const unknown = tr("Unknown");
     auto const now = time(nullptr);
     auto const& fmt = Formatter::get();
 
     // build a list of torrents
+    auto torrents = QList<Torrent const*>{};
     for (int const id : ids_)
     {
         Torrent const* tor = model_.getTorrentFromId(id);
@@ -450,6 +449,7 @@ void DetailsDialog::refreshUI()
     ///
 
     // myStateLabel
+    auto string = QString{};
     if (torrents.empty())
     {
         string = none;
@@ -1115,12 +1115,12 @@ void DetailsDialog::refreshUI()
             }
             else // new peer has connected
             {
-                item = new PeerItem(peer);
+                item = new PeerItem{ peer };
                 item->setTextAlignment(COL_UP, Qt::AlignRight | Qt::AlignVCenter);
                 item->setTextAlignment(COL_DOWN, Qt::AlignRight | Qt::AlignVCenter);
                 item->setTextAlignment(COL_PERCENT, Qt::AlignRight | Qt::AlignVCenter);
                 item->setIcon(COL_LOCK, peer.is_encrypted ? icon_encrypted_ : icon_unencrypted_);
-                item->setToolTip(COL_LOCK, peer.is_encrypted ? tr("Encrypted connection") : QString());
+                item->setToolTip(COL_LOCK, peer.is_encrypted ? tr("Encrypted connection") : QString{});
                 item->setText(COL_ADDRESS, peer.address);
                 item->setText(COL_CLIENT, peer.client_name);
                 new_items << item;
@@ -1201,11 +1201,11 @@ void DetailsDialog::refreshUI()
                 code_tip.resize(code_tip.size() - 1); // eat the trailing linefeed
             }
 
-            item->setText(COL_UP, peer.rate_to_peer.isZero() ? QString() : fmt.speedToString(peer.rate_to_peer));
-            item->setText(COL_DOWN, peer.rate_to_client.isZero() ? QString() : fmt.speedToString(peer.rate_to_client));
+            item->setText(COL_UP, peer.rate_to_peer.isZero() ? QString{} : fmt.speedToString(peer.rate_to_peer));
+            item->setText(COL_DOWN, peer.rate_to_client.isZero() ? QString{} : fmt.speedToString(peer.rate_to_client));
             item->setText(
                 COL_PERCENT,
-                peer.progress > 0 ? QStringLiteral("%1%").arg(static_cast<int>(peer.progress * 100.0)) : QString());
+                peer.progress > 0 ? QStringLiteral("%1%").arg(static_cast<int>(peer.progress * 100.0)) : QString{});
             item->setText(COL_STATUS, code);
             item->setToolTip(COL_STATUS, code_tip);
 
@@ -1249,10 +1249,10 @@ void DetailsDialog::setEnabled(bool enabled)
 
 void DetailsDialog::initInfoTab()
 {
-    int const h = QFontMetrics(ui_.commentBrowser->font()).lineSpacing() * 4;
+    int const h = QFontMetrics{ ui_.commentBrowser->font() }.lineSpacing() * 4;
     ui_.commentBrowser->setFixedHeight(h);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.activitySectionLayout);
     cr->addLayout(ui_.detailsSectionLayout);
     cr->update();
@@ -1417,7 +1417,7 @@ void DetailsDialog::onEditTrackersClicked()
         return;
     }
 
-    auto* dialog = new TrackersDialog(tor->trackerList(), this);
+    auto* dialog = new TrackersDialog{ tor->trackerList(), this };
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(dialog, &TrackersDialog::trackerListEdited, this, &DetailsDialog::onTrackerListEdited);
     dialog->open();
@@ -1471,7 +1471,7 @@ void DetailsDialog::initOptionsTab()
     ui_.idleCombo->addItem(tr("Seed regardless of activity"), TR_IDLELIMIT_UNLIMITED);
     ui_.idleCombo->addItem(tr("Stop seeding if idle for:"), TR_IDLELIMIT_SINGLE);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.speedSectionLayout);
     cr->addLayout(ui_.seedingLimitsSectionRatioLayout);
     cr->addLayout(ui_.seedingLimitsSectionIdleLayout);
@@ -1544,7 +1544,7 @@ void DetailsDialog::initTrackerTab()
 
 void DetailsDialog::initPeersTab()
 {
-    ui_.peersView->setHeaderLabels({ QString(), tr("Up"), tr("Down"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
+    ui_.peersView->setHeaderLabels({ QString{}, tr("Up"), tr("Down"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
     ui_.peersView->sortByColumn(COL_ADDRESS, Qt::AscendingOrder);
 
     ui_.peersView->setColumnWidth(COL_LOCK, 20);

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -46,7 +46,7 @@ public:
     // QWidget
     QSize sizeHint() const override
     {
-        return QSize(440, 460);
+        return QSize{ 440, 460 };
     }
 
 private:

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -18,7 +18,7 @@ QSize FileTreeDelegate::sizeHint(QStyleOptionViewItem const& item, QModelIndex c
     {
     case FileTreeModel::COL_PROGRESS:
     case FileTreeModel::COL_WANTED:
-        size = QSize(20, 1);
+        size = QSize{ 20, 1 };
         break;
 
     default:
@@ -50,7 +50,7 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
         p.state = option.state | QStyle::State_Horizontal | QStyle::State_Small;
         p.direction = QApplication::layoutDirection();
         p.rect = option.rect;
-        p.rect.setSize(QSize(option.rect.width() - 4, option.rect.height() - 8));
+        p.rect.setSize(QSize{ option.rect.width() - 4, option.rect.height() - 8 });
         p.rect.moveCenter(option.rect.center());
         p.fontMetrics = QFontMetrics{ QApplication::font() };
         p.minimum = 0;

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -16,7 +16,7 @@ class FileTreeDelegate : public QItemDelegate
 
 public:
     explicit FileTreeDelegate(QObject* parent = nullptr)
-        : QItemDelegate(parent)
+        : QItemDelegate{ parent }
     {
     }
 

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -28,7 +28,7 @@ public:
     static auto constexpr Normal = int{ 1 << 1 };
     static auto constexpr High = int{ 1 << 2 };
 
-    FileTreeItem(QString const& name = QString(), int file_index = -1, uint64_t size = 0)
+    FileTreeItem(QString const& name = QString{}, int file_index = -1, uint64_t size = 0)
         : name_(name)
         , total_size_(size)
         , file_index_(file_index)

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -20,8 +20,8 @@ class PathIteratorBase
 {
 protected:
     PathIteratorBase(QString const& path, int slash_index)
-        : path_(path)
-        , slash_index_(slash_index)
+        : path_{ path }
+        , slash_index_{ slash_index }
     {
         token_.reserve(path.size() / 2);
     }
@@ -62,7 +62,7 @@ class BackwardPathIterator : public PathIteratorBase
 {
 public:
     explicit BackwardPathIterator(QString const& path)
-        : PathIteratorBase(path, 0)
+        : PathIteratorBase{ path, 0 }
     {
     }
 
@@ -301,7 +301,7 @@ void FileTreeModel::clearSubtree(QModelIndex const& top)
 void FileTreeModel::clear()
 {
     beginResetModel();
-    clearSubtree(QModelIndex());
+    clearSubtree(QModelIndex{});
     root_item_ = std::make_unique<FileTreeItem>();
     endResetModel();
 
@@ -377,11 +377,11 @@ void FileTreeModel::addFile(
 
                 if (!filename_it.hasNext())
                 {
-                    child = new FileTreeItem(token, file_index, total_size);
+                    child = new FileTreeItem{ token, file_index, total_size };
                 }
                 else
                 {
-                    child = new FileTreeItem(token);
+                    child = new FileTreeItem{ token };
                 }
 
                 item->appendChild(child);

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -29,10 +29,10 @@ char const* const PriorityKey = "priority";
 }
 
 FileTreeView::FileTreeView(QWidget* parent, bool is_editable)
-    : QTreeView(parent)
-    , model_(new FileTreeModel(this, is_editable))
-    , proxy_(new QSortFilterProxyModel(this))
-    , delegate_(new FileTreeDelegate(this))
+    : QTreeView{ parent }
+    , model_{ new FileTreeModel(this, is_editable) }
+    , proxy_{ new QSortFilterProxyModel(this) }
+    , delegate_{ new FileTreeDelegate(this) }
 {
     proxy_->setSourceModel(model_);
     proxy_->setSortRole(FileTreeModel::SortRole);
@@ -349,7 +349,7 @@ void FileTreeView::refreshContextMenuActionsSensitivity()
 
 void FileTreeView::initContextMenu()
 {
-    context_menu_ = new QMenu(this);
+    context_menu_ = new QMenu{ this };
 
     check_selected_action_ = context_menu_->addAction(tr("Check Selected"), this, SLOT(checkSelectedItems()));
     uncheck_selected_action_ = context_menu_->addAction(tr("Uncheck Selected"), this, SLOT(uncheckSelectedItems()));

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -38,46 +38,46 @@ enum
 
 FilterBarComboBox* FilterBar::createActivityCombo()
 {
-    auto* c = new FilterBarComboBox(this);
-    auto* delegate = new FilterBarComboBoxDelegate(this, c);
+    auto* c = new FilterBarComboBox{ this };
+    auto* delegate = new FilterBarComboBoxDelegate{ this, c };
     c->setItemDelegate(delegate);
 
-    auto* model = new QStandardItemModel(this);
+    auto* model = new QStandardItemModel{ this };
 
-    auto* row = new QStandardItem(tr("All"));
+    auto* row = new QStandardItem{ tr("All") };
     row->setData(FilterMode::SHOW_ALL, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    model->appendRow(new QStandardItem); // separator
+    model->appendRow(new QStandardItem{}); // separator
     FilterBarComboBoxDelegate::setSeparator(model, model->index(1, 0));
 
     auto const& icons = IconCache::get();
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("system-run")), tr("Active"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("system-run")), tr("Active") };
     row->setData(FilterMode::SHOW_ACTIVE, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("go-down")), tr("Downloading"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("go-down")), tr("Downloading") };
     row->setData(FilterMode::SHOW_DOWNLOADING, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("go-up")), tr("Seeding"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("go-up")), tr("Seeding") };
     row->setData(FilterMode::SHOW_SEEDING, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("media-playback-pause")), tr("Paused"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("media-playback-pause")), tr("Paused") };
     row->setData(FilterMode::SHOW_PAUSED, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("dialog-ok")), tr("Finished"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("dialog-ok")), tr("Finished") };
     row->setData(FilterMode::SHOW_FINISHED, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("view-refresh")), tr("Verifying"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("view-refresh")), tr("Verifying") };
     row->setData(FilterMode::SHOW_VERIFYING, ACTIVITY_ROLE);
     model->appendRow(row);
 
-    row = new QStandardItem(icons.getThemeIcon(QStringLiteral("process-stop")), tr("Error"));
+    row = new QStandardItem{ icons.getThemeIcon(QStringLiteral("process-stop")), tr("Error") };
     row->setData(FilterMode::SHOW_ERROR, ACTIVITY_ROLE);
     model->appendRow(row);
 
@@ -167,7 +167,7 @@ void FilterBar::refreshTrackers()
     {
         if ((old_it == old_end) || ((new_it != new_end) && (old_it->first > new_it->first)))
         {
-            tracker_model_->insertRow(row, update_tracker_item(new QStandardItem(1), new_it));
+            tracker_model_->insertRow(row, update_tracker_item(new QStandardItem{ 1 }, new_it));
             any_added = true;
             ++new_it;
             ++row;
@@ -196,18 +196,18 @@ void FilterBar::refreshTrackers()
 
 FilterBarComboBox* FilterBar::createTrackerCombo(QStandardItemModel* model)
 {
-    auto* c = new FilterBarComboBox(this);
-    auto* delegate = new FilterBarComboBoxDelegate(this, c);
+    auto* c = new FilterBarComboBox{ this };
+    auto* delegate = new FilterBarComboBoxDelegate{ this, c };
     c->setItemDelegate(delegate);
 
-    auto* row = new QStandardItem(tr("All"));
-    row->setData(QString(), TRACKER_ROLE);
+    auto* row = new QStandardItem{ tr("All") };
+    row->setData(QString{}, TRACKER_ROLE);
     int const count = torrents_.rowCount();
     row->setData(count, FilterBarComboBox::CountRole);
     row->setData(getCountString(static_cast<size_t>(count)), FilterBarComboBox::CountStringRole);
     model->appendRow(row);
 
-    model->appendRow(new QStandardItem); // separator
+    model->appendRow(new QStandardItem{}); // separator
     FilterBarComboBoxDelegate::setSeparator(model, model->index(1, 0));
 
     c->setModel(model);
@@ -225,10 +225,10 @@ FilterBar::FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter c
     , filter_(filter)
     , is_bootstrapping_(true)
 {
-    auto* h = new QHBoxLayout(this);
+    auto* h = new QHBoxLayout{ this };
     h->setContentsMargins(3, 3, 3, 3);
 
-    count_label_ = new QLabel(tr("Show:"), this);
+    count_label_ = new QLabel{ tr("Show:"), this };
     h->addWidget(count_label_);
 
     h->addWidget(activity_combo_);
@@ -307,7 +307,7 @@ void FilterBar::refreshPref(int key)
 
                 if (!is_bootstrapping)
                 {
-                    prefs_.set(key, QString());
+                    prefs_.set(key, QString{});
                 }
             }
 

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -22,32 +22,32 @@ int getHSpacing(QWidget const* w)
 } // namespace
 
 FilterBarComboBox::FilterBarComboBox(QWidget* parent)
-    : QComboBox(parent)
+    : QComboBox{ parent }
 {
     setSizeAdjustPolicy(QComboBox::AdjustToContents);
 }
 
 QSize FilterBarComboBox::minimumSizeHint() const
 {
-    QFontMetrics const fm(fontMetrics());
-    QSize const text_size = fm.size(0, itemText(0));
-    QSize const count_size = fm.size(0, itemData(0, CountStringRole).toString());
+    auto const fm = fontMetrics();
+    auto const text_size = fm.size(0, itemText(0));
+    auto const count_size = fm.size(0, itemData(0, CountStringRole).toString());
     return calculateSize(text_size, count_size);
 }
 
 QSize FilterBarComboBox::sizeHint() const
 {
-    QFontMetrics const fm(fontMetrics());
-    QSize max_text_size(0, 0);
-    QSize max_count_size(0, 0);
+    auto const fm = fontMetrics();
+    auto max_text_size = QSize{ 0, 0 };
+    auto max_count_size = QSize{ 0, 0 };
 
     for (int i = 0, n = count(); i < n; ++i)
     {
-        QSize const text_size = fm.size(0, itemText(i));
+        auto const text_size = fm.size(0, itemText(i));
         max_text_size.setHeight(qMax(max_text_size.height(), text_size.height()));
         max_text_size.setWidth(qMax(max_text_size.width(), text_size.width()));
 
-        QSize const count_size = fm.size(0, itemData(i, CountStringRole).toString());
+        auto const count_size = fm.size(0, itemData(i, CountStringRole).toString());
         max_count_size.setHeight(qMax(max_count_size.height(), count_size.height()));
         max_count_size.setWidth(qMax(max_count_size.width(), count_size.width()));
     }
@@ -62,7 +62,7 @@ QSize FilterBarComboBox::calculateSize(QSize const& text_size, QSize const& coun
     QStyleOptionComboBox option;
     initStyleOption(&option);
 
-    QSize content_size = iconSize() + QSize(4, 2);
+    auto content_size = iconSize() + QSize{ 4, 2 };
     content_size.setHeight(qMax(content_size.height(), text_size.height()));
     content_size.rwidth() += hmargin + text_size.width();
     content_size.rwidth() += hmargin + count_size.width();
@@ -74,7 +74,7 @@ void FilterBarComboBox::paintEvent(QPaintEvent* e)
 {
     Q_UNUSED(e)
 
-    QStylePainter painter(this);
+    auto painter = QStylePainter{ this };
     painter.setPen(palette().color(QPalette::Text));
 
     // draw the combobox frame, focusrect and selected etc.
@@ -87,7 +87,7 @@ void FilterBarComboBox::paintEvent(QPaintEvent* e)
 
     if (model_index.isValid())
     {
-        QStyle const* const s = style();
+        auto const* const s = style();
         int const hmargin = getHSpacing(this);
 
         QRect rect = s->subControlRect(QStyle::CC_ComboBox, &opt, QStyle::SC_ComboBoxEditField, this);
@@ -102,7 +102,7 @@ void FilterBarComboBox::paintEvent(QPaintEvent* e)
         }
 
         // draw the count
-        QString text = model_index.data(CountStringRole).toString();
+        auto text = model_index.data(CountStringRole).toString();
 
         if (!text.isEmpty())
         {
@@ -111,7 +111,7 @@ void FilterBarComboBox::paintEvent(QPaintEvent* e)
             QRect const text_rect = QStyle::alignedRect(
                 opt.direction,
                 Qt::AlignRight | Qt::AlignVCenter,
-                QSize(opt.fontMetrics.size(0, text).width(), rect.height()),
+                QSize{ opt.fontMetrics.size(0, text).width(), rect.height() },
                 rect);
             painter.drawText(text_rect, Qt::AlignRight | Qt::AlignVCenter, text);
             Utils::narrowRect(rect, 0, text_rect.width() + hmargin, opt.direction);

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -68,7 +68,7 @@ void FreeSpaceLabel::onTimer()
     tr_variantInitDict(&args, 1);
     dictAdd(&args, TR_KEY_path, path_);
 
-    auto* q = new RpcQueue(this);
+    auto* q = new RpcQueue{ this };
 
     q->add([this, &args]() { return session_->exec("free-space", &args); });
 
@@ -82,7 +82,7 @@ void FreeSpaceLabel::onTimer()
             }
             else
             {
-                setText(QString());
+                setText(QString{});
             }
 
             // update the tooltip

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -100,7 +100,7 @@ QIcon IconCache::getMimeTypeIcon(QString const& mime_type_name, bool multifile) 
     }
 
     auto const mime_icon = getMimeTypeIcon(mime_type_name, false);
-    for (auto const& size : { QSize(24, 24), QSize(32, 32), QSize(48, 48) })
+    for (auto const& size : { QSize{ 24, 24 }, QSize{ 32, 32 }, QSize{ 48, 48 } })
     {
         // upper left corner
         auto const folder_size = size / 2;
@@ -224,7 +224,7 @@ QIcon IconCache::getThemeIcon(
     QString const& fallbackName,
     std::optional<QStyle::StandardPixmap> const& fallbackPixmap) const
 {
-    auto const rtl_suffix = QApplication::layoutDirection() == Qt::RightToLeft ? QStringLiteral("-rtl") : QString();
+    auto const rtl_suffix = QApplication::layoutDirection() == Qt::RightToLeft ? QStringLiteral("-rtl") : QString{};
 
     auto icon = QIcon::fromTheme(name + rtl_suffix);
 

--- a/qt/IconToolButton.cc
+++ b/qt/IconToolButton.cc
@@ -17,19 +17,19 @@ IconToolButton::IconToolButton(QWidget* parent)
 
 QSize IconToolButton::sizeHint() const
 {
-    QStyleOptionToolButton option;
+    auto option = QStyleOptionToolButton{};
     initStyleOption(&option);
     option.features = QStyleOptionToolButton::None;
     option.toolButtonStyle = Qt::ToolButtonIconOnly;
     QSize const size = style()->sizeFromContents(QStyle::CT_ToolButton, &option, iconSize(), this);
 
-    return size.expandedTo(iconSize() + QSize(4, 4));
+    return size.expandedTo(iconSize() + QSize{ 4, 4 });
 }
 
 void IconToolButton::paintEvent(QPaintEvent* /*event*/)
 {
-    QStylePainter painter(this);
-    QStyleOptionToolButton option;
+    auto painter = QStylePainter{ this };
+    auto option = QStyleOptionToolButton{};
     initStyleOption(&option);
     option.features = QStyleOptionToolButton::None;
     option.toolButtonStyle = Qt::ToolButtonIconOnly;

--- a/qt/LicenseDialog.cc
+++ b/qt/LicenseDialog.cc
@@ -6,7 +6,7 @@
 #include "LicenseDialog.h"
 
 LicenseDialog::LicenseDialog(QWidget* parent)
-    : BaseDialog(parent)
+    : BaseDialog{ parent }
 {
     ui_.setupUi(this);
 }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -105,16 +105,16 @@ QIcon MainWindow::addEmblem(QIcon base_icon, QStringList const& emblem_names) co
 
     for (QSize const& size : base_icon.availableSizes())
     {
-        QSize const emblem_size = size / 2;
-        QRect const emblem_rect = QStyle::alignedRect(
+        auto const emblem_size = size / 2;
+        auto const emblem_rect = QStyle::alignedRect(
             layoutDirection(),
             Qt::AlignBottom | Qt::AlignRight,
             emblem_size,
             QRect(QPoint(0, 0), size));
 
-        QPixmap pixmap = base_icon.pixmap(size);
-        QPixmap const emblem_pixmap = emblem_icon.pixmap(emblem_size);
-        QPainter(&pixmap).drawPixmap(emblem_rect, emblem_pixmap, emblem_pixmap.rect());
+        auto pixmap = base_icon.pixmap(size);
+        auto const emblem_pixmap = emblem_icon.pixmap(emblem_size);
+        QPainter{ &pixmap }.drawPixmap(emblem_rect, emblem_pixmap, emblem_pixmap.rect());
 
         icon.addPixmap(pixmap);
     }
@@ -123,19 +123,19 @@ QIcon MainWindow::addEmblem(QIcon base_icon, QStringList const& emblem_names) co
 }
 
 MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool minimized)
-    : session_(session)
-    , prefs_(prefs)
-    , model_(model)
-    , lvp_style_(std::make_shared<ListViewProxyStyle>())
-    , filter_model_(prefs)
-    , torrent_delegate_(new TorrentDelegate(this))
-    , torrent_delegate_min_(new TorrentDelegateMin(this))
-    , network_timer_(this)
-    , refresh_timer_(this)
+    : session_{ session }
+    , prefs_{ prefs }
+    , model_{ model }
+    , lvp_style_{ std::make_shared<ListViewProxyStyle>() }
+    , filter_model_{ prefs }
+    , torrent_delegate_{ new TorrentDelegate{ this } }
+    , torrent_delegate_min_{ new TorrentDelegateMin{ this } }
+    , network_timer_{ this }
+    , refresh_timer_{ this }
 {
     setAcceptDrops(true);
 
-    auto* sep = new QAction(this);
+    auto* sep = new QAction{ this };
     sep->setSeparator(true);
 
     ui_.setupUi(this);
@@ -256,7 +256,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     } };
 
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-    auto* action_group = new QActionGroup(this);
+    auto* action_group = new QActionGroup{ this };
 
     for (auto const& [action, mode] : sort_modes)
     {
@@ -267,12 +267,12 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     connect(action_group, &QActionGroup::triggered, this, &MainWindow::onSortModeChanged);
 
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-    alt_speed_action_ = new QAction(tr("Speed Limits"), this);
+    alt_speed_action_ = new QAction{ tr("Speed Limits"), this };
     alt_speed_action_->setIcon(ui_.altSpeedButton->icon());
     alt_speed_action_->setCheckable(true);
     connect(alt_speed_action_, &QAction::triggered, this, &MainWindow::toggleSpeedMode);
 
-    auto* menu = new QMenu(this);
+    auto* menu = new QMenu{ this };
     menu->addAction(ui_.action_OpenFile);
     menu->addAction(ui_.action_AddURL);
     menu->addSeparator();
@@ -295,7 +295,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     ui_.action_TrayIcon->setChecked(minimized || prefs.getBool(Prefs::SHOW_TRAY_ICON));
 
     initStatusBar();
-    auto* filter_bar = new FilterBar(prefs_, model_, filter_model_);
+    auto* filter_bar = new FilterBar{ prefs_, model_, filter_model_ };
     ui_.verticalLayout->insertWidget(0, filter_bar);
     filter_bar_ = filter_bar;
 
@@ -408,7 +408,7 @@ QMenu* MainWindow::createOptionsMenu()
         int const current_value = prefs_.get<int>(pref);
 
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-        auto* action_group = new QActionGroup(this);
+        auto* action_group = new QActionGroup{ this };
 
         off_action = menu->addAction(tr("Unlimited"));
         off_action->setCheckable(true);
@@ -438,7 +438,7 @@ QMenu* MainWindow::createOptionsMenu()
         static constexpr std::array<double, 7> StockRatios = { 0.25, 0.50, 0.75, 1, 1.5, 2, 3 };
         auto const current_value = prefs_.get<double>(pref);
 
-        auto* action_group = new QActionGroup(this);
+        auto* action_group = new QActionGroup{ this };
 
         off_action = menu->addAction(tr("Seed Forever"));
         off_action->setCheckable(true);
@@ -462,7 +462,7 @@ QMenu* MainWindow::createOptionsMenu()
         }
     };
 
-    auto* menu = new QMenu(this);
+    auto* menu = new QMenu{ this };
 
     init_speed_sub_menu(
         menu->addMenu(tr("Limit Download Speed")),
@@ -498,12 +498,12 @@ QMenu* MainWindow::createStatsModeMenu()
         { ui_.action_SessionTransfer, session_transfer_stats_mode_name_ },
     } };
 
-    auto* action_group = new QActionGroup(this);
-    auto* menu = new QMenu(this);
+    auto* action_group = new QActionGroup{ this };
+    auto* menu = new QMenu{ this };
 
     for (auto const& mode : stats_modes)
     {
-        mode.first->setProperty(StatsModeKey, QString(mode.second));
+        mode.first->setProperty(StatsModeKey, QString{ mode.second });
         action_group->addAction(mode.first);
         menu->addAction(mode.first);
     }
@@ -575,7 +575,7 @@ void MainWindow::openProperties()
 
 void MainWindow::setLocation()
 {
-    auto* d = new RelocateDialog(session_, model_, getSelectedTorrents(), this);
+    auto* d = new RelocateDialog{ session_, model_, getSelectedTorrents(), this };
     d->setAttribute(Qt::WA_DeleteOnClose, true);
     d->show();
 }
@@ -866,7 +866,7 @@ void MainWindow::refreshTorrentViewHeader()
 
     if (visible_count == total_count)
     {
-        ui_.listView->setHeaderText(QString());
+        ui_.listView->setHeaderText(QString{});
     }
     else
     {
@@ -1265,24 +1265,23 @@ void MainWindow::refreshPref(int key)
 
 void MainWindow::newTorrent()
 {
-    auto* dialog = new MakeDialog(session_, this);
+    auto* dialog = new MakeDialog{ session_, this };
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
 }
 
 void MainWindow::openTorrent()
 {
-    auto* const d = new QFileDialog(
-        this,
-        tr("Open Torrent"),
-        prefs_.getString(Prefs::OPEN_DIALOG_FOLDER),
-        tr("Torrent Files (*.torrent);;All Files (*.*)"));
+    auto* const d = new QFileDialog{ this,
+                                     tr("Open Torrent"),
+                                     prefs_.getString(Prefs::OPEN_DIALOG_FOLDER),
+                                     tr("Torrent Files (*.torrent);;All Files (*.*)") };
     d->setFileMode(QFileDialog::ExistingFiles);
     d->setAttribute(Qt::WA_DeleteOnClose);
 
     if (auto* const l = qobject_cast<QGridLayout*>(d->layout()); l != nullptr)
     {
-        auto* b = new QCheckBox(tr("Show &options dialog"));
+        auto* b = new QCheckBox{ tr("Show &options dialog") };
         b->setChecked(prefs_.getBool(Prefs::OPTIONS_PROMPT));
         b->setObjectName(show_options_checkbox_name_);
         l->addWidget(b, l->rowCount(), 0, 1, -1, Qt::AlignLeft);
@@ -1334,7 +1333,7 @@ void MainWindow::addTorrent(AddData add_me, bool show_options)
 {
     if (show_options)
     {
-        auto* o = new OptionsDialog(session_, prefs_, std::move(add_me), this);
+        auto* o = new OptionsDialog{ session_, prefs_, std::move(add_me), this };
         o->show();
         QApplication::alert(o);
     }
@@ -1433,11 +1432,11 @@ void MainWindow::removeTorrents(bool const delete_files)
 
     if (layout == nullptr)
     {
-        layout = new QGridLayout;
+        layout = new QGridLayout{};
         msg_box.setLayout(layout);
     }
 
-    auto* spacer = new QSpacerItem(450, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    auto* spacer = new QSpacerItem{ 450, 0, QSizePolicy::Minimum, QSizePolicy::Expanding };
     layout->addItem(spacer, layout->rowCount(), 0, 1, layout->columnCount());
 
     if (msg_box.exec() == QMessageBox::Ok)

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -63,11 +63,11 @@ MakeProgressDialog::MakeProgressDialog(
     std::future<tr_error*> future,
     QString outfile,
     QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
-    , builder_(builder)
-    , future_(std::move(future))
-    , outfile_(std::move(outfile))
+    : BaseDialog{ parent }
+    , session_{ session }
+    , builder_{ builder }
+    , future_{ std::move(future) }
+    , outfile_{ std::move(outfile) }
 {
     ui_.setupUi(this);
 
@@ -193,7 +193,7 @@ void MakeDialog::makeTorrent()
     builder_->set_private(ui_.privateCheck->isChecked());
 
     // pop up the dialog
-    auto* dialog = new MakeProgressDialog(session_, *builder_, builder_->make_checksums(), outfile, this);
+    auto* dialog = new MakeProgressDialog{ session_, *builder_, builder_->make_checksums(), outfile, this };
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->open();
 }
@@ -242,7 +242,7 @@ MakeDialog::MakeDialog(Session& session, QWidget* parent)
     ui_.sourceFolderButton->setMode(PathButton::DirectoryMode);
     ui_.sourceFileButton->setMode(PathButton::FileMode);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.filesSectionLayout);
     cr->addLayout(ui_.propertiesSectionLayout);
     cr->update();
@@ -277,8 +277,8 @@ void MakeDialog::dragEnterEvent(QDragEnterEvent* event)
 
 void MakeDialog::dropEvent(QDropEvent* event)
 {
-    QString const filename = event->mimeData()->urls().front().path();
-    QFileInfo const file_info(filename);
+    auto const filename = event->mimeData()->urls().front().path();
+    auto const file_info = QFileInfo{ filename };
 
     if (file_info.exists())
     {

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -32,10 +32,10 @@ using ::trqt::variant_helpers::listAdd;
 ***/
 
 OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme, QWidget* parent)
-    : BaseDialog(parent)
-    , add_(std::move(addme))
-    , session_(session)
-    , is_local_(session_.isLocal())
+    : BaseDialog{ parent }
+    , add_{ std::move(addme) }
+    , session_{ session }
+    , is_local_{ session_.isLocal() }
 {
     ui_.setupUi(this);
 
@@ -65,11 +65,11 @@ OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme
     ui_.sourceStack->setFixedHeight(ui_.sourceStack->currentWidget()->sizeHint().height());
     ui_.sourceLabel->setBuddy(ui_.sourceStack->currentWidget());
 
-    QFontMetrics const font_metrics(font());
+    auto const font_metrics = QFontMetrics{ font() };
     int const width = font_metrics.size(0, QStringLiteral("This is a pretty long torrent filename indeed.torrent")).width();
     ui_.sourceStack->setMinimumWidth(width);
 
-    QString const download_dir(Utils::removeTrailingDirSeparator(prefs.getString(Prefs::DOWNLOAD_DIR)));
+    auto const download_dir = Utils::removeTrailingDirSeparator(prefs.getString(Prefs::DOWNLOAD_DIR));
     ui_.freeSpaceLabel->setSession(session_);
     ui_.freeSpaceLabel->setPath(download_dir);
 

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -16,9 +16,9 @@
 #include "Utils.h"
 
 PathButton::PathButton(QWidget* parent)
-    : QToolButton(parent)
+    : QToolButton{ parent }
 {
-    setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed));
+    setSizePolicy(QSizePolicy{ QSizePolicy::Preferred, QSizePolicy::Fixed });
     setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     setText(tr("(None)")); // for minimum width
 
@@ -70,13 +70,13 @@ QString const& PathButton::path() const
 
 QSize PathButton::sizeHint() const
 {
-    QSize const sh(QToolButton::sizeHint());
+    auto const sh = QToolButton::sizeHint();
     return { qMin(sh.width(), 150), sh.height() };
 }
 
 void PathButton::paintEvent(QPaintEvent* /*event*/)
 {
-    QStylePainter painter(this);
+    auto painter = QStylePainter{ this };
     QStyleOptionToolButton option;
     initStyleOption(&option);
 
@@ -99,7 +99,7 @@ void PathButton::paintEvent(QPaintEvent* /*event*/)
 
 void PathButton::onClicked() const
 {
-    auto* dialog = new QFileDialog(window(), effectiveTitle());
+    auto* dialog = new QFileDialog{ window(), effectiveTitle() };
     dialog->setFileMode(isDirMode() ? QFileDialog::Directory : QFileDialog::ExistingFile);
 
     if (isDirMode())
@@ -141,7 +141,7 @@ void PathButton::onFileSelected(QString const& path)
 
 void PathButton::updateAppearance()
 {
-    QFileInfo const path_info(path_);
+    QFileInfo const path_info{ path_ };
 
     int const icon_size(style()->pixelMetric(QStyle::PM_SmallIconSize));
     QFileIconProvider const icon_provider;
@@ -158,9 +158,9 @@ void PathButton::updateAppearance()
         icon = icon_provider.icon(isDirMode() ? QFileIconProvider::Folder : QFileIconProvider::File);
     }
 
-    setIconSize(QSize(icon_size, icon_size));
+    setIconSize(QSize{ icon_size, icon_size });
     setIcon(icon);
-    setToolTip(path_ == text() ? QString() : path_);
+    setToolTip(path_ == text() ? QString{} : path_);
 
     update();
 }

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -190,8 +190,8 @@ bool isValidUtf8(QByteArray const& byteArray)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 
-    auto decoder = QStringDecoder(QStringConverter::Utf8, QStringConverter::Flag::Stateless);
-    auto const text = QString(decoder.decode(byteArray));
+    auto decoder = QStringDecoder{ QStringConverter::Utf8, QStringConverter::Flag::Stateless };
+    auto const text = QString{ decoder.decode(byteArray) };
     return !decoder.hasError() && !text.contains(QChar::ReplacementCharacter);
 
 #else

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -49,7 +49,7 @@ class PreferenceWidget
 
 public:
     explicit PreferenceWidget(QObject* object)
-        : object_(object)
+        : object_{ object }
     {
     }
 
@@ -155,7 +155,7 @@ QString qtDayName(int day)
 
 bool PrefsDialog::updateWidgetValue(QWidget* widget, int pref_key) const
 {
-    PreferenceWidget pref_widget(widget);
+    auto pref_widget = PreferenceWidget{ widget };
 
     if (pref_widget.is<QCheckBox>())
     {
@@ -199,7 +199,7 @@ bool PrefsDialog::updateWidgetValue(QWidget* widget, int pref_key) const
 
 void PrefsDialog::linkWidgetToPref(QWidget* widget, int pref_key)
 {
-    PreferenceWidget pref_widget(widget);
+    auto pref_widget = PreferenceWidget{ widget };
 
     pref_widget.setPrefKey(pref_key);
     updateWidgetValue(widget, pref_key);
@@ -279,7 +279,7 @@ void PrefsDialog::focusChanged(QWidget* old, QWidget* cur)
 
 void PrefsDialog::checkBoxToggled(bool checked)
 {
-    PreferenceWidget const pref_widget(sender());
+    auto const pref_widget = PreferenceWidget{ sender() };
 
     if (pref_widget.is<QCheckBox>())
     {
@@ -289,7 +289,7 @@ void PrefsDialog::checkBoxToggled(bool checked)
 
 void PrefsDialog::spinBoxEditingFinished()
 {
-    PreferenceWidget const pref_widget(sender());
+    auto const pref_widget = PreferenceWidget{ sender() };
 
     if (pref_widget.is<QDoubleSpinBox>())
     {
@@ -303,7 +303,7 @@ void PrefsDialog::spinBoxEditingFinished()
 
 void PrefsDialog::timeEditingFinished()
 {
-    PreferenceWidget const pref_widget(sender());
+    auto const pref_widget = PreferenceWidget{ sender() };
 
     if (pref_widget.is<QTimeEdit>())
     {
@@ -313,7 +313,7 @@ void PrefsDialog::timeEditingFinished()
 
 void PrefsDialog::lineEditingFinished()
 {
-    PreferenceWidget const pref_widget(sender());
+    auto const pref_widget = PreferenceWidget{ sender() };
 
     if (pref_widget.is<QLineEdit>())
     {
@@ -328,7 +328,7 @@ void PrefsDialog::lineEditingFinished()
 
 void PrefsDialog::pathChanged(QString const& path)
 {
-    PreferenceWidget const pref_widget(sender());
+    auto const pref_widget = PreferenceWidget{ sender() };
 
     if (pref_widget.is<PathButton>())
     {
@@ -410,7 +410,7 @@ void PrefsDialog::initSpeedTab()
     sched_widgets_ << ui_.altSpeedLimitStartTimeEdit << ui_.altSpeedLimitToLabel << ui_.altSpeedLimitEndTimeEdit
                    << ui_.altSpeedLimitDaysLabel << ui_.altSpeedLimitDaysCombo;
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.speedLimitsSectionLayout);
     cr->addLayout(ui_.altSpeedLimitsSectionLayout);
     cr->update();
@@ -466,7 +466,7 @@ void PrefsDialog::initNetworkTab()
     linkWidgetToPref(ui_.enableLpdCheck, Prefs::LPD_ENABLED);
     linkWidgetToPref(ui_.defaultTrackersPlainTextEdit, Prefs::DEFAULT_TRACKERS);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.incomingPeersSectionLayout);
     cr->addLayout(ui_.peerLimitsSectionLayout);
     cr->update();
@@ -500,12 +500,11 @@ void PrefsDialog::onBlocklistUpdated(int n)
 
 void PrefsDialog::onUpdateBlocklistClicked()
 {
-    blocklist_dialog_ = new QMessageBox(
-        QMessageBox::Information,
-        QString(),
-        tr("<b>Update Blocklist</b><p>Getting new blocklist…</p>"),
-        QMessageBox::Close,
-        this);
+    blocklist_dialog_ = new QMessageBox{ QMessageBox::Information,
+                                         QString{},
+                                         tr("<b>Update Blocklist</b><p>Getting new blocklist…</p>"),
+                                         QMessageBox::Close,
+                                         this };
     connect(blocklist_dialog_, &QDialog::rejected, this, &PrefsDialog::onUpdateBlocklistCancelled);
     connect(&session_, &Session::blocklistUpdated, this, &PrefsDialog::onBlocklistUpdated);
     blocklist_dialog_->show();
@@ -532,7 +531,7 @@ void PrefsDialog::initPrivacyTab()
     block_widgets_ << ui_.blocklistEdit << ui_.blocklistStatusLabel << ui_.updateBlocklistButton
                    << ui_.autoUpdateBlocklistCheck;
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.encryptionSectionLayout);
     cr->addLayout(ui_.blocklistSectionLayout);
     cr->update();
@@ -619,7 +618,7 @@ void PrefsDialog::initDownloadingTab()
     linkWidgetToPref(ui_.doneDownloadingScriptButton, Prefs::SCRIPT_TORRENT_DONE_FILENAME);
     linkWidgetToPref(ui_.doneDownloadingScriptEdit, Prefs::SCRIPT_TORRENT_DONE_FILENAME);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.addingSectionLayout);
     cr->addLayout(ui_.downloadQueueSectionLayout);
     cr->addLayout(ui_.incompleteSectionLayout);

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -27,9 +27,9 @@ void RelocateDialog::onMoveToggled(bool b) const
 }
 
 RelocateDialog::RelocateDialog(Session& session, TorrentModel const& model, torrent_ids_t ids, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
-    , ids_(std::move(ids))
+    : BaseDialog{ parent }
+    , session_{ session }
+    , ids_{ std::move(ids) }
 {
     ui_.setupUi(this);
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -45,7 +45,7 @@ TrVariantPtr createVariant()
 } // namespace
 
 RpcClient::RpcClient(QObject* parent)
-    : QObject(parent)
+    : QObject{ parent }
 {
     qRegisterMetaType<TrVariantPtr>("TrVariantPtr");
 }
@@ -198,7 +198,7 @@ QNetworkAccessManager* RpcClient::networkAccessManager()
 {
     if (nam_ == nullptr)
     {
-        nam_ = new QNetworkAccessManager();
+        nam_ = new QNetworkAccessManager{};
 
         connect(nam_, &QNetworkAccessManager::finished, this, &RpcClient::networkRequestFinished);
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -83,7 +83,7 @@ void Session::sessionSet(tr_quark const key, QVariant const& value)
 
 void Session::portTest()
 {
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this]() { return exec("port-test", nullptr); });
 
@@ -117,7 +117,7 @@ void Session::copyMagnetLinkToClipboard(int torrent_id)
     dictAdd(&args, TR_KEY_ids, std::array<int, 1>{ torrent_id });
     dictAdd(&args, TR_KEY_fields, Fields);
 
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this, &args]() { return exec(TR_KEY_torrent_get, &args); });
 
@@ -290,8 +290,8 @@ void Session::updatePref(int key)
 ***/
 
 Session::Session(QString config_dir, Prefs& prefs)
-    : config_dir_(std::move(config_dir))
-    , prefs_(prefs)
+    : config_dir_{ std::move(config_dir) }
+    , prefs_{ prefs }
 {
     connect(&prefs_, &Prefs::changed, this, &Session::updatePref);
     connect(&rpc_, &RpcClient::httpAuthenticationRequired, this, &Session::httpAuthenticationRequired);
@@ -407,7 +407,7 @@ void Session::addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent
 
 Session::Tag Session::torrentSetImpl(tr_variant* args)
 {
-    auto* const q = new RpcQueue();
+    auto* const q = new RpcQueue{};
     auto const tag = q->tag();
 
     q->add([this, args]() { return rpc_.exec(TR_KEY_torrent_set, args); });
@@ -491,7 +491,7 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
     dictAdd(&args, TR_KEY_path, oldpath);
     dictAdd(&args, TR_KEY_name, newname);
 
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add(
         [this, &args]() { return exec("torrent-rename-path", &args); },
@@ -500,7 +500,7 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
             auto const path = dictFind<QString>(r.args.get(), TR_KEY_path).value_or(QStringLiteral("(unknown)"));
             auto const name = dictFind<QString>(r.args.get(), TR_KEY_name).value_or(QStringLiteral("(unknown)"));
 
-            auto* d = new QMessageBox(
+            auto* d = new QMessageBox{
                 QMessageBox::Information,
                 tr("Error Renaming Path"),
                 tr(R"(<p><b>Unable to rename "%1" as "%2": %3.</b></p><p>Please correct the errors and try again.</p>)")
@@ -508,7 +508,8 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
                     .arg(name)
                     .arg(r.result),
                 QMessageBox::Close,
-                QApplication::activeWindow());
+                QApplication::activeWindow()
+            };
             QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
             d->show();
         });
@@ -661,7 +662,7 @@ void Session::refreshTorrents(torrent_ids_t const& torrent_ids, TorrentPropertie
     dictAdd(&args, TR_KEY_fields, getKeyNames(props));
     addOptionalIds(&args, torrent_ids);
 
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this, &args]() { return exec(TR_KEY_torrent_get, &args); });
 
@@ -702,7 +703,7 @@ void Session::sendTorrentRequest(std::string_view request, torrent_ids_t const& 
     tr_variantInitDict(&args, 1);
     addOptionalIds(&args, torrent_ids);
 
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this, request, &args]() { return exec(request, &args); });
 
@@ -766,7 +767,7 @@ void Session::initTorrents(torrent_ids_t const& ids)
 
 void Session::refreshSessionStats()
 {
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this]() { return exec("session-stats", nullptr); });
 
@@ -777,7 +778,7 @@ void Session::refreshSessionStats()
 
 void Session::refreshSessionInfo()
 {
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this]() { return exec("session-get", nullptr); });
 
@@ -788,7 +789,7 @@ void Session::refreshSessionInfo()
 
 void Session::updateBlocklist()
 {
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add([this]() { return exec("blocklist-update", nullptr); });
 
@@ -1023,18 +1024,17 @@ void Session::addTorrent(AddData add_me, tr_variant* args_dict, bool trash_origi
         break;
     }
 
-    auto* q = new RpcQueue();
+    auto* q = new RpcQueue{};
 
     q->add(
         [this, args_dict]() { return exec("torrent-add", args_dict); },
         [add_me](RpcResponse const& r)
         {
-            auto* d = new QMessageBox(
-                QMessageBox::Warning,
-                tr("Error Adding Torrent"),
-                QStringLiteral("<p><b>%1</b></p><p>%2</p>").arg(r.result).arg(add_me.readableName()),
-                QMessageBox::Close,
-                QApplication::activeWindow());
+            auto* d = new QMessageBox{ QMessageBox::Warning,
+                                       tr("Error Adding Torrent"),
+                                       QStringLiteral("<p><b>%1</b></p><p>%2</p>").arg(r.result).arg(add_me.readableName()),
+                                       QMessageBox::Close,
+                                       QApplication::activeWindow() };
             QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
             d->show();
         });
@@ -1100,7 +1100,7 @@ void Session::onDuplicatesTimer()
         auto const use_detail = lines.size() > 1;
         auto const text = use_detail ? detail_text : detail;
 
-        auto* d = new QMessageBox(QMessageBox::Warning, title, text, QMessageBox::Close, QApplication::activeWindow());
+        auto* d = new QMessageBox{ QMessageBox::Warning, title, text, QMessageBox::Close, QApplication::activeWindow() };
         if (use_detail)
         {
             d->setDetailedText(detail);

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -44,9 +44,9 @@ void SessionDialog::resensitize() const
 ***/
 
 SessionDialog::SessionDialog(Session& session, Prefs& prefs, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
-    , prefs_(prefs)
+    : BaseDialog{ parent }
+    , session_{ session }
+    , prefs_{ prefs }
 {
     ui_.setupUi(this);
 

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -46,12 +46,12 @@
 #include "SqueezeLabel.h"
 
 SqueezeLabel::SqueezeLabel(QString const& text, QWidget* parent)
-    : QLabel(text, parent)
+    : QLabel{ text, parent }
 {
 }
 
 SqueezeLabel::SqueezeLabel(QWidget* parent)
-    : QLabel(parent)
+    : QLabel{ parent }
 {
 }
 
@@ -62,9 +62,9 @@ void SqueezeLabel::paintEvent(QPaintEvent* paint_event)
         return QLabel::paintEvent(paint_event);
     }
 
-    QPainter painter(this);
-    QFontMetrics const fm = fontMetrics();
-    QStyleOption opt;
+    auto painter = QPainter{ this };
+    auto const fm = fontMetrics();
+    auto opt = QStyleOption{};
     opt.initFrom(this);
     auto const full_text = text();
     auto const elided_text = fm.elidedText(full_text, Qt::ElideRight, width());

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -16,12 +16,12 @@ enum
 };
 
 StatsDialog::StatsDialog(Session& session, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
+    : BaseDialog{ parent }
+    , session_{ session }
 {
     ui_.setupUi(this);
 
-    auto* cr = new ColumnResizer(this);
+    auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.currentSessionSectionLayout);
     cr->addLayout(ui_.totalSectionLayout);
     cr->update();

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -23,8 +23,8 @@
 using ::trqt::variant_helpers::change;
 
 Torrent::Torrent(Prefs const& prefs, int id)
-    : id_(id)
-    , prefs_(prefs)
+    : id_{ id }
+    , prefs_{ prefs }
 {
 }
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -84,7 +84,7 @@ public:
 private:
     [[nodiscard]] QString elidedText(QFont const& font, QString const& text, int width) const
     {
-        return QFontMetrics(font).elidedText(text, Qt::ElideRight, width);
+        return QFontMetrics{ font }.elidedText(text, Qt::ElideRight, width);
     }
 };
 
@@ -97,29 +97,29 @@ ItemLayout::ItemLayout(
     Qt::LayoutDirection direction,
     QPoint const& top_left,
     int width)
-    : name_text_(std::move(name_text))
-    , status_text_(std::move(status_text))
-    , progress_text_(std::move(progress_text))
-    , name_font(base_font)
-    , status_font(base_font)
-    , progress_font(base_font)
+    : name_text_{ std::move(name_text) }
+    , status_text_{ std::move(status_text) }
+    , progress_text_{ std::move(progress_text) }
+    , name_font{ base_font }
+    , status_font{ base_font }
+    , progress_font{ base_font }
 {
     QStyle const* style = QApplication::style();
     int const icon_size(style->pixelMetric(QStyle::PM_LargeIconSize));
 
     name_font.setWeight(QFont::Bold);
-    QFontMetrics const name_fm(name_font);
-    QSize const name_size(name_fm.size(0, name_text_));
+    auto const name_fm = QFontMetrics{ name_font };
+    auto const name_size = name_fm.size(0, name_text_);
 
     status_font.setPointSize(static_cast<int>(status_font.pointSize() * 0.9));
-    QFontMetrics const status_fm(status_font);
-    QSize const status_size(status_fm.size(0, status_text_));
+    auto const status_fm = QFontMetrics{ status_font };
+    auto const status_size = status_fm.size(0, status_text_);
 
     progress_font.setPointSize(static_cast<int>(progress_font.pointSize() * 0.9));
-    QFontMetrics const progress_fm(progress_font);
-    QSize const progress_size(progress_fm.size(0, progress_text_));
+    auto const progress_fm = QFontMetrics{ progress_font };
+    auto const progress_size = progress_fm.size(0, progress_text_);
 
-    QRect base_rect(top_left, QSize(width, 0));
+    auto base_rect = QRect{ top_left, QSize{ width, 0 } };
     Utils::narrowRect(base_rect, icon_size + GUI_PAD, 0, direction);
 
     name_rect = base_rect.adjusted(0, 0, 0, name_size.height());
@@ -129,8 +129,8 @@ ItemLayout::ItemLayout(
     icon_rect = QStyle::alignedRect(
         direction,
         Qt::AlignLeft | Qt::AlignVCenter,
-        QSize(icon_size, icon_size),
-        QRect(top_left, QSize(width, progress_rect.bottom() - name_rect.top())));
+        QSize{ icon_size, icon_size },
+        QRect{ top_left, QSize{ width, progress_rect.bottom() - name_rect.top() } });
     emblem_rect = QStyle::alignedRect(
         direction,
         Qt::AlignRight | Qt::AlignBottom,
@@ -400,15 +400,8 @@ QString TorrentDelegate::statusString(Torrent const& tor)
 QSize TorrentDelegate::sizeHint(QStyleOptionViewItem const& option, Torrent const& tor) const
 {
     auto const m = margin(*QApplication::style());
-    auto const layout = ItemLayout(
-        tor.name(),
-        progressString(tor),
-        statusString(tor),
-        QIcon(),
-        option.font,
-        option.direction,
-        QPoint(0, 0),
-        option.rect.width() - m.width() * 2);
+    auto const layout = ItemLayout{ tor.name(),  progressString(tor), statusString(tor), QIcon{},
+                                    option.font, option.direction,    QPoint(0, 0),      option.rect.width() - m.width() * 2 };
     return layout.size() + m * 2;
 }
 
@@ -538,21 +531,14 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     progress_bar_state |= QStyle::State_Small | QStyle::State_Horizontal;
 
-    QIcon::Mode const emblem_im = is_item_selected ? QIcon::Selected : QIcon::Normal;
-    QIcon const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon();
+    auto const emblem_im = is_item_selected ? QIcon::Selected : QIcon::Normal;
+    auto const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon{};
 
     // layout
-    QSize const m(margin(*style));
-    QRect const content_rect(option.rect.adjusted(m.width(), m.height(), -m.width(), -m.height()));
-    ItemLayout const layout(
-        tor.name(),
-        progressString(tor),
-        statusString(tor),
-        emblem_icon,
-        option.font,
-        option.direction,
-        content_rect.topLeft(),
-        content_rect.width());
+    auto const m = margin(*style);
+    auto const content_rect = QRect{ option.rect.adjusted(m.width(), m.height(), -m.width(), -m.height()) };
+    auto const layout = ItemLayout{ tor.name(),  progressString(tor), statusString(tor),      emblem_icon,
+                                    option.font, option.direction,    content_rect.topLeft(), content_rect.width() };
 
     // render
     if (tor.hasError() && !is_item_selected)

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -88,7 +88,7 @@ private:
 
     [[nodiscard]] QString elidedText(QFont const& font, QString const& text, int width) const
     {
-        return QFontMetrics(font).elidedText(text, Qt::ElideRight, width);
+        return QFontMetrics{ font }.elidedText(text, Qt::ElideRight, width);
     }
 };
 
@@ -100,23 +100,23 @@ ItemLayout::ItemLayout(
     Qt::LayoutDirection direction,
     QPoint const& top_left,
     int width)
-    : name_font(base_font)
-    , status_font(base_font)
-    , name_text_(std::move(name_text))
-    , status_text_(std::move(status_text))
+    : name_font{ base_font }
+    , status_font{ base_font }
+    , name_text_{ std::move(name_text) }
+    , status_text_{ std::move(status_text) }
 {
     auto const* style = QApplication::style();
     int const icon_size = style->pixelMetric(QStyle::PM_SmallIconSize);
 
-    auto const name_fm = QFontMetrics(name_font);
+    auto const name_fm = QFontMetrics{ name_font };
     auto const name_size = name_fm.size(0, name_text_);
 
     status_font.setPointSize(static_cast<int>(status_font.pointSize() * 0.85));
-    QFontMetrics const status_fm(status_font);
+    auto const status_fm = QFontMetrics{ status_font };
     QSize const status_size(status_fm.size(0, status_text_));
 
     QStyleOptionProgressBar bar_style;
-    bar_style.rect = QRect(0, 0, BAR_WIDTH, BAR_HEIGHT);
+    bar_style.rect = QRect{ 0, 0, BAR_WIDTH, BAR_HEIGHT };
     bar_style.maximum = 100;
     bar_style.progress = 100;
     bar_style.textVisible = true;
@@ -124,11 +124,10 @@ ItemLayout::ItemLayout(
         bar_style.rect.width() * 2 - style->subElementRect(QStyle::SE_ProgressBarGroove, &bar_style).width(),
         bar_style.rect.height());
 
-    QRect base_rect(
-        top_left,
-        QSize(width, std::max({ icon_size, name_size.height(), status_size.height(), bar_size.height() })));
+    QRect base_rect{ top_left,
+                     QSize{ width, std::max({ icon_size, name_size.height(), status_size.height(), bar_size.height() }) } };
 
-    icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize(icon_size, icon_size), base_rect);
+    icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignVCenter, QSize{ icon_size, icon_size }, base_rect);
     emblem_rect = QStyle::alignedRect(
         direction,
         Qt::AlignRight | Qt::AlignBottom,
@@ -139,7 +138,7 @@ ItemLayout::ItemLayout(
     status_rect = QStyle::alignedRect(
         direction,
         Qt::AlignRight | Qt::AlignVCenter,
-        QSize(status_size.width(), base_rect.height()),
+        QSize{ status_size.width(), base_rect.height() },
         base_rect);
     Utils::narrowRect(base_rect, 0, status_rect.width() + GUI_PAD, direction);
     name_rect = base_rect;
@@ -225,7 +224,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     progress_bar_state |= QStyle::State_Small | QStyle::State_Horizontal;
 
     QIcon::Mode const emblem_im = is_item_selected ? QIcon::Selected : QIcon::Normal;
-    QIcon const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon();
+    QIcon const emblem_icon = tor.hasError() ? getWarningEmblem() : QIcon{};
 
     // layout
     QSize const m(margin(*style));

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -242,7 +242,7 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
 
         if (tor == nullptr)
         {
-            tor = new Torrent(prefs_, *id);
+            tor = new Torrent{ prefs_, *id };
             instantiated.push_back(tor);
             is_new = true;
         }
@@ -433,9 +433,9 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
 
     if (torrents_.empty())
     {
-        beginInsertRows(QModelIndex(), 0, torrents.size() - 1);
+        beginInsertRows(QModelIndex{}, 0, torrents.size() - 1);
         torrents_ = torrents;
-        std::sort(torrents_.begin(), torrents_.end(), TorrentIdLessThan());
+        std::sort(torrents_.begin(), torrents_.end(), TorrentIdLessThan{});
         endInsertRows();
     }
     else
@@ -445,7 +445,7 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
             auto const it = std::lower_bound(torrents_.begin(), torrents_.end(), tor, compare);
             auto const row = static_cast<int>(std::distance(torrents_.begin(), it));
 
-            beginInsertRows(QModelIndex(), row, row);
+            beginInsertRows(QModelIndex{}, row, row);
             torrents_.insert(it, tor);
             endInsertRows();
         }
@@ -460,7 +460,7 @@ void TorrentModel::rowsRemove(torrents_t const& torrents)
     {
         auto const& [first, last] = *it;
 
-        beginRemoveRows(QModelIndex(), first, last);
+        beginRemoveRows(QModelIndex{}, first, last);
         torrents_.erase(torrents_.begin() + first, torrents_.begin() + last + 1);
         endRemoveRows();
     }

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -52,7 +52,7 @@ public:
     }
 
     // QAbstractItemModel
-    int rowCount(QModelIndex const& parent = QModelIndex()) const override;
+    int rowCount(QModelIndex const& parent = QModelIndex{}) const override;
     QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const override;
 
 public slots:

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -13,7 +13,7 @@ class TorrentView::HeaderWidget : public QWidget
 {
 public:
     explicit HeaderWidget(TorrentView* parent)
-        : QWidget(parent)
+        : QWidget{ parent }
     {
         setFont(QApplication::font("QMiniFont"));
     }
@@ -28,7 +28,7 @@ public:
     [[nodiscard]] QSize sizeHint() const override
     {
         QStyleOptionHeader option;
-        option.rect = QRect(0, 0, 100, 100);
+        option.rect = QRect{ 0, 0, 100, 100 };
 
         QRect const label_rect = style()->subElementRect(QStyle::SE_HeaderLabel, &option, this);
 
@@ -44,7 +44,7 @@ protected:
         option.state = QStyle::State_Enabled;
         option.position = QStyleOptionHeader::OnlyOneSection;
 
-        QStylePainter painter(this);
+        QStylePainter painter{ this };
         painter.drawControl(QStyle::CE_HeaderSection, option);
 
         option.rect = style()->subElementRect(QStyle::SE_HeaderLabel, &option, this);

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -60,7 +60,7 @@ ItemLayout::ItemLayout(
 {
     auto const icon_size = QSize{ FaviconCache<QPixmap>::Width, FaviconCache<QPixmap>::Height };
 
-    QRect base_rect(top_left, QSize(width, 0));
+    QRect base_rect{ top_left, QSize{ width, 0 } };
 
     icon_rect = QStyle::alignedRect(direction, Qt::AlignLeft | Qt::AlignTop, icon_size, base_rect);
     Utils::narrowRect(base_rect, icon_size.width() + Spacing, 0, direction);
@@ -91,7 +91,7 @@ ItemLayout::ItemLayout(
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, TrackerInfo const& info) const
 {
-    ItemLayout const layout(getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - Margin.width() * 2);
+    ItemLayout const layout{ getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - Margin.width() * 2 };
     return layout.size() + Margin * 2;
 }
 

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -78,7 +78,7 @@ struct CompareTrackers
 void TrackerModel::refresh(TorrentModel const& torrent_model, torrent_ids_t const& ids)
 {
     // build a list of the TrackerInfos
-    std::vector<TrackerInfo> trackers;
+    auto trackers = std::vector<TrackerInfo>{};
 
     for (int const id : ids)
     {
@@ -99,8 +99,8 @@ void TrackerModel::refresh(TorrentModel const& torrent_model, torrent_ids_t cons
     }
 
     // sort 'em
-    CompareTrackers const comp;
-    std::sort(trackers.begin(), trackers.end(), comp);
+    static auto constexpr Comp = CompareTrackers{};
+    std::sort(trackers.begin(), trackers.end(), Comp);
 
     // merge 'em with the existing list
     unsigned int old_index = 0;
@@ -111,19 +111,19 @@ void TrackerModel::refresh(TorrentModel const& torrent_model, torrent_ids_t cons
         bool const is_end_of_old = old_index == rows_.size();
         bool const is_end_of_new = new_index == trackers.size();
 
-        if (is_end_of_old || (!is_end_of_new && comp(trackers.at(new_index), rows_.at(old_index))))
+        if (is_end_of_old || (!is_end_of_new && Comp(trackers.at(new_index), rows_.at(old_index))))
         {
             // add this new row
-            beginInsertRows(QModelIndex(), old_index, old_index);
+            beginInsertRows(QModelIndex{}, old_index, old_index);
             rows_.insert(rows_.begin() + old_index, trackers.at(new_index));
             endInsertRows();
             ++old_index;
             ++new_index;
         }
-        else if (is_end_of_new || (!is_end_of_old && comp(rows_.at(old_index), trackers.at(new_index))))
+        else if (is_end_of_new || (!is_end_of_old && Comp(rows_.at(old_index), trackers.at(new_index))))
         {
             // remove this old row
-            beginRemoveRows(QModelIndex(), old_index, old_index);
+            beginRemoveRows(QModelIndex{}, old_index, old_index);
             rows_.erase(rows_.begin() + old_index);
             endRemoveRows();
         }

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -41,7 +41,7 @@ public:
     int find(int torrent_id, QString const& url) const;
 
     // QAbstractItemModel
-    int rowCount(QModelIndex const& parent = QModelIndex()) const override;
+    int rowCount(QModelIndex const& parent = QModelIndex{}) const override;
     QVariant data(QModelIndex const& index, int role = Qt::DisplayRole) const override;
 
 private:

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -82,7 +82,7 @@ int Utils::measureViewItem(QAbstractItemView const* view, QString const& text)
     option.font = view->font();
 
     return view->style()
-        ->sizeFromContents(QStyle::CT_ItemViewItem, &option, QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX), view)
+        ->sizeFromContents(QStyle::CT_ItemViewItem, &option, QSize{ QWIDGETSIZE_MAX, QWIDGETSIZE_MAX }, view)
         .width();
 }
 
@@ -93,7 +93,7 @@ int Utils::measureHeaderItem(QHeaderView const* view, QString const& text)
     option.text = text;
     option.sortIndicator = view->isSortIndicatorShown() ? QStyleOptionHeader::SortDown : QStyleOptionHeader::None;
 
-    return view->style()->sizeFromContents(QStyle::CT_HeaderSection, &option, QSize(), view).width();
+    return view->style()->sizeFromContents(QStyle::CT_HeaderSection, &option, QSize{}, view).width();
 }
 
 QColor Utils::getFadedColor(QColor const& color)

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -64,7 +64,7 @@ public:
     {
         if (dialog.isNull())
         {
-            dialog = new DialogT(std::forward<ArgsT>(args)...); // NOLINT clang-analyzer-cplusplus.NewDelete
+            dialog = new DialogT{ std::forward<ArgsT>(args)... }; // NOLINT clang-analyzer-cplusplus.NewDelete
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->show();
         }

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -22,7 +22,7 @@
 ***/
 
 WatchDir::WatchDir(TorrentModel const& model)
-    : model_(model)
+    : model_{ model }
 {
 }
 
@@ -76,7 +76,7 @@ void WatchDir::setPath(QString const& path, bool is_enabled)
 
 void WatchDir::watcherActivated(QString const& path)
 {
-    QDir const dir(path);
+    auto const dir = QDir{ path };
 
     // get the list of files currently in the watch directory
     QSet<QString> files;
@@ -108,7 +108,7 @@ void WatchDir::watcherActivated(QString const& path)
             case AddResult::Error:
                 {
                     // give the torrent a few seconds to finish downloading
-                    auto* t = new QTimer(this);
+                    auto* t = new QTimer{ this };
                     t->setObjectName(dir.absoluteFilePath(name));
                     t->setSingleShot(true);
                     connect(t, &QTimer::timeout, this, &WatchDir::onTimeout);


### PR DESCRIPTION
A small style commit to prefer direct brace initialization.

Except for when this causes ambiguity, e.g. in the std::vector constructor, we generally should be preferring this style since it forces us to use correct types / to avoid implicit conversions to the constructor.
