### PR TITLE
Add scrollability to overflow-menu and context-menu

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1320,6 +1320,8 @@ $video-image: '../img/film.svg';
   padding: 10px 5px;
   position: absolute;
   z-index: 9999;
+  overflow: scroll;
+  max-height: 90vh;
 
   .context-menuitem {
     font-size: 13px;
@@ -1332,7 +1334,6 @@ $video-image: '../img/film.svg';
       background-color: var(--color-bg-hover);
       border-radius: 6px;
       cursor: pointer;
-      font-weight: 500;
     }
 
     &:disabled {
@@ -1364,18 +1365,14 @@ $video-image: '../img/film.svg';
     0 9px 28px 8px #0000000d;
   color: var(--color-fg-on-popup);
   min-width: 220px;
-  overflow: auto;
+  overflow: scroll;
   -webkit-overflow-scrolling: touch;
   padding: 10px;
   position: absolute;
-
+  max-height: 80vh;
   right: 20px;
   top: 50px;
   z-index: $z-index-popup;
-
-  @include for-phone-only() {
-    height: 80vh;
-  }
 
   fieldset {
     border: 0;

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -148,15 +148,6 @@ export class Transmission extends EventTarget {
                 this.action_manager,
               ),
             );
-            const btnbox = document
-              .querySelector('#toolbar-overflow')
-              .getBoundingClientRect();
-            movePopup(
-              this.popup.root,
-              btnbox.left + btnbox.width,
-              btnbox.top + btnbox.height,
-              document.body,
-            );
           }
           break;
         case 'show-preferences-dialog':


### PR DESCRIPTION
The overflow-menu and context-menu both had trouble with short viewports.

- Fixes #5299

--

- add overflow: scroll to each div
- add a maximum height (80vh and 90vh)
- remove the added font-weight from context menu on hover
- remove `movePopup` function from overflow-menu, as it didn't do anything with our absolute positioning