### PR TITLE
Use clang-format for qualifier alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -56,6 +56,7 @@ ConstructorInitializerIndentWidth: 4
 FixNamespaceComments: true
 IndentGotoLabels: false
 KeepEmptyLinesAtTheStartOfBlocks: true
+QualifierAlignment: Right
 SortUsingDeclarations: true
 SpaceAfterTemplateKeyword: false
 StatementMacros:
@@ -71,3 +72,4 @@ ObjCBlockIndentWidth: 4
 ObjCBreakBeforeNestedBlockParam: false
 ObjCSpaceBeforeProtocolList: false
 PenaltyExcessCharacter: 1
+QualifierAlignment: Right

--- a/code_style.sh
+++ b/code_style.sh
@@ -65,22 +65,6 @@ if ! find_cfiles -exec "${clang_format_exe}" $clang_format_args '{}' '+'; then
   exitcode=1
 fi
 
-# enforce east const
-# look for 'const'
-#  - as the first token in the line
-#  - or preceded by 'static'
-#  - or following any of (<,;
-#  - but not if 'const' is followed by ` override` (const virtual function)
-#  - but not if 'const' is followed by ` = 0` (const virtual function)
-matches="$(find_cfiles -exec perl -ne 'print "west const:",$ARGV,":",$_ if /((?:^|[(<,;]|\bstatic\s+)\s*)\b(const)\b(?!\s+((\w+\s*\[)|(override)|(\=\ 0)))/' '{}' '+')"
-if [ -n "$matches" ]; then
-  echo "$matches"
-  exitcode=1
-fi
-if [ -n "$fix" ]; then
-  find_cfiles -exec perl -pi -e 's/((?:^|[(<,;]|\bstatic\s+)\s*)\b(const)\b(?!\s+((\w+\s*\[)|(override)|(\=\ 0)))/\1>\2</g' '{}' '+'
-fi
-
 # format JS
 # but only if js has changed
 git diff --cached --quiet -- "web/**" && exit $exitcode

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -75,7 +75,7 @@ public:
             return ::dht_search(id, port, af, callback, closure);
         }
 
-        virtual int init(int s, int s6, unsigned const char* id, unsigned const char* v)
+        virtual int init(int s, int s6, unsigned char const* id, unsigned char const* v)
         {
             return ::dht_init(s, s6, id, v);
         }

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -26,7 +26,7 @@ private:
 
 public:
     using value_type = Char;
-    using const_reference = const Char&;
+    using const_reference = Char const&;
 
     tr_strbuf()
     {

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -509,7 +509,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
         return;
     }
 
-    volatile int status;
+    int volatile status;
     tr_torrentSetLocation(self.fHandle, folder.UTF8String, YES, NULL, &status);
 
     while (status == TR_LOC_MOVING) //block while moving (for now)

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -209,7 +209,7 @@ protected:
             return 0;
         }
 
-        int init(int dht_socket, int dht_socket6, unsigned const char* id, unsigned const char* /*v*/) override
+        int init(int dht_socket, int dht_socket6, unsigned char const* id, unsigned char const* /*v*/) override
         {
             inited_ = true;
             dht_socket_ = dht_socket;


### PR DESCRIPTION
`QualifierAlignment` option is available since clang-format v14 and works better than our own script.