### PR TITLE
fix: announce with query replace bug (fixes #5802)

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -88,6 +88,7 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
     tracker.id = next_unique_id();
     tracker.host_and_port = fmt::format(FMT_STRING("{:s}:{:d}"), announce->host, announce->port);
     tracker.sitename = announce->sitename;
+    tracker.query = announce->query;
 
     if (auto const scrape_str = announce_to_scrape(announce_url_sv); scrape_str)
     {
@@ -226,7 +227,8 @@ bool tr_announce_list::can_add(tr_url_parsed_t const& announce) const noexcept
 
         auto const tracker_parsed = tr_urlParse(tracker_announce);
         return tracker_parsed->scheme == announce.scheme && tracker_parsed->host == announce.host &&
-            tracker_parsed->port == announce.port && tracker_parsed->path == announce.path;
+            tracker_parsed->port == announce.port && tracker_parsed->path == announce.path &&
+            tracker_parsed->query == announce.query;
     };
     return std::none_of(std::begin(trackers_), std::end(trackers_), is_same);
 }

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -29,6 +29,7 @@ public:
         tr_interned_string scrape;
         tr_interned_string host_and_port; // 'example.org:80'
         tr_interned_string sitename; // 'example'
+        tr_interned_string query; // 'name=ferret'
         tr_tracker_tier_t tier = 0;
         tr_tracker_id_t id = 0;
 

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -276,6 +276,18 @@ TEST_F(AnnounceListTest, canReplace)
     EXPECT_EQ(Announce2, announce_list.at(0).announce.sv());
 }
 
+TEST_F(AnnounceListTest, canReplaceWithDiffQuery)
+{
+    auto constexpr Tier = tr_tracker_tier_t{ 1 };
+    auto constexpr Announce1 = "https://www.example.com/1/announce"sv;
+    auto constexpr Announce2 = "https://www.example.com/2/announce?pass=1999"sv;
+
+    auto announce_list = tr_announce_list{};
+    EXPECT_TRUE(announce_list.add(Announce1, Tier));
+    EXPECT_TRUE(announce_list.replace(announce_list.at(0).id, Announce2));
+    EXPECT_EQ(Announce2, announce_list.at(0).announce.sv());
+}
+
 TEST_F(AnnounceListTest, canNotReplaceInvalidId)
 {
     auto constexpr Tier = tr_tracker_tier_t{ 1 };


### PR DESCRIPTION
I've added a comparison about the query part of announce's comparison. It fixes #5802.