### PR TITLE
fix: announce LDP on listening interface

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -257,6 +257,11 @@ private:
         {
         }
 
+        [[nodiscard]] tr_address bind_address(tr_address_type type) const override
+        {
+            return session_.bind_address(type);
+        }
+
         [[nodiscard]] tr_port port() const override
         {
             return session_.advertisedPeerPort();

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -100,9 +100,7 @@ auto makeAnnounceMsg(std::string_view cookie, tr_port port, std::vector<std::str
         ret += fmt::format("cookie: {:s}\r\n", cookie);
     }
 
-    ret += "\r\n\r\n";
-
-    return ret;
+    return ret + "\r\n\r\n";
 }
 
 struct ParsedAnnounce
@@ -359,6 +357,16 @@ private:
             }
 
             if (evutil_make_socket_nonblocking(mcast_snd_socket_) == -1)
+            {
+                return false;
+            }
+
+            if (setsockopt(
+                    mcast_snd_socket_,
+                    SOL_SOCKET,
+                    SO_REUSEADDR,
+                    reinterpret_cast<char const*>(&opt_on),
+                    sizeof(opt_on)) == -1)
             {
                 return false;
             }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -363,6 +363,12 @@ private:
                 return false;
             }
 
+            if (auto [ss, sslen] = mediator_.bind_address(TR_AF_INET).to_sockaddr(tr_port{});
+                bind(mcast_snd_socket_, reinterpret_cast<sockaddr*>(&ss), sslen) == -1)
+            {
+                return false;
+            }
+
             /* configure outbound multicast TTL */
             if (setsockopt(
                     mcast_snd_socket_,

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -363,7 +363,7 @@ private:
                 return false;
             }
 
-            if (auto [ss, sslen] = mediator_.bind_address(TR_AF_INET).to_sockaddr(tr_port{});
+            if (auto [ss, sslen] = mediator_.bind_address(TR_AF_INET).to_sockaddr({});
                 bind(mcast_snd_socket_, reinterpret_cast<sockaddr*>(&ss), sslen) == -1)
             {
                 return false;

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -41,6 +41,8 @@ public:
 
         virtual ~Mediator() = default;
 
+        [[nodiscard]] virtual tr_address bind_address(tr_address_type type) const = 0;
+
         [[nodiscard]] virtual tr_port port() const = 0;
 
         [[nodiscard]] virtual bool allowsLPD() const = 0;

--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -40,6 +40,11 @@ public:
     {
     }
 
+    [[nodiscard]] tr_address bind_address(tr_address_type /* type */) const override
+    {
+        return {};
+    }
+
     [[nodiscard]] tr_port port() const override
     {
         return port_;


### PR DESCRIPTION
Fixes #5874.

Notes: Fixed a bug where Transmission may not announce LPD on its listening interface.