### PR TITLE
fix: do not mark peer as not connectable when we are currently connected

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1097,7 +1097,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, tr_
     {
         if (s != nullptr)
         {
-            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr && !info->is_connected())
+            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr)
             {
                 info->on_connection_failed();
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -466,28 +466,19 @@ public:
             break;
 
         case tr_peer_event::Type::ClientGotPort:
-            if (!std::empty(event.port))
+            if (std::empty(event.port))
             {
-                auto const& info = *msgs->peer_info;
-                auto result = false;
-
-                // If we don't know the listening port of this peer (i.e. incoming connection and first time ClientGotPort)
-                if (std::empty(info.listen_port()))
-                {
-                    result = s->on_got_port(msgs, event, false);
-                }
-                // If we got a new listening port from a known connectable peer
-                else if (info.listen_port() != event.port)
-                {
-                    result = s->on_got_port(msgs, event, true);
-                }
-
-                if (result)
-                {
-                    // Abort any outgoing handshakes with this peer
-                    // https://github.com/transmission/transmission/issues/5869#issuecomment-1674434709
-                    s->outgoing_handshakes.erase(info.listen_socket_address());
-                }
+                // Do nothing
+            }
+            // If we don't know the listening port of this peer (i.e. incoming connection and first time ClientGotPort)
+            else if (auto const& info = *msgs->peer_info; std::empty(info.listen_port()))
+            {
+                s->on_got_port(msgs, event, false);
+            }
+            // If we got a new listening port from a known connectable peer
+            else if (info.listen_port() != event.port)
+            {
+                s->on_got_port(msgs, event, true);
             }
 
             break;
@@ -691,7 +682,7 @@ private:
         tor->session->add_downloaded(sent_length);
     }
 
-    bool on_got_port(tr_peerMsgs* const msgs, tr_peer_event const& event, bool was_connectable)
+    void on_got_port(tr_peerMsgs* const msgs, tr_peer_event const& event, bool was_connectable)
     {
         auto& info_this = *msgs->peer_info;
         TR_ASSERT(info_this.is_connected());
@@ -709,7 +700,7 @@ private:
             // If there is an existing connection to this peer, keep the better one
             if (info_that.is_connected() && on_got_port_duplicate_connection(msgs, it_that, was_connectable))
             {
-                return false;
+                return;
             }
 
             info_this.merge(info_that);
@@ -737,7 +728,6 @@ private:
         info_this.set_listen_port(event.port);
 
         mark_all_seeds_flag_dirty();
-        return true;
     }
 
     bool on_got_port_duplicate_connection(tr_peerMsgs* const msgs, Pool::iterator& it_that, bool was_connectable)
@@ -1108,7 +1098,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, tr_
     {
         if (s != nullptr)
         {
-            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr)
+            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr && !info->is_connected())
             {
                 info->on_connection_failed();
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -273,6 +273,7 @@ public:
 
         auto* const peer_info = peer->peer_info;
         auto const socket_address = peer->socket_address();
+        auto const listen_socket_address = peer_info->listen_socket_address();
         auto const was_incoming = peer->is_incoming_connection();
         TR_ASSERT(peer_info != nullptr);
 
@@ -295,7 +296,7 @@ public:
                 TR_ASSERT(port_empty);
             }
         }
-        graveyard_pool.erase(socket_address);
+        graveyard_pool.erase(listen_socket_address);
     }
 
     void remove_all_peers()

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -486,7 +486,7 @@ public:
                 {
                     // Abort any outgoing handshakes with this peer
                     // https://github.com/transmission/transmission/issues/5869#issuecomment-1674434709
-                    s->outgoing_handshakes.erase({ info.listen_address(), event.port });
+                    s->outgoing_handshakes.erase(info.listen_socket_address());
                 }
             }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -474,6 +474,7 @@ public:
             {
                 if (s->on_got_port(msgs, event, false))
                 {
+                    // Abort any outgoing handshakes with this peer
                     // https://github.com/transmission/transmission/issues/5869#issuecomment-1674434709
                     s->outgoing_handshakes.erase(info.listen_socket_address());
                 }
@@ -1077,7 +1078,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, tr_
 }
 
 /* FIXME: this is kind of a mess. */
-[[nodiscard]] bool on_handshake_done(tr_peerMgr* manager, tr_handshake::Result const& result)
+[[nodiscard]] bool on_handshake_done(tr_peerMgr* const manager, tr_handshake::Result const& result)
 {
     TR_ASSERT(result.io != nullptr);
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1097,7 +1097,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, tr_
     {
         if (s != nullptr)
         {
-            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr)
+            if (auto* const info = s->get_existing_peer_info(socket_address); info != nullptr && !info->is_connected())
             {
                 info->on_connection_failed();
 

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(libtransmission-test
         torrent-magnet-test.cc
         torrent-metainfo-test.cc
         torrents-test.cc
+        tr-peer-info-test.cc
         utils-test.cc
         variant-test.cc
         watchdir-test.cc

--- a/tests/libtransmission/tr-peer-info-test.cc
+++ b/tests/libtransmission/tr-peer-info-test.cc
@@ -1,0 +1,73 @@
+// This file Copyright © 2008-2023 Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <optional>
+#include <tuple>
+#include <utility>
+
+#include <libtransmission/net.h>
+#include <libtransmission/peer-mgr.h>
+
+#include "gtest/gtest.h"
+
+using PeerInfoTest = ::testing::Test;
+
+TEST_F(PeerInfoTest, mergeConnectable)
+{
+    // Same as the truth table in tr_peer_info::merge()
+    static auto constexpr Tests = std::array{
+        std::pair{ std::tuple{ std::optional{ true }, true, std::optional{ true }, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, true, std::optional{ true }, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, true, std::optional{ false }, false }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional{ true }, true, std::optional<bool>{}, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, true, std::optional<bool>{}, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, false, std::optional{ true }, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, false, std::optional{ true }, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, false, std::optional{ false }, false }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional{ true }, false, std::optional<bool>{}, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ true }, false, std::optional<bool>{}, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional{ false }, false, std::optional{ true }, true }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional{ false }, false, std::optional{ true }, false }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional{ false }, false, std::optional{ false }, false }, std::optional{ false } },
+        std::pair{ std::tuple{ std::optional{ false }, false, std::optional<bool>{}, true }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional{ false }, false, std::optional<bool>{}, false }, std::optional{ false } },
+        std::pair{ std::tuple{ std::optional<bool>{}, true, std::optional{ true }, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional<bool>{}, true, std::optional{ true }, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional<bool>{}, true, std::optional{ false }, false }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional<bool>{}, true, std::optional<bool>{}, true }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional<bool>{}, true, std::optional<bool>{}, false }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional<bool>{}, false, std::optional{ true }, true }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional<bool>{}, false, std::optional{ true }, false }, std::optional{ true } },
+        std::pair{ std::tuple{ std::optional<bool>{}, false, std::optional{ false }, false }, std::optional{ false } },
+        std::pair{ std::tuple{ std::optional<bool>{}, false, std::optional<bool>{}, true }, std::optional<bool>{} },
+        std::pair{ std::tuple{ std::optional<bool>{}, false, std::optional<bool>{}, false }, std::optional<bool>{} },
+    };
+    static_assert(std::size(Tests) == 25U);
+
+    for (auto const& [condition, result] : Tests)
+    {
+        auto const& [this_connectable, this_connected, that_connectable, that_connected] = condition;
+
+        auto info_this = tr_peer_info{ tr_address{}, 0, TR_PEER_FROM_PEX };
+        auto info_that = tr_peer_info{ tr_address{}, 0, TR_PEER_FROM_PEX };
+
+        if (this_connectable)
+        {
+            info_this.set_connectable(*this_connectable);
+        }
+        info_this.set_connected(time_t{}, this_connected);
+
+        if (that_connectable)
+        {
+            info_that.set_connectable(*that_connectable);
+        }
+        info_that.set_connected(time_t{}, that_connected);
+
+        info_this.merge(info_that);
+
+        EXPECT_EQ(info_this.is_connectable(), result);
+    }
+}


### PR DESCRIPTION
Fixes #5869.

After #5801, it is possible for a connectable pool entry to be marked as "connected" by an ltep port handshake within the time frame from Transmission initiating an outgoing handshake to a remote peer and the handshake completing. In the current state of `main`, if the handshaked failed, the peer info object will be marked is "not connectable" despite Transmission being connected to the peer, leading to an invalid state and failing the assertion.