### PR TITLE
WebUI: Fix graying out inspector

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -310,11 +310,21 @@ $toolbar-height: $toolbar-height-number * 1px;
     user-select: none;
     width: $toolbar-height;
 
+    svg {
+      stroke: var(--color-fg-primary);
+    }
+
+    svg g path {
+      fill: var(--color-fg-primary);
+    }
+
     &:disabled {
       cursor: default;
+
       svg {
         stroke: var(--color-fg-disabled);
       }
+
       svg g path {
         fill: var(--color-fg-disabled);
       }

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -310,15 +310,13 @@ $toolbar-height: $toolbar-height-number * 1px;
     user-select: none;
     width: $toolbar-height;
 
-    svg {
-      stroke: var(--color-fg-primary); // ios only? idk yet
-    }
-
     &:disabled {
       cursor: default;
-      // opacity: 0.25;
       svg {
         stroke: var(--color-fg-disabled);
+      }
+      svg g path {
+        fill: var(--color-fg-disabled);
       }
     }
   }
@@ -337,12 +335,6 @@ $toolbar-height: $toolbar-height-number * 1px;
 
 .toolbar-icon {
   stroke: var(--color-fg-primary);
-}
-
-#toolbar-inspector {
-  svg {
-    color: var(--color-fg-primary);
-  }
 }
 
 #toolbar-overflow {

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -137,15 +137,17 @@
             xmlns:xl="http://www.w3.org/1999/xlink"
             xmlns:dc="http://purl.org/dc/elements/1.1/"
             viewBox="-1 -1 26 26"
+            fill-opacity="1"
+            stroke="currentColor"
+            fill="none"
             width="26"
             height="26"
           >
-            <g fill-opacity="1" stroke="currentColor" fill="none">
+            <g>
               <circle
                 cx="12"
                 cy="12"
                 r="12.0000191748228"
-                stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"


### PR DESCRIPTION
Left: this PR, right: original
Top: not selecting any torrent (inspector not graying out for original), bottom: selected a torrent (inspector is ungrayed as normal for original)

![Transmission inspector](https://github.com/transmission/transmission/assets/2275021/9a5300ed-a6ee-4d7b-88a8-39bc87adbaab)

animated diff:

![Transmission inspector 1 (apng)](https://github.com/transmission/transmission/assets/2275021/50b087cf-7354-4714-a91f-dcf1c10a1803)
