### PR TITLE
feat: improved overflow menu for web client

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1412,13 +1412,6 @@ $video-image: '../img/film.svg';
     display: flex;
     flex-direction: row;
     padding: 3px 0;
-
-    // hide the fullscreen button unless we're on mobile
-    @include for-tablet-portrait-up {
-      &.display-fullscreen-row {
-        display: none;
-      }
-    }
   }
 
   legend {
@@ -1427,7 +1420,6 @@ $video-image: '../img/film.svg';
     margin: 12px 0 4px;
   }
 
-  a,
   button,
   label {
     color: var(--color-fg-primary);
@@ -1436,7 +1428,6 @@ $video-image: '../img/film.svg';
     width: 100%;
   }
 
-  a,
   button {
     background: transparent;
     border: 0;

--- a/web/src/about-dialog.js
+++ b/web/src/about-dialog.js
@@ -10,7 +10,7 @@ export class AboutDialog extends EventTarget {
     super();
 
     this.elements = AboutDialog._create(version_info);
-    this.elements.dismiss.addEventListener('click', () => this._onDismiss());
+    this.elements.dismiss.addEventListener('click', () => this.close());
     document.body.append(this.elements.root);
     this.elements.dismiss.focus();
   }
@@ -19,10 +19,6 @@ export class AboutDialog extends EventTarget {
     this.elements.root.remove();
     this.dispatchEvent(new Event('close'));
     delete this.elements;
-  }
-
-  _onDismiss() {
-    this.close();
   }
 
   static _create(version_info) {
@@ -46,6 +42,12 @@ export class AboutDialog extends EventTarget {
     elements.workarea.append(e);
     e = document.createElement('div');
     e.textContent = 'Copyright © The Transmission Project';
+    elements.workarea.append(e);
+
+    e = document.createElement('a');
+    e.href = 'https://transmissionbt.com/';
+    e.target = '_blank';
+    e.textContent = 'https://transmissionbt.com/';
     elements.workarea.append(e);
 
     elements.confirm.remove();

--- a/web/src/overflow-menu.js
+++ b/web/src/overflow-menu.js
@@ -473,15 +473,12 @@ export class OverflowMenu extends EventTarget {
     options = document.createElement('div');
     section.append(options);
 
-    for (const action_name of [
-      'show-statistics-dialog',
-      'show-about-dialog',
-    ]) {
+    for (const action_name of ['show-statistics-dialog', 'show-about-dialog']) {
       const text = this.action_manager.text(action_name);
       actions[action_name] = make_button(options, text, action_name, on_click);
     }
 
-    let e = document.createElement('a');
+    const e = document.createElement('a');
     e.href = 'https://transmissionbt.com/donate.html';
     e.target = '_blank';
     e.textContent = 'Donate';

--- a/web/src/overflow-menu.js
+++ b/web/src/overflow-menu.js
@@ -459,6 +459,7 @@ export class OverflowMenu extends EventTarget {
 
     for (const action_name of [
       'show-preferences-dialog',
+      'show-shortcuts-dialog',
       'pause-all-torrents',
       'start-all-torrents',
     ]) {
@@ -466,50 +467,25 @@ export class OverflowMenu extends EventTarget {
       actions[action_name] = make_button(section, text, action_name, on_click);
     }
 
-    section = make_section('info', 'Info');
+    section = make_section('help', 'Help');
     root.append(section);
 
     options = document.createElement('div');
     section.append(options);
 
     for (const action_name of [
-      'show-about-dialog',
-      'show-shortcuts-dialog',
       'show-statistics-dialog',
+      'show-about-dialog',
     ]) {
       const text = this.action_manager.text(action_name);
       actions[action_name] = make_button(options, text, action_name, on_click);
     }
 
-    section = make_section('links', 'Links');
-    root.append(section);
-
-    options = document.createElement('ul');
-    section.append(options);
-
     let e = document.createElement('a');
-    e.href = 'https://transmissionbt.com/';
-    e.tabindex = '0';
-    e.textContent = 'Homepage';
-    let li = document.createElement('li');
-    li.append(e);
-    options.append(li);
-
-    e = document.createElement('a');
-    e.href = 'https://transmissionbt.com/donate/';
-    e.tabindex = '0';
-    e.textContent = 'Tip Jar';
-    li = document.createElement('li');
-    li.append(e);
-    options.append(li);
-
-    e = document.createElement('a');
-    e.href = 'https://github.com/transmission/transmission/';
-    e.tabindex = '0';
-    e.textContent = 'Source Code';
-    li = document.createElement('li');
-    li.append(e);
-    options.append(li);
+    e.href = 'https://transmissionbt.com/donate.html';
+    e.target = '_blank';
+    e.textContent = 'Donate';
+    options.append(e);
 
     this._updateElement = this._updateElement.bind(this);
 


### PR DESCRIPTION
Always show fullscreen option, larger viewports seem capable of going fullscreen so why need small viewport to see this option? Alternatively why this option at all?

Links Tip Jar -> Help Donate, inspired from QT application!

Relocated links to save space on overflow menu. Removed Source Code link - is it worthwhile?

Notes: Improved overflow menu for web client

Left/top: this PR right/bottom: original
![Transmission om](https://github.com/transmission/transmission/assets/2275021/297b50df-7eda-4022-9281-03582c0ff7c2)

animated diff (well, our naked eyes can see the diffs above just fine!):

![Transmission om 1 (apng)](https://github.com/transmission/transmission/assets/2275021/186e71c3-bfcb-4588-93e7-1325b839b013)

Both are having bottom padding problem which I'll do separate PR about it soon.