### PR TITLE
fix: cherry-pick 28d423d

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -249,6 +249,11 @@ private:
         {
         }
 
+        [[nodiscard]] tr_address bind_address(tr_address_type type) const override
+        {
+            return session_.publicAddress(type).address;
+        }
+
         [[nodiscard]] tr_port port() const override
         {
             return session_.advertisedPeerPort();

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -99,9 +99,7 @@ auto makeAnnounceMsg(std::string_view cookie, tr_port port, std::vector<std::str
         ret += fmt::format("cookie: {:s}\r\n", cookie);
     }
 
-    ret += "\r\n\r\n";
-
-    return ret;
+    return ret + "\r\n\r\n";
 }
 
 struct ParsedAnnounce
@@ -360,6 +358,22 @@ private:
             }
 
             if (evutil_make_socket_nonblocking(mcast_snd_socket_) == -1)
+            {
+                return false;
+            }
+
+            if (setsockopt(
+                    mcast_snd_socket_,
+                    SOL_SOCKET,
+                    SO_REUSEADDR,
+                    reinterpret_cast<char const*>(&opt_on),
+                    sizeof(opt_on)) == -1)
+            {
+                return false;
+            }
+
+            if (auto [ss, sslen] = mediator_.bind_address(TR_AF_INET).to_sockaddr({});
+                bind(mcast_snd_socket_, reinterpret_cast<sockaddr*>(&ss), sslen) == -1)
             {
                 return false;
             }

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -41,6 +41,8 @@ public:
 
         virtual ~Mediator() = default;
 
+        [[nodiscard]] virtual tr_address bind_address(tr_address_type type) const = 0;
+
         [[nodiscard]] virtual tr_port port() const = 0;
 
         [[nodiscard]] virtual bool allowsLPD() const = 0;

--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -35,6 +35,11 @@ public:
     {
     }
 
+    [[nodiscard]] tr_address bind_address(tr_address_type /* type */) const override
+    {
+        return {};
+    }
+
     [[nodiscard]] tr_port port() const override
     {
         return port_;


### PR DESCRIPTION
@tearfur this is a  cherry-pick of 28d423d + this change because `4.0.x` still has that `PublicAddressResult` struct that got subsumed by the `tr_address::is_any*()` funcs in `main`.

Submitting to you for review to make sure this is what's intended, since at this point you understand this part of the code better than I do. :smile_cat: 