### PR TITLE
WebUI: X buttons for ease of closing Inspector and Prefs dialog windows

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -982,16 +982,13 @@ $video-image: '../img/film.svg';
 }
 
 .tabs-container-close {
-  text-align: center;
   font-size: 150%;
   cursor: pointer;
-  appearance: none;
   background: var(--color-bg-primary);
   border: 0;
   color: var(--color-fg-primary);
   position: absolute;
   padding: 10px 16px;
-  text-decoration: none;
 }
 
 .tabs-buttons {

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -987,7 +987,7 @@ $video-image: '../img/film.svg';
   cursor: pointer;
   appearance: none;
   background: var(--color-bg-primary);
-  border: none;
+  border: 0;
   color: var(--color-fg-primary);
   position: absolute;
   padding: 10px 16px;

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -981,6 +981,19 @@ $video-image: '../img/film.svg';
   }
 }
 
+.tabs-container-close {
+  text-align: center;
+  font-size: 150%;
+  cursor: pointer;
+  appearance: none;
+  background: var(--color-bg-primary);
+  border: none;
+  color: var(--color-fg-primary);
+  position: absolute;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
 .tabs-buttons {
   align-self: center;
   background-color: var(--color-bg-tabs);

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -39,6 +39,7 @@ export class Inspector extends EventTarget {
     this.file_torrent = null;
     this.file_torrent_n = null;
     this.file_rows = null;
+    this.elements.dismiss.addEventListener('click', () => this.close());
     this.outside = new OutsideClickListener(this.elements.root);
     this.outside.addEventListener('click', () => this.close());
     Object.seal(this);

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -50,6 +50,10 @@ export class PrefsDialog extends EventTarget {
   }
 
   _onPortChecked(response) {
+    if (this.closed) {
+      return;
+    }
+
     const element = this.elements.network.port_status_label;
     const is_open = response.arguments['port-is-open'];
     element.dataset.open = is_open;
@@ -783,6 +787,7 @@ export class PrefsDialog extends EventTarget {
         PrefsDialog._toggleProtocolHandler(event_.currentTarget);
       },
     );
+    this.elements.dismiss.addEventListener('click', () => this.close());
     this.outside = new OutsideClickListener(this.elements.root);
     this.outside.addEventListener('click', () => this.close());
 

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -93,8 +93,8 @@ export function createTextualTabsContainer(id, tabs, callback) {
   pages.children[0].classList.remove('hidden');
 
   return {
-    dismiss,
     buttons: button_array,
+    dismiss,
     root,
   };
 }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -58,6 +58,11 @@ export function createTextualTabsContainer(id, tabs, callback) {
   root.id = id;
   root.classList.add('tabs-container');
 
+  const dismiss = document.createElement('button');
+  dismiss.classList.add('tabs-container-close');
+  dismiss.innerHTML = '&times;';
+  root.append(dismiss);
+
   const buttons = document.createElement('div');
   buttons.classList.add('tabs-buttons');
   root.append(buttons);
@@ -88,6 +93,7 @@ export function createTextualTabsContainer(id, tabs, callback) {
   pages.children[0].classList.remove('hidden');
 
   return {
+    dismiss,
     buttons: button_array,
     root,
   };

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -58,14 +58,14 @@ export function createTextualTabsContainer(id, tabs, callback) {
   root.id = id;
   root.classList.add('tabs-container');
 
+  const buttons = document.createElement('div');
+  buttons.classList.add('tabs-buttons');
+  root.append(buttons);
+
   const dismiss = document.createElement('button');
   dismiss.classList.add('tabs-container-close');
   dismiss.innerHTML = '&times;';
   root.append(dismiss);
-
-  const buttons = document.createElement('div');
-  buttons.classList.add('tabs-buttons');
-  root.append(buttons);
 
   const pages = document.createElement('div');
   pages.classList.add('tabs-pages');


### PR DESCRIPTION
 - Implemented X button as way to dismiss right hand windows (inspector and prefs dialog)
 - Quick fix for "Connection failed" after closing the prefs dialog too quickly. What has happened is the port check was still ongoing and once it gets a response it will try to update the status label but failed because the window is no longer around.

Requesting design & code review from @dareiff

See animated diff
![Transmission di 1 (apng)](https://github.com/transmission/transmission/assets/2275021/969a7c2e-cb5b-47f3-bddc-17b8cd382ae0)

![IMG_0587 (apng)](https://github.com/transmission/transmission/assets/2275021/ea49a4ff-f4ee-4166-99b5-8afa5c389763)

Clickable area
![IMG_0586](https://github.com/transmission/transmission/assets/2275021/f28adb2c-cede-40ab-86ea-a896c7cb6405)