### PR TITLE
feat: display date & time in torrent detail for web client

### DIFF
--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -134,19 +134,17 @@ export const Formatter = {
   },
 
   timeInterval(seconds) {
-    const days = Math.floor(seconds / 86_400);
-    if (days) {
-      return this.countString('day', 'days', days);
-    }
+    let days = Math.floor(seconds / 86_400);
+    days = days ? this.countString('day', 'days', days) + ', ' : '';
 
-    const hours = Math.floor((seconds % 86_400) / 3600);
-    if (hours) {
-      return this.countString('hour', 'hours', hours);
-    }
+    let hours = Math.floor((seconds % 86_400) / 3600);
+    hours = (days.length || hours)
+      ? this.countString('hour', 'hours', hours) + ' and '
+      : '';
 
     const minutes = Math.floor((seconds % 3600) / 60);
-    if (minutes) {
-      return this.countString('minute', 'minutes', minutes);
+    if (hours.length || minutes) {
+      return `${days}${hours}` + this.countString('minute', 'minutes', minutes);
     }
 
     seconds = Math.floor(seconds % 60);

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -135,15 +135,16 @@ export const Formatter = {
 
   timeInterval(seconds) {
     let days = Math.floor(seconds / 86_400);
-    days = days ? this.countString('day', 'days', days) + ', ' : '';
+    days = days ? `${this.countString('day', 'days', days)}, ` : '';
 
     let hours = Math.floor((seconds % 86_400) / 3600);
-    hours = (days.length || hours)
-      ? this.countString('hour', 'hours', hours) + ' and '
-      : '';
+    hours =
+      days.length > 0 || hours
+        ? `${this.countString('hour', 'hours', hours)} and `
+        : '';
 
     const minutes = Math.floor((seconds % 3600) / 60);
-    if (hours.length || minutes) {
+    if (hours.length > 0 || minutes) {
       return `${days}${hours}` + this.countString('minute', 'minutes', minutes);
     }
 

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -133,23 +133,26 @@ export const Formatter = {
     return ['E2BIG', 'NaN'].some((badStr) => str.includes(badStr)) ? `…` : str;
   },
 
-  timeInterval(seconds) {
-    let days = Math.floor(seconds / 86_400);
-    days = days ? this.countString('day, ', 'days, ', days) : '';
-
-    let hours = Math.floor((seconds % 86_400) / 3600);
-    hours =
-      days.length > 0 || hours
-        ? this.countString('hour and ', 'hours and ', hours)
-        : '';
-
-    const minutes = Math.floor((seconds % 3600) / 60);
-    if (hours.length > 0 || minutes) {
-      return `${days}${hours}${this.countString('minute', 'minutes', minutes)}`;
+  timeInterval(seconds, granular_depth=3) {
+    const days = Math.floor(seconds / 86_400);
+    let buffer = [];
+    if (days) {
+      buffer.push(this.countString('day', 'days', days));
     }
 
-    seconds = Math.floor(seconds % 60);
-    return this.countString('second', 'seconds', seconds);
+    const hours = Math.floor((seconds % 86_400) / 3600);
+    if (days || hours) {
+      buffer.push(this.countString('hour', 'hours', hours));
+    }
+
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (days || hours || minutes) {
+      buffer.push(this.countString('minute', 'minutes', minutes));
+      buffer = buffer.slice(0, granular_depth);
+      return buffer.length > 1 ? `${buffer.slice(0, buffer.length-1).join(', ')} and ${buffer.slice(buffer.length-1)}` : buffer[0];
+    }
+
+    return this.countString('second', 'seconds', Math.floor(seconds % 60));
   },
 
   timestamp(seconds) {

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -145,7 +145,7 @@ export const Formatter = {
 
     const minutes = Math.floor((seconds % 3600) / 60);
     if (hours.length > 0 || minutes) {
-      return `${days}${hours}` + this.countString('minute', 'minutes', minutes);
+      return `${days}${hours}${this.countString('minute', 'minutes', minutes)}`;
     }
 
     seconds = Math.floor(seconds % 60);

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -135,12 +135,12 @@ export const Formatter = {
 
   timeInterval(seconds) {
     let days = Math.floor(seconds / 86_400);
-    days = days ? `${this.countString('day', 'days', days)}, ` : '';
+    days = days ? this.countString('day, ', 'days, ', days) : '';
 
     let hours = Math.floor((seconds % 86_400) / 3600);
     hours =
       days.length > 0 || hours
-        ? `${this.countString('hour', 'hours', hours)} and `
+        ? this.countString('hour and ', 'hours and ', hours)
         : '';
 
     const minutes = Math.floor((seconds % 3600) / 60);

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -150,7 +150,7 @@ export const Formatter = {
       buffer.push(this.countString('minute', 'minutes', minutes));
       buffer = buffer.slice(0, granular_depth);
       return buffer.length > 1
-        ? `${buffer.slice(0, buffer.length-1).join(', ')} and ${buffer.slice(buffer.length-1)}`
+        ? `${buffer.slice(0, -1).join(', ')} and ${buffer.slice(-1)}`
         : buffer[0];
     }
 

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -133,7 +133,7 @@ export const Formatter = {
     return ['E2BIG', 'NaN'].some((badStr) => str.includes(badStr)) ? `…` : str;
   },
 
-  timeInterval(seconds, granular_depth=3) {
+  timeInterval(seconds, granular_depth = 3) {
     const days = Math.floor(seconds / 86_400);
     let buffer = [];
     if (days) {
@@ -149,7 +149,9 @@ export const Formatter = {
     if (days || hours || minutes) {
       buffer.push(this.countString('minute', 'minutes', minutes));
       buffer = buffer.slice(0, granular_depth);
-      return buffer.length > 1 ? `${buffer.slice(0, buffer.length-1).join(', ')} and ${buffer.slice(buffer.length-1)}` : buffer[0];
+      return buffer.length > 1
+        ? `${buffer.slice(0, buffer.length-1).join(', ')} and ${buffer.slice(buffer.length-1)}`
+        : buffer[0];
     }
 
     return this.countString('second', 'seconds', Math.floor(seconds % 60));

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,15 +540,15 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
-          day: '2-digit',
-          hour: '2-digit',
-          hour12: false,
-          minute: '2-digit',
-          month: 'short',
-          second: '2-digit',
-          timeZoneName: 'short',
-          weekday: 'short',
-          year: 'numeric',
+            day: '2-digit',
+            hour: '2-digit',
+            hour12: false,
+            minute: '2-digit',
+            month: 'short',
+            second: '2-digit',
+            timeZoneName: 'short',
+            weekday: 'short',
+            year: 'numeric',
           })
         : mixed;
     }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -539,12 +539,12 @@ export class Inspector extends EventTarget {
       const get = (t) => t.getDateAdded();
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
-        ? new Date(first * 1000).toLocaleString(undefined, {
+        ? new Date(first * 1000).toLocaleString(navigator.language, {
           day: '2-digit',
-          weekday: 'short',
           month: 'short',
-          year: 'numeric',
+          weekday: 'short',
           hour: '2-digit',
+          year: 'numeric',
           hour12: false,
           minute: '2-digit',
           second: '2-digit',

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -539,7 +539,17 @@ export class Inspector extends EventTarget {
       const get = (t) => t.getDateAdded();
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
-        ? new Date(first * 1000).toDateString()
+        ? new Date(first * 1000).toLocaleString(undefined, {
+          day: '2-digit',
+          weekday: 'short',
+          month: 'short',
+          year: 'numeric',
+          hour: '2-digit',
+          hour12: false,
+          minute: '2-digit',
+          second: '2-digit',
+          timeZoneName: 'short',
+          })
         : mixed;
     }
     setTextContent(e.info.dateAdded, string);

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,14 +540,14 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
-          second: '2-digit',
-          minute: '2-digit',
-          hour: '2-digit',
           day: '2-digit',
+          hour: '2-digit',
+          hour12: false,
+          minute: '2-digit',
+          second: '2-digit',
           month: 'short',
           weekday: 'short',
           year: 'numeric',
-          hour12: false,
           timeZoneName: 'short',
           })
         : mixed;

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,14 +540,14 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
+          second: '2-digit',
+          minute: '2-digit',
           hour: '2-digit',
-          hour12: false,
           day: '2-digit',
           month: 'short',
           weekday: 'short',
           year: 'numeric',
-          minute: '2-digit',
-          second: '2-digit',
+          hour12: false,
           timeZoneName: 'short',
           })
         : mixed;

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,14 +540,14 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
-          month: 'short',
           day: '2-digit',
           hour: '2-digit',
           hour12: false,
           minute: '2-digit',
+          month: 'short',
           second: '2-digit',
-          weekday: 'short',
           timeZoneName: 'short',
+          weekday: 'short',
           year: 'numeric',
           })
         : mixed;

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,15 +540,15 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
+          month: 'short',
           day: '2-digit',
           hour: '2-digit',
           hour12: false,
           minute: '2-digit',
           second: '2-digit',
-          month: 'short',
           weekday: 'short',
-          year: 'numeric',
           timeZoneName: 'short',
+          year: 'numeric',
           })
         : mixed;
     }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -540,12 +540,12 @@ export class Inspector extends EventTarget {
       const first = get(torrents[0]);
       string = torrents.every((t) => get(t) === first)
         ? new Date(first * 1000).toLocaleString(navigator.language, {
+          hour: '2-digit',
+          hour12: false,
           day: '2-digit',
           month: 'short',
           weekday: 'short',
-          hour: '2-digit',
           year: 'numeric',
-          hour12: false,
           minute: '2-digit',
           second: '2-digit',
           timeZoneName: 'short',

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -16,7 +16,7 @@ const TorrentRendererHelper = {
     if (eta < 0 || eta >= 999 * 60 * 60) {
       return '';
     }
-    return `ETA: ${Formatter.timeInterval(eta)}`;
+    return `ETA: ${Formatter.timeInterval(eta, 2)}`;
   },
   formatLabels: (t, label) => {
     const labels = t.getLabels();
@@ -209,7 +209,7 @@ export class TorrentRendererFull {
       if (eta < 0 || eta >= 999 * 60 * 60 /* arbitrary */) {
         c.push('remaining time unknown');
       } else {
-        c.push(Formatter.timeInterval(t.getETA()), ' remaining');
+        c.push(Formatter.timeInterval(t.getETA(), 2), ' remaining');
       }
     }
 

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -16,7 +16,7 @@ const TorrentRendererHelper = {
     if (eta < 0 || eta >= 999 * 60 * 60) {
       return '';
     }
-    return `ETA: ${Formatter.timeInterval(eta, 2)}`;
+    return `ETA: ${Formatter.timeInterval(eta, 1)}`;
   },
   formatLabels: (t, label) => {
     const labels = t.getLabels();
@@ -209,7 +209,7 @@ export class TorrentRendererFull {
       if (eta < 0 || eta >= 999 * 60 * 60 /* arbitrary */) {
         c.push('remaining time unknown');
       } else {
-        c.push(Formatter.timeInterval(t.getETA(), 2), ' remaining');
+        c.push(Formatter.timeInterval(t.getETA(), 1), ' remaining');
       }
     }
 


### PR DESCRIPTION
- Torrent running time will display number of days, hours and minutes (excluding seconds if it's been more than a minute).
- Torrent date added will display in date as well as time.

Closes #5917

Notes: Added display and time in torrent detail

See screenshot
![Transmission time 1](https://github.com/transmission/transmission/assets/2275021/345b5027-1e93-46d9-a254-5b861b1bf8c8)

Animated diff from original
![Transmission time 2 (apng)](https://github.com/transmission/transmission/assets/2275021/de5bd93b-39d7-4d4a-9512-0dc53b1acc74)
