### PR TITLE
fix: fixed graying out buttons in dark mode for web client

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -94,7 +94,7 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
     --color-fg-primary: #{$dark-mode-white};
     --color-fg-secondary: #{$nice-grey};
     --color-fg-on-popup: #{$nice-grey};
-    --color-fg-disabled: #{$dark-mode-white};
+    --color-fg-disabled: #808088;
     --color-bg-warn: #cf6679;
     --color-fg-warn: #{$dark-mode-black};
     --color-border: #{$dark-mode-white};


### PR DESCRIPTION
Side note: This is for 4.1.0 only, graying out buttons in 4.0.x is controlled by opacity

Closes #5919

Notes: A quick fix to buttons not graying out in dark mode

![Transmission graying out on dark ui](https://github.com/transmission/transmission/assets/2275021/77d7a770-7b70-4770-a091-07f50ab4dea2)