### PR TITLE
refactor: make tr_variant follow RAII

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -204,7 +204,7 @@ int tr_main(int argc, char* argv[])
 
     tr_locale_set_global("");
 
-    tr_variant settings;
+    auto settings = tr_variant{};
 
     tr_formatter_mem_init(MemK, MemKStr, MemMStr, MemGStr, MemTStr);
     tr_formatter_size_init(DiskK, DiskKStr, DiskMStr, DiskGStr, DiskTStr);
@@ -360,7 +360,6 @@ int tr_main(int argc, char* argv[])
     tr_sessionSaveSettings(h, config_dir.c_str(), &settings);
 
     printf("\n");
-    tr_variantClear(&settings);
     tr_sessionClose(h);
     return EXIT_SUCCESS;
 }

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -204,7 +204,7 @@ int tr_main(int argc, char* argv[])
 
     tr_locale_set_global("");
 
-    auto settings = tr_variant{};
+    tr_variant settings;
 
     tr_formatter_mem_init(MemK, MemKStr, MemMStr, MemGStr, MemTStr);
     tr_formatter_size_init(DiskK, DiskKStr, DiskMStr, DiskGStr, DiskTStr);

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -669,7 +669,7 @@ void tr_daemon::reconfigure(void)
     }
     else
     {
-        tr_variant newsettings;
+        auto new_settings = tr_variant{};
         char const* configDir;
 
         /* reopen the logfile to allow for log rotation */
@@ -680,11 +680,10 @@ void tr_daemon::reconfigure(void)
 
         configDir = tr_sessionGetConfigDir(my_session_);
         tr_logAddInfo(fmt::format(_("Reloading settings from '{path}'"), fmt::arg("path", configDir)));
-        tr_variantInitDict(&newsettings, 0);
-        tr_variantDictAddBool(&newsettings, TR_KEY_rpc_enabled, true);
-        tr_sessionLoadSettings(&newsettings, configDir, MyName);
-        tr_sessionSet(my_session_, &newsettings);
-        tr_variantClear(&newsettings);
+        tr_variantInitDict(&new_settings, 0);
+        tr_variantDictAddBool(&new_settings, TR_KEY_rpc_enabled, true);
+        tr_sessionLoadSettings(&new_settings, configDir, MyName);
+        tr_sessionSet(my_session_, &new_settings);
         tr_sessionReloadBlocklists(my_session_);
     }
 }
@@ -942,7 +941,6 @@ bool tr_daemon::init(int argc, char const* const argv[], bool* foreground, int* 
     return true;
 
 EXIT_EARLY:
-    tr_variantClear(&settings_);
     return false;
 }
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -669,7 +669,7 @@ void tr_daemon::reconfigure(void)
     }
     else
     {
-        auto new_settings = tr_variant{};
+        tr_variant newsettings;
         char const* configDir;
 
         /* reopen the logfile to allow for log rotation */
@@ -680,10 +680,10 @@ void tr_daemon::reconfigure(void)
 
         configDir = tr_sessionGetConfigDir(my_session_);
         tr_logAddInfo(fmt::format(_("Reloading settings from '{path}'"), fmt::arg("path", configDir)));
-        tr_variantInitDict(&new_settings, 0);
-        tr_variantDictAddBool(&new_settings, TR_KEY_rpc_enabled, true);
-        tr_sessionLoadSettings(&new_settings, configDir, MyName);
-        tr_sessionSet(my_session_, &new_settings);
+        tr_variantInitDict(&newsettings, 0);
+        tr_variantDictAddBool(&newsettings, TR_KEY_rpc_enabled, true);
+        tr_sessionLoadSettings(&newsettings, configDir, MyName);
+        tr_sessionSet(my_session_, &newsettings);
         tr_sessionReloadBlocklists(my_session_);
     }
 }

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -31,7 +31,6 @@ public:
             close(sigfd_);
         }
 #endif /* signalfd API */
-        tr_variantClear(&settings_);
     }
 
     bool spawn(bool foreground, int* exit_code, tr_error** error);

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -503,8 +503,6 @@ bool Application::Impl::on_rpc_changed_idle(tr_rpc_callback_type type, tr_torren
             {
                 core_->signal_prefs_changed().emit(changed_key);
             }
-
-            tr_variantClear(&tmp);
             break;
         }
 
@@ -1436,7 +1434,7 @@ void Application::Impl::show_about_dialog()
 
 bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method)
 {
-    tr_variant top;
+    auto top = tr_variant{};
     bool invoked = false;
     auto* session = core_->get_session();
 
@@ -1452,7 +1450,6 @@ bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method
         invoked = true;
     }
 
-    tr_variantClear(&top);
     return invoked;
 }
 
@@ -1467,23 +1464,21 @@ void Application::Impl::remove_selected(bool delete_files)
 void Application::Impl::start_all_torrents()
 {
     auto* session = core_->get_session();
-    tr_variant request;
+    auto request = tr_variant{};
 
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-start"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantClear(&request);
 }
 
 void Application::Impl::pause_all_torrents()
 {
     auto* session = core_->get_session();
-    tr_variant request;
+    auto request = tr_variant{};
 
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-stop"sv);
     tr_rpc_request_exec_json(session, &request, nullptr, nullptr);
-    tr_variantClear(&request);
 }
 
 void Application::Impl::copy_magnet_link_to_clipboard(Glib::RefPtr<Torrent> const& torrent) const

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1434,7 +1434,7 @@ void Application::Impl::show_about_dialog()
 
 bool Application::Impl::call_rpc_for_selected_torrents(std::string const& method)
 {
-    auto top = tr_variant{};
+    tr_variant top;
     bool invoked = false;
     auto* session = core_->get_session();
 
@@ -1464,7 +1464,7 @@ void Application::Impl::remove_selected(bool delete_files)
 void Application::Impl::start_all_torrents()
 {
     auto* session = core_->get_session();
-    auto request = tr_variant{};
+    tr_variant request;
 
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-start"sv);
@@ -1474,7 +1474,7 @@ void Application::Impl::start_all_torrents()
 void Application::Impl::pause_all_torrents()
 {
     auto* session = core_->get_session();
-    auto request = tr_variant{};
+    tr_variant request;
 
     tr_variantInitDict(&request, 1);
     tr_variantDictAddStrView(&request, TR_KEY_method, "torrent-stop"sv);

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -431,7 +431,7 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
 
 void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
 {
-    tr_variant top;
+    auto top = tr_variant{};
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -445,12 +445,11 @@ void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
     }
 
     core_->exec(&top);
-    tr_variantClear(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
 {
-    tr_variant top;
+    auto top = tr_variant{};
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -464,12 +463,11 @@ void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
     }
 
     core_->exec(&top);
-    tr_variantClear(&top);
 }
 
 void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
 {
-    tr_variant top;
+    auto top = tr_variant{};
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -483,7 +481,6 @@ void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
     }
 
     core_->exec(&top);
-    tr_variantClear(&top);
 }
 
 void DetailsDialog::Impl::options_page_init(Glib::RefPtr<Gtk::Builder> const& /*builder*/)
@@ -2374,7 +2371,7 @@ void AddTrackerDialog::on_response(int response)
         {
             if (tr_urlIsValidTracker(url.c_str()))
             {
-                tr_variant top;
+                auto top = tr_variant{};
 
                 tr_variantInitDict(&top, 2);
                 tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -2385,8 +2382,6 @@ void AddTrackerDialog::on_response(int response)
 
                 core_->exec(&top);
                 parent_.refresh();
-
-                tr_variantClear(&top);
             }
             else
             {
@@ -2423,7 +2418,7 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
     {
         auto const torrent_id = iter->get_value(tracker_cols.torrent_id);
         auto const tracker_id = iter->get_value(tracker_cols.tracker_id);
-        tr_variant top;
+        auto top = tr_variant{};
 
         tr_variantInitDict(&top, 2);
         tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -2434,8 +2429,6 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
 
         core_->exec(&top);
         refresh();
-
-        tr_variantClear(&top);
     }
 }
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -431,7 +431,7 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
 
 void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
 {
-    auto top = tr_variant{};
+    tr_variant top;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -449,7 +449,7 @@ void DetailsDialog::Impl::torrent_set_bool(tr_quark key, bool value)
 
 void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
 {
-    auto top = tr_variant{};
+    tr_variant top;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -467,7 +467,7 @@ void DetailsDialog::Impl::torrent_set_int(tr_quark key, int value)
 
 void DetailsDialog::Impl::torrent_set_real(tr_quark key, double value)
 {
-    auto top = tr_variant{};
+    tr_variant top;
 
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -2371,7 +2371,7 @@ void AddTrackerDialog::on_response(int response)
         {
             if (tr_urlIsValidTracker(url.c_str()))
             {
-                auto top = tr_variant{};
+                tr_variant top;
 
                 tr_variantInitDict(&top, 2);
                 tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);
@@ -2418,7 +2418,7 @@ void DetailsDialog::Impl::on_tracker_list_remove_button_clicked()
     {
         auto const torrent_id = iter->get_value(tracker_cols.torrent_id);
         auto const tracker_id = iter->get_value(tracker_cols.tracker_id);
-        auto top = tr_variant{};
+        tr_variant top;
 
         tr_variantInitDict(&top, 2);
         tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-set"sv);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -961,7 +961,7 @@ void Session::update()
 
 void Session::start_now(tr_torrent_id_t id)
 {
-    auto top = tr_variant{};
+    tr_variant top;
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-start-now");
 
@@ -1230,7 +1230,7 @@ void Session::port_test()
     auto const tag = nextTag;
     ++nextTag;
 
-    auto request = tr_variant{};
+    tr_variant request;
     tr_variantInitDict(&request, 2);
     tr_variantDictAddStrView(&request, TR_KEY_method, "port-test");
     tr_variantDictAddInt(&request, TR_KEY_tag, tag);
@@ -1261,7 +1261,7 @@ void Session::blocklist_update()
     auto const tag = nextTag;
     ++nextTag;
 
-    auto request = tr_variant{};
+    tr_variant request;
     tr_variantInitDict(&request, 2);
     tr_variantDictAddStrView(&request, TR_KEY_method, "blocklist-update");
     tr_variantDictAddInt(&request, TR_KEY_tag, tag);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -57,30 +57,6 @@
 
 using namespace std::literals;
 
-namespace
-{
-
-class TrVariantDeleter
-{
-public:
-    void operator()(tr_variant* ptr) const
-    {
-        tr_variantClear(ptr);
-        std::default_delete<tr_variant>()(ptr);
-    }
-};
-
-using TrVariantPtr = std::unique_ptr<tr_variant, TrVariantDeleter>;
-
-TrVariantPtr create_variant(tr_variant& other)
-{
-    auto result = TrVariantPtr(new tr_variant(other));
-    tr_variantInitBool(&other, false);
-    return result;
-}
-
-} // namespace
-
 class Session::Impl
 {
 public:
@@ -985,7 +961,7 @@ void Session::update()
 
 void Session::start_now(tr_torrent_id_t id)
 {
-    tr_variant top;
+    auto top = tr_variant{};
     tr_variantInitDict(&top, 2);
     tr_variantDictAddStrView(&top, TR_KEY_method, "torrent-start-now");
 
@@ -993,7 +969,6 @@ void Session::start_now(tr_torrent_id_t id)
     auto* ids = tr_variantDictAddList(args, TR_KEY_ids, 1);
     tr_variantListAddInt(ids, id);
     exec(&top);
-    tr_variantClear(&top);
 }
 
 void Session::Impl::update()
@@ -1214,8 +1189,11 @@ bool core_read_rpc_response_idle(tr_variant& response)
 
 void core_read_rpc_response(tr_session* /*session*/, tr_variant* response, gpointer /*user_data*/)
 {
-    Glib::signal_idle().connect([owned_response = std::shared_ptr(create_variant(*response))]() mutable
-                                { return core_read_rpc_response_idle(*owned_response); });
+    auto owned_response = std::make_shared<tr_variant>();
+    tr_variantInitBool(owned_response.get(), false);
+    std::swap(*owned_response, *response);
+
+    Glib::signal_idle().connect([owned_response]() mutable { return core_read_rpc_response_idle(*owned_response); });
 }
 
 } // namespace
@@ -1252,7 +1230,7 @@ void Session::port_test()
     auto const tag = nextTag;
     ++nextTag;
 
-    tr_variant request;
+    auto request = tr_variant{};
     tr_variantInitDict(&request, 2);
     tr_variantDictAddStrView(&request, TR_KEY_method, "port-test");
     tr_variantDictAddInt(&request, TR_KEY_tag, tag);
@@ -1272,7 +1250,6 @@ void Session::port_test()
 
             impl_->signal_port_tested().emit(is_open);
         });
-    tr_variantClear(&request);
 }
 
 /***
@@ -1284,7 +1261,7 @@ void Session::blocklist_update()
     auto const tag = nextTag;
     ++nextTag;
 
-    tr_variant request;
+    auto request = tr_variant{};
     tr_variantInitDict(&request, 2);
     tr_variantDictAddStrView(&request, TR_KEY_method, "blocklist-update");
     tr_variantDictAddInt(&request, TR_KEY_tag, tag);
@@ -1309,7 +1286,6 @@ void Session::blocklist_update()
 
             impl_->signal_blocklist_updated().emit(ruleCount >= 0);
         });
-    tr_variantClear(&request);
 }
 
 /***

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -257,7 +257,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
     }
     else if (this->size() > 1)
     {
-        tr_variant* tier_list = tr_variantDictAddList(&metainfo, TR_KEY_announce_list, 0);
+        auto* const tier_list = tr_variantDictAddList(&metainfo, TR_KEY_announce_list, 0);
 
         auto current_tier = std::optional<tr_tracker_tier_t>{};
         tr_variant* tracker_list = nullptr;
@@ -276,12 +276,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
 
     // confirm that it's good by parsing it back again
     auto const contents = serde.to_string(metainfo);
-    tr_variantClear(&metainfo);
-    if (auto tmp = serde.parse(contents); tmp)
-    {
-        tr_variantClear(&*tmp);
-    }
-    else
+    if (!serde.parse(contents).has_value())
     {
         return false;
     }

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -257,7 +257,7 @@ bool tr_announce_list::save(std::string_view torrent_file, tr_error** error) con
     }
     else if (this->size() > 1)
     {
-        auto* const tier_list = tr_variantDictAddList(&metainfo, TR_KEY_announce_list, 0);
+        tr_variant* tier_list = tr_variantDictAddList(&metainfo, TR_KEY_announce_list, 0);
 
         auto current_tier = std::optional<tr_tracker_tier_t>{};
         tr_variant* tracker_list = nullptr;

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -377,9 +377,7 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
         tr_variantDictAddStr(info_dict, TR_KEY_source, source_);
     }
 
-    auto ret = tr_variant_serde::benc().to_string(top);
-    tr_variantClear(&top);
-    return ret;
+    return tr_variant_serde::benc().to_string(top);
 }
 
 uint32_t tr_metainfo_builder::default_piece_size(uint64_t total_size) noexcept

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1033,7 +1033,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     auto const handshake_sv = payload.to_string_view();
 
     auto var = tr_variant_serde::benc().inplace().parse(handshake_sv);
-    if (!var || !tr_variantIsDict(&*var))
+    if (!var || !var->holds_alternative<tr_variant::Map>())
     {
         logtrace(msgs, "GET  extended-handshake, couldn't get dictionary");
         return;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1029,13 +1029,12 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
 {
     auto const handshake_sv = payload.to_string_view();
 
-    auto ovar = tr_variant_serde::benc().inplace().parse(handshake_sv);
-    if (!ovar || tr_variantIsDict(&*ovar))
+    auto var = tr_variant_serde::benc().inplace().parse(handshake_sv);
+    if (!var || !tr_variantIsDict(&*var))
     {
         logtrace(msgs, "GET  extended-handshake, couldn't get dictionary");
         return;
     }
-    auto& var = *ovar;
 
     logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(handshake_sv)));
 
@@ -1043,7 +1042,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     auto i = int64_t{};
     auto pex = tr_pex{};
     auto& [addr, port] = pex.socket_address;
-    if (tr_variantDictFindInt(&var, TR_KEY_e, &i))
+    if (tr_variantDictFindInt(&*var, TR_KEY_e, &i))
     {
         msgs->encryption_preference = i != 0 ? EncryptionPreference::Yes : EncryptionPreference::No;
 
@@ -1057,7 +1056,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     msgs->peerSupportsPex = false;
     msgs->peerSupportsMetadataXfer = false;
 
-    if (tr_variant* sub = nullptr; tr_variantDictFindDict(&var, TR_KEY_m, &sub))
+    if (tr_variant* sub = nullptr; tr_variantDictFindDict(&*var, TR_KEY_m, &sub))
     {
         if (tr_variantDictFindInt(sub, TR_KEY_ut_pex, &i))
         {
@@ -1083,13 +1082,13 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     }
 
     /* look for metainfo size (BEP 9) */
-    if (tr_variantDictFindInt(&var, TR_KEY_metadata_size, &i) && tr_torrentSetMetadataSizeHint(msgs->torrent, i))
+    if (tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &i) && tr_torrentSetMetadataSizeHint(msgs->torrent, i))
     {
         msgs->metadata_size_hint = i;
     }
 
     /* look for upload_only (BEP 21) */
-    if (tr_variantDictFindInt(&var, TR_KEY_upload_only, &i))
+    if (tr_variantDictFindInt(&*var, TR_KEY_upload_only, &i))
     {
         pex.flags |= ADDED_F_SEED_FLAG;
     }
@@ -1098,13 +1097,13 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     // Client name and version (as a utf-8 string). This is a much more
     // reliable way of identifying the client than relying on the
     // peer id encoding.
-    if (auto sv = std::string_view{}; tr_variantDictFindStrView(&var, TR_KEY_v, &sv))
+    if (auto sv = std::string_view{}; tr_variantDictFindStrView(&*var, TR_KEY_v, &sv))
     {
         msgs->set_user_agent(tr_interned_string{ sv });
     }
 
     /* get peer's listening port */
-    if (tr_variantDictFindInt(&var, TR_KEY_p, &i) && i > 0)
+    if (tr_variantDictFindInt(&*var, TR_KEY_p, &i) && i > 0)
     {
         port.set_host(i);
         msgs->publish(tr_peer_event::GotPort(port));
@@ -1113,14 +1112,14 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
 
     std::byte const* addr_compact = nullptr;
     auto addr_len = size_t{};
-    if (msgs->io->is_incoming() && tr_variantDictFindRaw(&var, TR_KEY_ipv4, &addr_compact, &addr_len) &&
+    if (msgs->io->is_incoming() && tr_variantDictFindRaw(&*var, TR_KEY_ipv4, &addr_compact, &addr_len) &&
         addr_len == tr_address::CompactAddrBytes[TR_AF_INET])
     {
         std::tie(addr, std::ignore) = tr_address::from_compact_ipv4(addr_compact);
         tr_peerMgrAddPex(msgs->torrent, TR_PEER_FROM_LTEP, &pex, 1);
     }
 
-    if (msgs->io->is_incoming() && tr_variantDictFindRaw(&var, TR_KEY_ipv6, &addr_compact, &addr_len) &&
+    if (msgs->io->is_incoming() && tr_variantDictFindRaw(&*var, TR_KEY_ipv6, &addr_compact, &addr_len) &&
         addr_len == tr_address::CompactAddrBytes[TR_AF_INET6])
     {
         std::tie(addr, std::ignore) = tr_address::from_compact_ipv6(addr_compact);
@@ -1128,7 +1127,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     }
 
     /* get peer's maximum request queue size */
-    if (tr_variantDictFindInt(&var, TR_KEY_reqq, &i))
+    if (tr_variantDictFindInt(&*var, TR_KEY_reqq, &i))
     {
         msgs->reqq = i;
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -805,7 +805,6 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_
      * same resume information... */
     tor->set_dirty(was_dirty);
 
-    tr_variantClear(&top);
     return fields_loaded;
 }
 
@@ -917,8 +916,6 @@ void save(tr_torrent* tor)
     {
         tor->set_local_error(fmt::format("Unable to save resume file: {:s}", serde.error_->message));
     }
-
-    tr_variantClear(&top);
 }
 
 } // namespace tr_resume

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -528,13 +528,13 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
                 auto* const b = tr_variantListChild(l, fi);
                 auto time_checked = time_t{};
 
-                if (b != nullptr && b->is_int())
+                if (b != nullptr && b->holds_alternative<int64_t>())
                 {
                     auto t = int64_t{};
                     tr_variantGetInt(b, &t);
                     time_checked = time_t(t);
                 }
-                else if (tr_variantIsList(b))
+                else if (b != nullptr && b->holds_alternative<tr_variant::Vector>())
                 {
                     auto offset = int64_t{};
                     tr_variantGetInt(tr_variantListChild(b, 0), &offset);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -525,7 +525,7 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
         {
             for (tr_file_index_t fi = 0; fi < n_files; ++fi)
             {
-                auto* const b = tr_variantListChild(l, fi);
+                tr_variant* const b = tr_variantListChild(l, fi);
                 auto time_checked = time_t{};
 
                 if (tr_variantIsInt(b))

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -525,10 +525,10 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
         {
             for (tr_file_index_t fi = 0; fi < n_files; ++fi)
             {
-                tr_variant* const b = tr_variantListChild(l, fi);
+                auto* const b = tr_variantListChild(l, fi);
                 auto time_checked = time_t{};
 
-                if (tr_variantIsInt(b))
+                if (b != nullptr && b->is_int())
                 {
                     auto t = int64_t{};
                     tr_variantGetInt(b, &t);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -528,13 +528,13 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
                 auto* const b = tr_variantListChild(l, fi);
                 auto time_checked = time_t{};
 
-                if (b != nullptr && b->holds_alternative<int64_t>())
+                if (tr_variantIsInt(b))
                 {
                     auto t = int64_t{};
                     tr_variantGetInt(b, &t);
                     time_checked = time_t(t);
                 }
-                else if (b != nullptr && b->holds_alternative<tr_variant::Vector>())
+                else if (tr_variantIsList(b))
                 {
                     auto offset = int64_t{};
                     tr_variantGetInt(tr_variantListChild(b, 0), &offset);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -364,11 +364,6 @@ void handle_rpc_from_json(struct evhttp_request* req, tr_rpc_server* server, std
     auto otop = tr_variant_serde::json().inplace().parse(json);
 
     tr_rpc_request_exec_json(server->session, otop ? &*otop : nullptr, rpc_response_func, new rpc_response_data{ req, server });
-
-    if (otop)
-    {
-        tr_variantClear(&*otop);
-    }
 }
 
 void handle_rpc(struct evhttp_request* req, tr_rpc_server* server)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -78,7 +78,6 @@ void tr_idle_function_done(struct tr_rpc_idle_data* data, std::string_view resul
 
     (*data->callback)(data->session, &data->response, data->callback_user_data);
 
-    tr_variantClear(&data->response);
     delete data;
 }
 
@@ -2535,8 +2534,6 @@ void tr_rpc_request_exec_json(
         }
 
         (*callback)(session, &response, callback_user_data);
-
-        tr_variantClear(&response);
     }
     else if (method->immediate)
     {
@@ -2558,8 +2555,6 @@ void tr_rpc_request_exec_json(
         }
 
         (*callback)(session, &response, callback_user_data);
-
-        tr_variantClear(&response);
     }
     else
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1741,7 +1741,7 @@ char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args_out, s
         for (size_t i = 0; i < names_count; ++i)
         {
             auto const* const v = tr_variantListChild(names_list, i);
-            if (std::string_view l; v != nullptr && v->holds_alternative<std::string_view>() && tr_variantGetStrView(v, &l))
+            if (std::string_view l; v != nullptr && tr_variantGetStrView(v, &l))
             {
                 names.insert(l);
             }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1742,7 +1742,7 @@ char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args_out, s
         for (size_t i = 0; i < names_count; ++i)
         {
             auto const* const v = tr_variantListChild(names_list, i);
-            if (std::string_view l; tr_variantIsString(v) && tr_variantGetStrView(v, &l))
+            if (std::string_view l; v != nullptr && v->holds_alternative<std::string_view>() && tr_variantGetStrView(v, &l))
             {
                 names.insert(l);
             }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -485,7 +485,7 @@ bool tr_sessionLoadSettings(tr_variant* settings_in, char const* config_dir, cha
 {
     using namespace settings_helpers;
 
-    TR_ASSERT(settings_in != nullptr && settings_in->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tr_variantIsDict(settings_in));
 
     // first, start with the libtransmission default settings
     auto settings = tr_variant{};
@@ -525,7 +525,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tr_variantIsDict(client_settings));
 
     auto settings = tr_variant{};
     auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
@@ -570,7 +570,7 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tr_variantIsDict(client_settings));
 
     tr_timeUpdate(time(nullptr));
 
@@ -622,7 +622,7 @@ void tr_session::initImpl(init_data& data)
     TR_ASSERT(am_in_session_thread());
 
     auto* const client_settings = data.client_settings;
-    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tr_variantIsDict(client_settings));
 
     tr_logAddTrace(fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&top_bandwidth_)));
 
@@ -658,7 +658,7 @@ void tr_session::initImpl(init_data& data)
 void tr_session::setSettings(tr_variant* settings_dict, bool force)
 {
     TR_ASSERT(am_in_session_thread());
-    TR_ASSERT(settings_dict != nullptr && settings_dict->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tr_variantIsDict(settings_dict));
 
     // load the session settings
     auto new_settings = tr_session_settings{};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -114,7 +114,6 @@ void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
             group.honor_parent_limits(TR_DOWN, honors);
         }
     }
-    tr_variantClear(&*groups_var);
 }
 
 void bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
@@ -139,7 +138,6 @@ void bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
 
     auto const filename = tr_pathbuf{ config_dir, '/', BandwidthGroupsFilename };
     tr_variant_serde::json().to_file(groups_dict, filename);
-    tr_variantClear(&groups_dict);
 }
 
 } // namespace bandwidth_group_helpers
@@ -483,21 +481,21 @@ void tr_sessionGetSettings(tr_session const* session, tr_variant* setme_dictiona
     tr_variantDictAddInt(setme_dictionary, TR_KEY_message_level, tr_logGetLevel());
 }
 
-bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const* app_name)
+bool tr_sessionLoadSettings(tr_variant* settings_in, char const* config_dir, char const* app_name)
 {
     using namespace settings_helpers;
 
-    TR_ASSERT(dict != nullptr && dict->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(settings_in != nullptr && settings_in->holds_alternative<tr_variant::Map>());
 
-    /* initializing the defaults: caller may have passed in some app-level defaults.
-     * preserve those and use the session defaults to fill in any missing gaps. */
-    auto old_dict = *dict;
-    tr_variantInitDict(dict, 0);
-    tr_sessionGetDefaultSettings(dict);
-    tr_variantMergeDicts(dict, &old_dict);
-    tr_variantClear(&old_dict);
+    // first, start with the libtransmission default settings
+    auto settings = tr_variant{};
+    tr_variantInitDict(&settings, 0);
+    tr_sessionGetDefaultSettings(&settings);
 
-    /* file settings override the defaults */
+    // now use the app default settings passed in
+    tr_variantMergeDicts(&settings, settings_in);
+
+    // now use a settings file to override all the defaults
     auto success = bool{};
     auto filename = tr_pathbuf{};
     get_settings_filename(filename, config_dir, app_name);
@@ -507,8 +505,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
     }
     else if (auto file_settings = tr_variant_serde::json().parse_file(filename); file_settings)
     {
-        tr_variantMergeDicts(dict, &*file_settings);
-        tr_variantClear(&*file_settings);
+        tr_variantMergeDicts(&settings, &*file_settings);
         success = true;
     }
     else
@@ -516,7 +513,11 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
         success = false;
     }
 
-    /* cleanup */
+    if (success)
+    {
+        std::swap(*settings_in, settings);
+    }
+
     return success;
 }
 
@@ -526,7 +527,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
 
     TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
 
-    tr_variant settings;
+    auto settings = tr_variant{};
     auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
 
     tr_variantInitDict(&settings, 0);
@@ -535,7 +536,6 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
     if (auto file_settings = tr_variant_serde::json().parse_file(filename); file_settings)
     {
         tr_variantMergeDicts(&settings, &*file_settings);
-        tr_variantClear(&*file_settings);
     }
 
     /* the client's settings override the file settings */
@@ -547,14 +547,10 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
         tr_variantInitDict(&session_settings, 0);
         tr_sessionGetSettings(session, &session_settings);
         tr_variantMergeDicts(&settings, &session_settings);
-        tr_variantClear(&session_settings);
     }
 
     /* save the result */
     tr_variant_serde::json().to_file(settings, filename);
-
-    /* cleanup */
-    tr_variantClear(&settings);
 
     /* Write bandwidth groups limits to file  */
     bandwidthGroupWrite(session, config_dir);
@@ -656,7 +652,6 @@ void tr_session::initImpl(init_data& data)
     tr_utpInit(this);
 
     /* cleanup */
-    tr_variantClear(&settings);
     data.done_cv.notify_one();
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -487,7 +487,7 @@ bool tr_sessionLoadSettings(tr_variant* dict, char const* config_dir, char const
 {
     using namespace settings_helpers;
 
-    TR_ASSERT(tr_variantIsDict(dict));
+    TR_ASSERT(dict != nullptr && dict->holds_alternative<tr_variant::Map>());
 
     /* initializing the defaults: caller may have passed in some app-level defaults.
      * preserve those and use the session defaults to fill in any missing gaps. */
@@ -524,7 +524,7 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
 
     tr_variant settings;
     auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
@@ -574,7 +574,7 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
 
     tr_timeUpdate(time(nullptr));
 
@@ -626,7 +626,7 @@ void tr_session::initImpl(init_data& data)
     TR_ASSERT(am_in_session_thread());
 
     auto* const client_settings = data.client_settings;
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr && client_settings->holds_alternative<tr_variant::Map>());
 
     tr_logAddTrace(fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&top_bandwidth_)));
 
@@ -663,7 +663,7 @@ void tr_session::initImpl(init_data& data)
 void tr_session::setSettings(tr_variant* settings_dict, bool force)
 {
     TR_ASSERT(am_in_session_thread());
-    TR_ASSERT(tr_variantIsDict(settings_dict));
+    TR_ASSERT(settings_dict != nullptr && settings_dict->holds_alternative<tr_variant::Map>());
 
     // load the session settings
     auto new_settings = tr_session_settings{};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -527,13 +527,13 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
 
     TR_ASSERT(tr_variantIsDict(client_settings));
 
-    auto settings = tr_variant{};
+    tr_variant settings;
     auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
 
     tr_variantInitDict(&settings, 0);
 
     /* the existing file settings are the fallback values */
-    if (auto file_settings = tr_variant_serde::json().parse_file(filename); file_settings)
+    if (auto const file_settings = tr_variant_serde::json().parse_file(filename); file_settings)
     {
         tr_variantMergeDicts(&settings, &*file_settings);
     }

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -55,8 +55,6 @@ tr_session_stats tr_stats::load_old_stats(std::string_view config_dir)
                 *tgt = val;
             }
         }
-
-        tr_variantClear(&*stats);
     }
 
     return ret;
@@ -73,7 +71,6 @@ void tr_stats::save() const
     tr_variantDictAddInt(&top, TR_KEY_session_count, saveme.sessionCount);
     tr_variantDictAddInt(&top, TR_KEY_uploaded_bytes, saveme.uploadedBytes);
     tr_variant_serde::json().to_file(top, tr_pathbuf{ config_dir_, "/stats.json"sv });
-    tr_variantClear(&top);
 }
 
 void tr_stats::clear()

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -242,8 +242,6 @@ bool use_new_metainfo(tr_torrent* tor, tr_error** error)
     build_metainfo_except_info_dict(tor->metainfo_, &top_v);
     tr_variantMergeDicts(tr_variantDictAddDict(&top_v, TR_KEY_info, 0), &*info_dict_v);
     auto const benc = serde.to_string(top_v);
-    tr_variantClear(&top_v);
-    tr_variantClear(&*info_dict_v);
 
     // does this synthetic torrent file parse?
     auto metainfo = tr_torrent_metainfo{};

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -425,7 +425,7 @@ private:
         auto const n = mediator_.api().get_nodes(std::data(sins4), &num4, std::data(sins6), &num6);
         tr_logAddTrace(fmt::format("Saving {} ({} + {}) nodes", n, num4, num6));
 
-        tr_variant benc;
+        auto benc = tr_variant{};
         tr_variantInitDict(&benc, 3);
         tr_variantDictAddRaw(&benc, TR_KEY_id, std::data(id_), std::size(id_));
 
@@ -460,7 +460,6 @@ private:
         }
 
         tr_variant_serde::benc().to_file(benc, state_filename_);
-        tr_variantClear(&benc);
     }
 
     [[nodiscard]] static std::pair<Id, Nodes> load_state(std::string_view filename)
@@ -509,8 +508,6 @@ private:
                     nodes.emplace_back(addr, port);
                 }
             }
-
-            tr_variantClear(&top);
         }
 
         return std::make_pair(id, nodes);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -425,7 +425,7 @@ private:
         auto const n = mediator_.api().get_nodes(std::data(sins4), &num4, std::data(sins6), &num6);
         tr_logAddTrace(fmt::format("Saving {} ({} + {}) nodes", n, num4, num6));
 
-        auto benc = tr_variant{};
+        tr_variant benc;
         tr_variantInitDict(&benc, 3);
         tr_variantDictAddRaw(&benc, TR_KEY_id, std::data(id_), std::size(id_));
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -155,7 +155,6 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
  *     tr_sessionGetDefaultSettings(&settings);
  *     if (tr_variantDictFindInt(&settings, TR_PREFS_KEY_PEER_PORT, &i))
  *         fprintf(stderr, "the default peer port is %d\n", (int)i);
- *     tr_variantClear(&settings);
  * @endcode
  *
  * @param setme_dictionary pointer to a tr_variant dictionary
@@ -218,8 +217,6 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, struct 
  *     tr_sessionGetDefaultSettings(&settings);
  *     configDir = tr_getDefaultConfigDir("Transmission");
  *     session = tr_sessionInit(configDir, true, &settings);
- *
- *     tr_variantClear(&settings);
  * @endcode
  *
  * @param config_dir where Transmission will look for resume files, blocklists, etc.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -189,7 +189,7 @@ void tr_sessionGetSettings(tr_session const* session, struct tr_variant* setme_d
  * @see `tr_sessionInit()`
  * @see `tr_sessionSaveSettings()`
  */
-bool tr_sessionLoadSettings(struct tr_variant* dictionary, char const* config_dir, char const* app_name);
+bool tr_sessionLoadSettings(tr_variant* settings, char const* config_dir, char const* app_name);
 
 /**
  * Add the session's configuration settings to the benc dictionary

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -247,11 +247,11 @@ private:
         {
             node = top_;
         }
-        else if (auto* const parent = stack_.back(); parent->holds_alternative<tr_variant::Vector>())
+        else if (auto* const parent = stack_.back(); tr_variantIsList(parent))
         {
             node = tr_variantListAdd(parent);
         }
-        else if (key_ && parent->holds_alternative<tr_variant::Map>())
+        else if (key_ && tr_variantIsDict(parent))
         {
             node = tr_variantDictAdd(parent, *key_);
             key_.reset();

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -247,11 +247,11 @@ private:
         {
             node = top_;
         }
-        else if (auto* parent = stack_.back(); tr_variantIsList(parent))
+        else if (auto* const parent = stack_.back(); parent->holds_alternative<tr_variant::Vector>())
         {
             node = tr_variantListAdd(parent);
         }
-        else if (key_ && tr_variantIsDict(parent))
+        else if (key_ && parent->holds_alternative<tr_variant::Map>())
         {
             node = tr_variantDictAdd(parent, *key_);
             key_.reset();

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -276,7 +276,6 @@ std::optional<tr_variant> tr_variant_serde::parse_benc(std::string_view input)
         return top;
     }
 
-    tr_variantClear(&top);
     return {};
 }
 
@@ -308,11 +307,9 @@ void saveStringImpl(OutBuf* out, std::string_view sv)
 {
     // `${sv.size()}:${sv}`
     auto const [buf, buflen] = out->reserve_space(std::size(sv) + 32U);
-    auto* walk = reinterpret_cast<char*>(buf);
-    auto const* const begin = walk;
-    walk = fmt::format_to(walk, FMT_COMPILE("{:d}:"), std::size(sv));
-    walk = std::copy_n(std::data(sv), std::size(sv), walk);
-    out->commit_space(walk - begin);
+    auto* begin = reinterpret_cast<char*>(buf);
+    auto* const end = fmt::format_to(begin, FMT_COMPILE("{:d}:{:s}"), std::size(sv), sv);
+    out->commit_space(end - begin);
 }
 
 void saveStringFunc(tr_variant const& /*var*/, std::string_view const val, void* vout)

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -273,7 +273,7 @@ std::optional<tr_variant> tr_variant_serde::parse_benc(std::string_view input)
     auto handler = MyHandler{ &top, parse_inplace_ };
     if (transmission::benc::parse(input, stack, handler, &end_, &error_) && std::empty(stack))
     {
-        return top;
+        return std::optional<tr_variant>{ std::move(top) };
     }
 
     return {};

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -247,7 +247,7 @@ private:
         {
             node = top_;
         }
-        else if (auto* const parent = stack_.back(); tr_variantIsList(parent))
+        else if (auto* parent = stack_.back(); tr_variantIsList(parent))
         {
             node = tr_variantListAdd(parent);
         }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -416,7 +416,7 @@ std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
 
     if (error_ == nullptr)
     {
-        return top;
+        return std::move(top);
     }
 
     return {};

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -74,11 +74,11 @@ tr_variant* get_node(struct jsonsl_st* jsn)
     {
         node = data->top;
     }
-    else if (tr_variantIsList(parent))
+    else if (parent->holds_alternative<tr_variant::Vector>())
     {
         node = tr_variantListAdd(parent);
     }
-    else if (tr_variantIsDict(parent) && !std::empty(data->key))
+    else if (parent->holds_alternative<tr_variant::Map>() && !std::empty(data->key))
     {
         node = tr_variantDictAdd(parent, tr_quark_new(data->key));
         data->key = ""sv;
@@ -506,8 +506,8 @@ void jsonChildFunc(struct JsonWalk* data)
 
 void jsonPushParent(struct JsonWalk* data, tr_variant const& v)
 {
-    auto const is_dict = tr_variantIsDict(&v);
-    auto const is_list = tr_variantIsList(&v);
+    auto const is_dict = v.holds_alternative<tr_variant::Map>();
+    auto const is_list = v.holds_alternative<tr_variant::Vector>();
     auto const n_children = is_dict ? v.val.l.count * 2U : v.val.l.count;
     data->parents.push_back({ is_dict, is_list, 0, n_children });
 }
@@ -686,7 +686,7 @@ void jsonContainerEndFunc(tr_variant const& var, void* vdata)
 
     jsonIndent(data);
 
-    if (tr_variantIsDict(&var))
+    if (var.holds_alternative<tr_variant::Map>())
     {
         data->out.push_back('}');
     }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -74,11 +74,11 @@ tr_variant* get_node(struct jsonsl_st* jsn)
     {
         node = data->top;
     }
-    else if (parent->holds_alternative<tr_variant::Vector>())
+    else if (tr_variantIsList(parent))
     {
         node = tr_variantListAdd(parent);
     }
-    else if (parent->holds_alternative<tr_variant::Map>() && !std::empty(data->key))
+    else if (tr_variantIsDict(parent) && !std::empty(data->key))
     {
         node = tr_variantDictAdd(parent, tr_quark_new(data->key));
         data->key = ""sv;
@@ -503,11 +503,11 @@ void jsonChildFunc(struct JsonWalk* data)
     }
 }
 
-void jsonPushParent(struct JsonWalk* data, tr_variant const& v)
+void jsonPushParent(struct JsonWalk* data, tr_variant const& var)
 {
-    auto const is_dict = v.holds_alternative<tr_variant::Map>();
-    auto const is_list = v.holds_alternative<tr_variant::Vector>();
-    auto const n_children = is_dict ? v.val.l.count * 2U : v.val.l.count;
+    auto const is_dict = tr_variantIsDict(&var);
+    auto const is_list = tr_variantIsList(&var);
+    auto const n_children = var.val.l.count * (is_dict ? 2U : 1U);
     data->parents.push_back({ is_dict, is_list, 0, n_children });
 }
 
@@ -685,7 +685,7 @@ void jsonContainerEndFunc(tr_variant const& var, void* vdata)
 
     jsonIndent(data);
 
-    if (var.holds_alternative<tr_variant::Map>())
+    if (tr_variantIsDict(&var))
     {
         data->out.push_back('}');
     }

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -419,7 +419,6 @@ std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
         return top;
     }
 
-    tr_variantClear(&top);
     return {};
 }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -503,11 +503,11 @@ void jsonChildFunc(struct JsonWalk* data)
     }
 }
 
-void jsonPushParent(struct JsonWalk* data, tr_variant const& var)
+void jsonPushParent(struct JsonWalk* data, tr_variant const& v)
 {
-    auto const is_dict = tr_variantIsDict(&var);
-    auto const is_list = tr_variantIsList(&var);
-    auto const n_children = var.val.l.count * (is_dict ? 2U : 1U);
+    auto const is_dict = tr_variantIsDict(&v);
+    auto const is_list = tr_variantIsList(&v);
+    auto const n_children = is_dict ? v.val.l.count * 2U : v.val.l.count;
     data->parents.push_back({ is_dict, is_list, 0, n_children });
 }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -243,7 +243,7 @@ bool tr_variantGetReal(tr_variant const* const var, double* setme)
 {
     bool success = false;
 
-    if (tr_variantIsReal(var))
+    if (var != nullptr && var->is_double())
     {
         *setme = var->val.d;
         success = true;
@@ -847,7 +847,7 @@ void tr_variantListCopy(tr_variant* target, tr_variant const* src)
             tr_variantGetBool(child, &val);
             tr_variantListAddBool(target, val);
         }
-        else if (tr_variantIsReal(child))
+        else if (child->is_double())
         {
             auto val = double{};
             tr_variantGetReal(child, &val);
@@ -919,7 +919,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
                 tr_variantGetBool(child, &val);
                 tr_variantDictAddBool(target, key, val);
             }
-            else if (tr_variantIsReal(child))
+            else if (child->is_double())
             {
                 auto val = double{};
                 tr_variantGetReal(child, &val);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -52,7 +52,7 @@ constexpr int dictIndexOf(tr_variant const* dict, tr_quark key)
     return -1;
 }
 
-bool dictFindType(tr_variant* dict, tr_quark key, int type, tr_variant** setme)
+bool dictFindType(tr_variant* dict, tr_quark key, tr_variant::Type type, tr_variant** setme)
 {
     *setme = tr_variantDictFind(dict, key);
     return tr_variantIsType(*setme, type);
@@ -82,7 +82,7 @@ tr_variant* containerReserve(tr_variant* v, size_t count)
     return v->val.l.vals + v->val.l.count;
 }
 
-tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, int type)
+tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, tr_variant::Type type)
 {
     /* see if it already exists, and if so, try to reuse it */
     tr_variant* child = tr_variantDictFind(dict, key);
@@ -93,7 +93,7 @@ tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, int type)
             tr_variantDictRemove(dict, key);
             child = nullptr;
         }
-        else if (child->type == TR_VARIANT_TYPE_STR)
+        else if (child->type == tr_variant::Type::String)
         {
             child->val.s.clear();
         }
@@ -296,12 +296,12 @@ bool tr_variantDictFindStrView(tr_variant* dict, tr_quark key, std::string_view*
 
 bool tr_variantDictFindList(tr_variant* dict, tr_quark key, tr_variant** setme)
 {
-    return dictFindType(dict, key, TR_VARIANT_TYPE_LIST, setme);
+    return dictFindType(dict, key, tr_variant::Type::Vector, setme);
 }
 
 bool tr_variantDictFindDict(tr_variant* dict, tr_quark key, tr_variant** setme)
 {
-    return dictFindType(dict, key, TR_VARIANT_TYPE_DICT, setme);
+    return dictFindType(dict, key, tr_variant::Type::Map, setme);
 }
 
 bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, uint8_t const** setme_raw, size_t* setme_len)
@@ -320,31 +320,31 @@ bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** set
 
 void tr_variantInitStrView(tr_variant* initme, std::string_view val)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variantInit(initme, tr_variant::Type::String);
     initme->val.s.set_shallow(val);
 }
 
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variantInit(initme, tr_variant::Type::String);
     initme->val.s.set({ static_cast<char const*>(value), value_len });
 }
 
 void tr_variantInitQuark(tr_variant* initme, tr_quark value)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variantInit(initme, tr_variant::Type::String);
     initme->val.s.set_shallow(tr_quark_get_string_view(value));
 }
 
 void tr_variantInitStr(tr_variant* initme, std::string_view value)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_STR);
+    tr_variantInit(initme, tr_variant::Type::String);
     initme->val.s.set(value);
 }
 
 void tr_variantInitList(tr_variant* initme, size_t reserve_count)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_LIST);
+    tr_variantInit(initme, tr_variant::Type::Vector);
     tr_variantListReserve(initme, reserve_count);
 }
 
@@ -357,7 +357,7 @@ void tr_variantListReserve(tr_variant* list, size_t count)
 
 void tr_variantInitDict(tr_variant* initme, size_t reserve_count)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_DICT);
+    tr_variantInit(initme, tr_variant::Type::Map);
     tr_variantDictReserve(initme, reserve_count);
 }
 
@@ -375,7 +375,7 @@ tr_variant* tr_variantListAdd(tr_variant* list)
     tr_variant* child = containerReserve(list, 1);
     ++list->val.l.count;
     child->key = 0;
-    tr_variantInit(child, TR_VARIANT_TYPE_INT);
+    tr_variantInit(child, tr_variant::Type::Int);
 
     return child;
 }
@@ -450,56 +450,56 @@ tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark key)
     tr_variant* val = containerReserve(dict, 1);
     ++dict->val.l.count;
     val->key = key;
-    tr_variantInit(val, TR_VARIANT_TYPE_INT);
+    tr_variantInit(val, tr_variant::Type::Int);
 
     return val;
 }
 
 tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark key, int64_t val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_INT);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Int);
     tr_variantInitInt(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark key, bool val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_BOOL);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Bool);
     tr_variantInitBool(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark key, double val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_REAL);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Double);
     tr_variantInitReal(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark key, tr_quark const val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
     tr_variantInitQuark(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark key, std::string_view val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
     tr_variantInitStr(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark key, std::string_view val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
     tr_variantInitStrView(child, val);
     return child;
 }
 
 tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark key, void const* value, size_t len)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, TR_VARIANT_TYPE_STR);
+    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
     tr_variantInitRaw(child, value, len);
     return child;
 }
@@ -738,23 +738,23 @@ void tr_variant_serde::walk(tr_variant const& top, WalkFuncs const& walk_funcs, 
         {
             switch (v->type)
             {
-            case TR_VARIANT_TYPE_INT:
+            case tr_variant::Type::Int:
                 walk_funcs.int_func(*v, v->val.i, user_data);
                 break;
 
-            case TR_VARIANT_TYPE_BOOL:
+            case tr_variant::Type::Bool:
                 walk_funcs.bool_func(*v, v->val.b, user_data);
                 break;
 
-            case TR_VARIANT_TYPE_REAL:
+            case tr_variant::Type::Double:
                 walk_funcs.double_func(*v, v->val.d, user_data);
                 break;
 
-            case TR_VARIANT_TYPE_STR:
+            case tr_variant::Type::String:
                 walk_funcs.string_func(*v, v->val.s.get(), user_data);
                 break;
 
-            case TR_VARIANT_TYPE_LIST:
+            case tr_variant::Type::Vector:
                 if (v == &node.v)
                 {
                     walk_funcs.list_begin_func(*v, user_data);
@@ -765,7 +765,7 @@ void tr_variant_serde::walk(tr_variant const& top, WalkFuncs const& walk_funcs, 
                 }
                 break;
 
-            case TR_VARIANT_TYPE_DICT:
+            case tr_variant::Type::Map:
                 if (v == &node.v)
                 {
                     walk_funcs.dict_begin_func(*v, user_data);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -145,25 +145,25 @@ bool tr_variantListRemove(tr_variant* list, size_t pos)
     return true;
 }
 
-bool tr_variantGetInt(tr_variant const* v, int64_t* setme)
+bool tr_variantGetInt(tr_variant const* const var, int64_t* setme)
 {
     bool success = false;
 
-    if (tr_variantIsInt(v))
+    if (tr_variantIsInt(var))
     {
         if (setme != nullptr)
         {
-            *setme = v->val.i;
+            *setme = var->val.i;
         }
 
         success = true;
     }
 
-    if (!success && tr_variantIsBool(v))
+    if (!success && var != nullptr && var->is_bool())
     {
         if (setme != nullptr)
         {
-            *setme = v->val.b ? 1 : 0;
+            *setme = var->val.b ? 1 : 0;
         }
 
         success = true;
@@ -207,21 +207,21 @@ bool tr_variantGetRaw(tr_variant const* v, uint8_t const** setme_raw, size_t* se
     return false;
 }
 
-bool tr_variantGetBool(tr_variant const* v, bool* setme)
+bool tr_variantGetBool(tr_variant const* const var, bool* setme)
 {
-    if (tr_variantIsBool(v))
+    if (var != nullptr && var->is_bool())
     {
-        *setme = v->val.b;
+        *setme = var->val.b;
         return true;
     }
 
-    if (tr_variantIsInt(v) && (v->val.i == 0 || v->val.i == 1))
+    if (tr_variantIsInt(var) && (var->val.i == 0 || var->val.i == 1))
     {
-        *setme = v->val.i != 0;
+        *setme = var->val.i != 0;
         return true;
     }
 
-    if (auto sv = std::string_view{}; tr_variantGetStrView(v, &sv))
+    if (auto sv = std::string_view{}; tr_variantGetStrView(var, &sv))
     {
         if (sv == "true"sv)
         {
@@ -841,7 +841,7 @@ void tr_variantListCopy(tr_variant* target, tr_variant const* src)
             break;
         }
 
-        if (tr_variantIsBool(child))
+        if (child->is_bool())
         {
             auto val = bool{};
             tr_variantGetBool(child, &val);
@@ -913,7 +913,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
                 tr_variantDictRemove(target, key);
             }
 
-            if (tr_variantIsBool(child))
+            if (child->is_bool())
             {
                 auto val = bool{};
                 tr_variantGetBool(child, &val);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -149,7 +149,7 @@ bool tr_variantGetInt(tr_variant const* const var, int64_t* setme)
 {
     bool success = false;
 
-    if (tr_variantIsInt(var))
+    if (var != nullptr && var->is_int())
     {
         if (setme != nullptr)
         {
@@ -215,7 +215,7 @@ bool tr_variantGetBool(tr_variant const* const var, bool* setme)
         return true;
     }
 
-    if (tr_variantIsInt(var) && (var->val.i == 0 || var->val.i == 1))
+    if (var != nullptr && var->is_int() && (var->val.i == 0 || var->val.i == 1))
     {
         *setme = var->val.i != 0;
         return true;
@@ -239,25 +239,25 @@ bool tr_variantGetBool(tr_variant const* const var, bool* setme)
     return false;
 }
 
-bool tr_variantGetReal(tr_variant const* v, double* setme)
+bool tr_variantGetReal(tr_variant const* const var, double* setme)
 {
     bool success = false;
 
-    if (tr_variantIsReal(v))
+    if (tr_variantIsReal(var))
     {
-        *setme = v->val.d;
+        *setme = var->val.d;
         success = true;
     }
 
-    if (!success && tr_variantIsInt(v))
+    if (!success && var != nullptr && var->is_int())
     {
-        *setme = (double)v->val.i;
+        *setme = static_cast<double>(var->val.i);
         success = true;
     }
 
-    if (!success && tr_variantIsString(v))
+    if (!success && tr_variantIsString(var))
     {
-        if (auto sv = std::string_view{}; tr_variantGetStrView(v, &sv))
+        if (auto sv = std::string_view{}; tr_variantGetStrView(var, &sv))
         {
             if (auto d = tr_num_parse<double>(sv); d)
             {
@@ -853,7 +853,7 @@ void tr_variantListCopy(tr_variant* target, tr_variant const* src)
             tr_variantGetReal(child, &val);
             tr_variantListAddReal(target, val);
         }
-        else if (tr_variantIsInt(child))
+        else if (child->is_int())
         {
             auto val = int64_t{};
             tr_variantGetInt(child, &val);
@@ -925,7 +925,7 @@ void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
                 tr_variantGetReal(child, &val);
                 tr_variantDictAddReal(target, key, val);
             }
-            else if (tr_variantIsInt(child))
+            else if (child->is_int())
             {
                 auto val = int64_t{};
                 tr_variantGetInt(child, &val);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -787,7 +787,7 @@ void tr_variant_serde::walk(tr_variant const& top, WalkFuncs const& walk_funcs, 
 
 // ---
 
-void tr_variantClear(tr_variant* clearme)
+void tr_variantClear(tr_variant* const clearme)
 {
     // clang-format off
     tr_variant_serde::WalkFuncs cleanup_funcs = {
@@ -801,7 +801,7 @@ void tr_variantClear(tr_variant* clearme)
     };
     // clang-format on
 
-    if (!tr_variantIsEmpty(clearme))
+    if (clearme != nullptr && clearme->has_value())
     {
         tr_variant_serde::walk(*clearme, cleanup_funcs, nullptr, false);
     }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -571,7 +571,7 @@ public:
         is_visited_ = true;
     }
 
-    tr_variant const* current() const noexcept
+    [[nodiscard]] tr_variant const* current() const noexcept
     {
         return var_;
     }
@@ -579,7 +579,7 @@ public:
 protected:
     friend class VariantWalker;
 
-    tr_variant const* var_;
+    tr_variant const* var_ = nullptr;
 
     bool is_visited_ = false;
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -52,9 +52,9 @@ constexpr int dictIndexOf(tr_variant const* const var, tr_quark key)
     return -1;
 }
 
-bool dictFindType(tr_variant* dict, tr_quark key, tr_variant::Type type, tr_variant** setme)
+bool dictFindType(tr_variant* const var, tr_quark key, tr_variant::Type type, tr_variant** setme)
 {
-    *setme = tr_variantDictFind(dict, key);
+    *setme = tr_variantDictFind(var, key);
     return tr_variantIsType(*setme, type);
 }
 
@@ -82,15 +82,15 @@ tr_variant* containerReserve(tr_variant* v, size_t count)
     return v->val.l.vals + v->val.l.count;
 }
 
-tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, tr_variant::Type type)
+tr_variant* dictFindOrAdd(tr_variant* const var, tr_quark key, tr_variant::Type type)
 {
     /* see if it already exists, and if so, try to reuse it */
-    tr_variant* child = tr_variantDictFind(dict, key);
+    tr_variant* child = tr_variantDictFind(var, key);
     if (child != nullptr)
     {
         if (!tr_variantIsType(child, type))
         {
-            tr_variantDictRemove(dict, key);
+            tr_variantDictRemove(var, key);
             child = nullptr;
         }
         else if (child->holds_alternative<std::string_view>())
@@ -102,7 +102,7 @@ tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, tr_variant::Type type)
     /* if it doesn't exist, create it */
     if (child == nullptr)
     {
-        child = tr_variantDictAdd(dict, key);
+        child = tr_variantDictAdd(var, key);
     }
 
     return child;
@@ -110,11 +110,11 @@ tr_variant* dictFindOrAdd(tr_variant* dict, tr_quark key, tr_variant::Type type)
 
 } // namespace
 
-tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark key)
+tr_variant* tr_variantDictFind(tr_variant* const var, tr_quark key)
 {
-    auto const i = dictIndexOf(dict, key);
+    auto const i = dictIndexOf(var, key);
 
-    return i < 0 ? nullptr : dict->val.l.vals + i;
+    return i < 0 ? nullptr : var->val.l.vals + i;
 }
 
 tr_variant* tr_variantListChild(tr_variant* const var, size_t pos)
@@ -278,49 +278,49 @@ bool tr_variantGetReal(tr_variant const* const var, double* setme)
     return false;
 }
 
-bool tr_variantDictFindInt(tr_variant* dict, tr_quark key, int64_t* setme)
+bool tr_variantDictFindInt(tr_variant* const var, tr_quark key, int64_t* setme)
 {
-    tr_variant const* child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetInt(child, setme);
 }
 
-bool tr_variantDictFindBool(tr_variant* dict, tr_quark key, bool* setme)
+bool tr_variantDictFindBool(tr_variant* const var, tr_quark key, bool* setme)
 {
-    tr_variant const* child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetBool(child, setme);
 }
 
-bool tr_variantDictFindReal(tr_variant* dict, tr_quark key, double* setme)
+bool tr_variantDictFindReal(tr_variant* const var, tr_quark key, double* setme)
 {
-    tr_variant const* child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetReal(child, setme);
 }
 
-bool tr_variantDictFindStrView(tr_variant* dict, tr_quark key, std::string_view* setme)
+bool tr_variantDictFindStrView(tr_variant* const var, tr_quark key, std::string_view* setme)
 {
-    tr_variant const* const child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetStrView(child, setme);
 }
 
-bool tr_variantDictFindList(tr_variant* dict, tr_quark key, tr_variant** setme)
+bool tr_variantDictFindList(tr_variant* const var, tr_quark key, tr_variant** setme)
 {
-    return dictFindType(dict, key, tr_variant::Type::Vector, setme);
+    return dictFindType(var, key, tr_variant::Type::Vector, setme);
 }
 
-bool tr_variantDictFindDict(tr_variant* dict, tr_quark key, tr_variant** setme)
+bool tr_variantDictFindDict(tr_variant* const var, tr_quark key, tr_variant** setme)
 {
-    return dictFindType(dict, key, tr_variant::Type::Map, setme);
+    return dictFindType(var, key, tr_variant::Type::Map, setme);
 }
 
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, uint8_t const** setme_raw, size_t* setme_len)
+bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, uint8_t const** setme_raw, size_t* setme_len)
 {
-    auto const* child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetRaw(child, setme_raw, setme_len);
 }
 
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** setme_raw, size_t* setme_len)
+bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, std::byte const** setme_raw, size_t* setme_len)
 {
-    auto const* child = tr_variantDictFind(dict, key);
+    auto const* const child = tr_variantDictFind(var, key);
     return tr_variantGetRaw(child, setme_raw, setme_len);
 }
 
@@ -388,65 +388,65 @@ tr_variant* tr_variantListAdd(tr_variant* const var)
     return child;
 }
 
-tr_variant* tr_variantListAddInt(tr_variant* list, int64_t value)
+tr_variant* tr_variantListAddInt(tr_variant* const var, int64_t value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitInt(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddReal(tr_variant* list, double value)
+tr_variant* tr_variantListAddReal(tr_variant* const var, double value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitReal(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddBool(tr_variant* list, bool value)
+tr_variant* tr_variantListAddBool(tr_variant* const var, bool value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitBool(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view value)
+tr_variant* tr_variantListAddStr(tr_variant* const var, std::string_view value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitStr(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value)
+tr_variant* tr_variantListAddStrView(tr_variant* const var, std::string_view value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitStrView(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark value)
+tr_variant* tr_variantListAddQuark(tr_variant* const var, tr_quark value)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitQuark(child, value);
     return child;
 }
 
-tr_variant* tr_variantListAddRaw(tr_variant* list, void const* value, size_t value_len)
+tr_variant* tr_variantListAddRaw(tr_variant* const var, void const* value, size_t value_len)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitRaw(child, value, value_len);
     return child;
 }
 
-tr_variant* tr_variantListAddList(tr_variant* list, size_t reserve_count)
+tr_variant* tr_variantListAddList(tr_variant* const var, size_t reserve_count)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitList(child, reserve_count);
     return child;
 }
 
-tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count)
+tr_variant* tr_variantListAddDict(tr_variant* const var, size_t reserve_count)
 {
-    tr_variant* child = tr_variantListAdd(list);
+    auto* const child = tr_variantListAdd(var);
     tr_variantInitDict(child, reserve_count);
     return child;
 }
@@ -464,94 +464,94 @@ tr_variant* tr_variantDictAdd(tr_variant* const var, tr_quark key)
     return val;
 }
 
-tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark key, int64_t val)
+tr_variant* tr_variantDictAddInt(tr_variant* const var, tr_quark key, int64_t val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Int);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::Int);
     tr_variantInitInt(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark key, bool val)
+tr_variant* tr_variantDictAddBool(tr_variant* const var, tr_quark key, bool val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Bool);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::Bool);
     tr_variantInitBool(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark key, double val)
+tr_variant* tr_variantDictAddReal(tr_variant* const var, tr_quark key, double val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::Double);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::Double);
     tr_variantInitReal(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark key, tr_quark const val)
+tr_variant* tr_variantDictAddQuark(tr_variant* const var, tr_quark key, tr_quark const val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::String);
     tr_variantInitQuark(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark key, std::string_view val)
+tr_variant* tr_variantDictAddStr(tr_variant* const var, tr_quark key, std::string_view val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::String);
     tr_variantInitStr(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark key, std::string_view val)
+tr_variant* tr_variantDictAddStrView(tr_variant* const var, tr_quark key, std::string_view val)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::String);
     tr_variantInitStrView(child, val);
     return child;
 }
 
-tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark key, void const* value, size_t len)
+tr_variant* tr_variantDictAddRaw(tr_variant* const var, tr_quark key, void const* value, size_t len)
 {
-    tr_variant* child = dictFindOrAdd(dict, key, tr_variant::Type::String);
+    auto* const child = dictFindOrAdd(var, key, tr_variant::Type::String);
     tr_variantInitRaw(child, value, len);
     return child;
 }
 
-tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark key, size_t reserve_count)
+tr_variant* tr_variantDictAddList(tr_variant* const var, tr_quark key, size_t reserve_count)
 {
-    tr_variant* child = tr_variantDictAdd(dict, key);
+    auto* const child = tr_variantDictAdd(var, key);
     tr_variantInitList(child, reserve_count);
     return child;
 }
 
-tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark key, size_t reserve_count)
+tr_variant* tr_variantDictAddDict(tr_variant* const var, tr_quark key, size_t reserve_count)
 {
-    tr_variant* child = tr_variantDictAdd(dict, key);
+    auto* const child = tr_variantDictAdd(var, key);
     tr_variantInitDict(child, reserve_count);
     return child;
 }
 
-tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark key, tr_variant* value)
+tr_variant* tr_variantDictSteal(tr_variant* const var, tr_quark key, tr_variant* value)
 {
-    tr_variant* child = tr_variantDictAdd(dict, key);
+    tr_variant* const child = tr_variantDictAdd(var, key);
     *child = *value;
     child->key = key;
     tr_variantInit(value, value->type);
     return child;
 }
 
-bool tr_variantDictRemove(tr_variant* dict, tr_quark key)
+bool tr_variantDictRemove(tr_variant* const var, tr_quark key)
 {
     bool removed = false;
 
-    if (int const i = dictIndexOf(dict, key); i >= 0)
+    if (int const i = dictIndexOf(var, key); i >= 0)
     {
-        int const last = (int)dict->val.l.count - 1;
+        int const last = (int)var->val.l.count - 1;
 
-        tr_variantClear(&dict->val.l.vals[i]);
+        tr_variantClear(&var->val.l.vals[i]);
 
         if (i != last)
         {
-            dict->val.l.vals[i] = dict->val.l.vals[last];
+            var->val.l.vals[i] = var->val.l.vals[last];
         }
 
-        --dict->val.l.count;
+        --var->val.l.count;
 
         removed = true;
     }
@@ -799,7 +799,7 @@ void tr_variant_serde::walk(tr_variant const& top, WalkFuncs const& walk_funcs, 
 void tr_variantClear(tr_variant* const clearme)
 {
     // clang-format off
-    tr_variant_serde::WalkFuncs cleanup_funcs = {
+    constexpr tr_variant_serde::WalkFuncs CleanupFuncs = {
         [](tr_variant const&, int64_t, void*) {},
         [](tr_variant const&, bool, void*) {},
         [](tr_variant const&, double, void*) {},
@@ -812,10 +812,10 @@ void tr_variantClear(tr_variant* const clearme)
 
     if (clearme != nullptr && clearme->has_value())
     {
-        tr_variant_serde::walk(*clearme, cleanup_funcs, nullptr, false);
-    }
+        tr_variant_serde::walk(*clearme, CleanupFuncs, nullptr, false);
 
-    *clearme = {};
+        *clearme = {};
+    }
 }
 
 // ---
@@ -897,76 +897,76 @@ constexpr size_t tr_variantDictSize(tr_variant const* const var)
 } // namespace merge_helpers
 } // namespace
 
-void tr_variantMergeDicts(tr_variant* target, tr_variant const* source)
+void tr_variantMergeDicts(tr_variant* const tgt, tr_variant const* const src)
 {
     using namespace merge_helpers;
 
-    TR_ASSERT(target != nullptr);
-    TR_ASSERT(target->holds_alternative<tr_variant::Map>());
-    TR_ASSERT(source != nullptr);
-    TR_ASSERT(source->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(tgt != nullptr);
+    TR_ASSERT(tgt->holds_alternative<tr_variant::Map>());
+    TR_ASSERT(src != nullptr);
+    TR_ASSERT(src->holds_alternative<tr_variant::Map>());
 
-    size_t const source_count = tr_variantDictSize(source);
+    size_t const source_count = tr_variantDictSize(src);
 
-    tr_variantDictReserve(target, source_count + tr_variantDictSize(target));
+    tr_variantDictReserve(tgt, source_count + tr_variantDictSize(tgt));
 
     for (size_t i = 0; i < source_count; ++i)
     {
         auto key = tr_quark{};
         tr_variant* child = nullptr;
-        if (tr_variantDictChild(const_cast<tr_variant*>(source), i, &key, &child))
+        if (tr_variantDictChild(const_cast<tr_variant*>(src), i, &key, &child))
         {
             tr_variant* t = nullptr;
 
             // if types differ, ensure that target will overwrite source
-            auto const* const target_child = tr_variantDictFind(target, key);
+            auto const* const target_child = tr_variantDictFind(tgt, key);
             if ((target_child != nullptr) && !tr_variantIsType(target_child, child->type))
             {
-                tr_variantDictRemove(target, key);
+                tr_variantDictRemove(tgt, key);
             }
 
             if (child->holds_alternative<bool>())
             {
                 auto val = bool{};
                 tr_variantGetBool(child, &val);
-                tr_variantDictAddBool(target, key, val);
+                tr_variantDictAddBool(tgt, key, val);
             }
             else if (child->holds_alternative<double>())
             {
                 auto val = double{};
                 tr_variantGetReal(child, &val);
-                tr_variantDictAddReal(target, key, val);
+                tr_variantDictAddReal(tgt, key, val);
             }
             else if (child->holds_alternative<int64_t>())
             {
                 auto val = int64_t{};
                 tr_variantGetInt(child, &val);
-                tr_variantDictAddInt(target, key, val);
+                tr_variantDictAddInt(tgt, key, val);
             }
             else if (child->holds_alternative<std::string_view>())
             {
                 auto val = std::string_view{};
                 (void)tr_variantGetStrView(child, &val);
-                tr_variantDictAddRaw(target, key, std::data(val), std::size(val));
+                tr_variantDictAddRaw(tgt, key, std::data(val), std::size(val));
             }
-            else if (child->holds_alternative<tr_variant::Map>() && tr_variantDictFindDict(target, key, &t))
+            else if (child->holds_alternative<tr_variant::Map>() && tr_variantDictFindDict(tgt, key, &t))
             {
                 tr_variantMergeDicts(t, child);
             }
             else if (child->holds_alternative<tr_variant::Vector>())
             {
-                if (tr_variantDictFind(target, key) == nullptr)
+                if (tr_variantDictFind(tgt, key) == nullptr)
                 {
-                    tr_variantListCopy(tr_variantDictAddList(target, key, tr_variantListSize(child)), child);
+                    tr_variantListCopy(tr_variantDictAddList(tgt, key, tr_variantListSize(child)), child);
                 }
             }
             else if (child->holds_alternative<tr_variant::Map>())
             {
-                tr_variant* target_dict = tr_variantDictFind(target, key);
+                tr_variant* target_dict = tr_variantDictFind(tgt, key);
 
                 if (target_dict == nullptr)
                 {
-                    target_dict = tr_variantDictAddDict(target, key, tr_variantDictSize(child));
+                    target_dict = tr_variantDictAddDict(tgt, key, tr_variantDictSize(child));
                 }
 
                 if (target_dict->holds_alternative<tr_variant::Map>())

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -28,19 +28,6 @@ struct tr_error;
  * @{
  */
 
-/* these are PRIVATE IMPLEMENTATION details that should not be touched.
- * I'll probably change them just to break your code! HA HA HA!
- * it's included in the header for inlining and composition */
-enum
-{
-    TR_VARIANT_TYPE_INT = 1,
-    TR_VARIANT_TYPE_STR = 2,
-    TR_VARIANT_TYPE_LIST = 4,
-    TR_VARIANT_TYPE_DICT = 8,
-    TR_VARIANT_TYPE_BOOL = 16,
-    TR_VARIANT_TYPE_REAL = 32
-};
-
 /* These are PRIVATE IMPLEMENTATION details that should not be touched.
  * I'll probably change them just to break your code! HA HA HA!
  * it's included in the header for inlining and composition */
@@ -114,7 +101,18 @@ private:
     };
 
 public:
-    char type = '\0';
+    enum class Type
+    {
+        None,
+        Bool,
+        Int,
+        Double,
+        String,
+        Vector,
+        Map
+    };
+
+    Type type = Type::None;
 
     tr_quark key = TR_KEY_NONE;
 
@@ -147,21 +145,21 @@ public:
  */
 void tr_variantClear(tr_variant* clearme);
 
-[[nodiscard]] constexpr bool tr_variantIsType(tr_variant const* b, int type)
+[[nodiscard]] constexpr bool tr_variantIsType(tr_variant const* const var, tr_variant::Type type)
 {
-    return b != nullptr && b->type == type;
+    return var != nullptr && var->type == type;
 }
 
-[[nodiscard]] constexpr bool tr_variantIsEmpty(tr_variant const* b)
+[[nodiscard]] constexpr bool tr_variantIsEmpty(tr_variant const* const var)
 {
-    return b == nullptr || b->type == '\0';
+    return tr_variantIsType(var, tr_variant::Type::None);
 }
 
 // --- Strings
 
-[[nodiscard]] constexpr bool tr_variantIsString(tr_variant const* b)
+[[nodiscard]] constexpr bool tr_variantIsString(tr_variant const* const var)
 {
-    return b != nullptr && b->type == TR_VARIANT_TYPE_STR;
+    return tr_variantIsType(var, tr_variant::Type::String);
 }
 
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
@@ -171,7 +169,7 @@ void tr_variantInitQuark(tr_variant* initme, tr_quark value);
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len);
 void tr_variantInitStrView(tr_variant* initme, std::string_view val);
 
-constexpr void tr_variantInit(tr_variant* initme, char type)
+constexpr void tr_variantInit(tr_variant* initme, tr_variant::Type type)
 {
     initme->val = {};
     initme->type = type;
@@ -182,54 +180,54 @@ bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size
 
 // --- Real Numbers
 
-[[nodiscard]] constexpr bool tr_variantIsReal(tr_variant const* v)
+[[nodiscard]] constexpr bool tr_variantIsReal(tr_variant const* const var)
 {
-    return v != nullptr && v->type == TR_VARIANT_TYPE_REAL;
+    return tr_variantIsType(var, tr_variant::Type::Double);
 }
 
 bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 
 constexpr void tr_variantInitReal(tr_variant* initme, double value)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_REAL);
+    tr_variantInit(initme, tr_variant::Type::Double);
     initme->val.d = value;
 }
 
 // --- Booleans
 
-[[nodiscard]] constexpr bool tr_variantIsBool(tr_variant const* v)
+[[nodiscard]] constexpr bool tr_variantIsBool(tr_variant const* const var)
 {
-    return v != nullptr && v->type == TR_VARIANT_TYPE_BOOL;
+    return tr_variantIsType(var, tr_variant::Type::Bool);
 }
 
 bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 
 constexpr void tr_variantInitBool(tr_variant* initme, bool value)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_BOOL);
+    tr_variantInit(initme, tr_variant::Type::Bool);
     initme->val.b = value;
 }
 
 // --- Ints
 
-[[nodiscard]] constexpr bool tr_variantIsInt(tr_variant const* v)
+[[nodiscard]] constexpr bool tr_variantIsInt(tr_variant const* const var)
 {
-    return v != nullptr && v->type == TR_VARIANT_TYPE_INT;
+    return tr_variantIsType(var, tr_variant::Type::Int);
 }
 
 bool tr_variantGetInt(tr_variant const* val, int64_t* setme);
 
 constexpr void tr_variantInitInt(tr_variant* initme, int64_t value)
 {
-    tr_variantInit(initme, TR_VARIANT_TYPE_INT);
+    tr_variantInit(initme, tr_variant::Type::Int);
     initme->val.i = value;
 }
 
 // --- Lists
 
-[[nodiscard]] constexpr bool tr_variantIsList(tr_variant const* v)
+[[nodiscard]] constexpr bool tr_variantIsList(tr_variant const* const var)
 {
-    return v != nullptr && v->type == TR_VARIANT_TYPE_LIST;
+    return tr_variantIsType(var, tr_variant::Type::Vector);
 }
 
 void tr_variantInitList(tr_variant* initme, size_t reserve_count);
@@ -256,9 +254,9 @@ bool tr_variantListRemove(tr_variant* list, size_t pos);
 
 // --- Dictionaries
 
-[[nodiscard]] constexpr bool tr_variantIsDict(tr_variant const* v)
+[[nodiscard]] constexpr bool tr_variantIsDict(tr_variant const* const var)
 {
-    return v != nullptr && v->type == TR_VARIANT_TYPE_DICT;
+    return tr_variantIsType(var, tr_variant::Type::Map);
 }
 
 void tr_variantInitDict(tr_variant* initme, size_t reserve_count);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -241,7 +241,7 @@ constexpr void tr_variantInitBool(tr_variant* initme, bool value)
 
 // --- Ints
 
-bool tr_variantGetInt(tr_variant const* val, int64_t* setme);
+bool tr_variantGetInt(tr_variant const* var, int64_t* setme);
 
 constexpr void tr_variantInitInt(tr_variant* initme, int64_t value)
 {
@@ -252,21 +252,21 @@ constexpr void tr_variantInitInt(tr_variant* initme, int64_t value)
 // --- Lists
 
 void tr_variantInitList(tr_variant* initme, size_t reserve_count);
-void tr_variantListReserve(tr_variant* list, size_t reserve_count);
+void tr_variantListReserve(tr_variant* var, size_t reserve_count);
 
-tr_variant* tr_variantListAdd(tr_variant* list);
-tr_variant* tr_variantListAddBool(tr_variant* list, bool value);
-tr_variant* tr_variantListAddInt(tr_variant* list, int64_t value);
-tr_variant* tr_variantListAddReal(tr_variant* list, double value);
-tr_variant* tr_variantListAddStr(tr_variant* list, std::string_view value);
-tr_variant* tr_variantListAddStrView(tr_variant* list, std::string_view value);
-tr_variant* tr_variantListAddQuark(tr_variant* list, tr_quark value);
-tr_variant* tr_variantListAddRaw(tr_variant* list, void const* value, size_t value_len);
-tr_variant* tr_variantListAddList(tr_variant* list, size_t reserve_count);
-tr_variant* tr_variantListAddDict(tr_variant* list, size_t reserve_count);
-tr_variant* tr_variantListChild(tr_variant* list, size_t pos);
+tr_variant* tr_variantListAdd(tr_variant* var);
+tr_variant* tr_variantListAddBool(tr_variant* var, bool value);
+tr_variant* tr_variantListAddInt(tr_variant* var, int64_t value);
+tr_variant* tr_variantListAddReal(tr_variant* var, double value);
+tr_variant* tr_variantListAddStr(tr_variant* var, std::string_view value);
+tr_variant* tr_variantListAddStrView(tr_variant* var, std::string_view value);
+tr_variant* tr_variantListAddQuark(tr_variant* var, tr_quark value);
+tr_variant* tr_variantListAddRaw(tr_variant* var, void const* value, size_t value_len);
+tr_variant* tr_variantListAddList(tr_variant* var, size_t reserve_count);
+tr_variant* tr_variantListAddDict(tr_variant* var, size_t reserve_count);
+tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
 
-bool tr_variantListRemove(tr_variant* list, size_t pos);
+bool tr_variantListRemove(tr_variant* var, size_t pos);
 
 [[nodiscard]] constexpr size_t tr_variantListSize(tr_variant const* const var)
 {
@@ -276,34 +276,34 @@ bool tr_variantListRemove(tr_variant* list, size_t pos);
 // --- Dictionaries
 
 void tr_variantInitDict(tr_variant* initme, size_t reserve_count);
-void tr_variantDictReserve(tr_variant* dict, size_t reserve_count);
-bool tr_variantDictRemove(tr_variant* dict, tr_quark key);
+void tr_variantDictReserve(tr_variant* var, size_t reserve_count);
+bool tr_variantDictRemove(tr_variant* var, tr_quark key);
 
-tr_variant* tr_variantDictAdd(tr_variant* dict, tr_quark key);
-tr_variant* tr_variantDictAddReal(tr_variant* dict, tr_quark key, double value);
-tr_variant* tr_variantDictAddInt(tr_variant* dict, tr_quark key, int64_t value);
-tr_variant* tr_variantDictAddBool(tr_variant* dict, tr_quark key, bool value);
-tr_variant* tr_variantDictAddStr(tr_variant* dict, tr_quark key, std::string_view value);
-tr_variant* tr_variantDictAddStrView(tr_variant* dict, tr_quark key, std::string_view value);
-tr_variant* tr_variantDictAddQuark(tr_variant* dict, tr_quark key, tr_quark val);
-tr_variant* tr_variantDictAddList(tr_variant* dict, tr_quark key, size_t reserve_count);
-tr_variant* tr_variantDictAddDict(tr_variant* dict, tr_quark key, size_t reserve_count);
-tr_variant* tr_variantDictSteal(tr_variant* dict, tr_quark key, tr_variant* value);
-tr_variant* tr_variantDictAddRaw(tr_variant* dict, tr_quark key, void const* value, size_t len);
+tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);
+tr_variant* tr_variantDictAddReal(tr_variant* var, tr_quark key, double value);
+tr_variant* tr_variantDictAddInt(tr_variant* var, tr_quark key, int64_t value);
+tr_variant* tr_variantDictAddBool(tr_variant* var, tr_quark key, bool value);
+tr_variant* tr_variantDictAddStr(tr_variant* var, tr_quark key, std::string_view value);
+tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
+tr_variant* tr_variantDictAddQuark(tr_variant* var, tr_quark key, tr_quark val);
+tr_variant* tr_variantDictAddList(tr_variant* var, tr_quark key, size_t reserve_count);
+tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t reserve_count);
+tr_variant* tr_variantDictSteal(tr_variant* var, tr_quark key, tr_variant* value);
+tr_variant* tr_variantDictAddRaw(tr_variant* var, tr_quark key, void const* value, size_t len);
 
-bool tr_variantDictChild(tr_variant* dict, size_t pos, tr_quark* setme_key, tr_variant** setme_value);
-tr_variant* tr_variantDictFind(tr_variant* dict, tr_quark key);
-bool tr_variantDictFindList(tr_variant* dict, tr_quark key, tr_variant** setme);
-bool tr_variantDictFindDict(tr_variant* dict, tr_quark key, tr_variant** setme_value);
-bool tr_variantDictFindInt(tr_variant* dict, tr_quark key, int64_t* setme);
-bool tr_variantDictFindReal(tr_variant* dict, tr_quark key, double* setme);
-bool tr_variantDictFindBool(tr_variant* dict, tr_quark key, bool* setme);
-bool tr_variantDictFindStrView(tr_variant* dict, tr_quark key, std::string_view* setme);
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, uint8_t const** setme_raw, size_t* setme_len);
-bool tr_variantDictFindRaw(tr_variant* dict, tr_quark key, std::byte const** setme_raw, size_t* setme_len);
+bool tr_variantDictChild(tr_variant* var, size_t pos, tr_quark* setme_key, tr_variant** setme_value);
+tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
+bool tr_variantDictFindList(tr_variant* var, tr_quark key, tr_variant** setme);
+bool tr_variantDictFindDict(tr_variant* var, tr_quark key, tr_variant** setme_value);
+bool tr_variantDictFindInt(tr_variant* var, tr_quark key, int64_t* setme);
+bool tr_variantDictFindReal(tr_variant* var, tr_quark key, double* setme);
+bool tr_variantDictFindBool(tr_variant* var, tr_quark key, bool* setme);
+bool tr_variantDictFindStrView(tr_variant* var, tr_quark key, std::string_view* setme);
+bool tr_variantDictFindRaw(tr_variant* var, tr_quark key, uint8_t const** setme_raw, size_t* setme_len);
+bool tr_variantDictFindRaw(tr_variant* var, tr_quark key, std::byte const** setme_raw, size_t* setme_len);
 
 /* this is only quasi-supported. don't rely on it too heavily outside of libT */
-void tr_variantMergeDicts(tr_variant* dict_target, tr_variant const* dict_source);
+void tr_variantMergeDicts(tr_variant* tgt, tr_variant const* src);
 
 // tr_variant serializer / deserializer
 class tr_variant_serde

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -117,6 +117,11 @@ public:
         return type == Type::None;
     }
 
+    [[nodiscard]] constexpr auto is_bool() const noexcept
+    {
+        return type == Type::Bool;
+    }
+
     Type type = Type::None;
 
     tr_quark key = TR_KEY_NONE;
@@ -194,11 +199,6 @@ constexpr void tr_variantInitReal(tr_variant* initme, double value)
 }
 
 // --- Booleans
-
-[[nodiscard]] constexpr bool tr_variantIsBool(tr_variant const* const var)
-{
-    return tr_variantIsType(var, tr_variant::Type::Bool);
-}
 
 bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -112,6 +112,11 @@ public:
         Map
     };
 
+    [[nodiscard]] constexpr auto has_value() const noexcept
+    {
+        return type == Type::None;
+    }
+
     Type type = Type::None;
 
     tr_quark key = TR_KEY_NONE;
@@ -138,7 +143,7 @@ public:
 /**
  * @brief Clear the variant to an empty state.
  *
- * `tr_variantIsEmpty()` will return true after this is called.
+ * `tr_variant::has_value()` will return false after this is called.
  *
  * The variant itself is not freed, but any memory used by
  * its *value* -- e.g. a string or child variants -- is freed.
@@ -148,11 +153,6 @@ void tr_variantClear(tr_variant* clearme);
 [[nodiscard]] constexpr bool tr_variantIsType(tr_variant const* const var, tr_variant::Type type)
 {
     return var != nullptr && var->type == type;
-}
-
-[[nodiscard]] constexpr bool tr_variantIsEmpty(tr_variant const* const var)
-{
-    return tr_variantIsType(var, tr_variant::Type::None);
 }
 
 // --- Strings

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -127,6 +127,11 @@ public:
         return type == Type::Int;
     }
 
+    [[nodiscard]] constexpr bool is_double() const noexcept
+    {
+        return type == Type::Double;
+    }
+
     Type type = Type::None;
 
     tr_quark key = TR_KEY_NONE;
@@ -189,11 +194,6 @@ bool tr_variantGetRaw(tr_variant const* variant, std::byte const** setme_raw, si
 bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size_t* setme_len);
 
 // --- Real Numbers
-
-[[nodiscard]] constexpr bool tr_variantIsReal(tr_variant const* const var)
-{
-    return tr_variantIsType(var, tr_variant::Type::Double);
-}
 
 bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -122,6 +122,11 @@ public:
         return type == Type::Bool;
     }
 
+    [[nodiscard]] constexpr auto is_int() const noexcept
+    {
+        return type == Type::Int;
+    }
+
     Type type = Type::None;
 
     tr_quark key = TR_KEY_NONE;
@@ -209,11 +214,6 @@ constexpr void tr_variantInitBool(tr_variant* initme, bool value)
 }
 
 // --- Ints
-
-[[nodiscard]] constexpr bool tr_variantIsInt(tr_variant const* const var)
-{
-    return tr_variantIsType(var, tr_variant::Type::Int);
-}
 
 bool tr_variantGetInt(tr_variant const* val, int64_t* setme);
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -11,7 +11,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <type_traits>
 
 #include "libtransmission/quark.h"
 
@@ -182,7 +181,7 @@ public:
 
 [[nodiscard]] constexpr bool tr_variantIsEmpty(tr_variant const* const var)
 {
-    return var != nullptr && var->type == tr_variant::Type::None;
+    return var == nullptr || var->type == tr_variant::Type::None;
 }
 
 // --- Strings

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -547,7 +547,6 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
         auto const default_config_dir = tr_getDefaultConfigDir("Transmission");
         _fLib = tr_sessionInit(default_config_dir.c_str(), YES, &settings);
-        tr_variantClear(&settings);
         _fConfigDirectory = @(default_config_dir.c_str());
 
         tr_sessionSetIdleLimitHitCallback(_fLib, onIdleLimitHit, (__bridge void*)(self));

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -227,7 +227,7 @@ Prefs::Prefs(QString config_dir)
     // when the application exits.
     temporary_prefs_ << FILTER_TEXT;
 
-    auto top = tr_variant{};
+    tr_variant top;
     tr_variantInitDict(&top, 0);
     initDefaults(&top);
     tr_sessionLoadSettings(&top, config_dir_.toUtf8().constData(), nullptr);
@@ -323,7 +323,7 @@ Prefs::Prefs(QString config_dir)
 Prefs::~Prefs()
 {
     // make a dict from settings.json
-    auto current_settings = tr_variant{};
+    tr_variant current_settings;
     tr_variantInitDict(&current_settings, PREFS_COUNT);
 
     for (int i = 0; i < PREFS_COUNT; ++i)

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -227,7 +227,7 @@ Prefs::Prefs(QString config_dir)
     // when the application exits.
     temporary_prefs_ << FILTER_TEXT;
 
-    tr_variant top;
+    auto top = tr_variant{};
     tr_variantInitDict(&top, 0);
     initDefaults(&top);
     tr_sessionLoadSettings(&top, config_dir_.toUtf8().constData(), nullptr);
@@ -318,14 +318,12 @@ Prefs::Prefs(QString config_dir)
             break;
         }
     }
-
-    tr_variantClear(&top);
 }
 
 Prefs::~Prefs()
 {
     // make a dict from settings.json
-    tr_variant current_settings;
+    auto current_settings = tr_variant{};
     tr_variantInitDict(&current_settings, PREFS_COUNT);
 
     for (int i = 0; i < PREFS_COUNT; ++i)
@@ -411,15 +409,11 @@ Prefs::~Prefs()
     {
         auto empty_dict = tr_variant{};
         tr_variantInitDict(&empty_dict, PREFS_COUNT);
-        settings = empty_dict;
+        settings = std::move(empty_dict);
     }
 
     tr_variantMergeDicts(&*settings, &current_settings);
     serde.to_file(*settings, filename);
-    tr_variantClear(&*settings);
-
-    // cleanup
-    tr_variantClear(&current_settings);
 }
 
 /**

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -356,7 +356,7 @@ void Session::start()
     }
     else
     {
-        auto settings = tr_variant{};
+        tr_variant settings;
         tr_variantInitDict(&settings, 0);
         tr_sessionLoadSettings(&settings, config_dir_.toUtf8().constData(), "qt");
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings);

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -356,11 +356,10 @@ void Session::start()
     }
     else
     {
-        tr_variant settings;
+        auto settings = tr_variant{};
         tr_variantInitDict(&settings, 0);
         tr_sessionLoadSettings(&settings, config_dir_.toUtf8().constData(), "qt");
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, &settings);
-        tr_variantClear(&settings);
 
         rpc_.start(session_);
 

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -164,7 +164,7 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
 
     // build a list of the property keys
     tr_variant* const first_child = tr_variantListChild(torrent_list, 0);
-    bool const table = tr_variantIsList(first_child);
+    bool const table = first_child != nullptr && first_child->holds_alternative<tr_variant::Vector>();
     std::vector<tr_quark> keys;
     if (table)
     {

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -163,7 +163,7 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
     };
 
     // build a list of the property keys
-    auto* const first_child = tr_variantListChild(torrent_list, 0);
+    tr_variant* const first_child = tr_variantListChild(torrent_list, 0);
     bool const table = tr_variantIsList(first_child);
     std::vector<tr_quark> keys;
     if (table)

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -163,8 +163,8 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
     };
 
     // build a list of the property keys
-    tr_variant* const first_child = tr_variantListChild(torrent_list, 0);
-    bool const table = first_child != nullptr && first_child->holds_alternative<tr_variant::Vector>();
+    auto* const first_child = tr_variantListChild(torrent_list, 0);
+    bool const table = tr_variantIsList(first_child);
     std::vector<tr_quark> keys;
     if (table)
     {

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -101,17 +101,17 @@ template<
     typename T = typename C::value_type,
     typename std::enable_if_t<
         std::is_same_v<C, QStringList> || std::is_same_v<C, QList<T>> || std::is_same_v<C, std::vector<T>>>* = nullptr>
-auto getValue(tr_variant const* variant)
+auto getValue(tr_variant const* var)
 {
     std::optional<C> ret;
 
-    if (tr_variantIsList(variant))
+    if (var != nullptr && var->holds_alternative<tr_variant::Vector>())
     {
         auto list = C{};
 
-        for (size_t i = 0, n = tr_variantListSize(variant); i < n; ++i)
+        for (size_t i = 0, n = tr_variantListSize(var); i < n; ++i)
         {
-            tr_variant* const child = tr_variantListChild(const_cast<tr_variant*>(variant), i);
+            tr_variant* const child = tr_variantListChild(const_cast<tr_variant*>(var), i);
             auto const value = getValue<T>(child);
             if (value)
             {

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -105,7 +105,7 @@ auto getValue(tr_variant const* var)
 {
     std::optional<C> ret;
 
-    if (var != nullptr && var->holds_alternative<tr_variant::Vector>())
+    if (tr_variantIsList(var))
     {
         auto list = C{};
 

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -344,68 +344,6 @@ TEST_F(AnnounceListTest, announceToScrape)
     }
 }
 
-TEST_F(AnnounceListTest, gronk)
-{
-    auto constexpr Urls = std::array<char const*, 3>{
-        "https://www.example.com/a/announce",
-        "https://www.example.com/b/announce",
-        "https://www.example.com/c/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 3>{ 0, 1, 2 };
-
-    // first, set up a scratch torrent
-    auto constexpr* const OriginalFile = LIBTRANSMISSION_TEST_ASSETS_DIR "/Android-x86 8.1 r6 iso.torrent";
-    auto original_content = std::vector<char>{};
-    auto const test_file = tr_pathbuf{ ::testing::TempDir(), "transmission-announce-list-test.torrent"sv };
-    tr_error* error = nullptr;
-    EXPECT_TRUE(tr_file_read(OriginalFile, original_content, &error));
-    EXPECT_EQ(nullptr, error) << *error;
-    EXPECT_TRUE(tr_file_save(test_file.sv(), original_content, &error));
-    EXPECT_EQ(nullptr, error) << *error;
-
-    // make an announce_list for it
-    auto announce_list = tr_announce_list{};
-    EXPECT_TRUE(announce_list.add(Urls[0], Tiers[0]));
-    EXPECT_TRUE(announce_list.add(Urls[1], Tiers[1]));
-    EXPECT_TRUE(announce_list.add(Urls[2], Tiers[2]));
-
-    // try saving to a nonexistent torrent file
-    EXPECT_FALSE(announce_list.save("/this/path/does/not/exist", &error));
-    EXPECT_NE(nullptr, error);
-    EXPECT_NE(0, error->code);
-    tr_error_clear(&error);
-
-    // now save to a real torrent file
-    EXPECT_TRUE(announce_list.save(std::string{ test_file.sv() }, &error));
-    EXPECT_EQ(nullptr, error) << *error;
-
-#if 0
-    // load the original
-    auto original_tm = tr_torrent_metainfo{};
-    EXPECT_TRUE(original_tm.parse_benc({ std::data(original_content), std::size(original_content) }));
-
-    // load the scratch that we saved to
-    auto modified_tm = tr_torrent_metainfo{};
-    EXPECT_TRUE(modified_tm.parse_torrent_file(test_file.sv()));
-
-    // test that non-announce parts of the metainfo are the same
-    EXPECT_EQ(original_tm.name(), modified_tm.name());
-    EXPECT_EQ(original_tm.file_count(), modified_tm.file_count());
-    EXPECT_EQ(original_tm.date_created(), modified_tm.date_created());
-    EXPECT_EQ(original_tm.piece_count(), modified_tm.piece_count());
-
-    // test that the saved version has the updated announce list
-    EXPECT_TRUE(std::equal(
-        std::begin(announce_list),
-        std::end(announce_list),
-        std::begin(modified_tm.announce_list()),
-        std::end(modified_tm.announce_list())));
-#endif
-
-    // cleanup
-    (void)std::remove(test_file.c_str());
-}
-
 TEST_F(AnnounceListTest, save)
 {
     auto constexpr Urls = std::array<char const*, 3>{

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -139,7 +139,6 @@ protected:
             }
             tr_variantDictAddRaw(&dict, TR_KEY_nodes6, std::data(compact), std::size(compact));
             tr_variant_serde::benc().to_file(dict, dat_file);
-            tr_variantClear(&dict);
         }
     };
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -59,36 +59,34 @@ TEST_P(JSONTest, testElements)
         "  \"null\": null }"
     };
 
-    auto top = tr_variant_serde::json().inplace().parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
+    auto var = tr_variant_serde::json().inplace().parse(in).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto key = tr_quark_new("string"sv);
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("hello world"sv, sv);
 
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("escaped"sv), &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("escaped"sv), &sv));
     EXPECT_EQ("bell \b formfeed \f linefeed \n carriage return \r tab \t"sv, sv);
 
     auto i = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&top, tr_quark_new("int"sv), &i));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, tr_quark_new("int"sv), &i));
     EXPECT_EQ(5, i);
 
     auto d = double{};
-    EXPECT_TRUE(tr_variantDictFindReal(&top, tr_quark_new("float"sv), &d));
+    EXPECT_TRUE(tr_variantDictFindReal(&var, tr_quark_new("float"sv), &d));
     EXPECT_EQ(65, int(d * 10));
 
     auto f = bool{};
-    EXPECT_TRUE(tr_variantDictFindBool(&top, tr_quark_new("true"sv), &f));
+    EXPECT_TRUE(tr_variantDictFindBool(&var, tr_quark_new("true"sv), &f));
     EXPECT_TRUE(f);
 
-    EXPECT_TRUE(tr_variantDictFindBool(&top, tr_quark_new("false"sv), &f));
+    EXPECT_TRUE(tr_variantDictFindBool(&var, tr_quark_new("false"sv), &f));
     EXPECT_FALSE(f);
 
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("null"sv), &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("null"sv), &sv));
     EXPECT_EQ(""sv, sv);
-
-    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, testUtf8)
@@ -99,18 +97,18 @@ TEST_P(JSONTest, testUtf8)
 
     auto serde = tr_variant_serde::json();
     serde.inplace();
-    auto top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    auto var = serde.parse(in).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantClear(&top);
+    var.clear();
 
     in = R"({ "key": "\u005C" })"sv;
-    top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    var = serde.parse(in).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("\\"sv, sv);
-    tr_variantClear(&top);
+    var.clear();
 
     /**
      * 1. Feed it JSON-escaped nonascii to the JSON decoder.
@@ -121,43 +119,40 @@ TEST_P(JSONTest, testUtf8)
      * 6. Confirm that the result is UTF-8.
      */
     in = R"({ "key": "Let\u00f6lt\u00e9sek" })"sv;
-    top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    var = serde.parse(in).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    auto json = serde.to_string(top);
-    tr_variantClear(&top);
+    auto json = serde.to_string(var);
+    var.clear();
 
     EXPECT_FALSE(std::empty(json));
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
     EXPECT_NE(std::string::npos, json.find("\\u00e9"));
-    top = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
+    var = serde.parse(json).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
-    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, testUtf16Surrogates)
 {
     static auto constexpr ThinkingFaceEmojiUtf8 = "\xf0\x9f\xa4\x94"sv;
-    auto top = tr_variant{};
-    tr_variantInitDict(&top, 1);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
     auto const key = tr_quark_new("key"sv);
-    tr_variantDictAddStr(&top, key, ThinkingFaceEmojiUtf8);
+    tr_variantDictAddStr(&var, key, ThinkingFaceEmojiUtf8);
 
     auto serde = tr_variant_serde::json();
-    auto const json = serde.compact().to_string(top);
+    auto const json = serde.compact().to_string(var);
     EXPECT_NE(std::string::npos, json.find("ud83e"));
     EXPECT_NE(std::string::npos, json.find("udd14"));
-    tr_variantClear(&top);
 
     auto parsed = serde.parse(json).value_or(tr_variant{});
     EXPECT_TRUE(parsed.holds_alternative<tr_variant::Map>());
     auto value = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
     EXPECT_EQ(ThinkingFaceEmojiUtf8, value);
-    tr_variantClear(&parsed);
 }
 
 TEST_P(JSONTest, test1)
@@ -177,19 +172,19 @@ TEST_P(JSONTest, test1)
         "}\n"sv;
 
     auto serde = tr_variant_serde::json();
-    auto top = serde.inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
+    auto var = serde.inplace().parse(Input).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto i = int64_t{};
-    auto* headers = tr_variantDictFind(&top, tr_quark_new("headers"sv));
+    auto* headers = tr_variantDictFind(&var, tr_quark_new("headers"sv));
     EXPECT_NE(nullptr, headers);
     EXPECT_TRUE(headers->holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(headers, tr_quark_new("type"sv), &sv));
     EXPECT_EQ("request"sv, sv);
     EXPECT_TRUE(tr_variantDictFindInt(headers, TR_KEY_tag, &i));
     EXPECT_EQ(666, i);
-    auto* body = tr_variantDictFind(&top, tr_quark_new("body"sv));
+    auto* body = tr_variantDictFind(&var, tr_quark_new("body"sv));
     EXPECT_NE(nullptr, body);
     EXPECT_TRUE(tr_variantDictFindStrView(body, TR_KEY_name, &sv));
     EXPECT_EQ("torrent-info"sv, sv);
@@ -204,15 +199,13 @@ TEST_P(JSONTest, test1)
     EXPECT_EQ(7, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 1), &i));
     EXPECT_EQ(10, i);
-
-    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, test2)
 {
     static auto constexpr Input = " "sv;
-    auto top = tr_variant_serde::json().inplace().parse(Input);
-    EXPECT_FALSE(top.has_value());
+    auto var = tr_variant_serde::json().inplace().parse(Input);
+    EXPECT_FALSE(var.has_value());
 }
 
 TEST_P(JSONTest, test3)
@@ -224,27 +217,24 @@ TEST_P(JSONTest, test3)
         "  \"id\": 25,"
         "  \"leftUntilDone\": 2275655680 }"sv;
 
-    auto top = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
+    auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, TR_KEY_errorString, &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, TR_KEY_errorString, &sv));
     EXPECT_EQ("torrent not registered with this tracker 6UHsVW'*C"sv, sv);
-
-    tr_variantClear(&top);
 }
 
 TEST_P(JSONTest, unescape)
 {
     static auto constexpr Input = R"({ "string-1": "\/usr\/lib" })"sv;
 
-    auto top = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
+    auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("string-1"sv), &sv));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("string-1"sv), &sv));
     EXPECT_EQ("/usr/lib"sv, sv);
-    tr_variantClear(&top);
 }
 
 INSTANTIATE_TEST_SUITE_P( //

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -60,7 +60,7 @@ TEST_P(JSONTest, testElements)
     };
 
     auto var = tr_variant_serde::json().inplace().parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
 
     auto sv = std::string_view{};
     auto key = tr_quark_new("string"sv);
@@ -98,14 +98,14 @@ TEST_P(JSONTest, testUtf8)
     auto serde = tr_variant_serde::json();
     serde.inplace();
     auto var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     var.clear();
 
     in = R"({ "key": "\u005C" })"sv;
     var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("\\"sv, sv);
     var.clear();
@@ -120,7 +120,7 @@ TEST_P(JSONTest, testUtf8)
      */
     in = R"({ "key": "Let\u00f6lt\u00e9sek" })"sv;
     var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     auto json = serde.to_string(var);
@@ -130,7 +130,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
     EXPECT_NE(std::string::npos, json.find("\\u00e9"));
     var = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
 }
@@ -149,7 +149,7 @@ TEST_P(JSONTest, testUtf16Surrogates)
     EXPECT_NE(std::string::npos, json.find("udd14"));
 
     auto parsed = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(parsed.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&parsed));
     auto value = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
     EXPECT_EQ(ThinkingFaceEmojiUtf8, value);
@@ -173,13 +173,13 @@ TEST_P(JSONTest, test1)
 
     auto serde = tr_variant_serde::json();
     auto var = serde.inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
 
     auto sv = std::string_view{};
     auto i = int64_t{};
     auto* headers = tr_variantDictFind(&var, tr_quark_new("headers"sv));
     EXPECT_NE(nullptr, headers);
-    EXPECT_TRUE(headers->holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(headers));
     EXPECT_TRUE(tr_variantDictFindStrView(headers, tr_quark_new("type"sv), &sv));
     EXPECT_EQ("request"sv, sv);
     EXPECT_TRUE(tr_variantDictFindInt(headers, TR_KEY_tag, &i));
@@ -190,10 +190,10 @@ TEST_P(JSONTest, test1)
     EXPECT_EQ("torrent-info"sv, sv);
     auto* args = tr_variantDictFind(body, tr_quark_new("arguments"sv));
     EXPECT_NE(nullptr, args);
-    EXPECT_TRUE(args->holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(args));
     auto* ids = tr_variantDictFind(args, TR_KEY_ids);
     EXPECT_NE(nullptr, ids);
-    EXPECT_TRUE(ids != nullptr && ids->holds_alternative<tr_variant::Vector>());
+    EXPECT_TRUE(tr_variantIsList(ids));
     EXPECT_EQ(2U, tr_variantListSize(ids));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 0), &i));
     EXPECT_EQ(7, i);
@@ -218,7 +218,7 @@ TEST_P(JSONTest, test3)
         "  \"leftUntilDone\": 2275655680 }"sv;
 
     auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&var, TR_KEY_errorString, &sv));
@@ -230,7 +230,7 @@ TEST_P(JSONTest, unescape)
     static auto constexpr Input = R"({ "string-1": "\/usr\/lib" })"sv;
 
     auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&var));
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("string-1"sv), &sv));

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -60,7 +60,7 @@ TEST_P(JSONTest, testElements)
     };
 
     auto top = tr_variant_serde::json().inplace().parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto key = tr_quark_new("string"sv);
@@ -100,14 +100,14 @@ TEST_P(JSONTest, testUtf8)
     auto serde = tr_variant_serde::json();
     serde.inplace();
     auto top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     tr_variantClear(&top);
 
     in = R"({ "key": "\u005C" })"sv;
     top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("\\"sv, sv);
     tr_variantClear(&top);
@@ -122,7 +122,7 @@ TEST_P(JSONTest, testUtf8)
      */
     in = R"({ "key": "Let\u00f6lt\u00e9sek" })"sv;
     top = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     auto json = serde.to_string(top);
@@ -132,7 +132,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
     EXPECT_NE(std::string::npos, json.find("\\u00e9"));
     top = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&top, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     tr_variantClear(&top);
@@ -153,7 +153,7 @@ TEST_P(JSONTest, testUtf16Surrogates)
     tr_variantClear(&top);
 
     auto parsed = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&parsed));
+    EXPECT_TRUE(parsed.holds_alternative<tr_variant::Map>());
     auto value = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
     EXPECT_EQ(ThinkingFaceEmojiUtf8, value);
@@ -178,13 +178,13 @@ TEST_P(JSONTest, test1)
 
     auto serde = tr_variant_serde::json();
     auto top = serde.inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto i = int64_t{};
     auto* headers = tr_variantDictFind(&top, tr_quark_new("headers"sv));
     EXPECT_NE(nullptr, headers);
-    EXPECT_TRUE(tr_variantIsDict(headers));
+    EXPECT_TRUE(headers->holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(headers, tr_quark_new("type"sv), &sv));
     EXPECT_EQ("request"sv, sv);
     EXPECT_TRUE(tr_variantDictFindInt(headers, TR_KEY_tag, &i));
@@ -195,10 +195,10 @@ TEST_P(JSONTest, test1)
     EXPECT_EQ("torrent-info"sv, sv);
     auto* args = tr_variantDictFind(body, tr_quark_new("arguments"sv));
     EXPECT_NE(nullptr, args);
-    EXPECT_TRUE(tr_variantIsDict(args));
+    EXPECT_TRUE(args->holds_alternative<tr_variant::Map>());
     auto* ids = tr_variantDictFind(args, TR_KEY_ids);
     EXPECT_NE(nullptr, ids);
-    EXPECT_TRUE(tr_variantIsList(ids));
+    EXPECT_TRUE(ids != nullptr && ids->holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(2U, tr_variantListSize(ids));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 0), &i));
     EXPECT_EQ(7, i);
@@ -225,7 +225,7 @@ TEST_P(JSONTest, test3)
         "  \"leftUntilDone\": 2275655680 }"sv;
 
     auto top = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&top, TR_KEY_errorString, &sv));
@@ -239,7 +239,7 @@ TEST_P(JSONTest, unescape)
     static auto constexpr Input = R"({ "string-1": "\/usr\/lib" })"sv;
 
     auto top = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&top, tr_quark_new("string-1"sv), &sv));

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -244,8 +244,6 @@ TEST_F(MakemetaTest, announceSingleTracker)
 
     // confirm there's not an "announce-list" entry
     EXPECT_EQ(nullptr, tr_variantDictFind(&*top, TR_KEY_announce_list));
-
-    tr_variantClear(&*top);
 }
 
 TEST_F(MakemetaTest, announceMultiTracker)
@@ -277,8 +275,6 @@ TEST_F(MakemetaTest, announceMultiTracker)
     EXPECT_TRUE(tr_variantDictFindList(&*top, TR_KEY_announce_list, &announce_list_variant));
     EXPECT_NE(nullptr, announce_list_variant);
     EXPECT_EQ(std::size(builder.announce_list()), tr_variantListSize(announce_list_variant));
-
-    tr_variantClear(&*top);
 }
 
 TEST_F(MakemetaTest, privateAndSourceHasDifferentInfoHash)

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,7 +35,7 @@ TEST_F(RpcTest, list)
     tr_variant top;
 
     tr_rpc_parse_list_str(&top, "12"sv);
-    EXPECT_TRUE(tr_variantIsInt(&top));
+    EXPECT_TRUE(top.is_int());
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
     tr_variantClear(&top);

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -38,7 +38,7 @@ TEST_F(RpcTest, list)
     EXPECT_TRUE(top.holds_alternative<int64_t>());
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
-    tr_variantClear(&top);
+    top.clear();
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
     EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
@@ -47,13 +47,13 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(6, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 1), &i));
     EXPECT_EQ(7, i);
-    tr_variantClear(&top);
+    top.clear();
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
     EXPECT_TRUE(top.holds_alternative<std::string_view>());
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
-    tr_variantClear(&top);
+    top.clear();
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
     EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
@@ -66,7 +66,6 @@ TEST_F(RpcTest, list)
     EXPECT_EQ(4, i);
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 3), &i));
     EXPECT_EQ(5, i);
-    tr_variantClear(&top);
 }
 
 /***
@@ -77,8 +76,7 @@ TEST_F(RpcTest, sessionGet)
 {
     auto const rpc_response_func = [](tr_session* /*session*/, tr_variant* response, void* setme) noexcept
     {
-        *static_cast<tr_variant*>(setme) = *response;
-        tr_variantInitBool(response, false);
+        std::swap(*static_cast<tr_variant*>(setme), *response);
     };
 
     auto* tor = zeroTorrentInit(ZeroTorrentState::NoFiles);
@@ -89,7 +87,6 @@ TEST_F(RpcTest, sessionGet)
     tr_variantDictAddStrView(&request, TR_KEY_method, "session-get");
     tr_variant response;
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
-    tr_variantClear(&request);
 
     EXPECT_TRUE(response.holds_alternative<tr_variant::Map>());
     tr_variant* args = nullptr;
@@ -187,7 +184,6 @@ TEST_F(RpcTest, sessionGet)
     EXPECT_EQ(decltype(unexpected_keys){}, unexpected_keys);
 
     // cleanup
-    tr_variantClear(&response);
     tr_torrentRemove(tor, false, nullptr, nullptr);
 }
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,13 +35,13 @@ TEST_F(RpcTest, list)
     tr_variant top;
 
     tr_rpc_parse_list_str(&top, "12"sv);
-    EXPECT_TRUE(top.holds_alternative<int64_t>());
+    EXPECT_TRUE(tr_variantIsInt(&top));
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
     top.clear();
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
+    EXPECT_TRUE(tr_variantIsList(&top));
     EXPECT_EQ(2U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(6, i);
@@ -50,13 +50,13 @@ TEST_F(RpcTest, list)
     top.clear();
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
-    EXPECT_TRUE(top.holds_alternative<std::string_view>());
+    EXPECT_TRUE(tr_variantIsString(&top));
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
     top.clear();
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
-    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
+    EXPECT_TRUE(tr_variantIsList(&top));
     EXPECT_EQ(4U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(1, i);
@@ -88,7 +88,7 @@ TEST_F(RpcTest, sessionGet)
     tr_variant response;
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
 
-    EXPECT_TRUE(response.holds_alternative<tr_variant::Map>());
+    EXPECT_TRUE(tr_variantIsDict(&response));
     tr_variant* args = nullptr;
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,13 +35,13 @@ TEST_F(RpcTest, list)
     tr_variant top;
 
     tr_rpc_parse_list_str(&top, "12"sv);
-    EXPECT_TRUE(top.is_int());
+    EXPECT_TRUE(top.holds_alternative<int64_t>());
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
     tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
-    EXPECT_TRUE(tr_variantIsList(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(2U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(6, i);
@@ -50,13 +50,13 @@ TEST_F(RpcTest, list)
     tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
-    EXPECT_TRUE(tr_variantIsString(&top));
+    EXPECT_TRUE(top.holds_alternative<std::string_view>());
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
     tr_variantClear(&top);
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
-    EXPECT_TRUE(tr_variantIsList(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(4U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(1, i);
@@ -91,7 +91,7 @@ TEST_F(RpcTest, sessionGet)
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
     tr_variantClear(&request);
 
-    EXPECT_TRUE(tr_variantIsDict(&response));
+    EXPECT_TRUE(response.holds_alternative<tr_variant::Map>());
     tr_variant* args = nullptr;
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -294,8 +294,6 @@ TEST_F(SessionTest, getDefaultSettingsIncludesSubmodules)
         EXPECT_TRUE(tr_variantDictFindBool(&settings, key, &flag));
         EXPECT_FALSE(flag);
     }
-
-    tr_variantClear(&settings);
 }
 
 TEST_F(SessionTest, honorsSettings)
@@ -316,7 +314,6 @@ TEST_F(SessionTest, honorsSettings)
         tr_variantDictAddBool(&settings, key, true);
     }
     auto* session = tr_sessionInit(sandboxDir().data(), false, &settings);
-    tr_variantClear(&settings);
 
     // confirm that these settings were enabled
     EXPECT_TRUE(session->isPortRandom());
@@ -347,7 +344,6 @@ TEST_F(SessionTest, savesSettings)
         EXPECT_TRUE(tr_variantDictFindBool(&settings, key, &flag));
         EXPECT_TRUE(flag);
     }
-    tr_variantClear(&settings);
 }
 
 } // namespace libtransmission::test

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -30,10 +30,9 @@ TEST_F(SettingsTest, canInstantiate)
 {
     auto settings = tr_session_settings{};
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
-    settings.save(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
+    settings.save(&var);
 }
 
 TEST_F(SettingsTest, canLoadBools)
@@ -43,11 +42,10 @@ TEST_F(SettingsTest, canLoadBools)
     auto settings = tr_session_settings{};
     auto const expected_value = !settings.seed_queue_enabled;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddBool(&dict, Key, expected_value);
-    settings.load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddBool(&var, Key, expected_value);
+    settings.load(&var);
 
     EXPECT_EQ(expected_value, settings.seed_queue_enabled);
 }
@@ -60,13 +58,12 @@ TEST_F(SettingsTest, canSaveBools)
     auto const expected_value = !settings.seed_queue_enabled;
     settings.seed_queue_enabled = expected_value;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
-    settings.save(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
+    settings.save(&var);
     auto val = bool{};
-    EXPECT_TRUE(tr_variantDictFindBool(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindBool(&var, Key, &val));
     EXPECT_EQ(expected_value, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadDoubles)
@@ -76,12 +73,11 @@ TEST_F(SettingsTest, canLoadDoubles)
     auto settings = tr_session_settings{};
     auto const expected_value = settings.ratio_limit + 1.0;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddReal(&dict, Key, expected_value);
-    settings.load(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddReal(&var, Key, expected_value);
+    settings.load(&var);
     EXPECT_NEAR(expected_value, settings.ratio_limit, 0.001);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canSaveDoubles)
@@ -93,13 +89,12 @@ TEST_F(SettingsTest, canSaveDoubles)
     auto const expected_value = !default_value;
     settings.seed_queue_enabled = expected_value;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
-    settings.save(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
+    settings.save(&var);
     auto val = bool{};
-    EXPECT_TRUE(tr_variantDictFindBool(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindBool(&var, Key, &val));
     EXPECT_EQ(expected_value, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadEncryptionMode)
@@ -110,18 +105,17 @@ TEST_F(SettingsTest, canLoadEncryptionMode)
     auto settings = std::make_unique<tr_session_settings>();
     ASSERT_NE(ExpectedValue, settings->encryption_mode);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ExpectedValue);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ExpectedValue);
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->encryption_mode);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "required");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "required");
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->encryption_mode);
 }
 
@@ -134,13 +128,12 @@ TEST_F(SettingsTest, canSaveEncryptionMode)
     EXPECT_NE(ExpectedValue, settings.seed_queue_enabled);
     settings.encryption_mode = ExpectedValue;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
-    settings.save(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
+    settings.save(&var);
     auto val = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, Key, &val));
     EXPECT_EQ(ExpectedValue, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadLogLevel)
@@ -152,18 +145,17 @@ TEST_F(SettingsTest, canLoadLogLevel)
     auto constexpr ExpectedValue = TR_LOG_DEBUG;
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ExpectedValue);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ExpectedValue);
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->log_level);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "debug");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "debug");
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->log_level);
 }
 
@@ -176,14 +168,13 @@ TEST_F(SettingsTest, canSaveLogLevel)
     auto constexpr ExpectedValue = TR_LOG_DEBUG;
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.log_level = ExpectedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, Key, &val));
     EXPECT_EQ(ExpectedValue, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadMode)
@@ -195,18 +186,17 @@ TEST_F(SettingsTest, canLoadMode)
     auto constexpr ExpectedValue = tr_mode_t{ 0777 };
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ExpectedValue);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ExpectedValue);
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->umask);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "0777");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "0777");
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->umask);
 }
 
@@ -219,14 +209,13 @@ TEST_F(SettingsTest, canSaveMode)
     auto constexpr ExpectedValue = tr_mode_t{ 0777 };
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.umask = ExpectedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, Key, &val));
     EXPECT_EQ("0777", val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadPort)
@@ -238,11 +227,10 @@ TEST_F(SettingsTest, canLoadPort)
     auto constexpr ExpectedValue = tr_port::from_host(8080);
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ExpectedValue.host());
-    settings.load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ExpectedValue.host());
+    settings.load(&var);
     EXPECT_EQ(ExpectedValue, settings.peer_port);
 }
 
@@ -255,14 +243,13 @@ TEST_F(SettingsTest, canSavePort)
     auto constexpr ExpectedValue = tr_port::from_host(8080);
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.peer_port = ExpectedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, Key, &val));
     EXPECT_EQ(ExpectedValue.host(), val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadPreallocation)
@@ -274,18 +261,17 @@ TEST_F(SettingsTest, canLoadPreallocation)
     auto constexpr ExpectedValue = TR_PREALLOCATE_FULL;
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ExpectedValue);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ExpectedValue);
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->preallocation_mode);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "full");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "full");
+    settings->load(&var);
     EXPECT_EQ(ExpectedValue, settings->preallocation_mode);
 }
 
@@ -298,14 +284,13 @@ TEST_F(SettingsTest, canSavePreallocation)
     auto constexpr ExpectedValue = TR_PREALLOCATE_FULL;
     ASSERT_NE(ExpectedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.preallocation_mode = ExpectedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, Key, &val));
     EXPECT_EQ(ExpectedValue, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadSizeT)
@@ -315,11 +300,10 @@ TEST_F(SettingsTest, canLoadSizeT)
     auto settings = tr_session_settings{};
     auto const expected_value = settings.queue_stalled_minutes + 5U;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, expected_value);
-    settings.load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, expected_value);
+    settings.load(&var);
     EXPECT_EQ(expected_value, settings.queue_stalled_minutes);
 }
 
@@ -330,14 +314,13 @@ TEST_F(SettingsTest, canSaveSizeT)
     auto settings = tr_session_settings{};
     auto const expected_value = settings.queue_stalled_minutes + 5U;
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.queue_stalled_minutes = expected_value;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = int64_t{};
-    EXPECT_TRUE(tr_variantDictFindInt(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindInt(&var, Key, &val));
     EXPECT_EQ(expected_value, static_cast<size_t>(val));
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadString)
@@ -348,11 +331,10 @@ TEST_F(SettingsTest, canLoadString)
     auto settings = tr_session_settings{};
     EXPECT_NE(ChangedValue, tr_session_settings{}.bind_address_ipv4);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, ChangedValue);
-    settings.load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, ChangedValue);
+    settings.load(&var);
     EXPECT_EQ(ChangedValue, settings.bind_address_ipv4);
 }
 
@@ -364,14 +346,13 @@ TEST_F(SettingsTest, canSaveString)
     auto settings = tr_session_settings{};
     EXPECT_NE(ChangedValue, tr_session_settings{}.bind_address_ipv4);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.bind_address_ipv4 = ChangedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, Key, &val));
     EXPECT_EQ(ChangedValue, val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadTos)
@@ -383,18 +364,17 @@ TEST_F(SettingsTest, canLoadTos)
     auto const default_value = settings->peer_socket_tos;
     ASSERT_NE(ChangedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, 0x20);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, 0x20);
+    settings->load(&var);
     EXPECT_EQ(ChangedValue, settings->peer_socket_tos);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "cs1");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "cs1");
+    settings->load(&var);
     EXPECT_EQ(ChangedValue, settings->peer_socket_tos);
 }
 
@@ -406,14 +386,13 @@ TEST_F(SettingsTest, canSaveTos)
     auto settings = tr_session_settings{};
     ASSERT_NE(ChangedValue, settings.peer_socket_tos);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.peer_socket_tos = tr_tos_t(0x20);
-    settings.save(&dict);
+    settings.save(&var);
     auto val = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, Key, &val));
     EXPECT_EQ(ChangedValue.toString(), val);
-    tr_variantClear(&dict);
 }
 
 TEST_F(SettingsTest, canLoadVerify)
@@ -425,18 +404,17 @@ TEST_F(SettingsTest, canLoadVerify)
     auto const default_value = settings->torrent_added_verify_mode;
     ASSERT_NE(ChangedValue, default_value);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddStrView(&dict, Key, "full");
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddStrView(&var, Key, "full");
+    settings->load(&var);
     EXPECT_EQ(ChangedValue, settings->torrent_added_verify_mode);
+    var.clear();
 
     settings = std::make_unique<tr_session_settings>();
-    tr_variantInitDict(&dict, 1);
-    tr_variantDictAddInt(&dict, Key, ChangedValue);
-    settings->load(&dict);
-    tr_variantClear(&dict);
+    tr_variantInitDict(&var, 1);
+    tr_variantDictAddInt(&var, Key, ChangedValue);
+    settings->load(&var);
     EXPECT_EQ(ChangedValue, settings->torrent_added_verify_mode);
 }
 
@@ -448,12 +426,11 @@ TEST_F(SettingsTest, canSaveVerify)
     auto settings = tr_session_settings{};
     ASSERT_NE(ChangedValue, settings.torrent_added_verify_mode);
 
-    auto dict = tr_variant{};
-    tr_variantInitDict(&dict, 100);
+    auto var = tr_variant{};
+    tr_variantInitDict(&var, 100);
     settings.torrent_added_verify_mode = ChangedValue;
-    settings.save(&dict);
+    settings.save(&var);
     auto val = std::string_view{};
-    EXPECT_TRUE(tr_variantDictFindStrView(&dict, Key, &val));
+    EXPECT_TRUE(tr_variantDictFindStrView(&var, Key, &val));
     EXPECT_EQ("full", val);
-    tr_variantClear(&dict);
 }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -515,12 +515,7 @@ protected:
         {
             auto* settings = new tr_variant{};
             tr_variantInitDict(settings, 10);
-            auto constexpr deleter = [](tr_variant* v)
-            {
-                tr_variantClear(v);
-                delete v;
-            };
-            settings_.reset(settings, deleter);
+            settings_.reset(settings);
         }
 
         return settings_.get();

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -230,7 +230,7 @@ TEST_F(VariantTest, parse)
 
     benc = "li64ei32ei16ee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsList(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(3, tr_variantListSize(&var));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&var, 0), &i));
@@ -250,7 +250,7 @@ TEST_F(VariantTest, parse)
 
     benc = "le"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsList(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(benc, serde.to_string(var));
     tr_variantClear(&var);

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -244,7 +244,7 @@ TEST_F(VariantTest, parse)
 
     benc = "lllee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsEmpty(&var));
+    EXPECT_FALSE(var.has_value());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     tr_variantClear(&var);
 
@@ -257,7 +257,7 @@ TEST_F(VariantTest, parse)
 
     benc = "d20:"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsEmpty(&var));
+    EXPECT_FALSE(var.has_value());
     EXPECT_EQ(std::data(benc) + 1U, serde.end());
 }
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -230,7 +230,7 @@ TEST_F(VariantTest, parse)
 
     benc = "li64ei32ei16ee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
+    EXPECT_TRUE(tr_variantIsList(&var));
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(3, tr_variantListSize(&var));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&var, 0), &i));
@@ -244,20 +244,20 @@ TEST_F(VariantTest, parse)
 
     benc = "lllee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_FALSE(var.has_value());
+    EXPECT_TRUE(tr_variantIsEmpty(&var));
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     var.clear();
 
     benc = "le"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
+    EXPECT_TRUE(tr_variantIsList(&var));
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(benc, serde.to_string(var));
     var.clear();
 
     benc = "d20:"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_FALSE(var.has_value());
+    EXPECT_TRUE(tr_variantIsEmpty(&var));
     EXPECT_EQ(std::data(benc) + 1U, serde.end());
 }
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -546,26 +546,3 @@ TEST_F(VariantTest, variantFromBufFuzz)
         (void)json_serde.inplace().parse(buf);
     }
 }
-
-TEST_F(VariantTest, mapRemove)
-{
-    auto const key_0 = tr_quark_new("0"sv);
-    auto const key_1 = tr_quark_new("1"sv);
-    auto const key_2 = tr_quark_new("2"sv);
-    auto const key_3 = tr_quark_new("3"sv);
-
-    auto var = tr_variant{};
-    tr_variantInitDict(&var, 0);
-    tr_variantDictAddInt(&var, key_0, 0);
-    tr_variantDictAddInt(&var, key_1, 1);
-    tr_variantDictAddInt(&var, key_2, 2);
-
-    auto* list = tr_variantDictAddList(&var, key_3, 3);
-    tr_variantListAddInt(list, 0);
-    tr_variantListAddInt(list, 1);
-    tr_variantListAddInt(list, 2);
-    tr_variantListAddInt(list, 3);
-
-    tr_variantListRemove(list, 0);
-    tr_variantDictRemove(&var, key_1);
-}

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -213,7 +213,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
                 {
                     auto const newstr = replaceSubstr(sv, oldval, newval);
                     fmt::print("\tReplaced in 'announce-list' tier #{:d}: '{:s}' --> '{:s}'\n", tierCount + 1, sv, newstr);
-                    tr_variantClear(node);
+                    node->clear();
                     tr_variantInitStr(node, newstr);
                     changed = true;
                 }
@@ -396,8 +396,6 @@ int tr_main(int argc, char* argv[])
             ++changedCount;
             serde.to_file(top, filename);
         }
-
-        tr_variantClear(&top);
     }
 
     fmt::print("Changed {:d} files\n", changedCount);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2404,7 +2404,7 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
 
 static tr_variant* ensure_sset(tr_variant& sset)
 {
-    if (sset.has_value())
+    if (!tr_variantIsEmpty(&sset))
     {
         return tr_variantDictFind(&sset, Arguments);
     }
@@ -2416,7 +2416,7 @@ static tr_variant* ensure_sset(tr_variant& sset)
 
 static tr_variant* ensure_tset(tr_variant& tset)
 {
-    if (tset.has_value())
+    if (!tr_variantIsEmpty(&tset))
     {
         return tr_variantDictFind(&tset, Arguments);
     }
@@ -2449,17 +2449,17 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             switch (c)
             {
             case 'a': /* add torrent */
-                if (sset.has_value())
+                if (!tr_variantIsEmpty(&sset))
                 {
                     status |= flush(rpcurl, &sset, config);
                 }
 
-                if (tadd.has_value())
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (tset.has_value())
+                if (!tr_variantIsEmpty(&tset))
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2509,12 +2509,12 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 't': /* set current torrent */
-                if (tadd.has_value())
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (tset.has_value())
+                if (!tr_variantIsEmpty(&tset))
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2538,7 +2538,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case TR_OPT_UNK:
-                if (tadd.has_value())
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                     auto const tmp = getEncodedMetainfo(optarg);
@@ -2571,7 +2571,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             args = tr_variantDictAddDict(&top, Arguments, 0);
             fields = tr_variantDictAddList(args, TR_KEY_fields, 0);
 
-            if (tset.has_value())
+            if (!tr_variantIsEmpty(&tset))
             {
                 addIdArg(tr_variantDictFind(&tset, Arguments), config);
                 status |= flush(rpcurl, &tset, config);
@@ -2943,7 +2943,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         {
             tr_variant* args;
 
-            if (tadd.has_value())
+            if (!tr_variantIsEmpty(&tadd))
             {
                 args = tr_variantDictFind(&tadd, Arguments);
             }
@@ -3016,7 +3016,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
         else if (c == 961) /* set location */
         {
-            if (tadd.has_value())
+            if (!tr_variantIsEmpty(&tadd))
             {
                 tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                 tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
@@ -3049,7 +3049,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
 
             case 's': /* start */
-                if (tadd.has_value())
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, false);
                 }
@@ -3064,7 +3064,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 'S': /* stop */
-                if (tadd.has_value())
+                if (!tr_variantIsEmpty(&tadd))
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, true);
                 }
@@ -3081,7 +3081,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'w':
                 {
-                    auto* args = tadd.has_value() ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(sset);
+                    auto* args = !tr_variantIsEmpty(&tadd) ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(sset);
                     tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
                     break;
                 }
@@ -3126,7 +3126,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 600:
                 {
-                    if (tset.has_value())
+                    if (!tr_variantIsEmpty(&tset))
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3142,7 +3142,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'v':
                 {
-                    if (tset.has_value())
+                    if (!tr_variantIsEmpty(&tset))
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3220,18 +3220,18 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
     }
 
-    if (tadd.has_value())
+    if (!tr_variantIsEmpty(&tadd))
     {
         status |= flush(rpcurl, &tadd, config);
     }
 
-    if (tset.has_value())
+    if (!tr_variantIsEmpty(&tset))
     {
         addIdArg(tr_variantDictFind(&tset, Arguments), config);
         status |= flush(rpcurl, &tset, config);
     }
 
-    if (sset.has_value())
+    if (!tr_variantIsEmpty(&sset))
     {
         status |= flush(rpcurl, &sset, config);
     }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2264,8 +2264,6 @@ static int processResponse(char const* rpcurl, std::string_view response, Config
         {
             status |= EXIT_FAILURE;
         }
-
-        tr_variantClear(&top);
     }
 
     return status;
@@ -2399,7 +2397,7 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
         tr_curl_easy_cleanup(curl);
     }
 
-    tr_variantClear(benc);
+    benc->clear();
 
     return status;
 }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2404,28 +2404,28 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
     return status;
 }
 
-static tr_variant* ensure_sset(tr_variant* sset)
+static tr_variant* ensure_sset(tr_variant& sset)
 {
-    if (!tr_variantIsEmpty(sset))
+    if (sset.has_value())
     {
-        return tr_variantDictFind(sset, Arguments);
+        return tr_variantDictFind(&sset, Arguments);
     }
 
-    tr_variantInitDict(sset, 3);
-    tr_variantDictAddStrView(sset, TR_KEY_method, "session-set"sv);
-    return tr_variantDictAddDict(sset, Arguments, 0);
+    tr_variantInitDict(&sset, 3);
+    tr_variantDictAddStrView(&sset, TR_KEY_method, "session-set"sv);
+    return tr_variantDictAddDict(&sset, Arguments, 0);
 }
 
-static tr_variant* ensure_tset(tr_variant* tset)
+static tr_variant* ensure_tset(tr_variant& tset)
 {
-    if (!tr_variantIsEmpty(tset))
+    if (tset.has_value())
     {
-        return tr_variantDictFind(tset, Arguments);
+        return tr_variantDictFind(&tset, Arguments);
     }
 
-    tr_variantInitDict(tset, 3);
-    tr_variantDictAddStrView(tset, TR_KEY_method, "torrent-set"sv);
-    return tr_variantDictAddDict(tset, Arguments, 1);
+    tr_variantInitDict(&tset, 3);
+    tr_variantDictAddStrView(&tset, TR_KEY_method, "torrent-set"sv);
+    return tr_variantDictAddDict(&tset, Arguments, 1);
 }
 
 static int processArgs(char const* rpcurl, int argc, char const* const* argv, Config& config)
@@ -2451,17 +2451,17 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             switch (c)
             {
             case 'a': /* add torrent */
-                if (!tr_variantIsEmpty(&sset))
+                if (sset.has_value())
                 {
                     status |= flush(rpcurl, &sset, config);
                 }
 
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (!tr_variantIsEmpty(&tset))
+                if (tset.has_value())
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2511,12 +2511,12 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 't': /* set current torrent */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (!tr_variantIsEmpty(&tset))
+                if (tset.has_value())
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2540,7 +2540,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case TR_OPT_UNK:
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                     auto const tmp = getEncodedMetainfo(optarg);
@@ -2573,7 +2573,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             args = tr_variantDictAddDict(&top, Arguments, 0);
             fields = tr_variantDictAddList(args, TR_KEY_fields, 0);
 
-            if (!tr_variantIsEmpty(&tset))
+            if (tset.has_value())
             {
                 addIdArg(tr_variantDictFind(&tset, Arguments), config);
                 status |= flush(rpcurl, &tset, config);
@@ -2652,7 +2652,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
         else if (stepMode == MODE_SESSION_SET)
         {
-            tr_variant* args = ensure_sset(&sset);
+            tr_variant* args = ensure_sset(sset);
 
             switch (c)
             {
@@ -2820,11 +2820,11 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             if (!std::empty(config.torrent_ids))
             {
-                targs = ensure_tset(&tset);
+                targs = ensure_tset(tset);
             }
             else
             {
-                sargs = ensure_sset(&sset);
+                sargs = ensure_sset(sset);
             }
 
             switch (c)
@@ -2900,7 +2900,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
         else if (stepMode == MODE_TORRENT_SET)
         {
-            tr_variant* args = ensure_tset(&tset);
+            tr_variant* args = ensure_tset(tset);
 
             switch (c)
             {
@@ -2945,13 +2945,13 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         {
             tr_variant* args;
 
-            if (!tr_variantIsEmpty(&tadd))
+            if (tadd.has_value())
             {
                 args = tr_variantDictFind(&tadd, Arguments);
             }
             else
             {
-                args = ensure_tset(&tset);
+                args = ensure_tset(tset);
             }
 
             switch (c)
@@ -3018,7 +3018,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
         else if (c == 961) /* set location */
         {
-            if (!tr_variantIsEmpty(&tadd))
+            if (tadd.has_value())
             {
                 tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                 tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
@@ -3051,7 +3051,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
 
             case 's': /* start */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, false);
                 }
@@ -3066,7 +3066,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 'S': /* stop */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, true);
                 }
@@ -3083,7 +3083,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'w':
                 {
-                    auto* args = !tr_variantIsEmpty(&tadd) ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(&sset);
+                    auto* args = tadd.has_value() ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(sset);
                     tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
                     break;
                 }
@@ -3128,7 +3128,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 600:
                 {
-                    if (!tr_variantIsEmpty(&tset))
+                    if (tset.has_value())
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3144,7 +3144,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'v':
                 {
-                    if (!tr_variantIsEmpty(&tset))
+                    if (tset.has_value())
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3222,18 +3222,18 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
     }
 
-    if (!tr_variantIsEmpty(&tadd))
+    if (tadd.has_value())
     {
         status |= flush(rpcurl, &tadd, config);
     }
 
-    if (!tr_variantIsEmpty(&tset))
+    if (tset.has_value())
     {
         addIdArg(tr_variantDictFind(&tset, Arguments), config);
         status |= flush(rpcurl, &tset, config);
     }
 
-    if (!tr_variantIsEmpty(&sset))
+    if (sset.has_value())
     {
         status |= flush(rpcurl, &sset, config);
     }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -392,8 +392,6 @@ void doScrape(tr_torrent_metainfo const& metainfo)
             }
         }
 
-        tr_variantClear(&top);
-
         if (!matched)
         {
             fmt::print("no match\n");


### PR DESCRIPTION
tr_variant now cleans up after itself; callers no longer need to call `tr_variantClear()` before it goes out-of-scope.