### PR TITLE
refactor: replace tr_variant::is_T() with tr_variant::holds_alternative<T>()

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1030,7 +1030,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     auto const handshake_sv = payload.to_string_view();
 
     auto var = tr_variant_serde::benc().inplace().parse(handshake_sv);
-    if (!var || !tr_variantIsDict(&*var))
+    if (!var || !var->holds_alternative<tr_variant::Map>())
     {
         logtrace(msgs, "GET  extended-handshake, couldn't get dictionary");
         return;

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -528,13 +528,13 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
                 tr_variant* const b = tr_variantListChild(l, fi);
                 auto time_checked = time_t{};
 
-                if (tr_variantIsInt(b))
+                if (b != nullptr && b->holds_alternative<int64_t>())
                 {
                     auto t = int64_t{};
                     tr_variantGetInt(b, &t);
                     time_checked = time_t(t);
                 }
-                else if (tr_variantIsList(b))
+                else if (b != nullptr && b->holds_alternative<tr_variant::Vector>())
                 {
                     auto offset = int64_t{};
                     tr_variantGetInt(tr_variantListChild(b, 0), &offset);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -485,7 +485,8 @@ bool tr_sessionLoadSettings(tr_variant* settings_in, char const* config_dir, cha
 {
     using namespace settings_helpers;
 
-    TR_ASSERT(tr_variantIsDict(settings_in));
+    TR_ASSERT(settings_in != nullptr);
+    TR_ASSERT(settings_in->holds_alternative<tr_variant::Map>());
 
     // first, start with the libtransmission default settings
     auto settings = tr_variant{};
@@ -525,7 +526,8 @@ void tr_sessionSaveSettings(tr_session* session, char const* config_dir, tr_vari
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr);
+    TR_ASSERT(client_settings->holds_alternative<tr_variant::Map>());
 
     tr_variant settings;
     auto const filename = tr_pathbuf{ config_dir, "/settings.json"sv };
@@ -570,7 +572,8 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
 {
     using namespace bandwidth_group_helpers;
 
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr);
+    TR_ASSERT(client_settings->holds_alternative<tr_variant::Map>());
 
     tr_timeUpdate(time(nullptr));
 
@@ -622,7 +625,8 @@ void tr_session::initImpl(init_data& data)
     TR_ASSERT(am_in_session_thread());
 
     auto* const client_settings = data.client_settings;
-    TR_ASSERT(tr_variantIsDict(client_settings));
+    TR_ASSERT(client_settings != nullptr);
+    TR_ASSERT(client_settings->holds_alternative<tr_variant::Map>());
 
     tr_logAddTrace(fmt::format("tr_sessionInit: the session's top-level bandwidth object is {}", fmt::ptr(&top_bandwidth_)));
 
@@ -658,7 +662,8 @@ void tr_session::initImpl(init_data& data)
 void tr_session::setSettings(tr_variant* settings_dict, bool force)
 {
     TR_ASSERT(am_in_session_thread());
-    TR_ASSERT(tr_variantIsDict(settings_dict));
+    TR_ASSERT(settings_dict != nullptr);
+    TR_ASSERT(settings_dict->holds_alternative<tr_variant::Map>());
 
     // load the session settings
     auto new_settings = tr_session_settings{};

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -247,11 +247,11 @@ private:
         {
             node = top_;
         }
-        else if (auto* parent = stack_.back(); tr_variantIsList(parent))
+        else if (auto* parent = stack_.back(); parent != nullptr && parent->holds_alternative<tr_variant::Vector>())
         {
             node = tr_variantListAdd(parent);
         }
-        else if (key_ && tr_variantIsDict(parent))
+        else if (key_ && parent != nullptr && parent->holds_alternative<tr_variant::Map>())
         {
             node = tr_variantDictAdd(parent, *key_);
             key_.reset();

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -164,7 +164,7 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
 
     // build a list of the property keys
     tr_variant* const first_child = tr_variantListChild(torrent_list, 0);
-    bool const table = tr_variantIsList(first_child);
+    bool const table = first_child != nullptr && first_child->holds_alternative<tr_variant::Vector>();
     std::vector<tr_quark> keys;
     if (table)
     {

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -105,7 +105,7 @@ auto getValue(tr_variant const* var)
 {
     std::optional<C> ret;
 
-    if (tr_variantIsList(var))
+    if (var != nullptr && var->holds_alternative<tr_variant::Vector>())
     {
         auto list = C{};
 

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -60,7 +60,7 @@ TEST_P(JSONTest, testElements)
     };
 
     auto var = tr_variant_serde::json().inplace().parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto key = tr_quark_new("string"sv);
@@ -98,14 +98,14 @@ TEST_P(JSONTest, testUtf8)
     auto serde = tr_variant_serde::json();
     serde.inplace();
     auto var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     var.clear();
 
     in = R"({ "key": "\u005C" })"sv;
     var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("\\"sv, sv);
     var.clear();
@@ -120,7 +120,7 @@ TEST_P(JSONTest, testUtf8)
      */
     in = R"({ "key": "Let\u00f6lt\u00e9sek" })"sv;
     var = serde.parse(in).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
     auto json = serde.to_string(var);
@@ -130,7 +130,7 @@ TEST_P(JSONTest, testUtf8)
     EXPECT_NE(std::string::npos, json.find("\\u00f6"));
     EXPECT_NE(std::string::npos, json.find("\\u00e9"));
     var = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(&var, key, &sv));
     EXPECT_EQ("Letöltések"sv, sv);
 }
@@ -149,7 +149,7 @@ TEST_P(JSONTest, testUtf16Surrogates)
     EXPECT_NE(std::string::npos, json.find("udd14"));
 
     auto parsed = serde.parse(json).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&parsed));
+    EXPECT_TRUE(parsed.holds_alternative<tr_variant::Map>());
     auto value = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&parsed, key, &value));
     EXPECT_EQ(ThinkingFaceEmojiUtf8, value);
@@ -173,13 +173,13 @@ TEST_P(JSONTest, test1)
 
     auto serde = tr_variant_serde::json();
     auto var = serde.inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     auto i = int64_t{};
     auto* headers = tr_variantDictFind(&var, tr_quark_new("headers"sv));
     EXPECT_NE(nullptr, headers);
-    EXPECT_TRUE(tr_variantIsDict(headers));
+    EXPECT_TRUE(headers->holds_alternative<tr_variant::Map>());
     EXPECT_TRUE(tr_variantDictFindStrView(headers, tr_quark_new("type"sv), &sv));
     EXPECT_EQ("request"sv, sv);
     EXPECT_TRUE(tr_variantDictFindInt(headers, TR_KEY_tag, &i));
@@ -190,10 +190,10 @@ TEST_P(JSONTest, test1)
     EXPECT_EQ("torrent-info"sv, sv);
     auto* args = tr_variantDictFind(body, tr_quark_new("arguments"sv));
     EXPECT_NE(nullptr, args);
-    EXPECT_TRUE(tr_variantIsDict(args));
+    EXPECT_TRUE(args->holds_alternative<tr_variant::Map>());
     auto* ids = tr_variantDictFind(args, TR_KEY_ids);
-    EXPECT_NE(nullptr, ids);
-    EXPECT_TRUE(tr_variantIsList(ids));
+    ASSERT_NE(nullptr, ids);
+    EXPECT_TRUE(ids->holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(2U, tr_variantListSize(ids));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(ids, 0), &i));
     EXPECT_EQ(7, i);
@@ -218,7 +218,7 @@ TEST_P(JSONTest, test3)
         "  \"leftUntilDone\": 2275655680 }"sv;
 
     auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&var, TR_KEY_errorString, &sv));
@@ -230,7 +230,7 @@ TEST_P(JSONTest, unescape)
     static auto constexpr Input = R"({ "string-1": "\/usr\/lib" })"sv;
 
     auto var = tr_variant_serde::json().inplace().parse(Input).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsDict(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Map>());
 
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("string-1"sv), &sv));

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -35,13 +35,13 @@ TEST_F(RpcTest, list)
     tr_variant top;
 
     tr_rpc_parse_list_str(&top, "12"sv);
-    EXPECT_TRUE(tr_variantIsInt(&top));
+    EXPECT_TRUE(top.holds_alternative<int64_t>());
     EXPECT_TRUE(tr_variantGetInt(&top, &i));
     EXPECT_EQ(12, i);
     top.clear();
 
     tr_rpc_parse_list_str(&top, "6,7"sv);
-    EXPECT_TRUE(tr_variantIsList(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(2U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(6, i);
@@ -50,13 +50,13 @@ TEST_F(RpcTest, list)
     top.clear();
 
     tr_rpc_parse_list_str(&top, "asdf"sv);
-    EXPECT_TRUE(tr_variantIsString(&top));
+    EXPECT_TRUE(top.holds_alternative<std::string_view>());
     EXPECT_TRUE(tr_variantGetStrView(&top, &sv));
     EXPECT_EQ("asdf"sv, sv);
     top.clear();
 
     tr_rpc_parse_list_str(&top, "1,3-5"sv);
-    EXPECT_TRUE(tr_variantIsList(&top));
+    EXPECT_TRUE(top.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(4U, tr_variantListSize(&top));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&top, 0), &i));
     EXPECT_EQ(1, i);
@@ -88,7 +88,7 @@ TEST_F(RpcTest, sessionGet)
     tr_variant response;
     tr_rpc_request_exec_json(session_, &request, rpc_response_func, &response);
 
-    EXPECT_TRUE(tr_variantIsDict(&response));
+    EXPECT_TRUE(response.holds_alternative<tr_variant::Map>());
     tr_variant* args = nullptr;
     EXPECT_TRUE(tr_variantDictFindDict(&response, TR_KEY_arguments, &args));
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -230,7 +230,7 @@ TEST_F(VariantTest, parse)
 
     benc = "li64ei32ei16ee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsList(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(3, tr_variantListSize(&var));
     EXPECT_TRUE(tr_variantGetInt(tr_variantListChild(&var, 0), &i));
@@ -244,20 +244,20 @@ TEST_F(VariantTest, parse)
 
     benc = "lllee"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsEmpty(&var));
+    EXPECT_FALSE(var.has_value());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     var.clear();
 
     benc = "le"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsList(&var));
+    EXPECT_TRUE(var.holds_alternative<tr_variant::Vector>());
     EXPECT_EQ(std::data(benc) + std::size(benc), serde.end());
     EXPECT_EQ(benc, serde.to_string(var));
     var.clear();
 
     benc = "d20:"sv;
     var = serde.parse(benc).value_or(tr_variant{});
-    EXPECT_TRUE(tr_variantIsEmpty(&var));
+    EXPECT_FALSE(var.has_value());
     EXPECT_EQ(std::data(benc) + 1U, serde.end());
 }
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2404,7 +2404,7 @@ static int flush(char const* rpcurl, tr_variant* benc, Config& config)
 
 static tr_variant* ensure_sset(tr_variant& sset)
 {
-    if (!tr_variantIsEmpty(&sset))
+    if (sset.has_value())
     {
         return tr_variantDictFind(&sset, Arguments);
     }
@@ -2416,7 +2416,7 @@ static tr_variant* ensure_sset(tr_variant& sset)
 
 static tr_variant* ensure_tset(tr_variant& tset)
 {
-    if (!tr_variantIsEmpty(&tset))
+    if (tset.has_value())
     {
         return tr_variantDictFind(&tset, Arguments);
     }
@@ -2449,17 +2449,17 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             switch (c)
             {
             case 'a': /* add torrent */
-                if (!tr_variantIsEmpty(&sset))
+                if (sset.has_value())
                 {
                     status |= flush(rpcurl, &sset, config);
                 }
 
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (!tr_variantIsEmpty(&tset))
+                if (tset.has_value())
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2509,12 +2509,12 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 't': /* set current torrent */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     status |= flush(rpcurl, &tadd, config);
                 }
 
-                if (!tr_variantIsEmpty(&tset))
+                if (tset.has_value())
                 {
                     addIdArg(tr_variantDictFind(&tset, Arguments), config);
                     status |= flush(rpcurl, &tset, config);
@@ -2538,7 +2538,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case TR_OPT_UNK:
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                     auto const tmp = getEncodedMetainfo(optarg);
@@ -2571,7 +2571,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
             args = tr_variantDictAddDict(&top, Arguments, 0);
             fields = tr_variantDictAddList(args, TR_KEY_fields, 0);
 
-            if (!tr_variantIsEmpty(&tset))
+            if (tset.has_value())
             {
                 addIdArg(tr_variantDictFind(&tset, Arguments), config);
                 status |= flush(rpcurl, &tset, config);
@@ -2943,7 +2943,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         {
             tr_variant* args;
 
-            if (!tr_variantIsEmpty(&tadd))
+            if (tadd.has_value())
             {
                 args = tr_variantDictFind(&tadd, Arguments);
             }
@@ -3016,7 +3016,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
         else if (c == 961) /* set location */
         {
-            if (!tr_variantIsEmpty(&tadd))
+            if (tadd.has_value())
             {
                 tr_variant* args = tr_variantDictFind(&tadd, Arguments);
                 tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
@@ -3049,7 +3049,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 }
 
             case 's': /* start */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, false);
                 }
@@ -3064,7 +3064,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
                 break;
 
             case 'S': /* stop */
-                if (!tr_variantIsEmpty(&tadd))
+                if (tadd.has_value())
                 {
                     tr_variantDictAddBool(tr_variantDictFind(&tadd, TR_KEY_arguments), TR_KEY_paused, true);
                 }
@@ -3081,7 +3081,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'w':
                 {
-                    auto* args = !tr_variantIsEmpty(&tadd) ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(sset);
+                    auto* args = tadd.has_value() ? tr_variantDictFind(&tadd, TR_KEY_arguments) : ensure_sset(sset);
                     tr_variantDictAddStr(args, TR_KEY_download_dir, optarg);
                     break;
                 }
@@ -3126,7 +3126,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 600:
                 {
-                    if (!tr_variantIsEmpty(&tset))
+                    if (tset.has_value())
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3142,7 +3142,7 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
 
             case 'v':
                 {
-                    if (!tr_variantIsEmpty(&tset))
+                    if (tset.has_value())
                     {
                         addIdArg(tr_variantDictFind(&tset, Arguments), config);
                         status |= flush(rpcurl, &tset, config);
@@ -3220,18 +3220,18 @@ static int processArgs(char const* rpcurl, int argc, char const* const* argv, Co
         }
     }
 
-    if (!tr_variantIsEmpty(&tadd))
+    if (tadd.has_value())
     {
         status |= flush(rpcurl, &tadd, config);
     }
 
-    if (!tr_variantIsEmpty(&tset))
+    if (tset.has_value())
     {
         addIdArg(tr_variantDictFind(&tset, Arguments), config);
         status |= flush(rpcurl, &tset, config);
     }
 
-    if (!tr_variantIsEmpty(&sset))
+    if (sset.has_value())
     {
         status |= flush(rpcurl, &sset, config);
     }


### PR DESCRIPTION
Part 2 in a PR series to modernize `tr_vector`. Previous: #5923.

This PR uses `std::`-inspired naming for the functions that check the variant's type.

- `tr_variantIsFoo()` -> `tr_variant::holds_alternative<Foo>()`
- `tr_variantIsEmpty()` -> `!tr_variant::has_value()`