### PR TITLE
refactor: use std::variant in tr_variant

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -206,7 +206,7 @@ bool tr_variantGetBool(tr_variant const* const var, bool* setme)
         {
             *setme = val != 0;
             return true;
-        };
+        }
         break;
 
     case tr_variant::StringIndex:

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -275,7 +275,7 @@ void tr_variantInitInt(tr_variant* initme, int64_t value)
 
 void tr_variantInitStrView(tr_variant* initme, std::string_view val)
 {
-    initme->set_unmanaged_string(val);
+    *initme = tr_variant::unmanaged_string(val);
 }
 
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
@@ -364,7 +364,7 @@ tr_variant* tr_variantListAddStr(tr_variant* const var, std::string_view value)
 tr_variant* tr_variantListAddStrView(tr_variant* const var, std::string_view value)
 {
     auto* const child = tr_variantListAdd(var);
-    child->set_unmanaged_string(value);
+    *child = tr_variant::unmanaged_string(value);
     return child;
 }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -273,17 +273,17 @@ bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, std::byte const*
 
 void tr_variantInitReal(tr_variant* initme, double value)
 {
-    initme->val = value;
+    *initme = value;
 }
 
 void tr_variantInitBool(tr_variant* initme, bool value)
 {
-    initme->val = value;
+    *initme = value;
 }
 
 void tr_variantInitInt(tr_variant* initme, int64_t value)
 {
-    initme->val = value;
+    *initme = value;
 }
 
 void tr_variantInitStrView(tr_variant* initme, std::string_view val)

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -146,13 +146,13 @@ private:
     public:
         StringContainer() = default;
 
-        explicit StringContainer(std::string&& str)
+        explicit StringContainer(std::string&& str) noexcept
         {
             str_ = std::move(str);
             sv_ = str_;
         }
 
-        explicit StringContainer(StringContainer&& that)
+        explicit StringContainer(StringContainer&& that) noexcept
         {
             *this = std::move(that);
         }
@@ -163,7 +163,7 @@ private:
             sv_ = sv;
         }
 
-        StringContainer& operator=(StringContainer&& that)
+        StringContainer& operator=(StringContainer&& that) noexcept
         {
             if (std::data(that.sv_) == std::data(that.str_))
             {

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -5,15 +5,15 @@
 
 #pragma once
 
-#include <algorithm>
+#include <algorithm> // std::move()
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
 #include <map>
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility> // std::as_const, std::pair
 #include <type_traits> // std::is_same_v
+#include <utility> // std::as_const, std::pair
 #include <variant>
 #include <vector>
 
@@ -22,8 +22,8 @@
 struct tr_error;
 
 /**
- * A variant that holds typical benc/json types: bool, int, double, string,
- * vectors of variants, and maps of string-to-variant.
+ * A variant that holds typical benc/json types: bool, int,
+ * double, string, vectors of variants, and maps of variants.
  * Useful when serializing / deserializing benc/json data.
  *
  * @see tr_variant_serde
@@ -42,30 +42,20 @@ public:
         MapIndex = 6
     };
 
-    using String = std::pair<std::string, std::string_view>;
     using Vector = std::vector<tr_variant>;
     using Map = std::map<tr_quark, tr_variant>;
 
-    tr_variant() noexcept = default;
+    constexpr tr_variant() noexcept = default;
+    tr_variant(tr_variant const&) = delete;
+    tr_variant(tr_variant&& that) noexcept = default;
+    tr_variant& operator=(tr_variant const&) = delete;
+    tr_variant& operator=(tr_variant&& that) noexcept = default;
 
     template<typename Val>
     explicit tr_variant(Val value)
     {
         *this = std::move(value);
     }
-
-    tr_variant(tr_variant const&) = delete;
-
-    tr_variant(tr_variant&& that) noexcept
-    {
-        *this = std::move(that);
-    }
-
-    ~tr_variant() = default;
-
-    tr_variant& operator=(tr_variant const&) = delete;
-
-    tr_variant& operator=(tr_variant&& that) noexcept = default;
 
     template<typename Val>
     tr_variant& operator=(Val value)
@@ -131,10 +121,12 @@ public:
 
     void clear()
     {
-        *this = tr_variant{};
+        val_.emplace<std::monostate>();
     }
 
 private:
+    using String = std::pair<std::string, std::string_view>;
+
     std::variant<std::monostate, bool, int64_t, double, String, Vector, Map> val_;
 };
 


### PR DESCRIPTION
Part 2 in a PR series to modernize tr_vector. First: #5923. Previous: #5930.

This PR replaces the union in `tr_variant` with a `std::variant`.

It leaves in place all the C API calls, but they're next in line :axe: 