### PR TITLE
fix: heap-use-after-free in peer communications

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -746,11 +746,8 @@ private:
             TR_ASSERT(it != std::end(peers));
             (*it)->do_purge = true;
 
-            if (was_connectable)
-            {
-                // Note that it_that is invalid after this point
-                graveyard_pool.insert(connectable_pool.extract(it_that));
-            }
+            // Note that it_that is invalid after this point
+            graveyard_pool.insert(connectable_pool.extract(it_that));
 
             return false;
         }


### PR DESCRIPTION
Fixes #5940.
Fixes #5881.
Fixes #5926.