### PR TITLE
refactor: tidy up announcer code

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -87,7 +87,7 @@ bool tr_announce_list::add(std::string_view announce_url_sv, tr_tracker_tier_t t
     tracker.announce = announce_url_sv;
     tracker.tier = get_tier(tier, *announce);
     tracker.id = next_unique_id();
-    tracker.host_and_port = fmt::format(FMT_STRING("{:s}:{:d}"), announce->host, announce->port);
+    tracker.host_and_port = fmt::format("{:s}:{:d}", announce->host, announce->port);
     tracker.sitename = announce->sitename;
     tracker.query = announce->query;
 

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -95,7 +95,7 @@ struct tr_announce_request
     tr_sha1_digest_t info_hash;
 
     /* the name to use when deep logging is enabled */
-    char log_name[128];
+    std::string log_name;
 };
 
 struct tr_announce_response
@@ -169,7 +169,7 @@ struct tr_scrape_request
     tr_interned_string scrape_url;
 
     /* the name to use when deep logging is enabled */
-    char log_name[128];
+    std::string log_name;
 
     /* info hashes of the torrents to scrape */
     std::array<tr_sha1_digest_t, TR_MULTISCRAPE_MAX> info_hash;

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -117,13 +117,13 @@ struct tr_announce_response
      * transmission treats this as the min interval for manual announces */
     int min_interval = 0;
 
-    /* how many peers are seeding this torrent */
+    /* how many peers are seeding this torrent (-1 means unset) */
     int seeders = -1;
 
-    /* how many peers are downloading this torrent */
+    /* how many peers are downloading this torrent (-1 means unset) */
     int leechers = -1;
 
-    /* how many times this torrent has been downloaded */
+    /* how many times this torrent has been downloaded (-1 means unset) */
     int downloads = -1;
 
     /* IPv4 peers that we acquired from the tracker */

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -117,14 +117,14 @@ struct tr_announce_response
      * transmission treats this as the min interval for manual announces */
     int min_interval = 0;
 
-    /* how many peers are seeding this torrent (-1 means unset) */
-    int seeders = -1;
+    /* how many peers are seeding this torrent */
+    std::optional<int64_t> seeders;
 
-    /* how many peers are downloading this torrent (-1 means unset) */
-    int leechers = -1;
+    /* how many peers are downloading this torrent */
+    std::optional<int64_t> leechers;
 
-    /* how many times this torrent has been downloaded (-1 means unset) */
-    int downloads = -1;
+    /* how many times this torrent has been downloaded */
+    std::optional<int64_t> downloads;
 
     /* IPv4 peers that we acquired from the tracker */
     std::vector<tr_pex> pex;
@@ -184,18 +184,18 @@ struct tr_scrape_response_row
     tr_sha1_digest_t info_hash;
 
     /* how many peers are seeding this torrent */
-    int seeders = 0;
+    std::optional<int64_t> seeders;
 
     /* how many peers are downloading this torrent */
-    int leechers = 0;
+    std::optional<int64_t> leechers;
 
     /* how many times this torrent has been downloaded */
-    int downloads = 0;
+    std::optional<int64_t> downloads;
 
     /* the number of active downloaders in the swarm.
      * this is a BEP 21 extension that some trackers won't support.
      * http://www.bittorrent.org/beps/bep_0021.html#tracker-scrapes  */
-    int downloaders = 0;
+    std::optional<int64_t> downloaders;
 };
 
 struct tr_scrape_response

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -371,15 +371,15 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             }
             else if (key == "complete"sv)
             {
-                response_.seeders = static_cast<int>(value);
+                response_.seeders = value;
             }
             else if (key == "incomplete"sv)
             {
-                response_.leechers = static_cast<int>(value);
+                response_.leechers = value;
             }
             else if (key == "downloaded"sv)
             {
-                response_.downloads = static_cast<int>(value);
+                response_.downloads = value;
             }
             else if (key == "port"sv)
             {
@@ -548,9 +548,6 @@ void tr_tracker_http_scrape(tr_session const* session, tr_scrape_request const& 
     for (int i = 0; i < response.row_count; ++i)
     {
         response.rows[i].info_hash = request.info_hash[i];
-        response.rows[i].seeders = -1;
-        response.rows[i].leechers = -1;
-        response.rows[i].downloads = -1;
     }
 
     auto scrape_url = tr_pathbuf{};

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -607,19 +607,19 @@ void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::stri
         {
             if (auto const key = currentKey(); row_ && key == "complete"sv)
             {
-                response_.rows[*row_].seeders = static_cast<int>(value);
+                response_.rows[*row_].seeders = value;
             }
             else if (row_ && key == "downloaded"sv)
             {
-                response_.rows[*row_].downloads = static_cast<int>(value);
+                response_.rows[*row_].downloads = value;
             }
             else if (row_ && key == "incomplete"sv)
             {
-                response_.rows[*row_].leechers = static_cast<int>(value);
+                response_.rows[*row_].leechers = value;
             }
             else if (row_ && key == "downloaders"sv)
             {
-                response_.rows[*row_].downloaders = static_cast<int>(value);
+                response_.rows[*row_].downloaders = value;
             }
             else if (key == "min_request_interval"sv)
             {

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -130,13 +130,8 @@ struct tau_scrape_request
 
         if (action == TAU_ACTION_SCRAPE)
         {
-            for (int i = 0; i < response.row_count; ++i)
+            for (int i = 0; i < response.row_count && std::size(buf) >= sizeof(uint32_t) * 3U; ++i)
             {
-                if (std::size(buf) < sizeof(uint32_t) * 3)
-                {
-                    break;
-                }
-
                 auto& row = response.rows[i];
                 row.seeders = buf.to_uint32();
                 row.downloads = buf.to_uint32();

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -88,9 +88,6 @@ struct tau_scrape_request
         this->response.row_count = in.info_hash_count;
         for (int i = 0; i < this->response.row_count; ++i)
         {
-            this->response.rows[i].seeders = -1;
-            this->response.rows[i].leechers = -1;
-            this->response.rows[i].downloads = -1;
             this->response.rows[i].info_hash = in.info_hash[i];
         }
 
@@ -657,11 +654,11 @@ public:
             // is it a response to one of this tracker's announces?
             if (auto& reqs = tracker.announces; !std::empty(reqs))
             {
-                auto it = std::find_if(
-                    std::begin(reqs),
-                    std::end(reqs),
-                    [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
-                if (it != std::end(reqs))
+                if (auto it = std::find_if(
+                        std::begin(reqs),
+                        std::end(reqs),
+                        [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
+                    it != std::end(reqs))
                 {
                     logtrace(tracker.key, fmt::format("{} is an announce request!", transaction_id));
                     auto req = *it;
@@ -674,11 +671,11 @@ public:
             // is it a response to one of this tracker's scrapes?
             if (auto& reqs = tracker.scrapes; !std::empty(reqs))
             {
-                auto it = std::find_if(
-                    std::begin(reqs),
-                    std::end(reqs),
-                    [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
-                if (it != std::end(reqs))
+                if (auto it = std::find_if(
+                        std::begin(reqs),
+                        std::end(reqs),
+                        [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
+                    it != std::end(reqs))
                 {
                     logtrace(tracker.key, fmt::format("{} is a scrape request!", transaction_id));
                     auto req = *it;

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -180,9 +180,6 @@ struct tau_announce_request
         // https://www.bittorrent.org/beps/bep_0015.html sets key size at 32 bits
         static_assert(sizeof(tr_announce_request::key) * CHAR_BIT == 32);
 
-        response.seeders = -1;
-        response.leechers = -1;
-        response.downloads = -1;
         response.info_hash = in.info_hash;
 
         // build the payload

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1016,7 +1016,7 @@ void tr_announcer_impl::onAnnounceDone(
     {
         auto const is_stopped = event == TR_ANNOUNCE_EVENT_STOPPED;
         auto leechers = int{};
-        auto scrape_fields = int{};
+        auto scrape_fields = uint8_t{};
         auto seeders = int{};
 
         publishErrorClear(tier);
@@ -1091,7 +1091,7 @@ void tr_announcer_impl::onAnnounceDone(
 
         /* if the tracker included scrape fields in its announce response,
            then a separate scrape isn't needed */
-        if (scrape_fields >= 3 || (scrape_fields >= 1 && tracker->scrape_info == nullptr))
+        if (scrape_fields >= 3U || (scrape_fields >= 1U && tracker->scrape_info == nullptr))
         {
             tr_logAddTraceTier(
                 tier,

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -304,7 +304,7 @@ struct tr_tracker
     {
         if (seeder_count_in >= 0)
         {
-            seeder_count_ = std::move(seeder_count_in);
+            seeder_count_ = seeder_count_in;
             return true;
         }
         return false;
@@ -319,7 +319,7 @@ struct tr_tracker
     {
         if (leecher_count_in >= 0)
         {
-            leecher_count_ = std::move(leecher_count_in);
+            leecher_count_ = leecher_count_in;
             return true;
         }
         return false;
@@ -334,7 +334,7 @@ struct tr_tracker
     {
         if (download_count_in >= 0)
         {
-            download_count_ = std::move(download_count_in);
+            download_count_ = download_count_in;
             return true;
         }
         return false;
@@ -349,7 +349,7 @@ struct tr_tracker
     {
         if (downloader_count_in >= 0)
         {
-            downloader_count_ = std::move(downloader_count_in);
+            downloader_count_ = downloader_count_in;
             return true;
         }
         return false;
@@ -728,8 +728,8 @@ void publishPeerCounts(tr_tier* tier, std::optional<int64_t> seeders, std::optio
     {
         auto e = tr_tracker_event{};
         e.type = tr_tracker_event::Type::Counts;
-        e.seeders = std::move(seeders);
-        e.leechers = std::move(leechers);
+        e.seeders = seeders;
+        e.leechers = leechers;
         tr_logAddDebugTier(
             tier,
             fmt::format("peer counts: {} seeders, {} leechers.", seeders.value_or(-1), leechers.value_or(-1)));

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -367,6 +367,7 @@ struct tr_tracker
     tr_tracker_id_t const id;
 
 private:
+    // -1 means the value is unknown to us
     int seeder_count_ = -1;
     int leecher_count_ = -1;
     int download_count_ = -1;

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1360,10 +1360,7 @@ void tr_announcer_impl::onScrapeDone(tr_scrape_response const& response)
                 tracker->consecutive_failures = 0;
             }
 
-            if (row.seeders >= 0 && row.leechers >= 0 && row.downloads >= 0)
-            {
-                publishPeerCounts(tier, row.seeders, row.leechers);
-            }
+            publishPeerCounts(tier, row.seeders, row.leechers);
         }
     }
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1015,9 +1015,7 @@ void tr_announcer_impl::onAnnounceDone(
     else
     {
         auto const is_stopped = event == TR_ANNOUNCE_EVENT_STOPPED;
-        auto leechers = int{};
         auto scrape_fields = uint8_t{};
-        auto seeders = int{};
 
         publishErrorClear(tier);
 
@@ -1028,13 +1026,13 @@ void tr_announcer_impl::onAnnounceDone(
 
             if (response.seeders >= 0)
             {
-                tracker->seeder_count = seeders = response.seeders;
+                tracker->seeder_count = response.seeders;
                 ++scrape_fields;
             }
 
             if (response.leechers >= 0)
             {
-                tracker->leecher_count = leechers = response.leechers;
+                tracker->leecher_count = response.leechers;
                 ++scrape_fields;
             }
 
@@ -1073,19 +1071,15 @@ void tr_announcer_impl::onAnnounceDone(
 
         if (!std::empty(response.pex))
         {
-            publishPeersPex(tier, seeders, leechers, response.pex);
+            publishPeersPex(tier, response.seeders, response.leechers, response.pex);
         }
 
         if (!std::empty(response.pex6))
         {
-            publishPeersPex(tier, seeders, leechers, response.pex6);
+            publishPeersPex(tier, response.seeders, response.leechers, response.pex6);
         }
 
-        /* Only publish leechers if it was actually returned during the announce */
-        if (response.leechers >= 0)
-        {
-            publishPeerCounts(tier, seeders, leechers);
-        }
+        publishPeerCounts(tier, response.seeders, response.leechers);
 
         tier->isRunning = is_running_on_success;
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -742,6 +742,8 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
     {
         auto e = tr_tracker_event{};
         e.type = tr_tracker_event::Type::Peers;
+        e.seeders = seeders;
+        e.leechers = leechers;
         e.pex = pex;
         tr_logAddDebugTier(
             tier,

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -742,8 +742,6 @@ void publishPeersPex(tr_tier* tier, int seeders, int leechers, std::vector<tr_pe
     {
         auto e = tr_tracker_event{};
         e.type = tr_tracker_event::Type::Peers;
-        e.seeders = seeders;
-        e.leechers = leechers;
         e.pex = pex;
         tr_logAddDebugTier(
             tier,

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -60,9 +60,9 @@ struct tr_tracker_event
     // for Peers events
     std::vector<tr_pex> pex;
 
-    // for Peers and Counts events
-    int leechers;
-    int seeders;
+    // for Peers and Counts events (-1 means unset)
+    int leechers = -1;
+    int seeders = -1;
 };
 
 using tr_tracker_callback = std::function<void(tr_torrent&, tr_tracker_event const*)>;

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -60,9 +60,9 @@ struct tr_tracker_event
     // for Peers events
     std::vector<tr_pex> pex;
 
-    // for Peers and Counts events (-1 means unset)
-    int leechers = -1;
-    int seeders = -1;
+    // for Peers and Counts events
+    std::optional<int64_t> leechers;
+    std::optional<int64_t> seeders;
 };
 
 using tr_tracker_callback = std::function<void(tr_torrent&, tr_tracker_event const*)>;

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -301,9 +301,9 @@ TEST_F(AnnouncerTest, parseHttpScrapeResponseMultiWithMissing)
     EXPECT_EQ(2, response.rows[0].leechers);
     EXPECT_EQ(3, response.rows[0].downloads);
 
-    EXPECT_EQ(0, response.rows[1].seeders);
-    EXPECT_EQ(0, response.rows[1].leechers);
-    EXPECT_EQ(0, response.rows[1].downloads);
+    EXPECT_EQ(std::nullopt, response.rows[1].seeders);
+    EXPECT_EQ(std::nullopt, response.rows[1].leechers);
+    EXPECT_EQ(std::nullopt, response.rows[1].downloads);
 
     EXPECT_EQ(7, response.rows[2].seeders);
     EXPECT_EQ(8, response.rows[2].leechers);

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -162,7 +162,7 @@ protected:
         response.rows[0].seeders = 1;
         response.rows[0].leechers = 2;
         response.rows[0].downloads = 3;
-        response.rows[0].downloaders = 0;
+        response.rows[0].downloaders = std::nullopt;
         response.scrape_url = DefaultScrapeUrl;
         response.min_request_interval = 0;
 
@@ -353,9 +353,9 @@ TEST_F(AnnouncerUdpTest, canScrape)
     auto buf = MessageBuffer{};
     buf.add_uint32(ScrapeAction);
     buf.add_uint32(scrape_transaction_id);
-    buf.add_uint32(expected_response.rows[0].seeders);
-    buf.add_uint32(expected_response.rows[0].downloads);
-    buf.add_uint32(expected_response.rows[0].leechers);
+    buf.add_uint32(expected_response.rows[0].seeders.value_or(-1));
+    buf.add_uint32(expected_response.rows[0].downloads.value_or(-1));
+    buf.add_uint32(expected_response.rows[0].leechers.value_or(-1));
     auto response_size = std::size(buf);
     auto arr = std::array<uint8_t, 256>{};
     buf.to_buf(std::data(arr), response_size);
@@ -408,8 +408,8 @@ TEST_F(AnnouncerUdpTest, canMultiScrape)
     expected_response.did_connect = true;
     expected_response.did_timeout = false;
     expected_response.row_count = 2;
-    expected_response.rows[0] = { tr_rand_obj<tr_sha1_digest_t>(), 1, 2, 3, 0 };
-    expected_response.rows[1] = { tr_rand_obj<tr_sha1_digest_t>(), 4, 5, 6, 0 };
+    expected_response.rows[0] = { tr_rand_obj<tr_sha1_digest_t>(), 1, 2, 3, std::nullopt };
+    expected_response.rows[1] = { tr_rand_obj<tr_sha1_digest_t>(), 4, 5, 6, std::nullopt };
     expected_response.scrape_url = DefaultScrapeUrl;
     expected_response.min_request_interval = 0;
 
@@ -432,9 +432,9 @@ TEST_F(AnnouncerUdpTest, canMultiScrape)
     buf.add_uint32(scrape_transaction_id);
     for (int i = 0; i < expected_response.row_count; ++i)
     {
-        buf.add_uint32(expected_response.rows[i].seeders);
-        buf.add_uint32(expected_response.rows[i].downloads);
-        buf.add_uint32(expected_response.rows[i].leechers);
+        buf.add_uint32(expected_response.rows[i].seeders.value_or(-1));
+        buf.add_uint32(expected_response.rows[i].downloads.value_or(-1));
+        buf.add_uint32(expected_response.rows[i].leechers.value_or(-1));
     }
     auto response_size = std::size(buf);
     auto arr = std::array<uint8_t, 256>{};
@@ -455,10 +455,10 @@ TEST_F(AnnouncerUdpTest, canHandleScrapeError)
     expected_response.did_timeout = false;
     expected_response.row_count = 1;
     expected_response.rows[0].info_hash = tr_rand_obj<tr_sha1_digest_t>();
-    expected_response.rows[0].seeders = -1;
-    expected_response.rows[0].leechers = -1;
-    expected_response.rows[0].downloads = -1;
-    expected_response.rows[0].downloaders = 0;
+    expected_response.rows[0].seeders = std::nullopt;
+    expected_response.rows[0].leechers = std::nullopt;
+    expected_response.rows[0].downloads = std::nullopt;
+    expected_response.rows[0].downloaders = std::nullopt;
     expected_response.scrape_url = DefaultScrapeUrl;
     expected_response.min_request_interval = 0;
     expected_response.errmsg = "Unrecognized info-hash";
@@ -505,10 +505,10 @@ TEST_F(AnnouncerUdpTest, canHandleConnectError)
     expected_response.did_timeout = false;
     expected_response.row_count = 1;
     expected_response.rows[0].info_hash = tr_rand_obj<tr_sha1_digest_t>();
-    expected_response.rows[0].seeders = -1; // -1 here & on next lines means error
-    expected_response.rows[0].leechers = -1;
-    expected_response.rows[0].downloads = -1;
-    expected_response.rows[0].downloaders = 0;
+    expected_response.rows[0].seeders = std::nullopt; // empty optional here & on next lines means error
+    expected_response.rows[0].leechers = std::nullopt;
+    expected_response.rows[0].downloads = std::nullopt;
+    expected_response.rows[0].downloaders = std::nullopt;
     expected_response.scrape_url = DefaultScrapeUrl;
     expected_response.min_request_interval = 0;
     expected_response.errmsg = "Unable to Connect";
@@ -646,8 +646,8 @@ TEST_F(AnnouncerUdpTest, canAnnounce)
     buf.add_uint32(AnnounceAction);
     buf.add_uint32(udp_ann_req.transaction_id);
     buf.add_uint32(expected_response.interval);
-    buf.add_uint32(expected_response.leechers);
-    buf.add_uint32(expected_response.seeders);
+    buf.add_uint32(expected_response.leechers.value_or(-1));
+    buf.add_uint32(expected_response.seeders.value_or(-1));
     for (auto const& [addr, port] : addresses)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -616,7 +616,7 @@ TEST_F(AnnouncerUdpTest, canAnnounce)
     expected_response.min_interval = 0; // not specified in UDP announce
     expected_response.seeders = Seeders;
     expected_response.leechers = Leechers;
-    expected_response.downloads = -1; // not specified in UDP announce
+    expected_response.downloads = std::nullopt; // not specified in UDP announce
     expected_response.pex = std::vector<tr_pex>{ tr_pex{ addresses[0] }, tr_pex{ addresses[1] }, tr_pex{ addresses[2] } };
     expected_response.pex6 = {};
     expected_response.errmsg = {};


### PR DESCRIPTION
Address some points raised by @reardonia in https://github.com/transmission/transmission/issues/2932#issuecomment-1100916297.

- [x] not create locals and just push the check into publishPeerCounts()
- [x] publishPeersPex() is not dependent on and should not use seeders & leechers stats
- [ ] probably treat scrape_fields as a mask rather than a counter.
  *Didn't touch this because I'm not too sure how @reardonia wanted to use the mask.*
- [x] clarify throughout the announcer and scrape code that counts of -1 designate fields not returned in response.
- [x] establish checks for -1 wherever tracker stats are set, probably through a universal setter func.

Also fixed a ping-ponging problem with scrape `downloaders`, similar in nature with what #5164 tackles.

Closes #2932.