### PR TITLE
fix: magnet data invalidates tracker IDs

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1180,6 +1180,7 @@ void tr_torrent::set_metainfo(tr_torrent_metainfo tm)
     this->mark_edited();
 
     on_metainfo_completed(this);
+    this->on_announce_list_changed();
 }
 
 tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)


### PR DESCRIPTION
When magnet metadata download completes the tracker info is merged into a new metainfo which causes the tracker IDs to change.  This should be accounted for by calling on_announce_list_changed()

Fixes #5293.