### PR TITLE
refactor: use singleton class for `tr_lib_init()`

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -200,7 +200,7 @@ static std::string getConfigDir(int argc, char const** argv)
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -953,7 +953,7 @@ void tr_daemon::handle_error(tr_error* error) const
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -51,7 +51,7 @@ Glib::OptionEntry create_option_entry(Glib::ustring const& long_name, gchar shor
 int main(int argc, char** argv)
 {
     /* init libtransmission */
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     /* init i18n */
     tr_locale_set_global("");

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -951,15 +951,14 @@ public:
 
     static void create()
     {
-        // NOLINT(exit-time-destructors)
         if (!instance)
         {
             instance = std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
         }
-        // NOLINTEND
     }
 
 private:
+    // NOLINTNEXTLINE(clang-diagnostic-exit-time-destructors)
     static inline std::unique_ptr<tr_net_init_mgr> instance{};
 };
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -929,36 +929,43 @@ std::string tr_env_get_string(std::string_view key, std::string_view default_val
 
 // ---
 
-tr_net_init_mgr::tr_net_init_mgr()
+class tr_net_init_mgr
 {
-    // try to init curl with default settings (currently ssl support + win32 sockets)
-    // but if that fails, we need to init win32 sockets as a bare minimum
-    if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+private:
+    tr_net_init_mgr()
     {
-        curl_global_init(CURL_GLOBAL_WIN32);
+        // try to init curl with default settings (currently ssl support + win32 sockets)
+        // but if that fails, we need to init win32 sockets as a bare minimum
+        if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+        {
+            curl_global_init(CURL_GLOBAL_WIN32);
+        }
     }
-}
+    TR_DISABLE_COPY_MOVE(tr_net_init_mgr)
 
-tr_net_init_mgr::~tr_net_init_mgr()
-{
-    curl_global_cleanup();
-}
-
-std::unique_ptr<tr_net_init_mgr> tr_net_init_mgr::create()
-{
-    if (!initialised)
+public:
+    ~tr_net_init_mgr()
     {
-        initialised = true;
-        return std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
+        curl_global_cleanup();
     }
-    return {};
-}
 
-bool tr_net_init_mgr::initialised = false;
+    static void create()
+    {
+        // NOLINT(exit-time-destructors)
+        if (!instance)
+        {
+            instance = std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
+        }
+        // NOLINTEND
+    }
 
-std::unique_ptr<tr_net_init_mgr> tr_lib_init()
+private:
+    static inline std::unique_ptr<tr_net_init_mgr> instance{};
+};
+
+void tr_lib_init()
 {
-    return tr_net_init_mgr::create();
+    tr_net_init_mgr::create();
 }
 
 // --- mime-type

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -357,20 +357,5 @@ void tr_formatter_get_units(void* dict);
 
 // ---
 
-class tr_net_init_mgr
-{
-private:
-    tr_net_init_mgr();
-    TR_DISABLE_COPY_MOVE(tr_net_init_mgr)
-
-public:
-    ~tr_net_init_mgr();
-    static std::unique_ptr<tr_net_init_mgr> create();
-
-private:
-    static bool initialised;
-};
-
-/** @brief Initialise libtransmission for each app
- *  @return A manager object to be kept in scope of main() */
-std::unique_ptr<tr_net_init_mgr> tr_lib_init();
+/** @brief Initialise libtransmission for each app */
+void tr_lib_init();

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -10,7 +10,7 @@
 
 int main(int argc, char** argv)
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -659,7 +659,7 @@ void Application::onNotificationActionInvoked(quint32 /* notification_id */, QSt
 
 int tr_main(int argc, char** argv)
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -53,7 +53,7 @@ private:
     void SetUp() override
     {
         ::testing::Test::SetUp();
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
         tr_timeUpdate(time(nullptr));
     }
 
@@ -306,8 +306,6 @@ protected:
         timer->start_repeating(200ms);
         return timer;
     }
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 
     // https://www.bittorrent.org/beps/bep_0015.html
     static auto constexpr ProtocolId = uint64_t{ 0x41727101980ULL };

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -412,7 +412,7 @@ protected:
     {
         SandboxedTest::SetUp();
 
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
 
         tr_session_thread::tr_evthread_init();
         event_base_ = event_base_new();
@@ -427,8 +427,6 @@ protected:
     }
 
     struct event_base* event_base_ = nullptr;
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 
     // Arbitrary values. Several tests requires socket/port values
     // to be provided but they aren't central to the tests, so they're

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -525,7 +525,7 @@ protected:
     {
         SandboxedTest::SetUp();
 
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
 
         auto callback = [this](tr_torrent* tor, bool /*aborted*/)
         {
@@ -551,8 +551,6 @@ private:
     std::mutex verified_mutex_;
     std::condition_variable verified_cv_;
     std::vector<tr_torrent*> verified_;
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 };
 
 } // namespace test

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -64,13 +64,11 @@ private:
     std::shared_ptr<struct event_base> ev_base_;
     std::unique_ptr<libtransmission::TimerMaker> timer_maker_;
 
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
-
 protected:
     void SetUp() override
     {
         SandboxedTest::SetUp();
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
         ev_base_.reset(event_base_new(), event_base_free);
         timer_maker_ = std::make_unique<libtransmission::EvTimerMaker>(ev_base_.get());
         Watchdir::set_generic_rescan_interval(GenericRescanInterval);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -3314,7 +3314,7 @@ static void getHostAndPortAndRpcUrl(int* argc, char** argv, std::string* host, i
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -403,7 +403,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 


### PR DESCRIPTION
This reduces the risk of user error, since the caller to `tr_lib_init()` does not have to be care about the scope of the returned `unique_ptr`.

I've tried this before but to no avail because of clang-tidy complaining about exit time constructors https://github.com/transmission/transmission/pull/5702#issuecomment-1616055991. I completely forgot about `NOLINT` at the time, so here's another go at it.