### PR TITLE
feat: check if local files exist after setting location

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2409,6 +2409,10 @@ void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)
             recheck_completeness();
         }
     }
+    else if (error == TR_STAT_LOCAL_ERROR && !setLocalErrorIfFilesDisappeared(this))
+    {
+        tr_torrentClearError(this);
+    }
 }
 
 // decide whether we should be looking for files in downloadDir or incompleteDir


### PR DESCRIPTION
Part 1 of tackling #83. Next part at #5981.

Suppose Transmission displayed the error message `No data found! Ensure your drives are connected or use "Set Location". To re-download, remove the torrent and re-add it.` because the user moved the torrent files to another location.

To clear the error, the user currently has to set the torrent location, then try to resume the torrent to see if the error clears.

With this PR, the files will immediately be checked after setting torrent location, and the error will clear if Transmission finds the files.

Notes: Transmission now checks if local files exists after setting torrent location.

Fixes #6048.