### PR TITLE
perf: do not call `session-set` in `session-get` callback

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -95,6 +95,12 @@ export class PrefsDialog extends EventTarget {
     }
   }
 
+  _onMaybePortChanged(key) {
+    if (key === 'peer-port' || key === 'port-forwarding-enabled') {
+      this._checkPort();
+    }
+  }
+
   // this callback is for controls whose changes can be applied
   // immediately, like checkboxs, radioboxes, and selects
   _onControlChanged(event_) {
@@ -102,9 +108,7 @@ export class PrefsDialog extends EventTarget {
     this.remote.savePrefs({
       [key]: PrefsDialog._getValue(event_.target),
     });
-    if (key === 'peer-port' || key === 'port-forwarding-enabled') {
-      this._checkPort();
-    }
+    this._onMaybePortChanged(key);
   }
 
   _onDialogClosed() {
@@ -121,6 +125,7 @@ export class PrefsDialog extends EventTarget {
       for (const element of this.elements.root.querySelectorAll(
         `[data-key="${key}"]`,
       )) {
+        this._onMaybePortChanged(key);
         if (key === 'blocklist-size') {
           const n = Formatter.number(value);
           element.innerHTML = `Blocklist has <span class="blocklist-size-number">${n}</span> rules`;

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -112,7 +112,7 @@ export class PrefsDialog extends EventTarget {
   }
 
   // update the dialog's controls
-  _update(o) {
+  _update(o, ui_only) {
     if (!o) {
       return;
     }
@@ -133,7 +133,9 @@ export class PrefsDialog extends EventTarget {
             case 'radio':
               if (element.checked !== value) {
                 element.checked = value;
-                element.dispatchEvent(new Event('change'));
+                if (!ui_only) {
+                  element.dispatchEvent(new Event('change'));
+                }
               }
               break;
             case 'text':
@@ -150,13 +152,17 @@ export class PrefsDialog extends EventTarget {
                 element !== document.activeElement
               ) {
                 element.value = value;
-                element.dispatchEvent(new Event('change'));
+                if (!ui_only) {
+                  element.dispatchEvent(new Event('change'));
+                }
               }
               break;
             case 'select-one':
               if (element.value !== value) {
                 element.value = value;
-                element.dispatchEvent(new Event('change'));
+                if (!ui_only) {
+                  element.dispatchEvent(new Event('change'));
+                }
               }
               break;
             default:
@@ -770,7 +776,7 @@ export class PrefsDialog extends EventTarget {
     this.session_manager = session_manager;
     this.remote = remote;
     this.update_soon = () =>
-      this._update(this.session_manager.session_properties);
+      this._update(this.session_manager.session_properties, false);
 
     this.elements = PrefsDialog._create();
     this.elements.peers.blocklist_update_button.addEventListener(
@@ -824,7 +830,8 @@ export class PrefsDialog extends EventTarget {
     walk(this.elements.torrents);
 
     this.session_manager.addEventListener('session-change', this.update_soon);
-    this.update_soon();
+    this._update(this.session_manager.session_properties, true);
+    this._checkPort();
 
     document.body.append(this.elements.root);
   }

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -116,7 +116,7 @@ export class PrefsDialog extends EventTarget {
   }
 
   // update the dialog's controls
-  _update_fields() {
+  _update() {
     this._setBlocklistButtonEnabled(true);
 
     for (const [key, value] of Object.entries(
@@ -761,7 +761,7 @@ export class PrefsDialog extends EventTarget {
     this.closed = false;
     this.session_manager = session_manager;
     this.remote = remote;
-    this.update_fields = () => this._update_fields();
+    this.update_from_session = () => this._update();
 
     this.elements = PrefsDialog._create();
     this.elements.peers.blocklist_update_button.addEventListener(
@@ -814,8 +814,11 @@ export class PrefsDialog extends EventTarget {
     walk(this.elements.speed);
     walk(this.elements.torrents);
 
-    this.session_manager.addEventListener('session-change', this.update_fields);
-    this.update_fields();
+    this.session_manager.addEventListener(
+      'session-change',
+      this.update_from_session,
+    );
+    this.update_from_session();
     this._checkPort();
 
     document.body.append(this.elements.root);
@@ -826,7 +829,7 @@ export class PrefsDialog extends EventTarget {
       this.outside.stop();
       this.session_manager.removeEventListener(
         'session-change',
-        this.update_fields,
+        this.update_from_session,
       );
       this.elements.root.remove();
       dispatchEvent(new Event('close'));

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -125,7 +125,6 @@ export class PrefsDialog extends EventTarget {
       for (const element of this.elements.root.querySelectorAll(
         `[data-key="${key}"]`,
       )) {
-        this._onMaybePortChanged(key);
         if (key === 'blocklist-size') {
           const n = Formatter.number(value);
           element.innerHTML = `Blocklist has <span class="blocklist-size-number">${n}</span> rules`;
@@ -145,6 +144,10 @@ export class PrefsDialog extends EventTarget {
               // don't change the text if the user's editing it.
               // it's very annoying when that happens!
               if (element !== document.activeElement) {
+                // eslint-disable-next-line eqeqeq
+                if (element.value != value) {
+                  this._onMaybePortChanged(key);
+                }
                 element.value = value;
               }
               break;
@@ -819,7 +822,6 @@ export class PrefsDialog extends EventTarget {
       this.update_from_session,
     );
     this.update_from_session();
-    this._checkPort();
 
     document.body.append(this.elements.root);
   }


### PR DESCRIPTION
Fixes #5956. The original issue stated that most of these excessive calls were `session-get`, while they are actually `session-set`.

Notes: Removed excessive `session-set` RPC calls related to WebUI preference dialogue.

Calling `session-set` in the callback function of `session-get` was unnecessary, so I removed it.