### PR TITLE
fix: properly check if value changed for drop-down menus

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -154,7 +154,8 @@ export class PrefsDialog extends EventTarget {
               }
               break;
             case 'select-one':
-              if (element.value !== value) {
+              // eslint-disable-next-line eqeqeq
+              if (element.value != value) {
                 element.value = value;
                 element.dispatchEvent(new Event('change'));
               }


### PR DESCRIPTION
The WebUI currently does not properly check if the values of the drop-down menus in the preference dialogue was changed.