### PR TITLE
refactor: tr_variant API update

### DIFF
--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -8,7 +8,6 @@
 #include <algorithm> // std::move()
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
-#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -18,6 +17,7 @@
 #include <vector>
 
 #include "libtransmission/quark.h"
+#include "libtransmission/tr-macros.h"
 
 struct tr_error;
 
@@ -43,7 +43,82 @@ public:
     };
 
     using Vector = std::vector<tr_variant>;
-    using Map = std::map<tr_quark, tr_variant>;
+
+    class Map : public std::vector<std::pair<tr_quark, tr_variant>>
+    {
+    public:
+        Map(size_t const n_reserve = 0U)
+        {
+            reserve(n_reserve);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto find(tr_quark const key) noexcept
+        {
+            return std::find_if(begin(), end(), [key](auto const& item) { return item.first == key; });
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto find(tr_quark const key) const noexcept
+        {
+            return std::find_if(cbegin(), cend(), [key](auto const& item) { return item.first == key; });
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto contains(tr_quark const key) const noexcept
+        {
+            return find(key) != end();
+        }
+
+        auto erase(tr_quark const key)
+        {
+            if (auto iter = find(key); iter != end())
+            {
+                std::vector<std::pair<tr_quark, tr_variant>>::erase(iter);
+                return 1U;
+            }
+
+            return 0U;
+        }
+
+        [[nodiscard]] tr_variant& operator[](tr_quark const& key)
+        {
+            if (auto const iter = find(key); iter != end())
+            {
+                return iter->second;
+            }
+
+            return emplace_back(key, tr_variant{}).second;
+        }
+
+        template<typename Val>
+        std::pair<tr_variant&, bool> try_emplace(tr_quark const key, Val&& val)
+        {
+            if (auto iter = find(key); iter != end())
+            {
+                return { iter->second, false };
+            }
+
+            return { emplace_back(key, tr_variant{ std::move(val) }).second, true };
+        }
+
+        // --- custom functions
+
+        template<typename Type>
+        [[nodiscard]] TR_CONSTEXPR20 auto TR_CONSTEXPR20 find_if(tr_quark const key) const noexcept
+        {
+            auto const iter = find(key);
+            return iter != end() ? iter->second.get_if<Type>() : nullptr;
+        }
+
+        template<typename Type>
+        [[nodiscard]] TR_CONSTEXPR20 std::optional<Type> value_if(tr_quark const key) const noexcept
+        {
+            if (auto const* const value = find_if<Type>(key); value != nullptr)
+            {
+                return std::optional<Type>{ *value };
+            }
+
+            return {};
+        }
+    };
 
     constexpr tr_variant() noexcept = default;
     tr_variant(tr_variant const&) = delete;
@@ -51,23 +126,66 @@ public:
     tr_variant& operator=(tr_variant const&) = delete;
     tr_variant& operator=(tr_variant&& that) noexcept = default;
 
-    [[nodiscard]] static auto make_map() noexcept
-    {
-        auto ret = tr_variant{};
-        ret.val_.emplace<Map>();
-        return ret;
-    }
-
     template<typename Val>
     tr_variant(Val value)
     {
         *this = std::move(value);
     }
 
+    [[nodiscard]] static auto make_map(size_t const n_reserve = 0U) noexcept
+    {
+        auto ret = tr_variant{};
+        ret.val_.emplace<Map>(n_reserve);
+        return ret;
+    }
+
+    [[nodiscard]] static auto make_vector(size_t const n_reserve = 0U)
+    {
+        auto ret = tr_variant{};
+        ret.val_.emplace<Vector>().reserve(n_reserve);
+        return ret;
+    }
+
+    [[nodiscard]] static auto make_raw(void const* value, size_t n_bytes)
+    {
+        return tr_variant{ std::string{ static_cast<char const*>(value), n_bytes } };
+    }
+
+    template<typename CharSpan>
+    [[nodiscard]] static auto make_raw(CharSpan const& value)
+    {
+        static_assert(sizeof(CharSpan::value_type) == 1U);
+        return make_raw(std::data(value), std::size(value));
+    }
+
+    [[nodiscard]] static tr_variant unmanaged_string(std::string_view val)
+    {
+        auto ret = tr_variant{};
+        ret.val_.emplace<StringHolder>().set_unmanaged(val);
+        return ret;
+    }
+
     template<typename Val>
     tr_variant& operator=(Val value)
     {
-        val_ = std::move(value);
+        if constexpr (std::is_same_v<Val, std::string_view>)
+        {
+            val_.emplace<StringHolder>(std::string{ value });
+        }
+        // note: std::is_integral_v<bool> is true, so this check
+        // must come first to prevent bools from being stored as ints
+        else if constexpr (std::is_same_v<Val, bool>)
+        {
+            val_.emplace<bool>(value);
+        }
+        else if constexpr (std::is_integral_v<Val> || std::is_enum_v<Val>)
+        {
+            val_ = static_cast<int64_t>(value);
+        }
+        else
+        {
+            val_ = std::move(value);
+        }
         return *this;
     }
 
@@ -79,25 +197,13 @@ public:
 
     tr_variant& operator=(std::string const& value)
     {
-        val_.emplace<StringHolder>(std::string(value));
+        *this = std::string{ value };
         return *this;
     }
 
-    tr_variant& operator=(std::string_view value)
+    tr_variant& operator=(char const* const value)
     {
-        val_.emplace<StringHolder>(std::string(value));
-        return *this;
-    }
-
-    tr_variant& operator=(int value)
-    {
-        *this = static_cast<int64_t>(value);
-        return *this;
-    }
-
-    tr_variant& operator=(uint64_t value)
-    {
-        *this = static_cast<int64_t>(value); // hmmm
+        *this = std::string{ value != nullptr ? value : "" };
         return *this;
     }
 
@@ -132,7 +238,7 @@ public:
     }
 
     template<size_t Index>
-    [[nodiscard]] auto* get_if() noexcept
+    [[nodiscard]] constexpr auto* get_if() noexcept
     {
         if constexpr (Index == StringIndex)
         {
@@ -149,13 +255,6 @@ public:
     [[nodiscard]] constexpr auto const* get_if() const noexcept
     {
         return const_cast<tr_variant*>(this)->get_if<Index>();
-    }
-
-    [[nodiscard]] static tr_variant unmanaged_string(std::string_view val)
-    {
-        auto ret = tr_variant{};
-        ret.val_.emplace<StringHolder>().set_unmanaged(val);
-        return ret;
     }
 
     template<typename Val>
@@ -250,8 +349,8 @@ void tr_variantInitInt(tr_variant* initme, int64_t value);
 
 // --- Lists
 
-void tr_variantInitList(tr_variant* initme, size_t reserve_count);
-void tr_variantListReserve(tr_variant* var, size_t reserve_count);
+void tr_variantInitList(tr_variant* initme, size_t n_reserve);
+void tr_variantListReserve(tr_variant* var, size_t n_reserve);
 
 tr_variant* tr_variantListAdd(tr_variant* var);
 tr_variant* tr_variantListAddBool(tr_variant* var, bool value);
@@ -260,9 +359,9 @@ tr_variant* tr_variantListAddReal(tr_variant* var, double value);
 tr_variant* tr_variantListAddStr(tr_variant* var, std::string_view value);
 tr_variant* tr_variantListAddStrView(tr_variant* var, std::string_view value);
 tr_variant* tr_variantListAddQuark(tr_variant* var, tr_quark value);
-tr_variant* tr_variantListAddRaw(tr_variant* var, void const* value, size_t value_len);
-tr_variant* tr_variantListAddList(tr_variant* var, size_t reserve_count);
-tr_variant* tr_variantListAddDict(tr_variant* var, size_t reserve_count);
+tr_variant* tr_variantListAddRaw(tr_variant* var, void const* value, size_t n_bytes);
+tr_variant* tr_variantListAddList(tr_variant* var, size_t n_reserve);
+tr_variant* tr_variantListAddDict(tr_variant* var, size_t n_reserve);
 tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
 
 bool tr_variantListRemove(tr_variant* var, size_t pos);
@@ -282,8 +381,8 @@ bool tr_variantListRemove(tr_variant* var, size_t pos);
 
 // --- Dictionaries
 
-void tr_variantInitDict(tr_variant* initme, size_t reserve_count);
-void tr_variantDictReserve(tr_variant* var, size_t reserve_count);
+void tr_variantInitDict(tr_variant* initme, size_t n_reserve);
+void tr_variantDictReserve(tr_variant* var, size_t n_reserve);
 bool tr_variantDictRemove(tr_variant* var, tr_quark key);
 
 tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);
@@ -293,9 +392,9 @@ tr_variant* tr_variantDictAddBool(tr_variant* var, tr_quark key, bool value);
 tr_variant* tr_variantDictAddStr(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictAddQuark(tr_variant* var, tr_quark key, tr_quark val);
-tr_variant* tr_variantDictAddList(tr_variant* var, tr_quark key, size_t reserve_count);
-tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t reserve_count);
-tr_variant* tr_variantDictAddRaw(tr_variant* var, tr_quark key, void const* value, size_t len);
+tr_variant* tr_variantDictAddList(tr_variant* var, tr_quark key, size_t n_reserve);
+tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserve);
+tr_variant* tr_variantDictAddRaw(tr_variant* var, tr_quark key, void const* value, size_t n_bytes);
 
 bool tr_variantDictChild(tr_variant* var, size_t pos, tr_quark* setme_key, tr_variant** setme_value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
@@ -321,12 +420,12 @@ class tr_variant_serde
 public:
     ~tr_variant_serde();
 
-    static tr_variant_serde benc() noexcept
+    [[nodiscard]] static tr_variant_serde benc() noexcept
     {
         return tr_variant_serde{ Type::Benc };
     }
 
-    static tr_variant_serde json() noexcept
+    [[nodiscard]] static tr_variant_serde json() noexcept
     {
         return tr_variant_serde{ Type::Json };
     }

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -12,12 +12,12 @@
 #include <string>
 #include <string_view>
 #include <type_traits> // std::is_same_v
-#include <utility> // std::as_const, std::pair
+#include <utility> // std::pair
 #include <variant>
 #include <vector>
 
 #include "libtransmission/quark.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/tr-macros.h" // TR_CONSTEXPR20
 
 struct tr_error;
 
@@ -44,12 +44,42 @@ public:
 
     using Vector = std::vector<tr_variant>;
 
-    class Map : public std::vector<std::pair<tr_quark, tr_variant>>
+    class Map
     {
     public:
         Map(size_t const n_reserve = 0U)
         {
-            reserve(n_reserve);
+            vec_.reserve(n_reserve);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto begin() noexcept
+        {
+            return std::begin(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto begin() const noexcept
+        {
+            return std::cbegin(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto cbegin() const noexcept
+        {
+            return std::cbegin(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto end() noexcept
+        {
+            return std::end(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto end() const noexcept
+        {
+            return std::cend(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto cend() const noexcept
+        {
+            return std::cend(vec_);
         }
 
         [[nodiscard]] TR_CONSTEXPR20 auto find(tr_quark const key) noexcept
@@ -59,19 +89,29 @@ public:
 
         [[nodiscard]] TR_CONSTEXPR20 auto find(tr_quark const key) const noexcept
         {
-            return std::find_if(cbegin(), cend(), [key](auto const& item) { return item.first == key; });
+            return std::find_if(begin(), end(), [key](auto const& item) { return item.first == key; });
         }
 
-        [[nodiscard]] TR_CONSTEXPR20 auto contains(tr_quark const key) const noexcept
+        [[nodiscard]] TR_CONSTEXPR20 auto size() const noexcept
         {
-            return find(key) != end();
+            return std::size(vec_);
+        }
+
+        [[nodiscard]] TR_CONSTEXPR20 auto empty() const noexcept
+        {
+            return std::empty(vec_);
+        }
+
+        void reserve(size_t new_cap)
+        {
+            vec_.reserve(new_cap);
         }
 
         auto erase(tr_quark const key)
         {
             if (auto iter = find(key); iter != end())
             {
-                std::vector<std::pair<tr_quark, tr_variant>>::erase(iter);
+                vec_.erase(iter);
                 return 1U;
             }
 
@@ -85,7 +125,7 @@ public:
                 return iter->second;
             }
 
-            return emplace_back(key, tr_variant{}).second;
+            return vec_.emplace_back(key, tr_variant{}).second;
         }
 
         template<typename Val>
@@ -96,7 +136,7 @@ public:
                 return { iter->second, false };
             }
 
-            return { emplace_back(key, tr_variant{ std::move(val) }).second, true };
+            return { vec_.emplace_back(key, tr_variant{ std::move(val) }).second, true };
         }
 
         // --- custom functions
@@ -118,6 +158,10 @@ public:
 
             return {};
         }
+
+    private:
+        using Vector = std::vector<std::pair<tr_quark, tr_variant>>;
+        Vector vec_;
     };
 
     constexpr tr_variant() noexcept = default;


### PR DESCRIPTION
add API for creating tr_variant maps/vectors.

culled from the refactor/variant-rpcimpl branch into a separate PR.