### PR TITLE
feat: view & edit torrent name, location, and labels from Inspector

### DIFF
--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -285,7 +285,9 @@ export class Inspector extends EventTarget {
       string = torrents[0].getName();
       action = true;
     }
-    e.info.name.value = string;
+    if (e.info.name !== document.activeElement) {
+      e.info.name.value = string;
+    }
     e.info.name.placeholder = placeholder;
     e.info.name.disabled = !action;
 
@@ -297,7 +299,9 @@ export class Inspector extends EventTarget {
       string = torrents[0].getLabels().join(', ');
       action = true;
     }
-    e.info.labels.value = string;
+    if (e.info.labels !== document.activeElement) {
+      e.info.labels.value = string;
+    }
     e.info.labels.placeholder = none;
     e.info.labels.disabled = !action;
 
@@ -315,7 +319,9 @@ export class Inspector extends EventTarget {
         placeholder = mixed;
       }
     }
-    e.info.location.value = string;
+    if (e.info.location !== document.activeElement) {
+      e.info.location.value = string;
+    }
     e.info.location.placeholder = placeholder;
     e.info.location.disabled = !action;
 

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -80,9 +80,8 @@ export class Inspector extends EventTarget {
       setTextContent(lhs, text);
       root.append(lhs);
 
-      let rhs;
       if (action) {
-        rhs = document.createElement("input");
+        const rhs = document.createElement("input");
         rhs.setAttribute("type", "text");
         rhs.addEventListener("keydown", (k) => {
           if (k.keyCode === 13) {
@@ -90,12 +89,13 @@ export class Inspector extends EventTarget {
             controller.action_manager.click(action);
           }
         });
+        root.append(rhs);
+        return rhs;
       } else {
-        rhs = document.createElement('span');
+        const rhs = document.createElement('span');
+        root.append(rhs);
+        return rhs;
       }
-
-      root.append(rhs);
-      return rhs;
     };
 
     append_section_title('Torrent');

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -551,7 +551,10 @@ export class Inspector extends EventTarget {
     string = string || none;
     if (string.startsWith('https://') || string.startsWith('http://')) {
       string = encodeURI(string);
-      e.info.comment.innerHTML = `<a href="${string}" target="_blank" >${string}</a>`;
+      Utils.setInnerHTML(
+        e.info.comment,
+        `<a href="${string}" target="_blank" >${string}</a>`,
+      );
     } else {
       setTextContent(e.info.comment, string);
     }
@@ -605,7 +608,10 @@ export class Inspector extends EventTarget {
       setTextContent(e.info.magnetLink, mixed);
     } else {
       const link = torrents[0].getMagnetLink();
-      e.info.magnetLink.innerHTML = `<a class="inspector-info-magnet" href="${link}"><button></button></a>`;
+      Utils.setInnerHTML(
+        e.info.magnetLink,
+        `<a class="inspector-info-magnet" href="${link}"><button></button></a>`,
+      );
     }
   }
 

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -81,21 +81,20 @@ export class Inspector extends EventTarget {
       root.append(lhs);
 
       if (action) {
-        const rhs = document.createElement("input");
-        rhs.setAttribute("type", "text");
-        rhs.addEventListener("keydown", (k) => {
-          if (k.keyCode === 13) {
+        const rhs = document.createElement('input');
+        rhs.setAttribute('type', 'text');
+        rhs.addEventListener('keydown', (k) => {
+          if (k.key === 'Enter') {
             controller.action_input_value = rhs.value;
             controller.action_manager.click(action);
           }
         });
         root.append(rhs);
         return rhs;
-      } else {
-        const rhs = document.createElement('span');
-        root.append(rhs);
-        return rhs;
       }
+      const rhs = document.createElement('span');
+      root.append(rhs);
+      return rhs;
     };
 
     append_section_title('Torrent');
@@ -309,7 +308,7 @@ export class Inspector extends EventTarget {
     string = null;
     action = false;
     placeholder = none;
-    if (torrents.length >= 1) {
+    if (torrents.length > 0) {
       const get = (t) => t.getDownloadDir();
       const first = get(torrents[0]);
       if (torrents.every((t) => get(t) === first)) {

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value !== null
+    this.elements = LabelsDialog._create(this.action_input_value !== false
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value !== false
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value !== false
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value !== null
+    this.elements = LabelsDialog._create(this.action_input_value != null
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value != null
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value != null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -6,11 +6,12 @@
 import { createDialogContainer } from './utils.js';
 
 export class LabelsDialog extends EventTarget {
-  constructor(controller, remote) {
+  constructor(controller, remote, action_input_value) {
     super();
 
     this.controller = controller;
     this.remote = remote;
+    this.action_input_value = action_input_value;
     this.elements = {};
     this.torrents = [];
 
@@ -26,10 +27,15 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create();
+    this.elements = LabelsDialog._create(this.action_input_value
+        ? 'Confirm'
+        : 'Save'
+    );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = first.getLabels().join(', ');
+    this.elements.entry.value = this.action_input_value
+      ? this.action_input_value
+      : first.getLabels().join(', ');
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -44,7 +50,9 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.close();
+    this.action_input_value
+      ? this.controller.action_manager.click('show-inspector')
+      : this.close();
   }
 
   _onConfirm() {
@@ -63,14 +71,15 @@ export class LabelsDialog extends EventTarget {
         }
       }
     });
-    this.close();
+
+    this._onDismiss();
   }
 
-  static _create() {
+  static _create(confirm_text) {
     const elements = createDialogContainer('labels-dialog');
     elements.root.setAttribute('aria-label', 'Edit Labels');
     elements.heading.textContent = 'Edit Labels:';
-    elements.confirm.textContent = 'Save';
+    elements.confirm.textContent = confirm_text;
 
     const label = document.createElement('label');
     label.setAttribute('for', 'torrent-labels');

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value != null
+    this.elements = LabelsDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value != null
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value != null
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,15 +27,15 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value !== null
-        ? 'Confirm'
-        : 'Save'
+    this.elements = LabelsDialog._create(
+      this.action_input_value === null ? 'Save' : 'Confirm',
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
-      ? this.action_input_value
-      : first.getLabels().join(', ');
+    this.elements.entry.value =
+      this.action_input_value === null
+        ? first.getLabels().join(', ')
+        : this.action_input_value;
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -50,10 +50,10 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    if (this.action_input_value !== null) {
-      this.controller.action_manager.click('show-inspector');
-    } else {
+    if (this.action_input_value === null) {
       this.close();
+    } else {
+      this.controller.action_manager.click('show-inspector');
     }
   }
 

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(typeof this.action_input_value === 'string'
+    this.elements = LabelsDialog._create(typeof this.action_input_value == 'string'
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = typeof this.action_input_value === 'string'
+    this.elements.entry.value = typeof this.action_input_value == 'string'
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value === 'string'
+    typeof this.action_input_value == 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(typeof this.action_input_value == 'string'
-        ? 'Confirm'
-        : 'Save'
-    );
+    const confirm_text = this.action_input_value !== null
+      ? 'Confirm'
+      : 'Save'
+    this.elements = LabelsDialog._create(confirm_text);
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = typeof this.action_input_value == 'string'
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value == 'string'
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value !== false
+    this.elements = LabelsDialog._create(typeof this.action_input_value === 'string'
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== false
+    this.elements.entry.value = typeof this.action_input_value === 'string'
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== false
+    typeof this.action_input_value === 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,10 +27,10 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    const confirm_text = this.action_input_value !== null
-      ? 'Confirm'
-      : 'Save'
-    this.elements = LabelsDialog._create(confirm_text);
+    this.elements = LabelsDialog._create(this.action_input_value !== null
+        ? 'Confirm'
+        : 'Save'
+    );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.entry.value = this.action_input_value !== null
@@ -50,9 +50,11 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
-      ? this.controller.action_manager.click('show-inspector')
-      : this.close();
+    if (this.action_input_value !== null) {
+      this.controller.action_manager.click('show-inspector');
+    } else {
+      this.close();
+    }
   }
 
   _onConfirm() {

--- a/web/src/labels-dialog.js
+++ b/web/src/labels-dialog.js
@@ -27,13 +27,13 @@ export class LabelsDialog extends EventTarget {
     const [first] = torrents;
 
     this.torrents = torrents;
-    this.elements = LabelsDialog._create(this.action_input_value
+    this.elements = LabelsDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Save'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : first.getLabels().join(', ');
     document.body.append(this.elements.root);
@@ -50,7 +50,7 @@ export class LabelsDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,14 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value !== null
-        ? 'Confirm'
-        : 'Apply');
+    this.elements = MoveDialog._create(
+      this.action_input_value === null ? 'Apply' : 'Confirm',
+    );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value !== null
-      ? this.action_input_value
-      : default_path;
+    this.elements.entry.value =
+      this.action_input_value === null ? default_path : this.action_input_value;
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -54,10 +53,10 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    if (this.action_input_value !== null) {
-      this.controller.action_manager.click('show-inspector');
-    } else {
+    if (this.action_input_value === null) {
       this.close();
+    } else {
+      this.controller.action_manager.click('show-inspector');
     }
   }
 

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value != null
+    this.elements = MoveDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value != null
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value != null
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value !== null
+    this.elements = MoveDialog._create(this.action_input_value != null
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value != null
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value != null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,12 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(typeof this.action_input_value == 'string'
+    this.elements = MoveDialog._create(this.action_input_value !== null
         ? 'Confirm'
-        : 'Apply'
-    );
+        : 'Apply');
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = typeof this.action_input_value == 'string'
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,9 +54,11 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value == 'string'
-      ? this.controller.action_manager.click('show-inspector')
-      : this.close();
+    if (this.action_input_value !== null) {
+      this.controller.action_manager.click('show-inspector');
+    } else {
+      this.close();
+    }
   }
 
   _onConfirm() {

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(typeof this.action_input_value === 'string'
+    this.elements = MoveDialog._create(typeof this.action_input_value == 'string'
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = typeof this.action_input_value === 'string'
+    this.elements.entry.value = typeof this.action_input_value == 'string'
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value === 'string'
+    typeof this.action_input_value == 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value !== null
+    this.elements = MoveDialog._create(this.action_input_value !== false
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value !== false
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value !== false
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -8,11 +8,12 @@ let default_path = '';
 import { createDialogContainer } from './utils.js';
 
 export class MoveDialog extends EventTarget {
-  constructor(controller, remote) {
+  constructor(controller, remote, action_input_value) {
     super();
 
     this.controller = controller;
     this.remote = remote;
+    this.action_input_value = action_input_value;
     this.elements = {};
     this.torrents = [];
 
@@ -28,10 +29,15 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create();
+    this.elements = MoveDialog._create(this.action_input_value
+        ? 'Confirm'
+        : 'Apply'
+    );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = default_path;
+    this.elements.entry.value = this.action_input_value
+      ? this.action_input_value
+      : default_path;
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -49,7 +55,9 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.close();
+    this.action_input_value
+      ? this.controller.action_manager.click('show-inspector')
+      : this.close();
   }
 
   _onConfirm() {
@@ -57,14 +65,15 @@ export class MoveDialog extends EventTarget {
     const path = this.elements.entry.value.trim();
     default_path = path;
     this.remote.moveTorrents(ids, path);
-    this.close();
+
+    this._onDismiss();
   }
 
-  static _create() {
+  static _create(confirm_text) {
     const elements = createDialogContainer('move-dialog');
     elements.root.setAttribute('aria-label', 'Move Torrent');
     elements.heading.textContent = 'Set Torrent Location';
-    confirm.textContent = 'Apply';
+    elements.confirm.textContent = confirm_text;
 
     const label = document.createElement('label');
     label.setAttribute('for', 'torrent-path');

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value !== false
+    this.elements = MoveDialog._create(typeof this.action_input_value === 'string'
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value !== false
+    this.elements.entry.value = typeof this.action_input_value === 'string'
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== false
+    typeof this.action_input_value === 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/move-dialog.js
+++ b/web/src/move-dialog.js
@@ -29,13 +29,13 @@ export class MoveDialog extends EventTarget {
     default_path = default_path || torrents[0].getDownloadDir();
 
     this.torrents = torrents;
-    this.elements = MoveDialog._create(this.action_input_value
+    this.elements = MoveDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Apply'
     );
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
-    this.elements.entry.value = this.action_input_value
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : default_path;
     document.body.append(this.elements.root);
@@ -55,7 +55,7 @@ export class MoveDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value !== null
+    this.elements = RenameDialog._create(this.action_input_value != null
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value != null
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value != null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value !== false
+    this.elements = RenameDialog._create(typeof this.action_input_value === 'string'
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== false
+    this.elements.entry.value = typeof this.action_input_value === 'string'
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== false
+    typeof this.action_input_value === 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -27,7 +27,7 @@ export class RenameDialog extends EventTarget {
 
     this.torrents = torrents;
     this.elements = RenameDialog._create(
-      this.action_input_value === null ? 'Rename' : 'Confirm' ,
+      this.action_input_value === null ? 'Rename' : 'Confirm',
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
@@ -54,7 +54,7 @@ export class RenameDialog extends EventTarget {
   _onDismiss() {
     if (this.action_input_value === null) {
       this.close();
-    } else  {
+    } else {
       this.controller.action_manager.click('show-inspector');
     }
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value !== null
+    this.elements = RenameDialog._create(this.action_input_value !== false
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
+    this.elements.entry.value = this.action_input_value !== false
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value !== null
+    this.action_input_value !== false
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(typeof this.action_input_value === 'string'
+    this.elements = RenameDialog._create(typeof this.action_input_value == 'string'
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = typeof this.action_input_value === 'string'
+    this.elements.entry.value = typeof this.action_input_value == 'string'
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value === 'string'
+    typeof this.action_input_value == 'string'
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value
+    this.elements = RenameDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value != null
+    this.elements = RenameDialog._create(this.action_input_value !== null
         ? 'Confirm'
         : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value != null
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,7 +52,7 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.action_input_value != null
+    this.action_input_value !== null
       ? this.controller.action_manager.click('show-inspector')
       : this.close();
   }

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,15 +26,15 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(this.action_input_value !== null
-      ? 'Confirm'
-      : 'Rename'
+    this.elements = RenameDialog._create(
+      this.action_input_value === null ? 'Rename' : 'Confirm' ,
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = this.action_input_value !== null
-      ? this.action_input_value
-      : torrents[0].getName();
+    this.elements.entry.value =
+      this.action_input_value === null
+        ? torrents[0].getName()
+        : this.action_input_value;
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -52,10 +52,10 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    if (this.action_input_value !== null) {
-      this.controller.action_manager.click('show-inspector');
-    } else  {
+    if (this.action_input_value === null) {
       this.close();
+    } else  {
+      this.controller.action_manager.click('show-inspector');
     }
   }
 

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -6,11 +6,12 @@
 import { createDialogContainer } from './utils.js';
 
 export class RenameDialog extends EventTarget {
-  constructor(controller, remote) {
+  constructor(controller, remote, action_input_value) {
     super();
 
     this.controller = controller;
     this.remote = remote;
+    this.action_input_value = action_input_value;
     this.elements = {};
     this.torrents = [];
 
@@ -25,10 +26,15 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create();
+    this.elements = RenameDialog._create(this.action_input_value
+        ? 'Confirm'
+        : 'Rename'
+    );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = torrents[0].getName();
+    this.elements.entry.value = this.action_input_value
+      ? this.action_input_value
+      : torrents[0].getName();
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
@@ -46,7 +52,9 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    this.close();
+    this.action_input_value
+      ? this.controller.action_manager.click('show-inspector')
+      : this.close();
   }
 
   _onConfirm() {
@@ -59,14 +67,14 @@ export class RenameDialog extends EventTarget {
       }
     });
 
-    this.close();
+    this._onDismiss();
   }
 
-  static _create() {
+  static _create(confirm_text) {
     const elements = createDialogContainer('rename-dialog');
     elements.root.setAttribute('aria-label', 'Rename Torrent');
     elements.heading.textContent = 'Enter new name:';
-    elements.confirm.textContent = 'Rename';
+    elements.confirm.textContent = confirm_text;
 
     const label = document.createElement('label');
     label.setAttribute('for', 'torrent-rename-name');

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -26,13 +26,13 @@ export class RenameDialog extends EventTarget {
     }
 
     this.torrents = torrents;
-    this.elements = RenameDialog._create(typeof this.action_input_value == 'string'
-        ? 'Confirm'
-        : 'Rename'
+    this.elements = RenameDialog._create(this.action_input_value !== null
+      ? 'Confirm'
+      : 'Rename'
     );
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = typeof this.action_input_value == 'string'
+    this.elements.entry.value = this.action_input_value !== null
       ? this.action_input_value
       : torrents[0].getName();
     document.body.append(this.elements.root);
@@ -52,9 +52,11 @@ export class RenameDialog extends EventTarget {
   }
 
   _onDismiss() {
-    typeof this.action_input_value == 'string'
-      ? this.controller.action_manager.click('show-inspector')
-      : this.close();
+    if (this.action_input_value !== null) {
+      this.controller.action_manager.click('show-inspector');
+    } else  {
+      this.close();
+    }
   }
 
   _onConfirm() {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -31,7 +31,7 @@ export class Transmission extends EventTarget {
 
     // Initialize the helper classes
     this.action_manager = action_manager;
-    this.action_input_value = false;
+    this.action_input_value = null;
     this.notifications = notifications;
     this.prefs = prefs;
     this.remote = new Remote(this);
@@ -177,7 +177,7 @@ export class Transmission extends EventTarget {
         default:
           console.warn(`unhandled action: ${event_.action}`);
       }
-      this.action_input_value = false;
+      this.action_input_value = null;
     });
 
     // listen to filter changes

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -128,7 +128,9 @@ export class Transmission extends EventTarget {
           }
           break;
         case 'show-move-dialog':
-          this.setCurrentPopup(new MoveDialog(this, this.remote, this.action_input_value));
+          this.setCurrentPopup(
+            new MoveDialog(this, this.remote, this.action_input_value),
+          );
           break;
         case 'show-overflow-menu':
           if (this.popup instanceof OverflowMenu) {
@@ -154,10 +156,14 @@ export class Transmission extends EventTarget {
           this.setCurrentPopup(new StatisticsDialog(this.remote));
           break;
         case 'show-rename-dialog':
-          this.setCurrentPopup(new RenameDialog(this, this.remote, this.action_input_value));
+          this.setCurrentPopup(
+            new RenameDialog(this, this.remote, this.action_input_value),
+          );
           break;
         case 'show-labels-dialog':
-          this.setCurrentPopup(new LabelsDialog(this, this.remote, this.action_input_value));
+          this.setCurrentPopup(
+            new LabelsDialog(this, this.remote, this.action_input_value),
+          );
           break;
         case 'start-all-torrents':
           this._startTorrents(this._getAllTorrents());

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -31,7 +31,7 @@ export class Transmission extends EventTarget {
 
     // Initialize the helper classes
     this.action_manager = action_manager;
-    this.action_input_value = null;
+    this.action_input_value = false;
     this.notifications = notifications;
     this.prefs = prefs;
     this.remote = new Remote(this);
@@ -177,7 +177,7 @@ export class Transmission extends EventTarget {
         default:
           console.warn(`unhandled action: ${event_.action}`);
       }
-      this.action_input_value = null;
+      this.action_input_value = false;
     });
 
     // listen to filter changes

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -31,6 +31,7 @@ export class Transmission extends EventTarget {
 
     // Initialize the helper classes
     this.action_manager = action_manager;
+    this.action_input_value = null;
     this.notifications = notifications;
     this.prefs = prefs;
     this.remote = new Remote(this);
@@ -127,7 +128,7 @@ export class Transmission extends EventTarget {
           }
           break;
         case 'show-move-dialog':
-          this.setCurrentPopup(new MoveDialog(this, this.remote));
+          this.setCurrentPopup(new MoveDialog(this, this.remote, this.action_input_value));
           break;
         case 'show-overflow-menu':
           if (this.popup instanceof OverflowMenu) {
@@ -153,10 +154,10 @@ export class Transmission extends EventTarget {
           this.setCurrentPopup(new StatisticsDialog(this.remote));
           break;
         case 'show-rename-dialog':
-          this.setCurrentPopup(new RenameDialog(this, this.remote));
+          this.setCurrentPopup(new RenameDialog(this, this.remote, this.action_input_value));
           break;
         case 'show-labels-dialog':
-          this.setCurrentPopup(new LabelsDialog(this, this.remote));
+          this.setCurrentPopup(new LabelsDialog(this, this.remote, this.action_input_value));
           break;
         case 'start-all-torrents':
           this._startTorrents(this._getAllTorrents());
@@ -176,6 +177,7 @@ export class Transmission extends EventTarget {
         default:
           console.warn(`unhandled action: ${event_.action}`);
       }
+      this.action_input_value = null;
     });
 
     // listen to filter changes

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -22,23 +22,6 @@ export const Utils = {
 
     return result;
   },
-
-  /**
-   * Checks to see if the content actually changed before poking the DOM.
-   */
-  setInnerHTML(e, html) {
-    if (!e) {
-      return;
-    }
-
-    /* innerHTML is listed as a string, but the browser seems to change it.
-     * For example, "&infin;" gets changed to "∞" somewhere down the line.
-     * So, let's use an arbitrary  different field to test our state... */
-    if (e.currentHTML !== html) {
-      e.currentHTML = html;
-      e.innerHTML = html;
-    }
-  },
 };
 
 function toggleClass(buttons, button, pages, page, callback) {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -22,6 +22,23 @@ export const Utils = {
 
     return result;
   },
+
+  /**
+   * Checks to see if the content actually changed before poking the DOM.
+   */
+  setInnerHTML(e, html) {
+    if (!e) {
+      return;
+    }
+
+    /* innerHTML is listed as a string, but the browser seems to change it.
+     * For example, "&infin;" gets changed to "∞" somewhere down the line.
+     * So, let's use an arbitrary  different field to test our state... */
+    if (e.currentHTML !== html) {
+      e.currentHTML = html;
+      e.innerHTML = html;
+    }
+  },
 };
 
 function toggleClass(buttons, button, pages, page, callback) {


### PR DESCRIPTION
- Added new section in Inspector - Info page: "Torrent" for torrent details: name (new entry), labels (moved from "Details"), and directory location (moved from "Details"), turned them into input fields as way to edit them.

These new input fields will not apply the change immediately- you will be taken to the same dialog as you would to open from context menu, it will be your "confirmation" dialog with input value carried over.

| Before | After |
| --- | --- |
| ![Transmission inspector 2](https://github.com/transmission/transmission/assets/2275021/c20ae356-aff7-4ff6-b231-52ed3540127a) | ![Transmission inspector 1](https://github.com/transmission/transmission/assets/2275021/87913149-26eb-4893-ad21-50caef8085a1) |

Notes: Transformed edit-encouraged torrent details into input field to be edited directly from Inspector.

Requesting design & code review from @dareiff