### PR TITLE
fix: check if incoming VC is all 0 on MSE step 3

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -538,6 +538,11 @@ ReadState tr_handshake::read_crypto_provide(tr_peerIo* peer_io)
 
     auto vc_in = vc_t{};
     peer_io->read_bytes(std::data(vc_in), std::size(vc_in));
+    if (vc_in != VC)
+    {
+        tr_logAddTraceHand(this, "incoming VC is not all 0...");
+        return done(false);
+    }
 
     peer_io->read_uint32(&crypto_provide);
     crypto_provide_ = crypto_provide;


### PR DESCRIPTION
Added an extra safety check during MSE handshake step 3.

> 3 A->B: HASH('req1', S), HASH('req2', SKEY) xor HASH('req3', S), ENCRYPT(**VC**, crypto_provide, len(PadC), PadC, len(IA)), ENCRYPT(IA)