### PR TITLE
feat: BT and MSE handshake rework

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -135,7 +135,7 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     /* now send these: HASH('req1', S), HASH('req2', SKEY) xor HASH('req3', S),
      * ENCRYPT(VC, crypto_provide, len(PadC), PadC, len(IA)), ENCRYPT(IA) */
     static auto constexpr BufSize = std::tuple_size_v<tr_sha1_digest_t> * 2 + std::size(VC) + sizeof(crypto_provide_) +
-        sizeof(pad_c_len_) + HandshakeSize;
+        sizeof(pad_c_len_) + sizeof(ia_len_) + HandshakeSize;
     auto outbuf = libtransmission::StackBuffer<BufSize, std::byte>{};
 
     /* HASH('req1', S) */

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -213,12 +213,12 @@ ReadState tr_handshake::read_vc(tr_peerIo* peer_io)
             // We already know it's a match; now we just need to
             // consume it from the read buffer.
             peer_io->decrypt_init(peer_io->is_incoming(), dh_, info_hash);
-            peer_io->read_bytes(std::data(*encrypted_vc_), std::size(*encrypted_vc_));
+            peer_io->read_buffer_discard(std::size(*encrypted_vc_));
             set_state(tr_handshake::State::AwaitingCryptoSelect);
             return READ_NOW;
         }
 
-        peer_io->read_buffer_drain(1);
+        peer_io->read_buffer_discard(1U);
     }
 
     tr_logAddTraceHand(this, "couldn't find ENCRYPT(VC)");
@@ -266,7 +266,7 @@ ReadState tr_handshake::read_pad_d(tr_peerIo* peer_io)
         return READ_LATER;
     }
 
-    peer_io->read_buffer_drain(needlen);
+    peer_io->read_buffer_discard(needlen);
 
     set_state(tr_handshake::State::AwaitingHandshake);
     return READ_NOW;
@@ -439,12 +439,12 @@ ReadState tr_handshake::read_pad_a(tr_peerIo* peer_io)
         if (peer_io->read_buffer_starts_with(needle))
         {
             tr_logAddTraceHand(this, "found it... setting state to AwaitingCryptoProvide");
-            peer_io->read_buffer_drain(std::size(needle));
+            peer_io->read_buffer_discard(std::size(needle));
             set_state(State::AwaitingCryptoProvide);
             return READ_NOW;
         }
 
-        peer_io->read_buffer_drain(1U);
+        peer_io->read_buffer_discard(1U);
     }
 
     tr_logAddTraceHand(this, "couldn't find HASH('req1', S)");
@@ -527,7 +527,7 @@ ReadState tr_handshake::read_pad_c(tr_peerIo* peer_io)
     }
 
     // read the throwaway padc
-    peer_io->read_buffer_drain(pad_c_len_);
+    peer_io->read_buffer_discard(pad_c_len_);
 
     /* read ia_len */
     uint16_t ia_len = 0;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -202,7 +202,7 @@ ReadState tr_handshake::read_vc(tr_peerIo* peer_io)
         filter.encrypt(std::data(VC), std::size(VC), std::data(*encrypted_vc_));
     }
 
-    for (; pad_b_recv_len_ < PadbMaxlen; ++pad_b_recv_len_)
+    for (; pad_b_recv_len_ <= PadbMaxlen; ++pad_b_recv_len_)
     {
         if (peer_io->read_buffer_size() < std::size(*encrypted_vc_))
         {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -210,8 +210,8 @@ ReadState tr_handshake::read_pad_d(tr_peerIo* peer_io)
     /* maybe de-encrypt our connection */
     if (crypto_select_ == CryptoProvidePlaintext)
     {
-        peer_io->encrypt_deactivate();
-        peer_io->decrypt_deactivate();
+        peer_io->encrypt_disable();
+        peer_io->decrypt_disable();
     }
 
     set_state(tr_handshake::State::AwaitingHandshake);
@@ -537,8 +537,8 @@ ReadState tr_handshake::read_ia(tr_peerIo* peer_io)
         TR_ASSERT(std::empty(outbuf));
 
         // All future communications will use ENCRYPT2()
-        peer_io->encrypt_deactivate();
-        peer_io->decrypt_deactivate(ia_len_);
+        peer_io->encrypt_disable();
+        peer_io->decrypt_disable(ia_len_);
     }
 
     /* now await the handshake */

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -604,15 +604,13 @@ ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* p
 {
     auto* handshake = static_cast<tr_handshake*>(vhandshake);
 
-    bool ready_for_more = true;
-
     /* no piece data in handshake */
     *piece = 0;
 
     tr_logAddTraceHand(handshake, fmt::format("handling canRead; state is [{}]", handshake->state_string()));
 
     ReadState ret = READ_NOW;
-    while (ready_for_more)
+    while (ret == READ_NOW)
     {
         switch (handshake->state())
         {
@@ -661,31 +659,11 @@ ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* p
             break;
 
         default:
-#ifdef TR_ENABLE_ASSERTS
             TR_ASSERT_MSG(
                 false,
                 fmt::format(FMT_STRING("unhandled handshake state {:d}"), static_cast<int>(handshake->state())));
-#else
             ret = READ_ERR;
             break;
-#endif
-        }
-
-        if (ret != READ_NOW)
-        {
-            ready_for_more = false;
-        }
-        else if (handshake->is_state(State::AwaitingPadC))
-        {
-            ready_for_more = peer_io->read_buffer_size() >= handshake->pad_c_len_;
-        }
-        else if (handshake->is_state(State::AwaitingPadD))
-        {
-            ready_for_more = peer_io->read_buffer_size() >= handshake->pad_d_len_;
-        }
-        else if (handshake->is_state(State::AwaitingIa))
-        {
-            ready_for_more = peer_io->read_buffer_size() >= handshake->ia_len_;
         }
     }
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -500,6 +500,11 @@ ReadState tr_handshake::read_crypto_provide(tr_peerIo* peer_io)
 
     auto vc_in = vc_t{};
     peer_io->read_bytes(std::data(vc_in), std::size(vc_in));
+    if (vc_in != VC)
+    {
+        tr_logAddTraceHand(this, "incoming VC is not all 0...");
+        return done(false);
+    }
 
     peer_io->read_uint32(&crypto_provide);
     crypto_provide_ = crypto_provide;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -329,7 +329,7 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
     auto hash = tr_sha1_digest_t{};
     peer_io->read_bytes(std::data(hash), std::size(hash));
 
-    if (is_incoming() && peer_io->torrent_hash() == tr_sha1_digest_t{}) // incoming and plain handshake
+    if (is_incoming() && peer_io->torrent_hash() == tr_sha1_digest_t{}) // incoming plain handshake
     {
         if (!mediator_->torrent(hash))
         {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -106,10 +106,9 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     outbuf.add_uint16(0);
 
     /* ENCRYPT len(IA)), ENCRYPT(IA) */
-    if (auto msg = libtransmission::StackBuffer<HandshakeSize, std::byte>{}; build_handshake_message(peer_io, msg))
+    outbuf.add_uint16(HandshakeSize);
+    if (build_handshake_message(peer_io, outbuf))
     {
-        outbuf.add_uint16(std::size(msg));
-        outbuf.add(msg);
         have_sent_bittorrent_handshake_ = true;
     }
     else
@@ -697,6 +696,7 @@ bool tr_handshake::send_handshake(tr_peerIo* io)
     {
         return false;
     }
+    TR_ASSERT(std::size(msg) == HandshakeSize);
     io->write(msg, false);
     have_sent_bittorrent_handshake_ = true;
     return true;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -498,7 +498,7 @@ ReadState tr_handshake::read_crypto_provide(tr_peerIo* peer_io)
     uint16_t padc_len = 0;
     uint32_t crypto_provide = 0;
     auto obfuscated_hash = tr_sha1_digest_t{};
-    size_t const needlen = sizeof(obfuscated_hash) + /* HASH('req2', SKEY) xor HASH('req3', S) */
+    size_t const needlen = std::size(obfuscated_hash) + /* HASH('req2', SKEY) xor HASH('req3', S) */
         std::size(VC) + sizeof(crypto_provide) + sizeof(padc_len);
 
     if (peer_io->read_buffer_size() < needlen)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -106,7 +106,7 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     outbuf.add_uint16(0);
 
     /* ENCRYPT len(IA)), ENCRYPT(IA) */
-    if (auto msg = std::array<uint8_t, HandshakeSize>{}; build_handshake_message(peer_io, std::data(msg)))
+    if (auto msg = libtransmission::StackBuffer<HandshakeSize, std::byte>{}; build_handshake_message(peer_io, msg))
     {
         outbuf.add_uint16(std::size(msg));
         outbuf.add(msg);

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -195,9 +195,8 @@ ReadState tr_handshake::read_vc(tr_peerIo* peer_io)
         auto filter = tr_message_stream_encryption::Filter{};
         filter.encrypt_init(true, dh_, info_hash);
 
-        auto needle = decltype(VC){};
-        filter.encrypt(std::data(VC), std::size(VC), std::data(needle));
-        encrypted_vc_ = needle;
+        encrypted_vc_.emplace();
+        filter.encrypt(std::data(VC), std::size(VC), std::data(*encrypted_vc_));
     }
 
     for (; pad_b_recv_len_ < PadbMaxlen; ++pad_b_recv_len_)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -146,13 +146,12 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     {
         auto const req2 = tr_sha1::digest("req2"sv, info_hash);
         auto const req3 = tr_sha1::digest("req3"sv, dh_.secret());
-        auto x_or = tr_sha1_digest_t{};
-        for (size_t i = 0, n = std::size(x_or); i < n; ++i)
+        auto [x_or, n_x_or] = outbuf.reserve_space(std::tuple_size_v<tr_sha1_digest_t>);
+        for (size_t i = 0; i < n_x_or; ++i)
         {
             x_or[i] = req2[i] ^ req3[i];
         }
-
-        outbuf.add(x_or);
+        outbuf.commit_space(n_x_or);
     }
 
     /* ENCRYPT(VC, crypto_provide, len(PadC), PadC

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -268,6 +268,13 @@ ReadState tr_handshake::read_pad_d(tr_peerIo* peer_io)
 
     peer_io->read_buffer_discard(needlen);
 
+    /* maybe de-encrypt our connection */
+    if (crypto_provide_ == CryptoProvidePlaintext)
+    {
+        peer_io->encrypt_deactivate();
+        peer_io->decrypt_deactivate();
+    }
+
     set_state(tr_handshake::State::AwaitingHandshake);
     return READ_NOW;
 }
@@ -581,6 +588,10 @@ ReadState tr_handshake::read_ia(tr_peerIo* peer_io)
     {
         peer_io->write(outbuf, false);
         TR_ASSERT(std::empty(outbuf));
+
+        // All future communications will use ENCRYPT2()
+        peer_io->encrypt_deactivate();
+        peer_io->decrypt_deactivate(ia_len_);
     }
 
     tr_logAddTraceHand(this, "sending handshake");

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -449,7 +449,7 @@ ReadState tr_handshake::read_pad_a(tr_peerIo* peer_io)
         peer_io->read_buffer_drain(1U);
     }
 
-    tr_logAddTraceHand(this, "couldn't find HASH('req', S)");
+    tr_logAddTraceHand(this, "couldn't find HASH('req1', S)");
     return done(false);
 }
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -25,7 +25,8 @@
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
 
-#define tr_logAddTraceHand(handshake, msg) tr_logAddTrace(msg, (handshake)->peer_io_->display_name())
+#define tr_logAddTraceHand(handshake, msg) \
+    tr_logAddTrace(msg, fmt::format("handshake {}", (handshake)->peer_io_->display_name()))
 
 using namespace std::literals;
 using DH = tr_message_stream_encryption::DH;

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -267,7 +267,7 @@ ReadState tr_handshake::read_pad_d(tr_peerIo* peer_io)
     peer_io->read_buffer_discard(pad_d_len_);
 
     /* maybe de-encrypt our connection */
-    if (crypto_provide_ == CryptoProvidePlaintext)
+    if (crypto_select_ == CryptoProvidePlaintext)
     {
         peer_io->encrypt_deactivate();
         peer_io->decrypt_deactivate();

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -312,11 +312,13 @@ ReadState tr_handshake::read_peer_id(tr_peerIo* peer_io)
 {
     // read the peer_id
     auto peer_id = tr_peer_id_t{};
-    if (peer_io->read_buffer_size() < std::size(peer_id))
+    static auto constexpr Needlen = std::size(peer_id);
+    tr_logAddTraceHand(this, fmt::format("read_peer_id: need {}, got {}", Needlen, peer_io->read_buffer_size()));
+    if (peer_io->read_buffer_size() < Needlen)
     {
         return READ_LATER;
     }
-    peer_io->read_bytes(std::data(peer_id), std::size(peer_id));
+    peer_io->read_bytes(std::data(peer_id), Needlen);
     set_peer_id(peer_id);
 
     auto client = std::array<char, 128>{};

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -290,7 +290,11 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
 
     have_read_anything_from_peer_ = true;
 
-    if (peer_io->read_buffer_starts_with(HandshakeName)) // unencrypted
+    if (ia_len_ > 0)
+    {
+        // do nothing, the check below won't work correctly
+    }
+    else if (peer_io->read_buffer_starts_with(HandshakeName)) // unencrypted
     {
         if (encryption_mode_ == TR_ENCRYPTION_REQUIRED)
         {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -117,13 +117,13 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     }
 
     auto peer_public_key = DH::key_bigend_t{};
+    tr_logAddTraceHand(
+        this,
+        fmt::format("in read_yb... need {}, have {}", std::size(peer_public_key), peer_io->read_buffer_size()));
     if (peer_io->read_buffer_size() < std::size(peer_public_key))
     {
         return READ_LATER;
     }
-    tr_logAddTraceHand(
-        this,
-        fmt::format("in read_yb... need {}, have {}", std::size(peer_public_key), peer_io->read_buffer_size()));
 
     have_read_anything_from_peer_ = true;
 
@@ -276,7 +276,7 @@ ReadState tr_handshake::read_pad_d(tr_peerIo* peer_io)
     return READ_NOW;
 }
 
-// --- Incoming Connections
+// --- Incoming and Outgoing Connections
 
 ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
 {
@@ -388,6 +388,8 @@ ReadState tr_handshake::read_peer_id(tr_peerIo* peer_io)
 
     return done(!connected_to_self);
 }
+
+// --- Incoming Connections
 
 ReadState tr_handshake::read_ya(tr_peerIo* peer_io)
 {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -529,8 +529,7 @@ ReadState tr_handshake::read_pad_c(tr_peerIo* peer_io)
     }
 
     // read the throwaway padc
-    auto pad_c = std::array<char, PadcMaxlen>{};
-    peer_io->read_bytes(std::data(pad_c), pad_c_len_);
+    peer_io->read_buffer_drain(pad_c_len_);
 
     /* read ia_len */
     uint16_t ia_len = 0;

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -161,6 +161,18 @@ private:
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
 
+    bool send_handshake(tr_peerIo* io)
+    {
+        auto msg = std::array<uint8_t, HandshakeSize>{};
+        if (!build_handshake_message(io, std::data(msg)))
+        {
+            return false;
+        }
+        io->write_bytes(std::data(msg), std::size(msg), false);
+        have_sent_bittorrent_handshake_ = true;
+        return true;
+    }
+
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)
     {

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -161,17 +161,7 @@ private:
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
 
-    bool send_handshake(tr_peerIo* io)
-    {
-        auto msg = std::array<uint8_t, HandshakeSize>{};
-        if (!build_handshake_message(io, std::data(msg)))
-        {
-            return false;
-        }
-        io->write_bytes(std::data(msg), std::size(msg), false);
-        have_sent_bittorrent_handshake_ = true;
-        return true;
-    }
+    bool send_handshake(tr_peerIo* io);
 
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -87,9 +87,11 @@ private:
 
     enum class State
     {
-        // incoming
+        // incoming and outgoing
         AwaitingHandshake,
         AwaitingPeerId,
+
+        // incoming
         AwaitingYa,
         AwaitingPadA,
         AwaitingCryptoProvide,
@@ -136,11 +138,6 @@ private:
     void set_peer_id(tr_peer_id_t const& id) noexcept
     {
         peer_id_ = id;
-    }
-
-    constexpr void set_have_read_anything_from_peer(bool val) noexcept
-    {
-        have_read_anything_from_peer_ = val;
     }
 
     ReadState done(bool is_connected)

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -77,14 +77,6 @@ public:
     tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);
 
 private:
-    enum class ParseResult
-    {
-        Ok,
-        EncryptionWrong,
-        BadTorrent,
-        PeerIsSelf,
-    };
-
     enum class State
     {
         // incoming and outgoing
@@ -97,7 +89,6 @@ private:
         AwaitingCryptoProvide,
         AwaitingPadC,
         AwaitingIa,
-        AwaitingPayloadStream,
 
         // outgoing
         AwaitingYb,
@@ -125,15 +116,12 @@ private:
     ReadState read_pad_a(tr_peerIo*);
     ReadState read_pad_c(tr_peerIo*);
     ReadState read_pad_d(tr_peerIo*);
-    ReadState read_payload_stream(tr_peerIo*);
     ReadState read_peer_id(tr_peerIo*);
     ReadState read_vc(tr_peerIo*);
     ReadState read_ya(tr_peerIo*);
     ReadState read_yb(tr_peerIo*);
 
     void send_ya(tr_peerIo*);
-
-    ParseResult parse_handshake(tr_peerIo* peer_io);
 
     void set_peer_id(tr_peer_id_t const& id) noexcept
     {

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -227,9 +227,10 @@ private:
     // http://wiki.vuze.com/w/Message_Stream_Encryption
     // > PadA, PadB: Random data with a random length of 0 to 512 bytes each
     // > PadC, PadD: Arbitrary data with a length of 0 to 512 bytes
-    static auto constexpr PadaMaxlen = int{ 512 };
-    static auto constexpr PadbMaxlen = int{ 512 };
-    static auto constexpr PadcMaxlen = int{ 512 };
+    static auto constexpr PadaMaxlen = uint16_t{ 512U };
+    static auto constexpr PadbMaxlen = uint16_t{ 512U };
+    static auto constexpr PadcMaxlen = uint16_t{ 512U };
+    static auto constexpr PaddMaxlen = uint16_t{ 512U };
 
     // "VC is a verification constant that is used to verify whether the
     // other side knows S and SKEY and thus defeats replay attacks of the
@@ -313,6 +314,9 @@ private:
     uint16_t pad_c_len_ = {};
     uint16_t pad_d_len_ = {};
     uint16_t ia_len_ = {};
+
+    uint16_t pad_a_recv_len_ = {};
+    uint16_t pad_b_recv_len_ = {};
 
     bool have_read_anything_from_peer_ = false;
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -217,8 +217,8 @@ private:
     static auto constexpr DhtFlag = size_t{ 63U };
 
     // Next comes the 20 byte sha1 info_hash and the 20-byte peer_id
-    static auto constexpr HandshakeSize = sizeof(HandshakeName) + HandshakeFlagsBytes + sizeof(tr_sha1_digest_t) +
-        sizeof(tr_peer_id_t);
+    static auto constexpr HandshakeSize = std::size(HandshakeName) + HandshakeFlagsBytes + std::tuple_size_v<tr_sha1_digest_t> +
+        std::tuple_size_v<tr_peer_id_t>;
     static_assert(HandshakeSize == 68);
 
     // Length of handhshake up through the info_hash. From theory.org:
@@ -226,7 +226,8 @@ private:
     // > the recipient must respond as soon as it sees the info_hash part
     // > of the handshake (the peer id will presumably be sent after the
     // > recipient sends its own handshake).
-    static auto constexpr IncomingHandshakeLen = sizeof(HandshakeName) + HandshakeFlagsBytes + sizeof(tr_sha1_digest_t);
+    static auto constexpr IncomingHandshakeLen = std::size(HandshakeName) + HandshakeFlagsBytes +
+        std::tuple_size_v<tr_sha1_digest_t>;
     static_assert(IncomingHandshakeLen == 48);
 
     // MSE constants.

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -107,7 +107,9 @@ private:
 
     static void on_error(tr_peerIo* io, tr_error const&, void* vhandshake);
 
-    bool build_handshake_message(tr_peerIo* io, uint8_t* buf) const;
+    bool build_handshake_message(tr_peerIo* io, libtransmission::BufferWriter<std::byte>& buf) const;
+
+    bool send_handshake(tr_peerIo* io);
 
     ReadState read_crypto_provide(tr_peerIo*);
     ReadState read_crypto_select(tr_peerIo*);
@@ -160,8 +162,6 @@ private:
     }
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
-
-    bool send_handshake(tr_peerIo* io);
 
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -99,18 +99,6 @@ private:
 
     ///
 
-    [[nodiscard]] static std::string_view state_string(State state) noexcept;
-
-    [[nodiscard]] static uint32_t get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept;
-
-    static ReadState can_read(tr_peerIo* peer_io, void* vhandshake, size_t* piece);
-
-    static void on_error(tr_peerIo* io, tr_error const&, void* vhandshake);
-
-    bool build_handshake_message(tr_peerIo* io, libtransmission::BufferWriter<std::byte>& buf) const;
-
-    bool send_handshake(tr_peerIo* io);
-
     ReadState read_crypto_provide(tr_peerIo*);
     ReadState read_crypto_select(tr_peerIo*);
     ReadState read_handshake(tr_peerIo*);
@@ -156,12 +144,20 @@ private:
         state_ = state;
     }
 
+    [[nodiscard]] static std::string_view state_string(State state) noexcept;
+
     [[nodiscard]] std::string_view state_string() const noexcept
     {
         return state_string(state_);
     }
 
-    [[nodiscard]] uint32_t crypto_provide() const noexcept;
+    static ReadState can_read(tr_peerIo* peer_io, void* vhandshake, size_t* piece);
+
+    static void on_error(tr_peerIo* io, tr_error const&, void* vhandshake);
+
+    bool build_handshake_message(tr_peerIo* io, libtransmission::BufferWriter<std::byte>& buf) const;
+
+    bool send_handshake(tr_peerIo* io);
 
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)
@@ -174,6 +170,10 @@ private:
         walk += mediator_->pad(walk, PadMax);
         io->write_bytes(data, walk - data, false);
     }
+
+    [[nodiscard]] uint32_t crypto_provide() const noexcept;
+
+    [[nodiscard]] static uint32_t get_crypto_select(tr_encryption_mode encryption_mode, uint32_t crypto_provide) noexcept;
 
     bool fire_done(bool is_connected);
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -206,7 +206,7 @@ private:
     // Next comes the 20 byte sha1 info_hash and the 20-byte peer_id
     static auto constexpr HandshakeSize = std::size(HandshakeName) + HandshakeFlagsBytes + std::tuple_size_v<tr_sha1_digest_t> +
         std::tuple_size_v<tr_peer_id_t>;
-    static_assert(HandshakeSize == 68);
+    static_assert(HandshakeSize == 68U);
 
     // Length of handhshake up through the info_hash. From theory.org:
     // > The recipient may wait for the initiator's handshake... however,
@@ -215,7 +215,7 @@ private:
     // > recipient sends its own handshake).
     static auto constexpr IncomingHandshakeLen = std::size(HandshakeName) + HandshakeFlagsBytes +
         std::tuple_size_v<tr_sha1_digest_t>;
-    static_assert(IncomingHandshakeLen == 48);
+    static_assert(IncomingHandshakeLen == 48U);
 
     // MSE constants.
     // http://wiki.vuze.com/w/Message_Stream_Encryption

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -220,8 +220,8 @@ private:
     // > crypto_provide and crypto_select are a 32bit bitfields.
     // > As of now 0x01 means plaintext, 0x02 means RC4. (see Functions)
     // > The remaining bits are reserved for future use.
-    static auto constexpr CryptoProvidePlaintext = size_t{ 0x01 };
-    static auto constexpr CryptoProvideCrypto = size_t{ 0x02 };
+    static auto constexpr CryptoProvidePlaintext = uint32_t{ 0x01 };
+    static auto constexpr CryptoProvideCrypto = uint32_t{ 0x02 };
 
     // MSE constants.
     // http://wiki.vuze.com/w/Message_Stream_Encryption
@@ -266,13 +266,13 @@ private:
         return DH{ mediator->private_key() };
     }
 
-    static void add_dh(DH&& dh)
+    static void add_dh(DH dh)
     {
         auto lock = std::unique_lock(dh_pool_mutex_);
 
         if (dh_pool_size_ < std::size(dh_pool_))
         {
-            dh_pool_[dh_pool_size_] = std::move(dh);
+            dh_pool_[dh_pool_size_] = dh;
             ++dh_pool_size_;
         }
     }
@@ -288,12 +288,12 @@ private:
 
         auto dh = DH{};
         std::swap(dh_, dh);
-        add_dh(std::move(dh));
+        add_dh(dh);
     }
 
     ///
 
-    DH dh_ = {};
+    DH dh_{};
 
     DoneFunc on_done_;
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -77,7 +77,7 @@ public:
     tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);
 
 private:
-    enum class State
+    enum class State : uint8_t
     {
         // incoming and outgoing
         AwaitingHandshake,

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -249,19 +249,19 @@ private:
     ///
 
     static constexpr auto DhPoolMaxSize = size_t{ 32 };
-    static inline auto dh_pool_size_ = size_t{};
-    static inline auto dh_pool_ = std::array<tr_message_stream_encryption::DH, DhPoolMaxSize>{};
-    static inline auto dh_pool_mutex_ = std::mutex{};
+    static inline auto dh_pool_size = size_t{};
+    static inline auto dh_pool = std::array<tr_message_stream_encryption::DH, DhPoolMaxSize>{};
+    static inline auto dh_pool_mutex = std::mutex{};
 
     [[nodiscard]] static DH get_dh(Mediator* mediator)
     {
-        auto lock = std::unique_lock(dh_pool_mutex_);
+        auto lock = std::unique_lock(dh_pool_mutex);
 
-        if (dh_pool_size_ > 0U)
+        if (dh_pool_size > 0U)
         {
             auto dh = DH{};
-            std::swap(dh, dh_pool_[dh_pool_size_ - 1U]);
-            --dh_pool_size_;
+            std::swap(dh, dh_pool[dh_pool_size - 1U]);
+            --dh_pool_size;
             return dh;
         }
 
@@ -270,12 +270,12 @@ private:
 
     static void add_dh(DH dh)
     {
-        auto lock = std::unique_lock(dh_pool_mutex_);
+        auto lock = std::unique_lock(dh_pool_mutex);
 
-        if (dh_pool_size_ < std::size(dh_pool_))
+        if (dh_pool_size < std::size(dh_pool))
         {
-            dh_pool_[dh_pool_size_] = dh;
-            ++dh_pool_size_;
+            dh_pool[dh_pool_size] = dh;
+            ++dh_pool_size;
         }
     }
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -625,14 +625,7 @@ void tr_peerIo::read_uint32(uint32_t* setme)
 
 void tr_peerIo::read_buffer_drain(size_t byte_count)
 {
-    auto buf = std::array<char, 4096>{};
-
-    while (byte_count > 0)
-    {
-        auto const this_pass = std::min(byte_count, std::size(buf));
-        read_bytes(std::data(buf), this_pass);
-        byte_count -= this_pass;
-    }
+    filter_.decrypt_skip(byte_count);
 }
 
 // --- UTP

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -623,9 +623,11 @@ void tr_peerIo::read_uint32(uint32_t* setme)
     *setme = ntohl(tmp);
 }
 
-void tr_peerIo::read_buffer_drain(size_t byte_count)
+void tr_peerIo::read_buffer_discard(size_t n_bytes)
 {
-    filter_.decrypt_skip(byte_count);
+    n_bytes = std::min(n_bytes, std::size(inbuf_));
+    filter_.decrypt_skip(n_bytes);
+    inbuf_.drain(n_bytes);
 }
 
 // --- UTP

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -623,13 +623,6 @@ void tr_peerIo::read_uint32(uint32_t* setme)
     *setme = ntohl(tmp);
 }
 
-void tr_peerIo::read_buffer_discard(size_t n_bytes)
-{
-    n_bytes = std::min(n_bytes, std::size(inbuf_));
-    filter_.decrypt_skip(n_bytes);
-    inbuf_.drain(n_bytes);
-}
-
 // --- UTP
 
 #ifdef WITH_UTP

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -298,13 +298,13 @@ public:
         filter_.decrypt_init(is_incoming, dh, info_hash);
     }
 
-    constexpr void decrypt_deactivate(size_t decrypt_len = 0U) noexcept
+    constexpr void decrypt_disable(size_t decrypt_len = 0U) noexcept
     {
         // optionally decrypt remaining data in the read buffer in-place,
         // so that they can be read normally later on
         auto const n_bytes = std::min(decrypt_len, std::size(inbuf_));
         filter_.decrypt(std::data(inbuf_), n_bytes, std::data(inbuf_));
-        filter_.decrypt_deactivate();
+        filter_.decrypt_disable();
     }
 
     void encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)
@@ -312,12 +312,12 @@ public:
         filter_.encrypt_init(is_incoming, dh, info_hash);
     }
 
-    constexpr void encrypt_deactivate() noexcept
+    constexpr void encrypt_disable() noexcept
     {
         // unlike the read buffer, we don't need deactivation
         // since we control whether we add data before or after
-        // calling encrypt_deactivate()
-        filter_.encrypt_deactivate();
+        // calling encrypt_disable()
+        filter_.encrypt_disable();
     }
 
     ///

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -120,7 +120,7 @@ public:
         return inbuf_.starts_with(t);
     }
 
-    void read_buffer_drain(size_t byte_count);
+    void read_buffer_discard(size_t n_bytes);
 
     void read_bytes(void* bytes, size_t n_bytes)
     {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -292,10 +292,10 @@ public:
         filter_.decrypt_init(is_incoming, dh, info_hash);
     }
 
-    constexpr void decrypt_disable(size_t decrypt_len = 0U) noexcept
+    TR_CONSTEXPR20 void decrypt_disable(size_t decrypt_len = 0U) noexcept
     {
         // optionally decrypt decrypt_len more bytes before disabling decryption
-        decrypt_remain_len_ = std::make_optional(decrypt_len);
+        decrypt_remain_len_ = decrypt_len;
     }
 
     void encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -292,10 +292,25 @@ public:
     {
         filter_.decrypt_init(is_incoming, dh, info_hash);
     }
+    constexpr void decrypt_deactivate(size_t decrypt_len = 0U) noexcept
+    {
+        // optionally decrypt remaining data in the read buffer so that
+        // they can be read normally later on
+        auto const n_bytes = std::min(decrypt_len, std::size(inbuf_));
+        filter_.decrypt(std::data(inbuf_), n_bytes, std::data(inbuf_));
+        filter_.decrypt_deactivate();
+    }
 
     void encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)
     {
         filter_.encrypt_init(is_incoming, dh, info_hash);
+    }
+    constexpr void encrypt_deactivate() noexcept
+    {
+        // unlike the read buffer, we don't need to decrypt anything in
+        // the write buffer since we control whether we add data before
+        // or after we deactivate encryption
+        filter_.encrypt_deactivate();
     }
 
     ///

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -122,17 +122,10 @@ public:
 
     void read_buffer_discard(size_t n_bytes)
     {
-        n_bytes = std::min(n_bytes, std::size(inbuf_));
-        filter_.decrypt_skip(n_bytes);
-        inbuf_.drain(n_bytes);
+        read_bytes(nullptr, n_bytes);
     }
 
-    void read_bytes(void* bytes, size_t n_bytes)
-    {
-        n_bytes = std::min(n_bytes, std::size(inbuf_));
-        filter_.decrypt(std::data(inbuf_), n_bytes, reinterpret_cast<std::byte*>(bytes));
-        inbuf_.drain(n_bytes);
-    }
+    void read_bytes(void* bytes, size_t n_bytes);
 
     void read_uint8(uint8_t* setme)
     {
@@ -295,16 +288,14 @@ public:
 
     void decrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)
     {
+        decrypt_remain_len_.reset();
         filter_.decrypt_init(is_incoming, dh, info_hash);
     }
 
-    constexpr void decrypt_disable(size_t decrypt_len = 0U) noexcept
+    constexpr void decrypt_disable(std::optional<size_t> decrypt_len = {}) noexcept
     {
-        // optionally decrypt remaining data in the read buffer in-place,
-        // so that they can be read normally later on
-        auto const n_bytes = std::min(decrypt_len, std::size(inbuf_));
-        filter_.decrypt(std::data(inbuf_), n_bytes, std::data(inbuf_));
-        filter_.decrypt_disable();
+        // optionally decrypt decrypt_len more bytes before disabling decryption
+        decrypt_remain_len_ = decrypt_len;
     }
 
     void encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)
@@ -314,9 +305,9 @@ public:
 
     constexpr void encrypt_disable() noexcept
     {
-        // unlike the read buffer, we don't need deactivation
-        // since we control whether we add data before or after
-        // calling encrypt_disable()
+        // unlike the read buffer, we don't need to "encrypt xxx
+        // more bytes before disabling encryption" since we control
+        // whether we add data before or after calling encrypt_disable()
         filter_.encrypt_disable();
     }
 
@@ -376,6 +367,7 @@ private:
         bool is_seed);
 
     Filter filter_;
+    std::optional<size_t> decrypt_remain_len_;
 
     std::deque<std::pair<size_t /*n_bytes*/, bool /*is_piece_data*/>> outbuf_info_;
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -307,9 +307,9 @@ public:
     }
     constexpr void encrypt_deactivate() noexcept
     {
-        // unlike the read buffer, we don't need to decrypt anything in
-        // the write buffer since we control whether we add data before
-        // or after we deactivate encryption
+        // unlike the read buffer, we don't need deactivation
+        // since we control whether we add data before or after
+        // calling encrypt_deactivate()
         filter_.encrypt_deactivate();
     }
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -295,7 +295,7 @@ public:
     constexpr void decrypt_disable(size_t decrypt_len = 0U) noexcept
     {
         // optionally decrypt decrypt_len more bytes before disabling decryption
-        decrypt_remain_len_ = decrypt_len;
+        decrypt_remain_len_ = std::make_optional(decrypt_len);
     }
 
     void encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const& info_hash)

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -292,7 +292,7 @@ public:
         filter_.decrypt_init(is_incoming, dh, info_hash);
     }
 
-    constexpr void decrypt_disable(std::optional<size_t> decrypt_len = {}) noexcept
+    constexpr void decrypt_disable(size_t decrypt_len = 0U) noexcept
     {
         // optionally decrypt decrypt_len more bytes before disabling decryption
         decrypt_remain_len_ = decrypt_len;

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -77,6 +77,10 @@ class Filter
 {
 public:
     void decrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
+    constexpr void decrypt_deactivate() noexcept
+    {
+        dec_active_ = false;
+    }
 
     template<typename T>
     constexpr void decrypt(T const* buf_in, size_t buf_len, T* buf_out) noexcept
@@ -90,6 +94,10 @@ public:
     }
 
     void encrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
+    constexpr void encrypt_deactivate() noexcept
+    {
+        enc_active_ = false;
+    }
 
     template<typename T>
     constexpr void encrypt(T const* buf_in, size_t buf_len, T* buf_out) noexcept

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -88,11 +88,6 @@ public:
         process(buf_in, buf_len, buf_out, dec_active_, dec_key_);
     }
 
-    constexpr void decrypt_skip(size_t len) noexcept
-    {
-        skip(len, dec_active_, dec_key_);
-    }
-
     void encrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
     constexpr void encrypt_disable() noexcept
     {
@@ -114,7 +109,11 @@ private:
     template<typename T>
     static constexpr void process(T const* buf_in, size_t buf_len, T* buf_out, bool active, tr_arc4& arc4) noexcept
     {
-        if (active)
+        if (buf_in == nullptr || buf_out == nullptr)
+        {
+            skip(buf_len, active, arc4);
+        }
+        else if (active)
         {
             arc4.process(reinterpret_cast<uint8_t const*>(buf_in), buf_len, reinterpret_cast<uint8_t*>(buf_out));
         }

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -118,7 +118,7 @@ private:
         {
             arc4.process(reinterpret_cast<uint8_t const*>(buf_in), buf_len, reinterpret_cast<uint8_t*>(buf_out));
         }
-        else
+        else if (buf_in != buf_out)
         {
             std::copy_n(buf_in, buf_len, buf_out);
         }

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -33,7 +33,7 @@ public:
     // MSE spec: "Minimum length [for the private key] is 128 bit.
     // Anything beyond 180 bit is not believed to add any further
     // security and only increases the necessary calculation time.
-    // You should use a length of 160bits whenever possible[.]
+    // You should use a length of 160bits whenever possible[.]"
     static auto constexpr PrivateKeySize = size_t{ 20 };
 
     // MSE spec: "P, S [the shared secret], Ya and Yb

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -77,7 +77,7 @@ class Filter
 {
 public:
     void decrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
-    constexpr void decrypt_deactivate() noexcept
+    constexpr void decrypt_disable() noexcept
     {
         dec_active_ = false;
     }
@@ -94,7 +94,7 @@ public:
     }
 
     void encrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
-    constexpr void encrypt_deactivate() noexcept
+    constexpr void encrypt_disable() noexcept
     {
         enc_active_ = false;
     }

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -84,6 +84,11 @@ public:
         process(buf_in, buf_len, buf_out, dec_active_, dec_key_);
     }
 
+    constexpr void decrypt_skip(size_t len) noexcept
+    {
+        skip(len, dec_active_, dec_key_);
+    }
+
     void encrypt_init(bool is_incoming, DH const&, tr_sha1_digest_t const& info_hash);
 
     template<typename T>
@@ -108,6 +113,14 @@ private:
         else
         {
             std::copy_n(buf_in, buf_len, buf_out);
+        }
+    }
+
+    static constexpr void skip(size_t len, bool active, tr_arc4& arc4)
+    {
+        if (active)
+        {
+            arc4.discard(len);
         }
     }
 

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -262,7 +262,7 @@ public:
         }
     }
 
-    virtual std::pair<value_type*, size_t> reserve_space(size_t n_bytes) override
+    std::pair<value_type*, size_t> reserve_space(size_t n_bytes) override
     {
         if (auto const free_at_end = buf_.size() - end_pos_; free_at_end < n_bytes)
         {
@@ -283,7 +283,7 @@ public:
         return { buf_.data() + end_pos_, n_bytes };
     }
 
-    virtual void commit_space(size_t n_bytes) override
+    void commit_space(size_t n_bytes) override
     {
         end_pos_ += n_bytes;
     }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -28,7 +28,7 @@ public:
     virtual ~BufferReader() = default;
     virtual void drain(size_t n_bytes) = 0;
     [[nodiscard]] virtual size_t size() const noexcept = 0;
-    [[nodiscard]] virtual value_type const* data() const = 0;
+    [[nodiscard]] virtual value_type const* data() const noexcept = 0;
 
     [[nodiscard]] auto empty() const noexcept
     {
@@ -247,7 +247,12 @@ public:
         return end_pos_ - begin_pos_;
     }
 
-    [[nodiscard]] value_type const* data() const override
+    [[nodiscard]] value_type const* data() const noexcept override
+    {
+        return std::data(buf_) + begin_pos_;
+    }
+
+    [[nodiscard]] value_type* data() noexcept
     {
         return std::data(buf_) + begin_pos_;
     }

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -252,11 +252,6 @@ public:
         return std::data(buf_) + begin_pos_;
     }
 
-    [[nodiscard]] value_type* data() noexcept
-    {
-        return std::data(buf_) + begin_pos_;
-    }
-
     void drain(size_t n_bytes) override
     {
         begin_pos_ += std::min(n_bytes, size());


### PR DESCRIPTION
Fixes #6022.

This PR makes a number of changes, most notably:
1. Transmission used to ignore plaintext `crypto_select` (`0x01`) and keep using encrypted connections, this is now fixed.
2. Transmission did not check if the VC sent from the MSE handshake initiator is valid, the check has been added back.
3. Transmission used to read more than 512 bytes for PadA and PadB, this is now fixed.
4. `sizeof` was used to check to the total size of an `std::array`. This is not reliable, and `std::tuple_size_v` is now used instead.
5. Deduped code for reading and parsing BT handshakes.