### PR TITLE
fix: Fixed updating magnet link after selecting same torrent again

### DIFF
--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -483,10 +483,7 @@ export class Inspector extends EventTarget {
     string = string || none;
     if (string.startsWith('https://') || string.startsWith('http://')) {
       string = encodeURI(string);
-      Utils.setInnerHTML(
-        e.info.comment,
-        `<a href="${string}" target="_blank" >${string}</a>`,
-      );
+      e.info.comment.innerHTML = `<a href="${string}" target="_blank" >${string}</a>`;
     } else {
       setTextContent(e.info.comment, string);
     }
@@ -554,10 +551,7 @@ export class Inspector extends EventTarget {
       setTextContent(e.info.magnetLink, mixed);
     } else {
       const link = torrents[0].getMagnetLink();
-      Utils.setInnerHTML(
-        e.info.magnetLink,
-        `<a class="inspector-info-magnet" href="${link}"><button></button></a>`,
-      );
+      e.info.magnetLink.innerHTML = `<a class="inspector-info-magnet" href="${link}"><button></button></a>`;
     }
   }
 

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -22,23 +22,6 @@ export const Utils = {
 
     return result;
   },
-
-  /**
-   * Checks to see if the content actually changed before poking the DOM.
-   */
-  setInnerHTML(e, html) {
-    if (!e) {
-      return;
-    }
-
-    /* innerHTML is listed as a string, but the browser seems to change it.
-     * For example, "&infin;" gets changed to "∞" somewhere down the line.
-     * So, let's use an arbitrary  different field to test our state... */
-    if (e.currentHTML !== html) {
-      e.currentHTML = html;
-      e.innerHTML = html;
-    }
-  },
 };
 
 function toggleClass(buttons, button, pages, page, callback) {


### PR DESCRIPTION
There are several ways to deselect the torrent to be selected again: Mouse click while holding a Ctrl key or click on the blank below torrent list. When the torrent was selected again the magnet link in Inspector page isn't updating. This PR should resolve it.

Notes: Fixed updating magnet link after selecting same torrent again.