### PR TITLE
chore: more specific peer error log

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -658,12 +658,14 @@ private:
                 tr_logAddDebugSwarm(
                     s,
                     fmt::format(
-                        "setting {} do_purge flag because we got an ERANGE, EMSGSIZE, or ENOTCONN error",
-                        peer->display_name()));
+                        "setting {} do_purge flag because we got [({}) {}]",
+                        peer->display_name(),
+                        event.err,
+                        tr_strerror(event.err)));
             }
             else
             {
-                tr_logAddDebugSwarm(s, fmt::format("unhandled error: {}", tr_strerror(event.err)));
+                tr_logAddDebugSwarm(s, fmt::format("unhandled error: ({}) {}", event.err, tr_strerror(event.err)));
             }
 
             break;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -651,8 +651,10 @@ private:
             break;
 
         case tr_peer_event::Type::Error:
-            if (event.err == ERANGE || event.err == EMSGSIZE || event.err == ENOTCONN)
+            switch (event.err)
             {
+            case ERANGE:
+            case EMSGSIZE:
                 /* some protocol error from the peer */
                 peer->do_purge = true;
                 tr_logAddDebugSwarm(
@@ -662,10 +664,15 @@ private:
                         peer->display_name(),
                         event.err,
                         tr_strerror(event.err)));
-            }
-            else
-            {
+                break;
+
+            case ENOTCONN:
+                tr_logAddTraceSwarm(s, fmt::format("peer {} disconnected with us", peer->display_name()));
+                break;
+
+            default:
                 tr_logAddDebugSwarm(s, fmt::format("unhandled error: ({}) {}", event.err, tr_strerror(event.err)));
+                break;
             }
 
             break;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -667,7 +667,6 @@ private:
                 break;
 
             case ENOTCONN:
-                peer->do_purge = true;
                 tr_logAddTraceSwarm(s, fmt::format("peer {} disconnected with us", peer->display_name()));
                 break;
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -651,10 +651,8 @@ private:
             break;
 
         case tr_peer_event::Type::Error:
-            switch (event.err)
+            if (event.err == ERANGE || event.err == EMSGSIZE || event.err == ENOTCONN)
             {
-            case ERANGE:
-            case EMSGSIZE:
                 /* some protocol error from the peer */
                 peer->do_purge = true;
                 tr_logAddDebugSwarm(
@@ -664,15 +662,10 @@ private:
                         peer->display_name(),
                         event.err,
                         tr_strerror(event.err)));
-                break;
-
-            case ENOTCONN:
-                tr_logAddTraceSwarm(s, fmt::format("peer {} disconnected with us", peer->display_name()));
-                break;
-
-            default:
+            }
+            else
+            {
                 tr_logAddDebugSwarm(s, fmt::format("unhandled error: ({}) {}", event.err, tr_strerror(event.err)));
-                break;
             }
 
             break;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -667,6 +667,7 @@ private:
                 break;
 
             case ENOTCONN:
+                peer->do_purge = true;
                 tr_logAddTraceSwarm(s, fmt::format("peer {} disconnected with us", peer->display_name()));
                 break;
 


### PR DESCRIPTION
99% of the time this line of debug log is triggered by `ENOTCONN`, which just means that a peer disconnected with us. But since it does not print the error code and error message, I've seen it falsely alerting a lot of issue authors, thinking this has to do with the issue they are facing.

This PR adds the error code and error message to the log line.