### PR TITLE
fix: add seed progress percentage to compact rows

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -728,11 +728,7 @@ $video-image: '../img/film.svg';
       background-color: var(--color-progressbar-seed-paused);
     }
 
-    &.seed {
-      background-color: var(--color-progressbar-seed-1);
-    }
-
-    &.seed.full:not(.paused) {
+    &.seed:not(.paused) {
       background: linear-gradient(
           to right,
           var(--color-progressbar-seed-1) 0,


### PR DESCRIPTION
Simple fix, Fixes #6009

TorrentRendererFull actually uses the class `full` to add seeding progress. We can get seeding progress functionality in compact mode if we just apply the same progress indication to the compact rows, too. (Put simply: don't rely on the `full` class to apply progress percentage.)