### PR TITLE
Fix macOS 14 UI not clipping views and crashing on window restoration

### DIFF
--- a/macosx/Base.lproj/InfoActivityView.xib
+++ b/macosx/Base.lproj/InfoActivityView.xib
@@ -31,7 +31,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Activity">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Activity">
             <rect key="frame" x="0.0" y="0.0" width="358" height="358"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2aX-cc-oXC">
@@ -112,7 +112,7 @@
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <imageView verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="19" customClass="PiecesView">
+                                <imageView clipsToBounds="YES" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="19" customClass="PiecesView">
                                     <rect key="frame" x="241" y="89" width="93" height="93"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="93" id="bsS-qa-kx6"/>

--- a/macosx/Base.lproj/InfoGeneralView.xib
+++ b/macosx/Base.lproj/InfoGeneralView.xib
@@ -21,7 +21,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Info">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Info">
             <rect key="frame" x="0.0" y="0.0" width="356" height="228"/>
             <subviews>
                 <scrollView horizontalHuggingPriority="249" horizontalCompressionResistancePriority="249" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4">

--- a/macosx/Base.lproj/InfoOptionsView.xib
+++ b/macosx/Base.lproj/InfoOptionsView.xib
@@ -34,7 +34,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Options">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Options">
             <rect key="frame" x="0.0" y="0.0" width="375" height="298"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="750" verticalStackHuggingPriority="250" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KYq-Jm-g2s">

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
     TrackerSegmentTagRemove = 1,
 };
 
-@interface CreatorWindowController ()
+@interface CreatorWindowController ()<NSWindowRestoration>
 
 @property(nonatomic) IBOutlet NSImageView* fIconView;
 @property(nonatomic) IBOutlet NSTextField* fNameField;

--- a/macosx/FilterBar.xib
+++ b/macosx/FilterBar.xib
@@ -22,7 +22,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="2" userLabel="FilterBar" customClass="FilterBarView">
+        <customView clipsToBounds="YES" id="2" userLabel="FilterBar" customClass="FilterBarView">
             <rect key="frame" x="0.0" y="0.0" width="501" height="23"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>

--- a/macosx/InfoFileView.xib
+++ b/macosx/InfoFileView.xib
@@ -17,7 +17,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Files">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Files">
             <rect key="frame" x="0.0" y="0.0" width="340" height="365"/>
             <subviews>
                 <searchField wantsLayer="YES" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3">

--- a/macosx/InfoPeersView.xib
+++ b/macosx/InfoPeersView.xib
@@ -17,7 +17,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Peers">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Peers">
             <rect key="frame" x="0.0" y="0.0" width="324" height="282"/>
             <subviews>
                 <scrollView verticalHuggingPriority="750" autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="0.0" verticalLineScroll="16" verticalPageScroll="0.0" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4">

--- a/macosx/InfoTrackersView.xib
+++ b/macosx/InfoTrackersView.xib
@@ -15,7 +15,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Trackers">
+        <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2" userLabel="Trackers">
             <rect key="frame" x="0.0" y="0.0" width="382" height="352"/>
             <subviews>
                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4">

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSUInteger, LevelButtonLevel) {
 
 static NSTimeInterval const kUpdateSeconds = 0.75;
 
-@interface MessageWindowController ()
+@interface MessageWindowController ()<NSWindowRestoration>
 
 @property(nonatomic) IBOutlet NSTableView* fMessageTable;
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -41,7 +41,7 @@ static char const* const kRPCKeychainName = "Remote";
 
 static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
-@interface PrefsController ()
+@interface PrefsController ()<NSWindowRestoration>
 
 @property(nonatomic, readonly) tr_session* fHandle;
 @property(nonatomic, readonly) NSUserDefaults* fDefaults;

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -8,7 +8,7 @@
 
 static NSTimeInterval const kUpdateSeconds = 1.0;
 
-@interface StatsWindowController ()
+@interface StatsWindowController ()<NSWindowRestoration>
 
 @property(nonatomic) IBOutlet NSTextField* fUploadedField;
 @property(nonatomic) IBOutlet NSTextField* fUploadedAllField;

--- a/macosx/StatusBar.xib
+++ b/macosx/StatusBar.xib
@@ -18,7 +18,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="2" userLabel="StatusBar" customClass="StatusBarView">
+        <customView clipsToBounds="YES" id="2" userLabel="StatusBar" customClass="StatusBarView">
             <rect key="frame" x="0.0" y="0.0" width="400" height="21"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>


### PR DESCRIPTION
Cherry-pick of #6016 for the 4.0.x branch, otherwise that branch is unusable when building from source on current stable macOS.

Notes: Support macOS Sonoma when building from sources