### PR TITLE
fix 'setNeedsDisplay' is deprecated: first deprecated in macOS 10.14

### DIFF
--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -61,7 +61,7 @@
 
     NSImage* revealImage = [NSImage imageNamed:self.revealImageString];
     self.image = revealImage;
-    [self setNeedsDisplay:YES];
+    self.needsDisplay = YES;
 }
 
 - (void)updateTrackingAreas

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -119,7 +119,13 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)awakeFromNib
 {
-    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(setNeedsDisplay) name:@"RefreshTorrentTable" object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(refreshTorrentTable) name:@"RefreshTorrentTable"
+                                             object:nil];
+}
+
+- (void)refreshTorrentTable
+{
+    self.needsDisplay = YES;
 }
 
 //make sure we don't lose selection on manual reloads

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -227,7 +227,7 @@ NSMutableSet* fTrackerIconLoading;
                 {
                     [fTrackerIconCache setObject:icon forKey:baseAddress];
 
-                    [self.controlView setNeedsDisplay:YES];
+                    self.controlView.needsDisplay = YES;
                 }
                 else
                 {


### PR DESCRIPTION
Redo of #5633 which got an accidental regression with #5147.

The actual fix is in TorrentTableView.mm, and the other two changes (TorrentCellRevealButton.mm and TrackerCell.mm) are cosmetics.