### PR TITLE
Update transmission-daemon.1 to sync with --help

### DIFF
--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -127,12 +127,14 @@ Disable uTP for peer connections.
 Where to store downloaded data.
 .It Fl e Fl -logfile
 Where to store transmission's log messages.
+.It Fl -log-level Ar level
+Log level. Must be 'critical', 'error', 'warn', 'info', 'debug', or 'trace'.
 .It Fl -log-error
-Show error messages
+Deprecated. Use --log-level=error
 .It Fl -log-info
-Show error and info messages
+Deprecated. Use --log-level=info
 .It Fl -log-debug
-Show error, info, and debug messages
+Deprecated. Use --log-level=debug
 .It Fl x Fl -pid-file
 Name of PID file
 .El


### PR DESCRIPTION
Man page does not contain entry for log-level, does not describe log-error, log-info, log-debug as deprecated. 