### PR TITLE
fixup! refactor: remove redundant code when adding announce lists to metainfo (#6050)

### DIFF
--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -336,7 +336,7 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
             file_vec.emplace_back(std::move(file_map));
         }
 
-        info_dict.try_emplace(TR_KEY_files, file_vec);
+        info_dict.try_emplace(TR_KEY_files, std::move(file_vec));
     }
 
     if (!std::empty(base))

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -335,6 +335,8 @@ std::string tr_metainfo_builder::benc(tr_error** error) const
 
             file_vec.emplace_back(std::move(file_map));
         }
+
+        info_dict.try_emplace(TR_KEY_files, file_vec);
     }
 
     if (!std::empty(base))


### PR DESCRIPTION
Fixes #6056.