### PR TITLE
fix: `assertion failed: port_empty` in `tr_swarm::remove_peer()`

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -273,8 +273,7 @@ public:
 
         auto* const peer_info = peer->peer_info;
         auto const socket_address = peer->socket_address();
-        auto const listen_socket_address = peer_info->listen_socket_address();
-        auto const was_incoming = peer->is_incoming_connection();
+        [[maybe_unused]] auto const is_incoming = peer->is_incoming_connection();
         TR_ASSERT(peer_info != nullptr);
 
         --stats.peer_count;
@@ -288,15 +287,16 @@ public:
 
         delete peer;
 
-        if (was_incoming)
+        if (std::empty(peer_info->listen_port())) // is not connectable
         {
-            [[maybe_unused]] auto const port_empty = std::empty(peer_info->listen_port());
-            if (incoming_pool.erase(socket_address) != 0U)
-            {
-                TR_ASSERT(port_empty);
-            }
+            TR_ASSERT(is_incoming);
+            [[maybe_unused]] auto const count = incoming_pool.erase(socket_address);
+            TR_ASSERT(count != 0U);
         }
-        graveyard_pool.erase(listen_socket_address);
+        else
+        {
+            graveyard_pool.erase(peer_info->listen_socket_address());
+        }
     }
 
     void remove_all_peers()


### PR DESCRIPTION
Fixes #5881.

The existing code that cleans up after a disconnected peer does not correctly handle peers that uses the same port for initiating outgoing connections and listening for incoming connections. This is common when uTP is being used.

What would happen is:

```
We get an incoming connection from a peer (conn1).
We create a tr_peer_info object (obj1) for it and stores it in incoming_pool.
                                   │
                                   │
                                   ▼
We get an ltep port handshake on conn1. Consequentially,
obj1 gets moved from incoming_pool to connectable_pool.
                                   │
                                   │
                                   ▼
We get another incoming connection from the same peer (conn2).
We create a tr_peer_info object (obj2) for it and stores it in incoming_pool.
                                   │
                                   │
                                   ▼
conn1 disconnects and we perform the cleanup for it.
We will accidentally delete obj2 because it has the same key as obj1 did
when obj1 was still in incoming_pool.
```