### PR TITLE
refactor: remove tr_torrentStatCached()

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -626,7 +626,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     infos.reserve(torrents.size());
     for (auto* const torrent : torrents)
     {
-        stats.push_back(tr_torrentStatCached(torrent));
+        stats.push_back(tr_torrentStat(torrent));
         infos.push_back(tr_torrentView(torrent));
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1441,12 +1441,7 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     auto const now = tr_time_msec();
     auto const now_sec = tr_time();
 
-    auto swarm_stats = tr_swarm_stats{};
-
-    if (tor->swarm != nullptr)
-    {
-        swarm_stats = tr_swarmGetStats(tor->swarm);
-    }
+    auto const swarm_stats = tor->swarm != nullptr ? tr_swarmGetStats(tor->swarm) : tr_swarm_stats{};
 
     tr_stat* const s = &tor->stats;
     s->id = tor->id();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1443,8 +1443,6 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
 
     auto swarm_stats = tr_swarm_stats{};
 
-    tor->lastStatTime = now_sec;
-
     if (tor->swarm != nullptr)
     {
         swarm_stats = tr_swarmGetStats(tor->swarm);
@@ -1598,13 +1596,6 @@ tr_stat const* tr_torrentStat(tr_torrent* tor)
     TR_ASSERT(s->desiredAvailable <= s->leftUntilDone);
 
     return s;
-}
-
-tr_stat const* tr_torrentStatCached(tr_torrent* tor)
-{
-    time_t const now = tr_time();
-
-    return (tr_isTorrent(tor) && now == tor->lastStatTime) ? &tor->stats : tr_torrentStat(tor);
 }
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -875,8 +875,6 @@ public:
     time_t editDate = 0;
     time_t startDate = 0;
 
-    time_t lastStatTime = 0;
-
     time_t seconds_downloading_before_current_start_ = 0;
     time_t seconds_seeding_before_current_start_ = 0;
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -1610,11 +1610,6 @@ struct tr_stat
     second or so to get a new snapshot of the torrent's status. */
 tr_stat const* tr_torrentStat(tr_torrent* torrent);
 
-/** Like `tr_torrentStat()`, but only recalculates the statistics if it's
-    been longer than a second since they were last calculated. This can
-    reduce the CPU load if you're calling `tr_torrentStat()` frequently. */
-tr_stat const* tr_torrentStatCached(tr_torrent* torrent);
-
 /** @} */
 
 /** @brief Sanity checker to test that the direction is `TR_UP` or `TR_DOWN` */


### PR DESCRIPTION
This function only one caller, and it was always called at intervals too infrequently for us to hit the cache -- so there is no benefit in keeping this function. For that reason I'm not bothered by this API removal from libtransmission; but at some point we should decide on how seriously to take semver in `libtransmission/transmission.h` :thinking: 