### PR TITLE
perf: reduce unnecessary size overhead in tr_torrent struct

### DIFF
--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -104,7 +104,7 @@ private:
     }
 
     static auto inline next_key_ = Key{ 1U };
-    small::map<Key, Observer, 64U> observers_;
+    small::map<Key, Observer, 4U> observers_;
 };
 
 } // namespace libtransmission

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -32,7 +32,7 @@ namespace
 // don't ask for the same metadata piece more than this often
 auto constexpr MinRepeatIntervalSecs = int{ 3 };
 
-auto create_all_needed(int n_pieces)
+[[nodiscard]] auto create_all_needed(int n_pieces)
 {
     auto ret = std::deque<tr_incomplete_metadata::metadata_node>{};
 
@@ -72,13 +72,12 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
         return false;
     }
 
-    auto m = tr_incomplete_metadata{};
+    auto m = std::make_unique<tr_incomplete_metadata>();
+    m->piece_count = n;
+    m->metadata.resize(size);
+    m->pieces_needed = create_all_needed(n);
 
-    m.piece_count = n;
-    m.metadata.resize(size);
-    m.pieces_needed = create_all_needed(n);
-
-    if (std::empty(m.metadata) || std::empty(m.pieces_needed))
+    if (std::empty(m->metadata) || std::empty(m->pieces_needed))
     {
         return false;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -916,8 +916,8 @@ public:
     tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
     tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
-    tr_file_priorities file_priorities_{ &fpm_ };
     tr_files_wanted files_wanted_{ &fpm_ };
+    tr_file_priorities file_priorities_{ &fpm_ };
 
     std::string error_string;
 
@@ -927,7 +927,22 @@ public:
     // when Transmission thinks the torrent's files were last changed
     std::vector<time_t> file_mtimes_;
 
+    tr_interned_string error_announce_url;
+
+    // Where the files are when the torrent is complete.
+    tr_interned_string download_dir_;
+
+    // Where the files are when the torrent is incomplete.
+    // a value of TR_KEY_NONE indicates the 'incomplete_dir' feature is unused
+    tr_interned_string incomplete_dir_;
+
+    // Where the files are now.
+    // Will equal either download_dir or incomplete_dir
+    tr_interned_string current_dir_;
+
     tr_sha1_digest_t obfuscated_hash = {};
+
+    tr_stat_errtype error = TR_STAT_OK;
 
     tr_session* session = nullptr;
 
@@ -960,21 +975,6 @@ public:
     uint64_t corruptPrev = 0;
 
     uint64_t etaSpeedCalculatedAt = 0;
-
-    tr_interned_string error_announce_url;
-
-    // Where the files are when the torrent is complete.
-    tr_interned_string download_dir_;
-
-    // Where the files are when the torrent is incomplete.
-    // a value of TR_KEY_NONE indicates the 'incomplete_dir' feature is unused
-    tr_interned_string incomplete_dir_;
-
-    // Where the files are now.
-    // Will equal either download_dir or incomplete_dir
-    tr_interned_string current_dir_;
-
-    tr_stat_errtype error = TR_STAT_OK;
 
     tr_bytes_per_second_t etaSpeed_Bps = 0;
 
@@ -1064,6 +1064,8 @@ private:
         }
     }
 
+    tr_interned_string bandwidth_group_;
+
     /* If the initiator of the connection receives a handshake in which the
      * peer_id does not match the expected peerid, then the initiator is
      * expected to drop the connection. Note that the initiator presumably
@@ -1073,8 +1075,6 @@ private:
      */
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
-    tr_verify_state verify_state_ = TR_VERIFY_NONE;
-
     float verify_progress_ = -1.0F;
     float seed_ratio_ = 0.0F;
 
@@ -1082,11 +1082,11 @@ private:
 
     tr_announce_key_t announce_key_ = tr_rand_obj<tr_announce_key_t>();
 
-    tr_interned_string bandwidth_group_;
-
     tr_ratiolimit seed_ratio_mode_ = TR_RATIOLIMIT_GLOBAL;
 
     tr_idlelimit idle_limit_mode_ = TR_IDLELIMIT_GLOBAL;
+
+    tr_verify_state verify_state_ = TR_VERIFY_NONE;
 
     bool needs_completeness_check_ = true;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -11,6 +11,7 @@
 
 #include <cstddef> // size_t
 #include <ctime>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -78,8 +79,6 @@ enum tr_verify_state : uint8_t
     TR_VERIFY_WAIT,
     TR_VERIFY_NOW
 };
-
-struct tr_incomplete_metadata;
 
 /** @brief Torrent object */
 struct tr_torrent final : public tr_completion::torrent_view
@@ -942,8 +941,6 @@ public:
 
     tr_sha1_digest_t obfuscated_hash = {};
 
-    tr_stat_errtype error = TR_STAT_OK;
-
     tr_session* session = nullptr;
 
     tr_torrent_announcer* torrent_announcer = nullptr;
@@ -953,7 +950,7 @@ public:
     /* Used when the torrent has been created with a magnet link
      * and we're in the process of downloading the metainfo from
      * other peers */
-    std::optional<tr_incomplete_metadata> incomplete_metadata;
+    std::unique_ptr<tr_incomplete_metadata> incomplete_metadata;
 
     time_t lpdAnnounceAt = 0;
 
@@ -981,6 +978,8 @@ public:
     size_t queuePosition = 0;
 
     tr_torrent_id_t unique_id_ = 0;
+
+    tr_stat_errtype error = TR_STAT_OK;
 
     tr_completeness completeness = TR_LEECH;
 
@@ -1078,8 +1077,6 @@ private:
     float verify_progress_ = -1.0F;
     float seed_ratio_ = 0.0F;
 
-    uint16_t idle_limit_minutes_ = 0;
-
     tr_announce_key_t announce_key_ = tr_rand_obj<tr_announce_key_t>();
 
     tr_ratiolimit seed_ratio_mode_ = TR_RATIOLIMIT_GLOBAL;
@@ -1087,6 +1084,8 @@ private:
     tr_idlelimit idle_limit_mode_ = TR_IDLELIMIT_GLOBAL;
 
     tr_verify_state verify_state_ = TR_VERIFY_NONE;
+
+    uint16_t idle_limit_minutes_ = 0;
 
     bool needs_completeness_check_ = true;
 


### PR DESCRIPTION
- lower the preallocated size of the `SimpleObservable.observers` array to 4. In practice we only have 1 or 2; the previous size was just unnecessarily large.
- make `tr_torrent.incomplete_metadata` a `std::unique_ptr` instead of a `std::optional`. This way we avoid allocating it for each torrent that already has metadata (most of them) and also avoid the extra overhead that `std::optional` introduces (it is 2x the size of the type it wraps, which in this case was 120 bytes)
- re-arrange some `tr_torrent` fields to avoid padding holes.

None of these has any intentional behavior changes, but does shrink the size of a `t_torrent` instance by a good amount.