### PR TITLE
fix: reconstruct `utp_core_` when toggling utp

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -729,8 +729,6 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
         port_forwarding_->local_port_changed();
     }
 
-    bool const dht_changed = new_settings.dht_enabled != old_settings.dht_enabled;
-
     if (!udp_core_ || force || port_changed || utp_changed)
     {
         udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this, udpPort());
@@ -750,11 +748,11 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
         }
     }
 
-    if (!allowsDHT())
+    if (!new_settings.dht_enabled)
     {
         dht_.reset();
     }
-    else if (force || !dht_ || port_changed || addr_changed || dht_changed)
+    else if (force || !dht_ || port_changed || addr_changed || new_settings.dht_enabled != old_settings.dht_enabled)
     {
         dht_ = tr_dht::create(dht_mediator_, localPeerPort(), udp_core_->socket4(), udp_core_->socket6());
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -677,9 +677,11 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
         setDefaultTrackers(val);
     }
 
+    bool utp_changed = false;
     if (auto const& val = new_settings.utp_enabled; force || val != old_settings.utp_enabled)
     {
         tr_sessionSetUTPEnabled(this, val);
+        utp_changed = true;
     }
 
     useBlocklist(new_settings.blocklist_enabled);
@@ -729,7 +731,7 @@ void tr_session::setSettings(tr_session_settings&& settings_in, bool force)
 
     bool const dht_changed = new_settings.dht_enabled != old_settings.dht_enabled;
 
-    if (!udp_core_ || force || port_changed || dht_changed)
+    if (!udp_core_ || force || port_changed || utp_changed)
     {
         udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this, udpPort());
     }


### PR DESCRIPTION
Whether uTP is enabled or not affects the UDP socket buffer sizes, but toggling uTP mid-execution does not refresh the buffer sizes (by reconstructing `udp_core_`).

https://github.com/transmission/transmission/blob/68f3c89e3c84c862f83fc91c08fbb3a26e05e4e0/libtransmission/tr-udp.cc#L175
https://github.com/transmission/transmission/blob/68f3c89e3c84c862f83fc91c08fbb3a26e05e4e0/libtransmission/tr-udp.cc#L209

On the other hand, toggling DHT does reconstruct `udp_core_` in the current code. I removed this behaviour because I don't see any reason why it needs to.