### PR TITLE
refactor: add tr_torrent::Error helper class

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -220,7 +220,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
 
         if (error != nullptr) // if IO failed, set torrent's error if not already set
         {
-            if (io_mode == IoMode::Write && std::empty(tor->error()))
+            if (io_mode == IoMode::Write && tor->error().error_type() != TR_STAT_LOCAL_ERROR)
             {
                 tor->error().set_local_error(error->message);
                 tr_torrentStop(tor);

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -218,11 +218,11 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         tr_error* error = nullptr;
         readOrWriteBytes(tor->session, tor, io_mode, file_index, file_offset, buf, bytes_this_pass, &error);
 
-        if (error != nullptr)
+        if (error != nullptr) // if IO failed, set torrent's error if not already set
         {
-            if (io_mode == IoMode::Write && tor->error != TR_STAT_LOCAL_ERROR)
+            if (io_mode == IoMode::Write && std::empty(tor->error()))
             {
-                tor->set_local_error(error->message);
+                tor->error().set_local_error(error->message);
                 tr_torrentStop(tor);
             }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1886,7 +1886,7 @@ namespace peer_pulse_helpers
 
         if (!ok)
         {
-            msgs->torrent->set_local_error(
+            msgs->torrent->error().set_local_error(
                 fmt::format(FMT_STRING("Please Verify Local Data! Piece #{:d} is corrupt."), req.index));
         }
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -914,7 +914,7 @@ void save(tr_torrent* tor)
     auto serde = tr_variant_serde::benc();
     if (!serde.to_file(top, tor->resume_file()))
     {
-        tor->set_local_error(fmt::format("Unable to save resume file: {:s}", serde.error_->message));
+        tor->error().set_local_error(fmt::format("Unable to save resume file: {:s}", serde.error_->message));
     }
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -55,6 +55,52 @@ using namespace std::literals;
 
 // ---
 
+void tr_torrent::Error::set_tracker_warning(tr_interned_string announce_url, std::string_view errmsg)
+{
+    announce_url_ = announce_url;
+    errmsg_.assign(errmsg);
+    error_type_ = TR_STAT_TRACKER_WARNING;
+}
+
+void tr_torrent::Error::set_tracker_error(tr_interned_string announce_url, std::string_view errmsg)
+{
+    announce_url_ = announce_url;
+    errmsg_.assign(errmsg);
+    error_type_ = TR_STAT_TRACKER_ERROR;
+}
+
+void tr_torrent::Error::set_local_error(std::string_view errmsg)
+{
+    announce_url_.clear();
+    errmsg_.assign(errmsg);
+    error_type_ = TR_STAT_LOCAL_ERROR;
+}
+
+void tr_torrent::Error::clear() noexcept
+{
+    announce_url_.clear();
+    errmsg_.clear();
+    error_type_ = TR_STAT_OK;
+}
+
+void tr_torrent::Error::clear_if_local() noexcept
+{
+    if (error_type_ == TR_STAT_LOCAL_ERROR)
+    {
+        clear();
+    }
+}
+
+void tr_torrent::Error::clear_if_tracker() noexcept
+{
+    if (error_type_ == TR_STAT_TRACKER_WARNING || error_type_ == TR_STAT_TRACKER_ERROR)
+    {
+        clear();
+    }
+}
+
+// ---
+
 char const* tr_torrentName(tr_torrent const* tor)
 {
     return tor != nullptr ? tor->name().c_str() : "";
@@ -117,7 +163,7 @@ bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* m
 
     if (error != nullptr)
     {
-        tor->set_local_error(fmt::format(
+        tor->error().set_local_error(fmt::format(
             _("Couldn't use metainfo from '{path}' for '{magnet}': {error} ({error_code})"),
             fmt::arg("path", filename),
             fmt::arg("magnet", tor->magnet()),
@@ -152,18 +198,11 @@ bool setLocalErrorIfFilesDisappeared(tr_torrent* tor, std::optional<bool> has_lo
     if (files_disappeared)
     {
         tr_logAddTraceTor(tor, "[LAZY] uh oh, the files disappeared");
-        tor->set_local_error(_(
+        tor->error().set_local_error(_(
             "No data found! Ensure your drives are connected or use \"Set Location\". To re-download, remove the torrent and re-add it."));
     }
 
     return files_disappeared;
-}
-
-void tr_torrentClearError(tr_torrent* tor)
-{
-    tor->error = TR_STAT_OK;
-    tor->error_announce_url.clear();
-    tor->error_string.clear();
 }
 
 /* returns true if the seed ratio applies --
@@ -645,7 +684,7 @@ void torrentStartImpl(tr_torrent* const tor)
     tor->completeness = tor->completion.status();
     tor->startDate = now;
     tor->mark_changed();
-    tr_torrentClearError(tor);
+    tor->error().clear();
     tor->finished_seeding_by_idle_ = false;
 
     torrentResetTransferStats(tor);
@@ -978,7 +1017,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
     }
     tor->bandwidth_.set_parent(&session->top_bandwidth_);
     tor->bandwidth_.set_priority(tr_ctorGetBandwidthPriority(ctor));
-    tor->error = TR_STAT_OK;
+    tor->error().clear();
     tor->finished_seeding_by_idle_ = false;
 
     auto const& labels = tr_ctorGetLabels(ctor);
@@ -1067,7 +1106,7 @@ void torrentInit(tr_torrent* tor, tr_ctor const* ctor)
 
         if (error != nullptr)
         {
-            tor->set_local_error(fmt::format(
+            tor->error().set_local_error(fmt::format(
                 _("Couldn't save '{path}': {error} ({error_code})"),
                 fmt::arg("path", filename),
                 fmt::arg("error", error->message),
@@ -1177,7 +1216,7 @@ void setLocationInSessionThread(
         ok = tor->metainfo_.files().move(tor->current_dir(), path, setme_progress, tor->name(), &error);
         if (error != nullptr)
         {
-            tor->set_local_error(fmt::format(
+            tor->error().set_local_error(fmt::format(
                 _("Couldn't move '{old_path}' to '{path}': {error} ({error_code})"),
                 fmt::arg("old_path", tor->current_dir()),
                 fmt::arg("path", path),
@@ -1372,11 +1411,11 @@ tr_stat const* tr_torrentStat(tr_torrent* const tor)
     tr_stat* const s = &tor->stats;
     s->id = tor->id();
     s->activity = activity;
-    s->error = tor->error;
+    s->error = tor->error().error_type();
     s->queuePosition = tor->queuePosition;
     s->idleSecs = idle_seconds ? static_cast<time_t>(*idle_seconds) : -1;
     s->isStalled = tr_torrentIsStalled(tor, idle_seconds);
-    s->errorString = tor->error_string.c_str();
+    s->errorString = tor->error().errmsg().c_str();
 
     s->peersConnected = swarm_stats.peer_count;
     s->peersSendingToUs = swarm_stats.active_peer_count[TR_DOWN];
@@ -1988,7 +2027,7 @@ bool tr_torrent::set_tracker_list(std::string_view text)
         tr_error* save_error = nullptr;
         if (!tr_file_save(magnet_file, magnet_link, &save_error))
         {
-            this->set_local_error(fmt::format(
+            this->error().set_local_error(fmt::format(
                 _("Couldn't save '{path}': {error} ({error_code})"),
                 fmt::arg("path", magnet_file),
                 fmt::arg("error", save_error->message),
@@ -2000,16 +2039,14 @@ bool tr_torrent::set_tracker_list(std::string_view text)
     /* if we had a tracker-related error on this torrent,
      * and that tracker's been removed,
      * then clear the error */
-    if (this->error == TR_STAT_TRACKER_WARNING || this->error == TR_STAT_TRACKER_ERROR)
+    if (auto const& error_url = error_.announce_url(); !std::empty(error_url))
     {
-        auto const error_url = this->error_announce_url;
-
         if (std::any_of(
                 std::begin(this->announce_list()),
                 std::end(this->announce_list()),
                 [error_url](auto const& tracker) { return tracker.announce == error_url; }))
         {
-            tr_torrentClearError(this);
+            error_.clear();
         }
     }
 
@@ -2042,23 +2079,15 @@ void tr_torrent::on_tracker_response(tr_tracker_event const* event)
                 _("Tracker warning: '{warning}' ({url})"),
                 fmt::arg("warning", event->text),
                 fmt::arg("url", tr_urlTrackerLogName(event->announce_url))));
-        error = TR_STAT_TRACKER_WARNING;
-        error_announce_url = event->announce_url;
-        error_string = event->text;
+        error_.set_tracker_warning(event->announce_url, event->text);
         break;
 
     case tr_tracker_event::Type::Error:
-        error = TR_STAT_TRACKER_ERROR;
-        error_announce_url = event->announce_url;
-        error_string = event->text;
+        error_.set_tracker_error(event->announce_url, event->text);
         break;
 
     case tr_tracker_event::Type::ErrorClear:
-        if (error != TR_STAT_LOCAL_ERROR)
-        {
-            tr_torrentClearError(this);
-        }
-
+        error_.clear_if_tracker();
         break;
     }
 }
@@ -2282,9 +2311,9 @@ void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)
             recheck_completeness();
         }
     }
-    else if (error == TR_STAT_LOCAL_ERROR && !setLocalErrorIfFilesDisappeared(this))
+    else if (!std::empty(error_) && !setLocalErrorIfFilesDisappeared(this))
     {
-        tr_torrentClearError(this);
+        error_.clear_if_local();
     }
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -83,14 +83,6 @@ void tr_torrent::Error::clear() noexcept
     error_type_ = TR_STAT_OK;
 }
 
-void tr_torrent::Error::clear_if_local() noexcept
-{
-    if (error_type_ == TR_STAT_LOCAL_ERROR)
-    {
-        clear();
-    }
-}
-
 void tr_torrent::Error::clear_if_tracker() noexcept
 {
     if (error_type_ == TR_STAT_TRACKER_WARNING || error_type_ == TR_STAT_TRACKER_ERROR)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2311,9 +2311,9 @@ void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)
             recheck_completeness();
         }
     }
-    else if (!std::empty(error_) && !setLocalErrorIfFilesDisappeared(this))
+    else if (error_.error_type() == TR_STAT_LOCAL_ERROR && !setLocalErrorIfFilesDisappeared(this))
     {
-        error_.clear_if_local();
+        error_.clear();
     }
 }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -577,13 +577,6 @@ public:
         return this->is_piece_transfer_allowed(TR_CLIENT_TO_PEER);
     }
 
-    void set_local_error(std::string_view errmsg)
-    {
-        this->error = TR_STAT_LOCAL_ERROR;
-        this->error_announce_url = TR_KEY_NONE;
-        this->error_string = errmsg;
-    }
-
     void set_download_dir(std::string_view path, bool is_new_torrent = false);
 
     void refresh_current_dir();
@@ -891,6 +884,16 @@ public:
         session->announcer_->resetTorrent(this);
     }
 
+    [[nodiscard]] constexpr auto& error() noexcept
+    {
+        return error_;
+    }
+
+    [[nodiscard]] constexpr auto const& error() const noexcept
+    {
+        return error_;
+    }
+
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
@@ -918,15 +921,11 @@ public:
     tr_files_wanted files_wanted_{ &fpm_ };
     tr_file_priorities file_priorities_{ &fpm_ };
 
-    std::string error_string;
-
     using labels_t = std::vector<tr_quark>;
     labels_t labels;
 
     // when Transmission thinks the torrent's files were last changed
     std::vector<time_t> file_mtimes_;
-
-    tr_interned_string error_announce_url;
 
     // Where the files are when the torrent is complete.
     tr_interned_string download_dir_;
@@ -975,8 +974,6 @@ public:
 
     tr_torrent_id_t unique_id_ = 0;
 
-    tr_stat_errtype error = TR_STAT_OK;
-
     tr_completeness completeness = TR_LEECH;
 
     uint16_t max_connected_peers_ = TR_DEFAULT_PEER_LIMIT_TORRENT;
@@ -995,6 +992,45 @@ public:
 
 private:
     friend tr_stat const* tr_torrentStat(tr_torrent* tor);
+
+    // Tracks a torrent's error state, either local (e.g. file IO errors)
+    // or tracker errors (e.g. warnings returned by a tracker).
+    class Error
+    {
+    public:
+        [[nodiscard]] constexpr auto empty() const noexcept
+        {
+            return error_type_ == TR_STAT_OK;
+        }
+
+        [[nodiscard]] constexpr auto error_type() const noexcept
+        {
+            return error_type_;
+        }
+
+        [[nodiscard]] constexpr auto const& announce_url() const noexcept
+        {
+            return announce_url_;
+        }
+
+        [[nodiscard]] constexpr auto const& errmsg() const noexcept
+        {
+            return errmsg_;
+        }
+
+        void set_tracker_warning(tr_interned_string announce_url, std::string_view errmsg);
+        void set_tracker_error(tr_interned_string announce_url, std::string_view errmsg);
+        void set_local_error(std::string_view errmsg);
+
+        void clear() noexcept;
+        void clear_if_local() noexcept;
+        void clear_if_tracker() noexcept;
+
+    private:
+        tr_interned_string announce_url_; // the source for tracker errors/warnings
+        std::string errmsg_;
+        tr_stat_errtype error_type_ = TR_STAT_OK;
+    };
 
     // Helper class to smooth out speed estimates.
     // Used to prevent temporary speed changes from skewing the ETA too much.
@@ -1093,6 +1129,8 @@ private:
             recheck_completeness();
         }
     }
+
+    Error error_;
 
     tr_interned_string bandwidth_group_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1023,7 +1023,6 @@ private:
         void set_local_error(std::string_view errmsg);
 
         void clear() noexcept;
-        void clear_if_local() noexcept;
         void clear_if_tracker() noexcept;
 
     private:


### PR DESCRIPTION
Another incremental PR to reduce `tr_torrent`  sprawl by dividing its code into more self-contained chunks.

This replaces three error fields (`error`, `error_string`, and `error_announce_url`) with a single `error` field that is an instance of a new helper class to improve semantics, e.g. client code can call `error().set_tracker_warning()` instead of manually updating all the fields.