### PR TITLE
feat: WebUI display full peer address in tooltip

### DIFF
--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -603,7 +603,10 @@ export class Inspector extends EventTarget {
         setTextContent(td, peer.flagStr);
         td.setAttribute('title', Inspector._peerStatusTitle(peer.flagStr));
       },
-      (peer, td) => setTextContent(td, peer.address),
+      (peer, td) => {
+        setTextContent(td, peer.address);
+        td.setAttribute('title', peer.address);
+      },
       (peer, td) => setTextContent(td, peer.clientName),
     ];
 


### PR DESCRIPTION
Just so that there is at least somewhere you can see the full IPv6 addresses.

![image](https://github.com/transmission/transmission/assets/46261767/8c4808c8-a0a5-478d-b3de-8ecb2ae99642)
