### PR TITLE
fix: EVUTIL_SET_SOCKET_ERROR(0) to avoid err EAGAIN with n_read 0

### DIFF
--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -18,6 +18,8 @@
 #include "net.h" // tr_socket_t
 #include "utils.h" // for tr_htonll(), tr_ntohll()
 
+#include "event2/util.h"
+
 namespace libtransmission
 {
 
@@ -199,6 +201,7 @@ public:
 
     size_t add_socket(tr_socket_t sockfd, size_t n_bytes, tr_error** error = nullptr)
     {
+        EVUTIL_SET_SOCKET_ERROR(0);
         auto const [buf, buflen] = reserve_space(n_bytes);
         auto const n_read = recv(sockfd, reinterpret_cast<char*>(buf), std::min(n_bytes, buflen), 0);
         auto const err = sockerrno;

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -18,8 +18,6 @@
 #include "net.h" // tr_socket_t
 #include "utils.h" // for tr_htonll(), tr_ntohll()
 
-#include "event2/util.h"
-
 namespace libtransmission
 {
 
@@ -201,8 +199,8 @@ public:
 
     size_t add_socket(tr_socket_t sockfd, size_t n_bytes, tr_error** error = nullptr)
     {
-        EVUTIL_SET_SOCKET_ERROR(0);
         auto const [buf, buflen] = reserve_space(n_bytes);
+        sockerrno = 0;
         auto const n_read = recv(sockfd, reinterpret_cast<char*>(buf), std::min(n_bytes, buflen), 0);
         auto const err = sockerrno;
 


### PR DESCRIPTION
Possible fix for #5943.
Address possible regression from #5543 in May 2023.

After the call to recv:
https://github.com/transmission/transmission/blob/0c52b710ad241c2b68cb9c7a9eb68a8532b290d0/libtransmission/tr-buffer.h#L203

The value in `n_read` may be 0 with errno set to EAGAIN (instead of being `n_read` -1). This might steam from the removal of EVUTIL_SET_SOCKET_ERROR(0) in #5543. And when `n_read` is 0, then error is set to ENOTCONN (instead of EAGAIN), and peer is lost.

This is speculation. I'll continue to test this potential fix for the regression that I started to observe in June 2023.