### PR TITLE
fix: URL cleanup in BlocklistDownloader on macOS

### DIFF
--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -175,9 +175,13 @@ BlocklistDownloader* fBLDownloader = nil;
     {
         urlString = @"";
     }
-    else if (![urlString isEqualToString:@""] && [urlString rangeOfString:@"://"].location == NSNotFound)
+    else
     {
-        urlString = [@"https://" stringByAppendingString:urlString];
+        urlString = [urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if (![urlString isEqualToString:@""] && [urlString rangeOfString:@"://"].location == NSNotFound)
+        {
+            urlString = [@"https://" stringByAppendingString:urlString];
+        }
     }
 
     NSURLSessionDownloadTask* task = [self.fSession downloadTaskWithURL:[NSURL URLWithString:urlString]];


### PR DESCRIPTION
in file macosx/BlocklistDownloader.mm:

in (void)startDownload: now trimming whitespaces at the beginning and end of the BlocklistURL, otherwise the download will fail, if the URL contains a beginning or trailing whitespace.