### PR TITLE
chore: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ For a more detailed description, and dependencies, visit [How to Build Transmiss
 
 ### Building a Transmission release from the command line
 
-    $ tar xf transmission-4.0.4.tar.xz
-    $ cd transmission-4.0.4
-    # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
-    # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
-    $ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    $ cd build
-    $ cmake --build .
-    $ sudo cmake --install .
+```bash
+$ tar xf transmission-4.0.4.tar.xz
+$ cd transmission-4.0.4
+# Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
+# Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
+$ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+$ cd build
+$ cmake --build .
+$ sudo cmake --install .
+```
 
 ### Building Transmission from the nightly builds
 
@@ -48,23 +50,27 @@ If you're new to building programs from source code, this is typically easier th
 
 ### Building Transmission from Git (first time)
 
-    $ git clone --recurse-submodules https://github.com/transmission/transmission Transmission
-    $ cd Transmission
-    # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
-    # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
-    $ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    $ cd build
-    $ cmake --build .
-    $ sudo cmake --install .
+```bash
+$ git clone --recurse-submodules https://github.com/transmission/transmission Transmission
+$ cd Transmission
+# Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
+# Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
+$ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+$ cd build
+$ cmake --build .
+$ sudo cmake --install .
+```
 
 ### Building Transmission from Git (updating)
 
-    $ cd Transmission/build
-    $ git submodule foreach --recursive git clean -xfd
-    $ git pull --rebase --prune
-    $ git submodule update --init --recursive
-    $ cmake --build . --clean-first
-    $ sudo cmake --install .
+```bash
+$ cd Transmission/build
+$ git submodule foreach --recursive git clean -xfd
+$ git pull --rebase --prune
+$ git submodule update --init --recursive
+$ cmake --build . --clean-first
+$ sudo cmake --install .
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ For a more detailed description, and dependencies, visit [How to Build Transmiss
 
 ### Building a Transmission release from the command line
 
-    $ tar xf transmission-3.00.tar.xz
-    $ cd transmission-3.00
-    $ mkdir build
-    $ cd build
+    $ tar xf transmission-4.0.4.tar.xz
+    $ cd transmission-4.0.4
     # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
     # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
-    $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    $ make
-    $ sudo make install
+    $ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    $ cd build
+    $ cmake --build .
+    $ sudo cmake --install .
 
 ### Building Transmission from the nightly builds
 
@@ -49,29 +48,23 @@ If you're new to building programs from source code, this is typically easier th
 
 ### Building Transmission from Git (first time)
 
-    $ git clone https://github.com/transmission/transmission Transmission
+    $ git clone --recurse-submodules https://github.com/transmission/transmission Transmission
     $ cd Transmission
-    $ git submodule update --init --recursive
-    $ mkdir build
-    $ cd build
     # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
     # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
-    $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    $ make
-    $ sudo make install
+    $ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    $ cd build
+    $ cmake --build .
+    $ sudo cmake --install .
 
 ### Building Transmission from Git (updating)
 
     $ cd Transmission/build
-    $ make clean
     $ git submodule foreach --recursive git clean -xfd
     $ git pull --rebase --prune
     $ git submodule update --init --recursive
-    # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
-    # Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
-    $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-    $ make
-    $ sudo make install
+    $ cmake --build . --clean-first
+    $ sudo cmake --install .
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ $ sudo cmake --install .
 
 ```bash
 $ cd Transmission/build
+$ cmake --build . -t clean
 $ git submodule foreach --recursive git clean -xfd
 $ git pull --rebase --prune
 $ git submodule update --init --recursive
-$ cmake --build . --clean-first
+$ cmake --build .
 $ sudo cmake --install .
 ```
 

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -19,20 +19,20 @@ Transmission has an Xcode project file for building in Xcode.
 - Open Transmission.xcodeproj
 - Run the Transmission scheme
 
-### Building the native app with ninja ###
+### Building the native app with CMake ###
 Build the app:
 ```console
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
-ninja -C build transmission-mac
+cmake --build build -t transmission-mac
 open ./build/macosx/Transmission.app
 ```
 
-### Building the GTK app with ninja ###
+### Building the GTK app with CMake ###
 Install GTK and build the app:
 ```console
 brew install gtk4 gtkmm4
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_GTK=ON -DENABLE_MAC=OFF
-ninja -C build transmission-gtk
+cmake --build build -t transmission-gtk
 ./build/gtk/transmission-gtk
 ```
 
@@ -96,27 +96,24 @@ $ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 ### Building Transmission from Git (first time) ###
 ```console
-$ git clone https://github.com/transmission/transmission Transmission
+$ git clone --recurse-submodules https://github.com/transmission/transmission Transmission
 $ cd Transmission
-$ git submodule update --init --recursive
-$ mkdir build
+# Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
+# Use -DCMAKE_BUILD_TYPE=Release to build full optimized binary.
+$ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 $ cd build
-$ # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary.
-$ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-$ make
-$ sudo make install
+$ cmake --build .
+$ sudo cmake --install .
 ```
 
 ### Building Transmission from Git (updating) ###
 ```console
 $ cd Transmission/build
-$ make clean
+$ git submodule foreach --recursive git clean -xfd
 $ git pull --rebase --prune
-$ git submodule update --recursive
-$ # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary.
-$ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-$ make
-$ sudo make install
+$ git submodule update --init --recursive
+$ cmake --build . --clean-first
+$ sudo cmake --install .
 ```
 
 ## On Windows ##

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -109,10 +109,11 @@ $ sudo cmake --install .
 ### Building Transmission from Git (updating) ###
 ```bash
 $ cd Transmission/build
+$ cmake --build . -t clean
 $ git submodule foreach --recursive git clean -xfd
 $ git pull --rebase --prune
 $ git submodule update --init --recursive
-$ cmake --build . --clean-first
+$ cmake --build .
 $ sudo cmake --install .
 ```
 

--- a/docs/Building-Transmission.md
+++ b/docs/Building-Transmission.md
@@ -43,17 +43,17 @@ cmake --build build -t transmission-gtk
 On Debian, you can build transmission with a few dependencies on top of a base installation.
 
 For building transmission-daemon you will need basic dependencies
-```console
+```bash
 $ sudo apt install git build-essential cmake libcurl4-openssl-dev libssl-dev python3
 ```
 You likely want to install transmission as a native GUI application. There are two options, GTK and QT.
 
 For GTK 3 client, two additional packages are required
-```console
+```bash
 $ sudo apt install libgtkmm-3.0-dev gettext
 ```
 For QT client, one additional package is needed on top of basic dependencies
-```console
+```bash
 $ sudo apt install qttools5-dev
 ```
 
@@ -62,7 +62,7 @@ Then you can begin [building.](#building-transmission-from-git-first-time)
 #### Ubuntu ####
 On Ubuntu, you can install the required development tools for GTK with this command:
 
-```console
+```bash
 $ sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libevent-dev libminiupnpc-dev libgtk-3-dev libappindicator3-dev libssl-dev
 ```
 
@@ -80,7 +80,7 @@ The packages you need are:
  * openssl-devel
 
 Or simply run the following command:
-```console
+```bash
 $ yum install gcc gcc-c++ m4 make automake libtool gettext openssl-devel
 ```
 
@@ -90,12 +90,12 @@ However, Transmission needs other packages unavailable in `yum`:
  * [intltool](https://ftp.gnome.org/pub/gnome/sources/intltool/)
 
 Before building Transmission, you need to set the pkgconfig environment setting:
-```console
+```bash
 $ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
 ### Building Transmission from Git (first time) ###
-```console
+```bash
 $ git clone --recurse-submodules https://github.com/transmission/transmission Transmission
 $ cd Transmission
 # Use -DCMAKE_BUILD_TYPE=RelWithDebInfo to build optimized binary with debug information. (preferred)
@@ -107,7 +107,7 @@ $ sudo cmake --install .
 ```
 
 ### Building Transmission from Git (updating) ###
-```console
+```bash
 $ cd Transmission/build
 $ git submodule foreach --recursive git clean -xfd
 $ git pull --rebase --prune
@@ -135,17 +135,17 @@ You need the following installed:
 Vcpkg will install x86 libraries by default. To install x64 add the `--triplet=x64-windows` flag at the end of the commands below.
 
 Common dependencies:
-```
+```bat
 vcpkg install curl zlib openssl
 ```
 
 Additional dependencies for the Qt client:
-```
+```bat
 vcpkg install qt5-tools qt5-winextras
 ```
 
 ### Get Transmission source
-```
+```bat
 git clone https://github.com/transmission/transmission
 cd transmission
 git submodule update --init --recursive
@@ -160,11 +160,11 @@ Each option can be set to `ON` or `OFF`, values shown below are the defaults.
 * `-DENABLE_UTILS=ON` - build transmission-remote, transmission-create, transmission-edit and transmission-show cli tools
 * `-DENABLE_CLI=OFF` - build the cli client
 
-```
+```bat
 cmake -B build -DCMAKE_TOOLCHAIN_FILE="<path-to-vcpkg>\scripts\buildsystems\vcpkg.cmake" <flags-from-above> <other-cmake-configurations>
 ```
 
 To build the project run:
-```
+```bat
 cmake --build build
 ```


### PR DESCRIPTION
1. Updated Transmission release verison in README.
2. Use more generic build commands (e.g. `make` -> `cmake --build`)
3. Combined commands.
4. Updated syntax highlighting.