### PR TITLE
UI fix: larger display group name

### DIFF
--- a/macosx/Base.lproj/PrefsWindow.xib
+++ b/macosx/Base.lproj/PrefsWindow.xib
@@ -1310,7 +1310,7 @@
                                                 </tableHeaderCell>
                                                 <imageCell key="dataCell" controlSize="small" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="imageCell:1782:image" id="1782"/>
                                             </tableColumn>
-                                            <tableColumn identifier="Name" editable="NO" width="77" minWidth="40" maxWidth="1000" id="1779">
+                                            <tableColumn identifier="Name" editable="NO" width="115" minWidth="40" maxWidth="1000" id="1779">
                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Fix #6098

Before:
<img width="768" alt="Capture d’écran 2023-10-13 à 19 47 21" src="https://github.com/transmission/transmission/assets/839992/0dd13a6e-f26d-41cb-ab22-c567cb5ca1fa">

After:
<img width="768" alt="Capture d’écran 2023-10-13 à 19 22 53" src="https://github.com/transmission/transmission/assets/839992/78dab1d3-8985-4292-a9b0-51516f9e3e37">


This does not make it resizable or scrollable, but it's a good enough enhancement for now. I do not plan to do better this year.