### PR TITLE
perf: periodically purge inactive peer info objects from pool

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -339,6 +339,23 @@ public:
         }
     }
 
+    void remove_inactive_peer_info() noexcept
+    {
+        auto const now = tr_time();
+        for (auto iter = std::begin(connectable_pool), end = std::end(connectable_pool); iter != end;)
+        {
+            auto& [socket_address, peer_info] = *iter;
+            if (peer_info.is_inactive(now))
+            {
+                iter = connectable_pool.erase(iter);
+            }
+            else
+            {
+                ++iter;
+            }
+        }
+    }
+
     [[nodiscard]] uint16_t countActiveWebseeds(uint64_t now) const noexcept
     {
         if (!tor->is_running() || tor->is_done())
@@ -1145,6 +1162,7 @@ void tr_peerMgr::refillUpkeep() const
     for (auto* const tor : session->torrents())
     {
         tor->swarm->cancelOldRequests();
+        tor->swarm->remove_inactive_peer_info();
     }
 }
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -300,6 +300,11 @@ public:
         return now - std::max(piece_data_at_, connection_changed_at_);
     }
 
+    [[nodiscard]] auto is_inactive(time_t const now) const noexcept
+    {
+        return !is_in_use() && now - connection_changed_at_ >= UselessThresSecs;
+    }
+
     // ---
 
     constexpr void on_connection_failed() noexcept
@@ -417,6 +422,7 @@ private:
 
     // the minimum we'll wait before attempting to reconnect to a peer
     static auto constexpr MinimumReconnectIntervalSecs = time_t{ 5U };
+    static auto constexpr UselessThresSecs = time_t{ 24 * 60 * 60 };
 
     static auto inline n_known_connectable = size_t{};
 


### PR DESCRIPTION
Periodically purge inactive peer info objects from the peer pool, so that the pool size doesn't grow indefinitely.

This and my other pending PRs marks the point where I'd consider the peer communications code ready for `4.1.0` release.

Notes: Improved libtransmission code to use less CPU.