### PR TITLE
fix: encode `ip` in network byte order for udp announce (#6126)

### DIFF
--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -355,6 +355,22 @@ public:
         add(&nport, sizeof(nport));
     }
 
+    void add_address(tr_address const& addr)
+    {
+        switch (addr.type)
+        {
+        case TR_AF_INET:
+            add(&addr.addr.addr4.s_addr, sizeof(addr.addr.addr4.s_addr));
+            break;
+        case TR_AF_INET6:
+            add(&addr.addr.addr6.s6_addr, sizeof(addr.addr.addr6.s6_addr));
+            break;
+        default:
+            TR_ASSERT_MSG(false, "invalid type");
+            break;
+        }
+    }
+
     void add_uint8(uint8_t uch)
     {
         add(&uch, 1);

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -16,6 +16,7 @@
 
 #include "error.h"
 #include "net.h" // tr_socket_t
+#include "tr-assert.h"
 #include "utils-ev.h"
 #include "utils.h" // for tr_htonll(), tr_ntohll()
 


### PR DESCRIPTION
(cherry picked from commit c70c49e87bf29828045920b7cd2ac2741107daf6)

Manual cherry pick to `4.0.x`.