### PR TITLE
fix: json string serializer improperly escaping characters (#6005)

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -62,18 +62,32 @@ time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---
 
-void tr_locale_set_global(char const* locale_name) noexcept
+std::optional<std::locale> tr_locale_set_global(char const* locale_name) noexcept
 {
     try
     {
-        std::ignore = std::locale::global(std::locale{ locale_name });
+        return tr_locale_set_global(std::locale{ locale_name });
+    }
+    catch (std::runtime_error const&)
+    {
+        return {};
+    }
+}
 
-        std::ignore = std::cout.imbue(std::locale{});
-        std::ignore = std::cerr.imbue(std::locale{});
+std::optional<std::locale> tr_locale_set_global(std::locale const& locale) noexcept
+{
+    try
+    {
+        auto old_locale = std::locale::global(locale);
+
+        std::cout.imbue(std::locale{});
+        std::cerr.imbue(std::locale{});
+
+        return old_locale;
     }
     catch (std::exception const&)
     {
-        // Ignore.
+        return {};
     }
 }
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -11,6 +11,8 @@
 #include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <cstddef> // size_t
 #include <ctime> // time_t
+#include <locale>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -56,7 +58,9 @@ struct tr_error;
 #define tr_ngettext(singular, plural, count) ((count) == 1 ? (singular) : (plural))
 #endif
 
-void tr_locale_set_global(char const* locale_name) noexcept;
+std::optional<std::locale> tr_locale_set_global(char const* locale_name) noexcept;
+
+std::optional<std::locale> tr_locale_set_global(std::locale const& locale) noexcept;
 
 // ---
 


### PR DESCRIPTION
Manual cherrypick to `4.0.x`.