### PR TITLE
Optimize rendering of long torrent lists

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -563,6 +563,18 @@ $video-image: '../img/film.svg';
       $icon-size-num: 16;
       $icon-size: $icon-size-num * 1px;
 
+      // This is an optimization to ensure that browsers don't need
+      // to render torrents that are far off screen. It improves
+      // browser performance when a large number of torrents are running.
+      // In terms of appearace, the only thing you need to know is this
+      // works the same as overflow: hidden;
+      contain: strict;
+      // We need to match this to the height of a torrent or the scrollbar
+      // will get confused
+      contain-intrinsic-height: 30px;
+      content-visibility: auto;
+
+
       align-items: center;
       display: flex;
       flex-direction: row-reverse;
@@ -601,6 +613,17 @@ $video-image: '../img/film.svg';
         'icon peers peers';
       grid-template-columns: $icon-size auto 1fr;
       padding: 6px 12px;
+
+      // This is an optimization to ensure that browsers don't need
+      // to render torrents that are far off screen. It improves
+      // browser performance when a large number of torrents are running.
+      // In terms of appearace, the only thing you need to know is this
+      // works the same as overflow: hidden;
+      contain: strict;
+      // We need to match this to the height of a torrent or the scrollbar
+      // will get confused
+      contain-intrinsic-height: 72px;
+      content-visibility: auto;
 
       .icon {
         background-size:


### PR DESCRIPTION
This is a non-cosmetic CSS change intended to make the Transmission WebUI load faster and use less CPU time.

When transmission daemon is running on a sufficiently fast server, with many thousands of torrents loaded the slowest part of the WebUI is actually the CPU cycles spent rendering on the users browser. On a Transmission with 19.5K torrents loaded, we were able to shave 2.6 seconds off the WebUI load time by helping browsers skip rendering torrents that are scrolled very far off screen. A 60.7% reduction in load time for the WebUI.

While there's no visible benefit when transmission is already loaded and idling in a tab. We also get a CPU time decrease of 73.2% which will conserve energy and battery life even though I don't think anyone will notice that part.

Benchmarks follow, extracted from Chrome performance tab. Your numbers may vary but the percentages should hold at these torrent counts.

Transmission WebUI with 2,750 torrents
======================================

Initial load up to 5 second mark
--------------------------------

| Task      | Original | Optimized | Multiple faster |
|-----------|----------|-----------|-----------------|
| Loading   | 4        | 4         |                 |
| Scripting | 170      | 172       |                 |
| Rendering | 349      | 56        | 6.2x            |
| Painting  | 10       | 4         | 2.5x            |
| System    | 25       | 33        |                 |
| Idle      | 4404     | 4776      |                 |
| Total     | 4963     | 5044      |                 |

Already open, and idle for 60 seconds
-------------------------------------

| Task      | Original | Optimized | Multiple faster |
|-----------|----------|-----------|-----------------|
| Loading   | 0        | 0         |                 |
| Scripting | 145      | 134       |                 |
| Rendering | 290      | 126       | 2.3x            |
| Painting  | 58       | 8         | 7.3x            |
| System    | 88       | 40        |                 |
| Idle      | 59488    | 59631     |                 |
| Total     | 60068    | 59938     |                 |

Transmission with 19,500 torrents
=================================

Initial load up to 5 second mark
--------------------------------

| Task      | Original | Optimized | Multiple faster |
|-----------|----------|-----------|-----------------|
| Loading   | 5        | 5         |                 |
| Scripting | 1194     | 1788      |                 |
| Rendering | 2772     | 546       | 5.1x            |
| Painting  | 53       | 8         | 6.6x            |
| System    | 107      | 159       |                 |
| Idle      | 1134     | 2758      |                 |
| Total     | 5264     | 5264      |                 |

Already open, and idle for 60 seconds
-------------------------------------

| Task      | Original | Optimized | Multiple faster |
|-----------|----------|-----------|-----------------|
| Loading   | 0        | 0         |                 |
| Scripting | 1094     | 666       |                 |
| Rendering | 1931     | 169       | 11.4x           |
| Painting  | 2        | 0         |                 |
| System    | 247      | 54        |                 |
| Idle      | 56694    | 59115     |                 |
| Total     | 59968    | 60003     |                 |