### PR TITLE
refactor: make tr_torrent::labels_ private

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -84,11 +84,11 @@ auto loadPeers(tr_variant* dict, tr_torrent* tor)
 
 void saveLabels(tr_variant* dict, tr_torrent const* tor)
 {
-    auto const& labels = tor->labels;
+    auto const& labels = tor->labels();
     tr_variant* list = tr_variantDictAddList(dict, TR_KEY_labels, std::size(labels));
     for (auto const& label : labels)
     {
-        tr_variantListAddQuark(list, label);
+        tr_variantListAddStrView(list, label.sv());
     }
 }
 
@@ -101,18 +101,18 @@ auto loadLabels(tr_variant* dict, tr_torrent* tor)
     }
 
     auto const n = tr_variantListSize(list);
-    auto labels = std::vector<tr_quark>{};
+    auto labels = tr_torrent::labels_t{};
     labels.reserve(n);
     for (size_t i = 0; i < n; ++i)
     {
         auto sv = std::string_view{};
         if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv))
         {
-            labels.emplace_back(tr_quark_new(sv));
+            labels.emplace_back(tr_interned_string{ sv });
         }
     }
 
-    tor->setLabels(labels);
+    tor->set_labels(labels);
     return tr_resume::Labels;
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -331,14 +331,15 @@ namespace make_torrent_field_helpers
 
 [[nodiscard]] auto make_labels_vec(tr_torrent const& tor)
 {
-    auto const n_labels = std::size(tor.labels);
-    auto labels = tr_variant::Vector{};
-    labels.reserve(n_labels);
-    for (auto const& label : tor.labels)
+    auto const& labels = tor.labels();
+    auto const n_labels = std::size(labels);
+    auto vec = tr_variant::Vector{};
+    vec.reserve(n_labels);
+    for (auto const& label : labels)
     {
-        labels.emplace_back(tr_variant::unmanaged_string(tr_quark_get_string_view(label)));
+        vec.emplace_back(tr_variant::unmanaged_string(label.sv()));
     }
-    return tr_variant{ std::move(labels) };
+    return tr_variant{ std::move(vec) };
 }
 
 [[nodiscard]] auto make_file_priorities_vec(tr_torrent const& tor)
@@ -801,9 +802,9 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
 
 // ---
 
-[[nodiscard]] std::pair<std::vector<tr_quark>, char const* /*errmsg*/> makeLabels(tr_variant* list)
+[[nodiscard]] std::pair<tr_torrent::labels_t, char const* /*errmsg*/> makeLabels(tr_variant* list)
 {
-    auto labels = std::vector<tr_quark>{};
+    auto labels = tr_torrent::labels_t{};
     size_t const n = tr_variantListSize(list);
     labels.reserve(n);
 
@@ -826,7 +827,7 @@ char const* torrentGet(tr_session* session, tr_variant* args_in, tr_variant* arg
             return { {}, "labels cannot contain comma (,) character" };
         }
 
-        labels.emplace_back(tr_quark_new(label));
+        labels.emplace_back(label);
     }
 
     return { labels, nullptr };
@@ -841,7 +842,7 @@ char const* setLabels(tr_torrent* tor, tr_variant* list)
         return errmsg;
     }
 
-    tor->setLabels(labels);
+    tor->set_labels(labels);
     return nullptr;
 }
 
@@ -1518,7 +1519,7 @@ char const* torrentAdd(tr_session* session, tr_variant* args_in, tr_variant* /*a
             return errmsg;
         }
 
-        tr_ctorSetLabels(ctor, std::data(labels), std::size(labels));
+        tr_ctorSetLabels(ctor, std::move(labels));
     }
 
     tr_logAddTrace(fmt::format("torrentAdd: filename is '{}'", filename));

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -339,9 +339,9 @@ tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor)
 
 // ---
 
-void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels)
+void tr_ctorSetLabels(tr_ctor* ctor, tr_torrent::labels_t&& labels)
 {
-    ctor->labels = { labels, labels + n_labels };
+    ctor->labels = std::move(labels);
 }
 
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -359,13 +359,13 @@ namespace
 {
 namespace script_helpers
 {
-[[nodiscard]] std::string buildLabelsString(tr_torrent const* tor)
+[[nodiscard]] std::string build_labels_string(tr_torrent::labels_t const& labels)
 {
     auto buf = std::stringstream{};
 
-    for (auto it = std::begin(tor->labels), end = std::end(tor->labels); it != end;)
+    for (auto it = std::begin(labels), end = std::end(labels); it != end;)
     {
-        buf << tr_quark_get_string_view(*it);
+        buf << it->sv();
 
         if (++it != end)
         {
@@ -406,7 +406,7 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
     auto const cmd = std::array<char const*, 2>{ script.c_str(), nullptr };
 
     auto const id_str = std::to_string(tr_torrentId(tor));
-    auto const labels_str = buildLabelsString(tor);
+    auto const labels_str = build_labels_string(tor->labels());
     auto const trackers_str = buildTrackersString(tor);
     auto const bytes_downloaded_str = std::to_string(tor->downloadedCur + tor->downloadedPrev);
     auto const localtime_str = fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time()));
@@ -1014,7 +1014,7 @@ void tr_torrent::init(tr_ctor const* const ctor)
     error().clear();
     finished_seeding_by_idle_ = false;
 
-    setLabels(tr_ctorGetLabels(ctor));
+    set_labels(tr_ctorGetLabels(ctor));
 
     session->addTorrent(this);
 
@@ -1882,19 +1882,19 @@ void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file
 
 // ---
 
-void tr_torrent::setLabels(std::vector<tr_quark> const& new_labels)
+void tr_torrent::set_labels(labels_t const& new_labels)
 {
     auto const lock = unique_lock();
-    this->labels.clear();
+    labels_.clear();
 
     for (auto label : new_labels)
     {
-        if (std::find(std::begin(this->labels), std::end(this->labels), label) == std::end(this->labels))
+        if (std::find(std::begin(labels_), std::end(labels_), label) == std::end(labels_))
         {
-            this->labels.push_back(label);
+            labels_.push_back(label);
         }
     }
-    this->labels.shrink_to_fit();
+    labels_.shrink_to_fit();
     this->set_dirty();
 }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -79,6 +79,7 @@ void tr_torrentSave(tr_torrent* tor);
 struct tr_torrent final : public tr_completion::torrent_view
 {
 public:
+    using labels_t = std::vector<tr_interned_string>;
     using VerifyDoneCallback = std::function<void(tr_torrent*)>;
 
     class VerifyMediator : public tr_verify_worker::Mediator
@@ -663,7 +664,12 @@ public:
         return TR_STATUS_STOPPED;
     }
 
-    void setLabels(std::vector<tr_quark> const& new_labels);
+    [[nodiscard]] constexpr auto const& labels() const noexcept
+    {
+        return labels_;
+    }
+
+    void set_labels(labels_t const& new_labels);
 
     /** Return the mime-type (e.g. "audio/x-flac") that matches more of the
         torrent's content than any other mime-type. */
@@ -934,9 +940,6 @@ public:
 
     tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
 
-    using labels_t = std::vector<tr_quark>;
-    labels_t labels;
-
     // when Transmission thinks the torrent's files were last changed
     std::vector<time_t> file_mtimes_;
 
@@ -1168,6 +1171,8 @@ private:
 
     VerifyDoneCallback verify_done_callback_;
 
+    labels_t labels_;
+
     tr_interned_string bandwidth_group_;
 
     mutable SimpleSmoothedSpeed eta_speed_;
@@ -1222,7 +1227,7 @@ tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);
 
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error** error = nullptr);
 bool tr_ctorSetMetainfoFromMagnetLink(tr_ctor* ctor, std::string_view magnet_link, tr_error** error = nullptr);
-void tr_ctorSetLabels(tr_ctor* ctor, tr_quark const* labels, size_t n_labels);
+void tr_ctorSetLabels(tr_ctor* ctor, tr_torrent::labels_t&& labels);
 void tr_ctorSetBandwidthPriority(tr_ctor* ctor, tr_priority_t priority);
 tr_priority_t tr_ctorGetBandwidthPriority(tr_ctor const* ctor);
 tr_torrent::labels_t const& tr_ctorGetLabels(tr_ctor const* ctor);


### PR DESCRIPTION
another minor scope-limiting PR -- this time to make the `tr_torrent::labels_` field private