### PR TITLE
refactor: minor decoupling in peer-mgr

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -79,7 +79,10 @@ private:
     }
 
 public:
-    explicit HandshakeMediator(tr_session& session, libtransmission::TimerMaker& timer_maker, tr_torrents& torrents) noexcept
+    explicit HandshakeMediator(
+        tr_session const& session,
+        libtransmission::TimerMaker& timer_maker,
+        tr_torrents& torrents) noexcept
         : session_{ session }
         , timer_maker_{ timer_maker }
         , torrents_{ torrents }
@@ -122,7 +125,7 @@ public:
     }
 
 private:
-    tr_session& session_;
+    tr_session const& session_;
     libtransmission::TimerMaker& timer_maker_;
     tr_torrents& torrents_;
 };
@@ -1296,7 +1299,7 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, tr_peer_socket&& socket)
     TR_ASSERT(manager->session != nullptr);
     auto const lock = manager->unique_lock();
 
-    tr_session* session = manager->session;
+    auto* const session = manager->session;
 
     if (session->addressIsBlocked(socket.address()))
     {

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -130,7 +130,7 @@ size_t tr_peer_socket::try_read(InBuf& buf, size_t max, [[maybe_unused]] bool bu
     return {};
 }
 
-bool tr_peer_socket::limit_reached(tr_session* const session) noexcept
+bool tr_peer_socket::limit_reached(tr_session const* const session) noexcept
 {
     return n_open_sockets_.load() >= session->peerLimit();
 }

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -131,7 +131,7 @@ public:
         struct UTPSocket* utp;
     } handle = {};
 
-    [[nodiscard]] static bool limit_reached(tr_session* session) noexcept;
+    [[nodiscard]] static bool limit_reached(tr_session const* session) noexcept;
 
 private:
     enum class Type

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -130,19 +130,6 @@ tr_torrent* tr_torrentFindFromMagnetLink(tr_session* session, char const* magnet
     return magnet_link == nullptr ? nullptr : session->torrents().get(magnet_link);
 }
 
-tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, tr_sha1_digest_t const& obfuscated_hash)
-{
-    for (auto* const tor : session->torrents())
-    {
-        if (tor->obfuscated_hash == obfuscated_hash)
-        {
-            return tor;
-        }
-    }
-
-    return nullptr;
-}
-
 bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* metainfo, char const* filename)
 {
     if (tr_torrentHasMetadata(tor))

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -64,8 +64,6 @@ bool tr_ctorGetIncompleteDir(tr_ctor const* ctor, char const** setme_incomplete_
 
 void tr_torrentChangeMyPort(tr_torrent* tor);
 
-[[nodiscard]] tr_torrent* tr_torrentFindFromObfuscatedHash(tr_session* session, tr_sha1_digest_t const& hash);
-
 bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_t offset, uint32_t length);
 
 [[nodiscard]] tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file);

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -61,6 +61,19 @@ tr_torrent const* tr_torrents::get(tr_sha1_digest_t const& hash) const
     return begin == end ? nullptr : *begin;
 }
 
+tr_torrent* tr_torrents::find_from_obfuscated_hash(tr_sha1_digest_t const& obfuscated_hash)
+{
+    for (auto* const tor : *this)
+    {
+        if (tor->obfuscated_hash == obfuscated_hash)
+        {
+            return tor;
+        }
+    }
+
+    return nullptr;
+}
+
 tr_torrent_id_t tr_torrents::add(tr_torrent* tor)
 {
     auto const id = static_cast<tr_torrent_id_t>(std::size(by_id_));

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -53,6 +53,9 @@ public:
         return get(metainfo.info_hash());
     }
 
+    // O(n)}
+    [[nodiscard]] tr_torrent* find_from_obfuscated_hash(tr_sha1_digest_t const& obfuscated_hash);
+
     // These convenience functions use get(tr_sha1_digest_t const&)
     // after parsing the magnet link to get the info hash. If you have
     // the info hash already, use get() instead to avoid excess parsing.


### PR DESCRIPTION
Pass a `tr_torrents&` and `TimerMaker&` into the `tr_peerMgr` and `HandshakeMediator` constructors so they can be used directly instead of indirectly via `tr_session`.

No functional changes.