### PR TITLE
fix: Speed information in Web-UI from overflowing

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -370,19 +370,32 @@ $toolbar-height: $toolbar-height-number * 1px;
 
 $speed-icon-size: 20px;
 
-.speed-up-icon,
-.speed-dn-icon {
-  fill: var(--color-fg-primary);
+.speed-info-status {
+  align-items: center;
+  display: flex;
+  height: 30px;
+  padding: 0;
 
-  svg {
-    width: $speed-icon-size;
+  .speed-up-icon,
+  .speed-dn-icon {
+    fill: var(--color-fg-primary);
+    width: 20px;
+    height: 30px;
+    svg {
+      width: $speed-icon-size;
+    }    
   }
+
+  #speed-dn-label,
+  #speed-up-label {
+    line-height: 30px;
+    padding-left: 3px;
+    width: 88px;    
+  }
+
 }
 
-#speed-dn-label,
-#speed-up-label {
-  text-align: right;
-}
+
 
 /// TORRENT CONTAINER
 

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -204,40 +204,40 @@
         <span class="flexible-space"></span>
         <span class="flex"></span>
         <div class="speed-info-status">
-        <div class="speed-dn-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="feather feather-chevron-down"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
-        </div>
-        <div id="speed-dn-label"></div>
-        <div class="speed-up-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="feather feather-chevron-up"
-          >
-            <polyline points="18 15 12 9 6 15"></polyline>
-          </svg>
-        </div>
-        <div id="speed-up-label"></div>
+          <div class="speed-dn-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="feather feather-chevron-down"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </div>
+          <div id="speed-dn-label"></div>
+          <div class="speed-up-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="feather feather-chevron-up"
+            >
+              <polyline points="18 15 12 9 6 15"></polyline>
+            </svg>
+          </div>
+          <div id="speed-up-label"></div>
         </div>
       </header>
 

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -203,6 +203,7 @@
         <span id="filter-count">&nbsp;</span>
         <span class="flexible-space"></span>
         <span class="flex"></span>
+        <div class="speed-info-status">
         <div class="speed-dn-icon">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -237,6 +238,7 @@
           </svg>
         </div>
         <div id="speed-up-label"></div>
+        </div>
       </header>
 
       <main class="mainwin-workarea">


### PR DESCRIPTION
## Fix Speed information in Web-UI from overflowing on both wide-ish screens (1400px) and smaller screens like iPad Minis.

Text was overflowing since the width's were set too small for the font sizes (which I didn't change) and the `div` between was/is set to `flex-grow: 1`. Left that, just added a wrapper around the speed-info for between CSS-scoping and compartmentalization, which also allowed for better control of vertical alignment as well.

### Before:
##### Wide Screen
![image](https://github.com/transmission/transmission/assets/5835530/f3274385-4fd0-45dc-af9e-c7a568ec3d05)
##### Small Screen
![image](https://github.com/transmission/transmission/assets/5835530/4f3d4a5e-778f-473d-8a18-79b930fbcbcd)

### After:
##### Wide Screen
![image](https://github.com/transmission/transmission/assets/5835530/cb4620cf-2323-4c25-bb40-8ee4a0602a8d)
##### Small Screen <sup><i>The red-outline is only because I had dev tools open when taking the screenshot</i></sup>
![image](https://github.com/transmission/transmission/assets/5835530/419d3a84-ddf2-454b-bceb-c4e63101393b)


Let me know if anyone has any questions or concerns. Thanks!

@ckerr 
