### PR TITLE
fix: formatting cmdline help message

### DIFF
--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -55,7 +55,7 @@ void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t sh
     auto const arg = getArgName(opt);
 
     fmt::print(
-        FMT_STRING(" {:s}{:<{}s} {:s}{:<{}s} {:<{}s}"),
+        FMT_STRING(" {:s}{:<{}s} {:s}{:<{}s} {:<{}s} "),
         std::empty(short_name) ? " "sv : "-"sv,
         short_name,
         short_width,
@@ -65,7 +65,7 @@ void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t sh
         arg,
         arg_width);
 
-    auto const d_indent = short_width + long_width + arg_width + 6U;
+    auto const d_indent = short_width + long_width + arg_width + 7U;
     auto const d_width = 80U - d_indent;
 
     auto description = std::string_view{ opt->description };


### PR DESCRIPTION
Since #3551, the space between the option argument and the description in the command line help message is gone.
This PR restores it.

For example, in `transmission-daemon`'s help message (before: top, after: below):

```console 
 -c   --watch-dir            <directory>Where to watch for new torrent files
 -c   --watch-dir            <directory> Where to watch for new torrent files
```