### PR TITLE
fix: crash after nullptr dereference in rpcimpl

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -134,7 +134,7 @@ auto getTorrents(tr_session* session, tr_variant* args)
                 std::begin(by_id),
                 std::end(by_id),
                 std::back_inserter(torrents),
-                [&cutoff](auto const* tor) { return tor->has_changed_since(cutoff); });
+                [&cutoff](auto const* tor) { return tor != nullptr && tor->has_changed_since(cutoff); });
         }
         else
         {
@@ -148,7 +148,12 @@ auto getTorrents(tr_session* session, tr_variant* args)
     else // all of them
     {
         auto const& by_id = session->torrents().sorted_by_id();
-        torrents = std::vector<tr_torrent*>{ std::begin(by_id), std::end(by_id) };
+        torrents.reserve(std::size(by_id));
+        std::copy_if(
+            std::begin(by_id),
+            std::end(by_id),
+            std::back_inserter(torrents),
+            [](auto const* tor) { return tor != nullptr; });
     }
 
     return torrents;


### PR DESCRIPTION
Follow up for #5604
Fixes #6172
