### PR TITLE
refactor: move tr_session::getAllTorrents to tr_torrents

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -127,7 +127,8 @@ auto getTorrents(tr_session* session, tr_variant* args)
         if (sv == "recently-active"sv)
         {
             auto const cutoff = tr_time() - RecentlyActiveSeconds;
-            torrents = session->torrents().get_if([cutoff](tr_torrent const* tor) { return tor->has_changed_since(cutoff); });
+            torrents = session->torrents().get_matching([cutoff](tr_torrent const* tor)
+                                                        { return tor->has_changed_since(cutoff); });
         }
         else
         {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -126,15 +126,8 @@ auto getTorrents(tr_session* session, tr_variant* args)
     {
         if (sv == "recently-active"sv)
         {
-            time_t const cutoff = tr_time() - RecentlyActiveSeconds;
-
-            auto const& by_id = session->torrents().sorted_by_id();
-            torrents.reserve(std::size(by_id));
-            std::copy_if(
-                std::begin(by_id),
-                std::end(by_id),
-                std::back_inserter(torrents),
-                [&cutoff](auto const* tor) { return tor != nullptr && tor->has_changed_since(cutoff); });
+            auto const cutoff = tr_time() - RecentlyActiveSeconds;
+            torrents = session->torrents().get_if([cutoff](tr_torrent const* tor) { return tor->has_changed_since(cutoff); });
         }
         else
         {
@@ -147,13 +140,7 @@ auto getTorrents(tr_session* session, tr_variant* args)
     }
     else // all of them
     {
-        auto const& by_id = session->torrents().sorted_by_id();
-        torrents.reserve(std::size(by_id));
-        std::copy_if(
-            std::begin(by_id),
-            std::end(by_id),
-            std::back_inserter(torrents),
-            [](auto const* tor) { return tor != nullptr; });
+        torrents = session->torrents().get_all();
     }
 
     return torrents;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1345,7 +1345,7 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
     // Close the torrents in order of most active to least active
     // so that the most important announce=stopped events are
     // fired out first...
-    auto torrents = getAllTorrents();
+    auto torrents = torrents_.get_all();
     std::sort(
         std::begin(torrents),
         std::end(torrents),

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -795,11 +795,6 @@ public:
         return settings_.idle_seeding_limit_minutes;
     }
 
-    [[nodiscard]] std::vector<tr_torrent*> getAllTorrents() const
-    {
-        return std::vector<tr_torrent*>{ std::begin(torrents()), std::end(torrents()) };
-    }
-
     /*module_visible*/
 
     auto rpcNotify(tr_rpc_callback_type type, tr_torrent* tor = nullptr)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -498,9 +498,9 @@ constexpr struct
 } CompareTorrentByQueuePosition{};
 
 #ifdef TR_ENABLE_ASSERTS
-bool queueIsSequenced(tr_session const* session)
+bool queueIsSequenced(tr_session const* const session)
 {
-    auto torrents = session->getAllTorrents();
+    auto torrents = session->torrents().get_all();
     std::sort(
         std::begin(torrents),
         std::end(torrents),

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -110,7 +110,7 @@ public:
         return std::empty(by_hash_);
     }
 
-    [[nodiscard]] auto get_if(std::function<bool(tr_torrent const*)> pred_in) const
+    [[nodiscard]] auto get_matching(std::function<bool(tr_torrent const*)> pred_in) const
     {
         auto const pred = [&pred_in](tr_torrent const* const tor)
         {
@@ -125,7 +125,7 @@ public:
 
     [[nodiscard]] auto get_all() const
     {
-        return get_if([](tr_torrent const*) { return true; });
+        return get_matching([](tr_torrent const*) { return true; });
     }
 
 private:

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -9,8 +9,11 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <algorithm>
 #include <cstddef> // size_t
 #include <ctime>
+#include <functional>
+#include <iterator>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -107,9 +110,22 @@ public:
         return std::empty(by_hash_);
     }
 
-    [[nodiscard]] constexpr auto const& sorted_by_id() const noexcept
+    [[nodiscard]] auto get_if(std::function<bool(tr_torrent const*)> pred_in) const
     {
-        return by_id_;
+        auto const pred = [&pred_in](tr_torrent const* const tor)
+        {
+            return tor != nullptr && pred_in(tor);
+        };
+
+        auto vec = std::vector<tr_torrent*>{};
+        vec.reserve(size());
+        std::copy_if(std::begin(by_id_), std::end(by_id_), std::back_inserter(vec), pred);
+        return vec;
+    }
+
+    [[nodiscard]] auto get_all() const
+    {
+        return get_if([](tr_torrent const*) { return true; });
     }
 
 private:


### PR DESCRIPTION
Follow up for #6177 that cleans up overlap of responsibilities between `tr_session::getAllTorrents()` and `tr_torrents::sorted_by_id()`.

tldr:

```diff
- tr_session::getAllTorrents()
- tr_torrents::sorted_by_id()
+ tr_session::get_matches(UnaryPredicate) { ... }
+ tr_session::get_all() { return get_if([](tr_torrent const*){ return true; }); }
```