### PR TITLE
fix: appendSanitizedComponent is too aggressive on non-WIN32 (and not enough aggressive on WIN32)

### DIFF
--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -307,13 +307,10 @@ void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdi
 namespace
 {
 
-[[nodiscard]] bool isUnixReservedFile(std::string_view in) noexcept
+// `isUnixReservedFile` and `isWin32ReservedFile` kept as `maybe_unused`
+// for potential support of different filesystems on the same OS
+[[nodiscard, maybe_unused]] bool isUnixReservedFile(std::string_view in) noexcept
 {
-    if (std::empty(in))
-    {
-        return false;
-    }
-
     static auto constexpr ReservedNames = std::array<std::string_view, 2>{
         "."sv,
         ".."sv,
@@ -327,7 +324,7 @@ namespace
 // COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
 // Also avoid these names followed immediately by an extension;
 // for example, NUL.txt is not recommended.
-[[nodiscard]] bool isWin32ReservedFile(std::string_view in) noexcept
+[[nodiscard, maybe_unused]] bool isWin32ReservedFile(std::string_view in) noexcept
 {
     if (std::empty(in))
     {
@@ -376,7 +373,9 @@ namespace
 #endif
 }
 
-[[nodiscard]] auto constexpr isUnixReservedChar(unsigned char ch) noexcept
+// `isUnixReservedChar` and `isWin32ReservedChar` kept as `maybe_unused`
+// for potential support of different filesystems on the same OS
+[[nodiscard, maybe_unused]] auto constexpr isUnixReservedChar(unsigned char ch) noexcept
 {
     return ch == '/';
 }
@@ -385,7 +384,7 @@ namespace
 // Use any character in the current code page for a name, including Unicode
 // characters and characters in the extended character set (128–255),
 // except for the following:
-[[nodiscard]] auto constexpr isWin32ReservedChar(unsigned char ch) noexcept
+[[nodiscard, maybe_unused]] auto constexpr isWin32ReservedChar(unsigned char ch) noexcept
 {
     switch (ch)
     {

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -179,6 +179,7 @@ TEST_F(TorrentFilesTest, isSubpathPortable)
         { "hello.txt", true },
         { "hello#.txt", true },
     } };
+#undef PORTABLE_UNIX_NOT_WIN32
 
     for (auto const& [subpath, expected] : Tests)
     {

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -143,34 +143,31 @@ TEST_F(TorrentFilesTest, hasAnyLocalData)
 
 TEST_F(TorrentFilesTest, isSubpathPortable)
 {
-#ifdef _WIN32
-#define PORTABLE_UNIX_NOT_WIN32 false
-#else
-#define PORTABLE_UNIX_NOT_WIN32 true
-#endif
+    static auto constexpr NotWin32 = TR_IF_WIN32(false, true);
+
     static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 18>{ {
         // never portable
         { ".", false },
         { "..", false },
 
         // don't end with periods
-        { "foo.", PORTABLE_UNIX_NOT_WIN32 },
-        { "foo..", PORTABLE_UNIX_NOT_WIN32 },
+        { "foo.", NotWin32 },
+        { "foo..", NotWin32 },
 
         // don't begin or end with whitespace
-        { " foo ", PORTABLE_UNIX_NOT_WIN32 },
-        { " foo", PORTABLE_UNIX_NOT_WIN32 },
-        { "foo ", PORTABLE_UNIX_NOT_WIN32 },
+        { " foo ", NotWin32 },
+        { " foo", NotWin32 },
+        { "foo ", NotWin32 },
 
         // reserved names
-        { "COM1", PORTABLE_UNIX_NOT_WIN32 },
-        { "COM1.txt", PORTABLE_UNIX_NOT_WIN32 },
-        { "Com1", PORTABLE_UNIX_NOT_WIN32 },
-        { "com1", PORTABLE_UNIX_NOT_WIN32 },
+        { "COM1", NotWin32 },
+        { "COM1.txt", NotWin32 },
+        { "Com1", NotWin32 },
+        { "com1", NotWin32 },
 
         // reserved characters
-        { "hell:o.txt", PORTABLE_UNIX_NOT_WIN32 },
-        { "hell\to.txt", PORTABLE_UNIX_NOT_WIN32 },
+        { "hell:o.txt", NotWin32 },
+        { "hell\to.txt", NotWin32 },
 
         // everything else
         { ".foo", true },
@@ -179,7 +176,6 @@ TEST_F(TorrentFilesTest, isSubpathPortable)
         { "hello.txt", true },
         { "hello#.txt", true },
     } };
-#undef PORTABLE_UNIX_NOT_WIN32
 
     for (auto const& [subpath, expected] : Tests)
     {

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -148,7 +148,7 @@ TEST_F(TorrentFilesTest, isSubpathPortable)
 #else
 #define PORTABLE_UNIX_NOT_WIN32 true
 #endif
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 15>{ {
+    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 18>{ {
         // never portable
         { ".", false },
         { "..", false },

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -143,30 +143,34 @@ TEST_F(TorrentFilesTest, hasAnyLocalData)
 
 TEST_F(TorrentFilesTest, isSubpathPortable)
 {
+#ifdef _WIN32
+#define PORTABLE_UNIX_NOT_WIN32 false
+#else
+#define PORTABLE_UNIX_NOT_WIN32 true
+#endif
     static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 15>{ {
+        // never portable
+        { ".", false },
+        { "..", false },
+
         // don't end with periods
-        { "foo.", false },
-        { "foo..", false },
+        { "foo.", PORTABLE_UNIX_NOT_WIN32 },
+        { "foo..", PORTABLE_UNIX_NOT_WIN32 },
 
         // don't begin or end with whitespace
-        { " foo ", false },
-        { " foo", false },
-        { "foo ", false },
+        { " foo ", PORTABLE_UNIX_NOT_WIN32 },
+        { " foo", PORTABLE_UNIX_NOT_WIN32 },
+        { "foo ", PORTABLE_UNIX_NOT_WIN32 },
 
-    // reserved names and characters (platform-dependent)
-#ifdef _WIN32
-        { "COM1", false },
-        { "COM1.txt", false },
-        { "Com1", false },
-        { "com1", false },
-        { "hell:o.txt", false },
-#else
-        { "COM1", true },
-        { "COM1.txt", true },
-        { "Com1", true },
-        { "com1", true },
-        { "hell:o.txt", true },
-#endif
+        // reserved names
+        { "COM1", PORTABLE_UNIX_NOT_WIN32 },
+        { "COM1.txt", PORTABLE_UNIX_NOT_WIN32 },
+        { "Com1", PORTABLE_UNIX_NOT_WIN32 },
+        { "com1", PORTABLE_UNIX_NOT_WIN32 },
+
+        // reserved characters
+        { "hell:o.txt", PORTABLE_UNIX_NOT_WIN32 },
+        { "hell\to.txt", PORTABLE_UNIX_NOT_WIN32 },
 
         // everything else
         { ".foo", true },


### PR DESCRIPTION
fix #5112

The current sanitation is (partially) only valid for Windows and is too aggressive for Linux/Apple, losing correct filenames.

- leading and trailing spaces are valid on Unix-like
- trailing dots are valid on Unix-like
- no reserved filenames on Unix-like except "." and ".."
- control chars are reserved on Win32

Testing:
1. make files or folders with such characteristics (like leading space, trailing space, quotes, slashes, backslashes, ...
2. `transmission-create <that file>`
3. `transmission-show <the generated torrent>`

tip: to create files with control characters:
```
date > "$(printf "foo\tbar")"
date > "$(printf "foo\nbar")"
```
This will create two distinct files.