### PR TITLE
chore: automated copyright update with GitHub Actions

### DIFF
--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -32,9 +32,18 @@ jobs:
           commitTitle: 'chore: update copyright year in user-facing files (2)'
           token: ${{ secrets.GITHUB_TOKEN }}
           path: |
-            macosx/nl.lproj/InfoPlist.strings
             macosx/Info.plist
             macosx/Info.plist.in
+            macosx/da.lproj/InfoPlist.strings
+            macosx/de.lproj/InfoPlist.strings
+            macosx/en.lproj/InfoPlist.strings
+            macosx/es.lproj/InfoPlist.strings
+            macosx/fr.lproj/InfoPlist.strings
+            macosx/it.lproj/InfoPlist.strings
+            macosx/nl.lproj/InfoPlist.strings
+            macosx/pt_PT.lproj/InfoPlist.strings
+            macosx/ru.lproj/InfoPlist.strings
+            macosx/tr.lproj/InfoPlist.strings
             macosx/QuickLookPlugin/Info.plist.in
             macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
           transform: (?<=Copyright © )(?<from>\d{4})?-?(\d{4})

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -34,16 +34,7 @@ jobs:
           path: |
             macosx/Info.plist
             macosx/Info.plist.in
-            macosx/da.lproj/InfoPlist.strings
-            macosx/de.lproj/InfoPlist.strings
-            macosx/en.lproj/InfoPlist.strings
-            macosx/es.lproj/InfoPlist.strings
-            macosx/fr.lproj/InfoPlist.strings
-            macosx/it.lproj/InfoPlist.strings
-            macosx/nl.lproj/InfoPlist.strings
-            macosx/pt_PT.lproj/InfoPlist.strings
-            macosx/ru.lproj/InfoPlist.strings
-            macosx/tr.lproj/InfoPlist.strings
+            macosx/*/InfoPlist.strings
             macosx/QuickLookPlugin/Info.plist.in
             macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
           transform: (?<=Copyright © )(?<from>\d{4})?-?(\d{4})

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -1,0 +1,46 @@
+name: Update copyright year(s)
+
+on:
+  schedule:
+    - cron: '0 3 1 1 *' # 03:00 AM on January 1
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+jobs:
+  update-copyright-years:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          prTitle: 'chore: update copyright years'
+          commitTitle: 'chore: update copyright year in COPYING'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: COPYING
+          transform: (?<=Copyright )(?<from>\d{4})?-?(\d{4})?   
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          commitTitle: 'chore: update copyright year in user-facing files (1)'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: |
+            gtk/Application.cc
+            qt/LicenseDialog.ui
+          transform: (?<=Copyright )(?<from>\d{4})?-?(\d{4})
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          commitTitle: 'chore: update copyright year in user-facing files (2)'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: |
+            macosx/nl.lproj/InfoPlist.strings
+            macosx/Info.plist
+            macosx/Info.plist.in
+            macosx/QuickLookPlugin/Info.plist.in
+            macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
+          transform: (?<=Copyright © )(?<from>\d{4})?-?(\d{4})
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          commitTitle: 'chore: update copyright year in cmake/transmission.rc.in'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: cmake/Transmission.rc.in
+          transform: (?<from>\d{4})?-?(\d{4})(?= Transmission Project)


### PR DESCRIPTION
This is a re-submit of PR #4852. Sorry for the inconvinience.

Added a workflow/action that will run at 03:00 AM in January 1st (or on demand) to update the copyright year in the following files:

- COPYING (aka the license file)
- User-facing/GUI files:
  - gtk/Application.cc
  - qt/LicenseDialog.ui
  - macosx/*/InfoPlist.strings
  - macosx/Info.plist
  - macosx/Info.plist.in
  - macosx/QuickLookPlugin/Info.plist.in
  - macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
- cmake/Transmission.rc.in (string file in CMAKE)


The Action will create a new branch called "license/copyright-to-YYYY" and a matching PR ("chore: update copyright years") with 4 commits inside (one for the license, two for user facing files, one for the CMAKE string). PR/commits will originate from the "github-actions" user. You are also able to change this (including using GPG sig), with [some additional flags](https://github.com/FantasticFiasco/action-update-license-year/#api).

You might need to:

- [ ] Choose "Read and Write Permission" and Enable the "Allow GitHub Actions to create and approve pull requests" flag in the repo's Settings (Actions -> General).

Hope this helps take a little load off. Thanks for the awesome piece of software.