### PR TITLE
chore: updated some leftover front-facing copyright years

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -70,7 +70,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/macosx/Info.plist.in
+++ b/macosx/Info.plist.in
@@ -74,7 +74,7 @@
 		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/macosx/QuickLookPlugin/Info.plist.in
+++ b/macosx/QuickLookPlugin/Info.plist.in
@@ -47,7 +47,7 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>QLNeedsToBeRunInMainThread</key>
 	<false/>
 	<key>QLPreviewHeight</key>

--- a/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
+++ b/macosx/QuickLookPlugin/QuickLookPlugin-Info.plist
@@ -49,7 +49,7 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2022 The Transmission Project</string>
+	<string>Copyright © 2005-2023 The Transmission Project</string>
 	<key>QLNeedsToBeRunInMainThread</key>
 	<false/>
 	<key>QLPreviewHeight</key>

--- a/macosx/nl.lproj/InfoPlist.strings
+++ b/macosx/nl.lproj/InfoPlist.strings
@@ -1,3 +1,3 @@
 /* Localized versions of Info.plist keys */
 
-NSHumanReadableCopyright = "Copyright © 2005-2022 The Transmission Project";
+NSHumanReadableCopyright = "Copyright © 2005-2023 The Transmission Project";

--- a/qt/LicenseDialog.ui
+++ b/qt/LicenseDialog.ui
@@ -20,7 +20,7 @@
       <bool>true</bool>
      </property>
      <property name="plainText">
-      <string notr="true">Copyright 2005-2022. All code is copyrighted by the respective authors.
+      <string notr="true">Copyright 2005-2023. All code is copyrighted by the respective authors.
 
 
 In addition, linking to and/or using OpenSSL is allowed.


### PR DESCRIPTION
While testing #6195, I noticed that some front-facing copyright notices had escaped the last update. Now all years in notices should be covered (either gone with #4850 or already changed from #4834 and other PRs); and the remaining ones should/will be automatically updated on January 1st by #6195.

Cheers!