### PR TITLE
chore: cleanup timespans in remaining headers

### DIFF
--- a/gtk/DynamicPropertyStore.h
+++ b/gtk/DynamicPropertyStore.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2012-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2023-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/global-ip-cache.h
+++ b/libtransmission/global-ip-cache.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2023-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -37,7 +37,7 @@
 
 using namespace std::literals;
 
-// Code in this namespace Copyright © 2022 Mnemosyne LLC.
+// Code in this namespace Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only), MIT (SPDX: MIT),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/libtransmission/utils.mm
+++ b/libtransmission/utils.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2022-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/macosx/DefaultAppHelper.h
+++ b/macosx/DefaultAppHelper.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/DefaultAppHelper.mm
+++ b/macosx/DefaultAppHelper.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2007-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupCell.h
+++ b/macosx/GroupCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ProgressBarView.h
+++ b/macosx/ProgressBarView.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/ProgressBarView.mm
+++ b/macosx/ProgressBarView.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/SmallTorrentCell.h
+++ b/macosx/SmallTorrentCell.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellActionButton.h
+++ b/macosx/TorrentCellActionButton.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellControlButton.h
+++ b/macosx/TorrentCellControlButton.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellRevealButton.h
+++ b/macosx/TorrentCellRevealButton.h
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -1,4 +1,4 @@
-// This file Copyright © 2006-2023 Transmission authors and contributors.
+// This file Copyright © Transmission authors and contributors.
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 

--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -1,5 +1,5 @@
 //    VDKQueue.h
-//  Copyright © 2017-2022 Transmission authors and contributors.
+//  Copyright © Transmission authors and contributors.
 //
 //  Based on VDKQueue (https://github.com/bdkjones/VDKQueue) which was created and copyrighted by Bryan D K Jones on 28 March 2012.
 //  Based on UKKQueue (https://github.com/uliwitness/UKFileWatcher) which was created and copyrighted by Uli Kusterer on 21 Dec 2003.

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -1,5 +1,5 @@
 //    VDKQueue.mm
-//  Copyright © 2017-2022 Transmission authors and contributors.
+//  Copyright © Transmission authors and contributors.
 //
 //  Based on VDKQueue (https://github.com/bdkjones/VDKQueue) which was created and copyrighted by Bryan D K Jones on 28 March 2012.
 //  Based on UKKQueue (https://github.com/uliwitness/UKFileWatcher) which was created and copyrighted by Uli Kusterer on 21 Dec 2003.

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2023-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/tests/libtransmission/tr-peer-info-test.cc
+++ b/tests/libtransmission/tr-peer-info-test.cc
@@ -1,4 +1,4 @@
-// This file Copyright © 2008-2023 Mnemosyne LLC.
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.

--- a/web/public_html/transmission-app.js.LICENSE.txt
+++ b/web/public_html/transmission-app.js.LICENSE.txt
@@ -1,8 +1,13 @@
-/* @license This file Copyright © Mnemosyne LLC.
+/* @license This file Copyright © 2020-2023 Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */
 
 /* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
    It may be used under GPLv2 (SPDX: GPL-2.0-only).
+   License text can be found in the licenses/ folder. */
+
+/* @license This file Copyright © Mnemosyne LLC.
+   It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+   or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/public_html/transmission-app.js.LICENSE.txt
+++ b/web/public_html/transmission-app.js.LICENSE.txt
@@ -1,13 +1,8 @@
-/* @license This file Copyright © 2020-2023 Mnemosyne LLC.
+/* @license This file Copyright © Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */
 
 /* @license This file Copyright © Charles Kerr, Dave Perrett, Malcolm Jarvis and Bruno Bierbaumer
    It may be used under GPLv2 (SPDX: GPL-2.0-only).
-   License text can be found in the licenses/ folder. */
-
-/* @license This file Copyright © Mnemosyne LLC.
-   It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
-   or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */

--- a/web/src/force-verify-dialog.js
+++ b/web/src/force-verify-dialog.js
@@ -1,4 +1,4 @@
-/* @license This file Copyright © 2020-2023 Mnemosyne LLC.
+/* @license This file Copyright © Mnemosyne LLC.
    It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */


### PR DESCRIPTION
See #4850. Did a sweep through the repo to catch some "wrong" copyright headers and correct them. We should be good now.