### PR TITLE
ci: bump macos-11 to macos-12 in github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -227,8 +227,8 @@ jobs:
         run: |
           if grep 'warning:' makelog; then exit 1; fi
 
-  macos-11:
-    runs-on: macos-11
+  macos-12:
+    runs-on: macos-12
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-mac == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     steps:
@@ -500,10 +500,10 @@ jobs:
           name: source-tarball
           path: obj/transmission*.tar.*
 
-  macos-11-from-tarball:
+  macos-12-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-mac == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Show Configuration
         run: |

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1216,9 +1216,7 @@ constexpr bool tr_isTorrent(tr_torrent const* tor)
     return tor != nullptr && tor->session != nullptr;
 }
 
-/**
- * Tell the `tr_torrent` that it's gotten a block
- */
+// Tell the `tr_torrent` that it's gotten a block
 void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
 
 tr_torrent_metainfo tr_ctorStealMetainfo(tr_ctor* ctor);


### PR DESCRIPTION
This is an experimental PR to see if github has more `macos-12` runners available, since the `macos-11` actions seem to be permanently hung waiting for an available macos-11 runner.

I haven't seen any announcement that the macos-11 runners are being removed, so this is guesswork on my part from [this table](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) and from #6197. 6197 tells us that the runners have been getting updates lately, and the table shows us that actions support the latest two versions of each OS and that macos-13 has been in beta. So maybe what's happening is actions have moved on to macos-12 + macos-13.

Hey macOS @transmission/contributors, is there any downside to running these tasks with 12 instead of 11?