### PR TITLE
Adjust slider limits in Qt

### DIFF
--- a/qt/MakeDialog.ui
+++ b/qt/MakeDialog.ui
@@ -82,10 +82,10 @@
      <item row="4" column="1">
       <widget class="QSlider" name="pieceSizeSlider">
        <property name="minimum">
-        <number>10</number>
+        <number>14</number>
        </property>
        <property name="maximum">
-        <number>26</number>
+        <number>28</number>
        </property>
        <property name="pageStep">
         <number>1</number>


### PR DESCRIPTION
Modify the new torrent -dialog piece size slider to have a range between 16KiB - 256MiB

This fixes feature disparity for Qt https://github.com/transmission/transmission/issues/5955
