### PR TITLE
!build: turning Qt6 MACOS_SUPPORT_MINIMUM up to 11

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -1,5 +1,8 @@
 set_property(GLOBAL PROPERTY AUTOGEN_SOURCE_GROUP "Generated Files")
 
+# https://doc.qt.io/qt-6/macos.html#supported-versions
+set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
+
 add_executable(${TR_NAME}-qt WIN32)
 
 target_sources(${TR_NAME}-qt


### PR DESCRIPTION
Trying to workaround #6206 build regression on macOS, by increasing CMAKE_OSX_DEPLOYMENT_TARGET, but only for Qt.