### PR TITLE
chore: Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ node_modules/
 /third-party/suffixes_dafsa.h
 /web/public_html/transmission-app.js.map
 
+# clangd compile commands
+compile_commands.json
+
 # CLion IDE build directory
 /cmake-build-*/


### PR DESCRIPTION
This file should be placed in the project root
for clangd to pick it up.
At least VSCode do not have settings to specify some custom path.