### PR TITLE
refactor: optionally include 0 byte files when computing file offset

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -184,6 +184,7 @@ uint64_t tr_completion::count_has_bytes_in_span(tr_byte_span_t span) const
     span.begin = std::clamp(span.begin, uint64_t{ 0 }, block_info_->total_size());
     span.end = std::clamp(span.end, uint64_t{ 0 }, block_info_->total_size());
     auto const [begin_byte, end_byte] = span;
+    TR_ASSERT(end_byte >= begin_byte);
     if (begin_byte >= end_byte)
     {
         return 0;

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -39,7 +39,7 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
 
         if (file_size != 0)
         {
-            end_byte = offset + file_size;
+            end_byte = begin_byte + file_size;
             auto const final_byte = end_byte - 1;
             auto const final_piece = block_info.byte_loc(final_byte).piece;
             end_piece = final_piece + 1;
@@ -52,8 +52,8 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
             // TODO(ckerr): should end_piece == begin_piece, same as _bytes are?
             end_piece = begin_piece + 1;
         }
-        file_pieces_[i] = piece_span_t{ begin_piece, end_piece };
         file_bytes_[i] = byte_span_t{ begin_byte, end_byte };
+        file_pieces_[i] = piece_span_t{ begin_piece, end_piece };
         offset += file_size;
     }
 
@@ -73,7 +73,7 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
 
 tr_file_piece_map::file_span_t tr_file_piece_map::file_span(tr_piece_index_t piece) const
 {
-    constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
+    static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
     auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
     return { static_cast<tr_file_index_t>(equal_begin - begin), static_cast<tr_file_index_t>(equal_end - begin) };
@@ -81,7 +81,7 @@ tr_file_piece_map::file_span_t tr_file_piece_map::file_span(tr_piece_index_t pie
 
 tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset) const
 {
-    constexpr auto Compare = CompareToSpan<uint64_t>{};
+    static constexpr auto Compare = CompareToSpan<uint64_t>{};
     auto const begin = std::begin(file_bytes_);
     auto const it = std::lower_bound(begin, std::end(file_bytes_), offset, Compare);
     tr_file_index_t const file_index = std::distance(begin, it);

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -76,7 +76,7 @@ tr_file_piece_map::file_span_t tr_file_piece_map::file_span(tr_piece_index_t pie
     constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
     auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
-    return { tr_piece_index_t(equal_begin - begin), tr_piece_index_t(equal_end - begin) };
+    return { static_cast<tr_file_index_t>(equal_begin - begin), static_cast<tr_file_index_t>(equal_end - begin) };
 }
 
 tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset) const

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -26,8 +26,8 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
     auto edge_pieces = small::set<tr_piece_index_t, 1024U>{};
     edge_pieces.reserve(n_files * 2U);
 
-    uint64_t offset = 0;
-    for (tr_file_index_t i = 0; i < n_files; ++i)
+    uint64_t offset = 0U;
+    for (tr_file_index_t i = 0U; i < n_files; ++i)
     {
         auto const file_size = file_sizes[i];
         auto const begin_byte = offset;
@@ -37,12 +37,12 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
 
         edge_pieces.insert(begin_piece);
 
-        if (file_size != 0)
+        if (file_size != 0U)
         {
             end_byte = begin_byte + file_size;
-            auto const final_byte = end_byte - 1;
+            auto const final_byte = end_byte - 1U;
             auto const final_piece = block_info.byte_loc(final_byte).piece;
-            end_piece = final_piece + 1;
+            end_piece = final_piece + 1U;
 
             edge_pieces.insert(final_piece);
         }
@@ -50,7 +50,7 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* f
         {
             end_byte = begin_byte;
             // TODO(ckerr): should end_piece == begin_piece, same as _bytes are?
-            end_piece = begin_piece + 1;
+            end_piece = begin_piece + 1U;
         }
         file_bytes_[i] = byte_span_t{ begin_byte, end_byte };
         file_pieces_[i] = piece_span_t{ begin_piece, end_piece };
@@ -64,7 +64,7 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
 {
     auto const n = tm.file_count();
     auto file_sizes = std::vector<uint64_t>(n);
-    for (tr_file_index_t i = 0; i < n; ++i)
+    for (tr_file_index_t i = 0U; i < n; ++i)
     {
         file_sizes[i] = tm.file_size(i);
     }
@@ -115,7 +115,7 @@ void tr_file_priorities::set(tr_file_index_t file, tr_priority_t new_priority)
 
 void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority_t new_priority)
 {
-    for (size_t i = 0; i < n; ++i)
+    for (size_t i = 0U; i < n; ++i)
     {
         set(files[i], new_priority);
     }
@@ -173,7 +173,7 @@ void tr_files_wanted::set(tr_file_index_t file, bool wanted)
 
 void tr_files_wanted::set(tr_file_index_t const* files, size_t n, bool wanted)
 {
-    for (size_t i = 0; i < n; ++i)
+    for (size_t i = 0U; i < n; ++i)
     {
         set(files[i], wanted);
     }
@@ -187,5 +187,5 @@ bool tr_files_wanted::piece_wanted(tr_piece_index_t piece) const
     }
 
     auto const [begin, end] = fpm_->file_span(piece);
-    return wanted_.count(begin, end) != 0;
+    return wanted_.count(begin, end) != 0U;
 }

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -73,17 +73,17 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
 
 tr_file_piece_map::file_span_t tr_file_piece_map::file_span(tr_piece_index_t piece) const
 {
-    static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
+    static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{ false };
     auto const begin = std::begin(file_pieces_);
     auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
     return { static_cast<tr_file_index_t>(equal_begin - begin), static_cast<tr_file_index_t>(equal_end - begin) };
 }
 
-tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset) const
+tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset, bool include_empty_files) const
 {
-    static constexpr auto Compare = CompareToSpan<uint64_t>{};
+    auto const compare = CompareToSpan<uint64_t>{ include_empty_files };
     auto const begin = std::begin(file_bytes_);
-    auto const it = std::lower_bound(begin, std::end(file_bytes_), offset, Compare);
+    auto const it = std::lower_bound(begin, std::end(file_bytes_), offset, compare);
     tr_file_index_t const file_index = std::distance(begin, it);
     auto const file_offset = offset - it->begin;
     return file_offset_t{ file_index, file_offset };

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -18,6 +18,7 @@
 
 #include "libtransmission/bitfield.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR20
+#include "libtransmission/utils.h"
 
 struct tr_block_info;
 struct tr_torrent_metainfo;
@@ -62,7 +63,7 @@ public:
 
     [[nodiscard]] file_span_t file_span(tr_piece_index_t piece) const;
 
-    [[nodiscard]] file_offset_t file_offset(uint64_t offset) const;
+    [[nodiscard]] file_offset_t file_offset(uint64_t offset, bool include_empty_files) const;
 
     [[nodiscard]] TR_CONSTEXPR20 size_t size() const
     {
@@ -103,6 +104,11 @@ private:
 
         [[nodiscard]] constexpr int compare(T item, span_t span) const // <=>
         {
+            if (include_empty_span && span.begin == span.end)
+            {
+                return tr_compare_3way(item, span.begin);
+            }
+
             if (item < span.begin)
             {
                 return -1;
@@ -130,6 +136,8 @@ private:
         {
             return compare(span, item) < 0;
         }
+
+        bool const include_empty_span;
     };
 };
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -77,7 +77,7 @@ public:
     // TODO(ckerr) minor wart here, two identical span types
     [[nodiscard]] TR_CONSTEXPR20 tr_byte_span_t byte_span(tr_file_index_t file) const
     {
-        auto const& span = file_bytes_.at(file);
+        auto const& span = file_bytes_[file];
         return tr_byte_span_t{ span.begin, span.end };
     }
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -214,7 +214,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         return EINVAL;
     }
 
-    auto [file_index, file_offset] = tor->file_offset(loc);
+    auto [file_index, file_offset] = tor->file_offset(loc, true);
 
     while (buflen != 0)
     {

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -214,7 +214,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         return EINVAL;
     }
 
-    auto [file_index, file_offset] = tor->file_offset(loc, true);
+    auto [file_index, file_offset] = tor->file_offset(loc, false);
 
     while (buflen != 0)
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -321,9 +321,9 @@ public:
         return fpm_.piece_span(file);
     }
 
-    [[nodiscard]] auto file_offset(tr_block_info::Location loc) const
+    [[nodiscard]] auto file_offset(tr_block_info::Location loc, bool include_empty_files) const
     {
-        return fpm_.file_offset(loc.byte);
+        return fpm_.file_offset(loc.byte, include_empty_files);
     }
 
     [[nodiscard]] auto byte_span(tr_file_index_t file) const

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -518,7 +518,7 @@ void task_request_next_chunk(tr_webseed_task* task)
 
     auto const loc = tor->byte_loc(task->loc.byte + evbuffer_get_length(task->content()));
 
-    auto const [file_index, file_offset] = tor->file_offset(loc);
+    auto const [file_index, file_offset] = tor->file_offset(loc, false);
     auto const left_in_file = tor->file_size(file_index) - file_offset;
     auto const left_in_task = task->end_byte - loc.byte;
     auto const this_chunk = std::min(left_in_file, left_in_task);

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -25,10 +25,11 @@ protected:
     static constexpr size_t TotalSize{ 10 * PieceSize + 1 };
     tr_block_info const block_info_{ TotalSize, PieceSize };
 
-    static constexpr std::array<uint64_t, 17> FileSizes{
-        5 * PieceSize, // [offset 0] begins and ends on a piece boundary
+    static constexpr std::array<uint64_t, 18> FileSizes{
+        0, // [offset 0] zero-sized file
+        PieceSize, // [offset 0] begins and ends on a piece boundary (preceded by zero sized file)
+        4 * PieceSize, // [offset P] begins and ends on a piece boundary
         0, // [offset 5 P] zero-sized files
-        0,
         0,
         0,
         PieceSize / 2, // [offset 5 P] begins on a piece boundary
@@ -51,7 +52,7 @@ protected:
         static_assert(
             FileSizes[0] + FileSizes[1] + FileSizes[2] + FileSizes[3] + FileSizes[4] + FileSizes[5] + FileSizes[6] +
                 FileSizes[7] + FileSizes[8] + FileSizes[9] + FileSizes[10] + FileSizes[11] + FileSizes[12] + FileSizes[13] +
-                FileSizes[14] + FileSizes[15] + FileSizes[16] ==
+                FileSizes[14] + FileSizes[15] + FileSizes[16] + FileSizes[17] ==
             TotalSize);
 
         EXPECT_EQ(11U, block_info_.piece_count());
@@ -61,33 +62,59 @@ protected:
     }
 };
 
-TEST_F(FilePieceMapTest, fileOffset)
+TEST_F(FilePieceMapTest, fileOffsetNoEmptyFiles)
 {
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
 
-    // first byte of the first file
-    auto file_offset = fpm.file_offset(0);
-    EXPECT_EQ(0U, file_offset.index);
+    // first byte of file #1 (first nonzero file)
+    auto file_offset = fpm.file_offset(0, false);
+    EXPECT_EQ(1U, file_offset.index);
     EXPECT_EQ(0U, file_offset.offset);
 
-    // final byte of the first file
-    file_offset = fpm.file_offset(FileSizes[0] - 1);
-    EXPECT_EQ(0U, file_offset.index);
-    EXPECT_EQ(FileSizes[0] - 1, file_offset.offset);
+    // final byte of file #1 (first nonzero file)
+    file_offset = fpm.file_offset(FileSizes[1] - 1, false);
+    EXPECT_EQ(1U, file_offset.index);
+    EXPECT_EQ(FileSizes[1] - 1, file_offset.offset);
 
-    // first byte of the second file
-    // NB: this is an edge case, second file is 0 bytes.
-    // The second nonzero file is file #5
-    file_offset = fpm.file_offset(FileSizes[0]);
-    EXPECT_EQ(5U, file_offset.index);
+    // first byte of file #6 (nonzero file preceded by zero file)
+    // NB: this is an edge case, file #3 is 0 bytes.
+    // The next nonzero file is file #6
+    file_offset = fpm.file_offset(FileSizes[1] + FileSizes[2], false);
+    EXPECT_EQ(6U, file_offset.index);
     EXPECT_EQ(0U, file_offset.offset);
 
     // the last byte of in the torrent.
     // NB: reverse of previous edge case, since
     // the final 4 files in the torrent are all 0 bytes
-    file_offset = fpm.file_offset(TotalSize - 1);
-    EXPECT_EQ(12U, file_offset.index);
-    EXPECT_EQ(FileSizes[12] - 1, file_offset.offset);
+    // the fifth file from end will be selected
+    file_offset = fpm.file_offset(TotalSize - 1, false);
+    EXPECT_EQ(13U, file_offset.index);
+    EXPECT_EQ(FileSizes[13] - 1, file_offset.offset);
+}
+
+TEST_F(FilePieceMapTest, fileOffsetWithEmptyFiles)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+
+    // first byte of file #0 (zero file)
+    auto file_offset = fpm.file_offset(0, true);
+    EXPECT_EQ(0U, file_offset.index);
+    EXPECT_EQ(0U, file_offset.offset);
+
+    // first byte of file #3 (zero file preceded by nonzero file)
+    // NB: this is an edge case, file #3 is 0 bytes.
+    // The next nonzero file is file #6
+    file_offset = fpm.file_offset(FileSizes[1] + FileSizes[2], true);
+    EXPECT_EQ(3U, file_offset.index);
+    EXPECT_EQ(0U, file_offset.offset);
+
+    // the last byte of in the torrent.
+    // NB: reverse of previous edge case, since
+    // the final 4 files in the torrent are all 0 bytes
+    // the fifth file from end will be selected
+    file_offset = fpm.file_offset(TotalSize - 1, true);
+    EXPECT_EQ(13U, file_offset.index);
+    EXPECT_EQ(FileSizes[13] - 1, file_offset.offset);
 }
 
 TEST_F(FilePieceMapTest, pieceSpan)
@@ -95,9 +122,10 @@ TEST_F(FilePieceMapTest, pieceSpan)
     // Note to reviewers: it's easy to see a nonexistent fencepost error here.
     // Remember everything is zero-indexed, so the 11 valid pieces are [0..10]
     // and that last piece #10 has one byte in it. Piece #11 is the 'end' iterator position.
-    auto constexpr ExpectedPieceSpans = std::array<tr_file_piece_map::piece_span_t, 17>{ {
-        { 0, 5 },
-        { 5, 6 },
+    static auto constexpr ExpectedPieceSpans = std::array<tr_file_piece_map::piece_span_t, 18>{ {
+        { 0, 1 },
+        { 0, 1 },
+        { 1, 5 },
         { 5, 6 },
         { 5, 6 },
         { 5, 6 },
@@ -172,13 +200,14 @@ TEST_F(FilePieceMapTest, priorities)
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
-    // set the first file as high priority.
+    // set the file #2 as high priority.
     // since this begins and ends on a piece boundary,
+    // and it is not preceded by a zero sized file,
     // this shouldn't affect any other files' pieces
     auto pri = TR_PRI_HIGH;
-    file_priorities.set(0, pri);
-    expected_file_priorities[0] = pri;
-    for (size_t i = 0; i < 5; ++i)
+    file_priorities.set(2, pri);
+    expected_file_priorities[2] = pri;
+    for (size_t i = 1; i < 5; ++i)
     {
         expected_piece_priorities[i] = pri;
     }
@@ -187,27 +216,27 @@ TEST_F(FilePieceMapTest, priorities)
 
     // This file shares a piece with another file.
     // If _either_ is set to high, the piece's priority should be high.
-    // file #5: byte [500..550) piece [5, 6)
-    // file #6: byte [550..650) piece [5, 7)
+    // file #6: byte [500..550) piece [5, 6)
+    // file #7: byte [550..650) piece [5, 7)
     //
-    // first test setting file #5...
+    // first test setting file #6...
     pri = TR_PRI_HIGH;
-    file_priorities.set(5, pri);
-    expected_file_priorities[5] = pri;
+    file_priorities.set(6, pri);
+    expected_file_priorities[6] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // ...and that shared piece should still be the same when both are high...
-    file_priorities.set(6, pri);
-    expected_file_priorities[6] = pri;
+    file_priorities.set(7, pri);
+    expected_file_priorities[7] = pri;
     expected_piece_priorities[5] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
-    // ...and that shared piece should still be the same when only 6 is high...
+    // ...and that shared piece should still be the same when only 7 is high...
     pri = TR_PRI_NORMAL;
-    file_priorities.set(5, pri);
-    expected_file_priorities[5] = pri;
+    file_priorities.set(6, pri);
+    expected_file_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
@@ -224,19 +253,19 @@ TEST_F(FilePieceMapTest, priorities)
 
     // Raise the priority of a small 1-piece file.
     // Since it's the highest priority in the piece, piecePriority() should return its value.
-    // file #8: byte [650, 659) piece [6, 7)
+    // file #9: byte [650, 659) piece [6, 7)
     pri = TR_PRI_NORMAL;
-    file_priorities.set(8, pri);
-    expected_file_priorities[8] = pri;
+    file_priorities.set(9, pri);
+    expected_file_priorities[9] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Raise the priority of another small 1-piece file in the same piece.
     // Since _it_ now has the highest priority in the piece, piecePriority should return _its_ value.
-    // file #9: byte [659, 667) piece [6, 7)
+    // file #10: byte [659, 667) piece [6, 7)
     pri = TR_PRI_HIGH;
-    file_priorities.set(9, pri);
-    expected_file_priorities[9] = pri;
+    file_priorities.set(10, pri);
+    expected_file_priorities[10] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
@@ -259,17 +288,17 @@ TEST_F(FilePieceMapTest, priorities)
     // other does no real harm. Let's KISS.
     //
     // Check that even zero-sized files can change a piece's priority
-    // file #1: byte [500, 500) piece [5, 6)
+    // file #3: byte [500, 500) piece [5, 6)
     pri = TR_PRI_HIGH;
-    file_priorities.set(1, pri);
-    expected_file_priorities[1] = pri;
+    file_priorities.set(3, pri);
+    expected_file_priorities[3] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's priority.
-    // file #16 byte [1001, 1001) piece [10, 11)
-    file_priorities.set(16, pri);
-    expected_file_priorities[16] = pri;
+    // file #17 byte [1001, 1001) piece [10, 11)
+    file_priorities.set(17, pri);
+    expected_file_priorities[17] = pri;
     expected_piece_priorities[10] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
@@ -297,18 +326,22 @@ TEST_F(FilePieceMapTest, wanted)
     auto files_wanted = tr_files_wanted(&fpm);
     tr_file_index_t const n_files = std::size(FileSizes);
 
-    // make a helper to compare file & piece priorities
+    // make a helper to compare file & piece wanted bitfields
     auto expected_files_wanted = tr_bitfield(n_files);
     auto expected_pieces_wanted = tr_bitfield(block_info_.piece_count());
     auto const compare_to_expected = [&, this]()
     {
         for (tr_file_index_t i = 0; i < n_files; ++i)
         {
-            EXPECT_EQ(int(expected_files_wanted.test(i)), int(files_wanted.file_wanted(i)));
+            auto const expected = int{ expected_files_wanted.test(i) };
+            auto const actual = int{ files_wanted.file_wanted(i) };
+            EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
         for (tr_piece_index_t i = 0; i < block_info_.piece_count(); ++i)
         {
-            EXPECT_EQ(int(expected_pieces_wanted.test(i)), int(files_wanted.piece_wanted(i)));
+            auto const expected = int{ expected_pieces_wanted.test(i) };
+            auto const actual = int{ files_wanted.piece_wanted(i) };
+            EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
     };
 
@@ -317,57 +350,56 @@ TEST_F(FilePieceMapTest, wanted)
     expected_pieces_wanted.set_has_all();
     compare_to_expected();
 
-    // set the first file as not wanted.
-    // since this begins and ends on a piece boundary,
-    // this shouldn't affect any other files' pieces
+    // set file #2 as not wanted.
+    // since this file begins and ends on a piece boundary,
+    // and it is not preceded by a zero sized file,
+    // this shouldn't normally affect any other files' pieces
     bool const wanted = false;
-    files_wanted.set(0, wanted);
-    expected_files_wanted.set(0, wanted);
-    expected_pieces_wanted.set_span(0, 5, wanted);
+    files_wanted.set(2, wanted);
+    expected_files_wanted.set(2, wanted);
+    expected_pieces_wanted.set_span(1, 5, wanted);
     compare_to_expected();
 
     // now test when a piece has >1 file.
     // if *any* file in that piece is wanted, then we want the piece too.
-    // file #1: byte [100..100) piece [5, 6) (zero-byte file)
-    // file #2: byte [100..100) piece [5, 6) (zero-byte file)
     // file #3: byte [100..100) piece [5, 6) (zero-byte file)
     // file #4: byte [100..100) piece [5, 6) (zero-byte file)
-    // file #5: byte [500..550) piece [5, 6)
-    // file #6: byte [550..650) piece [5, 7)
+    // file #5: byte [100..100) piece [5, 6) (zero-byte file)
+    // file #6: byte [500..550) piece [5, 6)
+    // file #7: byte [550..650) piece [5, 7)
     //
-    // first test setting file #5...
-    files_wanted.set(5, false);
-    expected_files_wanted.unset(5);
+    // first test setting file #6...
+    files_wanted.set(6, false);
+    expected_files_wanted.unset(6);
     compare_to_expected();
     // marking all the files in the piece as unwanted
     // should cause the piece to become unwanted
-    files_wanted.set(1, false);
-    files_wanted.set(2, false);
     files_wanted.set(3, false);
     files_wanted.set(4, false);
     files_wanted.set(5, false);
     files_wanted.set(6, false);
-    expected_files_wanted.set_span(1, 7, false);
+    files_wanted.set(7, false);
+    expected_files_wanted.set_span(3, 8, false);
     expected_pieces_wanted.unset(5);
     compare_to_expected();
     // but as soon as any of them is turned back to wanted,
     // the piece should pop back.
-    files_wanted.set(6, true);
-    expected_files_wanted.set(6, true);
+    files_wanted.set(7, true);
+    expected_files_wanted.set(7, true);
     expected_pieces_wanted.set(5);
+    compare_to_expected();
+    files_wanted.set(6, true);
+    files_wanted.set(7, false);
+    expected_files_wanted.set(6);
+    expected_files_wanted.unset(7);
     compare_to_expected();
     files_wanted.set(5, true);
     files_wanted.set(6, false);
     expected_files_wanted.set(5);
     expected_files_wanted.unset(6);
     compare_to_expected();
-    files_wanted.set(4, true);
-    files_wanted.set(5, false);
-    expected_files_wanted.set(4);
-    expected_files_wanted.unset(5);
-    compare_to_expected();
 
-    // Prep for the next test: set all files to unwanted priority
+    // Prep for the next test: set all files to unwanted
     for (tr_file_index_t i = 0; i < n_files; ++i)
     {
         files_wanted.set(i, false);
@@ -379,18 +411,18 @@ TEST_F(FilePieceMapTest, wanted)
     // *Sigh* OK what happens to files_wanted if you say the only
     // file you want is a zero-byte file? Arguably nothing should happen
     // since you can't download a zero-byte file. But that would complicate
-    // the coe for a stupid use case, so let's KISS.
+    // the code for a stupid use case, so let's KISS.
     //
-    // Check that even zero-sized files can change a file's 'wanted' state
-    // file #1: byte [500, 500) piece [5, 6)
-    files_wanted.set(1, true);
-    expected_files_wanted.set(1);
+    // Check that even zero-sized files can change a piece's 'wanted' state
+    // file #3: byte [500, 500) piece [5, 6)
+    files_wanted.set(3, true);
+    expected_files_wanted.set(3);
     expected_pieces_wanted.set(5);
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's state.
-    // file #16 byte [1001, 1001) piece [10, 11)
-    files_wanted.set(16, true);
-    expected_files_wanted.set(16);
+    // file #17 byte [1001, 1001) piece [10, 11)
+    files_wanted.set(17, true);
+    expected_files_wanted.set(17);
     expected_pieces_wanted.set(10);
     compare_to_expected();
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -26,24 +26,24 @@ protected:
     tr_block_info const block_info_{ TotalSize, PieceSize };
 
     static constexpr std::array<uint64_t, 18> FileSizes{
-        0, // [offset 0] zero-sized file
+        0U, // [offset 0] zero-sized file
         PieceSize, // [offset 0] begins and ends on a piece boundary (preceded by zero sized file)
-        4 * PieceSize, // [offset P] begins and ends on a piece boundary
-        0, // [offset 5 P] zero-sized files
-        0,
-        0,
-        PieceSize / 2, // [offset 5 P] begins on a piece boundary
+        4U * PieceSize, // [offset P] begins and ends on a piece boundary
+        0U, // [offset 5 P] zero-sized files
+        0U,
+        0U,
+        PieceSize / 2U, // [offset 5 P] begins on a piece boundary
         PieceSize, // [offset 5.5 P] neither begins nor ends on a piece boundary, spans >1 piece
-        10, // [offset 6.5 P] small files all contained in a single piece
-        9,
-        8,
-        7,
-        6,
-        (3 * PieceSize + PieceSize / 2 + 1 - 10 - 9 - 8 - 7 - 6), // [offset 5.75P +10+9+8+7+6] ends end-of-torrent
-        0, // [offset 10P+1] zero-sized files at the end-of-torrent
-        0,
-        0,
-        0,
+        10U, // [offset 6.5 P] small files all contained in a single piece
+        9U,
+        8U,
+        7U,
+        6U,
+        (3U * PieceSize + PieceSize / 2U + 1U - 10U - 9U - 8U - 7U - 6U), // [offset 5.75P +10+9+8+7+6] ends end-of-torrent
+        0U, // [offset 10P+1] zero-sized files at the end-of-torrent
+        0U,
+        0U,
+        0U,
         // sum is 10P + 1 == TotalSize
     };
 
@@ -67,14 +67,14 @@ TEST_F(FilePieceMapTest, fileOffsetNoEmptyFiles)
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
 
     // first byte of file #1 (first nonzero file)
-    auto file_offset = fpm.file_offset(0, false);
+    auto file_offset = fpm.file_offset(0U, false);
     EXPECT_EQ(1U, file_offset.index);
     EXPECT_EQ(0U, file_offset.offset);
 
     // final byte of file #1 (first nonzero file)
-    file_offset = fpm.file_offset(FileSizes[1] - 1, false);
+    file_offset = fpm.file_offset(FileSizes[1] - 1U, false);
     EXPECT_EQ(1U, file_offset.index);
-    EXPECT_EQ(FileSizes[1] - 1, file_offset.offset);
+    EXPECT_EQ(FileSizes[1] - 1U, file_offset.offset);
 
     // first byte of file #6 (nonzero file preceded by zero file)
     // NB: this is an edge case, file #3 is 0 bytes.
@@ -87,9 +87,9 @@ TEST_F(FilePieceMapTest, fileOffsetNoEmptyFiles)
     // NB: reverse of previous edge case, since
     // the final 4 files in the torrent are all 0 bytes
     // the fifth file from end will be selected
-    file_offset = fpm.file_offset(TotalSize - 1, false);
+    file_offset = fpm.file_offset(TotalSize - 1U, false);
     EXPECT_EQ(13U, file_offset.index);
-    EXPECT_EQ(FileSizes[13] - 1, file_offset.offset);
+    EXPECT_EQ(FileSizes[13] - 1U, file_offset.offset);
 }
 
 TEST_F(FilePieceMapTest, fileOffsetWithEmptyFiles)
@@ -97,7 +97,7 @@ TEST_F(FilePieceMapTest, fileOffsetWithEmptyFiles)
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
 
     // first byte of file #0 (zero file)
-    auto file_offset = fpm.file_offset(0, true);
+    auto file_offset = fpm.file_offset(0U, true);
     EXPECT_EQ(0U, file_offset.index);
     EXPECT_EQ(0U, file_offset.offset);
 
@@ -112,9 +112,9 @@ TEST_F(FilePieceMapTest, fileOffsetWithEmptyFiles)
     // NB: reverse of previous edge case, since
     // the final 4 files in the torrent are all 0 bytes
     // the fifth file from end will be selected
-    file_offset = fpm.file_offset(TotalSize - 1, true);
+    file_offset = fpm.file_offset(TotalSize - 1U, true);
     EXPECT_EQ(13U, file_offset.index);
-    EXPECT_EQ(FileSizes[13] - 1, file_offset.offset);
+    EXPECT_EQ(FileSizes[13] - 1U, file_offset.offset);
 }
 
 TEST_F(FilePieceMapTest, pieceSpan)
@@ -123,39 +123,39 @@ TEST_F(FilePieceMapTest, pieceSpan)
     // Remember everything is zero-indexed, so the 11 valid pieces are [0..10]
     // and that last piece #10 has one byte in it. Piece #11 is the 'end' iterator position.
     static auto constexpr ExpectedPieceSpans = std::array<tr_file_piece_map::piece_span_t, 18>{ {
-        { 0, 1 },
-        { 0, 1 },
-        { 1, 5 },
-        { 5, 6 },
-        { 5, 6 },
-        { 5, 6 },
-        { 5, 6 },
-        { 5, 7 },
-        { 6, 7 },
-        { 6, 7 },
-        { 6, 7 },
-        { 6, 7 },
-        { 6, 7 },
-        { 6, 11 },
-        { 10, 11 },
-        { 10, 11 },
-        { 10, 11 },
-        { 10, 11 },
+        { 0U, 1U },
+        { 0U, 1U },
+        { 1U, 5U },
+        { 5U, 6U },
+        { 5U, 6U },
+        { 5U, 6U },
+        { 5U, 6U },
+        { 5U, 7U },
+        { 6U, 7U },
+        { 6U, 7U },
+        { 6U, 7U },
+        { 6U, 7U },
+        { 6U, 7U },
+        { 6U, 11U },
+        { 10U, 11U },
+        { 10U, 11U },
+        { 10U, 11U },
+        { 10U, 11U },
     } };
     EXPECT_EQ(std::size(FileSizes), std::size(ExpectedPieceSpans));
 
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
     tr_file_index_t const n = std::size(fpm);
     EXPECT_EQ(std::size(FileSizes), n);
-    uint64_t offset = 0;
-    for (tr_file_index_t file = 0; file < n; ++file)
+    uint64_t offset = 0U;
+    for (tr_file_index_t file = 0U; file < n; ++file)
     {
         EXPECT_EQ(ExpectedPieceSpans[file].begin, fpm.piece_span(file).begin);
         EXPECT_EQ(ExpectedPieceSpans[file].end, fpm.piece_span(file).end);
         offset += FileSizes[file];
     }
     EXPECT_EQ(TotalSize, offset);
-    EXPECT_EQ(block_info_.piece_count(), fpm.piece_span(std::size(FileSizes) - 1).end);
+    EXPECT_EQ(block_info_.piece_count(), fpm.piece_span(std::size(FileSizes) - 1U).end);
 }
 
 TEST_F(FilePieceMapTest, priorities)
@@ -169,13 +169,13 @@ TEST_F(FilePieceMapTest, priorities)
     auto expected_piece_priorities = std::vector<tr_priority_t>(block_info_.piece_count(), TR_PRI_NORMAL);
     auto const compare_to_expected = [&, this]()
     {
-        for (tr_file_index_t i = 0; i < n_files; ++i)
+        for (tr_file_index_t i = 0U; i < n_files; ++i)
         {
             auto const expected = int{ expected_file_priorities[i] };
             auto const actual = int{ file_priorities.file_priority(i) };
             EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
-        for (tr_piece_index_t i = 0; i < block_info_.piece_count(); ++i)
+        for (tr_piece_index_t i = 0U; i < block_info_.piece_count(); ++i)
         {
             auto const expected = int{ expected_piece_priorities[i] };
             auto const actual = int{ file_priorities.piece_priority(i) };
@@ -185,13 +185,13 @@ TEST_F(FilePieceMapTest, priorities)
 
     auto const mark_file_endpoints_as_high_priority = [&]()
     {
-        for (tr_file_index_t i = 0; i < n_files; ++i)
+        for (tr_file_index_t i = 0U; i < n_files; ++i)
         {
             auto const [begin_piece, end_piece] = fpm.piece_span(i);
             expected_piece_priorities[begin_piece] = TR_PRI_HIGH;
             if (end_piece > begin_piece)
             {
-                expected_piece_priorities[end_piece - 1] = TR_PRI_HIGH;
+                expected_piece_priorities[end_piece - 1U] = TR_PRI_HIGH;
             }
         }
     };
@@ -205,9 +205,9 @@ TEST_F(FilePieceMapTest, priorities)
     // and it is not preceded by a zero sized file,
     // this shouldn't affect any other files' pieces
     auto pri = TR_PRI_HIGH;
-    file_priorities.set(2, pri);
+    file_priorities.set(2U, pri);
     expected_file_priorities[2] = pri;
-    for (size_t i = 1; i < 5; ++i)
+    for (size_t i = 1U; i < 5U; ++i)
     {
         expected_piece_priorities[i] = pri;
     }
@@ -221,13 +221,13 @@ TEST_F(FilePieceMapTest, priorities)
     //
     // first test setting file #6...
     pri = TR_PRI_HIGH;
-    file_priorities.set(6, pri);
+    file_priorities.set(6U, pri);
     expected_file_priorities[6] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // ...and that shared piece should still be the same when both are high...
-    file_priorities.set(7, pri);
+    file_priorities.set(7U, pri);
     expected_file_priorities[7] = pri;
     expected_piece_priorities[5] = pri;
     expected_piece_priorities[6] = pri;
@@ -235,14 +235,14 @@ TEST_F(FilePieceMapTest, priorities)
     compare_to_expected();
     // ...and that shared piece should still be the same when only 7 is high...
     pri = TR_PRI_NORMAL;
-    file_priorities.set(6, pri);
+    file_priorities.set(6U, pri);
     expected_file_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
 
     // setup for the next test: set all files to low priority
     pri = TR_PRI_LOW;
-    for (tr_file_index_t i = 0; i < n_files; ++i)
+    for (tr_file_index_t i = 0U; i < n_files; ++i)
     {
         file_priorities.set(i, pri);
     }
@@ -255,7 +255,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Since it's the highest priority in the piece, piecePriority() should return its value.
     // file #9: byte [650, 659) piece [6, 7)
     pri = TR_PRI_NORMAL;
-    file_priorities.set(9, pri);
+    file_priorities.set(9U, pri);
     expected_file_priorities[9] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
@@ -264,7 +264,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Since _it_ now has the highest priority in the piece, piecePriority should return _its_ value.
     // file #10: byte [659, 667) piece [6, 7)
     pri = TR_PRI_HIGH;
-    file_priorities.set(10, pri);
+    file_priorities.set(10U, pri);
     expected_file_priorities[10] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
@@ -272,7 +272,7 @@ TEST_F(FilePieceMapTest, priorities)
 
     // Prep for the next test: set all files to normal priority
     pri = TR_PRI_NORMAL;
-    for (tr_file_index_t i = 0; i < n_files; ++i)
+    for (tr_file_index_t i = 0U; i < n_files; ++i)
     {
         file_priorities.set(i, pri);
     }
@@ -290,14 +290,14 @@ TEST_F(FilePieceMapTest, priorities)
     // Check that even zero-sized files can change a piece's priority
     // file #3: byte [500, 500) piece [5, 6)
     pri = TR_PRI_HIGH;
-    file_priorities.set(3, pri);
+    file_priorities.set(3U, pri);
     expected_file_priorities[3] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's priority.
     // file #17 byte [1001, 1001) piece [10, 11)
-    file_priorities.set(17, pri);
+    file_priorities.set(17U, pri);
     expected_file_priorities[17] = pri;
     expected_piece_priorities[10] = pri;
     mark_file_endpoints_as_high_priority();
@@ -305,7 +305,7 @@ TEST_F(FilePieceMapTest, priorities)
 
     // test the batch API
     auto file_indices = std::vector<tr_file_index_t>(n_files);
-    std::iota(std::begin(file_indices), std::end(file_indices), 0);
+    std::iota(std::begin(file_indices), std::end(file_indices), 0U);
     pri = TR_PRI_HIGH;
     file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
     std::fill(std::begin(expected_file_priorities), std::end(expected_file_priorities), pri);
@@ -331,13 +331,13 @@ TEST_F(FilePieceMapTest, wanted)
     auto expected_pieces_wanted = tr_bitfield(block_info_.piece_count());
     auto const compare_to_expected = [&, this]()
     {
-        for (tr_file_index_t i = 0; i < n_files; ++i)
+        for (tr_file_index_t i = 0U; i < n_files; ++i)
         {
             auto const expected = int{ expected_files_wanted.test(i) };
             auto const actual = int{ files_wanted.file_wanted(i) };
             EXPECT_EQ(expected, actual) << "idx[" << i << "] expected [" << expected << "] actual [" << actual << ']';
         }
-        for (tr_piece_index_t i = 0; i < block_info_.piece_count(); ++i)
+        for (tr_piece_index_t i = 0U; i < block_info_.piece_count(); ++i)
         {
             auto const expected = int{ expected_pieces_wanted.test(i) };
             auto const actual = int{ files_wanted.piece_wanted(i) };
@@ -355,9 +355,9 @@ TEST_F(FilePieceMapTest, wanted)
     // and it is not preceded by a zero sized file,
     // this shouldn't normally affect any other files' pieces
     bool const wanted = false;
-    files_wanted.set(2, wanted);
-    expected_files_wanted.set(2, wanted);
-    expected_pieces_wanted.set_span(1, 5, wanted);
+    files_wanted.set(2U, wanted);
+    expected_files_wanted.set(2U, wanted);
+    expected_pieces_wanted.set_span(1U, 5U, wanted);
     compare_to_expected();
 
     // now test when a piece has >1 file.
@@ -369,38 +369,38 @@ TEST_F(FilePieceMapTest, wanted)
     // file #7: byte [550..650) piece [5, 7)
     //
     // first test setting file #6...
-    files_wanted.set(6, false);
-    expected_files_wanted.unset(6);
+    files_wanted.set(6U, false);
+    expected_files_wanted.unset(6U);
     compare_to_expected();
     // marking all the files in the piece as unwanted
     // should cause the piece to become unwanted
-    files_wanted.set(3, false);
-    files_wanted.set(4, false);
-    files_wanted.set(5, false);
-    files_wanted.set(6, false);
-    files_wanted.set(7, false);
-    expected_files_wanted.set_span(3, 8, false);
-    expected_pieces_wanted.unset(5);
+    files_wanted.set(3U, false);
+    files_wanted.set(4U, false);
+    files_wanted.set(5U, false);
+    files_wanted.set(6U, false);
+    files_wanted.set(7U, false);
+    expected_files_wanted.set_span(3U, 8U, false);
+    expected_pieces_wanted.unset(5U);
     compare_to_expected();
     // but as soon as any of them is turned back to wanted,
     // the piece should pop back.
-    files_wanted.set(7, true);
-    expected_files_wanted.set(7, true);
-    expected_pieces_wanted.set(5);
+    files_wanted.set(7U, true);
+    expected_files_wanted.set(7U, true);
+    expected_pieces_wanted.set(5U);
     compare_to_expected();
-    files_wanted.set(6, true);
-    files_wanted.set(7, false);
-    expected_files_wanted.set(6);
-    expected_files_wanted.unset(7);
+    files_wanted.set(6U, true);
+    files_wanted.set(7U, false);
+    expected_files_wanted.set(6U);
+    expected_files_wanted.unset(7U);
     compare_to_expected();
-    files_wanted.set(5, true);
-    files_wanted.set(6, false);
-    expected_files_wanted.set(5);
-    expected_files_wanted.unset(6);
+    files_wanted.set(5U, true);
+    files_wanted.set(6U, false);
+    expected_files_wanted.set(5U);
+    expected_files_wanted.unset(6U);
     compare_to_expected();
 
     // Prep for the next test: set all files to unwanted
-    for (tr_file_index_t i = 0; i < n_files; ++i)
+    for (tr_file_index_t i = 0U; i < n_files; ++i)
     {
         files_wanted.set(i, false);
     }
@@ -415,15 +415,15 @@ TEST_F(FilePieceMapTest, wanted)
     //
     // Check that even zero-sized files can change a piece's 'wanted' state
     // file #3: byte [500, 500) piece [5, 6)
-    files_wanted.set(3, true);
-    expected_files_wanted.set(3);
-    expected_pieces_wanted.set(5);
+    files_wanted.set(3U, true);
+    expected_files_wanted.set(3U);
+    expected_pieces_wanted.set(5U);
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's state.
     // file #17 byte [1001, 1001) piece [10, 11)
-    files_wanted.set(17, true);
-    expected_files_wanted.set(17);
-    expected_pieces_wanted.set(10);
+    files_wanted.set(17U, true);
+    expected_files_wanted.set(17U);
+    expected_pieces_wanted.set(10U);
     compare_to_expected();
 
     // test the batch API


### PR DESCRIPTION
Part 1/4 of adding empty file support to Transmission. Part 4 of this series will resolve #417 and #6190.

- [x] Part 1: optionally include 0 byte files when computing file offset (`tr_file_piece_map::file_offset()`)
- [ ] Part 2: thread-safe `lru-cache` and `tr_open_files`
- [ ] Part 3: thread-safe `Cache` (file write cache)
- [ ] Part 4: handle 0 byte files

Next part at #6230.