### PR TITLE
refactor: thread-safe `lru-cache` and `tr_open_files`

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -34,7 +34,7 @@ namespace
 
 bool readEntireBuf(tr_sys_file_t fd, uint64_t file_offset, uint8_t* buf, uint64_t buflen, tr_error* error)
 {
-    while (buflen > 0)
+    while (buflen > 0U)
     {
         auto n_read = uint64_t{};
 
@@ -53,7 +53,7 @@ bool readEntireBuf(tr_sys_file_t fd, uint64_t file_offset, uint8_t* buf, uint64_
 
 bool writeEntireBuf(tr_sys_file_t fd, uint64_t file_offset, uint8_t const* buf, uint64_t buflen, tr_error* error)
 {
-    while (buflen > 0)
+    while (buflen > 0U)
     {
         auto n_written = uint64_t{};
 
@@ -112,10 +112,10 @@ void readOrWriteBytes(
 
     bool const do_write = io_mode == IoMode::Write;
     auto const file_size = tor->file_size(file_index);
-    TR_ASSERT(file_size == 0 || file_offset < file_size);
+    TR_ASSERT(file_size == 0U || file_offset < file_size);
     TR_ASSERT(file_offset + buflen <= file_size);
 
-    if (file_size == 0)
+    if (file_size == 0U)
     {
         return;
     }
@@ -217,7 +217,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
 
     auto [file_index, file_offset] = tor->file_offset(loc, false);
 
-    while (buflen != 0)
+    while (buflen != 0U)
     {
         uint64_t const bytes_this_pass = std::min(uint64_t{ buflen }, uint64_t{ tor->file_size(file_index) - file_offset });
 
@@ -241,7 +241,7 @@ int readOrWritePiece(tr_torrent* tor, IoMode io_mode, tr_block_info::Location lo
         buflen -= bytes_this_pass;
 
         ++file_index;
-        file_offset = 0;
+        file_offset = 0U;
     }
 
     return 0;
@@ -276,7 +276,7 @@ std::optional<tr_sha1_digest_t> recalculateHash(tr_torrent* tor, tr_piece_index_
         {
             begin += (begin_byte - block_loc.byte);
         }
-        if (block + 1 == end_block) // `block` may end after `piece` does
+        if (block + 1U == end_block) // `block` may end after `piece` does
         {
             end -= (block_loc.byte + block_len - end_byte);
         }

--- a/libtransmission/lru-cache.h
+++ b/libtransmission/lru-cache.h
@@ -80,16 +80,7 @@ public:
         }
     }
 
-    using PreEraseCallback = std::function<void(Key const&, Val&)>;
-
-    void set_pre_erase(PreEraseCallback&& func)
-    {
-        pre_erase_cb_ = std::move(func);
-    }
-
 private:
-    PreEraseCallback pre_erase_cb_;
-
     struct Entry
     {
         Key key_ = {};
@@ -117,10 +108,6 @@ private:
     void erase(Entry& entry)
     {
         auto const lock = std::lock_guard{ mutex_ };
-        if (pre_erase_cb_ && entry.sequence_ != InvalidSeq)
-        {
-            pre_erase_cb_(entry.key_, entry.val_);
-        }
 
         entry.key_ = {};
         entry.val_ = {};

--- a/libtransmission/lru-cache.h
+++ b/libtransmission/lru-cache.h
@@ -94,7 +94,7 @@ private:
     {
         Key key_ = {};
         Val val_ = {};
-        size_t in_use_ = 0;
+        size_t in_use_ = 0U;
         uint64_t sequence_ = InvalidSeq;
     };
 

--- a/libtransmission/lru-cache.h
+++ b/libtransmission/lru-cache.h
@@ -6,44 +6,53 @@
 #pragma once
 
 #include <array>
+#include <condition_variable>
 #include <cstddef> // size_t
 #include <cstdint>
 #include <functional>
+#include <mutex>
+#include <optional>
 #include <utility>
+
+#include "libtransmission/observable.h"
 
 // A fixed-size cache that erases least-recently-used items to make room for new ones.
 template<typename Key, typename Val, std::size_t N>
 class tr_lru_cache
 {
 public:
-    [[nodiscard]] constexpr Val* get(Key const& key) noexcept
+    [[nodiscard]] TR_CONSTEXPR23 std::optional<std::pair<Val&, libtransmission::ObserverTag>> get(Key const& key) noexcept
     {
-        if (auto const found = find(key); found != nullptr)
+        auto const lock = std::lock_guard{ mutex_ };
+        if (auto* const found = find(key); found != nullptr)
         {
             found->sequence_ = next_sequence_++;
-            return &found->val_;
+            return lock_and_get_entry(*found);
         }
 
-        return nullptr;
+        return {};
     }
 
-    [[nodiscard]] constexpr bool contains(Key const& key) const noexcept
+    [[nodiscard]] TR_CONSTEXPR23 bool contains(Key const& key) const noexcept
     {
-        return !!find(key);
+        return find(key) != nullptr;
     }
 
-    Val& add(Key&& key)
+    std::pair<Val&, libtransmission::ObserverTag> add(Key&& key)
     {
+        auto const lock = std::lock_guard{ mutex_ };
+
         auto& entry = getFreeSlot();
         entry.key_ = std::move(key);
         entry.sequence_ = next_sequence_++;
 
         key = {};
-        return entry.val_;
+        return lock_and_get_entry(entry);
     }
 
     void erase(Key const& key)
     {
+        auto const lock = std::lock_guard{ mutex_ };
         if (auto* const found = find(key); found != nullptr)
         {
             this->erase(*found);
@@ -52,6 +61,7 @@ public:
 
     void erase_if(std::function<bool(Key const&, Val const&)> test)
     {
+        auto const lock = std::lock_guard{ mutex_ };
         for (auto& entry : entries_)
         {
             if (entry.sequence_ != InvalidSeq && test(entry.key_, entry.val_))
@@ -63,6 +73,7 @@ public:
 
     void clear()
     {
+        auto const lock = std::lock_guard{ mutex_ };
         for (auto& entry : entries_)
         {
             erase(entry);
@@ -84,11 +95,28 @@ private:
     {
         Key key_ = {};
         Val val_ = {};
+        bool can_erase_ = true;
         uint64_t sequence_ = InvalidSeq;
     };
 
+    std::pair<Val&, libtransmission::ObserverTag> lock_and_get_entry(Entry& entry)
+    {
+        auto const lock = std::lock_guard{ mutex_ };
+        entry.can_erase_ = false;
+        return std::make_pair(
+            std::ref(entry.val_),
+            libtransmission::ObserverTag{ [this, &entry]()
+                                          {
+                                              auto lock2 = std::unique_lock{ mutex_ };
+                                              entry.can_erase_ = true;
+                                              lock2.unlock();
+                                              cv_.notify_one();
+                                          } });
+    }
+
     void erase(Entry& entry)
     {
+        auto const lock = std::lock_guard{ mutex_ };
         if (entry.sequence_ != InvalidSeq)
         {
             pre_erase_cb_(entry.key_, entry.val_);
@@ -99,8 +127,9 @@ private:
         entry.sequence_ = InvalidSeq;
     }
 
-    [[nodiscard]] constexpr Entry* find(Key const& key) noexcept
+    [[nodiscard]] TR_CONSTEXPR23 Entry* find(Key const& key) noexcept
     {
+        auto const lock = std::lock_guard{ mutex_ };
         for (auto& entry : entries_)
         {
             if (entry.sequence_ != InvalidSeq && entry.key_ == key)
@@ -112,8 +141,9 @@ private:
         return nullptr;
     }
 
-    [[nodiscard]] constexpr Entry const* find(Key const& key) const noexcept
+    [[nodiscard]] TR_CONSTEXPR23 Entry const* find(Key const& key) const noexcept
     {
+        auto const lock = std::lock_guard{ mutex_ };
         for (auto const& entry : entries_)
         {
             if (entry.sequence_ != InvalidSeq && entry.key_ == key)
@@ -127,10 +157,19 @@ private:
 
     Entry& getFreeSlot()
     {
+        auto lock = std::unique_lock{ mutex_ };
+        cv_.wait(
+            lock,
+            [this]() {
+                return std::any_of(
+                    std::begin(entries_),
+                    std::end(entries_),
+                    [](Entry const& entry) { return entry.can_erase_; });
+            });
         auto const iter = std::min_element(
             std::begin(entries_),
             std::end(entries_),
-            [](auto const& a, auto const& b) { return a.sequence_ < b.sequence_; });
+            [](auto const& a, auto const& b) { return !b.can_erase_ || a.sequence_ < b.sequence_; });
         this->erase(*iter);
         return *iter;
     }
@@ -138,4 +177,7 @@ private:
     std::array<Entry, N> entries_;
     uint64_t next_sequence_ = 1;
     static uint64_t constexpr InvalidSeq = 0;
+
+    mutable std::recursive_mutex mutex_;
+    std::condition_variable_any cv_;
 };

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -23,6 +23,8 @@
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h" // _()
 
+using namespace std::literals;
+
 namespace
 {
 
@@ -33,7 +35,7 @@ namespace
 
 bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error* error)
 {
-    if (length == 0)
+    if (length == 0U)
     {
         return true;
     }
@@ -49,12 +51,12 @@ bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error* error)
 
     if (!TR_ERROR_IS_ENOSPC(local_error.code()))
     {
-        char const zero = '\0';
+        static char constexpr Zero = '\0';
 
         local_error = {};
 
         /* fallback: the old-style seek-and-write */
-        if (tr_sys_file_write_at(fd, &zero, 1, length - 1, nullptr, &local_error) &&
+        if (tr_sys_file_write_at(fd, &Zero, 1, length - 1, nullptr, &local_error) &&
             tr_sys_file_truncate(fd, length, &local_error))
         {
             return true;
@@ -73,7 +75,7 @@ bool preallocate_file_sparse(tr_sys_file_t fd, uint64_t length, tr_error* error)
 
 bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error* error)
 {
-    if (length == 0)
+    if (length == 0U)
     {
         return true;
     }
@@ -205,20 +207,20 @@ std::optional<std::pair<tr_sys_file_t, libtransmission::ObserverTag>> tr_open_fi
     if (writable && !already_existed && allocation != TR_PREALLOCATE_NONE)
     {
         bool success = false;
-        char const* type = nullptr;
+        auto type = std::string_view{};
 
         if (allocation == TR_PREALLOCATE_FULL)
         {
             success = preallocate_file_full(fd, file_size, &error);
-            type = "full";
+            type = "full"sv;
         }
         else if (allocation == TR_PREALLOCATE_SPARSE)
         {
             success = preallocate_file_sparse(fd, file_size, &error);
-            type = "sparse";
+            type = "sparse"sv;
         }
 
-        TR_ASSERT(type != nullptr);
+        TR_ASSERT(!std::empty(type));
 
         if (!success)
         {

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -70,6 +70,6 @@ private:
         bool writable_ = false;
     };
 
-    static constexpr size_t MaxOpenFiles = 32;
+    static constexpr size_t MaxOpenFiles = 32U;
     tr_lru_cache<Key, Val, MaxOpenFiles> pool_;
 };

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -24,9 +24,12 @@
 class tr_open_files
 {
 public:
-    [[nodiscard]] std::optional<tr_sys_file_t> get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable);
+    [[nodiscard]] std::optional<std::pair<tr_sys_file_t, libtransmission::ObserverTag>> get(
+        tr_torrent_id_t tor_id,
+        tr_file_index_t file_num,
+        bool writable);
 
-    [[nodiscard]] std::optional<tr_sys_file_t> get(
+    [[nodiscard]] std::optional<std::pair<tr_sys_file_t, libtransmission::ObserverTag>> get(
         tr_torrent_id_t tor_id,
         tr_file_index_t file_num,
         bool writable,


### PR DESCRIPTION
Part 2/4 of adding empty file support to Transmission. Part 4 of this series will resolve #417 and #6190.

- [x] Part 1: optionally include 0 byte files when computing file offset (`tr_file_piece_map::file_offset()`)
- [x] Part 2: thread-safe `lru-cache` and `tr_open_files`
- [ ] Part 3: thread-safe `Cache` (file write cache)
- [ ] Part 4: handle 0 byte files

Previous part at #6229, next part at #6231.