### PR TITLE
refactor: Values pt. 2 - use Speed in tr_bandwidth

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -20,7 +20,7 @@
 #include "libtransmission/utils.h" // tr_time_msec()
 #include "libtransmission/values.h"
 
-using Speed = libtransmission::Values::Speed;
+using namespace libtransmission::Values;
 
 Speed tr_bandwidth::get_speed(RateControl& r, unsigned int interval_msec, uint64_t now)
 {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -67,11 +67,11 @@ size_t get_desired_output_buffer_size(tr_peerIo const* io, uint64_t now)
     // this is all kind of arbitrary, but what seems to work well is
     // being large enough to hold the next 20 seconds' worth of input,
     // or a few blocks, whichever is bigger. OK to tweak this as needed.
-    static auto constexpr PeriodSecs = 15U;
+    static auto constexpr PeriodSecs = uint64_t{ 15U };
 
     // the 3 is an arbitrary number of blocks;
     // the .5 is to leave room for protocol messages
-    static auto constexpr Floor = static_cast<size_t>(tr_block_info::BlockSize * 3.5);
+    static auto constexpr Floor = static_cast<uint64_t>(tr_block_info::BlockSize * 3.5);
 
     auto const current_speed = io->get_piece_speed(now, TR_UP);
     return std::max(Floor, current_speed.base_quantity() * PeriodSecs);

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -73,8 +73,8 @@ size_t get_desired_output_buffer_size(tr_peerIo const* io, uint64_t now)
     // the .5 is to leave room for protocol messages
     static auto constexpr Floor = static_cast<size_t>(tr_block_info::BlockSize * 3.5);
 
-    auto const current_speed_bytes_per_second = io->get_piece_speed_bytes_per_second(now, TR_UP);
-    return std::max(Floor, current_speed_bytes_per_second * PeriodSecs);
+    auto const current_speed = io->get_piece_speed(now, TR_UP);
+    return std::max(Floor, current_speed.base_quantity() * PeriodSecs);
 }
 } // namespace
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -170,9 +170,9 @@ public:
         return bandwidth_.clamp(dir, 1024) > 0;
     }
 
-    [[nodiscard]] auto get_piece_speed_bytes_per_second(uint64_t now, tr_direction dir) const noexcept
+    [[nodiscard]] auto get_piece_speed(uint64_t now, tr_direction dir) const noexcept
     {
-        return bandwidth_.get_piece_speed_bytes_per_second(now, dir);
+        return bandwidth_.get_piece_speed(now, dir);
     }
 
     ///

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -559,7 +559,7 @@ private:
         // Get the rate limit we should use.
         // TODO: this needs to consider all the other peers as well...
         uint64_t const now = tr_time_msec();
-        auto rate_bytes_per_second = get_piece_speed_bytes_per_second(now, TR_PEER_TO_CLIENT);
+        auto rate_bytes_per_second = uint64_t{ get_piece_speed_bytes_per_second(now, TR_PEER_TO_CLIENT) };
         if (torrent->uses_speed_limit(TR_PEER_TO_CLIENT))
         {
             rate_bytes_per_second = std::min(rate_bytes_per_second, torrent->speed_limit(TR_PEER_TO_CLIENT).base_quantity());
@@ -571,7 +571,7 @@ private:
             if (auto const irate_bytes_per_second = torrent->session->activeSpeedLimitBps(TR_PEER_TO_CLIENT);
                 irate_bytes_per_second)
             {
-                rate_bytes_per_second = std::min(rate_bytes_per_second, *irate_bytes_per_second);
+                rate_bytes_per_second = std::min(rate_bytes_per_second, uint64_t{ *irate_bytes_per_second });
             }
         }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -383,14 +383,14 @@ public:
 
     bool isTransferringPieces(uint64_t now, tr_direction dir, tr_bytes_per_second_t* setme_bytes_per_second) const override
     {
-        auto const bytes_per_second = io->get_piece_speed_bytes_per_second(now, dir);
+        auto const byps = io->get_piece_speed(now, dir).base_quantity();
 
         if (setme_bytes_per_second != nullptr)
         {
-            *setme_bytes_per_second = bytes_per_second;
+            *setme_bytes_per_second = byps;
         }
 
-        return bytes_per_second > 0;
+        return byps != 0U;
     }
 
     [[nodiscard]] size_t activeReqCount(tr_direction dir) const noexcept override
@@ -562,7 +562,7 @@ private:
         auto rate_bytes_per_second = get_piece_speed_bytes_per_second(now, TR_PEER_TO_CLIENT);
         if (torrent->uses_speed_limit(TR_PEER_TO_CLIENT))
         {
-            rate_bytes_per_second = std::min(rate_bytes_per_second, torrent->speed_limit_bps(TR_PEER_TO_CLIENT));
+            rate_bytes_per_second = std::min(rate_bytes_per_second, torrent->speed_limit(TR_PEER_TO_CLIENT).base_quantity());
         }
 
         // honor the session limits, if enabled

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -29,8 +29,8 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 namespace tr_resume
 {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -29,6 +29,7 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 
 namespace tr_resume
@@ -237,7 +238,7 @@ auto loadFilePriorities(tr_variant* dict, tr_torrent* tor)
 void saveSingleSpeedLimit(tr_variant* d, tr_torrent const* tor, tr_direction dir)
 {
     tr_variantDictReserve(d, 3);
-    tr_variantDictAddInt(d, TR_KEY_speed_Bps, tor->speed_limit_bps(dir));
+    tr_variantDictAddInt(d, TR_KEY_speed_Bps, tor->speed_limit(dir).base_quantity());
     tr_variantDictAddBool(d, TR_KEY_use_global_speed_limit, tor->uses_session_limits());
     tr_variantDictAddBool(d, TR_KEY_use_speed_limit, tor->uses_speed_limit(dir));
 }
@@ -266,11 +267,11 @@ void loadSingleSpeedLimit(tr_variant* d, tr_direction dir, tr_torrent* tor)
 {
     if (auto val = int64_t{}; tr_variantDictFindInt(d, TR_KEY_speed_Bps, &val))
     {
-        tor->set_speed_limit_bps(dir, val);
+        tor->set_speed_limit(dir, Speed{ val, Speed::Units::Byps });
     }
     else if (tr_variantDictFindInt(d, TR_KEY_speed, &val))
     {
-        tor->set_speed_limit_bps(dir, val * 1024);
+        tor->set_speed_limit(dir, Speed{ val, Speed::Units::KByps });
     }
 
     if (auto val = bool{}; tr_variantDictFindBool(d, TR_KEY_use_speed_limit, &val))

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -41,8 +41,8 @@
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 namespace
 {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -41,6 +41,7 @@
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 
 namespace
@@ -1604,9 +1605,9 @@ char const* groupGet(tr_session* s, tr_variant* args_in, tr_variant* args_out, s
             auto limits = group->get_limits();
             tr_variantDictAddBool(dict, TR_KEY_honorsSessionLimits, group->are_parent_limits_honored(TR_UP));
             tr_variantDictAddStr(dict, TR_KEY_name, name);
-            tr_variantDictAddInt(dict, TR_KEY_speed_limit_down, limits.down_limit_KBps);
+            tr_variantDictAddInt(dict, TR_KEY_speed_limit_down, limits.down_limit.count(Speed::Units::KByps));
             tr_variantDictAddBool(dict, TR_KEY_speed_limit_down_enabled, limits.down_limited);
-            tr_variantDictAddInt(dict, TR_KEY_speed_limit_up, limits.up_limit_KBps);
+            tr_variantDictAddInt(dict, TR_KEY_speed_limit_up, limits.up_limit.count(Speed::Units::KByps));
             tr_variantDictAddBool(dict, TR_KEY_speed_limit_up_enabled, limits.up_limited);
         }
     }
@@ -1632,12 +1633,12 @@ char const* groupSet(tr_session* session, tr_variant* args_in, tr_variant* /*arg
 
     if (auto limit = int64_t{}; tr_variantDictFindInt(args_in, TR_KEY_speed_limit_down, &limit))
     {
-        limits.down_limit_KBps = static_cast<tr_kilobytes_per_second_t>(limit);
+        limits.down_limit = Speed{ limit, Speed::Units::KByps };
     }
 
     if (auto limit = int64_t{}; tr_variantDictFindInt(args_in, TR_KEY_speed_limit_up, &limit))
     {
-        limits.up_limit_KBps = static_cast<tr_kilobytes_per_second_t>(limit);
+        limits.up_limit = Speed{ limit, Speed::Units::KByps };
     }
 
     group.set_limits(limits);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -59,6 +59,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 
 namespace
@@ -110,12 +111,12 @@ void bandwidthGroupRead(tr_session* session, std::string_view config_dir)
 
         if (auto const* val = group_map->find_if<int64_t>(TR_KEY_uploadLimit); val != nullptr)
         {
-            limits.up_limit_KBps = static_cast<tr_kilobytes_per_second_t>(*val);
+            limits.up_limit = Speed{ *val, Speed::Units::KByps };
         }
 
         if (auto const* val = group_map->find_if<int64_t>(TR_KEY_downloadLimit); val != nullptr)
         {
-            limits.down_limit_KBps = static_cast<tr_kilobytes_per_second_t>(*val);
+            limits.down_limit = Speed{ *val, Speed::Units::KByps };
         }
 
         group.set_limits(limits);
@@ -136,11 +137,11 @@ void bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
     {
         auto const limits = group->get_limits();
         auto group_map = tr_variant::Map{ 6U };
-        group_map.try_emplace(TR_KEY_downloadLimit, limits.down_limit_KBps);
+        group_map.try_emplace(TR_KEY_downloadLimit, limits.down_limit.count(Speed::Units::KByps));
         group_map.try_emplace(TR_KEY_downloadLimited, limits.down_limited);
         group_map.try_emplace(TR_KEY_honorsSessionLimits, group->are_parent_limits_honored(TR_UP));
         group_map.try_emplace(TR_KEY_name, name.sv());
-        group_map.try_emplace(TR_KEY_uploadLimit, limits.up_limit_KBps);
+        group_map.try_emplace(TR_KEY_uploadLimit, limits.up_limit.count(Speed::Units::KByps));
         group_map.try_emplace(TR_KEY_uploadLimited, limits.up_limited);
         groups_map.try_emplace(name.quark(), std::move(group_map));
     }
@@ -153,10 +154,10 @@ void bandwidthGroupWrite(tr_session const* session, std::string_view config_dir)
 
 void update_bandwidth(tr_session* session, tr_direction dir)
 {
-    if (auto const limit_bytes_per_second = session->activeSpeedLimitBps(dir); limit_bytes_per_second)
+    if (auto const limit_byps = session->activeSpeedLimitBps(dir); limit_byps)
     {
-        session->top_bandwidth_.set_limited(dir, *limit_bytes_per_second > 0U);
-        session->top_bandwidth_.set_desired_speed_bytes_per_second(dir, *limit_bytes_per_second);
+        session->top_bandwidth_.set_limited(dir, *limit_byps > 0U);
+        session->top_bandwidth_.set_desired_speed(dir, Speed{ *limit_byps, Speed::Units::Byps });
     }
     else
     {
@@ -1319,8 +1320,12 @@ void tr_sessionSetDeleteSource(tr_session* session, bool delete_source)
 
 double tr_sessionGetRawSpeed_KBps(tr_session const* session, tr_direction dir)
 {
-    auto const bps = session != nullptr ? session->top_bandwidth_.get_raw_speed_bytes_per_second(0, dir) : 0;
-    return tr_toSpeedKBps(bps);
+    if (session != nullptr)
+    {
+        return session->top_bandwidth_.get_raw_speed(0, dir).count(Speed::Units::KByps);
+    }
+
+    return {};
 }
 
 void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono::time_point<std::chrono::steady_clock> deadline)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -59,8 +59,8 @@
 
 struct tr_ctor;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 namespace
 {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -849,7 +849,7 @@ public:
 
     [[nodiscard]] auto pieceSpeedBps(tr_direction dir) const noexcept
     {
-        return top_bandwidth_.get_piece_speed_bytes_per_second(0, dir);
+        return top_bandwidth_.get_piece_speed(0, dir).base_quantity();
     }
 
     [[nodiscard]] std::optional<tr_bytes_per_second_t> activeSpeedLimitBps(tr_direction dir) const noexcept;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -48,8 +48,8 @@
 
 struct tr_ctor;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 // ---
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -48,6 +48,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 
 // ---
@@ -211,9 +212,9 @@ bool tr_torrentIsSeedRatioDone(tr_torrent const* tor)
 
 // --- PER-TORRENT UL / DL SPEEDS
 
-void tr_torrentSetSpeedLimit_KBps(tr_torrent* tor, tr_direction dir, tr_kilobytes_per_second_t kilo_per_second)
+void tr_torrentSetSpeedLimit_KBps(tr_torrent* tor, tr_direction dir, tr_kilobytes_per_second_t kbyps)
 {
-    tor->set_speed_limit_bps(dir, tr_toSpeedBytes(kilo_per_second));
+    tor->set_speed_limit(dir, Speed{ kbyps, Speed::Units::KByps });
 }
 
 tr_kilobytes_per_second_t tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr_direction dir)
@@ -221,7 +222,7 @@ tr_kilobytes_per_second_t tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isDirection(dir));
 
-    return tr_toSpeedKBps(tor->speed_limit_bps(dir));
+    return tor->speed_limit(dir).count(Speed::Units::KByps);
 }
 
 void tr_torrentUseSpeedLimit(tr_torrent* tor, tr_direction dir, bool enabled)
@@ -1021,9 +1022,9 @@ void tr_torrent::init(tr_ctor const* const ctor)
     if ((loaded & tr_resume::Speedlimit) == 0)
     {
         use_speed_limit(TR_UP, false);
-        set_speed_limit_bps(TR_UP, tr_toSpeedBytes(session->speedLimitKBps(TR_UP)));
+        set_speed_limit(TR_UP, Speed{ session->speedLimitKBps(TR_UP), Speed::Units::KByps });
         use_speed_limit(TR_DOWN, false);
-        set_speed_limit_bps(TR_DOWN, tr_toSpeedBytes(session->speedLimitKBps(TR_DOWN)));
+        set_speed_limit(TR_DOWN, Speed{ session->speedLimitKBps(TR_DOWN), Speed::Units::KByps });
         tr_torrentUseSessionLimits(this, true);
     }
 
@@ -1360,10 +1361,10 @@ tr_stat tr_torrent::stats() const
         stats.knownPeersFrom[i] = swarm_stats.known_peer_from_count[i];
     }
 
-    auto const piece_upload_speed_byps = this->bandwidth_.get_piece_speed_bytes_per_second(now_msec, TR_UP);
-    stats.pieceUploadSpeed_KBps = tr_toSpeedKBps(piece_upload_speed_byps);
-    auto const piece_download_speed_byps = this->bandwidth_.get_piece_speed_bytes_per_second(now_msec, TR_DOWN);
-    stats.pieceDownloadSpeed_KBps = tr_toSpeedKBps(piece_download_speed_byps);
+    auto const piece_upload_speed = this->bandwidth_.get_piece_speed(now_msec, TR_UP);
+    stats.pieceUploadSpeed_KBps = piece_upload_speed.count(Speed::Units::KByps);
+    auto const piece_download_speed = this->bandwidth_.get_piece_speed(now_msec, TR_DOWN);
+    stats.pieceDownloadSpeed_KBps = piece_download_speed.count(Speed::Units::KByps);
 
     stats.percentComplete = this->completion.percent_complete();
     stats.metadataPercentComplete = tr_torrentGetMetadataPercent(this);
@@ -1400,7 +1401,7 @@ tr_stat tr_torrent::stats() const
     stats.etaIdle = TR_ETA_NOT_AVAIL;
     if (activity == TR_STATUS_DOWNLOAD)
     {
-        if (auto const eta_speed_byps = eta_speed_.update(now_msec, piece_download_speed_byps); eta_speed_byps == 0U)
+        if (auto const eta_speed_byps = eta_speed_.update(now_msec, piece_download_speed).base_quantity(); eta_speed_byps == 0U)
         {
             stats.eta = TR_ETA_UNKNOWN;
         }
@@ -1411,7 +1412,7 @@ tr_stat tr_torrent::stats() const
     }
     else if (activity == TR_STATUS_SEED)
     {
-        auto const eta_speed_byps = eta_speed_.update(now_msec, piece_upload_speed_byps);
+        auto const eta_speed_byps = eta_speed_.update(now_msec, piece_upload_speed).base_quantity();
 
         if (seed_ratio_applies)
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -76,6 +76,8 @@ void tr_torrentSave(tr_torrent* tor);
 /** @brief Torrent object */
 struct tr_torrent final : public tr_completion::torrent_view
 {
+    using Speed = libtransmission::Values::Speed;
+
 public:
     using labels_t = std::vector<tr_interned_string>;
     using VerifyDoneCallback = std::function<void(tr_torrent*)>;
@@ -146,9 +148,9 @@ public:
         return bandwidth_;
     }
 
-    constexpr void set_speed_limit_bps(tr_direction dir, tr_bytes_per_second_t bytes_per_second)
+    constexpr void set_speed_limit(tr_direction dir, Speed limit)
     {
-        if (bandwidth().set_desired_speed_bytes_per_second(dir, bytes_per_second))
+        if (bandwidth().set_desired_speed(dir, limit))
         {
             set_dirty();
         }
@@ -162,9 +164,9 @@ public:
         }
     }
 
-    [[nodiscard]] constexpr auto speed_limit_bps(tr_direction dir) const
+    [[nodiscard]] constexpr auto speed_limit(tr_direction dir) const
     {
-        return bandwidth().get_desired_speed_bytes_per_second(dir);
+        return bandwidth().get_desired_speed(dir);
     }
 
     [[nodiscard]] constexpr auto uses_session_limits() const noexcept
@@ -1041,13 +1043,13 @@ private:
     class SimpleSmoothedSpeed
     {
     public:
-        constexpr auto update(uint64_t time_msec, tr_bytes_per_second_t speed_byps)
+        constexpr auto update(uint64_t time_msec, Speed speed)
         {
             // If the old speed is too old, just replace it
             if (timestamp_msec_ + MaxAgeMSec <= time_msec)
             {
                 timestamp_msec_ = time_msec;
-                speed_byps_ = speed_byps;
+                speed_ = speed;
             }
 
             // To prevent the smoothing from being overwhelmed by frequent calls
@@ -1055,10 +1057,10 @@ private:
             else if (timestamp_msec_ + MinUpdateMSec <= time_msec)
             {
                 timestamp_msec_ = time_msec;
-                speed_byps_ = (speed_byps_ * 4U + speed_byps) / 5U;
+                speed_ = (speed_ * 4U + speed) / 5U;
             }
 
-            return speed_byps_;
+            return speed_;
         }
 
     private:
@@ -1066,7 +1068,7 @@ private:
         static auto constexpr MinUpdateMSec = 800U;
 
         uint64_t timestamp_msec_ = {};
-        tr_bytes_per_second_t speed_byps_ = {};
+        Speed speed_ = {};
     };
 
     [[nodiscard]] TR_CONSTEXPR20 bool is_piece_checked(tr_piece_index_t piece) const
@@ -1111,7 +1113,7 @@ private:
 
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept
     {
-        if (uses_speed_limit(direction) && speed_limit_bps(direction) <= 0)
+        if (uses_speed_limit(direction) && speed_limit(direction).base_quantity() == 0U)
         {
             return false;
         }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -969,7 +969,7 @@ size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, 
 // --- Torrent speed limits
 
 tr_kilobytes_per_second_t tr_torrentGetSpeedLimit_KBps(tr_torrent const* tor, tr_direction dir);
-void tr_torrentSetSpeedLimit_KBps(tr_torrent* tor, tr_direction dir, tr_kilobytes_per_second_t kilo_per_second);
+void tr_torrentSetSpeedLimit_KBps(tr_torrent* tor, tr_direction dir, tr_kilobytes_per_second_t kbyps);
 
 bool tr_torrentUsesSpeedLimit(tr_torrent const* tor, tr_direction dir);
 void tr_torrentUseSpeedLimit(tr_torrent* tor, tr_direction dir, bool enabled);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -59,8 +59,6 @@
 
 using namespace std::literals;
 
-namespace Values = libtransmission::Values;
-
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -58,6 +58,7 @@
 #include "libtransmission/variant.h"
 
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 time_t libtransmission::detail::tr_time::current_time = {};
 
@@ -679,8 +680,6 @@ Config::Units<StorageUnits> Config::Storage{ Config::Base::Kilo, "B"sv, "kB"sv, 
 
 tr_variant tr_formatter_get_units()
 {
-    using namespace libtransmission::Values;
-
     auto const make_units_vec = [](auto const& units)
     {
         auto units_vec = tr_variant::Vector{};
@@ -718,8 +717,6 @@ void tr_formatter_size_init(size_t base, char const* kb, char const* mb, char co
 
 std::string tr_formatter_size_B(uint64_t bytes)
 {
-    using Storage = libtransmission::Values::Storage;
-
     return Storage{ bytes, Storage::Units::Bytes }.to_string();
 }
 
@@ -738,21 +735,15 @@ void tr_formatter_speed_init(size_t base, char const* kb, char const* mb, char c
 
 std::string tr_formatter_speed_KBps(double kbyps)
 {
-    using Speed = libtransmission::Values::Speed;
-
     return Speed{ kbyps, Speed::Units::KByps }.to_string();
 }
 uint64_t tr_toSpeedBytes(size_t kbyps)
 {
-    using Speed = libtransmission::Values::Speed;
-
     return Speed{ kbyps, Speed::Units::KByps }.base_quantity();
 }
 
 double tr_toSpeedKBps(size_t byps)
 {
-    using Speed = libtransmission::Values::Speed;
-
     return Speed{ byps, Speed::Units::Byps }.count(Speed::Units::KByps);
 }
 
@@ -771,29 +762,21 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 
 std::string tr_formatter_mem_B(uint64_t bytes)
 {
-    using Memory = libtransmission::Values::Memory;
-
     return Memory{ bytes, Memory::Units::Bytes }.to_string();
 }
 
 std::string tr_formatter_mem_MB(double mbytes)
 {
-    using Memory = libtransmission::Values::Memory;
-
     return Memory{ mbytes, Memory::Units::MBytes }.to_string();
 }
 
 uint64_t tr_toMemBytes(size_t mbytes)
 {
-    using Memory = libtransmission::Values::Memory;
-
     return Memory{ mbytes, Memory::Units::MBytes }.base_quantity();
 }
 
 double tr_toMemMB(uint64_t bytes)
 {
-    using Memory = libtransmission::Values::Memory;
-
     return Memory{ bytes, Memory::Units::Bytes }.count(Memory::Units::MBytes);
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -59,6 +59,8 @@
 
 using namespace std::literals;
 
+namespace Values = libtransmission::Values;
+
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -40,8 +40,8 @@
 
 struct evbuffer;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 namespace
 {

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -40,6 +40,7 @@
 
 struct evbuffer;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 
 namespace
@@ -203,18 +204,18 @@ public:
         tr_direction dir,
         tr_bytes_per_second_t* setme_bytes_per_second) const override
     {
-        tr_bytes_per_second_t bytes_per_second = 0;
-        bool is_active = false;
+        auto piece_speed = Speed{};
+        auto is_active = bool{ false };
 
         if (dir == TR_DOWN)
         {
             is_active = !std::empty(tasks);
-            bytes_per_second = bandwidth_.get_piece_speed_bytes_per_second(now, dir);
+            piece_speed = bandwidth_.get_piece_speed(now, dir);
         }
 
         if (setme_bytes_per_second != nullptr)
         {
-            *setme_bytes_per_second = bytes_per_second;
+            *setme_bytes_per_second = piece_speed.base_quantity();
         }
 
         return is_active;

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -380,12 +380,13 @@ TEST_F(UtilsTest, value)
 
     auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
+    EXPECT_EQ(1000000UL, val.base_quantity());
     EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
     EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
     EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
 
     val = Speed{ 1, Speed::Units::Byps };
+    EXPECT_EQ(1U, val.base_quantity());
     EXPECT_EQ("1 B/s", val.to_string());
 
     val = Speed{ 10, Speed::Units::KByps };

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,6 +29,7 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
+#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -371,4 +372,29 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
+}
+
+TEST_F(UtilsTest, value)
+{
+    namespace Values = libtransmission::Values;
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 MB/s", val_m.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto const val_k = val_m.to(Values::KByps);
+    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_b = val_m.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    val_b = val_k.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_g = val_m.to(Values::GByps);
+    EXPECT_EQ("0.00 GB/s", val_g.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -398,3 +398,14 @@ TEST_F(UtilsTest, value)
     EXPECT_EQ("0.00 GB/s", val_g.to_string());
     EXPECT_EQ(1000000U, val_m.base_quantity());
 }
+
+TEST_F(UtilsTest, valueHonorsFormatterInit)
+{
+    namespace Values = libtransmission::Values;
+
+    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ(1048576U, val_m.base_quantity());
+}

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,7 +29,6 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
-#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -372,37 +371,4 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
-}
-
-TEST_F(UtilsTest, value)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_EQ(1000000UL, val.base_quantity());
-    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
-
-    val = Speed{ 1, Speed::Units::Byps };
-    EXPECT_EQ(1U, val.base_quantity());
-    EXPECT_EQ("1 B/s", val.to_string());
-
-    val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
-
-    val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
-}
-
-TEST_F(UtilsTest, valueHonorsFormatterInit)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
-
-    auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
-    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -378,25 +378,21 @@ TEST_F(UtilsTest, value)
 {
     namespace Values = libtransmission::Values;
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 MB/s", val_m.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    auto val = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1.00 MB/s", val.to_string());
+    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
 
-    auto const val_k = val_m.to(Values::KByps);
-    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 1, Values::Byps };
+    EXPECT_EQ("1 B/s", val.to_string());
 
-    auto val_b = val_m.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 10, Values::KByps };
+    EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val_b = val_k.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
-
-    auto val_g = val_m.to(Values::GByps);
-    EXPECT_EQ("0.00 GB/s", val_g.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 999, Values::KByps };
+    EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
@@ -406,6 +402,6 @@ TEST_F(UtilsTest, valueHonorsFormatterInit)
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
     EXPECT_EQ(1048576U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -376,32 +376,32 @@ TEST_F(UtilsTest, ratioToString)
 
 TEST_F(UtilsTest, value)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
-    auto val = Values::Speed{ 1, Values::MByps };
+    auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
-    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
 
-    val = Values::Speed{ 1, Values::Byps };
+    val = Speed{ 1, Speed::Units::Byps };
     EXPECT_EQ("1 B/s", val.to_string());
 
-    val = Values::Speed{ 10, Values::KByps };
+    val = Speed{ 10, Speed::Units::KByps };
     EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val = Values::Speed{ 999, Values::KByps };
+    val = Speed{ 999, Speed::Units::KByps };
     EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
-    EXPECT_EQ(1048576U, val_m.base_quantity());
+    auto const val = Speed{ 1, Speed::Units::MByps };
+    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
+    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/values-test.cc
+++ b/tests/libtransmission/values-test.cc
@@ -10,12 +10,12 @@
 
 #include "gtest/gtest.h"
 
+using namespace libtransmission::Values;
+
 using ValuesTest = ::testing::Test;
 
 TEST_F(ValuesTest, value)
 {
-    using Speed = libtransmission::Values::Speed;
-
     auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_EQ(1000000UL, val.base_quantity());
@@ -36,8 +36,6 @@ TEST_F(ValuesTest, value)
 
 TEST_F(ValuesTest, valueHonorsFormatterInit)
 {
-    using Speed = libtransmission::Values::Speed;
-
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val = Speed{ 1, Speed::Units::MByps };


### PR DESCRIPTION
This PR uses the `Values::Speed` class in `tr_bandwidth` and in the code that calls it.

This is part 2 in the [`libtransmission::Values`](https://github.com/transmission/transmission/pull/6215) series. See #6215 for more information.