### PR TITLE
refactor: directly check if announcers are idle instead of using a stop counter

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -354,7 +354,7 @@ struct tau_tracker
         }
 
         // are there any requests pending?
-        if (this->isIdle())
+        if (this->is_idle())
         {
             return;
         }
@@ -402,6 +402,11 @@ struct tau_tracker
         }
     }
 
+    [[nodiscard]] bool is_idle() const noexcept
+    {
+        return std::empty(announces) && std::empty(scrapes) && !addr_pending_dns_;
+    }
+
 private:
     using Sockaddr = std::pair<sockaddr_storage, socklen_t>;
     using MaybeSockaddr = std::optional<Sockaddr>;
@@ -442,11 +447,6 @@ private:
 
         logdbg(logname, "DNS lookup succeeded");
         return std::make_pair(ss, len);
-    }
-
-    [[nodiscard]] bool isIdle() const noexcept
-    {
-        return std::empty(announces) && std::empty(scrapes) && !addr_pending_dns_;
     }
 
     void failAll(bool did_connect, bool did_timeout, std::string_view errmsg)
@@ -688,6 +688,11 @@ public:
 
         /* no match... */
         return false;
+    }
+
+    [[nodiscard]] bool is_idle() override
+    {
+        return std::all_of(std::begin(trackers_), std::end(trackers_), [](auto const& tracker) { return tracker.is_idle(); });
     }
 
 private:

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -690,7 +690,7 @@ public:
         return false;
     }
 
-    [[nodiscard]] bool is_idle() override
+    [[nodiscard]] bool is_idle() const noexcept override
     {
         return std::all_of(std::begin(trackers_), std::end(trackers_), [](auto const& tracker) { return tracker.is_idle(); });
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono> // operator""ms
-#include <cstdio>
+#include <cstddef> // size_t
 #include <ctime>
 #include <deque>
 #include <iterator>

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -9,7 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <atomic>
 #include <cstddef> // size_t
 #include <cstdint> // uint32_t
 #include <ctime>

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -158,5 +158,5 @@ public:
     // @return true if msg was a tracker response; false otherwise
     virtual bool handle_message(uint8_t const* msg, size_t msglen) = 0;
 
-    [[nodiscard]] virtual bool is_idle() = 0;
+    [[nodiscard]] virtual bool is_idle() const noexcept = 0;
 };

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -70,10 +70,7 @@ using tr_tracker_callback = std::function<void(tr_torrent&, tr_tracker_event con
 class tr_announcer
 {
 public:
-    [[nodiscard]] static std::unique_ptr<tr_announcer> create(
-        tr_session* session,
-        tr_announcer_udp&,
-        std::atomic<size_t>& n_pending_stops);
+    [[nodiscard]] static std::unique_ptr<tr_announcer> create(tr_session* session, tr_announcer_udp&);
     virtual ~tr_announcer() = default;
 
     virtual tr_torrent_announcer* addTorrent(tr_torrent*, tr_tracker_callback callback) = 0;
@@ -82,6 +79,8 @@ public:
     virtual void resetTorrent(tr_torrent* tor) = 0;
     virtual void removeTorrent(tr_torrent* tor) = 0;
     virtual void startShutdown() = 0;
+
+    virtual void upkeep() = 0;
 };
 
 std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
@@ -159,4 +158,6 @@ public:
     // @brief process an incoming udp message if it's a tracker response.
     // @return true if msg was a tracker response; false otherwise
     virtual bool handle_message(uint8_t const* msg, size_t msglen) = 0;
+
+    [[nodiscard]] virtual bool is_idle() = 0;
 };

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1378,13 +1378,14 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
 
 void tr_session::closeImplPart2(std::promise<void>* closed_promise, std::chrono::time_point<std::chrono::steady_clock> deadline)
 {
-    // try to keep the UDP announcer alive long enough to send out
+    // try to keep web_ and the UDP announcer alive long enough to send out
     // all the &event=stopped tracker announces.
     // also wait for all ip cache updates to finish so that web_ can
     // safely destruct.
-    if ((n_pending_stops_ != 0U || !global_ip_cache_->try_shutdown()) && std::chrono::steady_clock::now() < deadline)
+    if ((!web_->is_idle() || !announcer_udp_->is_idle() || !global_ip_cache_->try_shutdown()) &&
+        std::chrono::steady_clock::now() < deadline)
     {
-        announcer_udp_->upkeep();
+        announcer_->upkeep();
         return;
     }
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1097,10 +1097,6 @@ private:
     /// fields that aren't trivial,
     /// but are self-contained / don't hold references to others
 
-    // used during shutdown:
-    // how many &event=stopped announces are still being sent to trackers
-    std::atomic<size_t> n_pending_stops_ = {};
-
     mutable std::recursive_mutex session_mutex_;
 
     tr_stats session_stats_{ config_dir_, time(nullptr) };
@@ -1183,7 +1179,7 @@ public:
     std::unique_ptr<tr_announcer_udp> announcer_udp_ = tr_announcer_udp::create(announcer_udp_mediator_);
 
     // depends-on: settings_, torrents_, web_, announcer_udp_
-    std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this, *announcer_udp_, n_pending_stops_);
+    std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this, *announcer_udp_);
 
     // depends-on: public_peer_port_, udp_core_, dht_mediator_
     std::unique_ptr<tr_dht> dht_;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -227,6 +227,11 @@ public:
         queued_tasks_cv_.notify_one();
     }
 
+    [[nodiscard]] bool is_idle() const noexcept
+    {
+        return std::empty(queued_tasks_) && std::empty(running_tasks_);
+    }
+
     class Task
     {
     public:
@@ -621,11 +626,6 @@ public:
         }
     }
 
-    [[nodiscard]] bool is_idle() const noexcept
-    {
-        return std::empty(queued_tasks_) && std::empty(running_tasks_);
-    }
-
     void remove_task(Task const& task)
     {
         auto const lock = std::unique_lock{ tasks_mutex_ };
@@ -808,4 +808,9 @@ void tr_web::fetch(FetchOptions&& options)
 void tr_web::startShutdown(std::chrono::milliseconds deadline)
 {
     impl_->startShutdown(deadline);
+}
+
+bool tr_web::is_idle() const noexcept
+{
+    return impl_->is_idle();
 }

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -100,6 +100,8 @@ public:
     // are left alone so that they can finish.
     void startShutdown(std::chrono::milliseconds /*deadline*/);
 
+    [[nodiscard]] bool is_idle() const noexcept;
+
     // If you want to give running tasks a chance to finish, call closeSoon()
     // before destroying the tr_web object. Deleting the object will cancel
     // all of its tasks.


### PR DESCRIPTION
Fixes #6249.

Fixes `Closing transmission session...assertion failed: n_stops > 0U (/home/hyy/git_src/Transmission/libtransmission/announcer.cc:197)` after #6223, which made `n_stops` no longer reliable.

To ensure all `&event=stop` announces were sent out, instead of using yet another counter, just check if `web_` and `announcer_udp_` are currently idle or not.