### PR TITLE
refactor: migrate variant api

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1190,7 +1190,7 @@ bool core_read_rpc_response_idle(tr_variant& response)
 void core_read_rpc_response(tr_session* /*session*/, tr_variant* response, gpointer /*user_data*/)
 {
     auto owned_response = std::make_shared<tr_variant>();
-    tr_variantInitBool(owned_response.get(), false);
+    *owned_response.get() = false;
     std::swap(*owned_response, *response);
 
     Glib::signal_idle().connect([owned_response]() mutable { return core_read_rpc_response_idle(*owned_response); });

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -428,7 +428,7 @@ void bitfieldToRaw(tr_bitfield const& b, tr_variant* benc)
     else
     {
         auto const raw = b.raw();
-        tr_variantInitRaw(benc, raw.data(), std::size(raw));
+        *benc = std::string_view{ static_cast<char const*>(raw.data()), std::size(raw) };
     }
 }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -419,11 +419,11 @@ void bitfieldToRaw(tr_bitfield const& b, tr_variant* benc)
 {
     if (b.has_none() || std::empty(b))
     {
-        tr_variantInitStr(benc, "none"sv);
+        *benc = tr_variant::unmanaged_string("none"sv);
     }
     else if (b.has_all())
     {
-        tr_variantInitStrView(benc, "all"sv);
+        *benc = tr_variant::unmanaged_string("all"sv);
     }
     else
     {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -428,7 +428,7 @@ void bitfieldToRaw(tr_bitfield const& b, tr_variant* benc)
     else
     {
         auto const raw = b.raw();
-        *benc = std::string_view{ static_cast<char const*>(raw.data()), std::size(raw) };
+        *benc = std::string_view{ reinterpret_cast<char const*>(raw.data()), std::size(raw) };
     }
 }
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -158,7 +158,7 @@ struct MyHandler : public transmission::benc::Handler
             return false;
         }
 
-        tr_variantInitInt(variant, value);
+        *variant = value;
         return true;
     }
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -164,22 +164,13 @@ struct MyHandler : public transmission::benc::Handler
 
     bool String(std::string_view sv, Context const& /*context*/) final
     {
-        auto* const variant = get_node();
-        if (variant == nullptr)
+        if (auto* const variant = get_node(); variant != nullptr)
         {
-            return false;
+            *variant = inplace_ ? tr_variant::unmanaged_string(sv) : tr_variant{ sv };
+            return true;
         }
 
-        if (inplace_)
-        {
-            tr_variantInitStrView(variant, sv);
-        }
-        else
-        {
-            tr_variantInitStr(variant, sv);
-        }
-
-        return true;
+        return false;
     }
 
     bool StartDict(Context const& /*context*/) final

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -66,7 +66,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool Bool(bool const val)
     {
-        tr_variantInitBool(get_leaf(), val);
+        *get_leaf() = val;
         return true;
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -93,7 +93,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool Double(double const val)
     {
-        tr_variantInitReal(get_leaf(), val);
+        *get_leaf() = val;
         return true;
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -82,7 +82,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool Int64(int64_t const val)
     {
-        tr_variantInitInt(get_leaf(), val);
+        *get_leaf() = val;
         return true;
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -60,7 +60,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool Null()
     {
-        tr_variantInitStrView(get_leaf(), "");
+        *get_leaf() = tr_variant::unmanaged_string("");
         return true;
     }
 
@@ -99,14 +99,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool String(Ch const* const str, rapidjson::SizeType const len, bool const copy)
     {
-        if (copy)
-        {
-            tr_variantInitStr(get_leaf(), { str, len });
-        }
-        else
-        {
-            tr_variantInitStrView(get_leaf(), { str, len });
-        }
+        *get_leaf() = copy ? tr_variant{ std::string{ str, len } } : tr_variant::unmanaged_string({ str, len });
         return true;
     }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -346,11 +346,6 @@ bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, std::byte const*
 
 // ---
 
-void tr_variantInitBool(tr_variant* initme, bool value)
-{
-    *initme = value;
-}
-
 void tr_variantInitInt(tr_variant* initme, int64_t value)
 {
     *initme = value;
@@ -486,7 +481,7 @@ tr_variant* tr_variantDictAddBool(tr_variant* const var, tr_quark key, bool val)
 {
     tr_variantDictRemove(var, key);
     auto* const child = tr_variantDictAdd(var, key);
-    tr_variantInitBool(child, val);
+    *child = val;
     return child;
 }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -361,11 +361,6 @@ void tr_variantInitInt(tr_variant* initme, int64_t value)
     *initme = value;
 }
 
-void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
-{
-    *initme = std::string_view{ static_cast<char const*>(value), value_len };
-}
-
 void tr_variantInitList(tr_variant* initme, size_t n_reserve)
 {
     auto vec = tr_variant::Vector{};

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -346,11 +346,6 @@ bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, std::byte const*
 
 // ---
 
-void tr_variantInitReal(tr_variant* initme, double value)
-{
-    *initme = value;
-}
-
 void tr_variantInitBool(tr_variant* initme, bool value)
 {
     *initme = value;
@@ -499,7 +494,7 @@ tr_variant* tr_variantDictAddReal(tr_variant* const var, tr_quark key, double va
 {
     tr_variantDictRemove(var, key);
     auto* const child = tr_variantDictAdd(var, key);
-    tr_variantInitReal(child, val);
+    *child = val;
     return child;
 }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -363,12 +363,7 @@ void tr_variantInitInt(tr_variant* initme, int64_t value)
 
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
 {
-    tr_variantInitStr(initme, std::string_view{ static_cast<char const*>(value), value_len });
-}
-
-void tr_variantInitStr(tr_variant* initme, std::string_view value)
-{
-    *initme = value;
+    *initme = std::string_view{ static_cast<char const*>(value), value_len };
 }
 
 void tr_variantInitList(tr_variant* initme, size_t n_reserve)
@@ -517,7 +512,7 @@ tr_variant* tr_variantDictAddStr(tr_variant* const var, tr_quark key, std::strin
 {
     tr_variantDictRemove(var, key);
     auto* const child = tr_variantDictAdd(var, key);
-    tr_variantInitStr(child, val);
+    *child = val;
     return child;
 }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -361,11 +361,6 @@ void tr_variantInitInt(tr_variant* initme, int64_t value)
     *initme = value;
 }
 
-void tr_variantInitStrView(tr_variant* initme, std::string_view val)
-{
-    *initme = tr_variant::unmanaged_string(val);
-}
-
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len)
 {
     tr_variantInitStr(initme, std::string_view{ static_cast<char const*>(value), value_len });
@@ -530,7 +525,7 @@ tr_variant* tr_variantDictAddStrView(tr_variant* const var, tr_quark key, std::s
 {
     tr_variantDictRemove(var, key);
     auto* const child = tr_variantDictAdd(var, key);
-    tr_variantInitStrView(child, val);
+    *child = tr_variant::unmanaged_string(val);
     return child;
 }
 
@@ -758,9 +753,7 @@ void tr_variant_serde::walk(tr_variant const& top, WalkFuncs const& walk_funcs, 
                 if (node.current()->holds_alternative<tr_variant::Map>())
                 {
                     auto const keystr = tr_quark_get_string_view(key);
-                    auto tmp = tr_variant{};
-                    tr_variantInitStrView(&tmp, keystr);
-                    walk_funcs.string_func(tmp, keystr, user_data);
+                    walk_funcs.string_func(tr_variant::unmanaged_string(keystr), keystr, user_data);
                 }
             }
             else // finished with this node

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -346,11 +346,6 @@ bool tr_variantDictFindRaw(tr_variant* const var, tr_quark key, std::byte const*
 
 // ---
 
-void tr_variantInitInt(tr_variant* initme, int64_t value)
-{
-    *initme = value;
-}
-
 void tr_variantInitList(tr_variant* initme, size_t n_reserve)
 {
     auto vec = tr_variant::Vector{};
@@ -473,7 +468,7 @@ tr_variant* tr_variantDictAddInt(tr_variant* const var, tr_quark key, int64_t va
 {
     tr_variantDictRemove(var, key);
     auto* const child = tr_variantDictAdd(var, key);
-    tr_variantInitInt(child, val);
+    *child = val;
     return child;
 }
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -373,7 +373,6 @@ private:
 
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
-void tr_variantInitStr(tr_variant* initme, std::string_view value);
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len);
 
 bool tr_variantGetRaw(tr_variant const* variant, std::byte const** setme_raw, size_t* setme_len);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -380,8 +380,6 @@ bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size
 
 bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 
-void tr_variantInitReal(tr_variant* initme, double value);
-
 // --- Booleans
 
 bool tr_variantGetBool(tr_variant const* variant, bool* setme);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -384,8 +384,6 @@ bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 
 bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 
-void tr_variantInitBool(tr_variant* initme, bool value);
-
 // --- Ints
 
 bool tr_variantGetInt(tr_variant const* var, int64_t* setme);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -375,7 +375,6 @@ bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
 void tr_variantInitStr(tr_variant* initme, std::string_view value);
 void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len);
-void tr_variantInitStrView(tr_variant* initme, std::string_view val);
 
 bool tr_variantGetRaw(tr_variant const* variant, std::byte const** setme_raw, size_t* setme_len);
 bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size_t* setme_len);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -388,8 +388,6 @@ bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 
 bool tr_variantGetInt(tr_variant const* var, int64_t* setme);
 
-void tr_variantInitInt(tr_variant* initme, int64_t value);
-
 // --- Lists
 
 void tr_variantInitList(tr_variant* initme, size_t n_reserve);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -373,8 +373,6 @@ private:
 
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 
-void tr_variantInitRaw(tr_variant* initme, void const* value, size_t value_len);
-
 bool tr_variantGetRaw(tr_variant const* variant, std::byte const** setme_raw, size_t* setme_len);
 bool tr_variantGetRaw(tr_variant const* variant, uint8_t const** setme_raw, size_t* setme_len);
 

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -195,12 +195,12 @@ void variantInit(tr_variant* init_me, bool value)
 
 void variantInit(tr_variant* init_me, int64_t value)
 {
-    tr_variantInitInt(init_me, value);
+    *init_me = value;
 }
 
 void variantInit(tr_variant* init_me, int value)
 {
-    tr_variantInitInt(init_me, value);
+    *init_me = value;
 }
 
 void variantInit(tr_variant* init_me, double value)

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -190,7 +190,7 @@ bool change(TrackerStat& setme, tr_variant const* value)
 
 void variantInit(tr_variant* init_me, bool value)
 {
-    tr_variantInitBool(init_me, value);
+    *init_me = value;
 }
 
 void variantInit(tr_variant* init_me, int64_t value)
@@ -215,7 +215,7 @@ void variantInit(tr_variant* init_me, QByteArray const& value)
 
 void variantInit(tr_variant* init_me, QString const& value)
 {
-    variantInit(init_me, value.toUtf8());
+    *init_me = value.toStdString();
 }
 
 void variantInit(tr_variant* init_me, std::string_view value)

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -210,7 +210,7 @@ void variantInit(tr_variant* init_me, double value)
 
 void variantInit(tr_variant* init_me, QByteArray const& value)
 {
-    *init_me = std::string_view{ value.constData(), value.size() };
+    *init_me = std::string_view{ value.constData(), static_cast<size_t>(value.size()) };
 }
 
 void variantInit(tr_variant* init_me, QString const& value)

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -220,7 +220,7 @@ void variantInit(tr_variant* init_me, QString const& value)
 
 void variantInit(tr_variant* init_me, std::string_view value)
 {
-    tr_variantInitStr(init_me, value);
+    *init_me = value;
 }
 
 } // namespace trqt::variant_helpers

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -210,7 +210,7 @@ void variantInit(tr_variant* init_me, double value)
 
 void variantInit(tr_variant* init_me, QByteArray const& value)
 {
-    tr_variantInitRaw(init_me, value.constData(), value.size());
+    *init_me = std::string_view{ value.constData(), value.size() };
 }
 
 void variantInit(tr_variant* init_me, QString const& value)

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -205,7 +205,7 @@ void variantInit(tr_variant* init_me, int value)
 
 void variantInit(tr_variant* init_me, double value)
 {
-    tr_variantInitReal(init_me, value);
+    *init_me = value;
 }
 
 void variantInit(tr_variant* init_me, QByteArray const& value)

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -51,7 +51,7 @@ TEST_F(VariantTest, getType)
     EXPECT_FALSE(tr_variantGetStrView(&v, &sv));
 
     auto strkey = "foo"sv;
-    tr_variantInitStr(&v, strkey);
+    v = tr_variant{ strkey };
     EXPECT_FALSE(tr_variantGetBool(&v, &b));
     EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
     EXPECT_EQ(strkey, sv);
@@ -65,14 +65,14 @@ TEST_F(VariantTest, getType)
     EXPECT_EQ(std::size(strkey), std::size(sv));
 
     strkey = "true"sv;
-    tr_variantInitStr(&v, strkey);
+    v = tr_variant{ strkey };
     EXPECT_TRUE(tr_variantGetBool(&v, &b));
     EXPECT_TRUE(b);
     EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
     EXPECT_EQ(strkey, sv);
 
     strkey = "false"sv;
-    tr_variantInitStr(&v, strkey);
+    v = tr_variant{ strkey };
     EXPECT_TRUE(tr_variantGetBool(&v, &b));
     EXPECT_FALSE(b);
     EXPECT_TRUE(tr_variantGetStrView(&v, &sv));

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -58,7 +58,7 @@ TEST_F(VariantTest, getType)
     EXPECT_NE(std::data(strkey), std::data(sv));
 
     strkey = "anything"sv;
-    tr_variantInitStrView(&v, strkey);
+    v = tr_variant::unmanaged_string(strkey);
     EXPECT_TRUE(tr_variantGetStrView(&v, &sv));
     EXPECT_EQ(strkey, sv);
     EXPECT_EQ(std::data(strkey), std::data(sv)); // literally the same memory

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -42,7 +42,7 @@ TEST_F(VariantTest, getType)
     auto sv = std::string_view{};
     auto v = tr_variant{};
 
-    tr_variantInitInt(&v, 30);
+    v = 30;
     EXPECT_TRUE(tr_variantGetInt(&v, &i));
     EXPECT_EQ(30, i);
     EXPECT_TRUE(tr_variantGetReal(&v, &d));

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -214,7 +214,7 @@ static bool replaceURL(tr_variant* metainfo, std::string_view oldval, std::strin
                     auto const newstr = replaceSubstr(sv, oldval, newval);
                     fmt::print("\tReplaced in 'announce-list' tier #{:d}: '{:s}' --> '{:s}'\n", tierCount + 1, sv, newstr);
                     node->clear();
-                    tr_variantInitStr(node, newstr);
+                    *node = newstr;
                     changed = true;
                 }
 


### PR DESCRIPTION
This branch is from awhile back but I didn't get around to PRing it. I should have done, so here it is.

This PR removes most of the older `tr_variantInitFoo()` methods.