### PR TITLE
refactor: Values pt. 4 - use Values::Speed in Qt clien

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -181,10 +181,12 @@ using tr_peer_callback_generic = void (*)(tr_peer* peer, tr_peer_event const& ev
 class tr_peer
 {
 public:
+    using Speed = libtransmission::Values::Speed;
+
     tr_peer(tr_torrent const* tor);
     virtual ~tr_peer();
 
-    virtual bool isTransferringPieces(uint64_t now, tr_direction dir, tr_bytes_per_second_t* setme_bytes_per_second) const = 0;
+    [[nodiscard]] virtual Speed get_piece_speed(uint64_t now, tr_direction direction) const = 0;
 
     [[nodiscard]] bool hasPiece(tr_piece_index_t piece) const noexcept
     {
@@ -207,13 +209,6 @@ public:
 
     // requests that have been made but haven't been fulfilled yet
     [[nodiscard]] virtual size_t activeReqCount(tr_direction) const noexcept = 0;
-
-    [[nodiscard]] tr_bytes_per_second_t get_piece_speed_bytes_per_second(uint64_t now, tr_direction direction) const
-    {
-        auto bytes_per_second = tr_bytes_per_second_t{};
-        isTransferringPieces(now, direction, &bytes_per_second);
-        return bytes_per_second;
-    }
 
     virtual void requestBlocks(tr_block_span_t const* block_spans, size_t n_spans) = 0;
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -52,8 +52,8 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/webseed.h"
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
+using namespace libtransmission::Values;
 
 static auto constexpr CancelHistorySec = int{ 60 };
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1813,43 +1813,37 @@ namespace rechoke_uploads_helpers
 {
 struct ChokeData
 {
-    ChokeData(
-        tr_peerMsgs* msgs_in,
-        Speed rate_in,
-        uint8_t salt_in,
-        bool is_interested_in,
-        bool was_choked_in,
-        bool is_choked_in)
-        : msgs{ msgs_in }
-        , rate{ rate_in }
-        , salt{ salt_in }
-        , is_interested{ is_interested_in }
-        , was_choked{ was_choked_in }
-        , is_choked{ is_choked_in }
+    ChokeData(tr_peerMsgs* msgs, Speed rate, uint8_t salt, bool is_interested, bool was_choked, bool is_choked)
+        : msgs_{ msgs }
+        , rate_{ rate }
+        , salt_{ salt }
+        , is_interested_{ is_interested }
+        , was_choked_{ was_choked }
+        , is_choked_{ is_choked }
     {
     }
 
-    tr_peerMsgs* msgs;
-    Speed rate;
-    uint8_t salt;
-    bool is_interested;
-    bool was_choked;
-    bool is_choked;
+    tr_peerMsgs* msgs_;
+    Speed rate_;
+    uint8_t salt_;
+    bool is_interested_;
+    bool was_choked_;
+    bool is_choked_;
 
     [[nodiscard]] constexpr auto compare(ChokeData const& that) const noexcept // <=>
     {
         // prefer higher overall speeds
-        if (auto const val = tr_compare_3way(this->rate, that.rate); val != 0)
+        if (auto const val = tr_compare_3way(rate_, that.rate_); val != 0)
         {
             return -val;
         }
 
-        if (this->was_choked != that.was_choked) // prefer unchoked
+        if (was_choked_ != that.was_choked_) // prefer unchoked
         {
-            return this->was_choked ? 1 : -1;
+            return was_choked_ ? 1 : -1;
         }
 
-        return tr_compare_3way(this->salt, that.salt);
+        return tr_compare_3way(salt_, that.salt_);
     }
 
     [[nodiscard]] constexpr auto operator<(ChokeData const& that) const noexcept
@@ -1957,11 +1951,11 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
             break;
         }
 
-        item.is_choked = is_maxed_out ? item.was_choked : false;
+        item.is_choked_ = is_maxed_out ? item.was_choked_ : false;
 
         ++checked_choke_count;
 
-        if (item.is_interested)
+        if (item.is_interested_)
         {
             ++unchoked_interested;
         }
@@ -1974,7 +1968,7 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
 
         for (auto i = checked_choke_count, n = std::size(choked); i < n; ++i)
         {
-            if (choked[i].is_interested)
+            if (choked[i].is_interested_)
             {
                 rand_pool.push_back(&choked[i]);
             }
@@ -1983,15 +1977,15 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
         if (auto const n = std::size(rand_pool); n != 0)
         {
             auto* c = rand_pool[tr_rand_int(n)];
-            c->is_choked = false;
-            s->optimistic = c->msgs;
+            c->is_choked_ = false;
+            s->optimistic = c->msgs_;
             s->optimistic_unchoke_time_scaler = OptimisticUnchokeMultiplier;
         }
     }
 
     for (auto& item : choked)
     {
-        item.msgs->set_choke(item.is_choked);
+        item.msgs_->set_choke(item.is_choked_);
     }
 }
 } // namespace rechoke_uploads_helpers

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -52,6 +52,7 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/webseed.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -381,16 +381,9 @@ public:
         }
     }
 
-    bool isTransferringPieces(uint64_t now, tr_direction dir, tr_bytes_per_second_t* setme_bytes_per_second) const override
+    [[nodiscard]] Speed get_piece_speed(uint64_t now, tr_direction dir) const override
     {
-        auto const byps = io->get_piece_speed(now, dir).base_quantity();
-
-        if (setme_bytes_per_second != nullptr)
-        {
-            *setme_bytes_per_second = byps;
-        }
-
-        return byps != 0U;
+        return io->get_piece_speed(now, dir);
     }
 
     [[nodiscard]] size_t activeReqCount(tr_direction dir) const noexcept override
@@ -559,10 +552,10 @@ private:
         // Get the rate limit we should use.
         // TODO: this needs to consider all the other peers as well...
         uint64_t const now = tr_time_msec();
-        auto rate_bytes_per_second = uint64_t{ get_piece_speed_bytes_per_second(now, TR_PEER_TO_CLIENT) };
+        auto rate = get_piece_speed(now, TR_PEER_TO_CLIENT);
         if (torrent->uses_speed_limit(TR_PEER_TO_CLIENT))
         {
-            rate_bytes_per_second = std::min(rate_bytes_per_second, torrent->speed_limit(TR_PEER_TO_CLIENT).base_quantity());
+            rate = std::min(rate, torrent->speed_limit(TR_PEER_TO_CLIENT));
         }
 
         // honor the session limits, if enabled
@@ -570,7 +563,7 @@ private:
         {
             if (auto const limit = torrent->session->active_speed_limit(TR_PEER_TO_CLIENT); limit)
             {
-                rate_bytes_per_second = std::min(rate_bytes_per_second, limit->base_quantity());
+                rate = std::min(rate, *limit);
             }
         }
 
@@ -578,7 +571,7 @@ private:
         // many requests we should send to this peer
         size_t constexpr Floor = 32;
         size_t constexpr Seconds = RequestBufSecs;
-        size_t const estimated_blocks_in_period = (rate_bytes_per_second * Seconds) / tr_block_info::BlockSize;
+        size_t const estimated_blocks_in_period = (rate.base_quantity() * Seconds) / tr_block_info::BlockSize;
         size_t const ceil = reqq ? *reqq : 250;
 
         auto max_reqs = estimated_blocks_in_period;

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -29,6 +29,7 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -29,7 +29,6 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -41,6 +41,7 @@
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -480,8 +480,8 @@ namespace make_torrent_field_helpers
         peer_map.try_emplace(TR_KEY_peerIsInterested, peer.peerIsInterested);
         peer_map.try_emplace(TR_KEY_port, peer.port);
         peer_map.try_emplace(TR_KEY_progress, peer.progress);
-        peer_map.try_emplace(TR_KEY_rateToClient, tr_toSpeedBytes(peer.rateToClient_KBps));
-        peer_map.try_emplace(TR_KEY_rateToPeer, tr_toSpeedBytes(peer.rateToPeer_KBps));
+        peer_map.try_emplace(TR_KEY_rateToClient, Speed{ peer.rateToClient_KBps, Speed::Units::KByps }.base_quantity());
+        peer_map.try_emplace(TR_KEY_rateToPeer, Speed{ peer.rateToPeer_KBps, Speed::Units::KByps }.base_quantity());
         peers_vec.emplace_back(std::move(peer_map));
     }
     tr_torrentPeersFree(peers, n_peers);
@@ -675,8 +675,8 @@ namespace make_torrent_field_helpers
     case TR_KEY_primary_mime_type: return tor.primary_mime_type();
     case TR_KEY_priorities: return make_file_priorities_vec(tor);
     case TR_KEY_queuePosition: return st.queuePosition;
-    case TR_KEY_rateDownload: return tr_toSpeedBytes(st.pieceDownloadSpeed_KBps);
-    case TR_KEY_rateUpload: return tr_toSpeedBytes(st.pieceUploadSpeed_KBps);
+    case TR_KEY_rateDownload: return Speed{ st.pieceDownloadSpeed_KBps, Speed::Units::KByps }.base_quantity();
+    case TR_KEY_rateUpload: return Speed{ st.pieceUploadSpeed_KBps, Speed::Units::KByps }.base_quantity();
     case TR_KEY_recheckProgress: return st.recheckProgress;
     case TR_KEY_secondsDownloading: return st.secondsDownloading;
     case TR_KEY_secondsSeeding: return st.secondsSeeding;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -41,7 +41,6 @@
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -59,7 +59,6 @@
 
 struct tr_ctor;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -59,6 +59,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -981,11 +981,7 @@ private:
     friend size_t tr_sessionGetAltSpeedBegin(tr_session const* session);
     friend size_t tr_sessionGetAltSpeedEnd(tr_session const* session);
     friend size_t tr_sessionGetCacheLimit_MB(tr_session const* session);
-<<<<<<< HEAD
     friend size_t tr_sessionGetAltSpeed_KBps(tr_session const* session, tr_direction dir);
-=======
-    friend tr_kilobytes_per_second_t tr_sessionGetAltSpeed_KBps(tr_session const* session, tr_direction dir);
->>>>>>> 86053d7e6 (refactor: tr_session::speedLimitKBps() is now tr_session::speed_limit() and returns a Values::Speed)
     friend tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
     friend tr_sched_day tr_sessionGetAltSpeedDay(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant const& client_settings);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -981,7 +981,11 @@ private:
     friend size_t tr_sessionGetAltSpeedBegin(tr_session const* session);
     friend size_t tr_sessionGetAltSpeedEnd(tr_session const* session);
     friend size_t tr_sessionGetCacheLimit_MB(tr_session const* session);
+<<<<<<< HEAD
     friend size_t tr_sessionGetAltSpeed_KBps(tr_session const* session, tr_direction dir);
+=======
+    friend tr_kilobytes_per_second_t tr_sessionGetAltSpeed_KBps(tr_session const* session, tr_direction dir);
+>>>>>>> 86053d7e6 (refactor: tr_session::speedLimitKBps() is now tr_session::speed_limit() and returns a Values::Speed)
     friend tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
     friend tr_sched_day tr_sessionGetAltSpeedDay(tr_session const* session);
     friend tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled, tr_variant const& client_settings);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -48,6 +48,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -48,7 +48,6 @@
 
 struct tr_ctor;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -32,7 +32,6 @@ using tr_byte_index_t = uint64_t;
 using tr_tracker_tier_t = uint32_t;
 using tr_tracker_id_t = uint32_t;
 using tr_torrent_id_t = int;
-using tr_bytes_per_second_t = size_t;
 using tr_mode_t = uint16_t;
 
 struct tr_block_span_t
@@ -1331,7 +1330,7 @@ struct tr_webseed_view
 {
     char const* url; // the url to download from
     bool is_downloading; // can be true even if speed is 0, e.g. slow download
-    tr_bytes_per_second_t download_bytes_per_second; // current download speed
+    uint64_t download_bytes_per_second; // current download speed
 };
 
 struct tr_webseed_view tr_torrentWebseed(tr_torrent const* torrent, size_t nth);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -737,15 +737,6 @@ std::string tr_formatter_speed_KBps(double kbyps)
 {
     return Speed{ kbyps, Speed::Units::KByps }.to_string();
 }
-uint64_t tr_toSpeedBytes(size_t kbyps)
-{
-    return Speed{ kbyps, Speed::Units::KByps }.base_quantity();
-}
-
-double tr_toSpeedKBps(size_t byps)
-{
-    return Speed{ byps, Speed::Units::Byps }.count(Speed::Units::KByps);
-}
 
 // --- formatters: memory
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -759,7 +759,7 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
     tr_mem_K = base;
 }
 
-std::string tr_formatter_mem_B(size_t bytes)
+std::string tr_formatter_mem_B(uint64_t bytes)
 {
     return Memory{ bytes, Memory::Units::Bytes }.to_string();
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -755,12 +755,11 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 {
     namespace Values = libtransmission::Values;
 
-    auto const kval = base == 1000U ? Values::Config::Base::Kilo : Values::Config::Base::Kibi;
-    Values::Config::Memory = { kval, "B", kb, mb, gb, tb };
+    Values::Config::Memory = { base == 1000U ? Values::Kilo : Values::Kibi, "B", kb, mb, gb, tb };
     tr_mem_K = base;
 }
 
-std::string tr_formatter_mem_B(uint64_t bytes)
+std::string tr_formatter_mem_B(size_t bytes)
 {
     return Memory{ bytes, Memory::Units::Bytes }.to_string();
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -755,7 +755,8 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 {
     namespace Values = libtransmission::Values;
 
-    Values::Config::Memory = { base == 1000U ? Values::Kilo : Values::Kibi, "B", kb, mb, gb, tb };
+    auto const kval = base == 1000U ? Values::Config::Base::Kilo : Values::Config::Base::Kibi;
+    Values::Config::Memory = { kval, "B", kb, mb, gb, tb };
     tr_mem_K = base;
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,6 +60,8 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
+namespace Values = libtransmission::Values;
+
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,8 +60,6 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
-namespace Values = libtransmission::Values;
-
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---
@@ -682,6 +680,8 @@ Config::Units<StorageUnits> Config::Storage{ Config::Base::Kilo, "B"sv, "kB"sv, 
 
 tr_variant tr_formatter_get_units()
 {
+    using namespace libtransmission::Values;
+
     auto const make_units_vec = [](auto const& units)
     {
         auto units_vec = tr_variant::Vector{};

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -746,7 +746,8 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 {
     namespace Values = libtransmission::Values;
 
-    Values::Config::Memory = { base == 1000U ? Values::Kilo : Values::Kibi, "B", kb, mb, gb, tb };
+    auto const kval = base == 1000U ? Values::Config::Base::Kilo : Values::Config::Base::Kibi;
+    Values::Config::Memory = { kval, "B", kb, mb, gb, tb };
     tr_mem_K = base;
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,8 +60,6 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
-namespace Values = libtransmission::Values;
-
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---
@@ -757,12 +755,11 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 {
     namespace Values = libtransmission::Values;
 
-    auto const kval = base == 1000U ? Values::Config::Base::Kilo : Values::Config::Base::Kibi;
-    Values::Config::Memory = { kval, "B", kb, mb, gb, tb };
+    Values::Config::Memory = { base == 1000U ? Values::Kilo : Values::Kibi, "B", kb, mb, gb, tb };
     tr_mem_K = base;
 }
 
-std::string tr_formatter_mem_B(uint64_t bytes)
+std::string tr_formatter_mem_B(size_t bytes)
 {
     return Memory{ bytes, Memory::Units::Bytes }.to_string();
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -765,11 +765,6 @@ uint64_t tr_toMemBytes(size_t mbytes)
     return Memory{ mbytes, Memory::Units::MBytes }.base_quantity();
 }
 
-double tr_toMemMB(uint64_t bytes)
-{
-    return Memory{ bytes, Memory::Units::Bytes }.count(Memory::Units::MBytes);
-}
-
 // --- ENVIRONMENT
 
 bool tr_env_key_exists(char const* key)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,8 +60,6 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
-namespace Values = libtransmission::Values;
-
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -308,7 +308,6 @@ void tr_formatter_mem_init(size_t base, char const* kb, char const* mb, char con
 extern size_t tr_speed_K;
 extern size_t tr_mem_K;
 
-[[nodiscard]] double tr_toMemMB(uint64_t bytes);
 [[nodiscard]] uint64_t tr_toMemBytes(size_t mbytes);
 
 [[nodiscard]] std::string tr_formatter_mem_B(uint64_t bytes);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -309,7 +309,6 @@ extern size_t tr_speed_K;
 extern size_t tr_mem_K;
 
 [[nodiscard]] double tr_toMemMB(uint64_t bytes);
-[[nodiscard]] double tr_toSpeedKBps(size_t byps);
 [[nodiscard]] uint64_t tr_toMemBytes(size_t mbytes);
 [[nodiscard]] uint64_t tr_toSpeedBytes(size_t kbyps);
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -310,7 +310,6 @@ extern size_t tr_mem_K;
 
 [[nodiscard]] double tr_toMemMB(uint64_t bytes);
 [[nodiscard]] uint64_t tr_toMemBytes(size_t mbytes);
-[[nodiscard]] uint64_t tr_toSpeedBytes(size_t kbyps);
 
 [[nodiscard]] std::string tr_formatter_mem_B(uint64_t bytes);
 [[nodiscard]] std::string tr_formatter_mem_MB(double mbytes);

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -14,15 +14,6 @@
 
 namespace libtransmission::Values
 {
-<<<<<<< HEAD
-=======
-enum Base
-{
-    Kilo = 1000U,
-    Kibi = 1024U
-};
-
->>>>>>> c69a053d8 (refactor: add Units alias in the Value class)
 enum class MemoryUnits
 {
     Bytes,

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -14,6 +14,15 @@
 
 namespace libtransmission::Values
 {
+<<<<<<< HEAD
+=======
+enum Base
+{
+    Kilo = 1000U,
+    Kibi = 1024U
+};
+
+>>>>>>> c69a053d8 (refactor: add Units alias in the Value class)
 enum class MemoryUnits
 {
     Bytes,

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -40,7 +40,6 @@
 
 struct evbuffer;
 
-using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -40,6 +40,7 @@
 
 struct evbuffer;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1039,8 +1039,8 @@ void DetailsDialog::refreshUI()
 
         setIfIdle(ui_.bandwidthPriorityCombo, i);
 
-        setIfIdle(ui_.singleDownSpin, static_cast<int>(baseline.downloadLimit().getKBps()));
-        setIfIdle(ui_.singleUpSpin, static_cast<int>(baseline.uploadLimit().getKBps()));
+        setIfIdle(ui_.singleDownSpin, static_cast<int>(baseline.downloadLimit().count(Speed::Units::KByps)));
+        setIfIdle(ui_.singleUpSpin, static_cast<int>(baseline.uploadLimit().count(Speed::Units::KByps)));
         setIfIdle(ui_.peerLimitSpin, baseline.peerLimit());
     }
 
@@ -1201,8 +1201,8 @@ void DetailsDialog::refreshUI()
                 code_tip.resize(code_tip.size() - 1); // eat the trailing linefeed
             }
 
-            item->setText(COL_UP, peer.rate_to_peer.isZero() ? QString{} : fmt.speedToString(peer.rate_to_peer));
-            item->setText(COL_DOWN, peer.rate_to_client.isZero() ? QString{} : fmt.speedToString(peer.rate_to_client));
+            item->setText(COL_UP, peer.rate_to_peer.is_zero() ? QString{} : peer.rate_to_peer.to_qstring());
+            item->setText(COL_DOWN, peer.rate_to_client.is_zero() ? QString{} : peer.rate_to_client.to_qstring());
             item->setText(
                 COL_PERCENT,
                 peer.progress > 0 ? QStringLiteral("%1%").arg(static_cast<int>(peer.progress * 100.0)) : QString{});

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -5,11 +5,14 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_formatter
+#include <libtransmission/values.h> // tr_formatter
 
 #include "Formatter.h"
 #include "Speed.h"
 
 #include <algorithm>
+
+using namespace std::literals;
 
 Formatter& Formatter::get()
 {
@@ -25,13 +28,12 @@ Formatter::Formatter()
           { tr("B"), tr("KiB"), tr("MiB"), tr("GiB"), tr("TiB") } // MEM
       } }
 {
+    namespace Values = libtransmission::Values;
+
     auto const& speed = UnitStrings[SPEED];
-    tr_formatter_speed_init(
-        SpeedBase,
-        speed[KB].toUtf8().constData(),
-        speed[MB].toUtf8().constData(),
-        speed[GB].toUtf8().constData(),
-        speed[TB].toUtf8().constData());
+    Values::Config::Speed = { Values::Config::Base::Kilo, "B"sv,
+                              speed[KB].toStdString(),    speed[MB].toStdString(),
+                              speed[GB].toStdString(),    speed[TB].toStdString() };
 
     auto const& size = UnitStrings[SIZE];
     tr_formatter_size_init(
@@ -116,18 +118,4 @@ QString Formatter::timeToString(int seconds) const
     auto const days = hours / 24;
 
     return tr("%Ln day(s)", nullptr, days);
-}
-
-/***
-****
-***/
-
-double Speed::getKBps() const
-{
-    return getBps() / static_cast<double>(Formatter::SpeedBase);
-}
-
-Speed Speed::fromKBps(double KBps)
-{
-    return Speed{ static_cast<int>(KBps * Formatter::SpeedBase) };
 }

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -40,7 +40,6 @@ public:
         NUM_TYPES
     };
 
-    static constexpr int SpeedBase = 1000;
     static constexpr int SizeBase = 1000;
     static constexpr int MemBase = 1024;
 
@@ -51,25 +50,6 @@ public:
     [[nodiscard]] QString sizeToString(uint64_t bytes) const;
     [[nodiscard]] QString timeToString(int seconds) const;
     [[nodiscard]] QString unitStr(Type t, Size s) const;
-
-    [[nodiscard]] auto speedToString(Speed const& speed) const
-    {
-        return QString::fromStdString(tr_formatter_speed_KBps(speed.getKBps()));
-    }
-
-    [[nodiscard]] auto uploadSpeedToString(Speed const& upload_speed) const
-    {
-        static auto constexpr UploadSymbol = QChar{ 0x25B4 };
-
-        return tr("%1 %2").arg(speedToString(upload_speed)).arg(UploadSymbol);
-    }
-
-    [[nodiscard]] auto downloadSpeedToString(Speed const& download_speed) const
-    {
-        static auto constexpr DownloadSymbol = QChar{ 0x25BE };
-
-        return tr("%1 %2").arg(speedToString(download_speed)).arg(DownloadSymbol);
-    }
 
     [[nodiscard]] auto percentToString(double x) const
     {

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -5,66 +5,54 @@
 
 #pragma once
 
-class Speed
+#include <QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
+#include <QString>
+
+#include "libtransmission/values.h"
+
+class Speed : public libtransmission::Values::Speed
 {
+    Q_DECLARE_TR_FUNCTIONS(Speed)
+
 public:
     Speed() = default;
 
-    double getKBps() const;
-
-    [[nodiscard]] auto constexpr getBps() const noexcept
-    {
-        return bytes_per_second_;
-    }
-
-    [[nodiscard]] auto constexpr isZero() const noexcept
-    {
-        return bytes_per_second_ == 0;
-    }
-
-    static Speed fromKBps(double KBps);
-
-    [[nodiscard]] static constexpr Speed fromBps(int Bps) noexcept
-    {
-        return Speed{ Bps };
-    }
-
-    void constexpr setBps(int Bps) noexcept
-    {
-        bytes_per_second_ = Bps;
-    }
-
-    constexpr Speed& operator+=(Speed const& that) noexcept
-    {
-        bytes_per_second_ += that.bytes_per_second_;
-        return *this;
-    }
-
-    [[nodiscard]] auto constexpr operator+(Speed const& that) const noexcept
-    {
-        return Speed{ getBps() + that.getBps() };
-    }
-
-    [[nodiscard]] auto constexpr operator<(Speed const& that) const noexcept
-    {
-        return getBps() < that.getBps();
-    }
-
-    [[nodiscard]] auto constexpr operator==(Speed const& that) const noexcept
-    {
-        return getBps() == that.getBps();
-    }
-
-    [[nodiscard]] auto constexpr operator!=(Speed const& that) const noexcept
-    {
-        return getBps() != that.getBps();
-    }
-
-private:
-    explicit constexpr Speed(int bytes_per_second) noexcept
-        : bytes_per_second_{ bytes_per_second }
+    template<typename Number, typename std::enable_if_t<std::is_integral_v<Number>>* = nullptr>
+    constexpr Speed(Number value, Units multiple)
+        : libtransmission::Values::Speed{ value, multiple }
     {
     }
 
-    int bytes_per_second_ = {};
+    template<typename Number, typename std::enable_if_t<std::is_floating_point_v<Number>>* = nullptr>
+    Speed(Number value, Units multiple)
+        : libtransmission::Values::Speed{ value, multiple }
+    {
+    }
+
+    [[nodiscard]] auto constexpr is_zero() const noexcept
+    {
+        return base_quantity() == 0U;
+    }
+
+    [[nodiscard]] auto to_qstring() const noexcept
+    {
+        return QString::fromStdString(to_string());
+    }
+
+    [[nodiscard]] auto to_upload_qstring() const
+    {
+        static auto constexpr UploadSymbol = QChar{ 0x25B4 };
+        return tr("%1 %2").arg(to_qstring()).arg(UploadSymbol);
+    }
+
+    [[nodiscard]] auto to_download_qstring() const
+    {
+        static auto constexpr DownloadSymbol = QChar{ 0x25BE };
+        return tr("%1 %2").arg(to_qstring()).arg(DownloadSymbol);
+    }
+
+    [[nodiscard]] constexpr auto operator+(Speed const& other) const noexcept
+    {
+        return Speed{ base_quantity() + other.base_quantity(), Speed::Units::Byps };
+    }
 };

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -420,14 +420,14 @@ public:
         return sitenames_;
     }
 
-    [[nodiscard]] Speed uploadLimit() const
+    [[nodiscard]] constexpr auto uploadLimit() const
     {
-        return Speed::fromKBps(upload_limit_);
+        return Speed{ upload_limit_, Speed::Units::KByps };
     }
 
-    [[nodiscard]] Speed downloadLimit() const
+    [[nodiscard]] constexpr auto downloadLimit() const
     {
-        return Speed::fromKBps(download_limit_);
+        return Speed{ download_limit_, Speed::Units::KByps };
     }
 
     [[nodiscard]] constexpr auto uploadIsLimited() const noexcept
@@ -643,7 +643,6 @@ private:
     time_t start_date_ = {};
 
     int bandwidth_priority_ = {};
-    int download_limit_ = {};
     int error_ = {};
     int eta_ = {};
     int peer_limit_ = {};
@@ -656,10 +655,10 @@ private:
     int seed_idle_mode_ = {};
     int seed_ratio_mode_ = {};
     int status_ = {};
-    int upload_limit_ = {};
     int webseeds_sending_to_us_ = {};
 
     uint64_t desired_available_ = {};
+    uint64_t download_limit_ = {};
     uint64_t downloaded_ever_ = {};
     uint64_t failed_ever_ = {};
     uint64_t file_count_ = {};
@@ -669,6 +668,7 @@ private:
     uint64_t piece_size_ = {};
     uint64_t size_when_done_ = {};
     uint64_t total_size_ = {};
+    uint64_t upload_limit_ = {};
     uint64_t uploaded_ever_ = {};
 
     double metadata_percent_complete_ = {};

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -278,12 +278,11 @@ QString TorrentDelegate::shortTransferString(Torrent const& tor)
 
     if (have_down)
     {
-        str = Formatter::get().downloadSpeedToString(tor.downloadSpeed()) + QStringLiteral("   ") +
-            Formatter::get().uploadSpeedToString(tor.uploadSpeed());
+        str = tor.downloadSpeed().to_download_qstring() + QStringLiteral("   ") + tor.uploadSpeed().to_upload_qstring();
     }
     else if (have_up)
     {
-        str = Formatter::get().uploadSpeedToString(tor.uploadSpeed());
+        str = tor.uploadSpeed().to_upload_qstring();
     }
 
     return str.trimmed();

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -33,8 +33,8 @@ bool change(double& setme, double const& value)
 
 bool change(Speed& setme, tr_variant const* value)
 {
-    auto const bytes_per_second = getValue<int>(value);
-    return bytes_per_second && change(setme, Speed::fromBps(*bytes_per_second));
+    auto const byps = getValue<int>(value);
+    return byps && change(setme, Speed{ *byps, Speed::Units::Byps });
 }
 
 bool change(TorrentHash& setme, tr_variant const* value)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,7 +29,6 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
-#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -372,36 +371,4 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
-}
-
-TEST_F(UtilsTest, value)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
-    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
-
-    val = Speed{ 1, Speed::Units::Byps };
-    EXPECT_EQ("1 B/s", val.to_string());
-
-    val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
-
-    val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
-}
-
-TEST_F(UtilsTest, valueHonorsFormatterInit)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
-
-    auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
-    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -380,12 +380,13 @@ TEST_F(UtilsTest, value)
 
     auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
+    EXPECT_EQ(1000000UL, val.base_quantity());
     EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
     EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
     EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
 
     val = Speed{ 1, Speed::Units::Byps };
+    EXPECT_EQ(1U, val.base_quantity());
     EXPECT_EQ("1 B/s", val.to_string());
 
     val = Speed{ 10, Speed::Units::KByps };

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,6 +29,7 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
+#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -371,4 +372,29 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
+}
+
+TEST_F(UtilsTest, value)
+{
+    namespace Values = libtransmission::Values;
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 MB/s", val_m.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto const val_k = val_m.to(Values::KByps);
+    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_b = val_m.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    val_b = val_k.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_g = val_m.to(Values::GByps);
+    EXPECT_EQ("0.00 GB/s", val_g.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -398,3 +398,14 @@ TEST_F(UtilsTest, value)
     EXPECT_EQ("0.00 GB/s", val_g.to_string());
     EXPECT_EQ(1000000U, val_m.base_quantity());
 }
+
+TEST_F(UtilsTest, valueHonorsFormatterInit)
+{
+    namespace Values = libtransmission::Values;
+
+    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ(1048576U, val_m.base_quantity());
+}

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,7 +29,6 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
-#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -372,37 +371,4 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
-}
-
-TEST_F(UtilsTest, value)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_EQ(1000000UL, val.base_quantity());
-    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
-
-    val = Speed{ 1, Speed::Units::Byps };
-    EXPECT_EQ(1U, val.base_quantity());
-    EXPECT_EQ("1 B/s", val.to_string());
-
-    val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
-
-    val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
-}
-
-TEST_F(UtilsTest, valueHonorsFormatterInit)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
-
-    auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
-    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -378,25 +378,21 @@ TEST_F(UtilsTest, value)
 {
     namespace Values = libtransmission::Values;
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 MB/s", val_m.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    auto val = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1.00 MB/s", val.to_string());
+    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
 
-    auto const val_k = val_m.to(Values::KByps);
-    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 1, Values::Byps };
+    EXPECT_EQ("1 B/s", val.to_string());
 
-    auto val_b = val_m.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 10, Values::KByps };
+    EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val_b = val_k.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
-
-    auto val_g = val_m.to(Values::GByps);
-    EXPECT_EQ("0.00 GB/s", val_g.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 999, Values::KByps };
+    EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
@@ -406,6 +402,6 @@ TEST_F(UtilsTest, valueHonorsFormatterInit)
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
     EXPECT_EQ(1048576U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -376,32 +376,32 @@ TEST_F(UtilsTest, ratioToString)
 
 TEST_F(UtilsTest, value)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
-    auto val = Values::Speed{ 1, Values::MByps };
+    auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
-    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
 
-    val = Values::Speed{ 1, Values::Byps };
+    val = Speed{ 1, Speed::Units::Byps };
     EXPECT_EQ("1 B/s", val.to_string());
 
-    val = Values::Speed{ 10, Values::KByps };
+    val = Speed{ 10, Speed::Units::KByps };
     EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val = Values::Speed{ 999, Values::KByps };
+    val = Speed{ 999, Speed::Units::KByps };
     EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
-    EXPECT_EQ(1048576U, val_m.base_quantity());
+    auto const val = Speed{ 1, Speed::Units::MByps };
+    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
+    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/values-test.cc
+++ b/tests/libtransmission/values-test.cc
@@ -14,24 +14,40 @@ using namespace libtransmission::Values;
 
 using ValuesTest = ::testing::Test;
 
-TEST_F(ValuesTest, value)
+TEST_F(ValuesTest, baseQuantity)
 {
     auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_EQ(1000000UL, val.base_quantity());
+}
+
+TEST_F(ValuesTest, count)
+{
+    auto const val = Speed{ 1, Speed::Units::MByps };
     EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
     EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
     EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
+}
+
+TEST_F(ValuesTest, toString)
+{
+    auto val = Speed{ 1, Speed::Units::MByps };
+    EXPECT_EQ("1 MB/s", val.to_string());
 
     val = Speed{ 1, Speed::Units::Byps };
     EXPECT_EQ(1U, val.base_quantity());
     EXPECT_EQ("1 B/s", val.to_string());
 
     val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
+    EXPECT_EQ("10 kB/s", val.to_string());
 
     val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
+    EXPECT_EQ("999 kB/s", val.to_string());
+
+    val = Speed{ 99.22222, Speed::Units::KByps };
+    EXPECT_EQ("99.22 kB/s", val.to_string());
+
+    val = Speed{ 999.22222, Speed::Units::KByps };
+    EXPECT_EQ("999.2 kB/s", val.to_string());
 }
 
 TEST_F(ValuesTest, valueHonorsFormatterInit)
@@ -39,6 +55,6 @@ TEST_F(ValuesTest, valueHonorsFormatterInit)
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
+    EXPECT_EQ("1 EmmBeePerEss", val.to_string());
     EXPECT_EQ(1048576U, val.base_quantity());
 }


### PR DESCRIPTION
This PR reimplements the Qt client's `Speed` class as a subclass of `Values::Speed`.

This is part 5 in the libtransmission::Values series. See #6215 for more information.