### PR TITLE
Refactor/values pt 5 remove qt speed class

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -52,6 +52,7 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/webseed.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -29,6 +29,7 @@
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -41,6 +41,7 @@
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -59,6 +59,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -48,6 +48,7 @@
 
 struct tr_ctor;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,6 +60,8 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
+namespace Values = libtransmission::Values;
+
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -60,8 +60,6 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
-namespace Values = libtransmission::Values;
-
 time_t libtransmission::detail::tr_time::current_time = {};
 
 // ---
@@ -682,6 +680,8 @@ Config::Units<StorageUnits> Config::Storage{ Config::Base::Kilo, "B"sv, "kB"sv, 
 
 tr_variant tr_formatter_get_units()
 {
+    using namespace libtransmission::Values;
+
     auto const make_units_vec = [](auto const& units)
     {
         auto units_vec = tr_variant::Vector{};

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -40,6 +40,7 @@
 
 struct evbuffer;
 
+using Speed = libtransmission::Values::Speed;
 using namespace std::literals;
 using namespace libtransmission::Values;
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1039,8 +1039,8 @@ void DetailsDialog::refreshUI()
 
         setIfIdle(ui_.bandwidthPriorityCombo, i);
 
-        setIfIdle(ui_.singleDownSpin, static_cast<int>(baseline.downloadLimit().getKBps()));
-        setIfIdle(ui_.singleUpSpin, static_cast<int>(baseline.uploadLimit().getKBps()));
+        setIfIdle(ui_.singleDownSpin, static_cast<int>(baseline.downloadLimit().count(Speed::Units::KByps)));
+        setIfIdle(ui_.singleUpSpin, static_cast<int>(baseline.uploadLimit().count(Speed::Units::KByps)));
         setIfIdle(ui_.peerLimitSpin, baseline.peerLimit());
     }
 
@@ -1201,8 +1201,8 @@ void DetailsDialog::refreshUI()
                 code_tip.resize(code_tip.size() - 1); // eat the trailing linefeed
             }
 
-            item->setText(COL_UP, peer.rate_to_peer.isZero() ? QString{} : fmt.speedToString(peer.rate_to_peer));
-            item->setText(COL_DOWN, peer.rate_to_client.isZero() ? QString{} : fmt.speedToString(peer.rate_to_client));
+            item->setText(COL_UP, peer.rate_to_peer.is_zero() ? QString{} : peer.rate_to_peer.to_qstring());
+            item->setText(COL_DOWN, peer.rate_to_client.is_zero() ? QString{} : peer.rate_to_client.to_qstring());
             item->setText(
                 COL_PERCENT,
                 peer.progress > 0 ? QStringLiteral("%1%").arg(static_cast<int>(peer.progress * 100.0)) : QString{});

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -5,11 +5,14 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_formatter
+#include <libtransmission/values.h> // tr_formatter
 
 #include "Formatter.h"
 #include "Speed.h"
 
 #include <algorithm>
+
+using namespace std::literals;
 
 Formatter& Formatter::get()
 {
@@ -25,13 +28,12 @@ Formatter::Formatter()
           { tr("B"), tr("KiB"), tr("MiB"), tr("GiB"), tr("TiB") } // MEM
       } }
 {
+    namespace Values = libtransmission::Values;
+
     auto const& speed = UnitStrings[SPEED];
-    tr_formatter_speed_init(
-        SpeedBase,
-        speed[KB].toUtf8().constData(),
-        speed[MB].toUtf8().constData(),
-        speed[GB].toUtf8().constData(),
-        speed[TB].toUtf8().constData());
+    Values::Config::Speed = { Values::Config::Base::Kilo, "B"sv,
+                              speed[KB].toStdString(),    speed[MB].toStdString(),
+                              speed[GB].toStdString(),    speed[TB].toStdString() };
 
     auto const& size = UnitStrings[SIZE];
     tr_formatter_size_init(
@@ -116,18 +118,4 @@ QString Formatter::timeToString(int seconds) const
     auto const days = hours / 24;
 
     return tr("%Ln day(s)", nullptr, days);
-}
-
-/***
-****
-***/
-
-double Speed::getKBps() const
-{
-    return getBps() / static_cast<double>(Formatter::SpeedBase);
-}
-
-Speed Speed::fromKBps(double KBps)
-{
-    return Speed{ static_cast<int>(KBps * Formatter::SpeedBase) };
 }

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -40,7 +40,6 @@ public:
         NUM_TYPES
     };
 
-    static constexpr int SpeedBase = 1000;
     static constexpr int SizeBase = 1000;
     static constexpr int MemBase = 1024;
 
@@ -51,25 +50,6 @@ public:
     [[nodiscard]] QString sizeToString(uint64_t bytes) const;
     [[nodiscard]] QString timeToString(int seconds) const;
     [[nodiscard]] QString unitStr(Type t, Size s) const;
-
-    [[nodiscard]] auto speedToString(Speed const& speed) const
-    {
-        return QString::fromStdString(tr_formatter_speed_KBps(speed.getKBps()));
-    }
-
-    [[nodiscard]] auto uploadSpeedToString(Speed const& upload_speed) const
-    {
-        static auto constexpr UploadSymbol = QChar{ 0x25B4 };
-
-        return tr("%1 %2").arg(speedToString(upload_speed)).arg(UploadSymbol);
-    }
-
-    [[nodiscard]] auto downloadSpeedToString(Speed const& download_speed) const
-    {
-        static auto constexpr DownloadSymbol = QChar{ 0x25BE };
-
-        return tr("%1 %2").arg(speedToString(download_speed)).arg(DownloadSymbol);
-    }
 
     [[nodiscard]] auto percentToString(double x) const
     {

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -5,66 +5,54 @@
 
 #pragma once
 
-class Speed
+#include <QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
+#include <QString>
+
+#include "libtransmission/values.h"
+
+class Speed : public libtransmission::Values::Speed
 {
+    Q_DECLARE_TR_FUNCTIONS(Speed)
+
 public:
     Speed() = default;
 
-    double getKBps() const;
-
-    [[nodiscard]] auto constexpr getBps() const noexcept
-    {
-        return bytes_per_second_;
-    }
-
-    [[nodiscard]] auto constexpr isZero() const noexcept
-    {
-        return bytes_per_second_ == 0;
-    }
-
-    static Speed fromKBps(double KBps);
-
-    [[nodiscard]] static constexpr Speed fromBps(int Bps) noexcept
-    {
-        return Speed{ Bps };
-    }
-
-    void constexpr setBps(int Bps) noexcept
-    {
-        bytes_per_second_ = Bps;
-    }
-
-    constexpr Speed& operator+=(Speed const& that) noexcept
-    {
-        bytes_per_second_ += that.bytes_per_second_;
-        return *this;
-    }
-
-    [[nodiscard]] auto constexpr operator+(Speed const& that) const noexcept
-    {
-        return Speed{ getBps() + that.getBps() };
-    }
-
-    [[nodiscard]] auto constexpr operator<(Speed const& that) const noexcept
-    {
-        return getBps() < that.getBps();
-    }
-
-    [[nodiscard]] auto constexpr operator==(Speed const& that) const noexcept
-    {
-        return getBps() == that.getBps();
-    }
-
-    [[nodiscard]] auto constexpr operator!=(Speed const& that) const noexcept
-    {
-        return getBps() != that.getBps();
-    }
-
-private:
-    explicit constexpr Speed(int bytes_per_second) noexcept
-        : bytes_per_second_{ bytes_per_second }
+    template<typename Number, typename std::enable_if_t<std::is_integral_v<Number>>* = nullptr>
+    constexpr Speed(Number value, Units multiple)
+        : libtransmission::Values::Speed{ value, multiple }
     {
     }
 
-    int bytes_per_second_ = {};
+    template<typename Number, typename std::enable_if_t<std::is_floating_point_v<Number>>* = nullptr>
+    Speed(Number value, Units multiple)
+        : libtransmission::Values::Speed{ value, multiple }
+    {
+    }
+
+    [[nodiscard]] auto constexpr is_zero() const noexcept
+    {
+        return base_quantity() == 0U;
+    }
+
+    [[nodiscard]] auto to_qstring() const noexcept
+    {
+        return QString::fromStdString(to_string());
+    }
+
+    [[nodiscard]] auto to_upload_qstring() const
+    {
+        static auto constexpr UploadSymbol = QChar{ 0x25B4 };
+        return tr("%1 %2").arg(to_qstring()).arg(UploadSymbol);
+    }
+
+    [[nodiscard]] auto to_download_qstring() const
+    {
+        static auto constexpr DownloadSymbol = QChar{ 0x25BE };
+        return tr("%1 %2").arg(to_qstring()).arg(DownloadSymbol);
+    }
+
+    [[nodiscard]] constexpr auto operator+(Speed const& other) const noexcept
+    {
+        return Speed{ base_quantity() + other.base_quantity(), Speed::Units::Byps };
+    }
 };

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -420,14 +420,14 @@ public:
         return sitenames_;
     }
 
-    [[nodiscard]] Speed uploadLimit() const
+    [[nodiscard]] constexpr auto uploadLimit() const
     {
-        return Speed::fromKBps(upload_limit_);
+        return Speed{ upload_limit_, Speed::Units::KByps };
     }
 
-    [[nodiscard]] Speed downloadLimit() const
+    [[nodiscard]] constexpr auto downloadLimit() const
     {
-        return Speed::fromKBps(download_limit_);
+        return Speed{ download_limit_, Speed::Units::KByps };
     }
 
     [[nodiscard]] constexpr auto uploadIsLimited() const noexcept
@@ -643,7 +643,6 @@ private:
     time_t start_date_ = {};
 
     int bandwidth_priority_ = {};
-    int download_limit_ = {};
     int error_ = {};
     int eta_ = {};
     int peer_limit_ = {};
@@ -656,10 +655,10 @@ private:
     int seed_idle_mode_ = {};
     int seed_ratio_mode_ = {};
     int status_ = {};
-    int upload_limit_ = {};
     int webseeds_sending_to_us_ = {};
 
     uint64_t desired_available_ = {};
+    uint64_t download_limit_ = {};
     uint64_t downloaded_ever_ = {};
     uint64_t failed_ever_ = {};
     uint64_t file_count_ = {};
@@ -669,6 +668,7 @@ private:
     uint64_t piece_size_ = {};
     uint64_t size_when_done_ = {};
     uint64_t total_size_ = {};
+    uint64_t upload_limit_ = {};
     uint64_t uploaded_ever_ = {};
 
     double metadata_percent_complete_ = {};

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -278,12 +278,11 @@ QString TorrentDelegate::shortTransferString(Torrent const& tor)
 
     if (have_down)
     {
-        str = Formatter::get().downloadSpeedToString(tor.downloadSpeed()) + QStringLiteral("   ") +
-            Formatter::get().uploadSpeedToString(tor.uploadSpeed());
+        str = tor.downloadSpeed().to_download_qstring() + QStringLiteral("   ") + tor.uploadSpeed().to_upload_qstring();
     }
     else if (have_up)
     {
-        str = Formatter::get().uploadSpeedToString(tor.uploadSpeed());
+        str = tor.uploadSpeed().to_upload_qstring();
     }
 
     return str.trimmed();

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -33,8 +33,8 @@ bool change(double& setme, double const& value)
 
 bool change(Speed& setme, tr_variant const* value)
 {
-    auto const bytes_per_second = getValue<int>(value);
-    return bytes_per_second && change(setme, Speed::fromBps(*bytes_per_second));
+    auto const byps = getValue<int>(value);
+    return byps && change(setme, Speed{ *byps, Speed::Units::Byps });
 }
 
 bool change(TorrentHash& setme, tr_variant const* value)

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,7 +29,6 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
-#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -372,36 +371,4 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
-}
-
-TEST_F(UtilsTest, value)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
-    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
-    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
-
-    val = Speed{ 1, Speed::Units::Byps };
-    EXPECT_EQ("1 B/s", val.to_string());
-
-    val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
-
-    val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
-}
-
-TEST_F(UtilsTest, valueHonorsFormatterInit)
-{
-    using Speed = libtransmission::Values::Speed;
-
-    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
-
-    auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
-    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -29,6 +29,7 @@
 #include <libtransmission/file.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
+#include <libtransmission/values.h>
 
 #include "gtest/gtest.h"
 #include "test-fixtures.h"
@@ -371,4 +372,29 @@ TEST_F(UtilsTest, ratioToString)
     {
         ASSERT_EQ(tr_strratio(input, "inf"), expected);
     }
+}
+
+TEST_F(UtilsTest, value)
+{
+    namespace Values = libtransmission::Values;
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 MB/s", val_m.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto const val_k = val_m.to(Values::KByps);
+    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_b = val_m.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    val_b = val_k.to(Values::Byps);
+    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
+
+    auto val_g = val_m.to(Values::GByps);
+    EXPECT_EQ("0.00 GB/s", val_g.to_string());
+    EXPECT_EQ(1000000U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -398,3 +398,14 @@ TEST_F(UtilsTest, value)
     EXPECT_EQ("0.00 GB/s", val_g.to_string());
     EXPECT_EQ(1000000U, val_m.base_quantity());
 }
+
+TEST_F(UtilsTest, valueHonorsFormatterInit)
+{
+    namespace Values = libtransmission::Values;
+
+    tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
+
+    auto const val_m = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ(1048576U, val_m.base_quantity());
+}

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -378,25 +378,21 @@ TEST_F(UtilsTest, value)
 {
     namespace Values = libtransmission::Values;
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 MB/s", val_m.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    auto val = Values::Speed{ 1, Values::MByps };
+    EXPECT_EQ("1.00 MB/s", val.to_string());
+    EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
 
-    auto const val_k = val_m.to(Values::KByps);
-    EXPECT_EQ("1000.0 kB/s", val_k.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 1, Values::Byps };
+    EXPECT_EQ("1 B/s", val.to_string());
 
-    auto val_b = val_m.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 10, Values::KByps };
+    EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val_b = val_k.to(Values::Byps);
-    EXPECT_EQ("1000000.0 B/s", val_b.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
-
-    auto val_g = val_m.to(Values::GByps);
-    EXPECT_EQ("0.00 GB/s", val_g.to_string());
-    EXPECT_EQ(1000000U, val_m.base_quantity());
+    val = Values::Speed{ 999, Values::KByps };
+    EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
@@ -406,6 +402,6 @@ TEST_F(UtilsTest, valueHonorsFormatterInit)
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1 EmmBeePerEss", val_m.to_string());
+    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
     EXPECT_EQ(1048576U, val_m.base_quantity());
 }

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -376,32 +376,32 @@ TEST_F(UtilsTest, ratioToString)
 
 TEST_F(UtilsTest, value)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
-    auto val = Values::Speed{ 1, Values::MByps };
+    auto val = Speed{ 1, Speed::Units::MByps };
     EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_NEAR(1000000U, val.base_quantity(), 0.0001);
-    EXPECT_NEAR(1000U, val.count(Values::KByps), 0.0001);
-    EXPECT_NEAR(1U, val.count(Values::MByps), 0.0001);
-    EXPECT_NEAR(0.001, val.count(Values::GByps), 0.0001);
+    EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
+    EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
+    EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
 
-    val = Values::Speed{ 1, Values::Byps };
+    val = Speed{ 1, Speed::Units::Byps };
     EXPECT_EQ("1 B/s", val.to_string());
 
-    val = Values::Speed{ 10, Values::KByps };
+    val = Speed{ 10, Speed::Units::KByps };
     EXPECT_EQ("10.00 kB/s", val.to_string());
 
-    val = Values::Speed{ 999, Values::KByps };
+    val = Speed{ 999, Speed::Units::KByps };
     EXPECT_EQ("999.0 kB/s", val.to_string());
 }
 
 TEST_F(UtilsTest, valueHonorsFormatterInit)
 {
-    namespace Values = libtransmission::Values;
+    using Speed = libtransmission::Values::Speed;
 
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
-    auto const val_m = Values::Speed{ 1, Values::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val_m.to_string());
-    EXPECT_EQ(1048576U, val_m.base_quantity());
+    auto const val = Speed{ 1, Speed::Units::MByps };
+    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
+    EXPECT_EQ(1048576U, val.base_quantity());
 }

--- a/tests/libtransmission/values-test.cc
+++ b/tests/libtransmission/values-test.cc
@@ -14,24 +14,40 @@ using namespace libtransmission::Values;
 
 using ValuesTest = ::testing::Test;
 
-TEST_F(ValuesTest, value)
+TEST_F(ValuesTest, baseQuantity)
 {
     auto val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 MB/s", val.to_string());
     EXPECT_EQ(1000000UL, val.base_quantity());
+}
+
+TEST_F(ValuesTest, count)
+{
+    auto const val = Speed{ 1, Speed::Units::MByps };
     EXPECT_NEAR(1000U, val.count(Speed::Units::KByps), 0.0001);
     EXPECT_NEAR(1U, val.count(Speed::Units::MByps), 0.0001);
     EXPECT_NEAR(0.001, val.count(Speed::Units::GByps), 0.0001);
+}
+
+TEST_F(ValuesTest, toString)
+{
+    auto val = Speed{ 1, Speed::Units::MByps };
+    EXPECT_EQ("1 MB/s", val.to_string());
 
     val = Speed{ 1, Speed::Units::Byps };
     EXPECT_EQ(1U, val.base_quantity());
     EXPECT_EQ("1 B/s", val.to_string());
 
     val = Speed{ 10, Speed::Units::KByps };
-    EXPECT_EQ("10.00 kB/s", val.to_string());
+    EXPECT_EQ("10 kB/s", val.to_string());
 
     val = Speed{ 999, Speed::Units::KByps };
-    EXPECT_EQ("999.0 kB/s", val.to_string());
+    EXPECT_EQ("999 kB/s", val.to_string());
+
+    val = Speed{ 99.22222, Speed::Units::KByps };
+    EXPECT_EQ("99.22 kB/s", val.to_string());
+
+    val = Speed{ 999.22222, Speed::Units::KByps };
+    EXPECT_EQ("999.2 kB/s", val.to_string());
 }
 
 TEST_F(ValuesTest, valueHonorsFormatterInit)
@@ -39,6 +55,6 @@ TEST_F(ValuesTest, valueHonorsFormatterInit)
     tr_formatter_speed_init(1024, "KayBeePerEss", "EmmBeePerEss", "GeeBeePerEss", "TeeBeePerEss");
 
     auto const val = Speed{ 1, Speed::Units::MByps };
-    EXPECT_EQ("1.00 EmmBeePerEss", val.to_string());
+    EXPECT_EQ("1 EmmBeePerEss", val.to_string());
     EXPECT_EQ(1048576U, val.base_quantity());
 }


### PR DESCRIPTION
This PR reimplements the Qt client's `Speed` class as a subclass of `Values::Speed`.

This is part 5 in the libtransmission::Values series. See #6215 for more information.