### PR TITLE
refactor: make some tr_torrent fields private

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -236,7 +236,7 @@ char const* torrentStop(tr_session* session, tr_variant* args_in, tr_variant* /*
     {
         if (tor->activity() != TR_STATUS_STOPPED)
         {
-            tor->is_stopping_ = true;
+            tor->stop_soon();
             session->rpcNotify(TR_RPC_TORRENT_STOPPED, tor);
         }
     }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -389,7 +389,7 @@ double tr_torrentGetMetadataPercent(tr_torrent const* tor)
 
 std::string tr_torrentGetMagnetLink(tr_torrent const* tor)
 {
-    return tor->metainfo_.magnet();
+    return tor->magnet();
 }
 
 size_t tr_torrentGetMagnetLinkToBuf(tr_torrent const* tor, char* buf, size_t buflen)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -148,16 +148,6 @@ bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* m
 
 namespace
 {
-constexpr void torrentSetQueued(tr_torrent* tor, bool queued)
-{
-    if (tor->is_queued_ != queued)
-    {
-        tor->is_queued_ = queued;
-        tor->mark_changed();
-        tor->set_dirty();
-    }
-}
-
 bool setLocalErrorIfFilesDisappeared(tr_torrent* tor, std::optional<bool> has_local_data = {})
 {
     auto const has = has_local_data ? *has_local_data : tor->has_any_local_data();
@@ -642,7 +632,7 @@ void torrentStartImpl(tr_torrent* const tor)
     TR_ASSERT(tr_isTorrent(tor));
 
     tor->recheck_completeness();
-    torrentSetQueued(tor, false);
+    tor->set_is_queued(false);
 
     time_t const now = tr_time();
 
@@ -764,7 +754,7 @@ void torrentStart(tr_torrent* tor, torrent_start_opts opts)
     case TR_STATUS_STOPPED:
         if (!opts.bypass_queue && torrentShouldQueue(tor))
         {
-            torrentSetQueued(tor, true);
+            tor->set_is_queued();
             return;
         }
 
@@ -815,7 +805,7 @@ void tr_torrent::stop_now()
         tr_torrentSave(this);
     }
 
-    torrentSetQueued(this, false);
+    set_is_queued(false);
 }
 
 void tr_torrentStop(tr_torrent* tor)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1739,9 +1739,9 @@ void tr_torrentSave(tr_torrent* tor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tor->is_dirty_)
+    if (tor->is_dirty())
     {
-        tor->is_dirty_ = false;
+        tor->set_dirty(false);
         tr_resume::save(tor);
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -937,7 +937,7 @@ void on_metainfo_completed(tr_torrent* tor)
 void tr_torrent::on_metainfo_updated()
 {
     completion = tr_completion{ this, &block_info() };
-    obfuscated_hash = tr_sha1::digest("req2"sv, info_hash());
+    obfuscated_hash_ = tr_sha1::digest("req2"sv, info_hash());
     fpm_.reset(metainfo_);
     file_mtimes_.resize(file_count());
     file_priorities_.reset(&fpm_);
@@ -956,7 +956,6 @@ void tr_torrent::init(tr_ctor const* const ctor)
     queuePosition = std::size(session->torrents());
 
     on_metainfo_updated();
-
     char const* dir = nullptr;
     if (tr_ctorGetDownloadDir(ctor, TR_FORCE, &dir) || tr_ctorGetDownloadDir(ctor, TR_FALLBACK, &dir))
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1592,35 +1592,8 @@ void tr_torrentStartMagnet(tr_torrent* tor)
 
 // ---
 
-namespace
-{
-namespace verify_helpers
-{
-void onVerifyDoneThreadFunc(tr_torrent* const tor)
-{
-    TR_ASSERT(tor->session->am_in_session_thread());
-
-    if (tor->is_deleting_)
-    {
-        return;
-    }
-
-    tor->recheck_completeness();
-
-    if (tor->start_when_stable)
-    {
-        auto opts = torrent_start_opts{};
-        opts.has_local_data = !tor->checked_pieces_.has_none();
-        torrentStart(tor, opts);
-    }
-}
-} // namespace verify_helpers
-} // namespace
-
 void tr_torrentVerify(tr_torrent* tor, bool force)
 {
-    using namespace verify_helpers;
-
     tor->session->runInSessionThread(
         [tor, force]()
         {
@@ -1703,10 +1676,9 @@ void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, 
     tor_->verify_progress_ = std::clamp(static_cast<float>(piece + 1U) / tor_->metainfo_.piece_count(), 0.0F, 1.0F);
 }
 
+// (usually called from tr_verify_worker's thread)
 void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 {
-    using namespace verify_helpers;
-
     if (time_started_.has_value())
     {
         auto const total_size = tor_->total_size();
@@ -1724,12 +1696,28 @@ void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 
     if (!aborted && !tor_->is_deleting_)
     {
-        tor_->session->runInSessionThread(onVerifyDoneThreadFunc, tor_);
-    }
+        tor_->session->runInSessionThread(
+            [tor = tor_]()
+            {
+                if (tor->is_deleting_)
+                {
+                    return;
+                }
 
-    if (tor_->verify_done_callback_)
-    {
-        tor_->verify_done_callback_(tor_);
+                tor->recheck_completeness();
+
+                if (tor->verify_done_callback_)
+                {
+                    tor->verify_done_callback_(tor);
+                }
+
+                if (tor->start_when_stable)
+                {
+                    auto opts = torrent_start_opts{};
+                    opts.has_local_data = !tor->checked_pieces_.has_none();
+                    torrentStart(tor, opts);
+                }
+            });
     }
 }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -559,6 +559,16 @@ public:
         return this->is_queued_;
     }
 
+    void set_is_queued(bool queued = true) noexcept
+    {
+        if (is_queued_ != queued)
+        {
+            is_queued_ = queued;
+            mark_changed();
+            set_dirty();
+        }
+    }
+
     [[nodiscard]] constexpr auto queue_direction() const noexcept
     {
         return this->is_done() ? TR_UP : TR_DOWN;
@@ -983,7 +993,6 @@ public:
 
     bool is_deleting_ = false;
     bool is_dirty_ = false;
-    bool is_queued_ = false;
     bool is_running_ = false;
 
     // start the torrent after all the startup scaffolding is done,
@@ -1217,6 +1226,7 @@ private:
     uint16_t idle_limit_minutes_ = 0;
 
     bool is_stopping_ = false;
+    bool is_queued_ = false;
 
     bool needs_completeness_check_ = true;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -991,7 +991,6 @@ public:
 
     bool finished_seeding_by_idle_ = false;
 
-    bool is_deleting_ = false;
     bool is_running_ = false;
 
     // start the torrent after all the startup scaffolding is done,
@@ -1006,6 +1005,7 @@ private:
     friend void tr_torrentCheckSeedLimit(tr_torrent* tor);
     friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
     friend void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
+    friend void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func, void* user_data);
     friend void tr_torrentStop(tr_torrent* tor);
     friend void tr_torrentVerify(tr_torrent* tor, bool force);
 
@@ -1224,9 +1224,10 @@ private:
 
     uint16_t idle_limit_minutes_ = 0;
 
+    bool is_deleting_ = false;
     bool is_dirty_ = false;
-    bool is_stopping_ = false;
     bool is_queued_ = false;
+    bool is_stopping_ = false;
 
     bool needs_completeness_check_ = true;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -915,6 +915,11 @@ public:
 
     void init(tr_ctor const* ctor);
 
+    [[nodiscard]] TR_CONSTEXPR20 auto obfuscated_hash_equals(tr_sha1_digest_t const& test) const noexcept
+    {
+        return obfuscated_hash_ == test;
+    }
+
     tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
@@ -951,8 +956,6 @@ public:
     // Where the files are now.
     // Will equal either download_dir or incomplete_dir
     tr_interned_string current_dir_;
-
-    tr_sha1_digest_t obfuscated_hash = {};
 
     /* Used when the torrent has been created with a magnet link
      * and we're in the process of downloading the metainfo from
@@ -1192,6 +1195,8 @@ private:
     labels_t labels_;
 
     tr_interned_string bandwidth_group_;
+
+    tr_sha1_digest_t obfuscated_hash_ = {};
 
     mutable SimpleSmoothedSpeed eta_speed_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -992,7 +992,6 @@ public:
     bool finished_seeding_by_idle_ = false;
 
     bool is_deleting_ = false;
-    bool is_dirty_ = false;
     bool is_running_ = false;
 
     // start the torrent after all the startup scaffolding is done,
@@ -1225,6 +1224,7 @@ private:
 
     uint16_t idle_limit_minutes_ = 0;
 
+    bool is_dirty_ = false;
     bool is_stopping_ = false;
     bool is_queued_ = false;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -678,6 +678,11 @@ public:
         return is_stopping_;
     }
 
+    constexpr void stop_soon() noexcept
+    {
+        is_stopping_ = true;
+    }
+
     [[nodiscard]] constexpr auto is_dirty() const noexcept
     {
         return is_dirty_;
@@ -980,7 +985,6 @@ public:
     bool is_dirty_ = false;
     bool is_queued_ = false;
     bool is_running_ = false;
-    bool is_stopping_ = false;
 
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
@@ -991,7 +995,11 @@ private:
     friend tr_stat const* tr_torrentStat(tr_torrent* tor);
     friend tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
     friend uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor);
+    friend void tr_torrentCheckSeedLimit(tr_torrent* tor);
+    friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
     friend void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
+    friend void tr_torrentStop(tr_torrent* tor);
+    friend void tr_torrentVerify(tr_torrent* tor, bool force);
 
     enum class VerifyState : uint8_t
     {
@@ -1165,6 +1173,8 @@ private:
 
     void on_metainfo_updated();
 
+    void stop_now();
+
     tr_stat stats_ = {};
 
     Error error_;
@@ -1205,6 +1215,8 @@ private:
     VerifyState verify_state_ = VerifyState::None;
 
     uint16_t idle_limit_minutes_ = 0;
+
+    bool is_stopping_ = false;
 
     bool needs_completeness_check_ = true;
 

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -59,7 +59,7 @@ tr_torrent* tr_torrents::find_from_obfuscated_hash(tr_sha1_digest_t const& obfus
 {
     for (auto* const tor : *this)
     {
-        if (tor->obfuscated_hash == obfuscated_hash)
+        if (tor->obfuscated_hash_equals(obfuscated_hash))
         {
             return tor;
         }


### PR DESCRIPTION
Minor refactor to make some `tr_torrent` fields private:

- obfuscated_hash_
- is_deleting_
- is_dirty_
- is_queued_
- is_stopping_