### PR TITLE
refactor: add private helper class CumulativeCount

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -481,7 +481,7 @@ public:
                 auto const now = tr_time();
                 auto* const tor = s->tor;
 
-                tor->uploadedCur += event.length;
+                tor->bytes_uploaded_ += event.length;
                 tr_announcerAddBytes(tor, TR_ANN_UP, event.length);
                 tor->set_date_active(now);
                 tor->set_dirty();
@@ -795,7 +795,7 @@ private:
 
     static void on_client_got_piece_data(tr_torrent* const tor, uint32_t const sent_length, time_t const now)
     {
-        tor->downloadedCur += sent_length;
+        tor->bytes_downloaded_ += sent_length;
         tor->set_date_active(now);
         tor->set_dirty();
         tor->session->add_downloaded(sent_length);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -654,7 +654,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_
 
     if ((fields_to_load & tr_resume::Corrupt) != 0 && tr_variantDictFindInt(&top, TR_KEY_corrupt, &i))
     {
-        tor->corruptPrev = i;
+        tor->bytes_corrupt_.set_prev(i);
         fields_loaded |= tr_resume::Corrupt;
     }
 
@@ -686,13 +686,13 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_resume::fields_t fields_to_
 
     if ((fields_to_load & tr_resume::Downloaded) != 0 && tr_variantDictFindInt(&top, TR_KEY_downloaded, &i))
     {
-        tor->downloadedPrev = i;
+        tor->bytes_downloaded_.set_prev(i);
         fields_loaded |= tr_resume::Downloaded;
     }
 
     if ((fields_to_load & tr_resume::Uploaded) != 0 && tr_variantDictFindInt(&top, TR_KEY_uploaded, &i))
     {
-        tor->uploadedPrev = i;
+        tor->bytes_uploaded_.set_prev(i);
         fields_loaded |= tr_resume::Uploaded;
     }
 
@@ -871,7 +871,7 @@ fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor)
     return ret;
 }
 
-void save(tr_torrent* tor)
+void save(tr_torrent* const tor)
 {
     if (!tr_isTorrent(tor))
     {
@@ -885,7 +885,7 @@ void save(tr_torrent* tor)
     tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, tor->seconds_downloading(now));
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
-    tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->corruptPrev + tor->corruptCur);
+    tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->bytes_corrupt_.ever());
     tr_variantDictAddInt(&top, TR_KEY_done_date, tor->doneDate);
     tr_variantDictAddStrView(&top, TR_KEY_destination, tor->download_dir().sv());
 
@@ -894,8 +894,8 @@ void save(tr_torrent* tor)
         tr_variantDictAddStrView(&top, TR_KEY_incomplete_dir, tor->incomplete_dir().sv());
     }
 
-    tr_variantDictAddInt(&top, TR_KEY_downloaded, tor->downloadedPrev + tor->downloadedCur);
-    tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->uploadedPrev + tor->uploadedCur);
+    tr_variantDictAddInt(&top, TR_KEY_downloaded, tor->bytes_downloaded_.ever());
+    tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->bytes_uploaded_.ever());
     tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->peer_limit());
     tr_variantDictAddInt(&top, TR_KEY_bandwidth_priority, tor->get_priority());
     tr_variantDictAddBool(&top, TR_KEY_paused, !tor->start_when_stable);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1346,8 +1346,8 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
         std::end(torrents),
         [](auto const* a, auto const* b)
         {
-            auto const a_cur = a->downloadedCur + a->uploadedCur;
-            auto const b_cur = b->downloadedCur + b->uploadedCur;
+            auto const a_cur = a->bytes_downloaded_.ever();
+            auto const b_cur = b->bytes_downloaded_.ever();
             return a_cur > b_cur; // larger xfers go first
         });
     for (auto* tor : torrents)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -977,8 +977,8 @@ void tr_torrent::init(tr_ctor const* const ctor)
 
     session->addTorrent(this);
 
-    TR_ASSERT(tor->bytes_downloaded_.during_this_session() == 0U);
-    TR_ASSERT(tor->bytes_uploaded_.during_this_session() == 0);
+    TR_ASSERT(bytes_downloaded_.during_this_session() == 0U);
+    TR_ASSERT(bytes_uploaded_.during_this_session() == 0);
 
     mark_changed();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -78,9 +78,6 @@ struct tr_torrent final : public tr_completion::torrent_view
 {
     using Speed = libtransmission::Values::Speed;
 
-public:
-    using labels_t = std::vector<tr_interned_string>;
-
     class CumulativeCount
     {
     public:
@@ -120,6 +117,9 @@ public:
         uint64_t prev_ = {};
         uint64_t cur_ = {};
     };
+
+public:
+    using labels_t = std::vector<tr_interned_string>;
 
     using VerifyDoneCallback = std::function<void(tr_torrent*)>;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -80,6 +80,47 @@ struct tr_torrent final : public tr_completion::torrent_view
 
 public:
     using labels_t = std::vector<tr_interned_string>;
+
+    class CumulativeCount
+    {
+    public:
+        [[nodiscard]] constexpr auto start_new_session() noexcept
+        {
+            prev_ += cur_;
+            cur_ = {};
+        }
+
+        [[nodiscard]] constexpr auto during_this_session() const noexcept
+        {
+            return cur_;
+        }
+
+        [[nodiscard]] constexpr auto ever() const noexcept
+        {
+            return cur_ + prev_;
+        }
+
+        constexpr auto& operator+=(uint64_t count) noexcept
+        {
+            cur_ += count;
+            return *this;
+        }
+
+        constexpr void reduce(uint64_t count) // subtract w/underflow guard
+        {
+            cur_ = cur_ >= count ? cur_ - count : 0U;
+        }
+
+        constexpr void set_prev(uint64_t count) noexcept
+        {
+            prev_ = count;
+        }
+
+    private:
+        uint64_t prev_ = {};
+        uint64_t cur_ = {};
+    };
+
     using VerifyDoneCallback = std::function<void(tr_torrent*)>;
 
     class VerifyMediator : public tr_verify_worker::Mediator
@@ -104,6 +145,8 @@ public:
         tr_torrent* const tor_;
         std::optional<time_t> time_started_;
     };
+
+    // ---
 
     explicit tr_torrent(tr_torrent_metainfo&& tm)
         : metainfo_{ std::move(tm) }
@@ -957,6 +1000,10 @@ public:
     // Will equal either download_dir or incomplete_dir
     tr_interned_string current_dir_;
 
+    CumulativeCount bytes_corrupt_;
+    CumulativeCount bytes_downloaded_;
+    CumulativeCount bytes_uploaded_;
+
     /* Used when the torrent has been created with a magnet link
      * and we're in the process of downloading the metainfo from
      * other peers */
@@ -978,13 +1025,6 @@ public:
 
     time_t seconds_downloading_before_current_start_ = 0;
     time_t seconds_seeding_before_current_start_ = 0;
-
-    uint64_t downloadedCur = 0;
-    uint64_t downloadedPrev = 0;
-    uint64_t uploadedCur = 0;
-    uint64_t uploadedPrev = 0;
-    uint64_t corruptCur = 0;
-    uint64_t corruptPrev = 0;
 
     size_t queuePosition = 0;
 


### PR DESCRIPTION
Convenience / safety class used by `tr_torrent`:

```c++
    CumulativeCount bytes_corrupt_;
    CumulativeCount bytes_downloaded_;
    CumulativeCount bytes_uploaded_;
```