### PR TITLE
rollback 5791

### DIFF
--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -266,15 +266,15 @@ bool use_new_metainfo(tr_torrent* tor, tr_error* error)
 void on_have_all_metainfo(tr_torrent* tor)
 {
     auto error = tr_error{};
+    auto& m = tor->incomplete_metadata;
+    TR_ASSERT(m);
     if (use_new_metainfo(tor, &error))
     {
-        delete tor->incomplete_metadata;
-        tor->incomplete_metadata = nullptr;
+        delete m;
+        m = nullptr;
     }
     else /* drat. */
     {
-        auto& m = tor->incomplete_metadata;
-        TR_ASSERT(m);
         auto const n = m->piece_count;
 
         m->pieces_needed = create_all_needed(n);

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -66,7 +66,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
         return false;
     }
 
-    if (tor->incomplete_metadata)
+    if (tor->incomplete_metadata != nullptr)
     {
         return false;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -952,7 +952,7 @@ public:
     /* Used when the torrent has been created with a magnet link
      * and we're in the process of downloading the metainfo from
      * other peers */
-    std::unique_ptr<tr_incomplete_metadata> incomplete_metadata;
+    struct tr_incomplete_metadata* incomplete_metadata = nullptr;
 
     tr_session* session = nullptr;
 


### PR DESCRIPTION
In order to analyze #5943, tearfur is asking to check one commit before #5791.
But at that time (July 2023), the code was in a state that would not work on macOS Sonoma (which only got fixed two months later in #6016). So for now, I find it easier to revert #5791 and test it with that one change.

It's a draft, but it may help others encountering the issue to test it too.

[edit: so far, it does seem to work slightly better for me. But as the issue was only happening randomly on 1 magnet out of 10, I'd need more time to confirm, statistically, if the issue is resolved.]