### PR TITLE
chore: fix minor clang-tidy warnings

### DIFF
--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -11,6 +11,7 @@
 #include "Utils.h"
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/quark.h>
 
 #include <giomm/liststore.h>
 #include <giomm/menuattributeiter.h>
@@ -19,17 +20,21 @@
 #include <glibmm/i18n.h>
 #include <glibmm/variant.h>
 
-#if GTKMM_CHECK_VERSION(4, 0, 0)
-#include <gtkmm/shortcut.h>
-#include <gtkmm/shortcutaction.h>
-#include <gtkmm/shortcuttrigger.h>
-#endif
-
 #include <array>
 #include <stack>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
+#if GTKMM_CHECK_VERSION(4, 0, 0)
+#include <giomm/liststore.h>
+#include <gtkmm/shortcut.h>
+#include <gtkmm/shortcutaction.h>
+#include <gtkmm/shortcuttrigger.h>
+
+#include <stack>
+#include <utility>
+#endif
 
 using namespace std::string_view_literals;
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -26,6 +26,7 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/log.h>
+#include <libtransmission/quark.h>
 #include <libtransmission/rpcimpl.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>

--- a/gtk/IconCache.cc
+++ b/gtk/IconCache.cc
@@ -11,11 +11,11 @@
 
 #include <giomm/contenttype.h>
 
-#include <algorithm>
+#include <functional> // for std::less<>
 #include <map>
 #include <string>
 #include <string_view>
-#include <utility>
+#include <utility> // for std::move()
 
 using namespace std::literals;
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -54,7 +54,7 @@ void verboseLog(std::string_view description, tr_direction direction, std::strin
     }
 
     auto const direction_sv = direction == TR_DOWN ? "<< "sv : ">> "sv;
-    out << description << std::endl << "[raw]"sv << direction_sv;
+    out << description << '\n' << "[raw]"sv << direction_sv;
     for (unsigned char const ch : message)
     {
         if (isprint(ch) != 0)
@@ -67,7 +67,7 @@ void verboseLog(std::string_view description, tr_direction direction, std::strin
                 << std::setfill(' ');
         }
     }
-    out << std::endl << "[b64]"sv << direction_sv << tr_base64_encode(message) << std::endl;
+    out << '\n' << "[b64]"sv << direction_sv << tr_base64_encode(message) << '\n';
 }
 
 auto constexpr MaxBencDepth = 8;
@@ -499,7 +499,7 @@ void onScrapeDone(tr_web::FetchResponse const& web_response)
     if (status != HTTP_OK)
     {
         auto const* const response_str = tr_webGetResponseStr(status);
-        response.errmsg = fmt::format(FMT_STRING("Tracker HTTP response {:d} ({:s})"), status, response_str);
+        response.errmsg = fmt::format("Tracker HTTP response {:d} ({:s})", status, response_str);
     }
     else if (!std::empty(body))
     {

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -419,7 +419,7 @@ private:
     [[nodiscard]] static MaybeSockaddr lookup(tr_interned_string host, tr_port port, tr_interned_string logname)
     {
         auto szport = std::array<char, 16>{};
-        *fmt::format_to(std::data(szport), FMT_STRING("{:d}"), port.host()) = '\0';
+        *fmt::format_to(std::data(szport), "{:d}", port.host()) = '\0';
 
         auto hints = addrinfo{};
         hints.ai_family = AF_INET; // https://github.com/transmission/transmission/issues/4719

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -7,12 +7,14 @@
 #include <array>
 #include <chrono> // operator""ms
 #include <cstddef> // size_t
+#include <cstdint>
 #include <ctime>
 #include <deque>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -783,7 +785,7 @@ void tr_logAddTrace_tier_announce_queue(tr_tier const* tier)
     buf.reserve(std::size(events) * 20);
     for (size_t i = 0, n = std::size(events); i < n; ++i)
     {
-        fmt::format_to(std::back_inserter(buf), FMT_STRING("[{:d}:{:s}]"), i, tr_announce_event_get_string(events[i]));
+        fmt::format_to(std::back_inserter(buf), "[{:d}:{:s}]", i, tr_announce_event_get_string(events[i]));
     }
 
     tr_logAddTraceTier(tier, std::move(buf));

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -4,7 +4,11 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>
+#include <memory>
 #include <utility> // for std::swap()
 #include <vector>
 

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -88,7 +88,7 @@ public:
     explicit tr_bandwidth(tr_bandwidth* new_parent);
 
     tr_bandwidth()
-        : tr_bandwidth(nullptr)
+        : tr_bandwidth{ nullptr }
     {
     }
 

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -4,6 +4,8 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::copy, std::fill_n, std::min, std::max
+#include <cstddef>
+#include <cstdint>
 #include <vector> // std::vector
 
 #include "libtransmission/bitfield.h"

--- a/libtransmission/block-info.cc
+++ b/libtransmission/block-info.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstdint>
+
 #include "libtransmission/block-info.h"
 #include "libtransmission/tr-assert.h" // TR_ASSERT
 

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -9,7 +9,11 @@
 #include <cstdint>
 #include <fstream>
 #include <initializer_list>
+#include <ios>
+#include <optional>
+#include <string> // std::getline()
 #include <string_view>
+#include <utility> // for std::move, std::pair
 #include <vector>
 
 #ifdef _WIN32

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -4,7 +4,8 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <cerrno>
+#include <cerrno> // EINVAL
+#include <cstddef>
 #include <cstdint> // uint8_t
 #include <iterator> // std::distance(), std::next(), std::prev()
 #include <memory>
@@ -14,7 +15,6 @@
 #include <vector>
 
 #include <fmt/core.h>
-#include <small/vector.hpp>
 
 #include "libtransmission/transmission.h"
 
@@ -24,7 +24,6 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/utils.h" // tr_formatter
 
 Cache::Key Cache::make_key(tr_torrent const* torrent, tr_block_info::Location loc) noexcept
 {

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -113,7 +113,7 @@ constexpr std::string_view utSuffix(uint8_t ch)
 void two_major_two_minor_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
 {
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ', strint(&id[3], 2), '.');
-    *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:02d}"), strint(&id[5], 2)).out = '\0';
+    *fmt::format_to_n(buf, buflen - 1, "{:02d}", strint(&id[5], 2)).out = '\0';
 }
 
 // Shad0w with his experimental BitTorrent implementation and BitTornado
@@ -234,7 +234,7 @@ bool decodeBitCometClient(char* buf, size_t buflen, std::string_view peer_id)
     int const minor = uint8_t(peer_id[5]);
 
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ', mod, major, '.');
-    *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:02d}"), minor).out = '\0';
+    *fmt::format_to_n(buf, buflen - 1, "{:02d}", minor).out = '\0';
     return true;
 }
 
@@ -296,8 +296,7 @@ constexpr void bitrocket_formatter(char* buf, size_t buflen, std::string_view na
 void bittorrent_dna_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
 {
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ');
-    *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:d}.{:d}.{:d}"), strint(&id[3], 2), strint(&id[5], 2), strint(&id[7], 2))
-         .out = '\0';
+    *fmt::format_to_n(buf, buflen - 1, "{:d}.{:d}.{:d}", strint(&id[3], 2), strint(&id[5], 2), strint(&id[7], 2)).out = '\0';
 }
 
 void bits_on_wheels_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
@@ -423,16 +422,15 @@ void transmission_formatter(char* buf, size_t buflen, std::string_view name, tr_
 
     if (std::equal(&id[3], &id[6], "000")) // very old client style: -TR0006- is 0.6
     {
-        *fmt::format_to_n(buf, buflen - 1, FMT_STRING("0.{:c}"), id[6]).out = '\0';
+        *fmt::format_to_n(buf, buflen - 1, "0.{:c}", id[6]).out = '\0';
     }
     else if (std::equal(&id[3], &id[5], "00")) // pre-1.0 style: -TR0072- is 0.72
     {
-        *fmt::format_to_n(buf, buflen - 1, FMT_STRING("0.{:02d}"), strint(&id[5], 2)).out = '\0';
+        *fmt::format_to_n(buf, buflen - 1, "0.{:02d}", strint(&id[5], 2)).out = '\0';
     }
     else if (id[3] <= '3') // style up through 3.00: -TR111Z- is 1.11+
     {
-        *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:s}.{:02d}{:s}"), base62str(id[3]), strint(&id[4], 2), utSuffix(id[6]))
-             .out = '\0';
+        *fmt::format_to_n(buf, buflen - 1, "{:s}.{:02d}{:s}", base62str(id[3]), strint(&id[4], 2), utSuffix(id[6])).out = '\0';
     }
     else // -TR400X- is 4.0.0 (Beta)"
     {
@@ -492,7 +490,7 @@ constexpr void xfplay_formatter(char* buf, size_t buflen, std::string_view name,
 void xtorrent_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
 {
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ', base62str(id[3]), '.', base62str(id[4]), " ("sv);
-    *fmt::format_to_n(buf, buflen - 1, FMT_STRING("{:d}"), strint(&id[5], 2)).out = '\0';
+    *fmt::format_to_n(buf, buflen - 1, "{:d}", strint(&id[5], 2)).out = '\0';
 }
 
 struct Client
@@ -651,7 +649,7 @@ void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
 
     if (peer_id[0] == '\0' && peer_id[2] == 'B' && peer_id[3] == 'S')
     {
-        *fmt::format_to_n(buf, buflen - 1, FMT_STRING("BitSpirit {:d}"), peer_id[1] == '\0' ? 1 : int(peer_id[1])).out = '\0';
+        *fmt::format_to_n(buf, buflen - 1, "BitSpirit {:d}", peer_id[1] == '\0' ? 1 : int(peer_id[1])).out = '\0';
         return;
     }
 
@@ -692,7 +690,7 @@ void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
             }
             else
             {
-                walk = fmt::format_to_n(walk, end - walk - 1, FMT_STRING("%{:02X}"), static_cast<unsigned char>(c)).out;
+                walk = fmt::format_to_n(walk, end - walk - 1, "%{:02X}", static_cast<unsigned char>(c)).out;
             }
         }
 

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -3,6 +3,9 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -19,6 +19,7 @@
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
 
 #include <fmt/core.h>
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -6,7 +6,10 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <iterator>
+#include <optional>
 #include <random>
 #include <string>
 #include <string_view>
@@ -22,6 +25,7 @@ extern "C"
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;
@@ -49,7 +53,7 @@ std::string tr_salt(std::string_view plaintext, std::string_view salt)
 
     // convert it to a string. string holds three parts:
     // DigestPrefix, stringified digest of plaintext + salt, and the salt.
-    return fmt::format(FMT_STRING("{:s}{:s}{:s}"), SaltedPrefix, tr_sha1_to_string(digest), salt);
+    return fmt::format("{:s}{:s}{:s}", SaltedPrefix, tr_sha1_to_string(digest), salt);
 }
 
 } // namespace ssha1_impl

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -3,6 +3,10 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
 #include <vector>
 
 #include <small/set.hpp>

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -165,7 +165,7 @@ class tr_files_wanted
 {
 public:
     explicit tr_files_wanted(tr_file_piece_map const* fpm)
-        : wanted_(std::size(*fpm))
+        : wanted_{ std::size(*fpm) }
     {
         reset(fpm);
     }

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -4,7 +4,11 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::all_of
+#include <array>
 #include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <string_view>
 #include <utility> // std::move
 
@@ -21,6 +25,7 @@
 #include "libtransmission/global-ip-cache.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/utils.h"
+#include "libtransmission/web.h"
 
 namespace
 {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -6,7 +6,10 @@
 #include <algorithm>
 #include <array>
 #include <cerrno> // ECONNREFUSED, ETIMEDOUT
+#include <cstddef>
+#include <cstdint>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 #include <fmt/core.h>
@@ -24,6 +27,7 @@
 #include "libtransmission/timer.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
+#include "libtransmission/tr-macros.h" // tr_peer_id_t
 
 #define tr_logAddTraceHand(handshake, msg) \
     tr_logAddTrace(msg, fmt::format("handshake {}", (handshake)->peer_io_->display_name()))

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <cstddef>
 #include <optional>
 #include <string_view>
 #include <utility> // std::move

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -228,7 +228,7 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
     auto name_fallback = std::string{};
     if (std::empty(name))
     {
-        name_fallback = fmt::format(FMT_STRING("{}:{}"), filename, line);
+        name_fallback = fmt::format("{:s}:{:d}", filename, line);
         name = name_fallback;
     }
 

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -9,14 +9,16 @@
 #include <cstring>
 #include <iterator> // back_inserter
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include <fmt/core.h>
 
 #include "libtransmission/crypto-utils.h"
-#include "libtransmission/error.h"
 #include "libtransmission/error-types.h"
+#include "libtransmission/error.h"
 #include "libtransmission/magnet-metainfo.h"
+#include "libtransmission/tr-macros.h" // for tr_sha1_digest_t
 #include "libtransmission/tr-strbuf.h" // for tr_urlbuf
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"
@@ -213,7 +215,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
     magnet_link = tr_strv_strip(magnet_link);
     if (auto const hash = parseHash(magnet_link); hash)
     {
-        return parseMagnet(fmt::format(FMT_STRING("magnet:?xt=urn:btih:{:s}"), tr_sha1_to_string(*hash)));
+        return parseMagnet(fmt::format("magnet:?xt=urn:btih:{:s}", tr_sha1_to_string(*hash)));
     }
 
     auto const parsed = tr_urlParse(magnet_link);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -6,9 +6,12 @@
 #include <array>
 #include <cerrno>
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iterator> // std::back_inserter
+#include <optional>
+#include <string>
 #include <string_view>
 #include <utility> // std::pair
 
@@ -356,7 +359,7 @@ static tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool 
 
     if (!suppress_msgs)
     {
-        tr_logAddDebug(fmt::format(FMT_STRING("Bound socket {:d} to port {:d} on {:s}"), fd, port.host(), addr.display_name()));
+        tr_logAddDebug(fmt::format("Bound socket {:d} to port {:d} on {:s}", fd, port.host(), addr.display_name()));
     }
 
 #ifdef TCP_FASTOPEN

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -11,7 +11,9 @@
 #include <cstddef> // std::byte
 #include <cstdint>
 #include <ctime> // time_t
+#include <functional>
 #include <iterator> // std::back_inserter
+#include <memory>
 #include <optional>
 #include <tuple> // std::tie
 #include <unordered_map>
@@ -50,6 +52,7 @@
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-macros.h"
 #include "libtransmission/utils.h"
+#include "libtransmission/values.h"
 #include "libtransmission/webseed.h"
 
 using namespace std::literals;

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -4,6 +4,8 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <cstddef> // std::byte
+#include <cstdint>
 #include <limits> // std::numeric_limits
 #include <string_view>
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -15,6 +15,7 @@
 #include <memory> // std::unique_ptr
 #include <optional>
 #include <queue>
+#include <ratio>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::min
 #include <cerrno>
+#include <cstddef> // std::byte
 
 #include <fmt/core.h>
 
@@ -12,9 +13,10 @@
 
 #include "libtransmission/error.h"
 #include "libtransmission/log.h"
-#include "libtransmission/peer-socket.h"
 #include "libtransmission/net.h"
+#include "libtransmission/peer-socket.h"
 #include "libtransmission/session.h"
+#include "libtransmission/tr-assert.h"
 
 #define tr_logAddErrorIo(io, msg) tr_logAddError(msg, (io)->display_name())
 #define tr_logAddWarnIo(io, msg) tr_logAddWarn(msg, (io)->display_name())

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <iterator>
 #include <list>
 #include <string>
 #include <string_view>
@@ -119,7 +120,7 @@ std::string getXdgEntryFromUserDirs(std::string_view key)
     }
 
     // search for key="val" and extract val
-    auto const search = fmt::format(FMT_STRING("{:s}=\""), key);
+    auto const search = fmt::format("{:s}=\"", key);
     auto begin = std::search(std::begin(content), std::end(content), std::begin(search), std::end(search));
     if (begin == std::end(content))
     {

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -135,7 +135,7 @@ constexpr auto port_fwd_state(UpnpState upnp_state, bool is_mapped)
     auto int_client = std::array<char, 16>{};
     auto int_port = std::array<char, 16>{};
 
-    auto const port_str = fmt::format(FMT_STRING("{:d}"), handle->port.host());
+    auto const port_str = std::to_string(handle->port.host());
 
 #if (MINIUPNPC_API_VERSION >= 10) /* adds remoteHost arg */
     int const err = UPNP_GetSpecificPortMappingEntry(
@@ -178,7 +178,7 @@ constexpr auto port_fwd_state(UpnpState upnp_state, bool is_mapped)
     int const old_errno = errno;
     errno = 0;
 
-    auto const port_str = fmt::format(FMT_STRING("{:d}"), port.host());
+    auto const port_str = std::to_string(port.host());
 
 #if (MINIUPNPC_API_VERSION >= 8)
     int const err = UPNP_AddPortMapping(
@@ -214,7 +214,7 @@ constexpr auto port_fwd_state(UpnpState upnp_state, bool is_mapped)
 
 void tr_upnpDeletePortMapping(tr_upnp const* handle, char const* proto, tr_port port)
 {
-    auto const port_str = fmt::format(FMT_STRING("{:d}"), port.host());
+    auto const port_str = std::to_string(port.host());
 
     UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, port_str.c_str(), proto, nullptr);
 }
@@ -337,7 +337,7 @@ tr_port_forwarding_state tr_upnpPulse(tr_upnp* handle, tr_port port, bool is_ena
         }
         else
         {
-            auto const desc = fmt::format(FMT_STRING("Transmission at {:d}"), port.host());
+            auto const desc = fmt::format("Transmission at {:d}", port.host());
             int const err_tcp = upnp_add_port_mapping(handle, "TCP", port, desc.c_str());
             int const err_udp = upnp_add_port_mapping(handle, "UDP", port, desc.c_str());
 

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -5,6 +5,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <iterator> // for std::distance()
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::min
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <string_view>
@@ -114,7 +115,7 @@ auto loadLabels(tr_variant* dict, tr_torrent* tor)
         auto sv = std::string_view{};
         if (tr_variantGetStrView(tr_variantListChild(list, i), &sv) && !std::empty(sv))
         {
-            labels.emplace_back(tr_interned_string{ sv });
+            labels.emplace_back(sv);
         }
     }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -119,7 +119,7 @@ class tr_rpc_address
 {
 public:
     tr_rpc_address()
-        : inet_addr_(tr_address::any(TR_AF_INET))
+        : inet_addr_{ tr_address::any(TR_AF_INET) }
     {
     }
 
@@ -527,7 +527,7 @@ void handle_request(struct evhttp_request* req, void* arg)
 
         if (std::empty(location) || location == "web"sv)
         {
-            auto const new_location = fmt::format(FMT_STRING("{:s}web/"), server->url());
+            auto const new_location = fmt::format("{:s}web/", server->url());
             evhttp_add_header(req->output_headers, "Location", new_location.c_str());
             send_simple_response(req, HTTP_MOVEPERM, nullptr);
         }
@@ -555,16 +555,16 @@ void handle_request(struct evhttp_request* req, void* arg)
         {
             auto const session_id = std::string{ server->session->sessionId() };
             auto const tmp = fmt::format(
-                FMT_STRING("<p>Your request had an invalid session-id header.</p>"
-                           "<p>To fix this, follow these steps:"
-                           "<ol><li> When reading a response, get its X-Transmission-Session-Id header and remember it"
-                           "<li> Add the updated header to your outgoing requests"
-                           "<li> When you get this 409 error message, resend your request with the updated header"
-                           "</ol></p>"
-                           "<p>This requirement has been added to help prevent "
-                           "<a href=\"https://en.wikipedia.org/wiki/Cross-site_request_forgery\">CSRF</a> "
-                           "attacks.</p>"
-                           "<p><code>{:s}: {:s}</code></p>"),
+                "<p>Your request had an invalid session-id header.</p>"
+                "<p>To fix this, follow these steps:"
+                "<ol><li> When reading a response, get its X-Transmission-Session-Id header and remember it"
+                "<li> Add the updated header to your outgoing requests"
+                "<li> When you get this 409 error message, resend your request with the updated header"
+                "</ol></p>"
+                "<p>This requirement has been added to help prevent "
+                "<a href=\"https://en.wikipedia.org/wiki/Cross-site_request_forgery\">CSRF</a> "
+                "attacks.</p>"
+                "<p><code>{:s}: {:s}</code></p>",
                 TR_RPC_SESSION_ID_HEADER,
                 session_id);
             evhttp_add_header(req->output_headers, TR_RPC_SESSION_ID_HEADER, session_id.c_str());
@@ -842,7 +842,7 @@ void tr_rpc_server::set_anti_brute_force_enabled(bool enabled) noexcept
 tr_rpc_server::tr_rpc_server(tr_session* session_in, tr_variant const& settings)
     : compressor{ libdeflate_alloc_compressor(DeflateLevel), libdeflate_free_compressor }
     , web_client_dir_{ tr_getWebClientDir(session_in) }
-    , bind_address_(std::make_unique<class tr_rpc_address>())
+    , bind_address_{ std::make_unique<class tr_rpc_address>() }
     , session{ session_in }
 {
     load(settings);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -36,6 +36,7 @@
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
+#include "libtransmission/values.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"
 #include "libtransmission/web-utils.h"
@@ -2240,6 +2241,9 @@ void addSessionField(tr_session const* s, tr_variant* d, tr_quark key)
 
     case TR_KEY_session_id:
         tr_variantDictAddStr(d, key, s->sessionId());
+        break;
+
+    default:
         break;
     }
 }

--- a/libtransmission/session-alt-speeds.cc
+++ b/libtransmission/session-alt-speeds.cc
@@ -3,8 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <chrono>
 #include <cstddef> // size_t
+#include <ctime>
 #include <utility>
 
 #include <fmt/chrono.h>

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -30,7 +30,7 @@ namespace
 
 void get_lockfile_path(std::string_view session_id, tr_pathbuf& path)
 {
-    fmt::format_to(std::back_inserter(path), FMT_STRING("{:s}/tr_session_id_{:s}"), tr_getSessionIdDir(), session_id);
+    fmt::format_to(std::back_inserter(path), "{:s}/tr_session_id_{:s}", tr_getSessionIdDir(), session_id);
 }
 
 tr_sys_file_t create_lockfile(std::string_view session_id)

--- a/libtransmission/session-settings.cc
+++ b/libtransmission/session-settings.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <utility> // std::move()
+
 #include "libtransmission/session-settings.h"
 #include "libtransmission/variant.h"
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::partial_sort(), std::min(), std::max()
 #include <condition_variable>
+#include <chrono>
 #include <csignal>
 #include <cstddef> // size_t
 #include <cstdint>
@@ -13,6 +14,7 @@
 #include <iterator> // for std::back_inserter
 #include <limits> // std::numeric_limits
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -288,7 +288,7 @@ private:
     {
     public:
         explicit GlobalIPCacheMediator(tr_session& session) noexcept
-            : session_(session)
+            : session_{ session }
         {
         }
 

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -44,7 +44,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
 {
     if (error != nullptr)
     {
-        error->set(code, fmt::format(FMT_STRING("{:s} failed: {:s} ({:d})"), what, tr_strerror(code), code));
+        error->set(code, fmt::format("{:s} failed: {:s} ({:d})", what, tr_strerror(code), code));
     }
 }
 

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::find()
 #include <array>
+#include <cstddef>
 #include <cctype>
 #include <functional>
 #include <iterator>
@@ -163,7 +164,7 @@ bool tr_torrent_files::move(
 {
     auto const old_parent = tr_pathbuf{ old_parent_in };
     auto const parent = tr_pathbuf{ parent_in };
-    tr_logAddTrace(fmt::format(FMT_STRING("Moving files from '{:s}' to '{:s}'"), old_parent, parent), parent_name);
+    tr_logAddTrace(fmt::format("Moving files from '{:s}' to '{:s}'", old_parent, parent), parent_name);
 
     if (tr_sys_path_is_same(old_parent, parent))
     {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -5,12 +5,16 @@
 
 #include <algorithm>
 #include <climits> /* INT_MAX */
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <deque>
 #include <fstream>
+#include <ios>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <utility> // std::move
 #include <vector>
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <cerrno> // for EINVAL
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -18,8 +20,10 @@
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/log.h"
+#include "libtransmission/torrent-files.h"
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <ctime>
 #include <set>
 #include <string_view>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/tr-macros.h"
 
 namespace
 {

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <cstdint> // uint16_t
 #include <cstring> // memcpy()
 #include <ctime>
@@ -17,6 +18,7 @@
 #include <string_view>
 #include <tuple> // std::tie()
 #include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -555,7 +557,7 @@ private:
         hints.ai_flags = 0;
 
         auto port_str = std::array<char, 16>{};
-        *fmt::format_to(std::data(port_str), FMT_STRING("{:d}"), port_in.host()) = '\0';
+        *fmt::format_to(std::data(port_str), "{:d}", port_in.host()) = '\0';
 
         addrinfo* info = nullptr;
         if (int const rc = getaddrinfo(name, std::data(port_str), &hints, &info); rc != 0)

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -55,7 +55,7 @@ void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t sh
     auto const arg = getArgName(opt);
 
     fmt::print(
-        FMT_STRING(" {:s}{:<{}s} {:s}{:<{}s} {:<{}s} "),
+        " {:s}{:<{}s} {:s}{:<{}s} {:<{}s} ",
         std::empty(short_name) ? " "sv : "-"sv,
         short_name,
         short_width,
@@ -70,14 +70,14 @@ void getopts_usage_line(tr_option const* const opt, size_t long_width, size_t sh
 
     auto description = std::string_view{ opt->description };
     auto len = get_next_line_len(description, d_width);
-    fmt::print(FMT_STRING("{:s}\n"), description.substr(0, len));
+    fmt::print("{:s}\n", description.substr(0, len));
     description.remove_prefix(len);
     description = tr_strv_strip(description);
 
     auto const indent = std::string(d_indent, ' ');
     while ((len = get_next_line_len(description, d_width)) != 0)
     {
-        fmt::print(FMT_STRING("{:s}{:s}\n"), indent, description.substr(0, len));
+        fmt::print("{:s}{:s}\n", indent, description.substr(0, len));
         description.remove_prefix(len);
         description = tr_strv_strip(description);
     }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -13,6 +13,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -232,7 +234,7 @@ public:
 
         if (mcast_socket_ != TR_BAD_SOCKET)
         {
-            evutil_closesocket(mcast_socket_);
+            tr_net_close_socket(mcast_socket_);
         }
 
         tr_logAddTrace("Done uninitialising Local Peer Discovery");
@@ -247,7 +249,7 @@ private:
         }
 
         auto const err = sockerrno;
-        evutil_closesocket(mcast_socket_);
+        tr_net_close_socket(mcast_socket_);
         mcast_socket_ = TR_BAD_SOCKET;
         tr_logAddWarn(fmt::format(
             _("Couldn't initialize LPD: {error} ({error_code})"),

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cerrno>
+#include <cstddef>
 #include <string>
 
 #ifdef _WIN32

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -2,8 +2,9 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <cstdint>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 
 #include <fmt/core.h>
 
@@ -15,6 +16,7 @@
 #include "libtransmission/peer-io.h"
 #include "libtransmission/peer-socket.h"
 #include "libtransmission/session.h"
+#include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-utp.h"
 #include "libtransmission/utils.h"
 
@@ -129,6 +131,9 @@ uint64 utp_callback(utp_callback_arguments* args)
 
     case UTP_SENDTO:
         utp_send_to(session, args->buf, args->len, args->address, args->address_len);
+        break;
+
+    default:
         break;
     }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -11,17 +11,19 @@
 #include <cstdint> // SIZE_MAX
 #include <cstdlib> // getenv()
 #include <cstring> /* strerror() */
+#include <ctime>
 #include <exception>
 #include <iostream>
 #include <iterator> // for std::back_inserter
 #include <locale>
+#include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept> // std::runtime_error
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <utility>
+#include <type_traits>
 #include <vector>
 
 #ifdef _WIN32
@@ -50,12 +52,10 @@
 #include "libtransmission/file.h"
 #include "libtransmission/log.h"
 #include "libtransmission/mime-types.h"
-#include "libtransmission/quark.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
-#include "libtransmission/variant.h"
 
 using namespace std::literals;
 using namespace libtransmission::Values;
@@ -282,7 +282,7 @@ size_t tr_strlcpy(void* vdst, void const* vsrc, size_t siz)
     TR_ASSERT(dst != nullptr);
     TR_ASSERT(src != nullptr);
 
-    auto const res = fmt::format_to_n(dst, siz - 1, FMT_STRING("{:s}"), src);
+    auto const res = fmt::format_to_n(dst, siz - 1, "{:s}", src);
     *res.out = '\0';
     return res.size;
 }
@@ -363,7 +363,7 @@ std::string tr_win32_format_message(uint32_t code)
 
     if (wide_size == 0)
     {
-        return fmt::format(FMT_STRING("Unknown error ({:#08x})"), code);
+        return fmt::format("Unknown error ({:#08x})", code);
     }
 
     auto text = std::string{};
@@ -791,7 +791,7 @@ std::string_view tr_get_mime_type_for_filename(std::string_view filename)
 #include <iomanip> // std::setbase
 #include <sstream>
 
-template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder, int base)
 {
     auto val = T{};
@@ -820,7 +820,7 @@ template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
 
 #include <charconv> // std::from_chars()
 
-template<typename T, std::enable_if_t<std::is_integral<T>::value, bool>>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, bool>>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder, int base)
 {
     auto val = T{};
@@ -855,7 +855,7 @@ template std::optional<unsigned int> tr_num_parse(std::string_view str, std::str
 template std::optional<unsigned short> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
 template std::optional<unsigned char> tr_num_parse(std::string_view str, std::string_view* remainder, int base);
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool>>
+template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool>>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* remainder)
 {
     auto const* const begin_ch = std::data(str);

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -222,10 +222,10 @@ size_t tr_strv_to_buf(std::string_view src, char* buf, size_t buflen);
 
 // ---
 
-template<typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* setme_remainder = nullptr, int base = 10);
 
-template<typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 [[nodiscard]] std::optional<T> tr_num_parse(std::string_view str, std::string_view* setme_remainder = nullptr);
 
 /**

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -47,7 +47,7 @@ struct Config
     struct Units
     {
         template<typename... Names>
-        Units(Base base, Names... names)
+        Units(Base base, Names... names) noexcept
         {
             set_base(base);
 
@@ -76,7 +76,7 @@ struct Config
         }
 
     private:
-        constexpr void set_base(Base base)
+        constexpr void set_base(Base base) noexcept
         {
             base_ = base;
 

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -71,7 +71,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
     }
 
     // parse the string and make sure the next char is `Suffix`
-    auto const value = tr_num_parse<int64_t>(walk, &walk);
+    auto value = tr_num_parse<int64_t>(walk, &walk);
     if (!value || !tr_strv_starts_with(walk, Suffix))
     {
         return {};
@@ -79,7 +79,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
 
     walk.remove_prefix(std::size(Suffix));
     *benc = walk;
-    return *value;
+    return value;
 }
 
 /**

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -267,7 +267,7 @@ struct string_output_stream
     using Ch = char;
 
     explicit string_output_stream(std::string& str)
-        : str_ref_(str)
+        : str_ref_{ str }
     {
     }
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -4,9 +4,15 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::sort
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
+#include <variant>
 
 #ifdef _WIN32
 #include <share.h>

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -4,18 +4,22 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstddef> // std::byte
 #include <cstdint> // uint64_t, uint32_t
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <utility> // for std::move()
 #include <vector>
 
 #include "libtransmission/transmission.h"
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/file.h"
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/verify.h"
 
 using namespace std::chrono_literals;

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <cerrno>
+#include <cstddef>
 #include <cstdint> // uint32_t
 #include <memory>
 #include <string>
@@ -181,7 +182,7 @@ private:
 
             // NB: `name` may have extra trailing zeroes from inotify;
             // pass the c_str() so that processFile gets the right strlen
-            processFile(name.c_str());
+            processFile(name);
         }
     }
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -182,7 +182,7 @@ private:
 
             // NB: `name` may have extra trailing zeroes from inotify;
             // pass the c_str() so that processFile gets the right strlen
-            processFile(name);
+            processFile(name.c_str());
         }
     }
 

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -114,12 +114,12 @@ public:
 
         if (notify_pipe_[0] != TR_BAD_SOCKET)
         {
-            evutil_closesocket(notify_pipe_[0]);
+            tr_net_close_socket(notify_pipe_[0]);
         }
 
         if (notify_pipe_[1] != TR_BAD_SOCKET)
         {
-            evutil_closesocket(notify_pipe_[1]);
+            tr_net_close_socket(notify_pipe_[1]);
         }
 
         if (fd_ != INVALID_HANDLE_VALUE)

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib> // for strtoul()
 #include <limits>
 #include <optional>
@@ -407,7 +408,7 @@ std::string tr_urlTrackerLogName(std::string_view url)
 {
     if (auto const parsed = tr_urlParse(url); parsed)
     {
-        return fmt::format(FMT_STRING("{:s}://{:s}:{:d}"), parsed->scheme, parsed->host, parsed->port);
+        return fmt::format("{:s}://{:s}:{:d}", parsed->scheme, parsed->host, parsed->port);
     }
 
     // we have an invalid URL, we log the full string

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -8,8 +8,12 @@
 #include <array>
 #endif
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
-#include <cstdint> // uint64_t
+#include <cstddef>
+#include <cstdint> // for uint64_t
+#include <ctime>
+#include <functional> // for std::less()
 #include <list>
 #include <map>
 #include <memory>

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -223,7 +223,7 @@ public:
     {
         if (auto const parsed = tr_urlParse(base_url); parsed)
         {
-            return fmt::format(FMT_STRING("{:s}:{:d}"), parsed->host, parsed->port);
+            return fmt::format("{:s}:{:d}", parsed->host, parsed->port);
         }
 
         return base_url;
@@ -513,7 +513,7 @@ void task_request_next_chunk(tr_webseed_task* task)
     auto url = tr_urlbuf{};
     makeUrl(webseed, tor->file_subpath(file_index), std::back_inserter(url));
     auto options = tr_web::FetchOptions{ url.sv(), onPartialDataFetched, task };
-    options.range = fmt::format(FMT_STRING("{:d}-{:d}"), file_offset, file_offset + this_chunk - 1);
+    options.range = fmt::format("{:d}-{:d}", file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor->id();
     options.buffer = task->content();
     tor->session->fetch(std::move(options));

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -17,7 +17,7 @@
 #include "Utils.h"
 
 AboutDialog::AboutDialog(Session& session, QWidget* parent)
-    : BaseDialog(parent)
+    : BaseDialog{ parent }
 {
     ui_.setupUi(this);
 

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -5,6 +5,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 
 #include <libtransmission/transmission.h>
 
@@ -56,7 +57,7 @@ int AddData::set(QString const& key)
         this->url = key;
         type = URL;
     }
-    else if (QFile(key).exists())
+    else if (QFile{ key }.exists())
     {
         this->filename = QDir::fromNativeSeparators(key);
         type = FILENAME;
@@ -115,7 +116,7 @@ QString AddData::readableShortName() const
     switch (type)
     {
     case FILENAME:
-        return QFileInfo(filename).baseName();
+        return QFileInfo{ filename }.baseName();
 
     case URL:
         return url.path().split(QLatin1Char('/')).last();

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -650,9 +650,9 @@ bool Application::notifyApp(QString const& title, QString const& body, QStringLi
         args.append(title); // summary
         args.append(body); // body
         args.append(actions);
-        args.append(QVariantMap({
-            std::make_pair(QStringLiteral("category"), QVariant(QStringLiteral("transfer.complete"))),
-        })); // hints
+        args.append(QVariantMap{ {
+            std::make_pair(QStringLiteral("category"), QVariant{ QStringLiteral("transfer.complete") }),
+        } }); // hints
         args.append(static_cast<int32_t>(-1)); // use the default timeout period
         m.setArguments(args);
         QDBusReply<quint32> const reply_msg = bus.call(m);

--- a/qt/BaseDialog.h
+++ b/qt/BaseDialog.h
@@ -11,7 +11,7 @@ class BaseDialog : public QDialog
 {
 public:
     BaseDialog(QWidget* parent = nullptr, Qt::WindowFlags flags = {})
-        : QDialog(parent, flags)
+        : QDialog{ parent, flags }
     {
         setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     }

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -25,7 +25,7 @@ extern wchar_t qAxModuleFilename[MAX_PATH]; // NOLINT
 extern QString qAxInit(); // NOLINT
 
 ComInteropHelper::ComInteropHelper()
-    : client_(new QAxObject(QStringLiteral("Transmission.QtClient")))
+    : client_{ new QAxObject{ QStringLiteral("Transmission.QtClient") } }
 {
 }
 
@@ -52,5 +52,5 @@ void ComInteropHelper::initialize()
 void ComInteropHelper::registerObject(QObject* parent)
 {
     QAxFactory::startServer();
-    QAxFactory::registerActiveObject(new InteropObject(parent));
+    QAxFactory::registerActiveObject(new InteropObject{ parent });
 }

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -25,10 +25,10 @@ QVariant DBusInteropHelper::addMetainfo(QString const& metainfo) const
         QStringLiteral("/com/transmissionbt/Transmission"),
         QStringLiteral("com.transmissionbt.Transmission"),
         QStringLiteral("AddMetainfo"));
-    request.setArguments(QVariantList() << metainfo);
+    request.setArguments(QVariantList{} << metainfo);
 
     QDBusReply<bool> const response = QDBusConnection::sessionBus().call(request);
-    return response.isValid() ? QVariant(response.value()) : QVariant();
+    return response.isValid() ? QVariant{ response.value() } : QVariant{};
 }
 
 void DBusInteropHelper::registerObject(QObject* parent)
@@ -45,7 +45,7 @@ void DBusInteropHelper::registerObject(QObject* parent)
     }
 
     if (auto const object_path = QStringLiteral("/com/transmissionbt/Transmission");
-        !bus.registerObject(object_path, new InteropObject(parent), QDBusConnection::ExportAllSlots))
+        !bus.registerObject(object_path, new InteropObject{ parent }, QDBusConnection::ExportAllSlots))
     {
         qWarning() << "couldn't register" << qPrintable(object_path);
     }

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -170,7 +170,7 @@ class PeerItem : public QTreeWidgetItem
 
 public:
     explicit PeerItem(Peer p)
-        : peer_(std::move(p))
+        : peer_{ std::move(p) }
     {
     }
 
@@ -499,7 +499,7 @@ void DetailsDialog::refreshUI()
     }
 
     ui_.stateValueLabel->setText(string);
-    QString const state_string = string;
+    auto const state_string = string;
 
     // myHaveLabel
     uint64_t size_when_done = 0;
@@ -882,7 +882,7 @@ void DetailsDialog::refreshUI()
     {
         bool mixed_creator = false;
         bool mixed_date = false;
-        QString const creator = torrents[0]->creator();
+        auto const creator = torrents[0]->creator();
         auto const date = torrents[0]->dateCreated();
 
         for (Torrent const* const t : torrents)
@@ -1103,11 +1103,11 @@ void DetailsDialog::refreshUI()
 
     for (Torrent const* const t : torrents)
     {
-        QString const id_str(QString::number(t->id()));
+        auto const id_str = QString::number(t->id());
 
         for (Peer const& peer : t->peers())
         {
-            QString const key = id_str + QLatin1Char(':') + peer.address;
+            auto const key = id_str + QLatin1Char(':') + peer.address;
 
             PeerItem* item = nullptr;
             if (auto iter = peers_.find(key); iter != std::end(peers_))
@@ -1617,7 +1617,7 @@ void DetailsDialog::onOpenRequested(QString const& path) const
             continue;
         }
 
-        QString const local_file_path = tor->getPath() + QLatin1Char('/') + path;
+        auto const local_file_path = tor->getPath() + QLatin1Char('/') + path;
 
         if (!QFile::exists(local_file_path))
         {

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -138,7 +138,7 @@ private:
 
     std::map<QString, QTreeWidgetItem*> peers_;
 
-    QIcon const icon_encrypted_ = QIcon(QStringLiteral(":/icons/encrypted.svg"));
+    QIcon const icon_encrypted_ = QIcon{ QStringLiteral(":/icons/encrypted.svg") };
     QIcon const icon_unencrypted_ = {};
 
     static int prev_tab_index_;

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -29,9 +29,9 @@ public:
     static auto constexpr High = int{ 1 << 2 };
 
     FileTreeItem(QString const& name = QString{}, int file_index = -1, uint64_t size = 0)
-        : name_(name)
-        , total_size_(size)
-        , file_index_(file_index)
+        : name_{ name }
+        , total_size_{ size }
+        , file_index_{ file_index }
     {
     }
 

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -25,7 +25,7 @@ namespace
 class PathIteratorBase
 {
 protected:
-    PathIteratorBase(QString const& path, int slash_index)
+    PathIteratorBase(QString const& path, int const slash_index)
         : path_{ path }
         , slash_index_{ slash_index }
     {
@@ -45,7 +45,7 @@ class ForwardPathIterator : public PathIteratorBase
 {
 public:
     explicit ForwardPathIterator(QString const& path)
-        : PathIteratorBase{ path, path.size() - 1 }
+        : PathIteratorBase(path, path.size() - 1)
     {
     }
 

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -5,11 +5,16 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
 
 #include <libtransmission/transmission.h> // priorities
+
+#include <QAbstractItemModel>
+#include <QMutableListIterator>
 
 #include "FileTreeItem.h"
 #include "FileTreeModel.h"
@@ -40,7 +45,7 @@ class ForwardPathIterator : public PathIteratorBase
 {
 public:
     explicit ForwardPathIterator(QString const& path)
-        : PathIteratorBase(path, path.size() - 1)
+        : PathIteratorBase{ path, path.size() - 1 }
     {
     }
 
@@ -371,8 +376,8 @@ void FileTreeModel::addFile(
             if (child == nullptr)
             {
                 added = true;
-                QModelIndex const parent_index(indexOf(item, 0));
-                int const n(item->childCount());
+                auto const parent_index = indexOf(item, 0);
+                auto const n = item->childCount();
 
                 beginInsertRows(parent_index, n, n);
 

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -33,9 +33,9 @@ char const* const PriorityKey = "priority";
 
 FileTreeView::FileTreeView(QWidget* parent, bool is_editable)
     : QTreeView{ parent }
-    , model_{ new FileTreeModel(this, is_editable) }
-    , proxy_{ new QSortFilterProxyModel(this) }
-    , delegate_{ new FileTreeDelegate(this) }
+    , model_{ new FileTreeModel{ this, is_editable } }
+    , proxy_{ new QSortFilterProxyModel{ this } }
+    , delegate_{ new FileTreeDelegate{ this } }
 {
     proxy_->setSourceModel(model_);
     proxy_->setSortRole(FileTreeModel::SortRole);
@@ -59,11 +59,11 @@ void FileTreeView::onClicked(QModelIndex const& proxy_index)
 
     if (model_index.column() == FileTreeModel::COL_WANTED)
     {
-        model_->twiddleWanted(QModelIndexList() << model_index);
+        model_->twiddleWanted(QModelIndexList{} << model_index);
     }
     else if (model_index.column() == FileTreeModel::COL_PRIORITY)
     {
-        model_->twiddlePriority(QModelIndexList() << model_index);
+        model_->twiddlePriority(QModelIndexList{} << model_index);
     }
 }
 

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -219,11 +219,11 @@ FilterBarComboBox* FilterBar::createTrackerCombo(QStandardItemModel* model)
 ***/
 
 FilterBar::FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter const& filter, QWidget* parent)
-    : QWidget(parent)
-    , prefs_(prefs)
-    , torrents_(torrents)
-    , filter_(filter)
-    , is_bootstrapping_(true)
+    : QWidget{ parent }
+    , prefs_{ prefs }
+    , torrents_{ torrents }
+    , filter_{ filter }
+    , is_bootstrapping_{ true }
 {
     auto* h = new QHBoxLayout{ this };
     h->setContentsMargins(3, 3, 3, 3);

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -3,7 +3,12 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
+
 #include <QApplication>
+#include <QComboBox>
+#include <QPen>
+#include <QRect>
 #include <QStyle>
 #include <QStylePainter>
 
@@ -16,7 +21,7 @@ namespace
 
 int getHSpacing(QWidget const* w)
 {
-    return qMax(3, w->style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing, nullptr, w));
+    return std::max(3, w->style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing, nullptr, w));
 }
 
 } // namespace

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -24,8 +24,8 @@ int getHSpacing(QWidget const* w)
 } // namespace
 
 FilterBarComboBoxDelegate::FilterBarComboBoxDelegate(QObject* parent, QComboBox* combo)
-    : QItemDelegate(parent)
-    , combo_(combo)
+    : QItemDelegate{ parent }
+    , combo_{ combo }
 {
 }
 

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -26,7 +26,7 @@ public:
     };
 
     explicit FilterMode(int mode = SHOW_ALL)
-        : mode_(mode)
+        : mode_{ mode }
     {
     }
 

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -3,9 +3,15 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cstdint>
+
 #include <QDir>
+#include <QLabel>
+#include <QString>
+#include <QWidget>
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
 
 #include "Formatter.h"
@@ -25,8 +31,8 @@ int const IntervalMSec = 15000;
 } // namespace
 
 FreeSpaceLabel::FreeSpaceLabel(QWidget* parent)
-    : QLabel(parent)
-    , timer_(this)
+    : QLabel{ parent }
+    , timer_{ this }
 {
     timer_.setSingleShot(true);
     timer_.setInterval(IntervalMSec);

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -18,6 +18,7 @@
 #include <QMimeDatabase>
 #include <QObject>
 #include <QPainter>
+#include <QPixmap>
 #include <QStyle>
 
 #ifdef _WIN32
@@ -30,6 +31,9 @@
 #endif
 
 #include <libtransmission/transmission.h>
+
+#include <optional>
+#include <utility>
 
 /***
 ****
@@ -104,16 +108,16 @@ QIcon IconCache::getMimeTypeIcon(QString const& mime_type_name, bool multifile) 
     {
         // upper left corner
         auto const folder_size = size / 2;
-        auto const folder_rect = QRect(QPoint(), folder_size);
+        auto const folder_rect = QRect{ QPoint{}, folder_size };
 
         // fullsize
         auto const mime_size = size;
-        auto const mime_rect = QRect(QPoint(), mime_size);
+        auto const mime_rect = QRect{ QPoint{}, mime_size };
 
         // build the icon
-        auto pixmap = QPixmap(size);
+        auto pixmap = QPixmap{ size };
         pixmap.fill(Qt::transparent);
-        QPainter painter(&pixmap);
+        auto painter = QPainter{ &pixmap };
         painter.setRenderHints(QPainter::SmoothPixmapTransform);
         painter.drawPixmap(folder_rect, folder_icon_.pixmap(folder_size));
         painter.drawPixmap(mime_rect, mime_icon.pixmap(mime_size));
@@ -180,14 +184,14 @@ QIcon IconCache::getMimeIcon(QString const& filename) const
 {
     if (suffixes_.empty())
     {
-        for (auto const& type : QMimeDatabase().allMimeTypes())
+        for (auto const& type : QMimeDatabase{}.allMimeTypes())
         {
             auto const tmp = type.suffixes();
             suffixes_.insert(tmp.begin(), tmp.end());
         }
     }
 
-    auto const ext = QFileInfo(filename).suffix();
+    auto const ext = QFileInfo{ filename }.suffix();
     if (suffixes_.count(ext) == 0)
     {
         return {};

--- a/qt/IconToolButton.cc
+++ b/qt/IconToolButton.cc
@@ -11,7 +11,7 @@
 #include "IconToolButton.h"
 
 IconToolButton::IconToolButton(QWidget* parent)
-    : QToolButton(parent)
+    : QToolButton{ parent }
 {
 }
 

--- a/qt/InteropObject.cc
+++ b/qt/InteropObject.cc
@@ -8,7 +8,7 @@
 #include "InteropObject.h"
 
 InteropObject::InteropObject(QObject* parent)
-    : QObject(parent)
+    : QObject{ parent }
 {
 }
 

--- a/qt/LicenseDialog.cc
+++ b/qt/LicenseDialog.cc
@@ -3,6 +3,9 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <QWidget>
+
+#include "BaseDialog.h"
 #include "LicenseDialog.h"
 
 LicenseDialog::LicenseDialog(QWidget* parent)

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -110,7 +110,7 @@ QIcon MainWindow::addEmblem(QIcon base_icon, QStringList const& emblem_names) co
             layoutDirection(),
             Qt::AlignBottom | Qt::AlignRight,
             emblem_size,
-            QRect(QPoint(0, 0), size));
+            QRect{ QPoint{ 0, 0 }, size });
 
         auto pixmap = base_icon.pixmap(size);
         auto const emblem_pixmap = emblem_icon.pixmap(emblem_size);
@@ -151,7 +151,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     QIcon const icon_open = icons.getThemeIcon(QStringLiteral("document-open"), QStyle::SP_DialogOpenButton);
     ui_.action_OpenFile->setIcon(icon_open);
     ui_.action_AddURL->setIcon(
-        addEmblem(icon_open, QStringList() << QStringLiteral("emblem-web") << QStringLiteral("applications-internet")));
+        addEmblem(icon_open, QStringList{} << QStringLiteral("emblem-web") << QStringLiteral("applications-internet")));
     ui_.action_New->setIcon(icons.getThemeIcon(QStringLiteral("document-new"), QStyle::SP_DesktopIcon));
     ui_.action_Properties->setIcon(icons.getThemeIcon(QStringLiteral("document-properties"), QStyle::SP_DesktopIcon));
     ui_.action_OpenFolder->setIcon(icons.getThemeIcon(QStringLiteral("folder-open"), QStyle::SP_DirOpenIcon));
@@ -590,13 +590,13 @@ void openSelect(QString const& path)
     auto const explorer = QStringLiteral("explorer");
     QString param;
 
-    if (!QFileInfo(path).isDir())
+    if (!QFileInfo{ path }.isDir())
     {
         param = QStringLiteral("/select,");
     }
 
     param += QDir::toNativeSeparators(path);
-    QProcess::startDetached(explorer, QStringList(param));
+    QProcess::startDetached(explorer, QStringList{ param });
 }
 #elif defined(Q_OS_MAC)
 void openSelect(QString const& path)
@@ -703,7 +703,7 @@ void MainWindow::openStats()
 
 void MainWindow::openDonate() const
 {
-    QDesktopServices::openUrl(QUrl(QStringLiteral("https://transmissionbt.com/donate/")));
+    QDesktopServices::openUrl(QUrl{ QStringLiteral("https://transmissionbt.com/donate/") });
 }
 
 void MainWindow::openAbout()
@@ -714,7 +714,7 @@ void MainWindow::openAbout()
 void MainWindow::openHelp() const
 {
     QDesktopServices::openUrl(
-        QUrl(QStringLiteral("https://transmissionbt.com/help/gtk/%1.%2x").arg(MAJOR_VERSION).arg(MINOR_VERSION / 10)));
+        QUrl{ QStringLiteral("https://transmissionbt.com/help/gtk/%1.%2x").arg(MAJOR_VERSION).arg(MINOR_VERSION / 10) });
 }
 
 /****
@@ -788,7 +788,7 @@ void MainWindow::refreshTitle()
 {
     QString title(QStringLiteral("Transmission"));
 
-    if (auto const url = QUrl(session_.getRemoteUrl()); !url.isEmpty())
+    if (auto const url = QUrl{ session_.getRemoteUrl() }; !url.isEmpty())
     {
         //: Second (optional) part of main window title "Transmission - host:port" (added when connected to remote session)
         //: notice that leading space (before the dash) is included here
@@ -1589,7 +1589,7 @@ void MainWindow::dropEvent(QDropEvent* event)
 
         if (!key.isEmpty())
         {
-            if (auto const url = QUrl(key); url.isLocalFile())
+            if (auto const url = QUrl{ key }; url.isLocalFile())
             {
                 key = url.toLocalFile();
             }

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -6,14 +6,17 @@
 #include "MakeDialog.h"
 
 #include <chrono>
+#include <cmath>
 #include <future>
 #include <utility>
 #include <vector>
 
+#include <QDialogButtonBox>
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeData>
 #include <QPushButton>
+#include <QString>
 #include <QTimer>
 
 #include <libtransmission/error.h>
@@ -84,7 +87,7 @@ void MakeProgressDialog::onButtonBoxClicked(QAbstractButton* button)
     switch (ui_.dialogButtons->standardButton(button))
     {
     case QDialogButtonBox::Open:
-        session_.addNewlyCreatedTorrent(outfile_, QFileInfo(QString::fromStdString(builder_.top())).dir().path());
+        session_.addNewlyCreatedTorrent(outfile_, QFileInfo{ QString::fromStdString(builder_.top()) }.dir().path());
         break;
 
     case QDialogButtonBox::Abort:
@@ -118,7 +121,7 @@ void MakeProgressDialog::onProgress()
 
     // progress label
     auto const top = QString::fromStdString(builder_.top());
-    auto const base = QFileInfo(top).completeBaseName();
+    auto const base = QFileInfo{ top }.completeBaseName();
     QString str;
 
     auto success = false;
@@ -175,8 +178,8 @@ void MakeDialog::makeTorrent()
 
     // the file to create
     auto const path = QString::fromStdString(builder_->top());
-    auto const torrent_name = QFileInfo(path).completeBaseName() + QStringLiteral(".torrent");
-    auto const outfile = QDir(ui_.destinationButton->path()).filePath(torrent_name);
+    auto const torrent_name = QFileInfo{ path }.completeBaseName() + QStringLiteral(".torrent");
+    auto const outfile = QDir{ ui_.destinationButton->path() }.filePath(torrent_name);
 
     // comment
     if (ui_.commentCheck->isChecked())
@@ -231,8 +234,8 @@ void MakeDialog::onSourceChanged()
 }
 
 MakeDialog::MakeDialog(Session& session, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
+    : BaseDialog{ parent }
+    , session_{ session }
 {
     ui_.setupUi(this);
 
@@ -269,7 +272,7 @@ void MakeDialog::dragEnterEvent(QDragEnterEvent* event)
 {
     QMimeData const* mime = event->mimeData();
 
-    if (!mime->urls().isEmpty() && QFileInfo(mime->urls().front().path()).exists())
+    if (!mime->urls().isEmpty() && QFileInfo{ mime->urls().front().path() }.exists())
     {
         event->acceptProposedAction();
     }

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -11,6 +11,7 @@
 
 #include <libtransmission/transmission.h>
 
+#include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
 #include <libtransmission/torrent-metainfo.h>
 

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -112,7 +112,7 @@ void PathButton::onClicked() const
         dialog->setNameFilter(name_filter_);
     }
 
-    if (auto const path_info = QFileInfo(path_); !path_.isEmpty() && path_info.exists())
+    if (auto const path_info = QFileInfo{ path_ }; !path_.isEmpty() && path_info.exists())
     {
         if (path_info.isDir())
         {
@@ -150,7 +150,7 @@ void PathButton::updateAppearance()
 
     if (!path_.isEmpty() && path_info.exists())
     {
-        icon = icon_provider.icon(QFileInfo(path_));
+        icon = icon_provider.icon(QFileInfo{ path_ });
     }
 
     if (icon.isNull())

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -211,7 +211,7 @@ bool isValidUtf8(QByteArray const& byteArray)
 ***/
 
 Prefs::Prefs(QString config_dir)
-    : config_dir_(std::move(config_dir))
+    : config_dir_{ std::move(config_dir) }
 {
     static_assert(sizeof(Items) / sizeof(Items[0]) == PREFS_COUNT);
 

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -169,7 +169,7 @@ bool PrefsDialog::updateWidgetValue(QWidget* widget, int pref_key) const
     }
     else if (pref_widget.is<QTimeEdit>())
     {
-        pref_widget.as<QTimeEdit>()->setTime(QTime(0, 0).addSecs(prefs_.getInt(pref_key) * 60));
+        pref_widget.as<QTimeEdit>()->setTime(QTime{ 0, 0 }.addSecs(prefs_.getInt(pref_key) * 60));
     }
     else if (pref_widget.is<QLineEdit>())
     {
@@ -305,7 +305,7 @@ void PrefsDialog::timeEditingFinished()
 
     if (pref_widget.is<QTimeEdit>())
     {
-        setPref(pref_widget.getPrefKey(), QTime(0, 0).secsTo(pref_widget.as<QTimeEdit>()->time()) / 60);
+        setPref(pref_widget.getPrefKey(), QTime{ 0, 0 }.secsTo(pref_widget.as<QTimeEdit>()->time()) / 60);
     }
 }
 
@@ -377,9 +377,9 @@ void PrefsDialog::initSpeedTab()
     ui_.altUploadSpeedLimitSpin->setSuffix(suffix);
     ui_.altDownloadSpeedLimitSpin->setSuffix(suffix);
 
-    ui_.altSpeedLimitDaysCombo->addItem(tr("Every Day"), QVariant(TR_SCHED_ALL));
-    ui_.altSpeedLimitDaysCombo->addItem(tr("Weekdays"), QVariant(TR_SCHED_WEEKDAY));
-    ui_.altSpeedLimitDaysCombo->addItem(tr("Weekends"), QVariant(TR_SCHED_WEEKEND));
+    ui_.altSpeedLimitDaysCombo->addItem(tr("Every Day"), QVariant{ TR_SCHED_ALL });
+    ui_.altSpeedLimitDaysCombo->addItem(tr("Weekdays"), QVariant{ TR_SCHED_WEEKDAY });
+    ui_.altSpeedLimitDaysCombo->addItem(tr("Weekends"), QVariant{ TR_SCHED_WEEKEND });
     ui_.altSpeedLimitDaysCombo->insertSeparator(ui_.altSpeedLimitDaysCombo->count());
 
     for (int i = locale.firstDayOfWeek(); i <= Qt::Sunday; ++i)
@@ -661,11 +661,11 @@ void PrefsDialog::updateSeedingWidgetsLocality()
 ***/
 
 PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent)
-    : BaseDialog(parent)
-    , session_(session)
-    , prefs_(prefs)
-    , is_server_(session.isServer())
-    , is_local_(session_.isLocal())
+    : BaseDialog{ parent }
+    , session_{ session }
+    , prefs_{ prefs }
+    , is_server_{ session.isServer() }
+    , is_local_{ session_.isLocal() }
 {
     ui_.setupUi(this);
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -77,7 +77,7 @@ bool RpcClient::isLocal() const
         return true;
     }
 
-    if (QHostAddress(url_.host()).isLoopback())
+    if (QHostAddress{ url_.host() }.isLoopback())
     {
         return true;
     }

--- a/qt/RpcQueue.cc
+++ b/qt/RpcQueue.cc
@@ -8,7 +8,7 @@
 #include "RpcQueue.h"
 
 RpcQueue::RpcQueue(QObject* parent)
-    : QObject(parent)
+    : QObject{ parent }
 {
     connect(&future_watcher_, &QFutureWatcher<RpcResponse>::finished, this, &RpcQueue::stepFinished);
 }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -24,6 +24,7 @@
 
 #include <libtransmission/transmission.h>
 
+#include <libtransmission/quark.h>
 #include <libtransmission/session-id.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/variant.h>

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -11,6 +11,7 @@
 #include <QUrl>
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
 
 #include "Application.h"

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -399,7 +399,7 @@ QSize TorrentDelegate::sizeHint(QStyleOptionViewItem const& option, Torrent cons
 {
     auto const m = margin(*QApplication::style());
     auto const layout = ItemLayout{ tor.name(),  progressString(tor), statusString(tor), QIcon{},
-                                    option.font, option.direction,    QPoint(0, 0),      option.rect.width() - m.width() * 2 };
+                                    option.font, option.direction,    QPoint{ 0, 0 },    option.rect.width() - m.width() * 2 };
     return layout.size() + m * 2;
 }
 
@@ -541,7 +541,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     // render
     if (tor.hasError() && !is_item_selected)
     {
-        painter->setPen(QColor("red"));
+        painter->setPen(QColor{ "red" });
     }
     else
     {

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -240,7 +240,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     // render
     if (tor.hasError() && !is_item_selected)
     {
-        painter->setPen(QColor("red"));
+        painter->setPen(QColor{ "red" });
     }
     else
     {

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -16,7 +16,7 @@ class TorrentDelegateMin : public TorrentDelegate
 
 public:
     explicit TorrentDelegateMin(QObject* parent = nullptr)
-        : TorrentDelegate(parent)
+        : TorrentDelegate{ parent }
     {
     }
 

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -16,7 +16,7 @@
 #include "Utils.h"
 
 TorrentFilter::TorrentFilter(Prefs const& prefs)
-    : prefs_(prefs)
+    : prefs_{ prefs }
 {
     connect(&prefs_, &Prefs::changed, this, &TorrentFilter::onPrefChanged);
     connect(&refilter_timer_, &QTimer::timeout, this, &TorrentFilter::refilter);

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -5,14 +5,18 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <ctime>
 #include <iterator> // for std::back_inserter
 #include <set>
 #include <string_view>
+#include <vector>
 
 #include <libtransmission/transmission.h>
+
+#include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
 
-#include "Speed.h"
 #include "Torrent.h"
 #include "TorrentDelegate.h"
 #include "TorrentModel.h"
@@ -65,7 +69,7 @@ auto getIds(Iter it, Iter end)
 ***/
 
 TorrentModel::TorrentModel(Prefs const& prefs)
-    : prefs_(prefs)
+    : prefs_{ prefs }
 {
 }
 

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -61,8 +61,8 @@ private:
 };
 
 TorrentView::TorrentView(QWidget* parent)
-    : QListView(parent)
-    , header_widget_(new HeaderWidget(this))
+    : QListView{ parent }
+    , header_widget_{ new HeaderWidget{ this } }
 {
 }
 

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -90,7 +90,7 @@ ItemLayout::ItemLayout(
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, TrackerInfo const& info) const
 {
-    ItemLayout const layout{ getText(info), true, option.direction, QPoint(0, 0), option.rect.width() - Margin.width() * 2 };
+    ItemLayout const layout{ getText(info), true, option.direction, QPoint{ 0, 0 }, option.rect.width() - Margin.width() * 2 };
     return layout.size() + Margin * 2;
 }
 

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -21,7 +21,7 @@ class TrackerDelegate : public QItemDelegate
 
 public:
     explicit TrackerDelegate(QObject* parent = nullptr)
-        : QItemDelegate(parent)
+        : QItemDelegate{ parent }
     {
     }
 

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -33,7 +33,7 @@ QVariant TrackerModel::data(QModelIndex const& index, int role) const
             break;
 
         case Qt::DecorationRole:
-            var = QIcon(tracker_info.st.getFavicon());
+            var = QIcon{ tracker_info.st.getFavicon() };
             break;
 
         case TrackerRole:

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -7,7 +7,7 @@
 #include "TrackerModelFilter.h"
 
 TrackerModelFilter::TrackerModelFilter(QObject* parent)
-    : QSortFilterProxyModel(parent)
+    : QSortFilterProxyModel{ parent }
 {
 }
 

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -6,6 +6,7 @@
 #include "VariantHelpers.h"
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <string_view>
 

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -13,22 +13,17 @@
 
 #include <libtransmission/torrent-metainfo.h>
 
-#include "Prefs.h"
 #include "TorrentModel.h"
 #include "WatchDir.h"
 
-/***
-****
-***/
+// ---
 
 WatchDir::WatchDir(TorrentModel const& model)
     : model_{ model }
 {
 }
 
-/***
-****
-***/
+// ---
 
 WatchDir::AddResult WatchDir::metainfoTest(QString const& filename) const
 {
@@ -102,7 +97,7 @@ void WatchDir::watcherActivated(QString const& path)
         case AddResult::Error:
             {
                 // give the torrent a few seconds to finish downloading
-                auto* t = new QTimer(this);
+                auto* t = new QTimer{ this };
                 t->setObjectName(dir.absoluteFilePath(name));
                 t->setSingleShot(true);
                 connect(t, &QTimer::timeout, this, &WatchDir::onTimeout);

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef> // std::byte
+#include <optional>
 #include <string_view>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE

--- a/tests/libtransmission/benc-test.cc
+++ b/tests/libtransmission/benc-test.cc
@@ -81,13 +81,13 @@ TEST_F(BencTest, ContextTokenIsCorrect)
 
         bool Int64(int64_t value, Context const& context) override
         {
-            EXPECT_EQ(fmt::format(FMT_STRING("i{:d}e"), value), context.raw());
+            EXPECT_EQ(fmt::format("i{:d}e", value), context.raw());
             return true;
         }
 
         bool String(std::string_view value, Context const& context) override
         {
-            EXPECT_EQ(fmt::format(FMT_STRING("{:d}:{:s}"), std::size(value), value), context.raw());
+            EXPECT_EQ(fmt::format("{:d}:{:s}", std::size(value), value), context.raw());
             return true;
         }
     };

--- a/tests/libtransmission/buffer-test.cc
+++ b/tests/libtransmission/buffer-test.cc
@@ -98,39 +98,3 @@ TEST_F(BufferTest, Numbers)
         EXPECT_EQ(expected_u8, buf.to_uint8());
     }
 }
-
-#if 0
-TEST_F(BufferTest, NonBufferWriter)
-{
-    auto constexpr Hello = "Hello, "sv;
-    auto constexpr World = "World"sv;
-    auto constexpr Bang = "!"sv;
-
-    auto out1 = Buffer{};
-
-    auto out2_vec = std::vector<std::byte>{};
-    auto out2 = libtransmission::BufferWriter<std::vector<std::byte>, std::byte>{ &out2_vec };
-
-    out1.add_uint8(1);
-    out2.add_uint8(1);
-
-    out1.add_uint16(1);
-    out2.add_uint16(1);
-
-    out1.add_uint32(1);
-    out2.add_uint32(1);
-
-    out1.add(Hello);
-    out2.add(Hello);
-
-    out1.add(World);
-    out2.add(World);
-
-    out1.add(Bang);
-    out2.add(Bang);
-
-    auto const result1 = out1.to_string_view();
-    auto const result2 = std::string_view{ reinterpret_cast<char const*>(std::data(out2_vec)), std::size(out2_vec) };
-    EXPECT_EQ(result1, result2);
-}
-#endif

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -582,7 +582,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     static auto constexpr BootstrapNodePort = tr_port::from_host(8080);
     if (auto ofs = std::ofstream{ tr_pathbuf{ sandboxDir(), "/dht.bootstrap" } }; ofs)
     {
-        ofs << BootstrapNodeName << ' ' << BootstrapNodePort.host() << std::endl;
+        ofs << BootstrapNodeName << ' ' << BootstrapNodePort.host() << '\n';
         ofs.close();
     }
 

--- a/tests/libtransmission/global-ip-cache-test.cc
+++ b/tests/libtransmission/global-ip-cache-test.cc
@@ -156,7 +156,7 @@ TEST_F(GlobalIPCacheTest, setGlobalAddr)
         {
             auto const type = static_cast<tr_address_type>(i);
             auto const addr = tr_address::from_string(AddrStr[j]);
-            ASSERT_TRUE(addr);
+            ASSERT_TRUE(addr.has_value());
             EXPECT_EQ(global_ip_cache_->set_global_addr(type, *addr), AddrTests[i][j]);
             if (auto const val = global_ip_cache_->global_addr(type); val && AddrTests[i][j])
             {

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -262,7 +262,7 @@ TEST_F(HandshakeTest, incomingPlaintext)
     EXPECT_EQ(peer_id, res->peer_id);
     EXPECT_EQ(TorrentWeAreSeeding.info_hash, io->torrent_hash());
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 // The datastream is identical to HandshakeTest.incomingPlaintext,
@@ -289,7 +289,7 @@ TEST_F(HandshakeTest, incomingPlaintextUnknownInfoHash)
     EXPECT_FALSE(res->peer_id);
     EXPECT_EQ(tr_sha1_digest_t{}, io->torrent_hash());
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 TEST_F(HandshakeTest, outgoingPlaintext)
@@ -317,7 +317,7 @@ TEST_F(HandshakeTest, outgoingPlaintext)
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
     EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 TEST_F(HandshakeTest, incomingEncrypted)
@@ -356,7 +356,7 @@ TEST_F(HandshakeTest, incomingEncrypted)
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
     EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 // The datastream is identical to HandshakeTest.incomingEncrypted,
@@ -390,7 +390,7 @@ TEST_F(HandshakeTest, incomingEncryptedUnknownInfoHash)
     EXPECT_TRUE(res->read_anything_from_peer);
     EXPECT_EQ(tr_sha1_digest_t{}, io->torrent_hash());
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 TEST_F(HandshakeTest, outgoingEncrypted)
@@ -434,7 +434,7 @@ TEST_F(HandshakeTest, outgoingEncrypted)
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
     EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
 
-    evutil_closesocket(sock);
+    tr_net_close_socket(sock);
 }
 
 } // namespace libtransmission::test

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -38,9 +38,9 @@ protected:
     void SetUp() override
     {
         auto const download_dir = GetParam().second;
-        tr_variantDictAddStr(settings(), TR_KEY_download_dir, download_dir.c_str());
+        tr_variantDictAddStr(settings(), TR_KEY_download_dir, download_dir);
         auto const incomplete_dir = GetParam().first;
-        tr_variantDictAddStr(settings(), TR_KEY_incomplete_dir, incomplete_dir.c_str());
+        tr_variantDictAddStr(settings(), TR_KEY_incomplete_dir, incomplete_dir);
         tr_variantDictAddBool(settings(), TR_KEY_incomplete_dir_enabled, true);
 
         SessionTest::SetUp();

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <cstring>
+#include <iterator>
 #include <string_view>
 
 #include <libtransmission/tr-strbuf.h>

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -116,63 +116,6 @@ TEST_F(TorrentMetainfoTest, parseBencFuzz)
     }
 }
 
-#if 0
-TEST_F(TorrentMetainfoTest, sanitize)
-{
-    struct LocalTest
-    {
-        std::string_view input;
-        std::string_view expected_output;
-    };
-
-    auto const tests = std::array<LocalTest, 29>{
-        // skipped
-        LocalTest{ ""sv, ""sv },
-        { "."sv, ""sv },
-        { ".."sv, ""sv },
-        { "....."sv, ""sv },
-        { "  "sv, ""sv },
-        { " . "sv, ""sv },
-        { ". . ."sv, ""sv },
-        // replaced with '_'
-        { "/"sv, "_"sv },
-        { "////"sv, "____"sv },
-        { "\\\\"sv, "__"sv },
-        { "/../"sv, "_.._"sv },
-        { "foo<bar:baz/boo"sv, "foo_bar_baz_boo"sv },
-        { "t\0e\x01s\tt\ri\nn\fg"sv, "t_e_s_t_i_n_g"sv },
-        // appended with '_'
-        { "con"sv, "con_"sv },
-        { "cOm4"sv, "cOm4_"sv },
-        { "LPt9.txt"sv, "LPt9_.txt"sv },
-        { "NUL.tar.gz"sv, "NUL_.tar.gz"sv },
-        // trimmed
-        { " foo"sv, "foo"sv },
-        { "foo "sv, "foo"sv },
-        { " foo "sv, "foo"sv },
-        { "foo."sv, "foo"sv },
-        { "foo..."sv, "foo"sv },
-        { " foo... "sv, "foo"sv },
-        // unmodified
-        { "foo"sv, "foo"sv },
-        { ".foo"sv, ".foo"sv },
-        { "..foo"sv, "..foo"sv },
-        { "foo.bar.baz"sv, "foo.bar.baz"sv },
-        { "null"sv, "null"sv },
-        { "compass"sv, "compass"sv },
-    };
-
-    auto out = std::string{};
-    for (auto const& test : tests)
-    {
-        out.clear();
-        auto const success = tr_metainfoAppendSanitizedPathComponent(out, test.input);
-        EXPECT_EQ(!std::empty(out), success);
-        EXPECT_EQ(test.expected_output, out);
-    }
-}
-#endif
-
 TEST_F(TorrentMetainfoTest, AndroidTorrent)
 {
     auto const filename = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, "/Android-x86 8.1 r6 iso.torrent"sv };

--- a/tests/libtransmission/values-test.cc
+++ b/tests/libtransmission/values-test.cc
@@ -3,9 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
-
-#include <libtransmission/utils.h>
 #include <libtransmission/values.h>
 
 #include "gtest/gtest.h"

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -3,7 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cerrno>


### PR DESCRIPTION
Fix a lot of minor clang-tidy-18 warnings, mostly IWYU.