### PR TITLE
refactor: make tr_torrent::seconds_[seeding,downloading] private

### DIFF
--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -11,9 +11,9 @@
 
 #include <cstdint> // uint64_t
 
-#include <libtransmission/transmission.h>
+#include "libtransmission/transmission.h"
 
-#include <libtransmission/torrent.h>
+#include "libtransmission/torrent.h"
 
 namespace tr_resume
 {

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -11,8 +11,9 @@
 
 #include <cstdint> // uint64_t
 
-struct tr_ctor;
-struct tr_torrent;
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/torrent.h>
 
 namespace tr_resume
 {
@@ -46,8 +47,8 @@ auto inline constexpr Group = fields_t{ 1 << 23 };
 
 auto inline constexpr All = ~fields_t{ 0 };
 
-fields_t load(tr_torrent* tor, fields_t fields_to_load, tr_ctor const* ctor);
+fields_t load(tr_torrent* tor, tr_torrent::ResumeHelper& helper, fields_t fields_to_load, tr_ctor const* ctor);
 
-void save(tr_torrent* tor);
+void save(tr_torrent* tor, tr_torrent::ResumeHelper const& helper);
 
 } // namespace tr_resume

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -701,7 +701,7 @@ void tr_session::on_save_timer()
 {
     for (auto* const tor : torrents())
     {
-        tr_torrentSave(tor);
+        tor->save_resume_file();
     }
 
     stats().save();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -76,7 +76,8 @@ void tr_torrentSave(tr_torrent* tor);
 namespace libtransmission::test
 {
 
-class RenameTest;
+class RenameTest_multifileTorrent_Test;
+class RenameTest_singleFilenameTorrent_Test;
 
 } // namespace libtransmission::test
 
@@ -88,11 +89,6 @@ struct tr_torrent final : public tr_completion::torrent_view
     class ResumeHelper
     {
     public:
-        ResumeHelper(tr_torrent& tor)
-            : tor_{ tor }
-        {
-        }
-
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
@@ -100,6 +96,15 @@ struct tr_torrent final : public tr_completion::torrent_view
         [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
 
     private:
+        friend class libtransmission::test::RenameTest_multifileTorrent_Test;
+        friend class libtransmission::test::RenameTest_singleFilenameTorrent_Test;
+        friend struct tr_torrent;
+
+        ResumeHelper(tr_torrent& tor)
+            : tor_{ tor }
+        {
+        }
+
         tr_torrent& tor_;
     };
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -73,10 +73,35 @@ void tr_torrentCheckSeedLimit(tr_torrent* tor);
 /** save a torrent's .resume file if it's changed since the last time it was saved */
 void tr_torrentSave(tr_torrent* tor);
 
+namespace libtransmission::test
+{
+
+class RenameTest;
+
+} // namespace libtransmission::test
+
 /** @brief Torrent object */
 struct tr_torrent final : public tr_completion::torrent_view
 {
     using Speed = libtransmission::Values::Speed;
+
+    class ResumeHelper
+    {
+    public:
+        ResumeHelper(tr_torrent& tor)
+            : tor_{ tor }
+        {
+        }
+
+        void load_seconds_downloading_before_current_start(time_t when) noexcept;
+        void load_seconds_seeding_before_current_start(time_t when) noexcept;
+
+        [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
+        [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
+
+    private:
+        tr_torrent& tor_;
+    };
 
     class CumulativeCount
     {
@@ -178,6 +203,8 @@ public:
     {
         return session->unique_lock();
     }
+
+    void save_resume_file();
 
     /// SPEED LIMIT
 
@@ -883,44 +910,6 @@ public:
 
     // ---
 
-    [[nodiscard]] constexpr auto seconds_downloading(time_t now) const noexcept
-    {
-        auto n_secs = seconds_downloading_before_current_start_;
-
-        if (is_running())
-        {
-            if (doneDate > startDate)
-            {
-                n_secs += doneDate - startDate;
-            }
-            else if (doneDate == 0)
-            {
-                n_secs += now - startDate;
-            }
-        }
-
-        return n_secs;
-    }
-
-    [[nodiscard]] constexpr auto seconds_seeding(time_t now) const noexcept
-    {
-        auto n_secs = seconds_seeding_before_current_start_;
-
-        if (is_running())
-        {
-            if (doneDate > startDate)
-            {
-                n_secs += now - doneDate;
-            }
-            else if (doneDate != 0)
-            {
-                n_secs += now - startDate;
-            }
-        }
-
-        return n_secs;
-    }
-
     constexpr void set_needs_completeness_check() noexcept
     {
         needs_completeness_check_ = true;
@@ -1034,9 +1023,6 @@ public:
     time_t editDate = 0;
     time_t startDate = 0;
 
-    time_t seconds_downloading_before_current_start_ = 0;
-    time_t seconds_seeding_before_current_start_ = 0;
-
     size_t queuePosition = 0;
 
     tr_completeness completeness = TR_LEECH;
@@ -1140,6 +1126,44 @@ private:
         uint64_t timestamp_msec_ = {};
         Speed speed_ = {};
     };
+
+    [[nodiscard]] constexpr auto seconds_downloading(time_t now) const noexcept
+    {
+        auto n_secs = seconds_downloading_before_current_start_;
+
+        if (is_running())
+        {
+            if (doneDate > startDate)
+            {
+                n_secs += doneDate - startDate;
+            }
+            else if (doneDate == 0)
+            {
+                n_secs += now - startDate;
+            }
+        }
+
+        return n_secs;
+    }
+
+    [[nodiscard]] constexpr auto seconds_seeding(time_t now) const noexcept
+    {
+        auto n_secs = seconds_seeding_before_current_start_;
+
+        if (is_running())
+        {
+            if (doneDate > startDate)
+            {
+                n_secs += now - doneDate;
+            }
+            else if (doneDate != 0)
+            {
+                n_secs += now - startDate;
+            }
+        }
+
+        return n_secs;
+    }
 
     [[nodiscard]] TR_CONSTEXPR20 bool is_piece_checked(tr_piece_index_t piece) const
     {
@@ -1248,6 +1272,9 @@ private:
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
     time_t changed_date_ = 0;
+
+    time_t seconds_downloading_before_current_start_ = 0;
+    time_t seconds_seeding_before_current_start_ = 0;
 
     float verify_progress_ = -1.0F;
     float seed_ratio_ = 0.0F;

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -196,9 +196,10 @@ TEST_F(RenameTest, singleFilenameTorrent)
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 0, "hello, world!\n")); // confirm the contents are right
 
     // (while it's renamed: confirm that the .resume file remembers the changes)
-    tr_resume::save(tor);
+    auto resume_helper = tr_torrent::ResumeHelper{ *tor };
+    tr_resume::save(tor, resume_helper);
     sync();
-    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor);
+    auto const loaded = tr_resume::load(tor, resume_helper, tr_resume::All, ctor);
     EXPECT_STREQ("foobar", tr_torrentName(tor));
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Name));
 
@@ -306,10 +307,11 @@ TEST_F(RenameTest, multifileTorrent)
     EXPECT_TRUE(testFileExistsAndConsistsOfThisString(tor, 2, ExpectedContents[2]));
 
     // (while the branch is renamed: confirm that the .resume file remembers the changes)
-    tr_resume::save(tor);
+    auto resume_helper = tr_torrent::ResumeHelper{ *tor };
+    tr_resume::save(tor, resume_helper);
     // this is a bit dodgy code-wise, but let's make sure the .resume file got the name
     tor->set_file_subpath(1, "gabba gabba hey"sv);
-    auto const loaded = tr_resume::load(tor, tr_resume::All, ctor);
+    auto const loaded = tr_resume::load(tor, resume_helper, tr_resume::All, ctor);
     EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
     EXPECT_EQ(ExpectedFiles[0], tr_torrentFile(tor, 0).name);
     EXPECT_STREQ("Felidae/Felinae/Felis/placeholder/Kyphi", tr_torrentFile(tor, 1).name);


### PR DESCRIPTION
One reason why `tr_torrent` has so many public fields is so that the `resume.cc` functions -- some of which are in an anonymous namespace and can't be declared as friends of `tr_torrent` -- can serialize / deserialize them into `.resume` files. 

These could be moved out of the anonymous namespace and be made friends, but this PR lets `resume.cc` do its job with more limited access with a new helper class, `tr_torrent::ResumeHelper`, which is a simple [attorney-client](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Friendship_and_the_Attorney-Client) class to let `resume` get _some_ access to `tr_torrent`'s internals. This lets us make more of `tr_torrent` private.

As a proof-of-concept in this initial PR, these `tr_torrent` fields and methods are now private:

- `tr_torrent::seconds_downloading()`
    
- `tr_torrent::seconds_seeding()`
    
- `tr_torrent::seconds_downloading_before_current_start_`
    
- `tr_torrent::seconds_seeding_before_current_start_`

