### PR TITLE
refactor: make tr_torrent date fields private

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2328,14 +2328,9 @@ struct peer_candidate
     tr_peer_info const* peer_info;
 };
 
-[[nodiscard]] bool torrentWasRecentlyStarted(tr_torrent const* tor)
+[[nodiscard]] constexpr uint64_t addValToKey(uint64_t value, unsigned int width, uint64_t addme)
 {
-    return difftime(tr_time(), tor->startDate) < 120;
-}
-
-[[nodiscard]] constexpr uint64_t addValToKey(uint64_t value, int width, uint64_t addme)
-{
-    value = value << (uint64_t)width;
+    value <<= width;
     value |= addme;
     return value;
 }
@@ -2348,11 +2343,11 @@ struct peer_candidate
 
     /* prefer peers we've connected to, or never tried, over peers we failed to connect to. */
     i = peer_info.connection_failure_count() != 0U ? 1U : 0U;
-    score = addValToKey(score, 1, i);
+    score = addValToKey(score, 1U, i);
 
     /* prefer the one we attempted least recently (to cycle through all peers) */
     i = peer_info.connection_attempt_time();
-    score = addValToKey(score, 32, i);
+    score = addValToKey(score, 32U, i);
 
     /* prefer peers belonging to a torrent of a higher priority */
     switch (tor->get_priority())
@@ -2370,30 +2365,30 @@ struct peer_candidate
         break;
     }
 
-    score = addValToKey(score, 4, i);
+    score = addValToKey(score, 4U, i);
 
-    /* prefer recently-started torrents */
-    i = torrentWasRecentlyStarted(tor) ? 0 : 1;
-    score = addValToKey(score, 1, i);
+    // prefer recently-started torrents
+    i = tor->started_recently(tr_time()) ? 0 : 1;
+    score = addValToKey(score, 1U, i);
 
     /* prefer torrents we're downloading with */
     i = tor->is_done() ? 1 : 0;
-    score = addValToKey(score, 1, i);
+    score = addValToKey(score, 1U, i);
 
     /* prefer peers that are known to be connectible */
     i = peer_info.is_connectable().value_or(false) ? 0 : 1;
-    score = addValToKey(score, 1, i);
+    score = addValToKey(score, 1U, i);
 
     /* prefer peers that we might be able to upload to */
     i = peer_info.is_seed() ? 0 : 1;
-    score = addValToKey(score, 1, i);
+    score = addValToKey(score, 1U, i);
 
     /* Prefer peers that we got from more trusted sources.
      * lower `fromBest` values indicate more trusted sources */
-    score = addValToKey(score, 4, peer_info.from_best());
+    score = addValToKey(score, 4U, peer_info.from_best());
 
     /* salt */
-    score = addValToKey(score, 8, salt);
+    score = addValToKey(score, 8U, salt);
 
     return score;
 }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -884,7 +884,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     tr_variantInitDict(&top, 50); /* arbitrary "big enough" number */
     tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, helper.seconds_seeding(now));
     tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, helper.seconds_downloading(now));
-    tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
+    tr_variantDictAddInt(&top, TR_KEY_activity_date, helper.date_active());
     tr_variantDictAddInt(&top, TR_KEY_added_date, helper.date_added());
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->bytes_corrupt_.ever());
     tr_variantDictAddInt(&top, TR_KEY_done_date, helper.date_done());

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -711,7 +711,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
 
     if ((fields_to_load & tr_resume::AddedDate) != 0 && tr_variantDictFindInt(&top, TR_KEY_added_date, &i))
     {
-        tor->addedDate = i;
+        helper.load_date_added(static_cast<time_t>(i));
         fields_loaded |= tr_resume::AddedDate;
     }
 
@@ -885,7 +885,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     tr_variantDictAddInt(&top, TR_KEY_seeding_time_seconds, helper.seconds_seeding(now));
     tr_variantDictAddInt(&top, TR_KEY_downloading_time_seconds, helper.seconds_downloading(now));
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
-    tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
+    tr_variantDictAddInt(&top, TR_KEY_added_date, helper.date_added());
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->bytes_corrupt_.ever());
     tr_variantDictAddInt(&top, TR_KEY_done_date, helper.date_done());
     tr_variantDictAddStrView(&top, TR_KEY_destination, tor->download_dir().sv());

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -717,7 +717,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
 
     if ((fields_to_load & tr_resume::DoneDate) != 0 && tr_variantDictFindInt(&top, TR_KEY_done_date, &i))
     {
-        tor->doneDate = i;
+        helper.load_date_done(static_cast<time_t>(i));
         fields_loaded |= tr_resume::DoneDate;
     }
 
@@ -887,7 +887,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     tr_variantDictAddInt(&top, TR_KEY_activity_date, tor->activityDate);
     tr_variantDictAddInt(&top, TR_KEY_added_date, tor->addedDate);
     tr_variantDictAddInt(&top, TR_KEY_corrupt, tor->bytes_corrupt_.ever());
-    tr_variantDictAddInt(&top, TR_KEY_done_date, tor->doneDate);
+    tr_variantDictAddInt(&top, TR_KEY_done_date, helper.date_done());
     tr_variantDictAddStrView(&top, TR_KEY_destination, tor->download_dir().sv());
 
     if (!std::empty(tor->incomplete_dir()))

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1350,7 +1350,7 @@ tr_stat tr_torrent::stats() const
 
     auto const verify_progress = this->verify_progress();
     stats.recheckProgress = verify_progress.value_or(0.0);
-    stats.activityDate = this->activityDate;
+    stats.activityDate = this->date_active_;
     stats.addedDate = this->date_added_;
     stats.doneDate = this->date_done_;
     stats.editDate = this->date_edited_;
@@ -2600,24 +2600,16 @@ void tr_torrent::init_checked_pieces(tr_bitfield const& checked, time_t const* m
 
 // ---
 
+time_t tr_torrent::ResumeHelper::date_active() const noexcept
+{
+    return tor_.date_active_;
+}
+
+// ---
+
 time_t tr_torrent::ResumeHelper::date_added() const noexcept
 {
     return tor_.date_added_;
-}
-
-time_t tr_torrent::ResumeHelper::date_done() const noexcept
-{
-    return tor_.date_done_;
-}
-
-time_t tr_torrent::ResumeHelper::seconds_downloading(time_t now) const noexcept
-{
-    return tor_.seconds_downloading(now);
-}
-
-time_t tr_torrent::ResumeHelper::seconds_seeding(time_t now) const noexcept
-{
-    return tor_.seconds_seeding(now);
 }
 
 void tr_torrent::ResumeHelper::load_date_added(time_t when) noexcept
@@ -2625,14 +2617,35 @@ void tr_torrent::ResumeHelper::load_date_added(time_t when) noexcept
     tor_.date_added_ = when;
 }
 
+// ---
+
+time_t tr_torrent::ResumeHelper::date_done() const noexcept
+{
+    return tor_.date_done_;
+}
+
 void tr_torrent::ResumeHelper::load_date_done(time_t when) noexcept
 {
     tor_.date_done_ = when;
 }
 
+// ---
+
+time_t tr_torrent::ResumeHelper::seconds_downloading(time_t now) const noexcept
+{
+    return tor_.seconds_downloading(now);
+}
+
 void tr_torrent::ResumeHelper::load_seconds_downloading_before_current_start(time_t when) noexcept
 {
     tor_.seconds_downloading_before_current_start_ = when;
+}
+
+// ---
+
+time_t tr_torrent::ResumeHelper::seconds_seeding(time_t now) const noexcept
+{
+    return tor_.seconds_seeding(now);
 }
 
 void tr_torrent::ResumeHelper::load_seconds_seeding_before_current_start(time_t when) noexcept

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -749,7 +749,7 @@ void torrentStart(tr_torrent* tor, torrent_start_opts opts)
 
     tor->is_running_ = true;
     tor->set_dirty();
-    tor->session->runInSessionThread([tor](){ tor->start_in_session_thread(); });
+    tor->session->runInSessionThread([tor]() { tor->start_in_session_thread(); });
 }
 } // namespace
 
@@ -1365,7 +1365,7 @@ tr_stat tr_torrent::stats() const
     stats.activityDate = this->activityDate;
     stats.addedDate = this->addedDate;
     stats.doneDate = this->doneDate;
-    stats.editDate = this->editDate;
+    stats.editDate = this->date_edited_;
     stats.startDate = this->date_started_;
     stats.secondsSeeding = this->seconds_seeding(now_sec);
     stats.secondsDownloading = this->seconds_downloading(now_sec);
@@ -2556,7 +2556,7 @@ bool tr_torrentHasMetadata(tr_torrent const* tor)
 
 void tr_torrent::mark_edited()
 {
-    this->editDate = tr_time();
+    this->date_edited_ = tr_time();
 }
 
 void tr_torrent::mark_changed()

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -89,10 +89,12 @@ struct tr_torrent final : public tr_completion::torrent_view
     class ResumeHelper
     {
     public:
+        void load_date_added(time_t when) noexcept;
         void load_date_done(time_t when) noexcept;
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
+        [[nodiscard]] time_t date_added() const noexcept;
         [[nodiscard]] time_t date_done() const noexcept;
         [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
         [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
@@ -1032,7 +1034,6 @@ public:
     time_t lpdAnnounceAt = 0;
 
     time_t activityDate = 0;
-    time_t addedDate = 0;
 
     size_t queuePosition = 0;
 
@@ -1257,6 +1258,8 @@ private:
 
     void stop_now();
 
+    [[nodiscard]] bool is_new_torrent_a_seed();
+
     tr_stat stats_ = {};
 
     Error error_;
@@ -1283,6 +1286,7 @@ private:
      */
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
+    time_t date_added_ = 0;
     time_t date_changed_ = 0;
     time_t date_done_ = 0;
     time_t date_edited_ = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -94,6 +94,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
+        [[nodiscard]] time_t date_active() const noexcept;
         [[nodiscard]] time_t date_added() const noexcept;
         [[nodiscard]] time_t date_done() const noexcept;
         [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
@@ -701,7 +702,7 @@ public:
 
     constexpr void set_date_active(time_t when) noexcept
     {
-        this->activityDate = when;
+        this->date_active_ = when;
 
         bump_date_changed(when);
     }
@@ -845,7 +846,7 @@ public:
 
         if (activity == TR_STATUS_DOWNLOAD || activity == TR_STATUS_SEED)
         {
-            if (auto const latest = std::max(date_started_, activityDate); latest != 0)
+            if (auto const latest = std::max(date_started_, date_active_); latest != 0)
             {
                 TR_ASSERT(now >= latest);
                 return now - latest;
@@ -1032,8 +1033,6 @@ public:
     tr_swarm* swarm = nullptr;
 
     time_t lpdAnnounceAt = 0;
-
-    time_t activityDate = 0;
 
     size_t queuePosition = 0;
 
@@ -1286,6 +1285,7 @@ private:
      */
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
+    time_t date_active_ = 0;
     time_t date_added_ = 0;
     time_t date_changed_ = 0;
     time_t date_done_ = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1032,7 +1032,6 @@ public:
     time_t activityDate = 0;
     time_t addedDate = 0;
     time_t doneDate = 0;
-    time_t editDate = 0;
 
     size_t queuePosition = 0;
 
@@ -1283,6 +1282,7 @@ private:
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
     time_t date_changed_ = 0;
+    time_t date_edited_ = 0;
     time_t date_started_ = 0;
 
     time_t seconds_downloading_before_current_start_ = 0;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -89,9 +89,11 @@ struct tr_torrent final : public tr_completion::torrent_view
     class ResumeHelper
     {
     public:
+        void load_date_done(time_t when) noexcept;
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
+        [[nodiscard]] time_t date_done() const noexcept;
         [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
         [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
 
@@ -1031,7 +1033,6 @@ public:
 
     time_t activityDate = 0;
     time_t addedDate = 0;
-    time_t doneDate = 0;
 
     size_t queuePosition = 0;
 
@@ -1143,11 +1144,11 @@ private:
 
         if (is_running())
         {
-            if (doneDate > date_started_)
+            if (date_done_ > date_started_)
             {
-                n_secs += doneDate - date_started_;
+                n_secs += date_done_ - date_started_;
             }
-            else if (doneDate == 0)
+            else if (date_done_ == 0)
             {
                 n_secs += now - date_started_;
             }
@@ -1162,11 +1163,11 @@ private:
 
         if (is_running())
         {
-            if (doneDate > date_started_)
+            if (date_done_ > date_started_)
             {
-                n_secs += now - doneDate;
+                n_secs += now - date_done_;
             }
-            else if (doneDate != 0)
+            else if (date_done_ != 0)
             {
                 n_secs += now - date_started_;
             }
@@ -1252,6 +1253,7 @@ private:
     }
 
     void on_metainfo_updated();
+    void on_metainfo_completed();
 
     void stop_now();
 
@@ -1282,6 +1284,7 @@ private:
     tr_peer_id_t peer_id_ = tr_peerIdInit();
 
     time_t date_changed_ = 0;
+    time_t date_done_ = 0;
     time_t date_edited_ = 0;
     time_t date_started_ = 0;
 


### PR DESCRIPTION
Part 2 in a "make `tr_torrent` fields private" series. See more info in Part 1 at https://github.com/transmission/transmission/pull/6279

This PR makes these fields private:
  - tr_torrent::date_active_
  - tr_torrent::date_added_ 
  - tr_torrent::date_changed_ 
  - tr_torrent::date_done_ 
  - tr_torrent::date_edited_ 
  - tr_torrent::date_started_ 
