### PR TITLE
refactor: prefer css vars over sass

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Get dependencies
         run: |
           set -e # abort if any command fails
+          sudo apt-get update
           sudo apt-get install -y npm
       - name: Check for style diffs
         id: check-for-diffs

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -65,6 +65,15 @@
   --image-play-circle-active: url('../img/play-circle-active.svg');
   --image-play-circle-idle: url('../img/play-circle-idle.svg');
 
+  --app-image-url: url('../img/box.svg');
+  --audio-image-url: url('../img/music.svg');
+  --folder-image-url: url('../img/folder.svg');
+  --font-image-url: url('../img/type.svg');
+  --image-image-url: url('../img/image.svg');
+  --package-image-url: url('../img/package.svg');
+  --text-image-url: url('../img/file-text.svg');
+  --video-image-url: url('../img/film.svg');
+
   --progress: 100%;
   --color-fg-error: var(--red-500);
   --color-fg-port-closed: var(--red-500);
@@ -402,30 +411,21 @@ a {
   background-color: var(--white);
 }
 
-$app-image: '../img/box.svg';
-$audio-image: '../img/music.svg';
-$folder-image: '../img/folder.svg';
-$font-image: '../img/type.svg';
-$image-image: '../img/image.svg';
-$package-image: '../img/package.svg';
-$text-image: '../img/file-text.svg';
-$video-image: '../img/film.svg';
-
-@mixin mime-icon($mime-icon) {
+@mixin mime-icon($mime-icon-url) {
   background-color: var(--color-fg-primary);
-  -webkit-mask-image: url($mime-icon);
+  -webkit-mask-image: $mime-icon-url;
   -webkit-mask-repeat: no-repeat;
-  mask-image: url($mime-icon);
+  mask-image: $mime-icon-url;
   mask-repeat: no-repeat;
 
   &[data-icon-multifile='true'] {
-    -webkit-mask-image: url($mime-icon), url($folder-image);
+    -webkit-mask-image: $mime-icon-url, var(--folder-image-url);
     -webkit-mask-position:
       top left,
       bottom right;
     -webkit-mask-repeat: no-repeat, no-repeat;
     -webkit-mask-size: 16px, 16px;
-    mask-image: url($mime-icon), url($folder-image);
+    mask-image: $mime-icon-url, var(--folder-image-url);
     mask-position:
       top left,
       bottom right;
@@ -463,31 +463,31 @@ $video-image: '../img/film.svg';
         top left;
 
       &[data-icon-mime-type='audio'] {
-        @include mime-icon($audio-image);
+        @include mime-icon(var(--audio-image-url));
       }
 
       &[data-icon-mime-type='application'] {
-        @include mime-icon($app-image);
+        @include mime-icon(var(--app-image-url));
       }
 
       &[data-icon-mime-type='font'] {
-        @include mime-icon($font-image);
+        @include mime-icon(var(--font-image-url));
       }
 
       &[data-icon-mime-type='image'] {
-        @include mime-icon($image-image);
+        @include mime-icon(var(--image-image-url));
       }
 
       &[data-icon-mime-type='model'] {
-        @include mime-icon($package-image);
+        @include mime-icon(var(--package-image-url));
       }
 
       &[data-icon-mime-type='text'] {
-        @include mime-icon($text-image);
+        @include mime-icon(var(--text-image-url));
       }
 
       &[data-icon-mime-type='video'] {
-        @include mime-icon($video-image);
+        @include mime-icon(var(--video-image-url));
       }
     }
 
@@ -558,7 +558,7 @@ $video-image: '../img/film.svg';
         width: var(--icon-size);
 
         &[data-icon-multifile='true'] {
-          @include mime-icon($folder-image);
+          @include mime-icon(var(--folder-image-url));
         }
       }
 

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1,17 +1,3 @@
-// ICONS -- see assets/img/README.md for sources and license details
-// Are you a designer? New icon PRs welcomed!
-$image-alt-speed-disabled: '../img/modern-tortoise.png';
-$image-alt-speed-enabled: '../img/modern-tortoise-blue.png';
-$image-baseline: '../img/horizontal-rule.svg';
-$image-chevron-dn: '../img/chevron-down.svg';
-$image-chevron-up: '../img/chevron-up.svg';
-$image-lock-fill: '../img/lock-fill.svg';
-$image-magnet: '../img/magnet.svg';
-$image-pause-circle-active: '../img/pause-circle-active.svg';
-$image-pause-circle-idle: '../img/pause-circle-idle.svg';
-$image-play-circle-active: '../img/play-circle-active.svg';
-$image-play-circle-idle: '../img/play-circle-idle.svg';
-
 /// MIXINS
 
 @mixin for-phone-only {
@@ -35,35 +21,49 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
   --dialog-padding: 20px;
   --logo-size: 64px;
   --pauseresume-size: 20px;
-  --toolbar-height: 50px;
+  --popup-top: 51px; // TODO: ugly that this is hardcoded
   --progressbar-border: 1;
   --progressbar-height: 20;
-  --popup-top: 51px; // TODO: ugly that this is hardcoded
+  --toolbar-height: 50px;
 
   /* colors related to torrent status */
+  --black: #000;
   --blue-100: #51b3f7;
   --blue-200: #357aaa;
   --blue-300: #2c7fea;
   --blue-400: #1847d4;
+  --dark-mode-black: #121212;
+  --dark-mode-white: #c9d1d9;
+  --default-accent-color-dark: #0c2d6b;
+  --default-border-dark: #575757;
+  --default-border-light: #aeaeae;
+  --default-tinted: rgba(128, 128, 144, 0.125);
   --green-100: #26aa55;
   --green-300: #7cef99;
   --green-400: #67c87f;
   --green-500: #34dc70;
   --grey-200: #e1e4e8;
+  --grey-40: #666;
   --grey-500: #828282;
   --grey-900: #191919;
+  --nice-grey: #f8f8f8;
   --red-500: #d73a49;
   --white: #fff;
-  --black: #000;
-  --dark-mode-white: #c9d1d9;
   --yellow-300: #ffea7f;
-  --grey-40: #666;
-  --nice-grey: #f8f8f8;
-  --dark-mode-black: #121212;
-  --default-accent-color-dark: #0c2d6b;
-  --default-border-dark: #575757;
-  --default-border-light: #aeaeae;
-  --default-tinted: rgba(128, 128, 144, 0.125);
+
+  /* ICONS -- see assets/img/README.md for sources and license details */
+  /* Are you a designer? New icon PRs welcomed! */
+  --image-alt-speed-disabled: url('../img/modern-tortoise.png');
+  --image-alt-speed-enabled: url('../img/modern-tortoise-blue.png');
+  --image-baseline: url('../img/horizontal-rule.svg');
+  --image-chevron-dn: url('../img/chevron-down.svg');
+  --image-chevron-up: url('../img/chevron-up.svg');
+  --image-lock-fill: url('../img/lock-fill.svg');
+  --image-magnet: url('../img/magnet.svg');
+  --image-pause-circle-active: url('../img/pause-circle-active.svg');
+  --image-pause-circle-idle: url('../img/pause-circle-idle.svg');
+  --image-play-circle-active: url('../img/play-circle-active.svg');
+  --image-play-circle-idle: url('../img/play-circle-idle.svg');
 
   --progress: 100%;
   --color-fg-error: var(--red-500);
@@ -331,7 +331,7 @@ a {
   }
 
   &.alt-speed-enabled {
-    background-image: url($image-alt-speed-enabled);
+    background-image: var(--image-alt-speed-enabled);
     background-position: bottom left;
     background-size: 20px;
   }
@@ -637,20 +637,20 @@ $video-image: '../img/film.svg';
     width: var(--pauseresume-size);
 
     &[data-action='pause'] {
-      background-image: url($image-pause-circle-idle);
+      background-image: var(--image-pause-circle-idle);
 
       &:active,
       &:hover {
-        background-image: url($image-pause-circle-active);
+        background-image: var(--image-pause-circle-active);
       }
     }
 
     &[data-action='resume'] {
-      background-image: url($image-play-circle-idle);
+      background-image: var(--image-play-circle-idle);
 
       &:active,
       &:hover {
-        background-image: url($image-play-circle-active);
+        background-image: var(--image-play-circle-active);
       }
     }
   }
@@ -794,7 +794,7 @@ $video-image: '../img/film.svg';
   }
 
   .alt-speed-section-label {
-    background: transparent url($image-alt-speed-enabled) no-repeat;
+    background: transparent var(--image-alt-speed-enabled) no-repeat;
     background-position: left;
     background-position-y: 4px;
     background-size: 20px;
@@ -1029,8 +1029,8 @@ $video-image: '../img/film.svg';
     border: 0;
     cursor: pointer;
     height: 1rem;
-    -webkit-mask: url($image-magnet) no-repeat center / 14px;
-    mask: url($image-magnet) no-repeat center / 14px;
+    -webkit-mask: var(--image-magnet) no-repeat center / 14px;
+    mask: var(--image-magnet) no-repeat center / 14px;
     vertical-align: middle;
     width: 1rem;
   }
@@ -1199,8 +1199,8 @@ $video-image: '../img/film.svg';
   .encryption {
     &[data-encrypted='true'] {
       background-color: var(--color-border-selected);
-      -webkit-mask: url($image-lock-fill) no-repeat center / 14px;
-      mask: url($image-lock-fill) no-repeat center / 14px;
+      -webkit-mask: var(--image-lock-fill) no-repeat center / 14px;
+      mask: var(--image-lock-fill) no-repeat center / 14px;
       width: 10px;
     }
   }
@@ -1271,16 +1271,16 @@ $video-image: '../img/film.svg';
   }
 
   > .low {
-    background-image: url($image-chevron-dn);
+    background-image: var(--image-chevron-dn);
     border-right-width: 0;
   }
 
   > .normal {
-    background-image: url($image-baseline);
+    background-image: var(--image-baseline);
   }
 
   > .high {
-    background-image: url($image-chevron-up);
+    background-image: var(--image-chevron-up);
     border-left-width: 0;
   }
 
@@ -1446,13 +1446,13 @@ $video-image: '../img/film.svg';
       grid-area: check;
 
       &:checked ~ #alt-speed-image {
-        background-image: url($image-alt-speed-enabled);
+        background-image: var(--image-alt-speed-enabled);
         background-position: left;
         background-size: 22px;
       }
 
       &:not(:checked) ~ #alt-speed-image {
-        background-image: url($image-alt-speed-disabled);
+        background-image: var(--image-alt-speed-disabled);
         background-size: 22px;
       }
     }

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -22,8 +22,8 @@
   --logo-size: 64px;
   --pauseresume-size: 20px;
   --popup-top: 51px; // TODO: ugly that this is hardcoded
-  --progressbar-border: 1;
-  --progressbar-height: 20;
+  --progressbar-border: 1px;
+  --progressbar-height: 20px;
   --toolbar-height: 50px;
 
   /* colors related to torrent status */

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1,7 +1,3 @@
-// Z-INDEX ENUM
-// $z-index-progressbar: 1;
-$z-index-popup: 2;
-
 // ICONS -- see assets/img/README.md for sources and license details
 // Are you a designer? New icon PRs welcomed!
 $image-alt-speed-disabled: '../img/modern-tortoise.png';
@@ -31,9 +27,18 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
 }
 
 :root {
-  --pauseresume-size: 20px;
-  --dialog-padding: 20px;
+  /* z-index enum */
+  --z-index-popup: 2;
+
+  /* various dimensions */
   --dialog-logo-padding: calc(var(--dialog-padding) * 0.66);
+  --dialog-padding: 20px;
+  --logo-size: 64px;
+  --pauseresume-size: 20px;
+  --toolbar-height: 50px;
+  --progressbar-border: 1;
+  --progressbar-height: 20;
+  --popup-top: 51px; // TODO: ugly that this is hardcoded
 
   /* colors related to torrent status */
   --blue-100: #51b3f7;
@@ -256,16 +261,13 @@ a {
 
 /// TOOLBAR
 
-$toolbar-height-number: 50;
-$toolbar-height: $toolbar-height-number * 1px;
-
 #mainwin-toolbar {
   align-items: center;
   background: var(--color-toolbar-background);
   border-bottom: 1px solid var(--color-default-border);
   display: flex;
   flex-direction: row;
-  height: $toolbar-height;
+  height: var(--toolbar-height);
   margin: 0;
   width: 100%;
 
@@ -276,11 +278,11 @@ $toolbar-height: $toolbar-height-number * 1px;
     border: 0;
     border-radius: 5px;
     cursor: pointer;
-    height: $toolbar-height;
+    height: var(--toolbar-height);
     margin-right: 6px;
     user-select: none;
     -webkit-user-select: none;
-    width: $toolbar-height;
+    width: var(--toolbar-height);
 
     svg {
       stroke: var(--color-fg-primary);
@@ -367,14 +369,12 @@ $toolbar-height: $toolbar-height-number * 1px;
   }
 }
 
-$speed-icon-size: 20px;
-
 .speed-up-icon,
 .speed-dn-icon {
   fill: var(--color-fg-primary);
 
   svg {
-    width: $speed-icon-size;
+    width: 20px;
   }
 }
 
@@ -384,10 +384,6 @@ $speed-icon-size: 20px;
 }
 
 /// TORRENT CONTAINER
-
-$progressbar-border: 1;
-$progressbar-height: 20;
-$popup-top: 51px; // TODO: ugly that this is hardcoded
 
 .flexible-space {
   margin-right: auto;
@@ -416,25 +412,24 @@ $text-image: '../img/file-text.svg';
 $video-image: '../img/film.svg';
 
 @mixin mime-icon($mime-icon) {
-  // background-image: url($mime-icon);
   background-color: var(--color-fg-primary);
   -webkit-mask-image: url($mime-icon);
-  mask-image: url($mime-icon);
   -webkit-mask-repeat: no-repeat;
+  mask-image: url($mime-icon);
   mask-repeat: no-repeat;
 
   &[data-icon-multifile='true'] {
     -webkit-mask-image: url($mime-icon), url($folder-image);
-    mask-image: url($mime-icon), url($folder-image);
     -webkit-mask-position:
       top left,
       bottom right;
+    -webkit-mask-repeat: no-repeat, no-repeat;
+    -webkit-mask-size: 16px, 16px;
+    mask-image: url($mime-icon), url($folder-image);
     mask-position:
       top left,
       bottom right;
-    -webkit-mask-repeat: no-repeat, no-repeat;
     mask-repeat: no-repeat, no-repeat;
-    -webkit-mask-size: 16px, 16px;
     mask-size: 16px, 16px;
   }
 }
@@ -549,8 +544,7 @@ $video-image: '../img/film.svg';
     }
 
     &.compact {
-      $icon-size-num: 16;
-      $icon-size: $icon-size-num * 1px;
+      --icon-size: 16px;
 
       align-items: center;
       display: flex;
@@ -558,14 +552,10 @@ $video-image: '../img/film.svg';
 
       .icon {
         flex-shrink: 0;
-        height: $icon-size;
-        -webkit-mask-size:
-          $icon-size,
-          $icon-size-num * 0.5px;
-        mask-size:
-          $icon-size,
-          $icon-size-num * 0.5px;
-        width: $icon-size;
+        height: var(--icon-size);
+        -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
+        mask-size: var(--icon-size), calc(var(--icon-size) / 2);
+        width: var(--icon-size);
 
         &[data-icon-multifile='true'] {
           @include mime-icon($folder-image);
@@ -578,8 +568,7 @@ $video-image: '../img/film.svg';
     }
 
     &:not(.compact) {
-      $icon-size-num: 32;
-      $icon-size: $icon-size-num * 1px;
+      --icon-size: 32px;
       align-items: center;
       display: grid;
       grid-column-gap: 12px;
@@ -588,16 +577,14 @@ $video-image: '../img/film.svg';
         'icon progress-text progress-text'
         'icon progressbar progressbar'
         'icon peers peers';
-      grid-template-columns: $icon-size auto 1fr;
+      grid-template-columns: var(--icon-size) auto 1fr;
       padding: 6px 12px;
 
       .icon {
-        background-size:
-          $icon-size,
-          $icon-size-num * 0.5px;
+        background-size: var(--icon-size), calc(var(--icon-size) / 2);
         grid-area: icon;
-        height: $icon-size;
-        width: $icon-size;
+        height: var(--icon-size);
+        width: var(--icon-size);
       }
 
       .torrent-name {
@@ -674,7 +661,7 @@ $video-image: '../img/film.svg';
     border-radius: 3px;
     border-style: solid;
     border-width: 1px;
-    height: ($progressbar-height - ($progressbar-border * 2)) * 1px;
+    height: calc(var(--progressbar-height) - var(--progressbar-border) * 2);
 
     &.full {
       flex-grow: 1;
@@ -781,8 +768,8 @@ $video-image: '../img/film.svg';
   background: $background-color;
   bottom: 0;
   right: 0;
-  top: $popup-top;
-  z-index: $z-index-popup;
+  top: var(--popup-top);
+  z-index: var(--z-index-popup);
 
   .tabs-page {
     grid-column-gap: 8px;
@@ -929,8 +916,8 @@ $video-image: '../img/film.svg';
   flex-direction: column;
   position: absolute;
   right: 0;
-  top: $popup-top;
-  z-index: $z-index-popup;
+  top: var(--popup-top);
+  z-index: var(--z-index-popup);
   @include for-phone-only {
     left: 0;
   }
@@ -1177,9 +1164,9 @@ $video-image: '../img/film.svg';
 // Peers Tab
 
 .peer-list {
-  $table-border: 1px solid var(--color-default-border);
+  --table-border: 1px solid var(--color-default-border);
 
-  border: $table-border;
+  border: var(--table-border);
   border-collapse: collapse;
   cursor: default;
   table-layout: fixed;
@@ -1193,7 +1180,7 @@ $video-image: '../img/film.svg';
   }
 
   td {
-    border: $table-border;
+    border: var(--table-border);
     color: var(--color-fg-secondary);
     // padding: 5px 10px;
   }
@@ -1306,7 +1293,6 @@ $video-image: '../img/film.svg';
 /// CONTEXT MENU
 
 .context-menu {
-  $disabled-color: var(--color-fg-disabled);
   background-color: var(--color-bg-primary);
   border-radius: 5px;
   color: var(--color-fg-on-popup);
@@ -1330,7 +1316,7 @@ $video-image: '../img/film.svg';
     }
 
     &:disabled {
-      color: $disabled-color;
+      color: var(--color-fg-disabled);
       cursor: none;
     }
 
@@ -1359,7 +1345,7 @@ $video-image: '../img/film.svg';
   right: 0;
   margin: 6px;
   top: 50px;
-  z-index: $z-index-popup;
+  z-index: var(--z-index-popup);
 
   @include for-phone-only {
     height: 80vh;
@@ -1490,8 +1476,6 @@ $video-image: '../img/film.svg';
 
 /// DIALOGS
 
-$logo-size: 64px;
-
 @include for-phone-only {
   .dialog-buttons {
     padding-top: var(--dialog-logo-padding);
@@ -1500,7 +1484,7 @@ $logo-size: 64px;
   .dialog-container {
     opacity: 96%;
     position: absolute;
-    top: $popup-top;
+    top: var(--popup-top);
     width: 100%;
   }
 
@@ -1518,7 +1502,7 @@ $logo-size: 64px;
   .dialog-container {
     min-width: 500px;
     position: absolute;
-    top: $popup-top * 2;
+    top: calc(var(--popup-top) * 2);
   }
 
   .dialog-heading {
@@ -1540,7 +1524,7 @@ $logo-size: 64px;
       'icon message'
       'icon workarea'
       'icon buttons';
-    grid-template-columns: $logo-size 1fr;
+    grid-template-columns: var(--logo-size) 1fr;
     padding: 2px 12px;
   }
 }
@@ -1580,7 +1564,7 @@ dialog {
   color: var(--color-fg-primary);
   display: block;
   padding: 0;
-  z-index: $z-index-popup;
+  z-index: var(--z-index-popup);
 
   @include for-tablet-portrait-up {
     border: 0;
@@ -1598,8 +1582,8 @@ dialog {
 
 .dialog-logo {
   background: transparent url('../img/logo.png') top left no-repeat;
-  height: $logo-size;
-  width: $logo-size;
+  height: var(--logo-size);
+  width: var(--logo-size);
 }
 
 .dialog-message {

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1,28 +1,3 @@
-// Colors related to torrent status
-$blue-100: #51b3f7;
-$blue-200: #357aaa;
-$blue-300: #2c7fea;
-$blue-400: #1847d4;
-$green-100: #26aa55;
-$green-300: #7cef99;
-$green-400: #67c87f;
-$green-500: #34dc70;
-$grey-200: #e1e4e8;
-$grey-500: #828282;
-$grey-900: #191919;
-$red-500: #d73a49;
-$white: #fff;
-$black: #000;
-$dark-mode-white: #c9d1d9;
-$yellow-300: #ffea7f;
-$grey-40: #666;
-$nice-grey: #f8f8f8;
-$dark-mode-black: #121212;
-$default-accent-color-dark: #0c2d6b;
-$default-border-dark: #575757;
-$default-border-light: #aeaeae;
-$default-tinted: rgba(128, 128, 144, 0.125);
-
 // Z-INDEX ENUM
 // $z-index-progressbar: 1;
 $z-index-popup: 2;
@@ -55,140 +30,163 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
   }
 }
 
-/// GLOBAL
-
 :root {
   --pauseresume-size: 20px;
   --dialog-padding: 20px;
   --dialog-logo-padding: calc(var(--dialog-padding) * 0.66);
 
+  /* colors related to torrent status */
+  --blue-100: #51b3f7;
+  --blue-200: #357aaa;
+  --blue-300: #2c7fea;
+  --blue-400: #1847d4;
+  --green-100: #26aa55;
+  --green-300: #7cef99;
+  --green-400: #67c87f;
+  --green-500: #34dc70;
+  --grey-200: #e1e4e8;
+  --grey-500: #828282;
+  --grey-900: #191919;
+  --red-500: #d73a49;
+  --white: #fff;
+  --black: #000;
+  --dark-mode-white: #c9d1d9;
+  --yellow-300: #ffea7f;
+  --grey-40: #666;
+  --nice-grey: #f8f8f8;
+  --dark-mode-black: #121212;
+  --default-accent-color-dark: #0c2d6b;
+  --default-border-dark: #575757;
+  --default-border-light: #aeaeae;
+  --default-tinted: rgba(128, 128, 144, 0.125);
+
   --progress: 100%;
-  --color-fg-error: #{$red-500};
-  --color-fg-port-closed: #{$red-500};
-  --color-fg-port-open: #{$green-100};
-  --color-progressbar-background-2: #{$green-400};
-  --color-progressbar-verify: #{$yellow-300};
-  --color-progressbar-magnet: #{$yellow-300};
-  --color-progressbar-paused: #{$grey-200};
-  --color-progressbar-leech: #{$blue-200};
-  --color-progressbar-queued: #{$blue-400};
-  --color-bg-even: #{$default-tinted};
-  --color-toolbar-background: #{$default-tinted};
-  --color-bg-tabs: #{$default-tinted};
+  --color-fg-error: var(--red-500);
+  --color-fg-port-closed: var(--red-500);
+  --color-fg-port-open: var(--green-100);
+  --color-progressbar-background-2: var(--green-400);
+  --color-progressbar-verify: var(--yellow-300);
+  --color-progressbar-magnet: var(--yellow-300);
+  --color-progressbar-paused: var(--grey-200);
+  --color-progressbar-leech: var(--blue-200);
+  --color-progressbar-queued: var(--blue-400);
+  --color-bg-even: var(--default-tinted);
+  --color-toolbar-background: var(--default-tinted);
+  --color-bg-tabs: var(--default-tinted);
 
   color-scheme: light dark;
 
   @media (prefers-color-scheme: dark) {
-    --color-bg-odd: #{$black};
-    --color-bg-primary: #{$black};
-    --color-bg-popup: #{$black};
-    --color-bg-hover: #{$grey-40};
-    --color-fg-primary: #{$dark-mode-white};
-    --color-fg-secondary: #{$nice-grey};
-    --color-fg-on-popup: #{$nice-grey};
+    --color-bg-odd: var(--black);
+    --color-bg-primary: var(--black);
+    --color-bg-popup: var(--black);
+    --color-bg-hover: var(--grey-40);
+    --color-fg-primary: var(--dark-mode-white);
+    --color-fg-secondary: var(--nice-grey);
+    --color-fg-on-popup: var(--nice-grey);
     --color-fg-disabled: #808088;
     --color-bg-warn: #cf6679;
-    --color-fg-warn: #{$dark-mode-black};
-    --color-border: #{$dark-mode-white};
-    --color-border-selected: #{$grey-500};
-    --color-fg-tertiary: #{$grey-500};
-    --color-bg-selected: #{$default-accent-color-dark};
-    --color-default-border: #{$default-border-dark};
-    --color-progressbar-seed-1: #{$green-100};
-    --color-progressbar-seed-2: #{$green-400};
-    --color-progressbar-paused: #{$grey-500};
-    --color-progressbar-leech: #{$blue-200};
-    --color-progressbar-seed-paused: #{$grey-500};
+    --color-fg-warn: var(--dark-mode-black);
+    --color-border: var(--dark-mode-white);
+    --color-border-selected: var(--grey-500);
+    --color-fg-tertiary: var(--grey-500);
+    --color-bg-selected: var(--default-accent-color-dark);
+    --color-default-border: var(--default-border-dark);
+    --color-progressbar-seed-1: var(--green-100);
+    --color-progressbar-seed-2: var(--green-400);
+    --color-progressbar-paused: var(--grey-500);
+    --color-progressbar-leech: var(--blue-200);
+    --color-progressbar-seed-paused: var(--grey-500);
 
     .contrast-more {
-      --color-fg-error: #{$red-500};
-      --color-fg-port-closed: #{$red-500};
-      --color-fg-port-open: #{$green-100};
-      --color-bg-hover: #{$grey-40};
-      --color-fg-primary: #{$white};
-      --color-bg-even: #{$black};
-      --color-fg-secondary: #{$white};
-      --color-fg-on-popup: #{$white};
-      --color-fg-disabled: #{$white};
+      --color-fg-error: var(--red-500);
+      --color-fg-port-closed: var(--red-500);
+      --color-fg-port-open: var(--green-100);
+      --color-bg-hover: var(--grey-40);
+      --color-fg-primary: var(--white);
+      --color-bg-even: var(--black);
+      --color-fg-secondary: var(--white);
+      --color-fg-on-popup: var(--white);
+      --color-fg-disabled: var(--white);
       --color-bg-warn: #cf6679;
-      --color-fg-warn: #{$black};
-      --color-border: #{$white};
-      --color-border-selected: #{$white};
-      --color-fg-tertiary: #{$white};
-      --color-toolbar-background: #{$black};
-      --color-bg-selected: #{$blue-300};
-      --color-bg-tabs: #{$black};
-      --color-fg-tabs: #{$white};
-      --color-default-border: #{$white};
-      --color-progressbar-seed-1: #{$black};
-      --color-progressbar-seed-2: #{$white};
-      --color-progressbar-seed-paused: #{$grey-500};
-      --color-progressbar-background-2: #{$white};
-      --color-progressbar-verify: #{$yellow-300};
-      --color-progressbar-magnet: #{$yellow-300};
-      --color-progressbar-paused: #{$grey-500};
-      --color-progressbar-leech: #{$blue-200};
-      --color-progressbar-queued: #{$blue-400};
+      --color-fg-warn: var(--black);
+      --color-border: var(--white);
+      --color-border-selected: var(--white);
+      --color-fg-tertiary: var(--white);
+      --color-toolbar-background: var(--black);
+      --color-bg-selected: var(--blue-300);
+      --color-bg-tabs: var(--black);
+      --color-fg-tabs: var(--white);
+      --color-default-border: var(--white);
+      --color-progressbar-seed-1: var(--black);
+      --color-progressbar-seed-2: var(--white);
+      --color-progressbar-seed-paused: var(--grey-500);
+      --color-progressbar-background-2: var(--white);
+      --color-progressbar-verify: var(--yellow-300);
+      --color-progressbar-magnet: var(--yellow-300);
+      --color-progressbar-paused: var(--grey-500);
+      --color-progressbar-leech: var(--blue-200);
+      --color-progressbar-queued: var(--blue-400);
     }
   }
   @media (prefers-color-scheme: light) {
-    --color-bg-odd: #{$white};
-    --color-bg-primary: #{$white};
-    --color-bg-popup: #{$white};
-    --color-fg-error: #{$red-500};
-    --color-fg-port-closed: #{$red-500};
-    --color-fg-port-open: #{$green-400};
-    --color-progressbar-verify: #{$yellow-300};
-    --color-progressbar-magnet: #{$yellow-300};
-    --color-progressbar-paused: #{$grey-200};
-    --color-progressbar-leech: #{$blue-100};
-    --color-progressbar-queued: #{$blue-400};
-    --color-bg-hover: #{$nice-grey};
+    --color-bg-odd: var(--white);
+    --color-bg-primary: var(--white);
+    --color-bg-popup: var(--white);
+    --color-fg-error: var(--red-500);
+    --color-fg-port-closed: var(--red-500);
+    --color-fg-port-open: var(--green-400);
+    --color-progressbar-verify: var(--yellow-300);
+    --color-progressbar-magnet: var(--yellow-300);
+    --color-progressbar-paused: var(--grey-200);
+    --color-progressbar-leech: var(--blue-100);
+    --color-progressbar-queued: var(--blue-400);
+    --color-bg-hover: var(--nice-grey);
     --color-fg-primary: #404040;
-    --color-fg-on-popup: #{$grey-900};
-    --color-fg-secondary: #{$grey-500};
-    --color-border: #{$grey-500};
+    --color-fg-on-popup: var(--grey-900);
+    --color-fg-secondary: var(--grey-500);
+    --color-border: var(--grey-500);
     --color-border-selected: #d0d7de;
-    --color-fg-tertiary: #{$grey-500};
+    --color-fg-tertiary: var(--grey-500);
     --color-bg-warn: #e4606d5b;
     --color-fg-warn: #cf212e;
-    --color-fg-disabled: #{$grey-500};
-    --color-bg-selected: #{$blue-300};
-    --color-default-border: #{$default-border-light};
-    --color-dialog-border: #{$nice-grey};
-    --color-progressbar-seed-1: #{$green-500};
-    --color-progressbar-seed-2: #{$green-300};
-    --color-progressbar-seed-paused: #{$grey-200};
+    --color-fg-disabled: var(--grey-500);
+    --color-bg-selected: var(--blue-300);
+    --color-default-border: var(--default-border-light);
+    --color-dialog-border: var(--nice-grey);
+    --color-progressbar-seed-1: var(--green-500);
+    --color-progressbar-seed-2: var(--green-300);
+    --color-progressbar-seed-paused: var(--grey-200);
 
     .contrast-more {
-      --color-fg-error: #{$red-500};
-      --color-fg-port-closed: #{$red-500};
-      --color-fg-port-open: #{$green-400};
-      --color-bg-hover: #{$grey-40};
-      --color-fg-primary: #{$black};
-      --color-bg-even: #{$white};
-      --color-fg-secondary: #{$black};
-      --color-fg-on-popup: #{$black};
-      --color-fg-disabled: #{$black};
+      --color-fg-error: var(--red-500);
+      --color-fg-port-closed: var(--red-500);
+      --color-fg-port-open: var(--green-400);
+      --color-bg-hover: var(--grey-40);
+      --color-fg-primary: var(--black);
+      --color-bg-even: var(--white);
+      --color-fg-secondary: var(--black);
+      --color-fg-on-popup: var(--black);
+      --color-fg-disabled: var(--black);
       --color-bg-warn: #cf6679;
-      --color-fg-warn: #{$white};
-      --color-border: #{$black};
-      --color-border-selected: #{$black};
-      --color-fg-tertiary: #{$black};
-      --color-toolbar-background: #{$white};
-      --color-bg-selected: #{$blue-300};
-      --color-bg-tabs: #{$white};
-      --color-fg-tabs: #{$black};
-      --color-default-border: #{$black};
-      --color-progressbar-seed-1: #{$black};
-      --color-progressbar-seed-2: #{$white};
-      --color-progressbar-seed-paused: #{$grey-500};
-      --color-progressbar-background-2: #{$white};
-      --color-progressbar-verify: #{$yellow-300};
-      --color-progressbar-magnet: #{$yellow-300};
-      --color-progressbar-paused: #{$grey-500};
-      --color-progressbar-leech: #{$blue-200};
-      --color-progressbar-queued: #{$blue-400};
+      --color-fg-warn: var(--white);
+      --color-border: var(--black);
+      --color-border-selected: var(--black);
+      --color-fg-tertiary: var(--black);
+      --color-toolbar-background: var(--white);
+      --color-bg-selected: var(--blue-300);
+      --color-bg-tabs: var(--white);
+      --color-fg-tabs: var(--black);
+      --color-default-border: var(--black);
+      --color-progressbar-seed-1: var(--black);
+      --color-progressbar-seed-2: var(--white);
+      --color-progressbar-seed-paused: var(--grey-500);
+      --color-progressbar-background-2: var(--white);
+      --color-progressbar-verify: var(--yellow-300);
+      --color-progressbar-magnet: var(--yellow-300);
+      --color-progressbar-paused: var(--grey-500);
+      --color-progressbar-leech: var(--blue-200);
+      --color-progressbar-queued: var(--blue-400);
     }
   }
 }
@@ -405,7 +403,7 @@ $popup-top: 51px; // TODO: ugly that this is hardcoded
 }
 
 .torrent-container {
-  background-color: $white;
+  background-color: var(--white);
 }
 
 $app-image: '../img/box.svg';

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -411,29 +411,6 @@ a {
   background-color: var(--white);
 }
 
-@mixin mime-icon($mime-icon-url) {
-  background-color: var(--color-fg-primary);
-  -webkit-mask-image: $mime-icon-url;
-  -webkit-mask-repeat: no-repeat;
-  mask-image: $mime-icon-url;
-  mask-repeat: no-repeat;
-
-  &[data-icon-multifile='true'] {
-    -webkit-mask-image: $mime-icon-url, var(--folder-image-url);
-    -webkit-mask-position:
-      top left,
-      bottom right;
-    -webkit-mask-repeat: no-repeat, no-repeat;
-    -webkit-mask-size: 16px, 16px;
-    mask-image: $mime-icon-url, var(--folder-image-url);
-    mask-position:
-      top left,
-      bottom right;
-    mask-repeat: no-repeat, no-repeat;
-    mask-size: 16px, 16px;
-  }
-}
-
 .torrent-list {
   cursor: pointer;
   list-style-type: none;
@@ -461,33 +438,52 @@ a {
       background-position:
         center,
         top left;
+      -webkit-mask-image: var(--mime-icon-url);
+      -webkit-mask-repeat: no-repeat;
+      mask-image: var(--mime-icon-url);
+      mask-repeat: no-repeat;
+
+      &[data-icon-multifile='true'] {
+        -webkit-mask-image: var(--mime-icon-url), var(--folder-image-url);
+        -webkit-mask-position:
+          top left,
+          bottom right;
+        -webkit-mask-repeat: no-repeat, no-repeat;
+        -webkit-mask-size: 16px, 16px;
+        mask-image: var(--mime-icon-url), var(--folder-image-url);
+        mask-position:
+          top left,
+          bottom right;
+        mask-repeat: no-repeat, no-repeat;
+        mask-size: 16px, 16px;
+      }
 
       &[data-icon-mime-type='audio'] {
-        @include mime-icon(var(--audio-image-url));
+        --mime-icon-url: var(--audio-image-url);
       }
 
       &[data-icon-mime-type='application'] {
-        @include mime-icon(var(--app-image-url));
+        --mime-icon-url: var(--app-image-url);
       }
 
       &[data-icon-mime-type='font'] {
-        @include mime-icon(var(--font-image-url));
+        --mime-icon-url: var(--font-image-url);
       }
 
       &[data-icon-mime-type='image'] {
-        @include mime-icon(var(--image-image-url));
+        --mime-icon-url: var(--image-image-url);
       }
 
       &[data-icon-mime-type='model'] {
-        @include mime-icon(var(--package-image-url));
+        --mime-icon-url: var(--package-image-url);
       }
 
       &[data-icon-mime-type='text'] {
-        @include mime-icon(var(--text-image-url));
+        --mime-icon-url: var(--text-image-url);
       }
 
       &[data-icon-mime-type='video'] {
-        @include mime-icon(var(--video-image-url));
+        --mime-icon-url: var(--video-image-url);
       }
     }
 
@@ -551,14 +547,14 @@ a {
       flex-direction: row-reverse;
 
       .icon {
+        -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
         flex-shrink: 0;
         height: var(--icon-size);
-        -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
         mask-size: var(--icon-size), calc(var(--icon-size) / 2);
         width: var(--icon-size);
 
         &[data-icon-multifile='true'] {
-          @include mime-icon(var(--folder-image-url));
+          --mime-icon-url: var(--folder-image-url);
         }
       }
 

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1,6 +1,3 @@
-@use 'sass:color';
-@use 'sass:math';
-
 // Colors related to torrent status
 $blue-100: #51b3f7;
 $blue-200: #357aaa;
@@ -70,6 +67,10 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
 /// GLOBAL
 
 :root {
+  --pauseresume-size: 20px;
+  --dialog-padding: 20px;
+  --dialog-logo-padding: calc(var(--dialog-padding) * 0.66);
+
   --progress: 100%;
   --color-fg-error: #{$red-500};
   --color-fg-port-closed: #{$red-500};
@@ -395,8 +396,6 @@ $speed-icon-size: 20px;
 
 /// TORRENT CONTAINER
 
-$pauseresume-size-number: 20;
-$pauseresume-size: $pauseresume-size-number * 1px;
 $progressbar-border: 1;
 $progressbar-height: 20;
 $popup-top: 51px; // TODO: ugly that this is hardcoded
@@ -665,9 +664,9 @@ $video-image: '../img/film.svg';
   .torrent-pauseresume-button {
     background-position: center center;
     background-repeat: no-repeat;
-    background-size: $pauseresume-size;
-    margin-left: math.floor(math.div($pauseresume-size-number, 2)) * 1px;
-    width: $pauseresume-size;
+    background-size: var(--pauseresume-size);
+    margin-left: calc(var(--pauseresume-size) / 2);
+    width: var(--pauseresume-size);
 
     &[data-action='pause'] {
       background-image: url($image-pause-circle-idle);
@@ -1510,13 +1509,11 @@ $video-image: '../img/film.svg';
 
 /// DIALOGS
 
-$dialog-padding-number: 20;
-$dialog-logo-padding-number: math.div($dialog-padding-number * 2, 3);
 $logo-size: 64px;
 
 @include for-phone-only {
   .dialog-buttons {
-    padding-top: $dialog-logo-padding-number * 1px;
+    padding-top: var(--dialog-logo-padding);
   }
 
   .dialog-container {
@@ -1527,7 +1524,7 @@ $logo-size: 64px;
   }
 
   .dialog-logo {
-    padding-bottom: $dialog-logo-padding-number * 1px;
+    padding-bottom: var(--dialog-logo-padding);
   }
 
   .dialog-window {
@@ -1549,7 +1546,7 @@ $logo-size: 64px;
 
   .dialog-logo {
     grid-area: icon;
-    padding-right: $dialog-logo-padding-number * 1px;
+    padding-right: var(--dialog-logo-padding);
   }
 
   .dialog-window {
@@ -1632,7 +1629,7 @@ dialog {
 .dialog-window {
   background: var(--color-bg-primary);
   border-radius: 8px;
-  padding: $dialog-padding-number * 1px;
+  padding: var(--dialog-padding);
 }
 
 .dialog-workarea {

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -55,15 +55,6 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
   }
 }
 
-@mixin button {
-  border: 1px solid var(--color-border);
-  cursor: pointer;
-  display: inline-block;
-  padding: 3px;
-  user-select: none;
-  -webkit-user-select: none;
-}
-
 /// GLOBAL
 
 :root {
@@ -425,14 +416,6 @@ $image-image: '../img/image.svg';
 $package-image: '../img/package.svg';
 $text-image: '../img/file-text.svg';
 $video-image: '../img/film.svg';
-
-@mixin mime-icon-compact($mime-icon) {
-  &[data-icon-multifile='true'] {
-    background-image: url($folder-image);
-    background-position: center;
-    background-size: 16px;
-  }
-}
 
 @mixin mime-icon($mime-icon) {
   // background-image: url($mime-icon);

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -19,13 +19,13 @@ $image-play-circle-idle: '../img/play-circle-idle.svg';
 /// MIXINS
 
 @mixin for-phone-only {
-  @media (max-width: 599px) {
+  @media (width < 600px) {
     @content;
   }
 }
 
 @mixin for-tablet-portrait-up {
-  @media (min-width: 600px) {
+  @media (width >= 600px) {
     @content;
   }
 }


### PR DESCRIPTION
This is a minor css cleanup PR. It replaces some sass use with modern css.

- prefer [css calc()](https://caniuse.com/calc) over sass.math
- prefer [css variables](https://caniuse.com/css-variables) over sass variables
- remove some unused sass mixins

This PR came about because I was reading through our sass use for #6280, but FWIW this is just a sass cleanup PR that doesn't affect the bigger changes in 6280.

CC @niol because this upstreams some of his work e.g. removing the sass math