### PR TITLE
VDKQueue: support deallocating the object

### DIFF
--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -140,6 +140,8 @@ extern NSString const* VDKQueueAccessRevocationNotification;
 - (void)addPath:(NSString*)aPath;
 - (void)addPath:(NSString*)aPath notifyingAbout:(u_int)flags; // See note above for values to pass in "flags"
 
+//  Either `removePath:` or `removeAllPaths` must be called if we want this object to ever be dealloc'd.
+//  This is because adding a path detaches a thread which retains self.
 - (void)removePath:(NSString*)aPath;
 - (void)removeAllPaths;
 

--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -136,7 +136,7 @@ extern NSString const* VDKQueueAccessRevocationNotification;
 //        Just add it or remove it and this class will take action only if appropriate.
 //        (Add only if we're not already watching it, remove only if we are.)
 //
-//  Warning: You must pass full, root-relative paths. Do not pass tilde-abbreviated paths or file URLs.
+//  Warning: Only pass file paths ("/path"), not string representations of URLs ("file://path").
 - (void)addPath:(NSString*)aPath;
 - (void)addPath:(NSString*)aPath notifyingAbout:(u_int)flags; // See note above for values to pass in "flags"
 

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -175,6 +175,7 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
 
     NSThread.currentThread.name = @"VDKQueue";
 
+    struct kevent ev;
     // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
     const struct timespec timeout = { 1, 0 };
     // So we don't have to risk accessing iVars when the thread is terminated.
@@ -184,7 +185,6 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
 
     while (_keepWatcherThreadRunning)
     {
-        struct kevent ev;
         int n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
         if (n <= 0 || ev.filter != EVFILT_VNODE || !ev.fflags)
         {

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -273,6 +273,8 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
         return;
     }
 
+    aPath = aPath.stringByStandardizingPath;
+
     @synchronized(self)
     {
         if (_watchedPathEntries[aPath])
@@ -298,6 +300,8 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
     {
         return;
     }
+
+    aPath = aPath.stringByStandardizingPath;
 
     @synchronized(self)
     {

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -169,22 +169,23 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
 
 - (void)watcherThread:(id)sender
 {
-    int n;
-    struct kevent ev;
-    // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
-    struct timespec timeout = { 1, 0 };
-    // So we don't have to risk accessing iVars when the thread is terminated.
-    int theFD = _coreQueueFD;
-
-    NSMutableArray* notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
-
 #if DEBUG_LOG_THREAD_LIFETIME
     NSLog(@"watcherThread started.");
 #endif
 
+    NSThread.currentThread.name = @"VDKQueue";
+
+    // 1 second timeout. Should be longer, but we need this thread to exit when a kqueue is dealloced, so 1 second timeout is quite a while to wait.
+    const struct timespec timeout = { 1, 0 };
+    // So we don't have to risk accessing iVars when the thread is terminated.
+    int const theFD = _coreQueueFD;
+
+    NSMutableArray* notesToPost = [[NSMutableArray alloc] initWithCapacity:5];
+
     while (_keepWatcherThreadRunning)
     {
-        n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
+        struct kevent ev;
+        int n = kevent(theFD, NULL, 0, &ev, 1, &timeout);
         if (n <= 0 || ev.filter != EVFILT_VNODE || !ev.fflags)
         {
             continue;


### PR DESCRIPTION
Context: a year ago, we took responsibility to maintain a fork of VDKQueue (#4202).
Today, @gobbledegook suggested a memory fix to the legacy repo (https://github.com/bdkjones/VDKQueue/pull/20).
Their observation is that `[NSThread detachNewThreadSelector:@selector(watcherThread:) toTarget:self withObject:nil]` will prevent `self` from ever being released.

The present pull request:
- fix the memory leak (more elegantly, in my opinion, than how gobbledegook is suggesting to do it, because I do not introduce an extra method (that has also the benefit of staying a drop-in replacement of the original VDKQueue).
- name the detached thread ("VDKQueue") for debugging.
- handle any form of paths, even those with `~`, by standardizing them.

Testing:
1. No regressions: if you go into Transmission Settings, turn on and off and on again the "Auto add" feature, it will still work (you can verify by adding a .torrent file to the watched folder, and a popup will prompt).
2. Debugging: if you pause the execution of Transmission in Xcode, you'll spot the "VDKQueue" thread when the feature is on, and you'll see it gets removed when the feature is turned off.
3. Memory fix: if you put a breakpoint or a log in VDKQueue's `dealloc`, and if you alter the Controller.mm code to call at some point `[_fileWatcherQueue removeAllPaths]; _fileWatcherQueue = nil;`, then you'll see that it gets deallocated. Before the present fix, `dealloc` would have not been called.