### PR TITLE
refactor: make tr_torrent fields, methods private where possible

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1040,7 +1040,7 @@ void tr_announcer_impl::onAnnounceDone(
            Don't bother publishing if there are other trackers -- it's
            all too common for people to load up dozens of dead trackers
            in a torrent's metainfo... */
-        if (tier->tor->tracker_count() < 2)
+        if (std::size(tier->tor->announce_list()) < 2U)
         {
             publishError(tier, response.errmsg);
         }

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -223,10 +223,10 @@ int Cache::flush_span(CIter const begin, CIter const end)
     return {};
 }
 
-int Cache::flush_file(tr_torrent const* torrent, tr_file_index_t file)
+int Cache::flush_file(tr_torrent const* const torrent, tr_file_index_t const file)
 {
     auto const tor_id = torrent->id();
-    auto const [block_begin, block_end] = tr_torGetFileBlockSpan(torrent, file);
+    auto const [block_begin, block_end] = torrent->block_span_for_file(file);
 
     auto const lock = std::lock_guard{ mutex_ };
     return flush_span(

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1293,7 +1293,7 @@ void create_bit_torrent_peer(tr_torrent* tor, std::shared_ptr<tr_peerIo> io, tr_
         client = tr_interned_string{ tr_quark_new(std::data(buf)) };
     }
 
-    result.io->set_bandwidth(&swarm->tor->bandwidth_);
+    result.io->set_bandwidth(&swarm->tor->bandwidth());
     create_bit_torrent_peer(swarm->tor, result.io, info, client);
 
     return true;
@@ -1888,7 +1888,7 @@ void rechokeUploads(tr_swarm* s, uint64_t const now)
     choked.reserve(peer_count);
     auto const* const session = s->manager->session;
     bool const choke_all = !s->tor->client_can_upload();
-    bool const is_maxed_out = s->tor->bandwidth_.is_maxed_out(TR_UP, now);
+    bool const is_maxed_out = s->tor->bandwidth().is_maxed_out(TR_UP, now);
 
     /* an optimistic unchoke peer's "optimistic"
      * state lasts for N calls to rechokeUploads(). */
@@ -2435,7 +2435,7 @@ void get_peer_candidates(size_t global_peer_limit, tr_torrents& torrents, tr_pee
         }
 
         /* if we've already got enough speed in this torrent... */
-        if (seeding && tor->bandwidth_.is_maxed_out(TR_UP, now_msec))
+        if (seeding && tor->bandwidth().is_maxed_out(TR_UP, now_msec))
         {
             continue;
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -765,7 +765,7 @@ private:
                 auto const loc = tor->piece_loc(event.pieceIndex, event.offset);
                 s->cancel_all_requests_for_block(loc.block, peer);
                 peer->blocks_sent_to_client.add(tr_time(), 1);
-                tr_torrentGotBlock(tor, loc.block);
+                tor->on_block_received(loc.block);
             }
 
             break;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2007,7 +2007,7 @@ void tr_peerMgr::rechoke_pulse() const
         if (tor->is_running())
         {
             // possibly stop torrents that have seeded enough
-            tr_torrentCheckSeedLimit(tor);
+            tor->stop_if_seed_limit_reached();
         }
 
         if (tor->is_running())

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -473,7 +473,7 @@ void saveProgress(tr_variant* dict, tr_torrent const* tor, tr_torrent::ResumeHel
     }
 
     /* add the blocks bitfield */
-    bitfieldToRaw(tor->blocks(), tr_variantDictAdd(prog, TR_KEY_blocks));
+    bitfieldToRaw(helper.blocks(), tr_variantDictAdd(prog, TR_KEY_blocks));
 }
 
 /*
@@ -496,7 +496,7 @@ void saveProgress(tr_variant* dict, tr_torrent const* tor, tr_torrent::ResumeHel
  * First approach (pre-2.20) had an "mtimes" list identical to
  * 3.10, but not the 'pieces' bitfield.
  */
-auto loadProgress(tr_variant* dict, tr_torrent* tor)
+auto loadProgress(tr_variant* dict, tr_torrent* tor, tr_torrent::ResumeHelper& helper)
 {
     if (tr_variant* prog = nullptr; tr_variantDictFindDict(dict, TR_KEY_progress, &prog))
     {
@@ -615,7 +615,7 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor)
         }
         else
         {
-            tor->set_blocks(blocks);
+            helper.load_blocks(blocks);
         }
 
         return tr_resume::Progress;
@@ -752,7 +752,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
     // seed or a partial seed.
     if ((fields_to_load & tr_resume::Progress) != 0)
     {
-        fields_loaded |= loadProgress(&top, tor);
+        fields_loaded |= loadProgress(&top, tor, helper);
     }
 
     if (!tor->is_done() && (fields_to_load & tr_resume::FilePriorities) != 0)

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -450,12 +450,12 @@ void rawToBitfield(tr_bitfield& bitfield, uint8_t const* raw, size_t rawlen)
     }
 }
 
-void saveProgress(tr_variant* dict, tr_torrent const* tor)
+void saveProgress(tr_variant* dict, tr_torrent const* tor, tr_torrent::ResumeHelper const& helper)
 {
     tr_variant* const prog = tr_variantDictAddDict(dict, TR_KEY_progress, 4);
 
     // add the mtimes
-    auto const& mtimes = tor->file_mtimes_;
+    auto const& mtimes = helper.file_mtimes();
     auto const n = std::size(mtimes);
     tr_variant* const l = tr_variantDictAddList(prog, TR_KEY_mtimes, n);
     for (auto const& mtime : mtimes)
@@ -900,7 +900,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     {
         saveFilePriorities(&top, tor);
         saveDND(&top, tor);
-        saveProgress(&top, tor);
+        saveProgress(&top, tor, helper);
     }
 
     saveSpeedLimits(&top, tor);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -464,7 +464,7 @@ void saveProgress(tr_variant* dict, tr_torrent const* tor, tr_torrent::ResumeHel
     }
 
     // add the 'checked pieces' bitfield
-    bitfieldToRaw(tor->checked_pieces_, tr_variantDictAdd(prog, TR_KEY_pieces));
+    bitfieldToRaw(helper.checked_pieces(), tr_variantDictAdd(prog, TR_KEY_pieces));
 
     /* add the progress */
     if (tor->completeness == TR_SEED)

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -569,7 +569,7 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor, tr_torrent::ResumeHelper& h
             mtimes.resize(n_files);
         }
 
-        tor->init_checked_pieces(checked, std::data(mtimes));
+        helper.load_checked_pieces(checked, std::data(mtimes));
 
         /// COMPLETION
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -641,7 +641,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_isStalled: return st.isStalled;
     case TR_KEY_labels: return make_labels_vec(tor);
     case TR_KEY_leftUntilDone: return st.leftUntilDone;
-    case TR_KEY_magnetLink: return tor.metainfo_.magnet();
+    case TR_KEY_magnetLink: return tor.magnet();
     case TR_KEY_manualAnnounceTime: return tr_announcerNextManualAnnounce(&tor);
     case TR_KEY_maxConnectedPeers: return tor.peer_limit();
     case TR_KEY_metadataPercentComplete: return st.metadataPercentComplete;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -902,7 +902,7 @@ char const* setFileDLs(tr_torrent* tor, bool wanted, tr_variant* list)
 
 char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
 {
-    auto const old_size = tor->tracker_count();
+    auto const old_list = tor->tracker_list();
 
     for (size_t i = 0, n = tr_variantListSize(urls); i < n; ++i)
     {
@@ -916,7 +916,7 @@ char const* addTrackerUrls(tr_torrent* tor, tr_variant* urls)
         tor->announce_list().add(announce);
     }
 
-    if (tor->tracker_count() == old_size)
+    if (tor->tracker_list() == old_list) // unchanged
     {
         return "error setting announce list";
     }
@@ -956,7 +956,7 @@ char const* replaceTrackers(tr_torrent* tor, tr_variant* urls)
 
 char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
 {
-    auto const old_size = tor->tracker_count();
+    auto const old_list = tor->tracker_list();
 
     for (size_t i = 0, n = tr_variantListSize(ids); i < n; ++i)
     {
@@ -970,7 +970,7 @@ char const* removeTrackers(tr_torrent* tor, tr_variant* ids)
         tor->announce_list().remove(static_cast<tr_tracker_id_t>(id));
     }
 
-    if (tor->tracker_count() == old_size)
+    if (tor->tracker_list() == old_list) // unchanged
     {
         return "error setting announce list";
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -338,7 +338,7 @@ size_t tr_session::WebMediator::clamp(int torrent_id, size_t byte_count) const
     auto const lock = session_->unique_lock();
 
     auto const* const tor = session_->torrents().get(torrent_id);
-    return tor == nullptr ? 0U : tor->bandwidth_.clamp(TR_DOWN, byte_count);
+    return tor == nullptr ? 0U : tor->bandwidth().clamp(TR_DOWN, byte_count);
 }
 
 void tr_session::WebMediator::notifyBandwidthConsumed(int torrent_id, size_t byte_count)
@@ -347,7 +347,7 @@ void tr_session::WebMediator::notifyBandwidthConsumed(int torrent_id, size_t byt
 
     if (auto* const tor = session_->torrents().get(torrent_id); tor != nullptr)
     {
-        tor->bandwidth_.notify_bandwidth_consumed(TR_DOWN, byte_count, true, tr_time_msec());
+        tor->bandwidth().notify_bandwidth_consumed(TR_DOWN, byte_count, true, tr_time_msec());
     }
 }
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -232,7 +232,7 @@ bool use_new_metainfo(tr_torrent* tor, tr_error* error)
     }
 
     // yay we have an info dict. Let's make a torrent file
-    auto top_var = build_metainfo_except_info_dict(tor->metainfo_);
+    auto top_var = build_metainfo_except_info_dict(tor->metainfo());
     tr_variantMergeDicts(tr_variantDictAddDict(&top_var, TR_KEY_info, 0), &*info_dict_v);
     auto const benc = serde.to_string(top_var);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2557,6 +2557,11 @@ void tr_torrent::mark_changed()
 
 // --- RESUME HELPER
 
+tr_bitfield const& tr_torrent::ResumeHelper::checked_pieces() const noexcept
+{
+    return tor_.checked_pieces_;
+}
+
 void tr_torrent::ResumeHelper::load_checked_pieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/)
 {
     TR_ASSERT(std::size(checked) == tor_.piece_count());

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -439,37 +439,35 @@ bool torrent_is_seed_idle_limit_done(tr_torrent const& tor, time_t now)
 } // namespace seed_limit_helpers
 } // namespace
 
-void tr_torrentCheckSeedLimit(tr_torrent* tor)
+void tr_torrent::stop_if_seed_limit_reached()
 {
     using namespace seed_limit_helpers;
 
-    TR_ASSERT(tr_isTorrent(tor));
-
-    if (!tor->is_running() || tor->is_stopping_ || !tor->is_done())
+    if (!is_running() || is_stopping_ || !is_done())
     {
         return;
     }
 
     /* if we're seeding and reach our seed ratio limit, stop the torrent */
-    if (tr_torrentIsSeedRatioDone(tor))
+    if (tr_torrentIsSeedRatioDone(this))
     {
-        tr_logAddInfoTor(tor, _("Seed ratio reached; pausing torrent"));
-        tor->stop_soon();
-        tor->session->onRatioLimitHit(tor);
+        tr_logAddInfoTor(this, _("Seed ratio reached; pausing torrent"));
+        stop_soon();
+        session->onRatioLimitHit(this);
     }
     /* if we're seeding and reach our inactivity limit, stop the torrent */
-    else if (torrent_is_seed_idle_limit_done(*tor, tr_time()))
+    else if (torrent_is_seed_idle_limit_done(*this, tr_time()))
     {
-        tr_logAddInfoTor(tor, _("Seeding idle limit reached; pausing torrent"));
+        tr_logAddInfoTor(this, _("Seeding idle limit reached; pausing torrent"));
 
-        tor->stop_soon();
-        tor->finished_seeding_by_idle_ = true;
-        tor->session->onIdleLimitHit(tor);
+        stop_soon();
+        finished_seeding_by_idle_ = true;
+        session->onIdleLimitHit(this);
     }
 
-    if (tor->is_stopping_)
+    if (is_stopping_)
     {
-        callScriptIfEnabled(tor, TR_SCRIPT_ON_TORRENT_DONE_SEEDING);
+        callScriptIfEnabled(this, TR_SCRIPT_ON_TORRENT_DONE_SEEDING);
     }
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -650,7 +650,8 @@ void removeTorrentInSessionThread(tr_torrent* tor, bool delete_flag, tr_fileFunc
         {
             delete_func(filename, user_data, nullptr);
         };
-        tor->metainfo_.files().remove(tor->current_dir(), tor->name(), delete_func_wrapper);
+
+        tor->files().remove(tor->current_dir(), tor->name(), delete_func_wrapper);
     }
 
     tr_torrentFreeInSessionThread(tor);
@@ -1167,7 +1168,7 @@ void tr_torrent::set_location_in_session_thread(std::string_view const path, boo
         session->verify_remove(this);
 
         auto error = tr_error{};
-        ok = metainfo_.files().move(current_dir(), path, name(), &error);
+        ok = files().move(current_dir(), path, name(), &error);
         if (error)
         {
             this->error().set_local_error(fmt::format(
@@ -1225,7 +1226,7 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent::find_file(tr_file_index_t
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return metainfo_.files().find(file_index, std::data(paths), n_paths);
+    return files().find(file_index, std::data(paths), n_paths);
 }
 
 bool tr_torrent::has_any_local_data() const
@@ -1234,7 +1235,7 @@ bool tr_torrent::has_any_local_data() const
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return metainfo_.files().hasAnyLocalData(std::data(paths), n_paths);
+    return files().hasAnyLocalData(std::data(paths), n_paths);
 }
 
 void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -240,7 +240,7 @@ void tr_torrentUseSessionLimits(tr_torrent* const tor, bool const enabled)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tor->bandwidth_.honor_parent_limits(TR_UP, enabled) || tor->bandwidth_.honor_parent_limits(TR_DOWN, enabled))
+    if (tor->bandwidth().honor_parent_limits(TR_UP, enabled) || tor->bandwidth().honor_parent_limits(TR_DOWN, enabled))
     {
         tor->set_dirty();
     }
@@ -965,8 +965,8 @@ void tr_torrent::init(tr_ctor const* const ctor)
     {
         incomplete_dir_ = dir;
     }
-    bandwidth_.set_parent(&session->top_bandwidth_);
-    bandwidth_.set_priority(tr_ctorGetBandwidthPriority(ctor));
+    bandwidth().set_parent(&session->top_bandwidth_);
+    bandwidth().set_priority(tr_ctorGetBandwidthPriority(ctor));
     error().clear();
     finished_seeding_by_idle_ = false;
 
@@ -1340,9 +1340,9 @@ tr_stat tr_torrent::stats() const
         stats.knownPeersFrom[i] = swarm_stats.known_peer_from_count[i];
     }
 
-    auto const piece_upload_speed = bandwidth_.get_piece_speed(now_msec, TR_UP);
+    auto const piece_upload_speed = bandwidth().get_piece_speed(now_msec, TR_UP);
     stats.pieceUploadSpeed_KBps = piece_upload_speed.count(Speed::Units::KByps);
-    auto const piece_download_speed = bandwidth_.get_piece_speed(now_msec, TR_DOWN);
+    auto const piece_download_speed = bandwidth().get_piece_speed(now_msec, TR_DOWN);
     stats.pieceDownloadSpeed_KBps = piece_download_speed.count(Speed::Units::KByps);
 
     stats.percentComplete = completion_.percent_complete();
@@ -1853,12 +1853,12 @@ void tr_torrent::set_bandwidth_group(std::string_view group_name) noexcept
     if (std::empty(group_name))
     {
         this->bandwidth_group_ = tr_interned_string{};
-        this->bandwidth_.set_parent(&this->session->top_bandwidth_);
+        this->bandwidth().set_parent(&this->session->top_bandwidth_);
     }
     else
     {
         this->bandwidth_group_ = group_name;
-        this->bandwidth_.set_parent(&this->session->getBandwidthGroup(group_name));
+        this->bandwidth().set_parent(&this->session->getBandwidthGroup(group_name));
     }
 
     this->set_dirty();
@@ -1878,9 +1878,9 @@ void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority)
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isPriority(priority));
 
-    if (tor->bandwidth_.get_priority() != priority)
+    if (tor->bandwidth().get_priority() != priority)
     {
-        tor->bandwidth_.set_priority(priority);
+        tor->bandwidth().set_priority(priority);
 
         tor->set_dirty();
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -427,22 +427,8 @@ void callScriptIfEnabled(tr_torrent const* tor, TrScript type)
 
 // ---
 
-namespace
-{
-namespace seed_limit_helpers
-{
-bool torrent_is_seed_idle_limit_done(tr_torrent const& tor, time_t now)
-{
-    auto const secs_left = tor.idle_seconds_left(now);
-    return secs_left && *secs_left == 0U;
-}
-} // namespace seed_limit_helpers
-} // namespace
-
 void tr_torrent::stop_if_seed_limit_reached()
 {
-    using namespace seed_limit_helpers;
-
     if (!is_running() || is_stopping_ || !is_done())
     {
         return;
@@ -456,7 +442,7 @@ void tr_torrent::stop_if_seed_limit_reached()
         session->onRatioLimitHit(this);
     }
     /* if we're seeding and reach our inactivity limit, stop the torrent */
-    else if (torrent_is_seed_idle_limit_done(*this, tr_time()))
+    else if (auto const secs_left = idle_seconds_left(tr_time()); secs_left && *secs_left == 0U)
     {
         tr_logAddInfoTor(this, _("Seeding idle limit reached; pausing torrent"));
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2569,31 +2569,33 @@ void tr_torrent::mark_changed()
     return checked;
 }
 
-void tr_torrent::init_checked_pieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/)
-{
-    TR_ASSERT(std::size(checked) == this->piece_count());
-    checked_pieces_ = checked;
+// --- RESUME HELPER
 
-    auto const n = this->file_count();
-    this->file_mtimes_.resize(n);
+void tr_torrent::ResumeHelper::load_checked_pieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/)
+{
+    TR_ASSERT(std::size(checked) == tor_.piece_count());
+    tor_.checked_pieces_ = checked;
+
+    auto const n = tor_.file_count();
+    tor_.file_mtimes_.resize(n);
 
     for (size_t i = 0; i < n; ++i)
     {
-        auto const found = this->find_file(i);
+        auto const found = tor_.find_file(i);
         auto const mtime = found ? found->last_modified_at : 0;
 
-        this->file_mtimes_[i] = mtime;
+        tor_.file_mtimes_[i] = mtime;
 
         // if a file has changed, mark its pieces as unchecked
         if (mtime == 0 || mtime != mtimes[i])
         {
-            auto const [begin, end] = pieces_in_file(i);
-            checked_pieces_.unset_span(begin, end);
+            auto const [begin, end] = tor_.pieces_in_file(i);
+            tor_.checked_pieces_.unset_span(begin, end);
         }
     }
 }
 
-// --- RESUME HELPER
+// ---
 
 tr_bitfield const& tr_torrent::ResumeHelper::blocks() const noexcept
 {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1456,7 +1456,7 @@ tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file)
         return { subpath.c_str(), length, length, 1.0, begin, end, priority, wanted };
     }
 
-    auto const have = tor->completion_.count_has_bytes_in_span(tor->fpm_.byte_span(file));
+    auto const have = tor->completion_.count_has_bytes_in_span(tor->byte_span(file));
     return { subpath.c_str(), have, length, have >= length ? 1.0 : have / double(length), begin, end, priority, wanted };
 }
 
@@ -1947,7 +1947,7 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
 
 tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) const noexcept
 {
-    auto const [begin_byte, end_byte] = fpm_.byte_span(file);
+    auto const [begin_byte, end_byte] = byte_span(file);
 
     auto const begin_block = byte_loc(begin_byte).block;
     if (begin_byte >= end_byte) // 0-byte file

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1944,18 +1944,17 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
     return err == 0;
 }
 
-// TODO(ckerr) migrate to fpm?
-tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file)
+tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) const noexcept
 {
-    auto const [begin_byte, end_byte] = tor->fpm_.byte_span(file);
+    auto const [begin_byte, end_byte] = fpm_.byte_span(file);
 
-    auto const begin_block = tor->byte_loc(begin_byte).block;
+    auto const begin_block = byte_loc(begin_byte).block;
     if (begin_byte >= end_byte) // 0-byte file
     {
         return { begin_block, begin_block + 1 };
     }
 
-    auto const final_block = tor->byte_loc(end_byte - 1).block;
+    auto const final_block = byte_loc(end_byte - 1).block;
     auto const end_block = final_block + 1;
     return { begin_block, end_block };
 }
@@ -2184,7 +2183,7 @@ void tr_torrent::on_piece_completed(tr_piece_index_t const piece)
     auto const span = fpm_.file_span(piece);
     for (auto file = span.begin; file < span.end; ++file)
     {
-        if (completion.has_blocks(tr_torGetFileBlockSpan(this, file)))
+        if (completion.has_blocks(block_span_for_file(file)))
         {
             on_file_completed(file);
         }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2552,11 +2552,6 @@ void tr_torrent::mark_changed()
     this->bump_date_changed(tr_time());
 }
 
-void tr_torrent::set_blocks(tr_bitfield blocks)
-{
-    completion_.set_blocks(std::move(blocks));
-}
-
 [[nodiscard]] bool tr_torrent::ensure_piece_is_checked(tr_piece_index_t piece)
 {
     TR_ASSERT(piece < this->piece_count());
@@ -2596,6 +2591,18 @@ void tr_torrent::init_checked_pieces(tr_bitfield const& checked, time_t const* m
             checked_pieces_.unset_span(begin, end);
         }
     }
+}
+
+// --- RESUME HELPER
+
+tr_bitfield const& tr_torrent::ResumeHelper::blocks() const noexcept
+{
+    return tor_.completion_.blocks();
+}
+
+void tr_torrent::ResumeHelper::load_blocks(tr_bitfield blocks)
+{
+    tor_.completion_.set_blocks(std::move(blocks));
 }
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -196,11 +196,6 @@ public:
         tr_torrent_rename_done_func callback,
         void* callback_user_data);
 
-    tr_sha1_digest_t piece_hash(tr_piece_index_t i) const
-    {
-        return metainfo_.piece_hash(i);
-    }
-
     // these functions should become private when possible,
     // but more refactoring is needed before that can happen
     // because much of tr_torrent's impl is in the non-member C bindings
@@ -479,7 +474,24 @@ public:
         return incomplete_dir_;
     }
 
+    /// METAINFO
+
+    [[nodiscard]] constexpr auto& metainfo() noexcept
+    {
+        return metainfo_;
+    }
+
+    [[nodiscard]] constexpr auto const& metainfo() const noexcept
+    {
+        return metainfo_;
+    }
+
     /// METAINFO - FILES
+
+    [[nodiscard]] TR_CONSTEXPR20 auto const& files() const noexcept
+    {
+        return metainfo_.files();
+    }
 
     [[nodiscard]] TR_CONSTEXPR20 auto file_count() const noexcept
     {
@@ -549,6 +561,11 @@ public:
     }
 
     /// METAINFO - OTHER
+
+    [[nodiscard]] auto piece_hash(tr_piece_index_t i) const
+    {
+        return metainfo_.piece_hash(i);
+    }
 
     void set_name(std::string_view name)
     {
@@ -985,8 +1002,6 @@ public:
         return obfuscated_hash_ == test;
     }
 
-    tr_torrent_metainfo metainfo_;
-
     libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
@@ -1252,6 +1267,8 @@ private:
     VerifyDoneCallback verify_done_callback_;
 
     labels_t labels_;
+
+    tr_torrent_metainfo metainfo_;
 
     tr_bandwidth bandwidth_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -387,11 +387,6 @@ public:
         return completion_.amount_done(tab, n_tabs);
     }
 
-    void set_has_piece(tr_piece_index_t piece, bool has)
-    {
-        completion_.set_has_piece(piece, has);
-    }
-
     /// FILE <-> PIECE
 
     [[nodiscard]] auto pieces_in_file(tr_file_index_t file) const
@@ -1241,6 +1236,13 @@ private:
         }
 
         return {};
+    }
+
+    // ---
+
+    void set_has_piece(tr_piece_index_t piece, bool has)
+    {
+        completion_.set_has_piece(piece, has);
     }
 
     void on_metainfo_updated();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -66,8 +66,6 @@ void tr_torrentChangeMyPort(tr_torrent* tor);
 
 bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_t offset, uint32_t length);
 
-[[nodiscard]] tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file);
-
 /** save a torrent's .resume file if it's changed since the last time it was saved */
 void tr_torrentSave(tr_torrent* tor);
 
@@ -312,6 +310,8 @@ public:
     {
         return metainfo_.total_size();
     }
+
+    [[nodiscard]] tr_block_span_t block_span_for_file(tr_file_index_t file) const noexcept;
 
     /// COMPLETION
 
@@ -1006,8 +1006,6 @@ public:
     // it means that piece needs to be checked before its data is used.
     tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
-    tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
-
     CumulativeCount bytes_corrupt_;
     CumulativeCount bytes_downloaded_;
     CumulativeCount bytes_uploaded_;
@@ -1259,6 +1257,8 @@ private:
     VerifyDoneCallback verify_done_callback_;
 
     labels_t labels_;
+
+    tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
 
     // when Transmission thinks the torrent's files were last changed
     std::vector<time_t> file_mtimes_;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -943,8 +943,6 @@ public:
         return error_;
     }
 
-    void init(tr_ctor const* ctor);
-
     void start_in_session_thread();
 
     void stop_if_seed_limit_reached();
@@ -1229,6 +1227,8 @@ private:
     {
         completion_.set_has_piece(piece, has);
     }
+
+    void init(tr_ctor const* ctor);
 
     void on_metainfo_updated();
     void on_metainfo_completed();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -946,8 +946,6 @@ public:
         return error_;
     }
 
-    void start_in_session_thread();
-
     void stop_if_seed_limit_reached();
 
     [[nodiscard]] TR_CONSTEXPR20 auto obfuscated_hash_equals(tr_sha1_digest_t const& test) const noexcept
@@ -1236,6 +1234,8 @@ private:
     void recheck_completeness();
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
+
+    void start_in_session_thread();
 
     void stop_now();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -85,6 +85,7 @@ struct tr_torrent final : public tr_completion::torrent_view
     class ResumeHelper
     {
     public:
+        void load_blocks(tr_bitfield blocks);
         void load_date_added(time_t when) noexcept;
         void load_date_done(time_t when) noexcept;
         void load_download_dir(std::string_view dir) noexcept;
@@ -92,6 +93,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
+        [[nodiscard]] tr_bitfield const& blocks() const noexcept;
         [[nodiscard]] std::vector<time_t> const& file_mtimes() const noexcept;
         [[nodiscard]] time_t date_active() const noexcept;
         [[nodiscard]] time_t date_added() const noexcept;
@@ -380,17 +382,10 @@ public:
         return completeness == TR_PARTIAL_SEED;
     }
 
-    [[nodiscard]] constexpr auto& blocks() const noexcept
-    {
-        return completion_.blocks();
-    }
-
     void amount_done_bins(float* tab, int n_tabs) const
     {
         return completion_.amount_done(tab, n_tabs);
     }
-
-    void set_blocks(tr_bitfield blocks);
 
     void set_has_piece(tr_piece_index_t piece, bool has)
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -900,11 +900,6 @@ public:
 
     // ---
 
-    constexpr void set_needs_completeness_check() noexcept
-    {
-        needs_completeness_check_ = true;
-    }
-
     void do_idle_work()
     {
         if (needs_completeness_check_)
@@ -1187,6 +1182,11 @@ private:
         }
 
         return true;
+    }
+
+    constexpr void set_needs_completeness_check() noexcept
+    {
+        needs_completeness_check_ = true;
     }
 
     void set_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted, bool is_bootstrapping)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -767,7 +767,7 @@ public:
         is_stopping_ = true;
     }
 
-    void start(bool bypass_queue, std::optional<bool> has_local_data);
+    void start(bool bypass_queue, std::optional<bool> has_any_local_data);
 
     [[nodiscard]] constexpr auto is_dirty() const noexcept
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -522,11 +522,6 @@ public:
         return std::size(this->announce_list());
     }
 
-    [[nodiscard]] TR_CONSTEXPR20 auto const& tracker(size_t i) const
-    {
-        return this->announce_list().at(i);
-    }
-
     [[nodiscard]] auto tracker_list() const
     {
         return this->announce_list().to_string();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -95,6 +95,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
 
         [[nodiscard]] tr_bitfield const& blocks() const noexcept;
+        [[nodiscard]] tr_bitfield const& checked_pieces() const noexcept;
         [[nodiscard]] std::vector<time_t> const& file_mtimes() const noexcept;
         [[nodiscard]] time_t date_active() const noexcept;
         [[nodiscard]] time_t date_added() const noexcept;
@@ -961,11 +962,6 @@ public:
     libtransmission::SimpleObservable<tr_torrent*> stopped_;
     libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
 
-    // true iff the piece was verified more recently than any of the piece's
-    // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
-    // it means that piece needs to be checked before its data is used.
-    tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
-
     CumulativeCount bytes_corrupt_;
     CumulativeCount bytes_downloaded_;
     CumulativeCount bytes_uploaded_;
@@ -1250,6 +1246,11 @@ private:
     Error error_;
 
     VerifyDoneCallback verify_done_callback_;
+
+    // true iff the piece was verified more recently than any of the piece's
+    // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
+    // it means that piece needs to be checked before its data is used.
+    tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
 
     labels_t labels_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -68,8 +68,6 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
 
 [[nodiscard]] tr_block_span_t tr_torGetFileBlockSpan(tr_torrent const* tor, tr_file_index_t file);
 
-void tr_torrentCheckSeedLimit(tr_torrent* tor);
-
 /** save a torrent's .resume file if it's changed since the last time it was saved */
 void tr_torrentSave(tr_torrent* tor);
 
@@ -977,6 +975,8 @@ public:
 
     void start_in_session_thread();
 
+    void stop_if_seed_limit_reached();
+
     [[nodiscard]] TR_CONSTEXPR20 auto obfuscated_hash_equals(tr_sha1_digest_t const& test) const noexcept
     {
         return obfuscated_hash_ == test;
@@ -1031,8 +1031,6 @@ public:
 
     uint16_t max_connected_peers_ = TR_DEFAULT_PEER_LIMIT_TORRENT;
 
-    bool finished_seeding_by_idle_ = false;
-
     bool is_running_ = false;
 
     // start the torrent after all the startup scaffolding is done,
@@ -1044,7 +1042,6 @@ private:
     friend tr_stat const* tr_torrentStat(tr_torrent* tor);
     friend tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
     friend uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor);
-    friend void tr_torrentCheckSeedLimit(tr_torrent* tor);
     friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
     friend void tr_torrentGotBlock(tr_torrent* tor, tr_block_index_t block);
     friend void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func, void* user_data);
@@ -1319,6 +1316,8 @@ private:
     bool is_dirty_ = false;
     bool is_queued_ = false;
     bool is_stopping_ = false;
+
+    bool finished_seeding_by_idle_ = false;
 
     bool needs_completeness_check_ = true;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -517,11 +517,6 @@ public:
         return metainfo_.announce_list();
     }
 
-    [[nodiscard]] TR_CONSTEXPR20 auto tracker_count() const noexcept
-    {
-        return std::size(this->announce_list());
-    }
-
     [[nodiscard]] auto tracker_list() const
     {
         return this->announce_list().to_string();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -987,8 +987,6 @@ public:
 
     tr_torrent_metainfo metainfo_;
 
-    tr_bandwidth bandwidth_;
-
     libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
@@ -1254,6 +1252,8 @@ private:
     VerifyDoneCallback verify_done_callback_;
 
     labels_t labels_;
+
+    tr_bandwidth bandwidth_;
 
     tr_completion completion_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -426,8 +426,6 @@ public:
         set_files_wanted(files, n_files, wanted, /*is_bootstrapping*/ false);
     }
 
-    void recheck_completeness(); // TODO(ckerr): should be private
-
     /// PRIORITIES
 
     [[nodiscard]] tr_priority_t piece_priority(tr_piece_index_t piece) const
@@ -1250,6 +1248,8 @@ private:
     void on_piece_completed(tr_piece_index_t piece);
     void on_piece_failed(tr_piece_index_t piece);
     void on_file_completed(tr_file_index_t file);
+
+    void recheck_completeness();
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -184,7 +184,7 @@ public:
 
     explicit tr_torrent(tr_torrent_metainfo&& tm)
         : metainfo_{ std::move(tm) }
-        , completion{ this, &this->metainfo_.block_info() }
+        , completion_{ this, &this->metainfo_.block_info() }
     {
     }
 
@@ -317,57 +317,57 @@ public:
 
     [[nodiscard]] auto left_until_done() const
     {
-        return completion.left_until_done();
+        return completion_.left_until_done();
     }
 
     [[nodiscard]] auto size_when_done() const
     {
-        return completion.size_when_done();
+        return completion_.size_when_done();
     }
 
     [[nodiscard]] constexpr auto has_metainfo() const noexcept
     {
-        return completion.has_metainfo();
+        return completion_.has_metainfo();
     }
 
     [[nodiscard]] constexpr auto has_all() const noexcept
     {
-        return completion.has_all();
+        return completion_.has_all();
     }
 
     [[nodiscard]] constexpr auto has_none() const noexcept
     {
-        return completion.has_none();
+        return completion_.has_none();
     }
 
     [[nodiscard]] auto has_piece(tr_piece_index_t piece) const
     {
-        return completion.has_piece(piece);
+        return completion_.has_piece(piece);
     }
 
     [[nodiscard]] TR_CONSTEXPR20 auto has_block(tr_block_index_t block) const
     {
-        return completion.has_block(block);
+        return completion_.has_block(block);
     }
 
     [[nodiscard]] auto count_missing_blocks_in_piece(tr_piece_index_t piece) const
     {
-        return completion.count_missing_blocks_in_piece(piece);
+        return completion_.count_missing_blocks_in_piece(piece);
     }
 
     [[nodiscard]] auto count_missing_bytes_in_piece(tr_piece_index_t piece) const
     {
-        return completion.count_missing_bytes_in_piece(piece);
+        return completion_.count_missing_bytes_in_piece(piece);
     }
 
     [[nodiscard]] constexpr auto has_total() const
     {
-        return completion.has_total();
+        return completion_.has_total();
     }
 
     [[nodiscard]] auto create_piece_bitfield() const
     {
-        return completion.create_piece_bitfield();
+        return completion_.create_piece_bitfield();
     }
 
     [[nodiscard]] constexpr bool is_done() const noexcept
@@ -387,19 +387,19 @@ public:
 
     [[nodiscard]] constexpr auto& blocks() const noexcept
     {
-        return completion.blocks();
+        return completion_.blocks();
     }
 
     void amount_done_bins(float* tab, int n_tabs) const
     {
-        return completion.amount_done(tab, n_tabs);
+        return completion_.amount_done(tab, n_tabs);
     }
 
     void set_blocks(tr_bitfield blocks);
 
     void set_has_piece(tr_piece_index_t piece, bool has)
     {
-        completion.set_has_piece(piece, has);
+        completion_.set_has_piece(piece, has);
     }
 
     /// FILE <-> PIECE
@@ -998,9 +998,6 @@ public:
     libtransmission::SimpleObservable<tr_torrent*> stopped_;
     libtransmission::SimpleObservable<tr_torrent*> swarm_is_all_seeds_;
 
-    // TODO(ckerr): make private once some of torrent.cc's `tr_torrentFoo()` methods are member functions
-    tr_completion completion;
-
     // true iff the piece was verified more recently than any of the piece's
     // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
     // it means that piece needs to be checked before its data is used.
@@ -1209,7 +1206,7 @@ private:
         auto const lock = unique_lock();
 
         files_wanted_.set(files, n_files, wanted);
-        completion.invalidate_size_when_done();
+        completion_.invalidate_size_when_done();
 
         if (!is_bootstrapping)
         {
@@ -1257,6 +1254,8 @@ private:
     VerifyDoneCallback verify_done_callback_;
 
     labels_t labels_;
+
+    tr_completion completion_;
 
     tr_file_piece_map fpm_ = tr_file_piece_map{ metainfo_ };
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -85,6 +85,7 @@ struct tr_torrent final : public tr_completion::torrent_view
     class ResumeHelper
     {
     public:
+        void load_checked_pieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/);
         void load_blocks(tr_bitfield blocks);
         void load_date_added(time_t when) noexcept;
         void load_date_done(time_t when) noexcept;
@@ -626,8 +627,6 @@ public:
     /// METAINFO - PIECE CHECKSUMS
 
     [[nodiscard]] bool ensure_piece_is_checked(tr_piece_index_t piece);
-
-    void init_checked_pieces(tr_bitfield const& checked, time_t const* mtimes /*fileCount()*/);
 
     ///
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -767,6 +767,8 @@ public:
         is_stopping_ = true;
     }
 
+    void start(bool bypass_queue, std::optional<bool> has_local_data);
+
     [[nodiscard]] constexpr auto is_dirty() const noexcept
     {
         return is_dirty_;
@@ -984,8 +986,6 @@ public:
     tr_completeness completeness = TR_LEECH;
 
     uint16_t max_connected_peers_ = TR_DEFAULT_PEER_LIMIT_TORRENT;
-
-    bool is_running_ = false;
 
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
@@ -1322,6 +1322,7 @@ private:
     bool is_deleting_ = false;
     bool is_dirty_ = false;
     bool is_queued_ = false;
+    bool is_running_ = false;
     bool is_stopping_ = false;
 
     bool finished_seeding_by_idle_ = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -524,8 +524,6 @@ public:
 
     bool set_tracker_list(std::string_view text);
 
-    void on_tracker_response(tr_tracker_event const* event);
-
     /// METAINFO - WEBSEEDS
 
     [[nodiscard]] TR_CONSTEXPR20 auto webseed_count() const noexcept
@@ -1238,6 +1236,7 @@ private:
     void on_piece_completed(tr_piece_index_t piece);
     void on_piece_failed(tr_piece_index_t piece);
     void on_file_completed(tr_file_index_t file);
+    void on_tracker_response(tr_tracker_event const* event);
 
     void recheck_completeness();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -849,24 +849,6 @@ public:
         return {};
     }
 
-    [[nodiscard]] constexpr std::optional<size_t> idle_seconds_left(time_t now) const noexcept
-    {
-        auto const idle_limit_minutes = effective_idle_limit_minutes();
-        if (!idle_limit_minutes)
-        {
-            return {};
-        }
-
-        auto const idle_seconds = this->idle_seconds(now);
-        if (!idle_seconds)
-        {
-            return {};
-        }
-
-        auto const idle_limit_seconds = size_t{ *idle_limit_minutes } * 60U;
-        return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : 0U;
-    }
-
     // --- seed ratio
 
     constexpr void set_seed_ratio_mode(tr_ratiolimit mode) noexcept
@@ -1169,6 +1151,24 @@ private:
         }
 
         return {};
+    }
+
+    [[nodiscard]] constexpr std::optional<size_t> idle_seconds_left(time_t now) const noexcept
+    {
+        auto const idle_limit_minutes = effective_idle_limit_minutes();
+        if (!idle_limit_minutes)
+        {
+            return {};
+        }
+
+        auto const idle_seconds = this->idle_seconds(now);
+        if (!idle_seconds)
+        {
+            return {};
+        }
+
+        auto const idle_limit_seconds = size_t{ *idle_limit_minutes } * 60U;
+        return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : 0U;
     }
 
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -176,7 +176,7 @@ public:
         , callback_data{ callback_data_in }
         , idle_timer_{ session->timerMaker().create([this]() { on_idle(this); }) }
         , have_{ tor->piece_count() }
-        , bandwidth_{ &tor->bandwidth_ }
+        , bandwidth_{ &tor->bandwidth() }
     {
         have_.set_has_all();
         idle_timer_->start_repeating(IdleTimerInterval);

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -88,7 +88,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
     auto const test_incomplete_dir_threadfunc = [](TestIncompleteDirData* data) noexcept
     {
         data->session->cache->write_block(data->tor->id(), data->block, std::move(data->buf));
-        tr_torrentGotBlock(data->tor, data->block);
+        data->tor->on_block_received(data->block);
         data->done = true;
     };
 


### PR DESCRIPTION
Part 3 in a "make `tr_torrent` fields private" series. See more info in Part 1 at #6279.

This PR makes the following private:

- `tr_torrent::download_dir_`
- `tr_torrent::incomplete_dir_`
- `tr_torrent::current_dir_`
- `tr_torrent::finished_seeding_by_idle_`
- `tr_torrent::file_mtimes_`
- `tr_torrent::fpm_`
- `tr_torrent::completion_`
- `tr_torrent::bandwidth_`
- `tr_torrent::metainfo_`
- `tr_torrent::blocks()`
- `tr_torrentt::set_has_piece()`
- `tr_torrent::recheck_completeness()`
- `tr_torrent::on_tracker_response()`
- `tr_torrent::init_checked_pieces()`
- `tr_torrent::idle_seconds_left()`
- `tr_torrent::set_needs_completeness_check()`
- `tr_torrent::init()`
- `tr_torrent::checked_pieces_`
- `tr_torrent::is_running_`
- `tr_torrent::start_in_session_thread()`
