### PR TITLE
Fix warning: "It's not legal to call -layoutSubtreeIfNeeded on a view which is already being laid out."

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -348,8 +348,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         torrentCell.fRevealButton.action = @selector(revealTorrentFile:);
 
         // redraw buttons
-        [torrentCell.fControlButton display];
-        [torrentCell.fRevealButton display];
+        torrentCell.fControlButton.needsDisplay = YES;
+        torrentCell.fRevealButton.needsDisplay = YES;
 
         return torrentCell;
     }


### PR DESCRIPTION
In Xcode 11, we're encountering this runtime warning:
>It's not legal to call -layoutSubtreeIfNeeded on a view which is already being laid out.  If you are implementing the view's -layout method, you can call -[super layout] instead. Break on void _NSDetectedLayoutRecursion(void) to debug.  This will be logged only once.  This may break in the future.

Setting a breakpoint on _NSDetectedLayoutRecursion reveals that it's caused by the two "redraw buttons" lines. Changing `display` to `needsDisplay` solves the runtime warning.

I think that it was originally `[controlView setNeedsDisplayInRect:cellFrame];` and that it was changed to `display` in #5147, so I'll let @sweetppro review this.