### PR TITLE
fix: Local variable 'pex' will be copied despite being returned by name

### DIFF
--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -388,7 +388,7 @@ private:
         };
 
         pex.erase(std::remove_if(std::begin(pex), std::end(pex), IsBadPex), std::end(pex));
-        return pex;
+        return std::move(pex);
     }
 
     static void callback(void* vself, int event, unsigned char const* info_hash, void const* data, size_t data_len)

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -143,7 +143,7 @@ public:
                 return { iter->second, false };
             }
 
-            return { vec_.emplace_back(key, tr_variant{ std::move(val) }).second, true };
+            return { vec_.emplace_back(key, tr_variant{ std::forward<Val>(val) }).second, true };
         }
 
         // --- custom functions


### PR DESCRIPTION
fix #6291

(credit: @ckerr)