### PR TITLE
refactor: make tr_torrent::queue_position_ private

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -193,18 +193,10 @@ char const* queueMoveBottom(tr_session* session, tr_variant* args_in, tr_variant
     return nullptr;
 }
 
-constexpr struct
-{
-    constexpr bool operator()(tr_torrent const* a, tr_torrent const* b) const
-    {
-        return a->queuePosition < b->queuePosition;
-    }
-} CompareTorrentByQueuePosition{};
-
 char const* torrentStart(tr_session* session, tr_variant* args_in, tr_variant* /*args_out*/, tr_rpc_idle_data* /*idle_data*/)
 {
     auto torrents = getTorrents(session, args_in);
-    std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (!tor->is_running())
@@ -220,7 +212,7 @@ char const* torrentStart(tr_session* session, tr_variant* args_in, tr_variant* /
 char const* torrentStartNow(tr_session* session, tr_variant* args_in, tr_variant* /*args_out*/, tr_rpc_idle_data* /*idle_data*/)
 {
     auto torrents = getTorrents(session, args_in);
-    std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (!tor->is_running())

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -616,7 +616,7 @@ std::vector<tr_torrent*> get_next_queued_torrents(tr_torrents& torrents, tr_dire
             std::begin(candidates),
             std::begin(candidates) + num_wanted,
             std::end(candidates),
-            [](auto const* a, auto const* b) { return tr_torrentGetQueuePosition(a) < tr_torrentGetQueuePosition(b); });
+            tr_torrent::CompareQueuePosition);
         candidates.resize(num_wanted);
     }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -521,9 +521,7 @@ void tr_torrent::set_unique_queue_position(size_t const new_pos)
     queue_position_ = std::min(new_pos, current);
     mark_changed();
 
-#ifdef TR_ENABLE_ASSERTS
     TR_ASSERT(torrents_are_sorted_by_queue_position(torrents.get_all()));
-#endif
 }
 
 void tr_torrentSetQueuePosition(tr_torrent* tor, size_t queue_position)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -464,22 +464,11 @@ namespace
 {
 namespace queue_helpers
 {
-constexpr struct
-{
-    constexpr bool operator()(tr_torrent const* a, tr_torrent const* b) const noexcept
-    {
-        return a->queuePosition < b->queuePosition;
-    }
-} CompareTorrentByQueuePosition{};
-
 #ifdef TR_ENABLE_ASSERTS
 bool queueIsSequenced(tr_session const* const session)
 {
     auto torrents = session->torrents().get_all();
-    std::sort(
-        std::begin(torrents),
-        std::end(torrents),
-        [](auto const* a, auto const* b) { return a->queuePosition < b->queuePosition; });
+    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
 
     /* test them */
     bool is_sequenced = true;
@@ -540,7 +529,7 @@ void tr_torrentsQueueMoveTop(tr_torrent* const* torrents_in, size_t torrent_coun
     using namespace queue_helpers;
 
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
-    std::sort(std::rbegin(torrents), std::rend(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::rbegin(torrents), std::rend(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         tr_torrentSetQueuePosition(tor, 0);
@@ -552,7 +541,7 @@ void tr_torrentsQueueMoveUp(tr_torrent* const* torrents_in, size_t torrent_count
     using namespace queue_helpers;
 
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
-    std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (tor->queuePosition > 0)
@@ -567,7 +556,7 @@ void tr_torrentsQueueMoveDown(tr_torrent* const* torrents_in, size_t torrent_cou
     using namespace queue_helpers;
 
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
-    std::sort(std::rbegin(torrents), std::rend(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::rbegin(torrents), std::rend(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (tor->queuePosition < UINT_MAX)
@@ -582,7 +571,7 @@ void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents_in, size_t torrent_c
     using namespace queue_helpers;
 
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
-    std::sort(std::begin(torrents), std::end(torrents), CompareTorrentByQueuePosition);
+    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         tr_torrentSetQueuePosition(tor, UINT_MAX);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -955,39 +955,7 @@ public:
         queue_position_ = new_pos;
     }
 
-    template<typename Iter>
-    void set_unique_queue_position(size_t const new_pos, Iter const begin, Iter const end)
-    {
-        auto current = size_t{};
-        auto const old_pos = queue_position();
-
-        queue_position_ = static_cast<size_t>(-1);
-
-        for (auto walk = begin; walk != end; ++walk)
-        {
-            tr_torrent* const tor = *walk;
-
-            if ((old_pos < new_pos) && (old_pos <= tor->queue_position()) && (tor->queue_position() <= new_pos))
-            {
-                --tor->queue_position_;
-                tor->mark_changed();
-            }
-
-            if ((old_pos > new_pos) && (new_pos <= tor->queue_position()) && (tor->queue_position() < old_pos))
-            {
-                ++tor->queue_position_;
-                tor->mark_changed();
-            }
-
-            if (current < tor->queue_position() + 1)
-            {
-                current = tor->queue_position() + 1;
-            }
-        }
-
-        queue_position_ = std::min(new_pos, current);
-        mark_changed();
-    }
+    void set_unique_queue_position(size_t const new_pos);
 
     static inline constexpr struct
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -950,11 +950,6 @@ public:
         return queue_position_;
     }
 
-    constexpr void set_queue_position(size_t const new_pos) noexcept
-    {
-        queue_position_ = new_pos;
-    }
-
     void set_unique_queue_position(size_t const new_pos);
 
     static inline constexpr struct

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -943,6 +943,14 @@ public:
         return obfuscated_hash_ == test;
     }
 
+    static inline constexpr struct
+    {
+        constexpr bool operator()(tr_torrent const* a, tr_torrent const* b) const noexcept
+        {
+            return a->queuePosition < b->queuePosition;
+        }
+    } CompareQueuePosition{};
+
     libtransmission::SimpleObservable<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -597,7 +597,7 @@ size_t tr_torrentGetQueuePosition(tr_torrent const* tor);
 
 /** @brief Set the queued torrent's position in the queue it's in.
  * Edge cases: `pos <= 0` moves to the front; `pos >= queue's length` moves to the back */
-void tr_torrentSetQueuePosition(tr_torrent* tor, size_t queue_position);
+void tr_torrentSetQueuePosition(tr_torrent* tor, size_t new_pos);
 
 // ---
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -597,7 +597,7 @@ size_t tr_torrentGetQueuePosition(tr_torrent const* tor);
 
 /** @brief Set the queued torrent's position in the queue it's in.
  * Edge cases: `pos <= 0` moves to the front; `pos >= queue's length` moves to the back */
-void tr_torrentSetQueuePosition(tr_torrent* tor, size_t new_pos);
+void tr_torrentSetQueuePosition(tr_torrent* tor, size_t queue_position);
 
 // ---
 


### PR DESCRIPTION
Part 4 in a series to make more `tr_torrent` fields and methods private. See more info in Part 1 at #6279.

This PR makes `tr_torrent::queuePosition` private.