### PR TITLE
refactor: make more tr_torrent fields private

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -487,7 +487,6 @@ public:
                 tor->bytes_uploaded_ += event.length;
                 tr_announcerAddBytes(tor, TR_ANN_UP, event.length);
                 tor->set_date_active(now);
-                tor->set_dirty();
                 tor->session->add_uploaded(event.length);
 
                 msgs->peer_info->set_latest_piece_data_time(now);
@@ -800,7 +799,6 @@ private:
     {
         tor->bytes_downloaded_ += sent_length;
         tor->set_date_active(now);
-        tor->set_dirty();
         tor->session->add_downloaded(sent_length);
     }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -468,7 +468,7 @@ void saveProgress(tr_variant* dict, tr_torrent const* tor, tr_torrent::ResumeHel
     bitfieldToRaw(helper.checked_pieces(), tr_variantDictAdd(prog, TR_KEY_pieces));
 
     /* add the progress */
-    if (tor->completeness == TR_SEED)
+    if (tor->is_seed())
     {
         tr_variantDictAddStrView(prog, TR_KEY_have, "all"sv);
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -688,7 +688,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
 
     if ((fields_to_load & tr_resume::MaxPeers) != 0 && tr_variantDictFindInt(&top, TR_KEY_max_peers, &i))
     {
-        tor->max_connected_peers_ = static_cast<uint16_t>(i);
+        tor->set_peer_limit(static_cast<uint16_t>(i));
         fields_loaded |= tr_resume::MaxPeers;
     }
 
@@ -826,7 +826,7 @@ auto set_from_ctor(
     {
         if (auto const val = ctor.peer_limit(mode); val)
         {
-            tor->max_connected_peers_ = *val;
+            tor->set_peer_limit(*val);
             ret |= tr_resume::MaxPeers;
         }
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -627,10 +627,9 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor, tr_torrent::ResumeHelper& h
 
 // ---
 
-tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& helper, tr_resume::fields_t fields_to_load)
+tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& helper, tr_resume::fields_t fields_to_load)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    auto const was_dirty = tor->is_dirty();
 
     tr_torrent_metainfo::migrate_file(tor->session->resumeDir(), tor->name(), tor->info_hash_string(), ".resume"sv);
 
@@ -796,11 +795,6 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
         fields_loaded |= loadGroup(&top, tor);
     }
 
-    /* loading the resume file triggers of a lot of changes,
-     * but none of them needs to trigger a re-saving of the
-     * same resume information... */
-    tor->set_dirty(was_dirty);
-
     return fields_loaded;
 }
 
@@ -870,7 +864,7 @@ fields_t load(tr_torrent* tor, tr_torrent::ResumeHelper& helper, fields_t fields
 
     ret |= use_mandatory_fields(tor, helper, fields_to_load, ctor);
     fields_to_load &= ~ret;
-    ret |= loadFromFile(tor, helper, fields_to_load);
+    ret |= load_from_file(tor, helper, fields_to_load);
     fields_to_load &= ~ret;
     ret |= use_fallback_fields(tor, helper, fields_to_load, ctor);
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -694,7 +694,7 @@ tr_resume::fields_t loadFromFile(tr_torrent* tor, tr_torrent::ResumeHelper& help
 
     if (auto val = bool{}; (fields_to_load & tr_resume::Run) != 0 && tr_variantDictFindBool(&top, TR_KEY_paused, &val))
     {
-        tor->start_when_stable = !val;
+        helper.load_start_when_stable(!val);
         fields_loaded |= tr_resume::Run;
     }
 
@@ -817,7 +817,7 @@ auto set_from_ctor(
     {
         if (auto const val = ctor.paused(mode); val)
         {
-            tor->start_when_stable = !*val;
+            helper.load_start_when_stable(!*val);
             ret |= tr_resume::Run;
         }
     }
@@ -904,7 +904,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     tr_variantDictAddInt(&top, TR_KEY_uploaded, tor->bytes_uploaded_.ever());
     tr_variantDictAddInt(&top, TR_KEY_max_peers, tor->peer_limit());
     tr_variantDictAddInt(&top, TR_KEY_bandwidth_priority, tor->get_priority());
-    tr_variantDictAddBool(&top, TR_KEY_paused, !tor->start_when_stable);
+    tr_variantDictAddBool(&top, TR_KEY_paused, !helper.start_when_stable());
     tr_variantDictAddBool(&top, TR_KEY_sequentialDownload, tor->is_sequential_download());
     savePeers(&top, tor);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1828,7 +1828,7 @@ tr_priority_t tr_torrentGetPriority(tr_torrent const* tor)
     return tor->get_priority();
 }
 
-void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority)
+void tr_torrentSetPriority(tr_torrent* const tor, tr_priority_t const priority)
 {
     TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(tr_isPriority(priority));

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1855,12 +1855,7 @@ void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    if (tor->max_connected_peers_ != max_connected_peers)
-    {
-        tor->max_connected_peers_ = max_connected_peers;
-
-        tor->set_dirty();
-    }
+    tor->set_peer_limit(max_connected_peers);
 }
 
 uint16_t tr_torrentGetPeerLimit(tr_torrent const* tor)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1530,13 +1530,8 @@ void tr_torrentStartNow(tr_torrent* tor)
     if (tr_isTorrent(tor))
     {
         tor->start_when_stable_ = true;
-        tor->start(false /*bypass_queue*/, {});
+        tor->start(true /*bypass_queue*/, {});
     }
-}
-
-void tr_torrentStartMagnet(tr_torrent* tor)
-{
-    tr_torrentStart(tor);
 }
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -453,11 +453,6 @@ public:
 
     /// METAINFO
 
-    [[nodiscard]] constexpr auto& metainfo() noexcept
-    {
-        return metainfo_;
-    }
-
     [[nodiscard]] constexpr auto const& metainfo() const noexcept
     {
         return metainfo_;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -361,17 +361,17 @@ public:
 
     [[nodiscard]] constexpr bool is_done() const noexcept
     {
-        return completeness != TR_LEECH;
+        return completeness_ != TR_LEECH;
     }
 
     [[nodiscard]] constexpr bool is_seed() const noexcept
     {
-        return completeness == TR_SEED;
+        return completeness_ == TR_SEED;
     }
 
     [[nodiscard]] constexpr bool is_partial_seed() const noexcept
     {
-        return completeness == TR_PARTIAL_SEED;
+        return completeness_ == TR_PARTIAL_SEED;
     }
 
     void amount_done_bins(float* tab, int n_tabs) const
@@ -982,8 +982,6 @@ public:
 
     time_t lpdAnnounceAt = 0;
 
-    tr_completeness completeness = TR_LEECH;
-
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
     bool start_when_stable = false;
@@ -1320,6 +1318,8 @@ private:
     tr_idlelimit idle_limit_mode_ = TR_IDLELIMIT_GLOBAL;
 
     VerifyState verify_state_ = VerifyState::None;
+
+    tr_completeness completeness_ = TR_LEECH;
 
     uint16_t idle_limit_minutes_ = 0;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -393,11 +393,6 @@ public:
         return fpm_.file_offset(loc.byte, include_empty_files);
     }
 
-    [[nodiscard]] auto byte_span(tr_file_index_t file) const
-    {
-        return fpm_.byte_span(file);
-    }
-
     /// WANTED
 
     [[nodiscard]] bool piece_is_wanted(tr_piece_index_t piece) const final
@@ -1206,6 +1201,11 @@ private:
 
     // must be called after the torrent's announce list changes.
     void on_announce_list_changed();
+
+    [[nodiscard]] auto byte_span(tr_file_index_t file) const
+    {
+        return fpm_.byte_span(file);
+    }
 
     // ---
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -673,6 +673,7 @@ public:
         this->date_active_ = when;
 
         bump_date_changed(when);
+        set_dirty();
     }
 
     [[nodiscard]] constexpr auto activity() const noexcept
@@ -742,11 +743,6 @@ public:
     }
 
     void start(bool bypass_queue, std::optional<bool> has_any_local_data);
-
-    constexpr void set_dirty(bool dirty = true) noexcept
-    {
-        is_dirty_ = dirty;
-    }
 
     [[nodiscard]] constexpr auto has_changed_since(time_t when) const noexcept
     {
@@ -974,9 +970,11 @@ private:
     friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
     friend void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func, void* user_data);
     friend void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path);
+    friend void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority);
     friend void tr_torrentStart(tr_torrent* tor);
     friend void tr_torrentStartNow(tr_torrent* tor);
     friend void tr_torrentStop(tr_torrent* tor);
+    friend void tr_torrentUseSessionLimits(tr_torrent* tor, bool enabled);
     friend void tr_torrentVerify(tr_torrent* tor);
 
     enum class VerifyState : uint8_t
@@ -1211,6 +1209,11 @@ private:
 
     void mark_changed();
     void mark_edited();
+
+    constexpr void set_dirty(bool dirty = true) noexcept
+    {
+        is_dirty_ = dirty;
+    }
 
     [[nodiscard]] constexpr auto is_dirty() const noexcept
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -786,6 +786,15 @@ public:
         return max_connected_peers_;
     }
 
+    constexpr void set_peer_limit(uint16_t val) noexcept
+    {
+        if (max_connected_peers_ != val)
+        {
+            max_connected_peers_ = val;
+            set_dirty();
+        }
+    }
+
     // --- idleness
 
     void set_idle_limit_mode(tr_idlelimit mode) noexcept
@@ -974,8 +983,6 @@ public:
     time_t lpdAnnounceAt = 0;
 
     tr_completeness completeness = TR_LEECH;
-
-    uint16_t max_connected_peers_ = TR_DEFAULT_PEER_LIMIT_TORRENT;
 
     // start the torrent after all the startup scaffolding is done,
     // e.g. fetching metadata from peers and/or verifying the torrent
@@ -1315,6 +1322,8 @@ private:
     VerifyState verify_state_ = VerifyState::None;
 
     uint16_t idle_limit_minutes_ = 0;
+
+    uint16_t max_connected_peers_ = TR_DEFAULT_PEER_LIMIT_TORRENT;
 
     bool is_deleting_ = false;
     bool is_dirty_ = false;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -761,8 +761,6 @@ public:
         is_dirty_ = dirty;
     }
 
-    void mark_changed();
-
     [[nodiscard]] constexpr auto has_changed_since(time_t when) const noexcept
     {
         return date_changed_ > when;
@@ -1221,6 +1219,7 @@ private:
         completion_.set_has_piece(piece, has);
     }
 
+    void mark_changed();
     void mark_edited();
 
     void init(tr_ctor const& ctor);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -83,6 +83,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         void load_incomplete_dir(std::string_view dir) noexcept;
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
+        void load_start_when_stable(bool val) noexcept;
 
         [[nodiscard]] tr_bitfield const& blocks() const noexcept;
         [[nodiscard]] tr_bitfield const& checked_pieces() const noexcept;
@@ -92,6 +93,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         [[nodiscard]] time_t date_done() const noexcept;
         [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
         [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
+        [[nodiscard]] bool start_when_stable() const noexcept;
 
     private:
         friend class libtransmission::test::RenameTest_multifileTorrent_Test;
@@ -979,10 +981,6 @@ public:
 
     time_t lpdAnnounceAt = 0;
 
-    // start the torrent after all the startup scaffolding is done,
-    // e.g. fetching metadata from peers and/or verifying the torrent
-    bool start_when_stable = false;
-
 private:
     friend tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file);
     friend tr_stat const* tr_torrentStat(tr_torrent* tor);
@@ -991,6 +989,8 @@ private:
     friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
     friend void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func, void* user_data);
     friend void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path);
+    friend void tr_torrentStart(tr_torrent* tor);
+    friend void tr_torrentStartNow(tr_torrent* tor);
     friend void tr_torrentStop(tr_torrent* tor);
     friend void tr_torrentVerify(tr_torrent* tor);
 
@@ -1342,6 +1342,10 @@ private:
     bool needs_completeness_check_ = true;
 
     bool sequential_download_ = false;
+
+    // start the torrent after all the startup scaffolding is done,
+    // e.g. fetching metadata from peers and/or verifying the torrent
+    bool start_when_stable_ = false;
 };
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -761,7 +761,6 @@ public:
         is_dirty_ = dirty;
     }
 
-    void mark_edited();
     void mark_changed();
 
     [[nodiscard]] constexpr auto has_changed_since(time_t when) const noexcept
@@ -1222,6 +1221,8 @@ private:
         completion_.set_has_piece(piece, has);
     }
 
+    void mark_edited();
+
     void init(tr_ctor const& ctor);
 
     void on_metainfo_updated();
@@ -1234,6 +1235,12 @@ private:
     void recheck_completeness();
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
+
+    void rename_path_in_session_thread(
+        std::string_view oldpath,
+        std::string_view newname,
+        tr_torrent_rename_done_func callback,
+        void* const callback_user_data);
 
     void start_in_session_thread();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -753,11 +753,6 @@ public:
 
     void start(bool bypass_queue, std::optional<bool> has_any_local_data);
 
-    [[nodiscard]] constexpr auto is_dirty() const noexcept
-    {
-        return is_dirty_;
-    }
-
     constexpr void set_dirty(bool dirty = true) noexcept
     {
         is_dirty_ = dirty;
@@ -1221,6 +1216,11 @@ private:
 
     void mark_changed();
     void mark_edited();
+
+    [[nodiscard]] constexpr auto is_dirty() const noexcept
+    {
+        return is_dirty_;
+    }
 
     void init(tr_ctor const& ctor);
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -589,9 +589,6 @@ void tr_sessionSetAntiBruteForceEnabled(tr_session* session, bool enabled);
 /** @brief Like `tr_torrentStart()`, but resumes right away regardless of the queues. */
 void tr_torrentStartNow(tr_torrent* tor);
 
-/** @brief DEPRECATED. Equivalent to `tr_torrentStart()`. Use that instead. */
-void tr_torrentStartMagnet(tr_torrent* tor);
-
 /** @brief Return the queued torrent's position in the queue it's in. [0...n) */
 size_t tr_torrentGetQueuePosition(tr_torrent const* tor);
 


### PR DESCRIPTION
Part 6 in a series to make more tr_torrent fields and methods private. See more info in Part 1 at #6279.

This PR makes these fields / methods private:

- `tr_torrent::byte_span()`
- `tr_torrent::completeness_`
- `tr_torrent::is_dirty()`
- `tr_torrent::mark_changed()`
- `tr_torrent::mark_edited()`
- `tr_torrent::max_connected_peers_`
- `tr_torrent::metainfo()`
- `tr_torrent::set_dirty()`
- `tr_torrent::start_when_stable_`