### PR TITLE
refactor: show 1.0 progress for zero-byte files

### DIFF
--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -188,34 +188,26 @@ QVariant FileTreeItem::data(int column, int role) const
     return value;
 }
 
-void FileTreeItem::getSubtreeWantedSize(uint64_t& have, uint64_t& total) const
+std::pair<uint64_t, uint64_t> FileTreeItem::get_subtree_wanted_size() const
 {
-    if (is_wanted_)
+    auto have = uint64_t{ is_wanted_ ? have_size_ : 0U };
+    auto total = uint64_t{ is_wanted_ ? total_size_ : 0U };
+
+    for (auto const* const child : children_)
     {
-        have += have_size_;
-        total += total_size_;
+        auto const [child_have, child_total] = child->get_subtree_wanted_size();
+        have += child_have;
+        total += child_total;
     }
 
-    for (FileTreeItem const* const i : children_)
-    {
-        i->getSubtreeWantedSize(have, total);
-    }
+    return { have, total };
 }
 
 double FileTreeItem::progress() const
 {
-    double d(0);
-    uint64_t have(0);
-    uint64_t total(0);
+    auto const [have, total] = get_subtree_wanted_size();
 
-    getSubtreeWantedSize(have, total);
-
-    if (total != 0)
-    {
-        d = static_cast<double>(have) / static_cast<double>(total);
-    }
-
-    return d;
+    return have >= total ? 1.0 : static_cast<double>(have) / static_cast<double>(total);
 }
 
 QString FileTreeItem::sizeString() const
@@ -225,14 +217,7 @@ QString FileTreeItem::sizeString() const
 
 uint64_t FileTreeItem::size() const
 {
-    if (std::empty(children_))
-    {
-        return total_size_;
-    }
-
-    uint64_t have = 0;
-    uint64_t total = 0;
-    getSubtreeWantedSize(have, total);
+    auto const [have, total] = get_subtree_wanted_size();
     return total;
 }
 

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <QCoreApplication>
@@ -94,7 +95,7 @@ public:
 private:
     QString priorityString() const;
     QString sizeString() const;
-    void getSubtreeWantedSize(uint64_t& have, uint64_t& total) const;
+    std::pair<uint64_t, uint64_t> get_subtree_wanted_size() const;
     double progress() const;
     uint64_t size() const;
     std::unordered_map<QString, int> const& getMyChildRows() const;


### PR DESCRIPTION
Update how a file's progress % is calculated in the Qt client's file tree s.t. zero-byte files show as complete.

CC @tearfur @Coeur 

Xref https://github.com/transmission/transmission/pull/6232#issuecomment-1827944236