### PR TITLE
feat: Only show .torrent files in the web UI

### DIFF
--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -138,7 +138,7 @@ export class OpenDialog extends EventTarget {
     input.name = 'torrent-files[]';
     input.id = input_id;
     input.multiple = 'multiple';
-    input.accept = '.torrent,application/x-bittorrent';
+    input.accept = '.torrent, application/x-bittorrent';
     workarea.append(input);
     elements.file_input = input;
 

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -138,6 +138,7 @@ export class OpenDialog extends EventTarget {
     input.name = 'torrent-files[]';
     input.id = input_id;
     input.multiple = 'multiple';
+    input.accept = '.torrent,application/x-bittorrent';
     workarea.append(input);
     elements.file_input = input;
 


### PR DESCRIPTION
![image](https://github.com/transmission/transmission/assets/19339842/9e68c8ef-cdd1-4d7c-954f-9a758b75238c)

Select dialog now uses the [accept attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) so only torrent files are shown in the dialog. Saves the UI being cluttered with unrelated files.

Specifies torrent files as either being files ending in `.torrent` or having the [application/x-bittorrent mime-type](https://mimeapplication.net/x-bittorrent) associated with them