### PR TITLE
Use screen.visibleFrame instead of screen.frame

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -5292,9 +5292,6 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         maxSize.height -= self.toolbarHeight;
         maxSize.height -= self.mainWindowComponentHeight;
 
-        //add a small buffer
-        maxSize.height -= 50;
-
         if (height > maxSize.height)
         {
             height = maxSize.height;

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -3351,7 +3351,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     NSView* senderView = sender;
     CGFloat width = NSWidth(senderView.frame);
 
-    if (NSMinX(self.fWindow.frame) < width || NSMaxX(self.fWindow.screen.frame) - NSMinX(self.fWindow.frame) < width * 2)
+    if (NSMinX(self.fWindow.frame) < width || NSMaxX(self.fWindow.screen.visibleFrame) - NSMinX(self.fWindow.frame) < width * 2)
     {
         // Ugly hack to hide NSPopover arrow.
         self.fPositioningView = [[NSView alloc] initWithFrame:senderView.bounds];
@@ -5288,7 +5288,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     NSScreen* screen = self.fWindow.screen;
     if (screen)
     {
-        NSSize maxSize = screen.frame.size;
+        NSSize maxSize = screen.visibleFrame.size;
         maxSize.height -= self.toolbarHeight;
         maxSize.height -= self.mainWindowComponentHeight;
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -877,7 +877,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     CGFloat width = NSWidth(rect);
 
-    if (NSMinX(self.window.frame) < width || NSMaxX(self.window.screen.frame) - NSMinX(self.window.frame) < 72)
+    if (NSMinX(self.window.frame) < width || NSMaxX(self.window.screen.visibleFrame) - NSMinX(self.window.frame) < 72)
     {
         // Ugly hack to hide NSPopover arrow.
         self.fPositioningView = [[NSView alloc] initWithFrame:rect];


### PR DESCRIPTION
NSScreen.frame does not account for the dock, which can be at the bottom or any of the sides. As a result, layout errors that smash things into the dock can occur in the Y or X direction. visibleFrame accounts for the dock.

Should fix #4779. Untested.