### PR TITLE
perf: fewer temporary strings

### DIFF
--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -42,10 +42,21 @@ public:
         return has_value();
     }
 
+    void set(int code, std::string&& message)
+    {
+        code_ = code;
+        message_ = std::move(message);
+    }
+
     void set(int code, std::string_view message)
     {
         code_ = code;
         message_.assign(message);
+    }
+
+    void set(int code, char const* const message)
+    {
+        set(code, std::string_view{ message != nullptr ? message : "" });
     }
 
     void prefix_message(std::string_view prefix)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -24,6 +24,8 @@
 
 #include <fmt/core.h>
 
+#include <small/vector.hpp>
+
 #include "libtransmission/transmission.h"
 
 #include "libtransmission/bitfield.h"
@@ -1983,7 +1985,7 @@ void tr_peerMsgsImpl::sendPex()
     auto val = tr_variant{};
     tr_variantInitDict(&val, 3); /* ipv6 support: left as 3: speed vs. likelihood? */
 
-    auto tmpbuf = std::vector<std::byte>{};
+    auto tmpbuf = small::vector<std::byte, 2048U>{};
 
     for (uint8_t i = 0; i < NUM_TR_AF_INET_TYPES; ++i)
     {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -634,13 +634,14 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
     tr_torrent_metainfo::migrate_file(tor->session->resumeDir(), tor->name(), tor->info_hash_string(), ".resume"sv);
 
     auto const filename = tor->resume_file();
-    if (!tr_sys_path_exists(filename))
+    auto benc = std::vector<char>{};
+    if (!tr_sys_path_exists(filename) || !tr_file_read(filename, benc))
     {
         return {};
     }
 
     auto serde = tr_variant_serde::benc();
-    auto otop = serde.parse_file(filename);
+    auto otop = serde.inplace().parse(benc);
     if (!otop)
     {
         tr_logAddDebugTor(tor, fmt::format("Couldn't read '{}': {}", filename, serde.error_.message()));

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -383,10 +383,10 @@ namespace make_torrent_field_helpers
     for (auto const& tracker : trackers)
     {
         auto tracker_map = tr_variant::Map{ 5U };
-        tracker_map.try_emplace(TR_KEY_announce, tracker.announce.sv());
+        tracker_map.try_emplace(TR_KEY_announce, tr_variant::unmanaged_string(tracker.announce.sv()));
         tracker_map.try_emplace(TR_KEY_id, tracker.id);
-        tracker_map.try_emplace(TR_KEY_scrape, tracker.scrape.sv());
-        tracker_map.try_emplace(TR_KEY_sitename, tracker.announce_parsed.sitename);
+        tracker_map.try_emplace(TR_KEY_scrape, tr_variant::unmanaged_string(tracker.scrape.sv()));
+        tracker_map.try_emplace(TR_KEY_sitename, tr_variant::unmanaged_string(tracker.announce_parsed.sitename));
         tracker_map.try_emplace(TR_KEY_tier, tracker.tier);
         vec.emplace_back(std::move(tracker_map));
     }
@@ -611,7 +611,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_dateCreated: return tor.date_created();
     case TR_KEY_desiredAvailable: return st.desiredAvailable;
     case TR_KEY_doneDate: return st.doneDate;
-    case TR_KEY_downloadDir: return tor.download_dir().sv();
+    case TR_KEY_downloadDir: return tr_variant::unmanaged_string(tor.download_dir().sv());
     case TR_KEY_downloadLimit: return tr_torrentGetSpeedLimit_KBps(&tor, TR_DOWN);
     case TR_KEY_downloadLimited: return tor.uses_speed_limit(TR_DOWN);
     case TR_KEY_downloadedEver: return st.downloadedEver;
@@ -623,8 +623,8 @@ namespace make_torrent_field_helpers
     case TR_KEY_fileStats: return make_file_stats_vec(tor);
     case TR_KEY_file_count: return tor.file_count();
     case TR_KEY_files: return make_file_vec(tor);
-    case TR_KEY_group: return tor.bandwidth_group().sv();
-    case TR_KEY_hashString: return tor.info_hash_string().sv();
+    case TR_KEY_group: return tr_variant::unmanaged_string(tor.bandwidth_group().sv());
+    case TR_KEY_hashString: return tr_variant::unmanaged_string(tor.info_hash_string().sv());
     case TR_KEY_haveUnchecked: return st.haveUnchecked;
     case TR_KEY_haveValid: return st.haveValid;
     case TR_KEY_honorsSessionLimits: return tor.uses_session_limits();
@@ -650,7 +650,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_pieceCount: return tor.piece_count();
     case TR_KEY_pieceSize: return tor.piece_size();
     case TR_KEY_pieces: return make_piece_bitfield(tor);
-    case TR_KEY_primary_mime_type: return tor.primary_mime_type();
+    case TR_KEY_primary_mime_type: return tr_variant::unmanaged_string(tor.primary_mime_type());
     case TR_KEY_priorities: return make_file_priorities_vec(tor);
     case TR_KEY_queuePosition: return st.queuePosition;
     case TR_KEY_rateDownload: return Speed{ st.pieceDownloadSpeed_KBps, Speed::Units::KByps }.base_quantity();


### PR DESCRIPTION
avoid a few unnecessary temporary heap allocations.

Notes: Made small performance improvements in libtransmission.