### PR TITLE
refactor: remove prefetch

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -81,7 +81,6 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **message-level:** Number (0 = None, 1 = Critical, 2 = Error, 3 = Warn, 4 = Info, 5 = Debug, 6 = Trace; default = 2) Set verbosity of Transmission's log messages.
  * **pex-enabled:** Boolean (default = true) Enable [Peer Exchange (PEX)](https://en.wikipedia.org/wiki/Peer_exchange).
  * **pidfile:** String Path to file in which daemon PID will be stored (transmission-daemon only)
- * **prefetch-enabled:** Boolean (default = true). When enabled, Transmission will hint to the OS which piece data it's about to read from disk in order to satisfy requests from peers. On Linux, this is done by passing `POSIX_FADV_WILLNEED` to [posix_fadvise()](https://www.kernel.org/doc/man-pages/online/pages/man2/posix_fadvise.2.html). On macOS, this is done by passing `F_RDADVISE` to [fcntl()](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html).
  * **scrape-paused-torrents-enabled:** Boolean (default = true)
  * **script-torrent-added-enabled:** Boolean (default = false) Run a script when a torrent is added to Transmission. Environmental variables are passed in as detailed on the [Scripts](./Scripts.md) page
  * **script-torrent-added-filename:** String (default = "") Path to script.

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -185,16 +185,6 @@ int Cache::read_block(tr_torrent const& tor, tr_block_info::Location const& loc,
     return tr_ioRead(tor, loc, len, setme);
 }
 
-int Cache::prefetch_block(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len)
-{
-    if (auto const iter = get_block(tor, loc); iter != std::end(blocks_))
-    {
-        return {}; // already have it
-    }
-
-    return tr_ioPrefetch(tor, loc, len);
-}
-
 // ---
 
 int Cache::flush_span(CIter const begin, CIter const end)

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -39,7 +39,6 @@ public:
     int write_block(tr_torrent_id_t tor, tr_block_index_t block, std::unique_ptr<BlockData> writeme);
 
     int read_block(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len, uint8_t* setme);
-    int prefetch_block(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len);
     int flush_torrent(tr_torrent_id_t tor_id);
     int flush_file(tr_torrent const& tor, tr_file_index_t file);
 

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1127,24 +1127,6 @@ bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error* error)
     return ret;
 }
 
-bool tr_sys_file_advise(
-    [[maybe_unused]] tr_sys_file_t handle,
-    uint64_t /*offset*/,
-    [[maybe_unused]] uint64_t size,
-    [[maybe_unused]] tr_sys_file_advice_t advice,
-    tr_error* /*error*/)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT(size > 0);
-    TR_ASSERT(advice == TR_SYS_FILE_ADVICE_WILL_NEED || advice == TR_SYS_FILE_ADVICE_DONT_NEED);
-
-    bool ret = true;
-
-    /* ??? */
-
-    return ret;
-}
-
 bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_error* error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -75,12 +75,6 @@ enum tr_sys_path_get_info_flags_t
     TR_SYS_PATH_NO_FOLLOW = (1 << 0)
 };
 
-enum tr_sys_file_advice_t
-{
-    TR_SYS_FILE_ADVICE_WILL_NEED,
-    TR_SYS_FILE_ADVICE_DONT_NEED
-};
-
 enum tr_sys_file_preallocate_flags_t
 {
     TR_SYS_FILE_PREALLOC_SPARSE = (1 << 0)
@@ -468,24 +462,6 @@ bool tr_sys_file_flush_possible(tr_sys_file_t handle, tr_error* error = nullptr)
  * @return `True` on success, `false` otherwise (with `error` set accordingly).
  */
 bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error* error = nullptr);
-
-/**
- * @brief Tell system to prefetch or discard some part of file which is [not] to be read soon.
- *
- * @param[in]  handle Valid file descriptor.
- * @param[in]  offset Offset in file to prefetch from.
- * @param[in]  size   Number of bytes to prefetch.
- * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
- *                    are not interested in error details.
- *
- * @return `True` on success, `false` otherwise (with `error` set accordingly).
- */
-bool tr_sys_file_advise(
-    tr_sys_file_t handle,
-    uint64_t offset,
-    uint64_t size,
-    tr_sys_file_advice_t advice,
-    tr_error* error = nullptr);
 
 /**
  * @brief Preallocate file to specified size in full or sparse mode.

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -29,8 +29,6 @@ struct tr_torrent;
  */
 [[nodiscard]] int tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len, uint8_t* setme);
 
-int tr_ioPrefetch(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len);
-
 /**
  * Writes the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -183,9 +183,6 @@ auto constexpr ReqQ = int{ 512 };
 
 // used in lowering the outMessages queue period
 
-// how many blocks to keep prefetched per peer
-auto constexpr PrefetchMax = size_t{ 18 };
-
 // when we're making requests from another peer,
 // batch them together to send enough requests to
 // meet our bandwidth goals for the next N seconds
@@ -635,17 +632,7 @@ public:
 
     std::shared_ptr<tr_peerIo> const io;
 
-    struct QueuedPeerRequest : public peer_request
-    {
-        explicit QueuedPeerRequest(peer_request in) noexcept
-            : peer_request{ in }
-        {
-        }
-
-        bool prefetched = false;
-    };
-
-    std::vector<QueuedPeerRequest> peer_requested_;
+    std::vector<peer_request> peer_requested_;
 
     std::array<std::vector<tr_pex>, NUM_TR_AF_INET_TYPES> pex;
 
@@ -897,15 +884,17 @@ std::optional<int> popNextMetadataRequest(tr_peerMsgsImpl* msgs)
 
 void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
 {
-    if (auto const must_send_rej = msgs->io->supports_fext(); must_send_rej)
+    if (auto const must_send_rej = msgs->io->supports_fext(); !must_send_rej)
     {
-        for (auto const& req : msgs->peer_requested_)
-        {
-            protocolSendReject(msgs, &req);
-        }
+        return;
     }
 
-    msgs->peer_requested_.clear();
+    auto& queue = msgs->peer_requested_;
+    for (auto const& req : queue)
+    {
+        protocolSendReject(msgs, &req);
+    }
+    queue.clear();
 }
 
 // ---
@@ -1257,25 +1246,6 @@ void parseLtep(tr_peerMsgsImpl* msgs, MessageReader& payload)
 
 ReadResult process_peer_message(tr_peerMsgsImpl* msgs, uint8_t id, MessageReader& payload);
 
-void prefetchPieces(tr_peerMsgsImpl* msgs)
-{
-    if (!msgs->session->allowsPrefetch())
-    {
-        return;
-    }
-
-    // ensure that the first `PrefetchMax` items in `msgs->peer_requested_` are prefetched.
-    auto& requests = msgs->peer_requested_;
-    for (size_t i = 0, n = std::min(PrefetchMax, std::size(requests)); i < n; ++i)
-    {
-        if (auto& req = requests[i]; !req.prefetched)
-        {
-            msgs->session->cache->prefetch_block(*msgs->torrent, msgs->torrent->piece_loc(req.index, req.offset), req.length);
-            req.prefetched = true;
-        }
-    }
-}
-
 [[nodiscard]] bool canAddRequestFromPeer(tr_peerMsgsImpl const* const msgs, struct peer_request const& req)
 {
     if (msgs->peer_is_choked())
@@ -1310,7 +1280,6 @@ void peerMadeRequest(tr_peerMsgsImpl* msgs, struct peer_request const* req)
     if (canAddRequestFromPeer(msgs, *req))
     {
         msgs->peer_requested_.emplace_back(*req);
-        prefetchPieces(msgs);
     }
     else if (msgs->io->supports_fext())
     {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -884,16 +884,16 @@ std::optional<int> popNextMetadataRequest(tr_peerMsgsImpl* msgs)
 
 void cancelAllRequestsToClient(tr_peerMsgsImpl* msgs)
 {
-    if (auto const must_send_rej = msgs->io->supports_fext(); !must_send_rej)
+    auto& queue = msgs->peer_requested_;
+
+    if (auto const must_send_rej = msgs->io->supports_fext(); must_send_rej)
     {
-        return;
+        for (auto const& req : queue)
+        {
+            protocolSendReject(msgs, &req);
+        }
     }
 
-    auto& queue = msgs->peer_requested_;
-    for (auto const& req : queue)
-    {
-        protocolSendReject(msgs, &req);
-    }
     queue.clear();
 }
 

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -19,7 +19,7 @@ using namespace std::literals;
 namespace
 {
 
-auto constexpr MyStatic = std::array<std::string_view, 406>{ ""sv,
+auto constexpr MyStatic = std::array<std::string_view, 405>{ ""sv,
                                                              "activeTorrentCount"sv,
                                                              "activity-date"sv,
                                                              "activityDate"sv,
@@ -252,7 +252,6 @@ auto constexpr MyStatic = std::array<std::string_view, 406>{ ""sv,
                                                              "port-is-open"sv,
                                                              "preallocation"sv,
                                                              "preferred-transport"sv,
-                                                             "prefetch-enabled"sv,
                                                              "primary-mime-type"sv,
                                                              "priorities"sv,
                                                              "priority"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -254,7 +254,6 @@ enum
     TR_KEY_port_is_open,
     TR_KEY_preallocation,
     TR_KEY_preferred_transport,
-    TR_KEY_prefetch_enabled,
     TR_KEY_primary_mime_type,
     TR_KEY_priorities,
     TR_KEY_priority,

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -53,7 +53,6 @@ struct tr_variant;
     V(TR_KEY_pex_enabled, pex_enabled, bool, true, "") \
     V(TR_KEY_port_forwarding_enabled, port_forwarding_enabled, bool, true, "") \
     V(TR_KEY_preallocation, preallocation_mode, tr_open_files::Preallocation, tr_open_files::Preallocation::Sparse, "") \
-    V(TR_KEY_prefetch_enabled, is_prefetch_enabled, bool, true, "") \
     V(TR_KEY_queue_stalled_enabled, queue_stalled_enabled, bool, true, "") \
     V(TR_KEY_queue_stalled_minutes, queue_stalled_minutes, size_t, 30U, "") \
     V(TR_KEY_ratio_limit, ratio_limit, double, 2.0, "") \

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -786,11 +786,6 @@ public:
         return settings_.preferred_transport;
     }
 
-    [[nodiscard]] constexpr auto allowsPrefetch() const noexcept
-    {
-        return settings_.is_prefetch_enabled;
-    }
-
     [[nodiscard]] constexpr auto isIdleLimited() const noexcept
     {
         return settings_.idle_seeding_limit_enabled;

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -75,7 +75,6 @@ void tr_verify_worker::verify_torrent(Mediator& verify_mediator, bool const abor
             {
                 bytes_this_pass = num_read;
                 sha->add(std::data(buffer), bytes_this_pass);
-                tr_sys_file_advise(fd, file_pos, bytes_this_pass, TR_SYS_FILE_ADVICE_DONT_NEED);
             }
         }
 


### PR DESCRIPTION
Prefetch was added as a way to ameliorate blocking disk reads in the session thread.

It's unimplemented on Win32, we've never done any metrics on its benefits / lack of benefits on Linux / macOS, and it's unnecessary when we're moving to async disk IO.