### PR TITLE
refactor: tr_block_info cleanup

### DIFF
--- a/libtransmission/block-info.cc
+++ b/libtransmission/block-info.cc
@@ -8,7 +8,7 @@
 #include "libtransmission/block-info.h"
 #include "libtransmission/tr-assert.h" // TR_ASSERT
 
-void tr_block_info::init_sizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept
+void tr_block_info::init_sizes(uint64_t const total_size_in, uint32_t const piece_size_in) noexcept
 {
     TR_ASSERT(piece_size_in == 0 || piece_size_in >= BlockSize);
     if (piece_size_in == 0)

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -16,7 +16,7 @@ public:
 
     tr_block_info() noexcept = default;
 
-    tr_block_info(uint64_t total_size_in, uint32_t piece_size_in) noexcept
+    tr_block_info(uint64_t const total_size_in, uint32_t const piece_size_in) noexcept
     {
         init_sizes(total_size_in, piece_size_in);
     }
@@ -26,7 +26,7 @@ public:
         return n_blocks_;
     }
 
-    [[nodiscard]] constexpr auto block_size(tr_block_index_t block) const noexcept
+    [[nodiscard]] constexpr auto block_size(tr_block_index_t const block) const noexcept
     {
         return block + 1 == n_blocks_ ? final_block_size_ : BlockSize;
     }
@@ -41,7 +41,7 @@ public:
         return piece_size_;
     }
 
-    [[nodiscard]] constexpr auto piece_size(tr_piece_index_t piece) const noexcept
+    [[nodiscard]] constexpr auto piece_size(tr_piece_index_t const piece) const noexcept
     {
         return piece + 1 == n_pieces_ ? final_piece_size_ : piece_size();
     }
@@ -73,7 +73,7 @@ public:
     };
 
     // Location of the torrent's nth byte
-    [[nodiscard]] constexpr auto byte_loc(uint64_t byte_idx) const noexcept
+    [[nodiscard]] constexpr auto byte_loc(uint64_t const byte_idx) const noexcept
     {
         auto loc = Location{};
 
@@ -100,18 +100,18 @@ public:
     }
 
     // Location of the first byte in `block`.
-    [[nodiscard]] constexpr auto block_loc(tr_block_index_t block) const noexcept
+    [[nodiscard]] constexpr auto block_loc(tr_block_index_t const block) const noexcept
     {
         return byte_loc(uint64_t{ block } * BlockSize);
     }
 
     // Location of the first byte (+ optional offset and length) in `piece`
-    [[nodiscard]] constexpr auto piece_loc(tr_piece_index_t piece, uint32_t offset = 0, uint32_t length = 0) const noexcept
+    [[nodiscard]] constexpr auto piece_loc(tr_piece_index_t piece, uint32_t offset = {}, uint32_t length = {}) const noexcept
     {
         return byte_loc(uint64_t{ piece } * piece_size() + offset + length);
     }
 
-    [[nodiscard]] constexpr tr_block_span_t block_span_for_piece(tr_piece_index_t piece) const noexcept
+    [[nodiscard]] constexpr tr_block_span_t block_span_for_piece(tr_piece_index_t const piece) const noexcept
     {
         if (!is_initialized())
         {
@@ -121,7 +121,7 @@ public:
         return { piece_loc(piece).block, piece_last_loc(piece).block + 1 };
     }
 
-    [[nodiscard]] constexpr tr_byte_span_t byte_span_for_piece(tr_piece_index_t piece) const noexcept
+    [[nodiscard]] constexpr tr_byte_span_t byte_span_for_piece(tr_piece_index_t const piece) const noexcept
     {
         if (!is_initialized())
         {
@@ -136,7 +136,7 @@ private:
     void init_sizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept;
 
     // Location of the last byte in `piece`.
-    [[nodiscard]] constexpr Location piece_last_loc(tr_piece_index_t piece) const noexcept
+    [[nodiscard]] constexpr Location piece_last_loc(tr_piece_index_t const piece) const noexcept
     {
         return byte_loc(static_cast<uint64_t>(piece) * piece_size() + piece_size(piece) - 1);
     }

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -11,17 +11,6 @@
 
 struct tr_block_info
 {
-private:
-    uint64_t total_size_ = 0;
-    uint32_t piece_size_ = 0;
-    tr_piece_index_t n_pieces_ = 0;
-
-    tr_block_index_t n_blocks_ = 0;
-    // should be same type as BlockSize
-    uint32_t final_block_size_ = 0;
-    // should be same type as piece_size
-    uint32_t final_piece_size_ = 0;
-
 public:
     static auto constexpr BlockSize = uint32_t{ 1024 * 16 };
 
@@ -64,14 +53,6 @@ public:
 
     struct Location
     {
-        uint64_t byte = 0;
-
-        tr_piece_index_t piece = 0;
-        uint32_t piece_offset = 0;
-
-        tr_block_index_t block = 0;
-        uint32_t block_offset = 0;
-
         [[nodiscard]] constexpr bool operator==(Location const& that) const noexcept
         {
             return this->byte == that.byte;
@@ -81,6 +62,14 @@ public:
         {
             return this->byte < that.byte;
         }
+
+        uint64_t byte = {};
+
+        tr_piece_index_t piece = {};
+        uint32_t piece_offset = {};
+
+        tr_block_index_t block = {};
+        uint32_t block_offset = {};
     };
 
     // Location of the torrent's nth byte
@@ -154,6 +143,16 @@ private:
 
     [[nodiscard]] constexpr bool is_initialized() const noexcept
     {
-        return piece_size_ != 0;
+        return piece_size_ != 0U;
     }
+
+    uint64_t total_size_ = {};
+
+    tr_block_index_t n_blocks_ = {};
+    tr_piece_index_t n_pieces_ = {};
+
+    uint32_t final_block_size_ = {};
+
+    uint32_t piece_size_ = {};
+    uint32_t final_piece_size_ = {};
 };

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -32,8 +32,6 @@ public:
         init_sizes(total_size_in, piece_size_in);
     }
 
-    void init_sizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept;
-
     [[nodiscard]] constexpr auto block_count() const noexcept
     {
         return n_blocks_;
@@ -146,6 +144,8 @@ public:
     }
 
 private:
+    void init_sizes(uint64_t total_size_in, uint32_t piece_size_in) noexcept;
+
     // Location of the last byte in `piece`.
     [[nodiscard]] constexpr Location piece_last_loc(tr_piece_index_t piece) const noexcept
     {

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -12,7 +12,7 @@
 struct tr_block_info
 {
 public:
-    static auto constexpr BlockSize = uint32_t{ 1024 * 16 };
+    static auto constexpr BlockSize = uint32_t{ 1024U * 16U };
 
     tr_block_info() noexcept = default;
 
@@ -28,7 +28,7 @@ public:
 
     [[nodiscard]] constexpr auto block_size(tr_block_index_t const block) const noexcept
     {
-        return block + 1 == n_blocks_ ? final_block_size_ : BlockSize;
+        return block + 1U == n_blocks_ ? final_block_size_ : BlockSize;
     }
 
     [[nodiscard]] constexpr auto piece_count() const noexcept
@@ -43,7 +43,7 @@ public:
 
     [[nodiscard]] constexpr auto piece_size(tr_piece_index_t const piece) const noexcept
     {
-        return piece + 1 == n_pieces_ ? final_piece_size_ : piece_size();
+        return piece + 1U == n_pieces_ ? final_piece_size_ : piece_size();
     }
 
     [[nodiscard]] constexpr auto total_size() const noexcept
@@ -83,8 +83,8 @@ public:
 
             if (byte_idx == total_size()) // handle 0-byte files at the end of a torrent
             {
-                loc.block = block_count() - 1;
-                loc.piece = piece_count() - 1;
+                loc.block = block_count() - 1U;
+                loc.piece = piece_count() - 1U;
             }
             else
             {
@@ -118,7 +118,7 @@ public:
             return { 0U, 0U };
         }
 
-        return { piece_loc(piece).block, piece_last_loc(piece).block + 1 };
+        return { piece_loc(piece).block, piece_last_loc(piece).block + 1U };
     }
 
     [[nodiscard]] constexpr tr_byte_span_t byte_span_for_piece(tr_piece_index_t const piece) const noexcept

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -75,7 +75,7 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
     reset({ tm.total_size(), tm.piece_size() }, std::data(file_sizes), std::size(file_sizes));
 }
 
-tr_file_piece_map::file_span_t tr_file_piece_map::file_span(tr_piece_index_t piece) const
+tr_file_piece_map::file_span_t tr_file_piece_map::file_span_for_piece(tr_piece_index_t piece) const
 {
     static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
@@ -142,7 +142,7 @@ tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t piece) const
     }
 
     // check the priorities of the files that touch this piece
-    if (auto const [begin_file, end_file] = fpm_->file_span(piece); end_file <= std::size(priorities_))
+    if (auto const [begin_file, end_file] = fpm_->file_span_for_piece(piece); end_file <= std::size(priorities_))
     {
         auto const begin = std::begin(priorities_) + begin_file;
         auto const end = std::begin(priorities_) + end_file;
@@ -184,6 +184,6 @@ bool tr_files_wanted::piece_wanted(tr_piece_index_t piece) const
         return true;
     }
 
-    auto const [begin, end] = fpm_->file_span(piece);
+    auto const [begin, end] = fpm_->file_span_for_piece(piece);
     return wanted_.count(begin, end) != 0U;
 }

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -153,7 +153,7 @@ void tr_file_priorities::set(tr_file_index_t file, tr_priority_t new_priority)
             return;
         }
 
-        priorities_.assign(std::size(*fpm_), TR_PRI_NORMAL);
+        priorities_.assign(fpm_->file_count(), TR_PRI_NORMAL);
         priorities_.shrink_to_fit();
     }
 
@@ -170,7 +170,7 @@ void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority
 
 tr_priority_t tr_file_priorities::file_priority(tr_file_index_t file) const
 {
-    TR_ASSERT(file < std::size(*fpm_));
+    TR_ASSERT(file < fpm_->file_count());
 
     if (std::empty(priorities_))
     {
@@ -208,7 +208,7 @@ tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t piece) const
 
 tr_files_wanted::tr_files_wanted(tr_file_piece_map const* fpm)
     : fpm_{ fpm }
-    , wanted_{ std::size(*fpm) }
+    , wanted_{ fpm->file_count() }
 {
     wanted_.set_has_all(); // by default we want all files
 }

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -19,6 +19,16 @@
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/tr-assert.h"
 
+tr_file_piece_map::tr_file_piece_map(tr_torrent_metainfo const& tm)
+{
+    reset(tm);
+}
+
+tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+{
+    reset(block_info, file_sizes, n_files);
+}
+
 void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
 {
     file_bytes_.resize(n_files);

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -24,12 +24,12 @@ tr_file_piece_map::tr_file_piece_map(tr_torrent_metainfo const& tm)
     reset(tm);
 }
 
-tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* const file_sizes, size_t const n_files)
 {
     reset(block_info, file_sizes, n_files);
 }
 
-void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
+void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* const file_sizes, size_t const n_files)
 {
     file_bytes_.resize(n_files);
     file_bytes_.shrink_to_fit();
@@ -107,24 +107,24 @@ struct CompareToSpan
         return 0;
     }
 
-    [[nodiscard]] constexpr bool operator()(T item, span_t span) const // <
+    [[nodiscard]] constexpr bool operator()(T const item, span_t const span) const // <
     {
         return compare(item, span) < 0;
     }
 
-    [[nodiscard]] constexpr int compare(span_t span, T item) const // <=>
+    [[nodiscard]] constexpr int compare(span_t const span, T const item) const // <=>
     {
         return -compare(item, span);
     }
 
-    [[nodiscard]] constexpr bool operator()(span_t span, T item) const // <
+    [[nodiscard]] constexpr bool operator()(span_t const span, T const item) const // <
     {
         return compare(span, item) < 0;
     }
 };
 } // namespace
 
-tr_file_piece_map::file_span_t tr_file_piece_map::file_span_for_piece(tr_piece_index_t piece) const
+tr_file_piece_map::file_span_t tr_file_piece_map::file_span_for_piece(tr_piece_index_t const piece) const
 {
     static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
@@ -132,7 +132,7 @@ tr_file_piece_map::file_span_t tr_file_piece_map::file_span_for_piece(tr_piece_i
     return { static_cast<tr_file_index_t>(equal_begin - begin), static_cast<tr_file_index_t>(equal_end - begin) };
 }
 
-tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset) const
+tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t const offset) const
 {
     static constexpr auto Compare = CompareToSpan<uint64_t>{};
     auto const begin = std::begin(file_bytes_);
@@ -144,7 +144,7 @@ tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset)
 
 // ---
 
-void tr_file_priorities::set(tr_file_index_t file, tr_priority_t new_priority)
+void tr_file_priorities::set(tr_file_index_t const file, tr_priority_t const new_priority)
 {
     if (std::empty(priorities_))
     {
@@ -160,7 +160,7 @@ void tr_file_priorities::set(tr_file_index_t file, tr_priority_t new_priority)
     priorities_[file] = new_priority;
 }
 
-void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority_t new_priority)
+void tr_file_priorities::set(tr_file_index_t const* const files, size_t const n, tr_priority_t const new_priority)
 {
     for (size_t i = 0U; i < n; ++i)
     {
@@ -168,7 +168,7 @@ void tr_file_priorities::set(tr_file_index_t const* files, size_t n, tr_priority
     }
 }
 
-tr_priority_t tr_file_priorities::file_priority(tr_file_index_t file) const
+tr_priority_t tr_file_priorities::file_priority(tr_file_index_t const file) const
 {
     TR_ASSERT(file < fpm_->file_count());
 
@@ -180,7 +180,7 @@ tr_priority_t tr_file_priorities::file_priority(tr_file_index_t file) const
     return priorities_[file];
 }
 
-tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t piece) const
+tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t const piece) const
 {
     // increase priority if a file begins or ends in this piece
     // because that makes life easier for code/users using at incomplete files.
@@ -206,27 +206,27 @@ tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t piece) const
 
 // ---
 
-tr_files_wanted::tr_files_wanted(tr_file_piece_map const* fpm)
+tr_files_wanted::tr_files_wanted(tr_file_piece_map const* const fpm)
     : fpm_{ fpm }
     , wanted_{ fpm->file_count() }
 {
     wanted_.set_has_all(); // by default we want all files
 }
 
-void tr_files_wanted::set(tr_file_index_t file, bool wanted)
+void tr_files_wanted::set(tr_file_index_t const file, bool const wanted)
 {
     wanted_.set(file, wanted);
 }
 
-void tr_files_wanted::set(tr_file_index_t const* files, size_t n, bool wanted)
+void tr_files_wanted::set(tr_file_index_t const* const files, size_t const n_files, bool const wanted)
 {
-    for (size_t i = 0U; i < n; ++i)
+    for (size_t idx = 0U; idx < n_files; ++idx)
     {
-        set(files[i], wanted);
+        set(files[idx], wanted);
     }
 }
 
-bool tr_files_wanted::piece_wanted(tr_piece_index_t piece) const
+bool tr_files_wanted::piece_wanted(tr_piece_index_t const piece) const
 {
     if (wanted_.has_all())
     {

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -157,10 +157,10 @@ tr_priority_t tr_file_priorities::piece_priority(tr_piece_index_t piece) const
 
 // ---
 
-void tr_files_wanted::reset(tr_file_piece_map const* fpm)
+tr_files_wanted::tr_files_wanted(tr_file_piece_map const* fpm)
+    : fpm_{ fpm }
+    , wanted_{ std::size(*fpm) }
 {
-    fpm_ = fpm;
-    wanted_ = tr_bitfield{ std::size(*fpm) };
     wanted_.set_has_all(); // by default we want all files
 }
 

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -95,12 +95,6 @@ tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t offset)
 
 // ---
 
-void tr_file_priorities::reset(tr_file_piece_map const* fpm)
-{
-    fpm_ = fpm;
-    priorities_ = {};
-}
-
 void tr_file_priorities::set(tr_file_index_t file, tr_priority_t new_priority)
 {
     if (std::empty(priorities_))

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -43,18 +43,8 @@ public:
     };
 
     using file_offset_t = offset_t<tr_file_index_t>;
-
-    explicit tr_file_piece_map(tr_torrent_metainfo const& tm)
-    {
-        reset(tm);
-    }
-
-    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files)
-    {
-        reset(block_info, file_sizes, n_files);
-    }
-
-    void reset(tr_torrent_metainfo const& tm);
+    explicit tr_file_piece_map(tr_torrent_metainfo const& tm);
+    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
 
     [[nodiscard]] TR_CONSTEXPR20 piece_span_t piece_span_for_file(tr_file_index_t file) const noexcept
     {
@@ -83,6 +73,7 @@ public:
     }
 
 private:
+    void reset(tr_torrent_metainfo const& tm);
     void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
 
     using byte_span_t = index_span_t<uint64_t>;

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -60,8 +60,7 @@ public:
         return std::size(file_pieces_);
     }
 
-    // TODO(ckerr) minor wart here, two identical span types
-    [[nodiscard]] TR_CONSTEXPR20 tr_byte_span_t byte_span(tr_file_index_t file) const
+    [[nodiscard]] TR_CONSTEXPR20 auto byte_span_for_file(tr_file_index_t const file) const
     {
         auto const& span = file_bytes_[file];
         return tr_byte_span_t{ span.begin, span.end };
@@ -73,10 +72,11 @@ public:
     }
 
 private:
+    using byte_span_t = index_span_t<uint64_t>;
+
     void reset(tr_torrent_metainfo const& tm);
     void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
 
-    using byte_span_t = index_span_t<uint64_t>;
     std::vector<byte_span_t> file_bytes_;
     std::vector<piece_span_t> file_pieces_;
     std::vector<tr_piece_index_t> edge_pieces_;

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -61,7 +61,7 @@ public:
         return file_pieces_[file];
     }
 
-    [[nodiscard]] file_span_t file_span(tr_piece_index_t piece) const;
+    [[nodiscard]] file_span_t file_span_for_piece(tr_piece_index_t piece) const;
 
     [[nodiscard]] file_offset_t file_offset(uint64_t offset) const;
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -137,7 +137,6 @@ public:
     {
     }
 
-    void reset(tr_file_piece_map const*);
     void set(tr_file_index_t file, tr_priority_t priority);
     void set(tr_file_index_t const* files, size_t n, tr_priority_t priority);
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -87,46 +87,8 @@ private:
 
     using byte_span_t = index_span_t<uint64_t>;
     std::vector<byte_span_t> file_bytes_;
-
     std::vector<piece_span_t> file_pieces_;
-
     std::vector<tr_piece_index_t> edge_pieces_;
-
-    template<typename T>
-    struct CompareToSpan
-    {
-        using span_t = index_span_t<T>;
-
-        [[nodiscard]] constexpr int compare(T item, span_t span) const // <=>
-        {
-            if (item < span.begin)
-            {
-                return -1;
-            }
-
-            if (item >= span.end)
-            {
-                return 1;
-            }
-
-            return 0;
-        }
-
-        [[nodiscard]] constexpr bool operator()(T item, span_t span) const // <
-        {
-            return compare(item, span) < 0;
-        }
-
-        [[nodiscard]] constexpr int compare(span_t span, T item) const // <=>
-        {
-            return -compare(item, span);
-        }
-
-        [[nodiscard]] constexpr bool operator()(span_t span, T item) const // <
-        {
-            return compare(span, item) < 0;
-        }
-    };
 };
 
 class tr_file_priorities

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -46,7 +46,7 @@ public:
     explicit tr_file_piece_map(tr_torrent_metainfo const& tm);
     tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
 
-    [[nodiscard]] TR_CONSTEXPR20 piece_span_t piece_span_for_file(tr_file_index_t file) const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 piece_span_t piece_span_for_file(tr_file_index_t const file) const noexcept
     {
         return file_pieces_[file];
     }
@@ -66,7 +66,7 @@ public:
         return tr_byte_span_t{ span.begin, span.end };
     }
 
-    [[nodiscard]] TR_CONSTEXPR20 bool is_edge_piece(tr_piece_index_t piece) const
+    [[nodiscard]] TR_CONSTEXPR20 bool is_edge_piece(tr_piece_index_t const piece) const
     {
         return std::binary_search(std::begin(edge_pieces_), std::end(edge_pieces_), piece);
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -70,11 +70,6 @@ public:
         return std::size(file_pieces_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR20 bool empty() const noexcept
-    {
-        return std::empty(file_pieces_);
-    }
-
     // TODO(ckerr) minor wart here, two identical span types
     [[nodiscard]] TR_CONSTEXPR20 tr_byte_span_t byte_span(tr_file_index_t file) const
     {

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -56,7 +56,7 @@ public:
 
     void reset(tr_torrent_metainfo const& tm);
 
-    [[nodiscard]] TR_CONSTEXPR20 piece_span_t piece_span(tr_file_index_t file) const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 piece_span_t piece_span_for_file(tr_file_index_t file) const noexcept
     {
         return file_pieces_[file];
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -151,12 +151,7 @@ private:
 class tr_files_wanted
 {
 public:
-    explicit tr_files_wanted(tr_file_piece_map const* fpm)
-        : wanted_{ std::size(*fpm) }
-    {
-        reset(fpm);
-    }
-    void reset(tr_file_piece_map const* fpm);
+    explicit tr_files_wanted(tr_file_piece_map const* fpm);
 
     void set(tr_file_index_t file, bool wanted);
     void set(tr_file_index_t const* files, size_t n, bool wanted);

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -55,7 +55,7 @@ public:
 
     [[nodiscard]] file_offset_t file_offset(uint64_t offset) const;
 
-    [[nodiscard]] TR_CONSTEXPR20 size_t size() const
+    [[nodiscard]] TR_CONSTEXPR20 size_t file_count() const
     {
         return std::size(file_pieces_);
     }

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -548,8 +548,8 @@ auto loadProgress(tr_variant* dict, tr_torrent* tor, tr_torrent::ResumeHelper& h
                     tr_variantGetInt(tr_variantListChild(b, 0), &offset);
 
                     time_checked = tr_time();
-                    auto const [begin, end] = tor->pieces_in_file(fi);
-                    for (size_t i = 0, n = end - begin; i < n; ++i)
+                    auto const [piece_begin, piece_end] = tor->piece_span_for_file(fi);
+                    for (size_t i = 0, n = piece_end - piece_begin; i < n; ++i)
                     {
                         int64_t piece_time = 0;
                         tr_variantGetInt(tr_variantListChild(b, i + 1), &piece_time);

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -62,7 +62,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
     using BasicHandler = transmission::benc::BasicHandler<MaxBencDepth>;
 
     tr_torrent_metainfo& tm_;
-    int64_t piece_size_ = 0;
+    uint32_t piece_size_ = {};
     int64_t length_ = 0;
     std::string encoding_ = "UTF-8";
     std::string_view info_dict_begin_;
@@ -225,7 +225,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         }
         else if (pathIs(PieceLengthKey) || pathIs(InfoKey, PieceLengthKey))
         {
-            piece_size_ = value;
+            piece_size_ = static_cast<uint32_t>(value);
         }
         else if (pathIs(InfoKey, LengthKey))
         {
@@ -537,7 +537,7 @@ private:
                 return false;
             }
 
-            if (piece_size_ == 0)
+            if (piece_size_ == 0U)
             {
                 if (!context.error)
                 {
@@ -546,7 +546,7 @@ private:
                 return false;
             }
 
-            tm_.block_info_.init_sizes(tm_.files_.totalSize(), piece_size_);
+            tm_.block_info_ = tr_block_info{ tm_.files_.totalSize(), piece_size_ };
             return true;
         }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1422,7 +1422,7 @@ tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file)
         return { subpath.c_str(), length, length, 1.0, begin, end, priority, wanted };
     }
 
-    auto const have = tor->completion_.count_has_bytes_in_span(tor->byte_span(file));
+    auto const have = tor->completion_.count_has_bytes_in_span(tor->byte_span_for_file(file));
     return { subpath.c_str(), have, length, have >= length ? 1.0 : have / double(length), begin, end, priority, wanted };
 }
 
@@ -1928,7 +1928,7 @@ bool tr_torrentReqIsValid(tr_torrent const* tor, tr_piece_index_t index, uint32_
 
 tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) const noexcept
 {
-    auto const [begin_byte, end_byte] = byte_span(file);
+    auto const [begin_byte, end_byte] = byte_span_for_file(file);
 
     auto const begin_block = byte_loc(begin_byte).block;
     if (begin_byte >= end_byte) // 0-byte file

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -873,7 +873,7 @@ void tr_torrent::on_metainfo_updated()
     fpm_.reset(metainfo_);
     file_mtimes_.resize(file_count());
     file_priorities_ = tr_file_priorities{ &fpm_ };
-    files_wanted_.reset(&fpm_);
+    files_wanted_ = tr_files_wanted{ &fpm_ };
     checked_pieces_ = tr_bitfield{ size_t(piece_count()) };
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -872,7 +872,7 @@ void tr_torrent::on_metainfo_updated()
     obfuscated_hash_ = tr_sha1::digest("req2"sv, info_hash());
     fpm_.reset(metainfo_);
     file_mtimes_.resize(file_count());
-    file_priorities_.reset(&fpm_);
+    file_priorities_ = tr_file_priorities{ &fpm_ };
     files_wanted_.reset(&fpm_);
     checked_pieces_ = tr_bitfield{ size_t(piece_count()) };
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -870,7 +870,7 @@ void tr_torrent::on_metainfo_updated()
 {
     completion_ = tr_completion{ this, &block_info() };
     obfuscated_hash_ = tr_sha1::digest("req2"sv, info_hash());
-    fpm_.reset(metainfo_);
+    fpm_ = tr_file_piece_map{ metainfo_ };
     file_mtimes_.resize(file_count());
     file_priorities_ = tr_file_priorities{ &fpm_ };
     files_wanted_ = tr_files_wanted{ &fpm_ };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2172,8 +2172,8 @@ void tr_torrent::on_piece_completed(tr_piece_index_t const piece)
     set_needs_completeness_check();
 
     // if this piece completes any file, invoke the fileCompleted func for it
-    auto const span = fpm_.file_span(piece);
-    for (auto file = span.begin; file < span.end; ++file)
+    auto const [file_begin, file_end] = fpm_.file_span_for_piece(piece);
+    for (auto file = file_begin; file < file_end; ++file)
     {
         if (completion_.has_blocks(block_span_for_file(file)))
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1195,9 +1195,9 @@ private:
     // must be called after the torrent's announce list changes.
     void on_announce_list_changed();
 
-    [[nodiscard]] auto byte_span(tr_file_index_t file) const
+    [[nodiscard]] TR_CONSTEXPR20 auto byte_span_for_file(tr_file_index_t file) const
     {
-        return fpm_.byte_span(file);
+        return fpm_.byte_span_for_file(file);
     }
 
     // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -383,9 +383,9 @@ public:
 
     /// FILE <-> PIECE
 
-    [[nodiscard]] auto pieces_in_file(tr_file_index_t file) const
+    [[nodiscard]] auto piece_span_for_file(tr_file_index_t file) const
     {
-        return fpm_.piece_span(file);
+        return fpm_.piece_span_for_file(file);
     }
 
     [[nodiscard]] auto file_offset(tr_block_info::Location loc) const

--- a/tests/libtransmission/block-info-test.cc
+++ b/tests/libtransmission/block-info-test.cc
@@ -21,8 +21,7 @@ TEST_F(BlockInfoTest, fieldsAreSet)
     static auto constexpr PieceCount = uint64_t{ 4U };
     static auto constexpr TotalSize = PieceSize * PieceCount;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto info = tr_block_info{ TotalSize, PieceSize };
 
     EXPECT_EQ(ExpectedBlockSize, info.block_size(info.block_count() - 1));
     EXPECT_EQ(PieceCount, info.piece_count());
@@ -30,7 +29,7 @@ TEST_F(BlockInfoTest, fieldsAreSet)
     EXPECT_EQ(PieceSize, info.piece_size());
     EXPECT_EQ(TotalSize, info.total_size());
 
-    info.init_sizes(0, 0);
+    info = tr_block_info{ 0U, 0U };
     EXPECT_EQ(0U, info.block_size(info.block_count() - 1));
     EXPECT_EQ(0U, info.piece_count());
     EXPECT_EQ(0U, info.piece_size(info.piece_count() - 1));
@@ -46,8 +45,7 @@ TEST_F(BlockInfoTest, handlesOddSize)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     EXPECT_EQ(1U, info.block_size(info.block_count() - 1));
     EXPECT_EQ(1U, info.piece_size(info.piece_count() - 1));
@@ -64,8 +62,7 @@ TEST_F(BlockInfoTest, pieceSize)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     EXPECT_EQ(PieceSize, info.piece_size(info.piece_count() - 2));
     EXPECT_EQ(1U, info.piece_size(info.piece_count() - 1));
@@ -79,8 +76,7 @@ TEST_F(BlockInfoTest, blockSize)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1) + 1;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     EXPECT_EQ(ExpectedBlockSize, info.block_size(info.block_count() - 2));
     EXPECT_EQ(1U, info.block_size(info.block_count() - 1));
@@ -94,8 +90,7 @@ TEST_F(BlockInfoTest, blockSpanForPiece)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto info = tr_block_info{ TotalSize, PieceSize };
 
     EXPECT_EQ(0U, info.block_span_for_piece(0).begin);
     EXPECT_EQ(4U, info.block_span_for_piece(0).end);
@@ -118,8 +113,7 @@ TEST_F(BlockInfoTest, blockLoc)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     // begin
     auto loc = info.block_loc(0);
@@ -150,8 +144,7 @@ TEST_F(BlockInfoTest, pieceLoc)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     // begin
     auto loc = info.piece_loc(0);
@@ -198,8 +191,7 @@ TEST_F(BlockInfoTest, byteLoc)
     static auto constexpr PieceCount = uint64_t{ 5U };
     static auto constexpr TotalSize = PieceSize * (PieceCount - 1U) + 1U;
 
-    auto info = tr_block_info{};
-    info.init_sizes(TotalSize, PieceSize);
+    auto const info = tr_block_info{ TotalSize, PieceSize };
 
     auto loc = info.byte_loc(0);
     EXPECT_EQ(tr_block_info::Location{}, loc);

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -122,12 +122,12 @@ TEST_F(FilePieceMapTest, pieceSpan)
     uint64_t offset = 0U;
     for (tr_file_index_t file = 0U; file < n; ++file)
     {
-        EXPECT_EQ(ExpectedPieceSpans[file].begin, fpm.piece_span(file).begin);
-        EXPECT_EQ(ExpectedPieceSpans[file].end, fpm.piece_span(file).end);
+        EXPECT_EQ(ExpectedPieceSpans[file].begin, fpm.piece_span_for_file(file).begin);
+        EXPECT_EQ(ExpectedPieceSpans[file].end, fpm.piece_span_for_file(file).end);
         offset += FileSizes[file];
     }
     EXPECT_EQ(TotalSize, offset);
-    EXPECT_EQ(block_info_.piece_count(), fpm.piece_span(std::size(FileSizes) - 1U).end);
+    EXPECT_EQ(block_info_.piece_count(), fpm.piece_span_for_file(std::size(FileSizes) - 1U).end);
 }
 
 TEST_F(FilePieceMapTest, priorities)
@@ -157,9 +157,9 @@ TEST_F(FilePieceMapTest, priorities)
 
     auto const mark_file_endpoints_as_high_priority = [&]()
     {
-        for (tr_file_index_t i = 0U; i < n_files; ++i)
+        for (tr_file_index_t file = 0U; file < n_files; ++file)
         {
-            auto const [begin_piece, end_piece] = fpm.piece_span(i);
+            auto const [begin_piece, end_piece] = fpm.piece_span_for_file(file);
             expected_piece_priorities[begin_piece] = TR_PRI_HIGH;
             if (end_piece > begin_piece)
             {

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -117,10 +117,10 @@ TEST_F(FilePieceMapTest, pieceSpan)
     EXPECT_EQ(std::size(FileSizes), std::size(ExpectedPieceSpans));
 
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
-    tr_file_index_t const n = std::size(fpm);
-    EXPECT_EQ(std::size(FileSizes), n);
+    auto const n_files = fpm.file_count();
+    EXPECT_EQ(std::size(FileSizes), n_files);
     uint64_t offset = 0U;
-    for (tr_file_index_t file = 0U; file < n; ++file)
+    for (tr_file_index_t file = 0U; file < n_files; ++file)
     {
         EXPECT_EQ(ExpectedPieceSpans[file].begin, fpm.piece_span_for_file(file).begin);
         EXPECT_EQ(ExpectedPieceSpans[file].end, fpm.piece_span_for_file(file).end);


### PR DESCRIPTION
Not what I was expecting to do today, but I wound up with a few of hours with no internet connectivity, so I did this cleanup PR.

This cleanup PR to `tr_block_info`, `tr_file_piece_map`, `tr_file_priorities`, `tr_files_wanted`:

- adds `const` to method args where possible
- moves complicated / non-constexpr methods out of the headers into the .cc files
- changes a couple of methods from public to private
- removes a couple of unused methods
- uses consistent method naming between classes (e.g. `foo_span_for_bar()`)
- fixes some minor signed vs unsigned comparisons / assignments
- uses standard class order declaration, e.g. public methods first, then private methods, then private fields