### PR TITLE
fix: crash after nullptr dereference in rpcimpl

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -136,7 +136,7 @@ auto getTorrents(tr_session* session, tr_variant* args)
                 std::begin(by_id),
                 std::end(by_id),
                 std::back_inserter(torrents),
-                [&cutoff](auto const* tor) { return tor->anyDate >= cutoff; });
+                [&cutoff](auto const* tor) { return tor != nullptr && tor->anyDate >= cutoff; });
         }
         else
         {
@@ -150,7 +150,12 @@ auto getTorrents(tr_session* session, tr_variant* args)
     else // all of them
     {
         auto const& by_id = session->torrents().sorted_by_id();
-        torrents = std::vector<tr_torrent*>{ std::begin(by_id), std::end(by_id) };
+        torrents.reserve(std::size(by_id));
+        std::copy_if(
+            std::begin(by_id),
+            std::end(by_id),
+            std::back_inserter(torrents),
+            [](auto const* tor) { return tor != nullptr; });
     }
 
     return torrents;


### PR DESCRIPTION
fix: crash after nullptr dereference in rpcimpl (#6177)