### PR TITLE
fix: mark torrent as changed when setting location

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2245,6 +2245,7 @@ size_t tr_torrentFindFileToBuf(tr_torrent const* tor, tr_file_index_t file_num, 
 void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)
 {
     download_dir_ = path;
+    mark_changed();
     mark_edited();
     set_dirty();
     refresh_current_dir();


### PR DESCRIPTION
Fixes #5996
Fixes #6352

Notes: Fixed `4.0.0` bugs where some RPC methods don't put torrents in `recently-active` anymore.