### PR TITLE
GTK: Add 4.0.4 and 4.0.5 releases to metainfo

### DIFF
--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -47,6 +47,8 @@ Copyright 2017 Endless Mobile, Inc.
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   <releases>
+    <release date="2023-12-06" version="4.0.5" />
+    <release date="2023-08-23" version="4.0.4" />
     <release date="2023-04-14" version="4.0.3" />
     <release date="2023-03-16" version="4.0.2" />
     <release date="2023-02-23" version="4.0.1" />


### PR DESCRIPTION
This is the novel patch from #6357. The other one was already on main.