### PR TITLE
refactor: convert `tr_incomplete_metadata` to c++ class

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2256,7 +2256,6 @@ void tr_peerMgr::bandwidth_pulse()
     for (auto* const tor : torrents_)
     {
         tor->do_idle_work();
-        tr_torrentMagnetDoIdleWork(tor);
     }
 
     reconnect_pulse();

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1015,12 +1015,11 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     logtrace(msgs, fmt::format(FMT_STRING("here is the base64-encoded handshake: [{:s}]"), tr_base64_encode(handshake_sv)));
 
     /* does the peer prefer encrypted connections? */
-    auto i = int64_t{};
     auto pex = tr_pex{};
     auto& [addr, port] = pex.socket_address;
-    if (tr_variantDictFindInt(&*var, TR_KEY_e, &i))
+    if (auto e = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_e, &e))
     {
-        msgs->encryption_preference = i != 0 ? EncryptionPreference::Yes : EncryptionPreference::No;
+        msgs->encryption_preference = e != 0 ? EncryptionPreference::Yes : EncryptionPreference::No;
 
         if (msgs->encryption_preference == EncryptionPreference::Yes)
         {
@@ -1034,21 +1033,21 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
 
     if (tr_variant* sub = nullptr; tr_variantDictFindDict(&*var, TR_KEY_m, &sub))
     {
-        if (tr_variantDictFindInt(sub, TR_KEY_ut_pex, &i))
+        if (auto ut_pex = int64_t{}; tr_variantDictFindInt(sub, TR_KEY_ut_pex, &ut_pex))
         {
-            msgs->peerSupportsPex = i != 0;
-            msgs->ut_pex_id = static_cast<uint8_t>(i);
+            msgs->peerSupportsPex = ut_pex != 0;
+            msgs->ut_pex_id = static_cast<uint8_t>(ut_pex);
             logtrace(msgs, fmt::format(FMT_STRING("msgs->ut_pex is {:d}"), static_cast<int>(msgs->ut_pex_id)));
         }
 
-        if (tr_variantDictFindInt(sub, TR_KEY_ut_metadata, &i))
+        if (auto ut_metadata = int64_t{}; tr_variantDictFindInt(sub, TR_KEY_ut_metadata, &ut_metadata))
         {
-            msgs->peerSupportsMetadataXfer = i != 0;
-            msgs->ut_metadata_id = static_cast<uint8_t>(i);
+            msgs->peerSupportsMetadataXfer = ut_metadata != 0;
+            msgs->ut_metadata_id = static_cast<uint8_t>(ut_metadata);
             logtrace(msgs, fmt::format(FMT_STRING("msgs->ut_metadata_id is {:d}"), static_cast<int>(msgs->ut_metadata_id)));
         }
 
-        if (tr_variantDictFindInt(sub, TR_KEY_ut_holepunch, &i))
+        if (auto ut_holepunch = int64_t{}; tr_variantDictFindInt(sub, TR_KEY_ut_holepunch, &ut_holepunch))
         {
             // Transmission doesn't support this extension yet.
             // But its presence does indicate µTP supports,
@@ -1058,20 +1057,20 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     }
 
     /* look for metainfo size (BEP 9) */
-    if (tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &i))
+    if (auto metadata_size = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &metadata_size))
     {
-        if (!tr_incomplete_metadata::is_valid_metadata_size(i))
+        if (!tr_incomplete_metadata::is_valid_metadata_size(metadata_size))
         {
             msgs->peerSupportsMetadataXfer = false;
         }
         else
         {
-            tr_torrentSetMetadataSizeHint(msgs->torrent, i);
+            tr_torrentSetMetadataSizeHint(msgs->torrent, metadata_size);
         }
     }
 
     /* look for upload_only (BEP 21) */
-    if (tr_variantDictFindInt(&*var, TR_KEY_upload_only, &i))
+    if (auto upload_only = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_upload_only, &upload_only))
     {
         pex.flags |= ADDED_F_SEED_FLAG;
     }
@@ -1086,11 +1085,11 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     }
 
     /* get peer's listening port */
-    if (tr_variantDictFindInt(&*var, TR_KEY_p, &i) && i > 0)
+    if (auto p = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_p, &p) && p > 0)
     {
-        port.set_host(i);
+        port.set_host(p);
         msgs->publish(tr_peer_event::GotPort(port));
-        logtrace(msgs, fmt::format(FMT_STRING("peer's port is now {:d}"), i));
+        logtrace(msgs, fmt::format(FMT_STRING("peer's port is now {:d}"), p));
     }
 
     std::byte const* addr_compact = nullptr;
@@ -1110,9 +1109,9 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     }
 
     /* get peer's maximum request queue size */
-    if (tr_variantDictFindInt(&*var, TR_KEY_reqq, &i))
+    if (auto reqq = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_reqq, &reqq))
     {
-        msgs->reqq = i;
+        msgs->reqq = reqq;
     }
 }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1799,8 +1799,8 @@ namespace peer_pulse_helpers
         return {};
     }
 
-    auto data = tr_metadata_piece{};
-    if (!tr_torrentGetMetadataPiece(msgs->torrent, *piece, data))
+    auto data = msgs->torrent->get_metadata_piece(*piece);
+    if (!data)
     {
         // send a reject
         auto tmp = tr_variant{};
@@ -1816,7 +1816,7 @@ namespace peer_pulse_helpers
     tr_variantDictAddInt(&tmp, TR_KEY_msg_type, MetadataMsgType::Data);
     tr_variantDictAddInt(&tmp, TR_KEY_piece, *piece);
     tr_variantDictAddInt(&tmp, TR_KEY_total_size, msgs->torrent->info_dict_size());
-    return protocol_send_message(msgs, BtPeerMsgs::Ltep, msgs->ut_metadata_id, tr_variant_serde::benc().to_string(tmp), data);
+    return protocol_send_message(msgs, BtPeerMsgs::Ltep, msgs->ut_metadata_id, tr_variant_serde::benc().to_string(tmp), *data);
 }
 
 [[nodiscard]] size_t add_next_piece(tr_peerMsgsImpl* msgs, uint64_t now)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1142,13 +1142,10 @@ void parseUtMetadata(tr_peerMsgsImpl* msgs, MessageReader& payload_in)
         /* NOOP */
     }
 
-    auto const* const benc_end = serde.end();
-
-    if (msg_type == MetadataMsgType::Data && !msgs->torrent->has_metainfo() && msg_end - benc_end <= MetadataPieceSize &&
-        piece * MetadataPieceSize + (msg_end - benc_end) <= total_size)
+    if (auto const piece_len = msg_end - serde.end();
+        msg_type == MetadataMsgType::Data && piece * MetadataPieceSize + piece_len <= total_size)
     {
-        size_t const piece_len = msg_end - benc_end;
-        tr_torrentSetMetadataPiece(msgs->torrent, piece, benc_end, piece_len);
+        tr_torrentSetMetadataPiece(msgs->torrent, piece, serde.end(), piece_len);
     }
 
     if (msg_type == MetadataMsgType::Request)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1060,7 +1060,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     /* look for metainfo size (BEP 9) */
     if (tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &i))
     {
-        if (!tr_isValidMetadataSizeHint(i))
+        if (!tr_incomplete_metadata::is_valid_metadata_size(i))
         {
             msgs->peerSupportsMetadataXfer = false;
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1060,7 +1060,14 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     /* look for metainfo size (BEP 9) */
     if (tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &i))
     {
-        tr_torrentSetMetadataSizeHint(msgs->torrent, i);
+        if (!tr_isValidMetadataSizeHint(i))
+        {
+            msgs->peerSupportsMetadataXfer = false;
+        }
+        else
+        {
+            tr_torrentSetMetadataSizeHint(msgs->torrent, i);
+        }
     }
 
     /* look for upload_only (BEP 21) */

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1144,7 +1144,7 @@ void parseUtMetadata(tr_peerMsgsImpl* msgs, MessageReader& payload_in)
     if (auto const piece_len = msg_end - serde.end();
         msg_type == MetadataMsgType::Data && piece * MetadataPieceSize + piece_len <= total_size)
     {
-        tr_torrentSetMetadataPiece(msgs->torrent, piece, serde.end(), piece_len);
+        msgs->torrent->set_metadata_piece(piece, serde.end(), piece_len);
     }
 
     if (msg_type == MetadataMsgType::Request)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1065,7 +1065,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
         }
         else
         {
-            tr_torrentSetMetadataSizeHint(msgs->torrent, metadata_size);
+            msgs->torrent->maybe_start_metadata_transfer(metadata_size);
         }
     }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1059,7 +1059,7 @@ void parseLtepHandshake(tr_peerMsgsImpl* msgs, MessageReader& payload)
     /* look for metainfo size (BEP 9) */
     if (auto metadata_size = int64_t{}; tr_variantDictFindInt(&*var, TR_KEY_metadata_size, &metadata_size))
     {
-        if (!tr_incomplete_metadata::is_valid_metadata_size(metadata_size))
+        if (!tr_metadata_download::is_valid_metadata_size(metadata_size))
         {
             msgs->peerSupportsMetadataXfer = false;
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1748,7 +1748,7 @@ void updateMetadataRequests(tr_peerMsgsImpl* msgs, time_t now)
         return;
     }
 
-    if (auto const piece = tr_torrentGetNextMetadataRequest(msgs->torrent, now); piece)
+    if (auto const piece = msgs->torrent->get_next_metadata_request(now); piece)
     {
         auto tmp = tr_variant{};
         tr_variantInitDict(&tmp, 3);

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -200,14 +200,14 @@ tr_variant build_metainfo_except_info_dict(tr_torrent_metainfo const& tm)
     TR_ASSERT(m);
 
     // test the info_dict checksum
-    if (tr_sha1::digest(m->metadata()) != info_hash())
+    if (tr_sha1::digest(m->get_metadata()) != info_hash())
     {
         return false;
     }
 
     // checksum passed; now try to parse it as benc
     auto serde = tr_variant_serde::benc().inplace();
-    auto info_dict_v = serde.parse(m->metadata());
+    auto info_dict_v = serde.parse(m->get_metadata());
     if (!info_dict_v)
     {
         if (error != nullptr)

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -57,8 +57,8 @@ void tr_metadata_download::create_all_needed(int64_t n_pieces) noexcept
     }
 }
 
-tr_metadata_download::tr_metadata_download(std::unique_ptr<Mediator> mediator, int64_t const size)
-    : mediator_{ std::move(mediator) }
+tr_metadata_download::tr_metadata_download(std::string_view log_name, int64_t const size)
+    : log_name_{ std::string{ log_name } }
 {
     TR_ASSERT(is_valid_metadata_size(size));
 
@@ -83,7 +83,7 @@ void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
         return;
     }
 
-    metadata_download_ = std::make_unique<tr_metadata_download>(std::make_unique<MagnetMediator>(*this), size);
+    metadata_download_ = std::make_unique<tr_metadata_download>(name(), size);
 }
 
 [[nodiscard]] std::optional<tr_metadata_piece> tr_torrent::get_metadata_piece(int64_t const piece) const

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -122,25 +122,21 @@ void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
     return {};
 }
 
-bool tr_torrentUseMetainfoFromFile(
-    tr_torrent* tor,
-    tr_torrent_metainfo const* metainfo,
-    char const* filename_in,
-    tr_error* error)
+bool tr_torrent::use_metainfo_from_file(tr_torrent_metainfo const* metainfo, char const* filename_in, tr_error* error)
 {
     // add .torrent file
-    if (!tr_sys_path_copy(filename_in, tor->torrent_file().c_str(), error))
+    if (!tr_sys_path_copy(filename_in, torrent_file().c_str(), error))
     {
         return false;
     }
 
     // remove .magnet file
-    tr_sys_path_remove(tor->magnet_file());
+    tr_sys_path_remove(magnet_file());
 
     // tor should keep this metainfo
-    tor->set_metainfo(*metainfo);
+    set_metainfo(*metainfo);
 
-    tor->incomplete_metadata.reset();
+    incomplete_metadata.reset();
 
     return true;
 }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -10,7 +10,6 @@
 #include <deque>
 #include <fstream>
 #include <ios>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -59,11 +58,6 @@ auto constexpr MinRepeatIntervalSecs = int{ 3 };
 }
 } // namespace
 
-bool tr_isValidMetadataSizeHint(int64_t const size)
-{
-    return size > 0 && size <= std::numeric_limits<int>::max();
-}
-
 bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
 {
     if (tor->has_metainfo())
@@ -76,7 +70,7 @@ bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
         return false;
     }
 
-    if (!tr_isValidMetadataSizeHint(size))
+    if (!tr_incomplete_metadata::is_valid_metadata_size(size))
     {
         TR_ASSERT(false);
         return false;

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -264,19 +264,6 @@ void on_have_all_metainfo(tr_torrent* tor)
 } // namespace set_metadata_piece_helpers
 } // namespace
 
-void tr_torrentMagnetDoIdleWork(tr_torrent* const tor)
-{
-    using namespace set_metadata_piece_helpers;
-
-    TR_ASSERT(tr_isTorrent(tor));
-
-    if (auto const& m = tor->incomplete_metadata; m && std::empty(m->pieces_needed))
-    {
-        tr_logAddDebugTor(tor, fmt::format("we now have all the metainfo!"));
-        on_have_all_metainfo(tor);
-    }
-}
-
 void tr_torrent::set_metadata_piece(int const piece, void const* data, size_t const len)
 {
     TR_ASSERT(data != nullptr);
@@ -318,6 +305,12 @@ void tr_torrent::set_metadata_piece(int const piece, void const* data, size_t co
 
     needed.erase(iter);
     tr_logAddDebugTor(this, fmt::format("saving metainfo piece {}... {} remain", piece, std::size(needed)));
+
+    if (std::empty(needed))
+    {
+        tr_logAddDebugTor(this, fmt::format("we now have all the metainfo!"));
+        on_have_all_metainfo(this);
+    }
 }
 
 // ---

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -318,11 +318,9 @@ void tr_torrent::set_metadata_piece(int const piece, void const* data, size_t co
 
 // ---
 
-std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now)
+std::optional<int> tr_torrent::get_next_metadata_request(time_t now) noexcept
 {
-    TR_ASSERT(tr_isTorrent(tor));
-
-    auto& m = tor->incomplete_metadata;
+    auto& m = incomplete_metadata;
     if (!m)
     {
         return {};
@@ -338,7 +336,7 @@ std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now)
     needed.pop_front();
     req.requested_at = now;
     needed.push_back(req);
-    tr_logAddDebugTor(tor, fmt::format("next piece to request: {}", req.piece));
+    tr_logAddDebugTor(this, fmt::format("next piece to request: {}", req.piece));
     return req.piece;
 }
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -342,7 +342,17 @@ void tr_torrent::set_metadata_piece(int const piece, void const* data, size_t co
     return {};
 }
 
-double tr_torrent::get_metadata_percent() const noexcept
+[[nodiscard]] double tr_incomplete_metadata::get_metadata_percent() const noexcept
+{
+    if (auto const n = piece_count; n != 0)
+    {
+        return (n - std::size(pieces_needed)) / static_cast<double>(n);
+    }
+
+    return 0.0;
+}
+
+[[nodiscard]] double tr_torrent::get_metadata_percent() const noexcept
 {
     if (has_metainfo())
     {
@@ -351,10 +361,7 @@ double tr_torrent::get_metadata_percent() const noexcept
 
     if (auto const& m = incomplete_metadata; m)
     {
-        if (auto const n = m->piece_count; n != 0)
-        {
-            return (n - std::size(m->pieces_needed)) / static_cast<double>(n);
-        }
+        return m->get_metadata_percent();
     }
 
     return 0.0;

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -58,33 +58,31 @@ auto constexpr MinRepeatIntervalSecs = int{ 3 };
 }
 } // namespace
 
-bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t size)
+void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
 {
-    if (tor->has_metainfo())
+    if (has_metainfo())
     {
-        return false;
+        return;
     }
 
-    if (tor->incomplete_metadata)
+    if (incomplete_metadata)
     {
-        return false;
+        return;
     }
 
     if (!tr_incomplete_metadata::is_valid_metadata_size(size))
     {
         TR_ASSERT(false);
-        return false;
+        return;
     }
     auto const n = div_ceil(static_cast<int>(size), MetadataPieceSize);
-    tr_logAddDebugTor(tor, fmt::format("metadata is {} bytes in {} pieces", size, n));
+    tr_logAddDebugTor(this, fmt::format("metadata is {} bytes in {} pieces", size, n));
 
-    auto& m = tor->incomplete_metadata;
+    auto& m = incomplete_metadata;
     m = std::make_unique<tr_incomplete_metadata>();
     m->piece_count = n;
     m->metadata.resize(size);
     m->pieces_needed = create_all_needed(n);
-
-    return true;
 }
 
 bool tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, tr_metadata_piece& setme)

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
-#include <deque>
 #include <fstream>
 #include <ios>
 #include <memory>
@@ -15,7 +14,6 @@
 #include <string>
 #include <string_view>
 #include <utility> // std::move
-#include <vector>
 
 #include <fmt/core.h>
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -109,7 +109,7 @@ bool tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, tr_metadata_pi
         return {};
     }
 
-    auto in = std::ifstream{ tor->torrent_file(), std::ios_base::in };
+    auto in = std::ifstream{ tor->torrent_file(), std::ios_base::in | std::ios_base::binary };
     if (!in.is_open())
     {
         return {};

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -273,24 +273,21 @@ void tr_torrentMagnetDoIdleWork(tr_torrent* const tor)
     }
 }
 
-void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, size_t len)
+void tr_torrent::set_metadata_piece(int const piece, void const* data, size_t const len)
 {
-    using namespace set_metadata_piece_helpers;
-
-    TR_ASSERT(tr_isTorrent(tor));
     TR_ASSERT(data != nullptr);
 
-    tr_logAddDebugTor(tor, fmt::format("got metadata piece {} of {} bytes", piece, len));
+    tr_logAddDebugTor(this, fmt::format("got metadata piece {} of {} bytes", piece, len));
 
     // are we set up to download metadata?
-    auto& m = tor->incomplete_metadata;
+    auto& m = incomplete_metadata;
     if (!m)
     {
         return;
     }
 
     // sanity test: is `piece` in range?
-    if ((piece < 0) || (piece >= m->piece_count))
+    if (piece < 0 || piece >= m->piece_count)
     {
         return;
     }
@@ -312,11 +309,11 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, si
         return;
     }
 
-    size_t const offset = piece * MetadataPieceSize;
+    auto const offset = piece * MetadataPieceSize;
     std::copy_n(reinterpret_cast<char const*>(data), len, std::begin(m->metadata) + offset);
 
     needed.erase(iter);
-    tr_logAddDebugTor(tor, fmt::format("saving metainfo piece {}... {} remain", piece, std::size(needed)));
+    tr_logAddDebugTor(this, fmt::format("saving metainfo piece {}... {} remain", piece, std::size(needed)));
 }
 
 // ---

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -340,14 +340,14 @@ std::optional<int> tr_torrent::get_next_metadata_request(time_t now) noexcept
     return req.piece;
 }
 
-double tr_torrentGetMetadataPercent(tr_torrent const* tor)
+double tr_torrent::get_metadata_percent() const noexcept
 {
-    if (tor->has_metainfo())
+    if (has_metainfo())
     {
         return 1.0;
     }
 
-    if (auto const& m = tor->incomplete_metadata; m)
+    if (auto const& m = incomplete_metadata; m)
     {
         if (auto const n = m->piece_count; n != 0)
         {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -114,8 +114,9 @@ void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
         return {};
     }
 
-    auto const piece_len = offset_in_info_dict + MetadataPieceSize <= info_dict_size ? MetadataPieceSize :
-                                                                                       info_dict_size - offset_in_info_dict;
+    auto const piece_len = static_cast<size_t>(offset_in_info_dict + MetadataPieceSize) <= info_dict_size ?
+        MetadataPieceSize :
+        info_dict_size - offset_in_info_dict;
     if (auto ret = tr_metadata_piece(piece_len); in.read(reinterpret_cast<char*>(std::data(ret)), std::size(ret)))
     {
         return ret;

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -152,13 +152,6 @@ namespace
 {
 namespace set_metadata_piece_helpers
 {
-[[nodiscard]] constexpr size_t get_piece_length(tr_incomplete_metadata const& m, int piece)
-{
-    return piece + 1 == m.piece_count ? // last piece
-        std::size(m.metadata) - (piece * MetadataPieceSize) :
-        MetadataPieceSize;
-}
-
 tr_variant build_metainfo_except_info_dict(tr_torrent_metainfo const& tm)
 {
     auto top = tr_variant::Map{ 8U };
@@ -308,7 +301,7 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, si
     }
 
     // sanity test: is `len` the right size?
-    if (get_piece_length(*m, piece) != len)
+    if (m->get_piece_length(piece) != len)
     {
         return;
     }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -79,7 +79,7 @@ void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
     tr_logAddDebugTor(this, fmt::format("metadata is {} bytes in {} pieces", size, n));
 
     auto& m = incomplete_metadata;
-    m = std::make_unique<tr_incomplete_metadata>();
+    m = std::make_unique<tr_incomplete_metadata>(std::make_unique<MagnetMediator>(*this));
     m->piece_count = n;
     m->metadata.resize(size);
     m->pieces_needed = create_all_needed(n);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -60,6 +60,8 @@ struct tr_incomplete_metadata
 
     bool set_metadata_piece(int piece, void const* data, size_t len);
 
+    [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
+
     [[nodiscard]] auto log_name() const noexcept
     {
         return mediator_->log_name();

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -62,8 +62,6 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, si
 
 std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);
 
-bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
-
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 
 void tr_torrentMagnetDoIdleWork(tr_torrent* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -56,8 +56,6 @@ struct tr_incomplete_metadata
     int piece_count = 0;
 };
 
-bool tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, tr_metadata_piece& setme);
-
 void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, size_t len);
 
 std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -63,5 +63,3 @@ std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now)
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 
 void tr_torrentMagnetDoIdleWork(tr_torrent* tor);
-
-bool tr_torrentUseMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* metainfo, char const* filename, tr_error* error);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -41,6 +41,13 @@ struct tr_incomplete_metadata
         return size > 0 && size <= std::numeric_limits<int>::max();
     }
 
+    [[nodiscard]] constexpr size_t get_piece_length(int const piece) const noexcept
+    {
+        return piece + 1 == piece_count ? // last piece
+            std::size(metadata) - (piece * MetadataPieceSize) :
+            MetadataPieceSize;
+    }
+
     std::vector<char> metadata;
 
     /** sorted from least to most recently requested */

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -20,6 +20,8 @@
 
 #include <small/vector.hpp>
 
+#include "libtransmission/tr-macros.h"
+
 struct tr_error;
 struct tr_torrent;
 struct tr_torrent_metainfo;
@@ -32,14 +34,7 @@ using tr_metadata_piece = small::max_size_vector<std::byte, MetadataPieceSize>;
 class tr_metadata_download
 {
 public:
-    struct Mediator
-    {
-        virtual ~Mediator() = default;
-
-        [[nodiscard]] virtual std::string log_name() const noexcept = 0;
-    };
-
-    tr_metadata_download(std::unique_ptr<Mediator> mediator, int64_t size);
+    tr_metadata_download(std::string_view log_name, int64_t size);
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {
@@ -64,9 +59,9 @@ public:
         return metadata_;
     }
 
-    [[nodiscard]] auto log_name() const noexcept
+    [[nodiscard]] TR_CONSTEXPR20 std::string_view log_name() const noexcept
     {
-        return mediator_->log_name();
+        return log_name_;
     }
 
 private:
@@ -82,5 +77,5 @@ private:
     std::deque<metadata_node> pieces_needed_;
     int64_t piece_count_ = {};
 
-    std::unique_ptr<Mediator> mediator_;
+    std::string log_name_;
 };

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -29,7 +29,7 @@ inline constexpr auto MetadataPieceSize = 1024 * 16;
 
 using tr_metadata_piece = small::max_size_vector<std::byte, MetadataPieceSize>;
 
-class tr_incomplete_metadata
+class tr_metadata_download
 {
 public:
     struct Mediator
@@ -39,7 +39,7 @@ public:
         [[nodiscard]] virtual std::string log_name() const noexcept = 0;
     };
 
-    tr_incomplete_metadata(std::unique_ptr<Mediator> mediator, int64_t size);
+    tr_metadata_download(std::unique_ptr<Mediator> mediator, int64_t size);
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -49,6 +49,8 @@ void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, si
 
 std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);
 
+bool tr_isValidMetadataSizeHint(int64_t const size);
+
 bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -13,6 +13,7 @@
 #include <cstdint> // int64_t
 #include <ctime> // time_t
 #include <deque>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -35,6 +36,11 @@ struct tr_incomplete_metadata
         int piece = 0;
     };
 
+    [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
+    {
+        return size > 0 && size <= std::numeric_limits<int>::max();
+    }
+
     std::vector<char> metadata;
 
     /** sorted from least to most recently requested */
@@ -48,8 +54,6 @@ bool tr_torrentGetMetadataPiece(tr_torrent const* tor, int piece, tr_metadata_pi
 void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, size_t len);
 
 std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);
-
-bool tr_isValidMetadataSizeHint(int64_t const size);
 
 bool tr_torrentSetMetadataSizeHint(tr_torrent* tor, int64_t metadata_size);
 

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -39,20 +39,13 @@ public:
         return size > 0 && size <= std::numeric_limits<int>::max();
     }
 
-    [[nodiscard]] constexpr size_t get_piece_length(int64_t const piece) const noexcept
-    {
-        return piece + 1 == piece_count_ ? // last piece
-            std::size(metadata_) - (piece * MetadataPieceSize) :
-            MetadataPieceSize;
-    }
-
     bool set_metadata_piece(int64_t piece, void const* data, size_t len);
 
     [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 
-    [[nodiscard]] constexpr auto const& metadata() const noexcept
+    [[nodiscard]] constexpr auto const& get_metadata() const noexcept
     {
         return metadata_;
     }
@@ -68,6 +61,13 @@ private:
         time_t requested_at = {};
         int64_t piece = {};
     };
+
+    [[nodiscard]] constexpr size_t get_piece_length(int64_t const piece) const noexcept
+    {
+        return piece + 1 == piece_count_ ? // last piece
+            std::size(metadata_) - (piece * MetadataPieceSize) :
+            MetadataPieceSize;
+    }
 
     void create_all_needed(int64_t n_pieces) noexcept;
 

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -16,15 +16,13 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <small/vector.hpp>
 
 #include "libtransmission/tr-macros.h"
-
-struct tr_error;
-struct tr_torrent;
-struct tr_torrent_metainfo;
 
 // defined by BEP #9
 inline constexpr auto MetadataPieceSize = 1024 * 16;

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -56,6 +56,4 @@ struct tr_incomplete_metadata
     int piece_count = 0;
 };
 
-double tr_torrentGetMetadataPercent(tr_torrent const* tor);
-
 void tr_torrentMagnetDoIdleWork(tr_torrent* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -62,6 +62,8 @@ struct tr_incomplete_metadata
 
     [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
 
+    [[nodiscard]] double get_metadata_percent() const noexcept;
+
     [[nodiscard]] auto log_name() const noexcept
     {
         return mediator_->log_name();

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -56,8 +56,6 @@ struct tr_incomplete_metadata
     int piece_count = 0;
 };
 
-std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);
-
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);
 
 void tr_torrentMagnetDoIdleWork(tr_torrent* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -44,10 +44,7 @@ struct tr_incomplete_metadata
         int piece = 0;
     };
 
-    explicit tr_incomplete_metadata(std::unique_ptr<Mediator> mediator)
-        : mediator_{ std::move(mediator) }
-    {
-    }
+    tr_incomplete_metadata(std::unique_ptr<Mediator> mediator, int64_t size);
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {
@@ -59,6 +56,11 @@ struct tr_incomplete_metadata
         return piece + 1 == piece_count ? // last piece
             std::size(metadata) - (piece * MetadataPieceSize) :
             MetadataPieceSize;
+    }
+
+    [[nodiscard]] auto log_name() const noexcept
+    {
+        return mediator_->log_name();
     }
 
     std::vector<char> metadata;

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -72,5 +72,3 @@ struct tr_incomplete_metadata
 
     std::unique_ptr<Mediator> mediator_;
 };
-
-void tr_torrentMagnetDoIdleWork(tr_torrent* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -58,6 +58,8 @@ struct tr_incomplete_metadata
             MetadataPieceSize;
     }
 
+    bool set_metadata_piece(int piece, void const* data, size_t len);
+
     [[nodiscard]] auto log_name() const noexcept
     {
         return mediator_->log_name();

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -56,8 +56,6 @@ struct tr_incomplete_metadata
     int piece_count = 0;
 };
 
-void tr_torrentSetMetadataPiece(tr_torrent* tor, int piece, void const* data, size_t len);
-
 std::optional<int> tr_torrentGetNextMetadataRequest(tr_torrent* tor, time_t now);
 
 double tr_torrentGetMetadataPercent(tr_torrent const* tor);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -25,7 +25,7 @@ struct tr_torrent;
 struct tr_torrent_metainfo;
 
 // defined by BEP #9
-inline constexpr int MetadataPieceSize = 1024 * 16;
+inline constexpr auto MetadataPieceSize = 1024 * 16;
 
 using tr_metadata_piece = small::max_size_vector<std::byte, MetadataPieceSize>;
 
@@ -46,16 +46,16 @@ public:
         return size > 0 && size <= std::numeric_limits<int>::max();
     }
 
-    [[nodiscard]] constexpr size_t get_piece_length(int const piece) const noexcept
+    [[nodiscard]] constexpr size_t get_piece_length(int64_t const piece) const noexcept
     {
         return piece + 1 == piece_count_ ? // last piece
             std::size(metadata_) - (piece * MetadataPieceSize) :
             MetadataPieceSize;
     }
 
-    bool set_metadata_piece(int piece, void const* data, size_t len);
+    bool set_metadata_piece(int64_t piece, void const* data, size_t len);
 
-    [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
+    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 
@@ -72,15 +72,15 @@ public:
 private:
     struct metadata_node
     {
-        time_t requested_at = 0U;
-        int piece = 0;
+        time_t requested_at = {};
+        int64_t piece = {};
     };
 
-    void create_all_needed(int n_pieces) noexcept;
+    void create_all_needed(int64_t n_pieces) noexcept;
 
     std::vector<char> metadata_;
     std::deque<metadata_node> pieces_needed_;
-    int piece_count_ = 0;
+    int64_t piece_count_ = {};
 
     std::unique_ptr<Mediator> mediator_;
 };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -890,7 +890,7 @@ void tr_torrent::on_metainfo_completed()
         // Potentially, we are in `tr_torrent::init`,
         // and we don't want any file created before `tr_torrent::start`
         // so we Verify but we don't Create files.
-        tr_torrentVerify(this);
+        session->queue_session_thread(tr_torrentVerify, this);
     }
     else
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -904,7 +904,7 @@ void tr_torrent::on_metainfo_completed()
         }
         else if (is_running())
         {
-            tr_torrentStop(this);
+            stop_soon();
         }
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -131,7 +131,7 @@ bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* m
     }
 
     auto error = tr_error{};
-    tr_torrentUseMetainfoFromFile(tor, metainfo, filename, &error);
+    tor->use_metainfo_from_file(metainfo, filename, &error);
     if (error)
     {
         tor->error().set_local_error(fmt::format(

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2693,10 +2693,3 @@ std::vector<time_t> const& tr_torrent::ResumeHelper::file_mtimes() const noexcep
 {
     return tor_.file_mtimes_;
 }
-
-// --- MagnetMediator
-
-std::string tr_torrent::MagnetMediator::log_name() const noexcept
-{
-    return tor_.name();
-}

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2693,3 +2693,10 @@ std::vector<time_t> const& tr_torrent::ResumeHelper::file_mtimes() const noexcep
 {
     return tor_.file_mtimes_;
 }
+
+// --- MagnetMediator
+
+std::string tr_torrent::MagnetMediator::log_name() const noexcept
+{
+    return tor_.name();
+}

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1315,7 +1315,7 @@ tr_stat tr_torrent::stats() const
     stats.pieceDownloadSpeed_KBps = piece_download_speed.count(Speed::Units::KByps);
 
     stats.percentComplete = this->completion_.percent_complete();
-    stats.metadataPercentComplete = tr_torrentGetMetadataPercent(this);
+    stats.metadataPercentComplete = get_metadata_percent();
 
     stats.percentDone = this->completion_.percent_done();
     stats.leftUntilDone = this->completion_.left_until_done();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -624,7 +624,7 @@ struct tr_torrent final : public tr_completion::torrent_view
 
     void set_metadata_piece(int piece, void const* data, size_t len);
 
-    std::optional<int> get_next_metadata_request(time_t now) noexcept;
+    [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
 
     double get_metadata_percent() const noexcept;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -609,6 +609,8 @@ public:
 
     [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int piece) const;
 
+    void set_metadata_piece(int piece, void const* data, size_t len);
+
     ///
 
     [[nodiscard]] tr_stat stats() const;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -613,6 +613,8 @@ public:
 
     std::optional<int> get_next_metadata_request(time_t now) noexcept;
 
+    double get_metadata_percent() const noexcept;
+
     ///
 
     [[nodiscard]] tr_stat stats() const;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -974,11 +974,6 @@ struct tr_torrent final : public tr_completion::torrent_view
     CumulativeCount bytes_downloaded_;
     CumulativeCount bytes_uploaded_;
 
-    /* Used when the torrent has been created with a magnet link
-     * and we're in the process of downloading the metainfo from
-     * other peers */
-    std::unique_ptr<tr_incomplete_metadata> incomplete_metadata;
-
     tr_session* session = nullptr;
 
     tr_torrent_announcer* torrent_announcer = nullptr;
@@ -1291,6 +1286,11 @@ private:
     labels_t labels_;
 
     tr_torrent_metainfo metainfo_;
+
+    /* Used when the torrent has been created with a magnet link
+     * and we're in the process of downloading the metainfo from
+     * other peers */
+    std::unique_ptr<tr_incomplete_metadata> incomplete_metadata_;
 
     tr_bandwidth bandwidth_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -148,7 +148,6 @@ struct tr_torrent final : public tr_completion::torrent_view
         uint64_t cur_ = {};
     };
 
-public:
     using labels_t = std::vector<tr_interned_string>;
 
     using VerifyDoneCallback = std::function<void(tr_torrent*)>;
@@ -174,6 +173,20 @@ public:
     private:
         tr_torrent* const tor_;
         std::optional<time_t> time_started_;
+    };
+
+    class MagnetMediator : public tr_incomplete_metadata::Mediator
+    {
+    public:
+        explicit MagnetMediator(tr_torrent const& tor)
+            : tor_{ tor }
+        {
+        }
+
+        [[nodiscard]] std::string log_name() const noexcept override;
+
+    private:
+        tr_torrent const& tor_;
     };
 
     // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -607,6 +607,8 @@ public:
 
     void maybe_start_metadata_transfer(int64_t size) noexcept;
 
+    [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int piece) const;
+
     ///
 
     [[nodiscard]] tr_stat stats() const;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -603,6 +603,10 @@ public:
 
     [[nodiscard]] bool ensure_piece_is_checked(tr_piece_index_t piece);
 
+    /// METAINFO - MAGNET
+
+    void maybe_start_metadata_transfer(int64_t size) noexcept;
+
     ///
 
     [[nodiscard]] tr_stat stats() const;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -620,11 +620,11 @@ struct tr_torrent final : public tr_completion::torrent_view
 
     void maybe_start_metadata_transfer(int64_t size) noexcept;
 
-    [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int piece) const;
+    [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int64_t piece) const;
 
-    void set_metadata_piece(int piece, void const* data, size_t len);
+    void set_metadata_piece(int64_t piece, void const* data, size_t len);
 
-    [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
+    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -175,7 +175,7 @@ struct tr_torrent final : public tr_completion::torrent_view
         std::optional<time_t> time_started_;
     };
 
-    class MagnetMediator : public tr_incomplete_metadata::Mediator
+    class MagnetMediator : public tr_metadata_download::Mediator
     {
     public:
         explicit MagnetMediator(tr_torrent const& tor)
@@ -1290,7 +1290,7 @@ private:
     /* Used when the torrent has been created with a magnet link
      * and we're in the process of downloading the metainfo from
      * other peers */
-    std::unique_ptr<tr_incomplete_metadata> incomplete_metadata_;
+    std::unique_ptr<tr_metadata_download> metadata_download_;
 
     tr_bandwidth bandwidth_;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -611,6 +611,8 @@ public:
 
     void set_metadata_piece(int piece, void const* data, size_t len);
 
+    std::optional<int> get_next_metadata_request(time_t now) noexcept;
+
     ///
 
     [[nodiscard]] tr_stat stats() const;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1261,7 +1261,7 @@ private:
     void create_empty_files() const;
     void recheck_completeness();
 
-    bool use_new_metainfo(tr_error* error);
+    [[nodiscard]] bool use_new_metainfo(tr_error* error);
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -175,20 +175,6 @@ struct tr_torrent final : public tr_completion::torrent_view
         std::optional<time_t> time_started_;
     };
 
-    class MagnetMediator : public tr_metadata_download::Mediator
-    {
-    public:
-        explicit MagnetMediator(tr_torrent const& tor)
-            : tor_{ tor }
-        {
-        }
-
-        [[nodiscard]] std::string log_name() const noexcept override;
-
-    private:
-        tr_torrent const& tor_;
-    };
-
     // ---
 
     explicit tr_torrent(tr_torrent_metainfo&& tm)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -969,6 +969,7 @@ public:
     time_t lpdAnnounceAt = 0;
 
 private:
+    friend bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* metainfo, char const* filename);
     friend tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file);
     friend tr_stat const* tr_torrentStat(tr_torrent* tor);
     friend tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
@@ -1205,6 +1206,8 @@ private:
     {
         return fpm_.byte_span_for_file(file);
     }
+
+    bool use_metainfo_from_file(tr_torrent_metainfo const* metainfo, char const* filename, tr_error* error);
 
     // ---
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1252,6 +1252,7 @@ private:
 
     void on_metainfo_updated();
     void on_metainfo_completed();
+    void on_have_all_metainfo();
     void on_piece_completed(tr_piece_index_t piece);
     void on_piece_failed(tr_piece_index_t piece);
     void on_file_completed(tr_file_index_t file);
@@ -1259,6 +1260,8 @@ private:
 
     void create_empty_files() const;
     void recheck_completeness();
+
+    bool use_new_metainfo(tr_error* error);
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -626,7 +626,7 @@ struct tr_torrent final : public tr_completion::torrent_view
 
     [[nodiscard]] std::optional<int> get_next_metadata_request(time_t now) noexcept;
 
-    double get_metadata_percent() const noexcept;
+    [[nodiscard]] double get_metadata_percent() const noexcept;
 
     ///
 

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -383,7 +383,7 @@ protected:
         // 1048576 files-filled-with-zeroes/1048576
         //    4096 files-filled-with-zeroes/4096
         //     512 files-filled-with-zeroes/512
-        char const* benc_base64 =
+        static auto constexpr BencBase64 =
             "ZDg6YW5ub3VuY2UzMTpodHRwOi8vd3d3LmV4YW1wbGUuY29tL2Fubm91bmNlMTA6Y3JlYXRlZCBi"
             "eTI1OlRyYW5zbWlzc2lvbi8yLjYxICgxMzQwNykxMzpjcmVhdGlvbiBkYXRlaTEzNTg3MDQwNzVl"
             "ODplbmNvZGluZzU6VVRGLTg0OmluZm9kNTpmaWxlc2xkNjpsZW5ndGhpMTA0ODU3NmU0OnBhdGhs"
@@ -404,7 +404,7 @@ protected:
             "OnByaXZhdGVpMGVlZQ==";
 
         // create the torrent ctor
-        auto const benc = tr_base64_decode(benc_base64);
+        auto const benc = tr_base64_decode(BencBase64);
         EXPECT_LT(0U, std::size(benc));
         auto* ctor = tr_ctorNew(session_);
         auto error = tr_error{};
@@ -444,6 +444,20 @@ protected:
         }
 
         auto* const tor = createTorrentAndWaitForVerifyDone(ctor);
+        tr_ctorFree(ctor);
+        return tor;
+    }
+
+    [[nodiscard]] tr_torrent* zeroTorrentMagnetInit()
+    {
+        static auto constexpr V1Hash = "fa5794674a18241bec985ddc3390e3cb171345e4";
+
+        auto ctor = tr_ctorNew(session_);
+        ctor->set_metainfo_from_magnet_link(V1Hash);
+        tr_ctorSetPaused(ctor, TR_FORCE, true);
+
+        auto* const tor = tr_torrentNew(ctor, nullptr);
+        EXPECT_NE(nullptr, tor);
         tr_ctorFree(ctor);
         return tor;
     }

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -72,16 +72,19 @@ TEST_F(TorrentMagnetTest, setMetadataPiece)
     auto* const tor = zeroTorrentMagnetInit();
     EXPECT_NE(nullptr, tor);
     EXPECT_FALSE(tor->has_metainfo());
+    session_->run_in_session_thread(
+        [tor]()
+        {
+            auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
+            auto const metainfo_size = std::size(metainfo_benc);
+            EXPECT_LE(metainfo_size, MetadataPieceSize);
 
-    auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
-    auto const metainfo_size = std::size(metainfo_benc);
-    EXPECT_LE(metainfo_size, MetadataPieceSize);
-    tor->maybe_start_metadata_transfer(metainfo_size);
-    tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
-
-    EXPECT_TRUE(tor->has_metainfo());
-    EXPECT_EQ(tor->info_dict_size(), metainfo_size);
-    EXPECT_EQ(tor->get_metadata_percent(), 1.0);
+            tor->maybe_start_metadata_transfer(metainfo_size);
+            tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
+            EXPECT_TRUE(tor->has_metainfo());
+            EXPECT_EQ(tor->info_dict_size(), metainfo_size);
+            EXPECT_EQ(tor->get_metadata_percent(), 1.0);
+        });
 }
 
 } // namespace libtransmission::test

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -28,16 +28,16 @@ TEST_F(TorrentMagnetTest, getMetadataPiece)
     };
     auto piece = int{ 0 };
     auto info_dict_size = size_t{ 0U };
-    auto data = tr_metadata_piece{};
     for (;;)
     {
-        if (!tr_torrentGetMetadataPiece(tor, piece++, data))
+        auto data = tor->get_metadata_piece(piece++);
+        if (!data)
         {
             break;
         }
 
-        benc.append(reinterpret_cast<char const*>(std::data(data)), std::size(data));
-        info_dict_size += std::size(data);
+        benc.append(reinterpret_cast<char const*>(std::data(*data)), std::size(*data));
+        info_dict_size += std::size(*data);
     }
     benc.append("e");
     EXPECT_EQ(tor->info_dict_size(), info_dict_size);

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -72,19 +72,16 @@ TEST_F(TorrentMagnetTest, setMetadataPiece)
     auto* const tor = zeroTorrentMagnetInit();
     EXPECT_NE(nullptr, tor);
     EXPECT_FALSE(tor->has_metainfo());
-    session_->run_in_session_thread(
-        [tor]()
-        {
-            auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
-            auto const metainfo_size = std::size(metainfo_benc);
-            EXPECT_LE(metainfo_size, MetadataPieceSize);
 
-            tor->maybe_start_metadata_transfer(metainfo_size);
-            tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
-            EXPECT_TRUE(tor->has_metainfo());
-            EXPECT_EQ(tor->info_dict_size(), metainfo_size);
-            EXPECT_EQ(tor->get_metadata_percent(), 1.0);
-        });
+    auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
+    auto const metainfo_size = std::size(metainfo_benc);
+    EXPECT_LE(metainfo_size, MetadataPieceSize);
+    tor->maybe_start_metadata_transfer(metainfo_size);
+    tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
+
+    EXPECT_TRUE(tor->has_metainfo());
+    EXPECT_EQ(tor->info_dict_size(), metainfo_size);
+    EXPECT_EQ(tor->get_metadata_percent(), 1.0);
 }
 
 } // namespace libtransmission::test

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -50,4 +50,38 @@ TEST_F(TorrentMagnetTest, getMetadataPiece)
     EXPECT_EQ(tor->piece_hash(0), torrent_metainfo.piece_hash(0));
 }
 
+TEST_F(TorrentMagnetTest, setMetadataPiece)
+{
+    static auto constexpr InfoDictBase64 =
+        "ZDU6ZmlsZXNsZDY6bGVuZ3RoaTEwNDg1NzZlNDpwYXRobDc6MTA0ODU3NmVlZDY6bGVuZ3RoaTQw"
+        "OTZlNDpwYXRobDQ6NDA5NmVlZDY6bGVuZ3RoaTUxMmU0OnBhdGhsMzo1MTJlZWU0Om5hbWUyNDpm"
+        "aWxlcy1maWxsZWQtd2l0aC16ZXJvZXMxMjpwaWVjZSBsZW5ndGhpMzI3NjhlNjpwaWVjZXM2NjA6"
+        "UYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv1726aj/wpP"
+        "1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv1726aj"
+        "/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv17"
+        "26aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGEx"
+        "Uv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJ"
+        "tGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GI"
+        "QxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZC"
+        "S1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8K"
+        "T9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9um"
+        "o/8KT9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9"
+        "e9umo/8KT9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRh"
+        "MVL9e9umo/8KT9ZCSzpX+QPk899JzAVbjTNoaVd8IP9dNzpwcml2YXRlaTBlZQ==";
+
+    auto* const tor = zeroTorrentMagnetInit();
+    EXPECT_NE(nullptr, tor);
+    EXPECT_FALSE(tor->has_metainfo());
+
+    auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
+    auto const metainfo_size = std::size(metainfo_benc);
+    EXPECT_LE(metainfo_size, MetadataPieceSize);
+    tor->maybe_start_metadata_transfer(metainfo_size);
+    tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
+
+    EXPECT_TRUE(tor->has_metainfo());
+    EXPECT_EQ(tor->info_dict_size(), metainfo_size);
+    EXPECT_EQ(tor->get_metadata_percent(), 1.0);
+}
+
 } // namespace libtransmission::test


### PR DESCRIPTION
2 commit containing minor functional changes:
- `refactor: unset peer BEP-9 support if size hint is invalid`
- `refactor: check metadata transfer completion in set_metadata_piece()`

It's a big refactor, so some help on spotting regressions and comments about how to improve code organisation is welcomed.