### PR TITLE
Harden systemd service

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -52,4 +52,10 @@ foreach(P daemon)
             FILES ${TR_NAME}-${P}.1
             DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
     endif()
+
+    if (WITH_SYSTEMD)
+        install(
+            FILES ${TR_NAME}-${P}.service
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+    endif()
 endforeach()

--- a/daemon/transmission-daemon.service
+++ b/daemon/transmission-daemon.service
@@ -8,10 +8,31 @@ User=transmission
 Type=notify
 ExecStart=/usr/bin/transmission-daemon -f --log-level=error
 ExecReload=/bin/kill -s HUP $MAINPID
+
+# Hardening
+CapabilityBoundingSet=
+DevicePolicy=closed
+KeyringMode=private
+LockPersonality=true
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true
-ProtectSystem=true
 PrivateTmp=true
+PrivateDevices=true
+ProtectClock=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectSystem=true
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictRealtime=true
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
See the commit message for the rationale. Fedora 40 is also looking to do [something similar](https://fedoraproject.org/wiki/Changes/SystemdSecurityHardening).

I have personally been running my daemon, with 1000+ torrents, for weeks without this blocking or preventing anything. I think this should also be distro-agnostic, but if anyone wants to attempt to test this on their own installs, you can do
```sh
systemctl edit transmission-daemon.service
# copy and paste the lines, no daemon-reload required
systemctl restart transmission-daemon.service
```