### PR TITLE
fix: TeamCity `Illegal instructions` error

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -18,16 +18,6 @@
 
 #include <fmt/core.h>
 
-// RapidJSON SIMD optimisations
-#ifdef __SSE2__
-#define RAPIDJSON_SSE2
-#endif
-#ifdef __SSE4_2__
-#define RAPIDJSON_SSE42
-#endif
-#ifdef __ARM_NEON
-#define RAPIDJSON_NEON
-#endif
 #include <rapidjson/encodedstream.h>
 #include <rapidjson/encodings.h>
 #include <rapidjson/error/en.h>


### PR DESCRIPTION
Fixes this test failure in TeamCity for the new test `TorrentMagnetTest.setMetadataPiece` added in #6383:

```
302/406 Test #302: LT.TorrentMagnetTest.setMetadataPiece ............................................................................................................***Exception: Illegal  0.67 sec
Running main() from ../../../third-party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = TorrentMagnetTest.setMetadataPiece
```