### PR TITLE
fix: allow aborting torrent verify mid-way again

### DIFF
--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -34,7 +34,7 @@ auto constexpr SleepPerSecondDuringVerify = 100ms;
 }
 } // namespace
 
-void tr_verify_worker::verify_torrent(Mediator& verify_mediator, bool const abort_flag)
+void tr_verify_worker::verify_torrent(Mediator& verify_mediator, std::atomic<bool> const& abort_flag)
 {
     verify_mediator.on_verify_started();
 

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -72,7 +72,7 @@ private:
         tr_priority_t priority_;
     };
 
-    static void verify_torrent(Mediator& verify_mediator, bool abort_flag);
+    static void verify_torrent(Mediator& verify_mediator, std::atomic<bool> const& abort_flag);
 
     void verify_thread_func();
 


### PR DESCRIPTION
This should fix the test failure at https://github.com/transmission/transmission/actions/runs/7237936380/job/19718165673. Since this is a previous regression that is not related to the PR that triggered the failed test, I have separated this fix out to its own PR.

Regression from ed4fad9b1868bbdddfe58d4aaf55032ba3eac70a.