### PR TITLE
fix: gcc-13 warnings pt. 2

### DIFF
--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -725,24 +725,25 @@ bool FileList::Impl::onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel:
 
         if (cid == file_cols.priority.index())
         {
-            auto priority = iter->get_value(file_cols.priority);
+            auto const old_priority = iter->get_value(file_cols.priority);
+            auto new_priority = TR_PRI_NORMAL;
 
-            switch (priority)
+            switch (old_priority)
             {
             case TR_PRI_NORMAL:
-                priority = TR_PRI_HIGH;
+                new_priority = TR_PRI_HIGH;
                 break;
 
             case TR_PRI_HIGH:
-                priority = TR_PRI_LOW;
+                new_priority = TR_PRI_LOW;
                 break;
 
             default:
-                priority = TR_PRI_NORMAL;
+                new_priority = TR_PRI_NORMAL;
                 break;
             }
 
-            tr_torrentSetFilePriorities(tor, indexBuf.data(), indexBuf.size(), priority);
+            tr_torrentSetFilePriorities(tor, indexBuf.data(), indexBuf.size(), new_priority);
         }
         else
         {

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -118,7 +118,7 @@ void OptionsDialog::Impl::addResponseCB(int response)
     {
         if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
         {
-            tr_torrentSetPriority(tor_, gtr_combo_box_get_active_enum(*priority_combo_));
+            tr_torrentSetPriority(tor_, static_cast<tr_priority_t>(gtr_combo_box_get_active_enum(*priority_combo_)));
 
             if (run_check_->get_active())
             {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -242,6 +242,7 @@ struct tr_address
     } addr;
 
     static auto constexpr CompactAddrBytes = std::array{ 4U, 16U };
+    static auto constexpr CompactAddrMaxBytes = 16U;
     static_assert(std::size(CompactAddrBytes) == NUM_TR_AF_INET_TYPES);
 
     [[nodiscard]] static auto any(tr_address_type type) noexcept

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -729,9 +729,9 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
     }
 
     if ((fields_to_load & tr_resume::BandwidthPriority) != 0 && tr_variantDictFindInt(&top, TR_KEY_bandwidth_priority, &i) &&
-        tr_isPriority(i))
+        tr_isPriority(static_cast<tr_priority_t>(i)))
     {
-        tr_torrentSetPriority(tor, i);
+        tr_torrentSetPriority(tor, static_cast<tr_priority_t>(i));
         fields_loaded |= tr_resume::BandwidthPriority;
     }
 

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -164,8 +164,8 @@ bool tr_spawn_async(
 
         if (!tr_spawn_async_in_child(cmd, env, work_dir))
         {
-            (void)write(pipe_fds[1], &errno, sizeof(errno));
-            _exit(0);
+            auto const ok = write(pipe_fds[1], &errno, sizeof(errno)) != -1;
+            _exit(ok ? EXIT_SUCCESS : EXIT_FAILURE);
         }
     }
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -53,8 +53,6 @@ struct tr_torrent;
 struct tr_torrent_metainfo;
 struct tr_variant;
 
-using tr_priority_t = int8_t;
-
 #define TR_RPC_SESSION_ID_HEADER "X-Transmission-Session-Id"
 
 enum tr_verify_added_mode
@@ -72,6 +70,13 @@ enum tr_encryption_mode
     TR_CLEAR_PREFERRED,
     TR_ENCRYPTION_PREFERRED,
     TR_ENCRYPTION_REQUIRED
+};
+
+enum tr_priority_t : int8_t
+{
+    TR_PRI_LOW = -1,
+    TR_PRI_NORMAL = 0, /* since Normal is 0, memset initializes nicely */
+    TR_PRI_HIGH = 1
 };
 
 #define TR_RATIO_NA (-1)
@@ -1009,13 +1014,6 @@ uint16_t tr_torrentGetPeerLimit(tr_torrent const* tor);
 void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers);
 
 // --- File Priorities
-
-enum : tr_priority_t
-{
-    TR_PRI_LOW = -1,
-    TR_PRI_NORMAL = 0, /* since Normal is 0, memset initializes nicely */
-    TR_PRI_HIGH = 1
-};
 
 /**
  * @brief Set a batch of files to a particular priority.

--- a/macosx/FilePriorityCell.mm
+++ b/macosx/FilePriorityCell.mm
@@ -47,7 +47,7 @@ static CGFloat const kImageOverlap = 1.0;
     [super setSelected:flag forSegment:segment];
 
     //only for when clicking manually
-    NSInteger priority;
+    tr_priority_t priority;
     switch (segment)
     {
     case 0:

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -2,6 +2,14 @@ set(GTEST_ROOT_DIR ${TR_THIRD_PARTY_SOURCE_DIR}/googletest/googletest)
 
 add_library(gtestall STATIC)
 
+# GTest 1.12 triggers nullptr warnings in gcc 13
+set(CACHE_ID "${CMAKE_CXX_COMPILER_ID}_CXX_HAS-Wnull-dereference")
+string(TOLOWER "${CACHE_ID}" CACHE_ID)
+check_c_compiler_flag(-Wnull-dereference ${CACHE_ID})
+if(${CACHE_ID})
+    target_compile_options(gtestall PRIVATE -Wno-null-dereference)
+endif()
+
 target_sources(gtestall
     PRIVATE
         ${GTEST_ROOT_DIR}/src/gtest-all.cc

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -71,7 +71,7 @@ TEST_F(NetTest, compact4)
     EXPECT_EQ(ExpectedPort, port);
 
     // ...serialize it back again
-    auto buf = std::array<std::byte, 64U>{};
+    auto buf = std::array<std::byte, tr_address::CompactAddrMaxBytes>{};
     auto out = std::data(buf);
     out = socket_address.to_compact(out);
     EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(buf)));


### PR DESCRIPTION
Fix some warnings generated when building with g++-13.