### PR TITLE
fix: mark torrent as changed when stopping

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -753,6 +753,7 @@ void tr_torrent::stop_now()
 
     is_running_ = false;
     is_stopping_ = false;
+    mark_changed();
 
     if (!session->isClosing())
     {


### PR DESCRIPTION
Fixes #6403.

Notes: Fixed `4.0.0` bugs where some RPC methods don't put torrents in `recently-active` anymore.