### PR TITLE
refactor: allow explicitly queuing functions in session thread

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -759,7 +759,7 @@ void tr_rpc_server::set_enabled(bool is_enabled)
 {
     is_enabled_ = is_enabled;
 
-    session->runInSessionThread(
+    session->run_in_session_thread(
         [this]()
         {
             if (!is_enabled_)
@@ -784,7 +784,7 @@ void tr_rpc_server::set_port(tr_port port) noexcept
 
     if (is_enabled())
     {
-        session->runInSessionThread(&restart_server, this);
+        session->run_in_session_thread(&restart_server, this);
     }
 }
 
@@ -894,7 +894,7 @@ void tr_rpc_server::load(tr_variant const& src)
     {
         auto const rpc_uri = bind_address_->to_string(this->port()) + this->url_;
         tr_logAddInfo(fmt::format(_("Serving RPC and Web requests on {address}"), fmt::arg("address", rpc_uri)));
-        session->runInSessionThread(start_server, this);
+        session->run_in_session_thread(start_server, this);
 
         if (this->is_whitelist_enabled())
         {

--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -107,7 +107,7 @@ unsigned long thread_current_id()
     return hashed;
 }
 
-void initEvthreadsOnce()
+void init_evthreads_once()
 {
     evthread_lock_callbacks constexpr LockCbs{
         EVTHREAD_LOCK_API_VERSION, EVTHREAD_LOCKTYPE_RECURSIVE, lock_alloc, lock_free, lock_lock, lock_unlock
@@ -126,7 +126,7 @@ void initEvthreadsOnce()
 
 } // namespace tr_evthread_init_helpers
 
-auto makeEventBase()
+auto make_event_base()
 {
     tr_session_thread::tr_evthread_init();
 
@@ -142,7 +142,7 @@ void tr_session_thread::tr_evthread_init()
     using namespace tr_evthread_init_helpers;
 
     static auto evthread_flag = std::once_flag{};
-    std::call_once(evthread_flag, initEvthreadsOnce);
+    std::call_once(evthread_flag, init_evthreads_once);
 }
 
 class tr_session_thread_impl final : public tr_session_thread
@@ -152,7 +152,7 @@ public:
     {
         auto lock = std::unique_lock(is_looping_mutex_);
 
-        thread_ = std::thread(&tr_session_thread_impl::sessionThreadFunc, this, event_base());
+        thread_ = std::thread(&tr_session_thread_impl::session_thread_func, this, event_base());
         thread_id_ = thread_.get_id();
 
         // wait for the session thread's main loop to start
@@ -170,7 +170,7 @@ public:
         TR_ASSERT(is_looping_);
 
         // Stop the first event loop. This is the steady-state loop that runs
-        // continuously, even when there are no events. See: sessionThreadFunc()
+        // continuously, even when there are no events. See: session_thread_func()
         is_shutting_down_ = true;
         event_base_loopexit(event_base(), nullptr);
 
@@ -218,7 +218,7 @@ private:
     using callback = std::function<void(void)>;
     using work_queue_t = std::list<callback>;
 
-    void sessionThreadFunc(struct event_base* evbase)
+    void session_thread_func(struct event_base* evbase)
     {
 #ifndef _WIN32
         /* Don't exit when writing on a broken socket */
@@ -252,11 +252,11 @@ private:
         ToggleLooping({}, {}, this);
     }
 
-    static void onWorkAvailableStatic(evutil_socket_t /*fd*/, short /*flags*/, void* vself)
+    static void on_work_available_static(evutil_socket_t /*fd*/, short /*flags*/, void* vself)
     {
-        static_cast<tr_session_thread_impl*>(vself)->onWorkAvailable();
+        static_cast<tr_session_thread_impl*>(vself)->on_work_available();
     }
-    void onWorkAvailable()
+    void on_work_available()
     {
         TR_ASSERT(am_in_session_thread());
 
@@ -273,9 +273,9 @@ private:
         }
     }
 
-    libtransmission::evhelpers::evbase_unique_ptr const evbase_{ makeEventBase() };
+    libtransmission::evhelpers::evbase_unique_ptr const evbase_{ make_event_base() };
     libtransmission::evhelpers::event_unique_ptr const work_queue_event_{
-        event_new(evbase_.get(), -1, 0, onWorkAvailableStatic, this)
+        event_new(evbase_.get(), -1, 0, on_work_available_static, this)
     };
 
     work_queue_t work_queue_;

--- a/libtransmission/session-thread.h
+++ b/libtransmission/session-thread.h
@@ -28,15 +28,19 @@ public:
 
     [[nodiscard]] virtual bool am_in_session_thread() const noexcept = 0;
 
+    virtual void queue(std::function<void(void)>&& func) = 0;
+
     virtual void run(std::function<void(void)>&& func) = 0;
+
+    template<typename Func, typename... Args>
+    void queue(Func&& func, Args&&... args)
+    {
+        queue(std::function<void(void)>{ std::bind(std::forward<Func>(func), std::forward<Args>(args)...) });
+    }
 
     template<typename Func, typename... Args>
     void run(Func&& func, Args&&... args)
     {
-        run(std::function<void(void)>{
-            [func = std::forward<Func&&>(func), args = std::make_tuple(std::forward<Args>(args)...)]()
-            {
-                std::apply(std::move(func), std::move(args));
-            } });
+        run(std::function<void(void)>{ std::bind(std::forward<Func>(func), std::forward<Args>(args)...) });
     }
 };

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -366,15 +366,16 @@ public:
         return session_thread_->am_in_session_thread();
     }
 
-    void runInSessionThread(std::function<void(void)>&& func)
+    template<typename Func, typename... Args>
+    void queueSessionThread(Func&& func, Args&&... args)
     {
-        session_thread_->run(std::move(func));
+        session_thread_->queue(std::forward<Func>(func), std::forward<Args>(args)...);
     }
 
     template<typename Func, typename... Args>
     void runInSessionThread(Func&& func, Args&&... args)
     {
-        session_thread_->run(std::forward<Func&&>(func), std::forward<Args>(args)...);
+        session_thread_->run(std::forward<Func>(func), std::forward<Args>(args)...);
     }
 
     [[nodiscard]] auto* event_base() noexcept

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -367,13 +367,13 @@ public:
     }
 
     template<typename Func, typename... Args>
-    void queueSessionThread(Func&& func, Args&&... args)
+    void queue_session_thread(Func&& func, Args&&... args)
     {
         session_thread_->queue(std::forward<Func>(func), std::forward<Args>(args)...);
     }
 
     template<typename Func, typename... Args>
-    void runInSessionThread(Func&& func, Args&&... args)
+    void run_in_session_thread(Func&& func, Args&&... args)
     {
         session_thread_->run(std::forward<Func>(func), std::forward<Args>(args)...);
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -710,7 +710,7 @@ void tr_torrent::start(bool bypass_queue, std::optional<bool> has_any_local_data
 
     is_running_ = true;
     set_dirty();
-    session->runInSessionThread([this]() { start_in_session_thread(); });
+    session->run_in_session_thread([this]() { start_in_session_thread(); });
 }
 
 void tr_torrent::start_in_session_thread()
@@ -786,7 +786,7 @@ void tr_torrentStop(tr_torrent* tor)
 
     tor->start_when_stable_ = false;
     tor->set_dirty();
-    tor->session->runInSessionThread([tor]() { tor->stop_now(); });
+    tor->session->run_in_session_thread([tor]() { tor->stop_now(); });
 }
 
 void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func, void* user_data)
@@ -797,7 +797,7 @@ void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_fileFunc delete_func
 
     tor->is_deleting_ = true;
 
-    tor->session->runInSessionThread(removeTorrentInSessionThread, tor, delete_flag, delete_func, user_data);
+    tor->session->run_in_session_thread(removeTorrentInSessionThread, tor, delete_flag, delete_func, user_data);
 }
 
 void tr_torrentFreeInSessionThread(tr_torrent* tor)
@@ -1175,8 +1175,8 @@ void tr_torrent::set_location(std::string_view location, bool move_from_old_path
         *setme_state = TR_LOC_MOVING;
     }
 
-    session->runInSessionThread([this, loc = std::string(location), move_from_old_path, setme_state]()
-                                { set_location_in_session_thread(loc, move_from_old_path, setme_state); });
+    session->run_in_session_thread([this, loc = std::string(location), move_from_old_path, setme_state]()
+                                   { set_location_in_session_thread(loc, move_from_old_path, setme_state); });
 }
 
 void tr_torrentSetLocation(tr_torrent* tor, char const* location, bool move_from_old_path, int volatile* setme_state)
@@ -1263,7 +1263,7 @@ void tr_torrentManualUpdate(tr_torrent* tor)
 
     TR_ASSERT(tr_isTorrent(tor));
 
-    tor->session->runInSessionThread(torrentManualUpdateImpl, tor);
+    tor->session->run_in_session_thread(torrentManualUpdateImpl, tor);
 }
 
 bool tr_torrentCanManualUpdate(tr_torrent const* tor)
@@ -1539,7 +1539,7 @@ void tr_torrentStartNow(tr_torrent* tor)
 
 void tr_torrentVerify(tr_torrent* tor)
 {
-    tor->session->runInSessionThread(
+    tor->session->run_in_session_thread(
         [tor]()
         {
             TR_ASSERT(tor->session->am_in_session_thread());
@@ -1646,7 +1646,7 @@ void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 
     if (!aborted && !tor_->is_deleting_)
     {
-        tor_->session->runInSessionThread(
+        tor_->session->run_in_session_thread(
             [tor = tor_]()
             {
                 if (tor->is_deleting_)
@@ -2493,7 +2493,7 @@ void tr_torrent::rename_path(
     tr_torrent_rename_done_func callback,
     void* callback_user_data)
 {
-    this->session->runInSessionThread(
+    this->session->run_in_session_thread(
         [this, oldpath = std::string(oldpath), newname = std::string(newname), callback, callback_user_data]()
         { rename_path_in_session_thread(oldpath, newname, callback, callback_user_data); });
 }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -386,7 +386,7 @@ void useFetchedBlocks(tr_webseed_task* task)
             auto block_buf = std::make_unique<Cache::BlockData>(block_size);
             evbuffer_remove(task->content(), std::data(*block_buf), std::size(*block_buf));
             auto* const data = new write_block_data{ session, tor->id(), task->loc.block, std::move(block_buf), webseed };
-            session->runInSessionThread(&write_block_data::write_block_func, data);
+            session->run_in_session_thread(&write_block_data::write_block_func, data);
         }
 
         task->loc = tor->byte_loc(task->loc.byte + block_size);

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -106,7 +106,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
             std::fill_n(std::data(*data.buf), tr_block_info::BlockSize, '\0');
             data.block = block_index;
             data.done = false;
-            session_->runInSessionThread(test_incomplete_dir_threadfunc, &data);
+            session_->run_in_session_thread(test_incomplete_dir_threadfunc, &data);
 
             auto const test = [&data]()
             {


### PR DESCRIPTION
This PR allows code that is running in the session thread to queue functions to the session thread instead of executing them immediately.

This removes the need for the `tr_torrentMagnetDoIdleWork()` indirection step, see https://github.com/transmission/transmission/pull/6383#discussion_r1429202253 for more details about this topic.

A patch to demonstrate how this can be done after this PR and #6383 are merged (already tested):

<details>
<summary>patch</summary>

```patch
From 1351cd07a168daa64c8e50219a32b7891ad5b6ad Mon Sep 17 00:00:00 2001
From: Yat Ho <lagoho7@gmail.com>
Date: Mon, 18 Dec 2023 15:13:54 +0800
Subject: [PATCH] refactor: check metadata transfer completion in
 `set_metadata_piece()`

---
 libtransmission/peer-mgr.cc       |  1 -
 libtransmission/torrent-magnet.cc | 24 +++++++++---------------
 libtransmission/torrent-magnet.h  |  2 +-
 libtransmission/torrent.cc        |  2 +-
 libtransmission/torrent.h         |  2 --
 5 files changed, 11 insertions(+), 20 deletions(-)

diff --git a/libtransmission/peer-mgr.cc b/libtransmission/peer-mgr.cc
index 503ef774b7..d30727b0b9 100644
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2256,7 +2256,6 @@ void tr_peerMgr::bandwidth_pulse()
     for (auto* const tor : torrents_)
     {
         tor->do_idle_work();
-        tor->do_magnet_idle_work();
     }
 
     reconnect_pulse();
diff --git a/libtransmission/torrent-magnet.cc b/libtransmission/torrent-magnet.cc
index a50784bb74..a0a8170905 100644
--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -262,29 +262,20 @@ void tr_torrent::on_have_all_metainfo()
     m.reset();
 }
 
-void tr_torrent::do_magnet_idle_work()
-{
-    if (auto& m = metadata_download_; m && m->is_all_pieces_downloaded())
-    {
-        tr_logAddDebugTor(this, fmt::format("we now have all the metainfo!"));
-        on_have_all_metainfo();
-    }
-}
-
-void tr_metadata_download::set_metadata_piece(int64_t const piece, void const* const data, size_t const len)
+bool tr_metadata_download::set_metadata_piece(int64_t const piece, void const* const data, size_t const len)
 {
     TR_ASSERT(data != nullptr);
 
     // sanity test: is `piece` in range?
     if (piece < 0 || piece >= piece_count_)
     {
-        return;
+        return false;
     }
 
     // sanity test: is `len` the right size?
     if (get_piece_length(piece) != len)
     {
-        return;
+        return false;
     }
 
     // do we need this piece?
@@ -295,7 +286,7 @@ void tr_metadata_download::set_metadata_piece(int64_t const piece, void const* c
         [piece](auto const& item) { return item.piece == piece; });
     if (iter == std::end(needed))
     {
-        return;
+        return false;
     }
 
     auto const offset = piece * MetadataPieceSize;
@@ -303,6 +294,8 @@ void tr_metadata_download::set_metadata_piece(int64_t const piece, void const* c
 
     needed.erase(iter);
     tr_logAddDebugMagnet(this, fmt::format("saving metainfo piece {}... {} remain", piece, std::size(needed)));
+
+    return std::empty(needed);
 }
 
 void tr_torrent::set_metadata_piece(int64_t const piece, void const* const data, size_t const len)
@@ -311,9 +304,10 @@ void tr_torrent::set_metadata_piece(int64_t const piece, void const* const data,
 
     tr_logAddDebugTor(this, fmt::format("got metadata piece {} of {} bytes", piece, len));
 
-    if (auto& m = metadata_download_; m)
+    if (auto& m = metadata_download_; m && m->set_metadata_piece(piece, data, len))
     {
-        m->set_metadata_piece(piece, data, len);
+        tr_logAddDebugTor(this, fmt::format("we now have all the metainfo!"));
+        on_have_all_metainfo();
     }
 }
 
diff --git a/libtransmission/torrent-magnet.h b/libtransmission/torrent-magnet.h
index bea91a0845..68fe74bd2a 100644
--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -51,7 +51,7 @@ class tr_metadata_download
         return std::empty(pieces_needed_);
     }
 
-    void set_metadata_piece(int64_t piece, void const* data, size_t len);
+    bool set_metadata_piece(int64_t piece, void const* data, size_t len);
 
     [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
 
diff --git a/libtransmission/torrent.cc b/libtransmission/torrent.cc
index 61ae697f54..18e4ba61e5 100644
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -889,7 +889,7 @@ void tr_torrent::on_metainfo_completed()
         // Potentially, we are in `tr_torrent::init`,
         // and we don't want any file created before `tr_torrent::start`
         // so we Verify but we don't Create files.
-        tr_torrentVerify(this);
+        session->queue_session_thread(tr_torrentVerify, this);
     }
     else
     {
diff --git a/libtransmission/torrent.h b/libtransmission/torrent.h
index 3f68a54bef..d35273be1a 100644
--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -614,8 +614,6 @@ struct tr_torrent final : public tr_completion::torrent_view
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 
-    void do_magnet_idle_work();
-
     ///
 
     [[nodiscard]] tr_stat stats() const;
```

</details>