### PR TITLE
add user presets to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ compile_commands.json
 
 # CLion IDE build directory
 /cmake-build-*/
+
+# CMake user presets
+CMakeUserPresets.json


### PR DESCRIPTION
Separated out from #6401 since it's simple. See https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html for more info. Note that even though presets require 3.19, it is not required that `cmake_minimum_version()` be 3.19, just that the actual cmake binary be that version. 