### PR TITLE
fix: esbuild load `svg` and `png` as `dataurl` type

### DIFF
--- a/web/esbuild.mjs
+++ b/web/esbuild.mjs
@@ -7,8 +7,8 @@ const ctx = await esbuild.context({
   entryPoints: ['./src/main.js'],
   legalComments: 'external',
   loader: {
-    '.png': 'binary',
-    '.svg': 'binary' },
+    '.png': 'dataurl',
+    '.svg': 'dataurl' },
   minify: true,
   outfile: './public_html/transmission-app.js',
   plugins: [sassPlugin()],


### PR DESCRIPTION
Fixes #6362.

https://esbuild.github.io/content-types/#data-url

Notes: Fixed `4.0.5` bug where svg and png icons in the WebUI might not be displayed.