### PR TITLE
Fix libtransmission build on very old cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -12,7 +12,7 @@ check_symbol_exists(SO_REUSEPORT "sys/types.h;sys/socket.h" HAVE_SO_REUSEPORT)
 
 add_compile_options(
     # equivalent of XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES for this directory
-    $<$<AND:$<BOOL:${APPLE}>,$<CXX_COMPILER_ID:AppleClang,Clang>,$<COMPILE_LANGUAGE:C,CXX>>:-fobjc-arc>)
+    $<$<AND:$<BOOL:${APPLE}>,$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>,$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>>:-fobjc-arc>)
 
 add_library(${TR_NAME} STATIC)
 


### PR DESCRIPTION
Fix #6415

Would also need to be cherry picked to 4.0.x branch.
Regression was caused by #5632 which uses CXX_COMPILER_ID and COMPILE_LANGUAGE with comma-separated lists, which is only possible since https://cmake.org/cmake/help/v3.15/manual/cmake-generator-expressions.7.html.

Rewriting CXX_COMPILER_ID and COMPILE_LANGUAGE usages to not use comma-separated lists would be a bit complex.
So I prefer to bump cmake minimum requirement.

cmake 3.12 was released on [Nov 30, 2018](https://github.com/Kitware/CMake/releases/tag/v3.12.0)
cmake 3.15 was released on [Jul 17, 2019](https://github.com/Kitware/CMake/releases/tag/v3.15.0)
So the version jump is less than 1 year diff, even though we raised to 3.12 about a year ago, in #4507.