### PR TITLE
fix: update WebUI build instructions to use `dataurl` loader for images

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -25,8 +25,8 @@ $ esbuild \
   --allow-overwrite \
   --bundle \
   --legal-comments=external \
-  --loader:.png=binary \
-  --loader:.svg=binary \
+  --loader:.png=dataurl \
+  --loader:.svg=dataurl \
   --minify \
   --outfile=public_html/transmission-app.js \
   src/main.js


### PR DESCRIPTION
I forgot about these in #6409.

Notes: Fixed `4.0.5` bug where svg and png icons in the WebUI might not be displayed.