### PR TITLE
refactor: reduce utils.h includes

### DIFF
--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -14,7 +14,7 @@
 #include "libtransmission/transmission.h"
 
 #include "libtransmission/interned-string.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/tr-macros.h" // TR_CONSTEXPR20
 #include "libtransmission/variant.h"
 #include "libtransmission/web-utils.h"
 

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -23,6 +23,7 @@
 #include "libtransmission/interned-string.h"
 #include "libtransmission/net.h"
 #include "libtransmission/peer-mgr.h" // tr_pex
+#include "libtransmission/tr-macros.h" // tr_peer_id_t
 
 struct tr_url_parsed_t;
 

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -21,7 +21,6 @@
 #include <fmt/core.h>
 
 #include <libtransmission/file.h>
-#include <libtransmission/utils.h>
 #include <libtransmission/web-utils.h>
 #include <libtransmission/web.h>
 

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -21,7 +21,7 @@
 #include <fmt/core.h>
 
 #include <libtransmission/file.h>
-#include <libtransmission/utils.h.h> // for tr_file_save()
+#include <libtransmission/utils.h> // for tr_file_save()
 #include <libtransmission/web-utils.h>
 #include <libtransmission/web.h>
 

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -21,6 +21,7 @@
 #include <fmt/core.h>
 
 #include <libtransmission/file.h>
+#include <libtransmission/utils.h.h> // for tr_file_save()
 #include <libtransmission/web-utils.h>
 #include <libtransmission/web.h>
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -18,7 +18,6 @@
 
 #include "libtransmission/bitfield.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR20
-#include "libtransmission/utils.h"
 
 struct tr_block_info;
 struct tr_torrent_metainfo;

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -10,6 +10,7 @@
 #include <iterator> // back_insert_iterator, empty
 #include <map>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -193,6 +193,11 @@ std::string tr_magnet_metainfo::magnet() const
     return std::string{ buf.sv() };
 }
 
+void tr_magnet_metainfo::set_name(std::string_view name)
+{
+    name_ = tr_strv_convert_utf8(name);
+}
+
 void tr_magnet_metainfo::add_webseed(std::string_view webseed)
 {
     if (!tr_urlIsValid(webseed))

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -13,7 +13,6 @@
 #include "libtransmission/announce-list.h"
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR20, tr_sha1_digest_t
-#include "libtransmission/utils.h" // tr_strv_convert_utf8()
 
 struct tr_error;
 
@@ -66,10 +65,7 @@ public:
         return info_hash2_str_;
     }
 
-    void set_name(std::string_view name)
-    {
-        name_ = tr_strv_convert_utf8(name);
-    }
+    void set_name(std::string_view name);
 
     void add_webseed(std::string_view webseed);
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -372,6 +372,11 @@ std::string tr_metainfo_builder::benc(tr_error* error) const
     return tr_variant_serde::benc().to_string(tr_variant{ std::move(top) });
 }
 
+bool tr_metainfo_builder::save(std::string_view filename, tr_error* error) const
+{
+    return tr_file_save(filename, benc(error), error);
+}
+
 uint32_t tr_metainfo_builder::default_piece_size(uint64_t total_size) noexcept
 {
     // Ideally, we want approximately 2^10 = 1024 pieces, give or take a few hundred pieces.

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -8,7 +8,6 @@
 #include <cmath>
 #include <ctime> // time()
 #include <iterator>
-#include <optional>
 #include <set>
 #include <string>
 #include <string_view>

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -21,7 +21,6 @@
 #include "libtransmission/file.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR20
-#include "libtransmission/utils.h" // for tr_file_save()
 
 class tr_metainfo_builder
 {
@@ -67,10 +66,7 @@ public:
     [[nodiscard]] std::string benc(tr_error* error = nullptr) const;
 
     // generate the metainfo and save it to a torrent file
-    bool save(std::string_view filename, tr_error* error = nullptr) const
-    {
-        return tr_file_save(filename, benc(error), error);
-    }
+    bool save(std::string_view filename, tr_error* error = nullptr) const;
 
     /// setters
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -61,7 +61,7 @@ using tr_socket_t = int;
 #endif
 
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/utils.h"
+#include "libtransmission/utils.h" // for tr_compare_3way()
 
 /**
  * Literally just a port number.

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -14,6 +14,7 @@
 #include <cstdint> // uintX_t
 #include <deque>
 #include <memory>
+#include <optional>
 #include <utility> // std::pair
 
 #include <event2/util.h> // for evutil_socket_t

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -20,7 +20,6 @@
 
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/torrent.h"
-#include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-macros.h"
 
 struct tr_error;

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -16,6 +16,7 @@
 
 #include "libtransmission/error.h"
 #include "libtransmission/net.h" // tr_socket_t
+#include "libtransmission/tr-assert.h"
 #include "libtransmission/utils.h" // for tr_htonll(), tr_ntohll()
 
 namespace libtransmission

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -17,6 +17,7 @@
 #include "libtransmission/error.h"
 #include "libtransmission/net.h" // tr_socket_t
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/tr-macros.h" // TR_CONSTEXPR
 #include "libtransmission/utils.h" // for tr_htonll(), tr_ntohll()
 
 namespace libtransmission

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -6,9 +6,9 @@
 #pragma once
 
 #include <algorithm> // for std::copy_n
-#include <cstddef>
-#include <iterator>
-#include <limits>
+#include <cstddef> // size_t
+#include <memory> // std::allocator
+#include <ratio>
 #include <string>
 #include <string_view>
 

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <array>
-#include <cstddef> // size_t
 #include <cstdint> // uint32_t
 
 // ---

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -6,7 +6,8 @@
 #pragma once
 
 #include <array>
-#include <cstdint> // uint32_t
+#include <cstddef> // for std::byte
+#include <cstdint> // for uint32_t
 
 // ---
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <algorithm> // for std::for_each()
 #include <cctype>
-#include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <cstddef> // size_t
+#include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <ctime> // time_t
 #include <locale>
 #include <memory>
@@ -16,10 +17,6 @@
 #include <string_view>
 #include <type_traits>
 #include <vector>
-
-#include "libtransmission/tr-macros.h"
-#include "libtransmission/variant.h"
-#include "libtransmission/values.h"
 
 struct tr_error;
 
@@ -310,15 +307,17 @@ constexpr void tr_timeUpdate(time_t now) noexcept
 
 class tr_net_init_mgr
 {
-private:
-    tr_net_init_mgr();
-    TR_DISABLE_COPY_MOVE(tr_net_init_mgr)
-
 public:
     ~tr_net_init_mgr();
     static std::unique_ptr<tr_net_init_mgr> create();
 
 private:
+    tr_net_init_mgr();
+    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
+    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
+    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
+    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
+
     static bool initialised;
 };
 

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef> // size_t
 #include <cmath> // for std::fabs(), std::floor()
 #include <cstdint> // for uint64_t
 #include <string>

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -10,7 +10,6 @@
 #include <cstdint> // uint64_t, uint32_t
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <thread>
 #include <utility> // for std::move()
 #include <vector>


### PR DESCRIPTION
- Remove unnecessary #include calls from utils.h
- Remove places where we include utils.h without using it
- If a header function uses utils.h and can be moved to a .cc file, do that to reduce other files including as a side-effect
- Fix a couple of nearby iwyu warnings