### PR TITLE
fix: invalid TR_TORRENT_TRACKERS env var for some torrents

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -358,7 +358,7 @@ namespace script_helpers
     {
         buf << tr_torrentTracker(tor, i).host_and_port;
 
-        if (++i < n)
+        if (i < n)
         {
             buf << ',';
         }


### PR DESCRIPTION
Notes: Fixed invalid `TR_TORRENT_TRACKERS` environment variable in user scripts.