### PR TITLE
fix: parsing sitename info from 3.xx Servers

### DIFF
--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -178,8 +178,11 @@ bool change(TrackerStat& setme, tr_variant const* value)
         changed = true;
     }
 
-    if (site_changed && !setme.sitename.isEmpty() && !setme.announce.isEmpty() && trApp != nullptr)
+    if (site_changed && !setme.announce.isEmpty() && trApp != nullptr)
     {
+        QStringList const separated_host = QUrl{ setme.announce }.host().split(QStringLiteral("."));
+
+        setme.sitename = separated_host.at(separated_host.size() - 2);
         setme.announce = trApp->intern(setme.announce);
         trApp->load_favicon(setme.announce);
     }

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -180,9 +180,12 @@ bool change(TrackerStat& setme, tr_variant const* value)
 
     if (site_changed && !setme.announce.isEmpty() && trApp != nullptr)
     {
-        QStringList const separated_host = QUrl{ setme.announce }.host().split(QStringLiteral("."));
+        if (setme.sitename.isEmpty())
+        {
+            QStringList const separated_host = QUrl{ setme.announce }.host().split(QStringLiteral("."));
+            setme.sitename = separated_host.at(separated_host.size() - 2);
+        }
 
-        setme.sitename = separated_host.at(separated_host.size() - 2);
         setme.announce = trApp->intern(setme.announce);
         trApp->load_favicon(setme.announce);
     }


### PR DESCRIPTION
Prior to Transmission 4.00 / RPC 5.3.0, sitenames were constructed from announce urls and used for filtering, favicon cache lookups, etc. Since Transmission 4.00 / RPC 5.3.0, sitenames are part of the RPC spec and can be fetched from the server. When a 4.00 client communicates with a 3.00 server, this behavior breaks and filtering and favicon lookup no longer work. This PR reintroduces compatibility of 4.00 clients with pre-RPC 5.3.0 servers.

Fixes #6402 