### PR TITLE
perf: Don't poll every second for kevents

### DIFF
--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -86,6 +86,8 @@
 //
 //  - macOS 10.10+: DispatchSource API (makeFileSystemObjectSource)
 //  (https://developer.apple.com/documentation/dispatch/dispatchsource/2300040-makefilesystemobjectsource)
+//  "DispatchSource is just the Swift version of gcd dispatch sources"
+//  (https://github.com/bdkjones/VDKQueue/pull/22#issuecomment-1871623127)
 //
 //  Example: SFSMonitor (https://github.com/ClassicalDude/SFSMonitor)
 

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -39,8 +39,8 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
 /// This is a simple model class used to hold info about each path we watch.
 @interface VDKQueuePathEntry : NSObject
 
-@property(atomic, copy) NSString* path;
-@property(atomic, assign) int watchedFD;
+@property(atomic, copy, readonly) NSString* path;
+@property(atomic, assign, readonly) int watchedFD;
 @property(atomic, assign) u_int subscriptionFlags;
 
 @end
@@ -69,7 +69,6 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
     {
         close(_watchedFD);
     }
-    _watchedFD = -1;
 }
 
 @end


### PR DESCRIPTION
Fix https://github.com/bdkjones/VDKQueue/pull/22.

Instead of polling `kevent` every second, we remove the `timeout` and we send a one-shot event when we want to stop watching.

Testing: with DEBUG_LOG_THREAD_LIFETIME enabled, I can see "watcherThread finished." instantly after turning off the "Watch for torrent files" option in the Transmission settings.