### PR TITLE
webui: make torrent row colours more readable

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -104,6 +104,7 @@
     --color-border: var(--dark-mode-white);
     --color-border-selected: var(--grey-500);
     --color-fg-tertiary: var(--grey-500);
+    --color-fg-selected: var(--dark-mode-white);
     --color-bg-selected: var(--default-accent-color-dark);
     --color-default-border: var(--default-border-dark);
     --color-progressbar-seed-1: var(--green-100);
@@ -128,6 +129,7 @@
       --color-border-selected: var(--white);
       --color-fg-tertiary: var(--white);
       --color-toolbar-background: var(--black);
+      --color-fg-selected: var(--white);
       --color-bg-selected: var(--blue-300);
       --color-bg-tabs: var(--black);
       --color-fg-tabs: var(--white);
@@ -165,6 +167,7 @@
     --color-bg-warn: #e4606d5b;
     --color-fg-warn: #cf212e;
     --color-fg-disabled: var(--grey-500);
+    --color-fg-selected: var(--nice-grey);
     --color-bg-selected: var(--blue-300);
     --color-default-border: var(--default-border-light);
     --color-dialog-border: var(--nice-grey);
@@ -188,6 +191,7 @@
       --color-border-selected: var(--black);
       --color-fg-tertiary: var(--black);
       --color-toolbar-background: var(--white);
+      --color-fg-selected: var(--white);
       --color-bg-selected: var(--blue-300);
       --color-bg-tabs: var(--white);
       --color-fg-tabs: var(--black);
@@ -499,10 +503,6 @@ a {
         font-size: 1em;
         font-weight: normal;
       }
-
-      &:not(.paused) {
-        color: var(--color-fg-primary);
-      }
     }
 
     .torrent-labels {
@@ -535,7 +535,6 @@ a {
 
     .torrent-progress-details,
     .torrent-peer-details {
-      color: var(--color-fg-primary);
       font-size: small;
     }
 
@@ -584,12 +583,7 @@ a {
       }
 
       .torrent-name {
-        color: var(--color-fg-primary);
         grid-area: name;
-
-        &.paused {
-          color: var(--color-fg-disabled);
-        }
       }
 
       .torrent-labels {
@@ -615,8 +609,21 @@ a {
       }
     }
 
+    &.paused {
+      color: var(--color-fg-disabled);
+
+      .icon {
+        background-color: var(--color-fg-disabled);
+      }
+    }
+
     &.selected {
       background-color: var(--color-bg-selected);
+      color: var(--color-fg-selected);
+
+      .icon {
+        background-color: var(--color-fg-selected);
+      }
     }
   }
 

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -220,10 +220,11 @@ export class TorrentRendererFull {
   render(controller, t, root) {
     const is_stopped = t.isStopped();
 
+    root.classList.toggle('paused', is_stopped);
+
     // name
     let e = root._name_container;
     setTextContent(e, t.getName());
-    e.classList.toggle('paused', is_stopped);
 
     // labels
     TorrentRendererHelper.formatLabels(t, root._labels_container);
@@ -332,9 +333,10 @@ export class TorrentRendererCompact {
 
   // eslint-disable-next-line class-methods-use-this
   render(controller, t, root) {
+    root.classList.toggle('paused', t.isStopped());
+
     // name
     let e = root._name_container;
-    e.classList.toggle('paused', t.isStopped());
     setTextContent(e, t.getName());
 
     // labels


### PR DESCRIPTION
Picking up @GaryElshaw's work from #5961 to bring the WebUI's colours closer to the macOS app, and also improve readability.

Changes:
- For paused torrents, instead of just the torrent name, now all text and also the MIME icon will be greyed out. I think this looks better and makes it even more obvious that the torrent is paused.
- Compact mode will also grey out paused torrents now.
- Following macOS app's palettte, the text for selected torrents will now be white to stand out against the bright blue background. Light/dark, normal/contrast mode differ only in the shade of white.

In https://github.com/transmission/transmission/pull/5961#issuecomment-1872068850, I stated that I prefer *not* greying out paused torrents. I have changed my mind now, because it is quite hard to notice at a glance that a 0% progress torrent is paused without the progress bar colour.

<details>
<summary>Screenshots</summary>

| Before | After |
| --- | --- |
| ![image](https://github.com/transmission/transmission/assets/46261767/ef90de75-77ec-40e2-9704-9c1ab14eb2f8) | ![image](https://github.com/transmission/transmission/assets/46261767/3280d66e-b592-4359-b124-2065ed9fb367) |
| ![image](https://github.com/transmission/transmission/assets/46261767/d1ca4eb2-cda0-4e3d-b9ae-cd192c9d0fa9) | ![image](https://github.com/transmission/transmission/assets/46261767/c131ffba-deb6-4319-be1d-19fe63b38253) |
| ![image](https://github.com/transmission/transmission/assets/46261767/2231d012-b56d-4744-98c5-95f16555e745) | ![image](https://github.com/transmission/transmission/assets/46261767/b376f93c-c65f-4230-ac29-d7820aab06a2) |
| ![image](https://github.com/transmission/transmission/assets/46261767/3cd6e797-d8ea-43cd-beb9-b6b5ad8f184b) | ![image](https://github.com/transmission/transmission/assets/46261767/8c63c7fe-4d40-40fd-aa84-c8546df3c73c) |
| ![image](https://github.com/transmission/transmission/assets/46261767/2f4f83d3-aafd-4860-9911-565d320d8bb0) | ![image](https://github.com/transmission/transmission/assets/46261767/fabb1e0b-8efe-4c3a-9ae1-d9f1fa29881d) |
| ![image](https://github.com/transmission/transmission/assets/46261767/371016a5-8e52-4b23-83f4-0b48488a70fc) | ![image](https://github.com/transmission/transmission/assets/46261767/d254ef34-6dc2-4b53-a688-c5d6baf9bed9) |
| ![image](https://github.com/transmission/transmission/assets/46261767/0ace79b6-d11b-416f-b93e-6df12d81b6b8) | ![image](https://github.com/transmission/transmission/assets/46261767/335666eb-3721-497e-af8d-af27c0ba114b) |
| ![image](https://github.com/transmission/transmission/assets/46261767/2b474ef5-16c3-42f8-aee4-341566d673dc) | ![image](https://github.com/transmission/transmission/assets/46261767/ec1a226a-0039-4085-a010-1db92996c9af) |

</details>