### PR TITLE
Support multiple magnets on the same line

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1711,7 +1711,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
     // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
     // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
-    // But for now, we'll keep the historical separator choice from #5777, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
+    // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
     NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
                                                                                       error:nil];
     for (NSString* itemString in arrayOfStrings)
@@ -1719,12 +1719,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         // We open all links
         for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0
                                                                      range:NSMakeRange(0, itemString.length)])
+        {
             [self openURL:result.URL.absoluteString];
+        }
 
         // We open all magnets
         for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
                                                                        range:NSMakeRange(0, itemString.length)])
+        {
             [self openURL:[itemString substringWithRange:result.range]];
+        }
     }
 }
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1697,30 +1697,34 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         return;
     }
 
-    // 2. If Pasteboard contains String objects, we'll search for magnet or links
+    // 2. If Pasteboard contains String objects, we'll search for both links and magnets
     NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
     if (arrayOfStrings.count == 0)
     {
         return;
     }
-    NSDataDetector* detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+    // The link detector (can't detect magnets)
+    NSDataDetector* linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+    // The magnet detector
+    // https://www.bittorrent.org/beps/bep_0009.html defines the magnet URI format as `magnet:?query` where query is non-empty.
+    // https://datatracker.ietf.org/doc/html/rfc3986 defines the query format rigorously as `([!$\&-;=?-Z_a-z~]|%[0-9A-F]{2})*`.
+    // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
+    // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
+    // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
+    // But for now, we'll keep the historical separator choice from #5777, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
+    NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
+                                                                                      error:nil];
     for (NSString* itemString in arrayOfStrings)
     {
-        NSArray<NSString*>* itemLines = [itemString componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
-        for (__strong NSString* pbItem in itemLines)
-        {
-            pbItem = [pbItem stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            if ([pbItem rangeOfString:@"magnet:" options:(NSAnchoredSearch | NSCaseInsensitiveSearch)].location != NSNotFound)
-            {
-                [self openURL:pbItem];
-            }
-            else
-            {
-#warning only accept full text?
-                for (NSTextCheckingResult* result in [detector matchesInString:pbItem options:0 range:NSMakeRange(0, pbItem.length)])
-                    [self openURL:result.URL.absoluteString];
-            }
-        }
+        // We open all links
+        for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0
+                                                                     range:NSMakeRange(0, itemString.length)])
+            [self openURL:result.URL.absoluteString];
+
+        // We open all magnets
+        for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
+                                                                       range:NSMakeRange(0, itemString.length)])
+            [self openURL:[itemString substringWithRange:result.range]];
     }
 }
 


### PR DESCRIPTION
1. This is an improvement over #3087, which granted support to one magnet per line: now I'm granting support to multiple magnets per line, in the same vein as what is supported for normal torrent links. And one can even mix a list of links and magnets altogether.

2. This also addresses the question written as a `#warning` introduced with 2a670d54a9d2c454c8a75933e20d88b44dc6e219 by providing code comments explaining that we're doing the right thing.

I tested the change.

Notes: Support pasting multiple magnets on the same line