### PR TITLE
Support multiple URL objects from pasteboard

### DIFF
--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -46,6 +46,8 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 - (void)openURL:(NSString*)urlString;
 - (IBAction)openURLShowSheet:(id)sender;
 
+- (void)openPasteboard;
+
 @property(nonatomic, readonly) tr_session* sessionHandle;
 
 - (IBAction)createFile:(id)sender;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -661,39 +661,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)paste:(id)sender
 {
-    NSURL* url;
-    if ((url = [NSURL URLFromPasteboard:NSPasteboard.generalPasteboard]))
-    {
-        [self.fController openURL:url.absoluteString];
-    }
-    else
-    {
-        NSArray<NSString*>* items = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
-        if (!items)
-        {
-            return;
-        }
-        NSDataDetector* detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
-        for (NSString* itemString in items)
-        {
-            NSArray<NSString*>* itemLines = [itemString componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
-            for (__strong NSString* pbItem in itemLines)
-            {
-                pbItem = [pbItem stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
-                if ([pbItem rangeOfString:@"magnet:" options:(NSAnchoredSearch | NSCaseInsensitiveSearch)].location != NSNotFound)
-                {
-                    [self.fController openURL:pbItem];
-                }
-                else
-                {
-#warning only accept full text?
-                    for (NSTextCheckingResult* result in [detector matchesInString:pbItem options:0
-                                                                             range:NSMakeRange(0, pbItem.length)])
-                        [self.fController openURL:result.URL.absoluteString];
-                }
-            }
-        }
-    }
+    [self.fController openPasteboard];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem*)menuItem


### PR DESCRIPTION
Adopts Apple recommendations and support multiple URL objects instead of a single one from pasteboard.

In practice:
- replace `URLFromPasteboard` with `readObjectsForClasses:@[ [NSURL class] ]`
- move the code outside of TableViewController