### PR TITLE
fix: restore `alt-speed-enabled` config parameter

### DIFF
--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -22,6 +22,7 @@
 struct tr_variant;
 
 #define ALT_SPEEDS_FIELDS(V) \
+    V(TR_KEY_alt_speed_enabled, is_active_, bool, false, "") \
     V(TR_KEY_alt_speed_up, speed_up_kbyps_, size_t, 50U, "") \
     V(TR_KEY_alt_speed_down, speed_down_kbyps_, size_t, 50U, "") \
     V(TR_KEY_alt_speed_time_enabled, scheduler_enabled_, bool, false, "whether alt speeds toggle on and off on schedule") \
@@ -145,9 +146,6 @@ private:
     static auto constexpr MinutesPerHour = int{ 60 };
     static auto constexpr MinutesPerDay = int{ MinutesPerHour * 24 };
     static auto constexpr MinutesPerWeek = int{ MinutesPerDay * 7 };
-
-    // are alt speeds active right now?
-    bool is_active_ = false;
 
     // bitfield of all the minutes in a week.
     // Each bit's value indicates whether the scheduler wants


### PR DESCRIPTION
Fixes #6449.

Regression from 611d36ac84f24adf4b4237b49a411cba3276ca60.

Notes: Fixed `4.0.0` bug where `alt-speed-enabled` had no effect in `settings.json`.