### PR TITLE
fix: reference to temporary

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -128,7 +128,7 @@ tr_file_piece_map::file_span_t tr_file_piece_map::file_span_for_piece(tr_piece_i
 {
     static constexpr auto Compare = CompareToSpan<tr_piece_index_t>{};
     auto const begin = std::begin(file_pieces_);
-    auto const& [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
+    auto const [equal_begin, equal_end] = std::equal_range(begin, std::end(file_pieces_), piece, Compare);
     return { static_cast<tr_file_index_t>(equal_begin - begin), static_cast<tr_file_index_t>(equal_end - begin) };
 }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2174,8 +2174,7 @@ void tr_torrent::on_piece_completed(tr_piece_index_t const piece)
     set_needs_completeness_check();
 
     // if this piece completes any file, invoke the fileCompleted func for it
-    auto const [file_begin, file_end] = fpm_.file_span_for_piece(piece);
-    for (auto file = file_begin; file < file_end; ++file)
+    for (auto [file, file_end] = fpm_.file_span_for_piece(piece); file < file_end; ++file)
     {
         if (completion_.has_blocks(block_span_for_file(file)))
         {


### PR DESCRIPTION
fix a minor bug in `tr_file_piece_map::file_span_for_piece()`  that took a reference to values returned by `std::equal_range()`