### PR TITLE
fixup! chore: webui scss cleanup (#6471)

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -253,6 +253,10 @@ a {
     margin: 0;
     padding: 0;
   }
+
+  .flexible-space {
+    margin-right: auto;
+  }
 }
 
 #mainwin-workarea {
@@ -396,10 +400,6 @@ a {
 }
 
 /// TORRENT CONTAINER
-
-.flexible-space {
-  margin-right: auto;
-}
 
 #torrent-container {
   flex-grow: 1;
@@ -1685,28 +1685,6 @@ dialog {
   font-style: italic;
 }
 
-.ui-menu {
-  width: 200px;
-}
-
 .upload-div {
   display: none;
-}
-
-.dropzone {
-  background: var(--color-bg-primary);
-  border: 2px dashed var(--color-border-stark);
-  border-radius: 5px;
-  color: var(--color-fg-primary);
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  font-size: 1.2em;
-  font-weight: bold;
-  height: 100%;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-  text-align: center;
-  width: 100%;
 }


### PR DESCRIPTION
These changes got lost when I was messing with git rebase and whatnot...

61ed621f55f6b4c8f5414260159c18129f304899 introduced a visual regression where the upload/download speed labels are not aligned to the right of the viewport, this PR restores it.