### PR TITLE
fix: WebUI render html entity in torrent ratio

### DIFF
--- a/web/src/statistics-dialog.js
+++ b/web/src/statistics-dialog.js
@@ -52,7 +52,7 @@ export class StatisticsDialog extends EventTarget {
     let ratio = Utils.ratio(s.uploadedBytes, s.downloadedBytes);
     setTextContent(this.elements.session.up, fmt.size(s.uploadedBytes));
     setTextContent(this.elements.session.down, fmt.size(s.downloadedBytes));
-    setTextContent(this.elements.session.ratio, fmt.ratioString(ratio));
+    this.elements.session.ratio.innerHTML = fmt.ratioString(ratio);
     setTextContent(
       this.elements.session.time,
       fmt.timeInterval(s.secondsActive),
@@ -62,7 +62,7 @@ export class StatisticsDialog extends EventTarget {
     ratio = Utils.ratio(s.uploadedBytes, s.downloadedBytes);
     setTextContent(this.elements.total.up, fmt.size(s.uploadedBytes));
     setTextContent(this.elements.total.down, fmt.size(s.downloadedBytes));
-    setTextContent(this.elements.total.ratio, fmt.ratioString(ratio));
+    this.elements.total.ratio.innerHTML = fmt.ratioString(ratio);
     setTextContent(this.elements.total.time, fmt.timeInterval(s.secondsActive));
   }
 

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -231,7 +231,7 @@ export class TorrentRendererFull {
 
     // progress details
     e = root._progress_details_container;
-    setTextContent(e, TorrentRendererFull.getProgressDetails(controller, t));
+    e.innerHTML = TorrentRendererFull.getProgressDetails(controller, t);
 
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, t, root._progressbar);


### PR DESCRIPTION
Fixes #6356.

Notes: Fixes a `4.0.0` bug where infinite ratio symbol is not displayed properly in the WebUI.