### PR TITLE
fix: app defaults should override libtransmission defaults

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -321,7 +321,7 @@ int tr_main(int argc, char* argv[])
 
     /* load the defaults from config file + libtransmission defaults */
     auto const config_dir = getConfigDir(argc, (char const**)argv);
-    auto settings = tr_sessionLoadSettings(config_dir.c_str(), MyConfigName);
+    auto settings = tr_sessionLoadSettings(nullptr, config_dir.c_str(), MyConfigName);
 
     /* the command line overrides defaults */
     if (parseCommandLine(&settings, argc, (char const**)argv) != 0)

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -660,9 +660,9 @@ void tr_daemon::reconfigure(void)
         configDir = tr_sessionGetConfigDir(my_session_);
         tr_logAddInfo(fmt::format(_("Reloading settings from '{path}'"), fmt::arg("path", configDir)));
 
-        auto newsettings = tr_variant::make_map();
-        tr_variantDictAddBool(&newsettings, TR_KEY_rpc_enabled, true);
-        newsettings.merge(tr_sessionLoadSettings(configDir, MyName));
+        auto app_defaults = tr_variant::make_map();
+        tr_variantDictAddBool(&app_defaults, TR_KEY_rpc_enabled, true);
+        auto const newsettings = tr_sessionLoadSettings(&app_defaults, configDir, MyName);
 
         tr_sessionSet(my_session_, newsettings);
         tr_sessionReloadBlocklists(my_session_);
@@ -882,9 +882,9 @@ bool tr_daemon::init(int argc, char const* const argv[], bool* foreground, int* 
     config_dir_ = getConfigDir(argc, argv);
 
     /* load settings from defaults + config file */
-    settings_ = tr_variant::make_map();
-    tr_variantDictAddBool(&settings_, TR_KEY_rpc_enabled, true);
-    settings_.merge(tr_sessionLoadSettings(config_dir_.c_str(), MyName));
+    auto app_defaults = tr_variant::make_map();
+    tr_variantDictAddBool(&app_defaults, TR_KEY_rpc_enabled, true);
+    settings_ = tr_sessionLoadSettings(&app_defaults, config_dir_.c_str(), MyName);
 
     bool dumpSettings;
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -360,6 +360,14 @@ tr_rpc_callback_status on_rpc_callback(tr_session* /*session*/, tr_rpc_callback_
     }
     return TR_RPC_OK;
 }
+
+tr_variant load_settings(char const* config_dir)
+{
+    auto app_defaults = tr_variant::make_map();
+    tr_variantDictAddBool(&app_defaults, TR_KEY_rpc_enabled, true);
+    return tr_sessionLoadSettings(&app_defaults, config_dir, MyName);
+}
+
 } // namespace
 
 bool tr_daemon::reopen_log_file(char const* filename)
@@ -660,11 +668,7 @@ void tr_daemon::reconfigure(void)
         configDir = tr_sessionGetConfigDir(my_session_);
         tr_logAddInfo(fmt::format(_("Reloading settings from '{path}'"), fmt::arg("path", configDir)));
 
-        auto app_defaults = tr_variant::make_map();
-        tr_variantDictAddBool(&app_defaults, TR_KEY_rpc_enabled, true);
-        auto const newsettings = tr_sessionLoadSettings(&app_defaults, configDir, MyName);
-
-        tr_sessionSet(my_session_, newsettings);
+        tr_sessionSet(my_session_, load_settings(configDir));
         tr_sessionReloadBlocklists(my_session_);
     }
 }
@@ -882,9 +886,7 @@ bool tr_daemon::init(int argc, char const* const argv[], bool* foreground, int* 
     config_dir_ = getConfigDir(argc, argv);
 
     /* load settings from defaults + config file */
-    auto app_defaults = tr_variant::make_map();
-    tr_variantDictAddBool(&app_defaults, TR_KEY_rpc_enabled, true);
-    settings_ = tr_sessionLoadSettings(&app_defaults, config_dir_.c_str(), MyName);
+    settings_ = load_settings(config_dir_.c_str());
 
     bool dumpSettings;
 

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -108,8 +108,8 @@ tr_variant& getPrefs()
 
     if (!settings.has_value())
     {
-        settings = get_default_app_settings();
-        settings.merge(tr_sessionLoadSettings(gl_confdir.c_str(), nullptr));
+        auto const app_defaults = get_default_app_settings();
+        settings.merge(tr_sessionLoadSettings(&app_defaults, gl_confdir.c_str(), nullptr));
         ensure_sound_cmd_is_a_list(&settings);
     }
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -175,6 +175,7 @@ tr_variant tr_sessionGetSettings(tr_session const* session);
  *
  * TODO: if we ever make libtransmissionapp, this would go there.
  *
+ * @param app_defaults tr_variant containing the app defaults
  * @param config_dir the configuration directory to find settings.json
  * @param app_name if config_dir is empty, app_name is used to find the default dir.
  * @return the loaded settings
@@ -182,7 +183,7 @@ tr_variant tr_sessionGetSettings(tr_session const* session);
  * @see `tr_sessionInit()`
  * @see `tr_sessionSaveSettings()`
  */
-tr_variant tr_sessionLoadSettings(char const* config_dir, char const* app_name);
+tr_variant tr_sessionLoadSettings(tr_variant const* app_defaults, char const* config_dir, char const* app_name);
 
 /**
  * Add the session's configuration settings to the benc dictionary

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -227,13 +227,13 @@ Prefs::Prefs(QString config_dir)
     // when the application exits.
     temporary_prefs_.insert(FILTER_TEXT);
 
-    auto top = get_default_app_settings();
-    top.merge(tr_sessionLoadSettings(config_dir_.toUtf8().constData(), nullptr));
-    ensureSoundCommandIsAList(&top);
+    auto const app_defaults = get_default_app_settings();
+    auto settings = tr_sessionLoadSettings(&app_defaults, config_dir_.toUtf8().constData(), nullptr);
+    ensureSoundCommandIsAList(&settings);
 
     for (int i = 0; i < PREFS_COUNT; ++i)
     {
-        tr_variant const* b = tr_variantDictFind(&top, Items[i].key);
+        tr_variant const* b = tr_variantDictFind(&settings, Items[i].key);
 
         switch (Items[i].type)
         {

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -357,7 +357,7 @@ void Session::start()
     }
     else
     {
-        auto const settings = tr_sessionLoadSettings(config_dir_.toUtf8().constData(), "qt");
+        auto const settings = tr_sessionLoadSettings(nullptr, config_dir_.toUtf8().constData(), "qt");
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, settings);
 
         rpc_.start(session_);


### PR DESCRIPTION
Regression from ebb1b775afa6ebac4e271cfec530d9639003f0df.

One example of the effects of this regression is that `rpc-enabled` should default to `true` for the daemon, but it does not right now in `main`.