### PR TITLE
fix: WebUI render html entity in torrent ratio (#6491)

### DIFF
--- a/web/src/statistics-dialog.js
+++ b/web/src/statistics-dialog.js
@@ -52,7 +52,7 @@ export class StatisticsDialog extends EventTarget {
     let ratio = Utils.ratio(s.uploadedBytes, s.downloadedBytes);
     setTextContent(this.elements.session.up, fmt.size(s.uploadedBytes));
     setTextContent(this.elements.session.down, fmt.size(s.downloadedBytes));
-    setTextContent(this.elements.session.ratio, fmt.ratioString(ratio));
+    this.elements.session.ratio.innerHTML = fmt.ratioString(ratio);
     setTextContent(
       this.elements.session.time,
       fmt.timeInterval(s.secondsActive)
@@ -62,7 +62,7 @@ export class StatisticsDialog extends EventTarget {
     ratio = Utils.ratio(s.uploadedBytes, s.downloadedBytes);
     setTextContent(this.elements.total.up, fmt.size(s.uploadedBytes));
     setTextContent(this.elements.total.down, fmt.size(s.downloadedBytes));
-    setTextContent(this.elements.total.ratio, fmt.ratioString(ratio));
+    this.elements.total.ratio.innerHTML = fmt.ratioString(ratio);
     setTextContent(this.elements.total.time, fmt.timeInterval(s.secondsActive));
   }
 

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -237,7 +237,7 @@ export class TorrentRendererFull {
 
     // progress details
     e = root._progress_details_container;
-    setTextContent(e, TorrentRendererFull.getProgressDetails(controller, t));
+    e.innerHTML = TorrentRendererFull.getProgressDetails(controller, t);
 
     // pause/resume button
     e = root._toggle_running_button;


### PR DESCRIPTION
(cherry picked from commit 3b017dbd86ec41403bebb74a8106d004241540e9)

Notes: Fixes a `4.0.0` bug where infinite ratio symbol is not displayed properly in the WebUI.