### PR TITLE
fix: performance-enum-size warnings

### DIFF
--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -49,7 +49,7 @@ using namespace std::literals;
 namespace
 {
 
-enum
+enum : uint16_t
 {
     /* these two fields could be any number at all so long as they're not
      * TR_PRI_LOW, TR_PRI_NORMAL, TR_PRI_HIGH, true, or false */

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -45,12 +45,18 @@
 #include <string>
 #include <unordered_map>
 
+namespace
+{
+using ActivityType = TorrentFilter::Activity;
+using TrackerType = TorrentFilter::Tracker;
+
+constexpr auto ActivitySeparator = static_cast<ActivityType>(-1);
+constexpr auto TrackerSeparator = static_cast<TrackerType>(-1);
+} // namespace
+
 class FilterBar::Impl
 {
     using FilterModel = IF_GTKMM4(Gtk::FilterListModel, Gtk::TreeModelFilter);
-
-    using TrackerType = TorrentFilter::Tracker;
-    using ActivityType = TorrentFilter::Activity;
 
 public:
     Impl(FilterBar& widget, Glib::RefPtr<Session> const& core);
@@ -118,15 +124,10 @@ private:
     sigc::connection update_filter_models_on_change_tag_;
 };
 
-/***
-****
-****  TRACKERS
-****
-***/
+// --- TRACKERS
 
 namespace
 {
-
 class TrackerFilterModelColumns : public Gtk::TreeModelColumnRecord
 {
 public:
@@ -141,7 +142,7 @@ public:
 
     Gtk::TreeModelColumn<Glib::ustring> displayname; /* human-readable name; ie, Legaltorrents */
     Gtk::TreeModelColumn<int> count; /* how many matches there are */
-    Gtk::TreeModelColumn<int> type;
+    Gtk::TreeModelColumn<TrackerType> type;
     Gtk::TreeModelColumn<Glib::ustring> sitename; // pattern-matching text; see tr_parsed_url.sitename
     Gtk::TreeModelColumn<Glib::RefPtr<Gdk::Pixbuf>> pixbuf;
 };
@@ -298,7 +299,7 @@ bool FilterBar::Impl::tracker_filter_model_update()
             add->set_value(tracker_filter_cols.sitename, Glib::ustring{ site.sitename });
             add->set_value(tracker_filter_cols.displayname, get_name_from_host(site.sitename));
             add->set_value(tracker_filter_cols.count, site.count);
-            add->set_value(tracker_filter_cols.type, static_cast<int>(TrackerType::HOST));
+            add->set_value(tracker_filter_cols.type, TrackerType::HOST);
             auto path = tracker_model_->get_path(add);
             core_->favicon_cache().load(
                 site.announce_url,
@@ -322,17 +323,17 @@ Glib::RefPtr<Gtk::TreeStore> FilterBar::Impl::tracker_filter_model_new()
 
     auto iter = store->append();
     iter->set_value(tracker_filter_cols.displayname, Glib::ustring(_("All")));
-    iter->set_value(tracker_filter_cols.type, static_cast<int>(TrackerType::ALL));
+    iter->set_value(tracker_filter_cols.type, TrackerType::ALL);
 
     iter = store->append();
-    iter->set_value(tracker_filter_cols.type, -1);
+    iter->set_value(tracker_filter_cols.type, TrackerSeparator);
 
     return store;
 }
 
 bool FilterBar::Impl::is_it_a_separator(Gtk::TreeModel::const_iterator const& iter)
 {
-    return iter->get_value(tracker_filter_cols.type) == -1;
+    return iter->get_value(tracker_filter_cols.type) == TrackerSeparator;
 }
 
 void FilterBar::Impl::render_pixbuf_func(Gtk::CellRendererPixbuf& cell_renderer, Gtk::TreeModel::const_iterator const& iter)
@@ -406,7 +407,7 @@ public:
 
     Gtk::TreeModelColumn<Glib::ustring> name;
     Gtk::TreeModelColumn<int> count;
-    Gtk::TreeModelColumn<int> type;
+    Gtk::TreeModelColumn<ActivityType> type;
     Gtk::TreeModelColumn<Glib::ustring> icon_name;
 };
 
@@ -416,7 +417,7 @@ ActivityFilterModelColumns const activity_filter_cols;
 
 bool FilterBar::Impl::activity_is_it_a_separator(Gtk::TreeModel::const_iterator const& iter)
 {
-    return iter->get_value(activity_filter_cols.type) == -1;
+    return iter->get_value(activity_filter_cols.type) == ActivitySeparator;
 }
 
 void FilterBar::Impl::status_model_update_count(Gtk::TreeModel::iterator const& iter, int n)
@@ -434,7 +435,7 @@ bool FilterBar::Impl::activity_filter_model_update()
     for (auto& row : activity_model_->children())
     {
         auto const type = row.get_value(activity_filter_cols.type);
-        if (type == -1)
+        if (type == ActivitySeparator)
         {
             continue;
         }
@@ -487,7 +488,7 @@ Glib::RefPtr<Gtk::ListStore> FilterBar::Impl::activity_filter_model_new()
             Glib::ustring();
         auto const iter = store->append();
         iter->set_value(activity_filter_cols.name, name);
-        iter->set_value(activity_filter_cols.type, static_cast<int>(type.type));
+        iter->set_value(activity_filter_cols.type, type.type);
         iter->set_value(activity_filter_cols.icon_name, Glib::ustring(type.icon_name != nullptr ? type.icon_name : ""));
     }
 

--- a/gtk/FilterBase.h
+++ b/gtk/FilterBase.h
@@ -15,12 +15,14 @@
 #include <glibmm/object.h>
 #endif
 
+#include <cstdint>
+
 template<typename T>
 class FilterBase : public IF_GTKMM4(Gtk::Filter, Glib::Object)
 {
 public:
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change{
+    enum class Change : uint8_t{
         DIFFERENT,
         LESS_STRICT,
         MORE_STRICT,

--- a/gtk/ListModelAdapter.h
+++ b/gtk/ListModelAdapter.h
@@ -26,7 +26,7 @@ class ListModelAdapter
     using IdGetter = std::function<int(Glib::RefPtr<Glib::ObjectBase const> const&)>;
     using ValueGetter = std::function<void(Glib::RefPtr<Glib::ObjectBase const> const&, int, Glib::ValueBase&)>;
 
-    enum class PositionAdjustment : uint8_t
+    enum class PositionAdjustment : int8_t
     {
         DECREMENT = -1,
         INCREMENT = 1,

--- a/gtk/ListModelAdapter.h
+++ b/gtk/ListModelAdapter.h
@@ -14,6 +14,7 @@
 #include <gtkmm/treemodel.h>
 #include <gtkmm/treemodelcolumn.h>
 
+#include <cstdint>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -25,7 +26,7 @@ class ListModelAdapter
     using IdGetter = std::function<int(Glib::RefPtr<Glib::ObjectBase const> const&)>;
     using ValueGetter = std::function<void(Glib::RefPtr<Glib::ObjectBase const> const&, int, Glib::ValueBase&)>;
 
-    enum class PositionAdjustment
+    enum class PositionAdjustment : uint8_t
     {
         DECREMENT = -1,
         INCREMENT = 1,

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -21,6 +21,7 @@
 #include <gtkmm/treemodel.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -29,7 +30,7 @@
 class Session : public Glib::Object
 {
 public:
-    enum ErrorCode
+    enum ErrorCode : uint16_t
     {
         ERR_ADD_TORRENT_ERR = 1,
         ERR_ADD_TORRENT_DUP = 2,

--- a/gtk/SorterBase.h
+++ b/gtk/SorterBase.h
@@ -20,7 +20,7 @@ class SorterBase : public IF_GTKMM4(Gtk::Sorter, Glib::Object)
 {
 public:
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change{
+    enum class Change : uint8_t{
         DIFFERENT,
         INVERTED,
         LESS_STRICT,

--- a/gtk/Torrent.h
+++ b/gtk/Torrent.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <cstdint>
 #include <initializer_list>
 #include <memory>
 
@@ -38,7 +39,7 @@ public:
         Gtk::TreeModelColumn<Glib::ustring> name_collated;
     };
 
-    enum class ChangeFlag
+    enum class ChangeFlag : uint8_t
     {
         ACTIVE_PEER_COUNT,
         ACTIVE_PEERS_DOWN,

--- a/gtk/TorrentFilter.h
+++ b/gtk/TorrentFilter.h
@@ -16,7 +16,7 @@
 class TorrentFilter : public FilterBase<Torrent>
 {
 public:
-    enum class Activity : uint8_t
+    enum class Activity : int8_t
     {
         ALL,
         DOWNLOADING,
@@ -28,7 +28,7 @@ public:
         ERROR,
     };
 
-    enum class Tracker : uint8_t
+    enum class Tracker : int8_t
     {
         ALL,
         HOST,

--- a/gtk/TorrentFilter.h
+++ b/gtk/TorrentFilter.h
@@ -11,10 +11,12 @@
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
 
+#include <cstdint>
+
 class TorrentFilter : public FilterBase<Torrent>
 {
 public:
-    enum class Activity
+    enum class Activity : uint8_t
     {
         ALL,
         DOWNLOADING,
@@ -26,7 +28,7 @@ public:
         ERROR,
     };
 
-    enum class Tracker
+    enum class Tracker : uint8_t
     {
         ALL,
         HOST,

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -30,6 +30,7 @@
 #include <fmt/core.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <ctime>
 #include <functional>
 #include <list>
@@ -52,7 +53,7 @@ void gtr_error(std::string const& message);
 ****
 ***/
 
-enum class GtrUnicode
+enum class GtrUnicode : uint8_t
 {
     Up,
     Down,

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -70,7 +70,7 @@ auto tau_transaction_new()
 }
 
 // used in the "action" field of a request. Values defined in bep 15.
-enum tau_action_t
+enum tau_action_t : uint8_t
 {
     TAU_ACTION_CONNECT = 0,
     TAU_ACTION_ANNOUNCE = 1,
@@ -254,7 +254,7 @@ struct tau_announce_request
         return created_at_ + TR_ANNOUNCE_TIMEOUT_SEC.count();
     }
 
-    enum tau_announce_event
+    enum tau_announce_event : uint8_t
     {
         // Used in the "event" field of an announce request.
         // These values come from BEP 15

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -150,7 +150,7 @@ auto constexpr Handshake = uint8_t{ 0 };
 // Client-defined extension message IDs that we tell peers about
 // in the LTEP handshake and will respond to when sent in an LTEP
 // message.
-enum LtepMessageIds
+enum LtepMessageIds : uint8_t
 {
     // we support peer exchange (bep 11)
     // https://www.bittorrent.org/beps/bep_0011.html
@@ -194,7 +194,7 @@ auto constexpr MaxPexPeerCount = size_t{ 50 };
 
 // ---
 
-enum class EncryptionPreference
+enum class EncryptionPreference : uint8_t
 {
     Unknown,
     Yes,

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <future>
 #include <optional>
 #include <string>
@@ -35,7 +36,7 @@
 
 namespace
 {
-enum class UpnpState
+enum class UpnpState : uint8_t
 {
     Idle,
     Failed,
@@ -219,7 +220,7 @@ void tr_upnpDeletePortMapping(tr_upnp const* handle, char const* proto, tr_port 
     UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, port_str.c_str(), proto, nullptr);
 }
 
-enum
+enum : uint8_t
 {
     UPNP_IGD_NONE = 0,
     UPNP_IGD_VALID_CONNECTED = 1,

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <cstring> /* for strcspn() */
 #include <ctime>
 #include <memory>
@@ -77,7 +78,7 @@ auto inline constexpr TrUnixAddrStrLen = size_t{ sizeof(((struct sockaddr_un*)nu
                                                  std::size(TrUnixSocketPrefix) };
 #endif
 
-enum tr_rpc_address_type
+enum tr_rpc_address_type : uint8_t
 {
     TR_RPC_INET_ADDR,
     TR_RPC_UNIX_ADDR

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -54,7 +54,7 @@ auto constexpr RpcVersion = int64_t{ 18 };
 auto constexpr RpcVersionMin = int64_t{ 14 };
 auto constexpr RpcVersionSemver = "5.4.0"sv;
 
-enum class TrFormat
+enum class TrFormat : uint8_t
 {
     Object,
     Table

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -71,7 +71,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
     std::string_view pieces_root_;
     int64_t file_length_ = 0;
 
-    enum class State
+    enum class State : uint8_t
     {
         UsePath,
         FileTree,

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -117,7 +117,7 @@ private:
     using Nodes = std::deque<Node>;
     using Id = std::array<unsigned char, 20>;
 
-    enum class SwarmStatus
+    enum class SwarmStatus : uint8_t
     {
         Stopped,
         Broken,

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>
@@ -50,7 +51,7 @@ static_assert(ProcessEventsTimeout > GenericRescanInterval);
 namespace libtransmission::test
 {
 
-enum class WatchMode
+enum class WatchMode : uint8_t
 {
     NATIVE,
     GENERIC


### PR DESCRIPTION
Another PR in a series to get the codebase green when checked with clang-tidy-18.

This is a smaller PR that fixes the `performance-enum-size` warnings