### PR TITLE
fix: always schedule uTP ack after receiving a packet

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -729,6 +729,9 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
                 io->set_enabled(TR_DOWN, true);
                 io->can_read_wrapper();
 
+                // utp_read_drained() notifies libutp that we read a packet from them.
+                // It opens up the congestion window by sending an ACK (soonish) if
+                // one was not going to be sent.
                 utp_read_drained(args->socket);
             }
             return {};

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -729,13 +729,7 @@ void tr_peerIo::utp_init([[maybe_unused]] struct_utp_context* ctx)
                 io->set_enabled(TR_DOWN, true);
                 io->can_read_wrapper();
 
-                // utp_read_drained() notifies libutp that this read buffer is empty.
-                // It opens up the congestion window by sending an ACK (soonish) if
-                // one was not going to be sent.
-                if (std::empty(io->inbuf_))
-                {
-                    utp_read_drained(args->socket);
-                }
+                utp_read_drained(args->socket);
             }
             return {};
         });


### PR DESCRIPTION
Fixes #5261.

Instead of scheduling an ACK to be sent when the read buffer is empty, this PR schedules an ACK as soon as we read a packet from libutp.

I've noted in https://github.com/transmission/transmission/issues/5261#issuecomment-1880924976 that this change improves download speeds a lot for me, and I think this a natural result.

For any TCP-like protocols, when receiving a packet, it is more beneficial to send the ACK sooner than later, so that the sender can also move on to the next packets sooner, thus maintaining a higher transfer rate. In our case, the `UTP_ON_READ` callback is called whenever libutp processed an incoming data packet, so it makes sense to call `utp_read_drained()` here unconditionally.

Notes: Improved µTP download performance.