### PR TITLE
fix: use one variable to store `TR_KEY_rpc_authentication_required`

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -811,7 +811,7 @@ void tr_rpc_server::set_password(std::string_view password) noexcept
 
 void tr_rpc_server::set_password_enabled(bool enabled)
 {
-    is_password_enabled_ = enabled;
+    authentication_required_ = enabled;
     tr_logAddDebug(fmt::format("setting password-enabled to '{}'", enabled));
 }
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -102,7 +102,7 @@ public:
 
     [[nodiscard]] constexpr auto is_password_enabled() const noexcept
     {
-        return is_password_enabled_;
+        return authentication_required_;
     }
 
     void set_password_enabled(bool enabled);
@@ -163,6 +163,4 @@ public:
 
     size_t login_attempts_ = 0U;
     int start_retry_counter = 0;
-
-    bool is_password_enabled_ = false;
 };


### PR DESCRIPTION
Fixes #6473.

Notes: Fixed `4.0.0` bug where the GTK client's "Use authentication" option is not saved across sessions.