### PR TITLE
Update pieces label on source change even if piece size doesn't change

### DIFF
--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -223,11 +223,9 @@ void MakeDialog::onSourceChanged()
         builder_.emplace(filename.toStdString());
     }
 
-    if (!builder_)
-    {
-        updatePiecesLabel();
-    }
-    else
+    updatePiecesLabel();
+
+    if (builder_)
     {
         ui_.pieceSizeSlider->setValue(log2(builder_->piece_size()));
     }


### PR DESCRIPTION
Label update is made when slider changes its value, and on source change slider value is being set to a newly calculated, but not necessarily different from the previous one, value. This means that the slider change signal may not be emitted, in which case label continues to show previous text, including "No source selected", which is misleading.

The issue could also lead to piece size slider staying disabled, preventing user from adjusting the size.

Notes: Fixed `4.0.0` bug where piece size description text and slider state in torrent creation dialog is not always up-to-date.