### PR TITLE
qt: add piecebar from Mac client

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -537,7 +537,8 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
         };
 
         // changing fields needed by the main window
-        static auto constexpr MainStatKeys = std::array<tr_quark, 25>{
+        static auto constexpr MainStatKeys = std::array<tr_quark, 27>{
+            TR_KEY_availability,
             TR_KEY_downloadedEver,
             TR_KEY_editDate,
             TR_KEY_error,
@@ -553,6 +554,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
             TR_KEY_peersGettingFromUs,
             TR_KEY_peersSendingToUs,
             TR_KEY_percentDone,
+            TR_KEY_pieceCount,
             TR_KEY_queuePosition,
             TR_KEY_rateDownload,
             TR_KEY_rateUpload,

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -538,33 +538,33 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 
         // changing fields needed by the main window
         static auto constexpr MainStatKeys = std::array<tr_quark, 27>{
-            TR_KEY_availability,
-            TR_KEY_downloadedEver,
-            TR_KEY_editDate,
-            TR_KEY_error,
-            TR_KEY_errorString,
-            TR_KEY_eta,
-            TR_KEY_haveUnchecked,
-            TR_KEY_haveValid,
-            TR_KEY_isFinished,
-            TR_KEY_leftUntilDone,
-            TR_KEY_manualAnnounceTime,
-            TR_KEY_metadataPercentComplete,
-            TR_KEY_peersConnected,
-            TR_KEY_peersGettingFromUs,
-            TR_KEY_peersSendingToUs,
-            TR_KEY_percentDone,
-            TR_KEY_pieceCount,
-            TR_KEY_queuePosition,
-            TR_KEY_rateDownload,
-            TR_KEY_rateUpload,
-            TR_KEY_recheckProgress,
-            TR_KEY_seedRatioLimit,
-            TR_KEY_seedRatioMode,
-            TR_KEY_sizeWhenDone,
-            TR_KEY_status,
-            TR_KEY_uploadedEver,
-            TR_KEY_webseedsSendingToUs,
+            TR_KEY_availability, //
+            TR_KEY_downloadedEver, //
+            TR_KEY_editDate, //
+            TR_KEY_error, //
+            TR_KEY_errorString, //
+            TR_KEY_eta, //
+            TR_KEY_haveUnchecked, //
+            TR_KEY_haveValid, //
+            TR_KEY_isFinished, //
+            TR_KEY_leftUntilDone, //
+            TR_KEY_manualAnnounceTime, //
+            TR_KEY_metadataPercentComplete, //
+            TR_KEY_peersConnected, //
+            TR_KEY_peersGettingFromUs, //
+            TR_KEY_peersSendingToUs, //
+            TR_KEY_percentDone, //
+            TR_KEY_pieceCount, //
+            TR_KEY_queuePosition, //
+            TR_KEY_rateDownload, //
+            TR_KEY_rateUpload, //
+            TR_KEY_recheckProgress, //
+            TR_KEY_seedRatioLimit, //
+            TR_KEY_seedRatioMode, //
+            TR_KEY_sizeWhenDone, //
+            TR_KEY_status, //
+            TR_KEY_uploadedEver, //
+            TR_KEY_webseedsSendingToUs, //
         };
 
         // unchanging fields needed by the details dialog

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -182,6 +182,7 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
 
             HANDLE_KEY(activityDate, activity_date, ACTIVITY_DATE)
             HANDLE_KEY(addedDate, added_date, ADDED_DATE)
+            HANDLE_KEY(availability, availability, AVAILABILITY)
             HANDLE_KEY(bandwidthPriority, bandwidth_priority, BANDWIDTH_PRIORITY)
             HANDLE_KEY(corruptEver, failed_ever, FAILED_EVER)
             HANDLE_KEY(dateCreated, date_created, DATE_CREATED)
@@ -261,6 +262,17 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
         {
             switch (key)
             {
+            case TR_KEY_availability:
+                {
+                    pieces_.clear();
+
+                    for (int i = 0; i < pieceCount(); i++)
+                    {
+                        pieces_.emplace_back(availability_[i] == -1);
+                    }
+                    break;
+                }
+
             case TR_KEY_file_count:
             case TR_KEY_primary_mime_type:
                 icon_ = {};

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -291,6 +291,16 @@ public:
         return piece_count_;
     }
 
+    std::vector<int> availability() const noexcept
+    {
+        return availability_;
+    }
+
+    std::vector<bool> pieces() const noexcept
+    {
+        return pieces_;
+    }
+
     [[nodiscard]] constexpr auto downloadedEver() const noexcept
     {
         return downloaded_ever_;
@@ -569,6 +579,7 @@ public:
     {
         ACTIVITY_DATE,
         ADDED_DATE,
+        AVAILABILITY,
         BANDWIDTH_PRIORITY,
         COMMENT,
         CREATOR,
@@ -605,6 +616,7 @@ public:
         PEERS_SENDING_TO_US,
         PEER_LIMIT,
         PERCENT_DONE,
+        PIECES,
         PIECE_COUNT,
         PIECE_SIZE,
         PRIMARY_MIME_TYPE,
@@ -703,6 +715,9 @@ private:
 
     Speed upload_speed_;
     Speed download_speed_;
+
+    std::vector<int> availability_ = {};
+    std::vector<bool> pieces_ = {};
 
     Prefs const& prefs_;
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -610,10 +610,9 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     progress_bar_style_.state = progress_bar_state;
     setProgressBarPercentDone(option, tor);
-    // style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
 
-    auto const cr = is_item_selected ? QPalette::HighlightedText : QPalette::Base;
-    float progress = static_cast<float>(progress_bar_style_.progress) / static_cast<float>(progress_bar_style_.maximum);
+    auto const cr = is_item_selected ? QPalette::Highlight : QPalette::Base;
+    float const progress = static_cast<float>(progress_bar_style_.progress) / static_cast<float>(progress_bar_style_.maximum);
 
     QRect progress_bar_fill_rect = layout.progress_bar_rect;
     progress_bar_fill_rect.setWidth(progress * layout.progress_bar_rect.width());
@@ -633,8 +632,10 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
             if (availability[i] == -1)
             {
                 int const offset = i * piece_width;
-                QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 2, layout.piece_bar_rect.top(),
-                                           static_cast<int>(std::ceil(piece_width)), PIECE_BAR_HEIGHT - 2 };
+                QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 2,
+                                           layout.piece_bar_rect.top() + 1,
+                                           static_cast<int>(std::ceil(piece_width)),
+                                           PIECE_BAR_HEIGHT - 3 };
 
                 painter->fillRect(piece_rect, progress_bar_style_.palette.brush(cr));
             }

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -616,7 +616,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     float progress = static_cast<float>(progress_bar_style_.progress) / static_cast<float>(progress_bar_style_.maximum);
 
     QRect progress_bar_fill_rect = layout.progress_bar_rect;
-    progress_bar_fill_rect.setWidth(progress*layout.progress_bar_rect.width());
+    progress_bar_fill_rect.setWidth(progress * layout.progress_bar_rect.width());
     painter->fillRect(progress_bar_fill_rect, progress_bar_style_.palette.brush(cr));
 
     std::vector<int> const availability = tor.availability();
@@ -632,7 +632,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
         {
             if (availability[i] == -1)
             {
-                int const offset = i*piece_width;
+                int const offset = i * piece_width;
                 QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 2, layout.piece_bar_rect.top(),
                                            static_cast<int>(std::ceil(piece_width)), PIECE_BAR_HEIGHT - 2 };
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -26,7 +26,8 @@
 enum
 {
     GUI_PAD = 6,
-    BAR_HEIGHT = 12
+    PROGRESS_BAR_HEIGHT = 4,
+    PIECE_BAR_HEIGHT = 8,
 };
 
 namespace
@@ -49,6 +50,8 @@ public:
     QRect name_rect;
     QRect status_rect;
     QRect bar_rect;
+    QRect progress_bar_rect;
+    QRect piece_bar_rect;
     QRect progress_rect;
 
     ItemLayout(
@@ -124,8 +127,10 @@ ItemLayout::ItemLayout(
 
     name_rect = base_rect.adjusted(0, 0, 0, name_size.height());
     status_rect = name_rect.adjusted(0, name_rect.height() + 1, 0, status_size.height() + 1);
-    bar_rect = status_rect.adjusted(0, status_rect.height() + 1, 0, BAR_HEIGHT + 1);
-    progress_rect = bar_rect.adjusted(0, bar_rect.height() + 1, 0, progress_size.height() + 1);
+    bar_rect = status_rect.adjusted(0, status_rect.height() + 1, 0, PROGRESS_BAR_HEIGHT + PIECE_BAR_HEIGHT + 1);
+    progress_bar_rect = bar_rect.adjusted(0, 0, 0, -PIECE_BAR_HEIGHT);
+    piece_bar_rect = bar_rect.adjusted(0, PROGRESS_BAR_HEIGHT + 1, 0, -PROGRESS_BAR_HEIGHT);
+    progress_rect = bar_rect.adjusted(0, bar_rect.height() + 1, 0, progress_size.height());
     icon_rect = QStyle::alignedRect(
         direction,
         Qt::AlignLeft | Qt::AlignVCenter,
@@ -582,7 +587,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     painter->drawText(layout.status_rect, Qt::AlignLeft | Qt::AlignVCenter, layout.statusText());
     painter->setFont(layout.progress_font);
     painter->drawText(layout.progress_rect, Qt::AlignLeft | Qt::AlignVCenter, layout.progressText());
-    progress_bar_style_.rect = layout.bar_rect;
+    progress_bar_style_.rect = layout.progress_bar_rect;
 
     if (tor.isDownloading())
     {
@@ -605,8 +610,26 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     progress_bar_style_.state = progress_bar_state;
     setProgressBarPercentDone(option, tor);
+    style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
 
-    StyleHelper::drawProgressBar(*style, *painter, progress_bar_style_);
+    std::vector<int> const availability = tor.availability();
+    float const piece_width = (float) (layout.piece_bar_rect.width() - 2) / tor.pieceCount();
+
+    for (int i = 0; i < tor.pieceCount(); i++)
+    {
+        if (availability[i] == -1)
+        {
+            int const offset = i*piece_width;
+            QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 1, layout.piece_bar_rect.top(),
+                                       (int) std::ceil(piece_width), PIECE_BAR_HEIGHT - 2 };
+
+            auto const cr = is_item_selected ? QPalette::HighlightedText : QPalette::Base;
+            painter->fillRect(piece_rect, progress_bar_style_.palette.brush(cr));
+        }
+    }
+
+    painter->drawRect(layout.progress_bar_rect);
+    painter->drawRect(layout.bar_rect);
 
     painter->restore();
 }

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -129,7 +129,7 @@ ItemLayout::ItemLayout(
     status_rect = name_rect.adjusted(0, name_rect.height() + 1, 0, status_size.height() + 1);
     bar_rect = status_rect.adjusted(0, status_rect.height() + 1, 0, PROGRESS_BAR_HEIGHT + PIECE_BAR_HEIGHT + 1);
     progress_bar_rect = bar_rect.adjusted(0, 0, 0, -PIECE_BAR_HEIGHT);
-    piece_bar_rect = bar_rect.adjusted(0, PROGRESS_BAR_HEIGHT + 1, 0, -PROGRESS_BAR_HEIGHT);
+    piece_bar_rect = bar_rect.adjusted(0, PROGRESS_BAR_HEIGHT + 1, 0, 0);
     progress_rect = bar_rect.adjusted(0, bar_rect.height() + 1, 0, progress_size.height());
     icon_rect = QStyle::alignedRect(
         direction,
@@ -610,21 +610,34 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
 
     progress_bar_style_.state = progress_bar_state;
     setProgressBarPercentDone(option, tor);
-    style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
+    // style->drawControl(QStyle::CE_ProgressBar, &progress_bar_style_, painter);
+
+    auto const cr = is_item_selected ? QPalette::HighlightedText : QPalette::Base;
+    float progress = static_cast<float>(progress_bar_style_.progress) / static_cast<float>(progress_bar_style_.maximum);
+
+    QRect progress_bar_fill_rect = layout.progress_bar_rect;
+    progress_bar_fill_rect.setWidth(progress*layout.progress_bar_rect.width());
+    painter->fillRect(progress_bar_fill_rect, progress_bar_style_.palette.brush(cr));
 
     std::vector<int> const availability = tor.availability();
-    float const piece_width = (float) (layout.piece_bar_rect.width() - 2) / tor.pieceCount();
+    float const piece_width = static_cast<float>(layout.piece_bar_rect.width() - 3) / tor.pieceCount();
 
-    for (int i = 0; i < tor.pieceCount(); i++)
+    if (progress == 1.0)
     {
-        if (availability[i] == -1)
+        painter->fillRect(layout.piece_bar_rect, progress_bar_style_.palette.brush(cr));
+    }
+    else
+    {
+        for (int i = 0; i < tor.pieceCount(); i++)
         {
-            int const offset = i*piece_width;
-            QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 1, layout.piece_bar_rect.top(),
-                                       (int) std::ceil(piece_width), PIECE_BAR_HEIGHT - 2 };
+            if (availability[i] == -1)
+            {
+                int const offset = i*piece_width;
+                QRect const piece_rect = { layout.piece_bar_rect.left() + offset + 2, layout.piece_bar_rect.top(),
+                                           static_cast<int>(std::ceil(piece_width)), PIECE_BAR_HEIGHT - 2 };
 
-            auto const cr = is_item_selected ? QPalette::HighlightedText : QPalette::Base;
-            painter->fillRect(piece_rect, progress_bar_style_.palette.brush(cr));
+                painter->fillRect(piece_rect, progress_bar_style_.palette.brush(cr));
+            }
         }
     }
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -31,7 +31,7 @@ enum
 {
     GUI_PAD = 6,
     BAR_WIDTH = 50,
-    BAR_HEIGHT = 16,
+    PROGRESS_BAR_HEIGHT = 16,
     LINE_SPACING = 4
 };
 
@@ -56,7 +56,7 @@ public:
     QRect emblem_rect;
     QRect name_rect;
     QRect status_rect;
-    QRect bar_rect;
+    QRect progress_bar_rect;
 
     ItemLayout(
         QString name_text,
@@ -69,7 +69,7 @@ public:
 
     [[nodiscard]] QSize size() const
     {
-        return (icon_rect | name_rect | status_rect | bar_rect).size();
+        return (icon_rect | name_rect | status_rect | progress_bar_rect).size();
     }
 
     [[nodiscard]] QString nameText() const
@@ -116,7 +116,7 @@ ItemLayout::ItemLayout(
     QSize const status_size(status_fm.size(0, status_text_));
 
     QStyleOptionProgressBar bar_style;
-    bar_style.rect = QRect{ 0, 0, BAR_WIDTH, BAR_HEIGHT };
+    bar_style.rect = QRect{ 0, 0, BAR_WIDTH, PROGRESS_BAR_HEIGHT };
     bar_style.maximum = 100;
     bar_style.progress = 100;
     bar_style.textVisible = true;
@@ -133,8 +133,8 @@ ItemLayout::ItemLayout(
         Qt::AlignRight | Qt::AlignBottom,
         emblem_icon.actualSize(icon_rect.size() / 2, QIcon::Normal, QIcon::On),
         icon_rect);
-    bar_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, bar_size, base_rect);
-    Utils::narrowRect(base_rect, icon_rect.width() + GUI_PAD, bar_rect.width() + GUI_PAD, direction);
+    progress_bar_rect = QStyle::alignedRect(direction, Qt::AlignRight | Qt::AlignVCenter, bar_size, base_rect);
+    Utils::narrowRect(base_rect, icon_rect.width() + GUI_PAD, progress_bar_rect.width() + GUI_PAD, direction);
     status_rect = QStyle::alignedRect(
         direction,
         Qt::AlignRight | Qt::AlignVCenter,
@@ -258,7 +258,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     painter->drawText(layout.name_rect, Qt::AlignLeft | Qt::AlignVCenter, layout.nameText());
     painter->setFont(layout.status_font);
     painter->drawText(layout.status_rect, Qt::AlignLeft | Qt::AlignVCenter, layout.statusText());
-    progress_bar_style_.rect = layout.bar_rect;
+    progress_bar_style_.rect = layout.progress_bar_rect;
 
     if (tor.isDownloading())
     {


### PR DESCRIPTION
Another PR that aims to get closer to feature parity between clients

before
![before](https://github.com/transmission/transmission/assets/74201845/57c7f371-a3ad-493d-939b-dfdb9d00a98a)

after
![after](https://github.com/transmission/transmission/assets/74201845/0d7f5206-937b-491c-908a-fb52e5d535b1)

also fixes the issue on windows where progressbar colors for different torrent states where not respected