### PR TITLE
Qt client accessibility improvements (part 1)

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1550,8 +1550,7 @@ void DetailsDialog::initOptionsTab()
 
     auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.speedSectionLayout);
-    cr->addLayout(ui_.seedingLimitsSectionRatioLayout);
-    cr->addLayout(ui_.seedingLimitsSectionIdleLayout);
+    cr->addLayout(ui_.seedingLimitsSectionLayout);
     cr->addLayout(ui_.peerConnectionsSectionLayout);
     cr->update();
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -262,7 +262,7 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     initOptionsTab();
 
     adjustSize();
-    ui_.commentBrowser->setMaximumHeight(QWIDGETSIZE_MAX);
+    ui_.commentTextEdit->setMaximumHeight(QWIDGETSIZE_MAX);
     ui_.tabs->setCurrentIndex(prev_tab_index_);
 
     static std::array<int, 2> constexpr InitKeys = {
@@ -900,7 +900,7 @@ void DetailsDialog::refreshUI()
         if (torrents.empty())
         {
             labels_baseline_.clear();
-            ui_.labelsTextEdit->setText({});
+            ui_.labelsTextEdit->setPlainText({});
             ui_.labelsTextEdit->setPlaceholderText(none);
             ui_.labelsTextEdit->setReadOnly(true);
             ui_.labelsTextEdit->setEnabled(true);
@@ -911,7 +911,7 @@ void DetailsDialog::refreshUI()
                      [&baseline](auto const* tor) { return tor->labels() == baseline; }))
         {
             labels_baseline_ = baseline.join(QStringLiteral(", "));
-            ui_.labelsTextEdit->setText(labels_baseline_);
+            ui_.labelsTextEdit->setPlainText(labels_baseline_);
             ui_.labelsTextEdit->setPlaceholderText(none);
             ui_.labelsTextEdit->setReadOnly(false);
             ui_.labelsTextEdit->setEnabled(true);
@@ -919,7 +919,7 @@ void DetailsDialog::refreshUI()
         else // mixed
         {
             labels_baseline_.clear();
-            ui_.labelsTextEdit->setText({});
+            ui_.labelsTextEdit->setPlainText({});
             ui_.labelsTextEdit->setPlaceholderText(mixed);
             ui_.labelsTextEdit->setEnabled(false);
         }
@@ -944,12 +944,12 @@ void DetailsDialog::refreshUI()
         }
     }
 
-    if (ui_.commentBrowser->toPlainText() != string)
+    if (ui_.commentTextEdit->toPlainText() != string)
     {
-        ui_.commentBrowser->setText(string);
+        ui_.commentTextEdit->setPlainText(string);
     }
 
-    ui_.commentBrowser->setEnabled(!is_comment_mixed && !string.isEmpty());
+    ui_.commentTextEdit->setEnabled(!is_comment_mixed && !string.isEmpty());
 
     // myOriginLabel
     string = none;
@@ -1044,7 +1044,7 @@ void DetailsDialog::refreshUI()
         }
     }
 
-    ui_.addedLabelValue->setText(string);
+    ui_.addedValueLabel->setText(string);
 
     ///
     ///  Options Tab
@@ -1324,12 +1324,12 @@ void DetailsDialog::setEnabled(bool enabled)
 
 void DetailsDialog::initInfoTab()
 {
-    int const cbh = QFontMetrics{ ui_.commentBrowser->font() }.lineSpacing() * 4;
-    ui_.commentBrowser->setFixedHeight(cbh);
+    int const cbh = QFontMetrics{ ui_.commentTextEdit->font() }.lineSpacing() * 4;
+    ui_.commentTextEdit->setFixedHeight(cbh);
 
     int const lteh = QFontMetrics{ ui_.labelsTextEdit->font() }.lineSpacing() * 2;
     ui_.labelsTextEdit->setFixedHeight(lteh);
-    ui_.labelsTextEdit->setText(QStringLiteral("Initializing..."));
+    ui_.labelsTextEdit->setPlainText(QStringLiteral("Initializing..."));
 
     auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.activitySectionLayout);

--- a/qt/DetailsDialog.ui
+++ b/qt/DetailsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>505</width>
-    <height>581</height>
+    <height>661</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,466 +31,536 @@
       </attribute>
       <layout class="QVBoxLayout" name="infoTabLayout">
        <item>
-        <widget class="QLabel" name="activitySectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="activitySection">
+         <property name="title">
           <string>Activity</string>
          </property>
+         <layout class="QGridLayout" name="activitySectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="haveLabel">
+            <property name="text">
+             <string>Have:</string>
+            </property>
+            <property name="buddy">
+             <cstring>haveValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="SqueezeLabel" name="haveValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="availabilityLabel">
+            <property name="text">
+             <string>Availability:</string>
+            </property>
+            <property name="buddy">
+             <cstring>availabilityValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="SqueezeLabel" name="availabilityValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="uploadedLabel">
+            <property name="text">
+             <string>Uploaded:</string>
+            </property>
+            <property name="buddy">
+             <cstring>uploadedValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="SqueezeLabel" name="uploadedValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="downloadedLabel">
+            <property name="text">
+             <string>Downloaded:</string>
+            </property>
+            <property name="buddy">
+             <cstring>downloadedValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="SqueezeLabel" name="downloadedValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="stateLabel">
+            <property name="text">
+             <string>State:</string>
+            </property>
+            <property name="buddy">
+             <cstring>stateValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="SqueezeLabel" name="stateValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="runningTimeLabel">
+            <property name="text">
+             <string>Running time:</string>
+            </property>
+            <property name="buddy">
+             <cstring>runningTimeValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="SqueezeLabel" name="runningTimeValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="remainingTimeLabel">
+            <property name="text">
+             <string>Remaining time:</string>
+            </property>
+            <property name="buddy">
+             <cstring>remainingTimeValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="SqueezeLabel" name="remainingTimeValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="lastActivityLabel">
+            <property name="text">
+             <string>Last activity:</string>
+            </property>
+            <property name="buddy">
+             <cstring>lastActivityValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="SqueezeLabel" name="lastActivityValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="errorLabel">
+            <property name="text">
+             <string>Error:</string>
+            </property>
+            <property name="buddy">
+             <cstring>errorValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="SqueezeLabel" name="errorValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="activitySectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="haveLabel">
-           <property name="text">
-            <string>Have:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="SqueezeLabel" name="haveValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="availabilityLabel">
-           <property name="text">
-            <string>Availability:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="SqueezeLabel" name="availabilityValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="uploadedLabel">
-           <property name="text">
-            <string>Uploaded:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="SqueezeLabel" name="uploadedValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="downloadedLabel">
-           <property name="text">
-            <string>Downloaded:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="SqueezeLabel" name="downloadedValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="stateLabel">
-           <property name="text">
-            <string>State:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="SqueezeLabel" name="stateValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="runningTimeLabel">
-           <property name="text">
-            <string>Running time:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="SqueezeLabel" name="runningTimeValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="remainingTimeLabel">
-           <property name="text">
-            <string>Remaining time:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="SqueezeLabel" name="remainingTimeValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="lastActivityLabel">
-           <property name="text">
-            <string>Last activity:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="SqueezeLabel" name="lastActivityValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="errorLabel">
-           <property name="text">
-            <string>Error:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="SqueezeLabel" name="errorValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="detailsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="detailsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="detailsSection">
+         <property name="title">
           <string>Details</string>
          </property>
+         <layout class="QGridLayout" name="detailsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="sizeLabel">
+            <property name="text">
+             <string>Size:</string>
+            </property>
+            <property name="buddy">
+             <cstring>sizeValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="SqueezeLabel" name="sizeValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="locationLabel">
+            <property name="text">
+             <string>Location:</string>
+            </property>
+            <property name="buddy">
+             <cstring>locationValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="SqueezeLabel" name="locationValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="hashLabel">
+            <property name="text">
+             <string>Hash:</string>
+            </property>
+            <property name="buddy">
+             <cstring>hashValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="SqueezeLabel" name="hashValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="privacyLabel">
+            <property name="text">
+             <string>Privacy:</string>
+            </property>
+            <property name="buddy">
+             <cstring>privacyValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="SqueezeLabel" name="privacyValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="originLabel">
+            <property name="text">
+             <string>Origin:</string>
+            </property>
+            <property name="buddy">
+             <cstring>originValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="SqueezeLabel" name="originValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="addedLabel">
+            <property name="text">
+             <string>Added:</string>
+            </property>
+            <property name="buddy">
+             <cstring>addedValueLabel</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="SqueezeLabel" name="addedValueLabel">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelsLabel">
+            <property name="text">
+             <string>Labels:</string>
+            </property>
+            <property name="buddy">
+             <cstring>labelsTextEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QPlainTextEdit" name="labelsTextEdit">
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="commentLabel">
+            <property name="text">
+             <string>Comment:</string>
+            </property>
+            <property name="buddy">
+             <cstring>commentTextEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QPlainTextEdit" name="commentTextEdit">
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="detailsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="1">
-          <widget class="SqueezeLabel" name="sizeValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="SqueezeLabel" name="locationValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="hashLabel">
-           <property name="text">
-            <string>Hash:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="privacyLabel">
-           <property name="text">
-            <string>Privacy:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="originLabel">
-           <property name="text">
-            <string>Origin:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="SqueezeLabel" name="originValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="SqueezeLabel" name="privacyValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::NoTextInteraction</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="sizeLabel">
-           <property name="text">
-            <string>Size:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="locationLabel">
-           <property name="text">
-            <string>Location:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="SqueezeLabel" name="hashValueLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-	 <item row="5" column="0">
-          <widget class="QLabel" name="addedLabel">
-           <property name="text">
-            <string>Added:</string>
-           </property>
-          </widget>
-         </item>
-	 <item row="5" column="1">
-          <widget class="QLabel" name="addedLabelValue">
-           <property name="text">
-            <string></string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="labelsLabel">
-           <property name="text">
-            <string>Labels:</string>
-           </property>
-           <property name="buddy">
-            <cstring>labelsTextEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QTextEdit" name="labelsTextEdit">
-           <property name="readOnly">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="commentLabel">
-           <property name="text">
-            <string>Comment:</string>
-           </property>
-           <property name="buddy">
-            <cstring>commentBrowser</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="QTextBrowser" name="commentBrowser">
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
       </layout>
      </widget>

--- a/qt/DetailsDialog.ui
+++ b/qt/DetailsDialog.ui
@@ -714,229 +714,174 @@
       </attribute>
       <layout class="QVBoxLayout" name="optionsTabLayout">
        <item>
-        <widget class="QLabel" name="speedSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="speedSection">
+         <property name="title">
           <string>Speed</string>
          </property>
+         <layout class="QGridLayout" name="speedSectionLayout" columnstretch="0,1">
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="sessionLimitCheck">
+            <property name="text">
+             <string>Honor global &amp;limits</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="singleUpCheck">
+            <property name="text">
+             <string>Limit &amp;upload speed:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="singleUpSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="singleDownCheck">
+            <property name="text">
+             <string>Limit &amp;download speed:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="singleDownSpin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="bandwidthPriorityLabel">
+            <property name="text">
+             <string>Torrent &amp;priority:</string>
+            </property>
+            <property name="buddy">
+             <cstring>bandwidthPriorityCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="bandwidthPriorityCombo"/>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="speedSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0" colspan="2">
-          <widget class="QCheckBox" name="sessionLimitCheck">
-           <property name="text">
-            <string>Honor global &amp;limits</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="singleUpCheck">
-           <property name="text">
-            <string>Limit &amp;upload speed:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="singleUpSpin">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="singleDownCheck">
-           <property name="text">
-            <string>Limit &amp;download speed:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="singleDownSpin">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="bandwidthPriorityLabel">
-           <property name="text">
-            <string>Torrent &amp;priority:</string>
-           </property>
-           <property name="buddy">
-            <cstring>bandwidthPriorityCombo</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QComboBox" name="bandwidthPriorityCombo"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="seedingLimitsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="seedingLimitsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="seedingLimitsSection">
+         <property name="title">
           <string>Seeding Limits</string>
          </property>
+         <layout class="QGridLayout" name="seedingLimitsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="ratioLabel">
+            <property name="text">
+             <string>&amp;Ratio:</string>
+            </property>
+            <property name="buddy">
+             <cstring>ratioCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="seedingLimitsSectionRatioLayout" stretch="1,0">
+            <item>
+             <widget class="QComboBox" name="ratioCombo"/>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="ratioSpin">
+              <property name="maximum">
+               <double>999999999.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.500000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="idleLabel">
+            <property name="text">
+             <string>&amp;Idle:</string>
+            </property>
+            <property name="buddy">
+             <cstring>idleCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="seedingLimitsSectionIdleLayout" stretch="1,0">
+            <item>
+             <widget class="QComboBox" name="idleCombo"/>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="idleSpin">
+              <property name="suffix">
+               <string notr="true"> minute(s)</string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>40320</number>
+              </property>
+              <property name="singleStep">
+               <number>5</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="seedingLimitsSectionRatioLayout" columnstretch="0,1,0">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="ratioLabel">
-           <property name="text">
-            <string>&amp;Ratio:</string>
-           </property>
-           <property name="buddy">
-            <cstring>ratioCombo</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="ratioCombo"/>
-         </item>
-         <item row="0" column="2">
-          <widget class="QDoubleSpinBox" name="ratioSpin">
-           <property name="maximum">
-            <double>999999999.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.500000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="seedingLimitsSectionIdleLayout" columnstretch="0,1,0">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="idleLabel">
-           <property name="text">
-            <string>&amp;Idle:</string>
-           </property>
-           <property name="buddy">
-            <cstring>idleCombo</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="idleCombo"/>
-         </item>
-         <item row="0" column="2">
-          <widget class="QSpinBox" name="idleSpin">
-           <property name="suffix">
-            <string notr="true"> minute(s)</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>40320</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="peerConnectionsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="peerConnectionsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="peerConnectionsSection">
+         <property name="title">
           <string>Peer Connections</string>
          </property>
+         <layout class="QGridLayout" name="peerConnectionsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="peerLimitLabel">
+            <property name="text">
+             <string>&amp;Maximum peers:</string>
+            </property>
+            <property name="buddy">
+             <cstring>peerLimitSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="peerLimitSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>300</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="peerConnectionsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="peerLimitLabel">
-           <property name="text">
-            <string>&amp;Maximum peers:</string>
-           </property>
-           <property name="buddy">
-            <cstring>peerLimitSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="peerLimitSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>300</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="optionsTabBottomSpacer">
@@ -988,8 +933,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>26</x>
-     <y>563</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1004,8 +949,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>26</x>
-     <y>563</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1020,12 +965,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>35</x>
-     <y>99</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>247</x>
-     <y>93</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1036,12 +981,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>35</x>
-     <y>131</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>247</x>
-     <y>125</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -223,25 +223,21 @@ FilterBar::FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter c
     , prefs_{ prefs }
     , torrents_{ torrents }
     , filter_{ filter }
+    , count_label_{ new QLabel{ tr("Show:"), this } }
     , is_bootstrapping_{ true }
 {
     auto* h = new QHBoxLayout{ this };
     h->setContentsMargins(3, 3, 3, 3);
 
-    count_label_ = new QLabel{ tr("Show:"), this };
     h->addWidget(count_label_);
-
     h->addWidget(activity_combo_);
-
-    tracker_combo_ = createTrackerCombo(tracker_model_);
     h->addWidget(tracker_combo_);
-
     h->addStretch();
+    h->addWidget(line_edit_, 1);
 
     line_edit_->setClearButtonEnabled(true);
     line_edit_->setPlaceholderText(tr("Search…"));
     line_edit_->setMaximumWidth(250);
-    h->addWidget(line_edit_, 1);
     connect(line_edit_, &QLineEdit::textChanged, this, &FilterBar::onTextChanged);
 
     // listen for changes from the other players

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -56,13 +56,15 @@ private:
     TorrentModel const& torrents_;
     TorrentFilter const& filter_;
 
-    std::map<QString, int> sitename_counts_;
-    FilterBarComboBox* const activity_combo_ = createActivityCombo();
-    FilterBarComboBox* tracker_combo_ = {};
-    QLabel* count_label_ = {};
     QStandardItemModel* const tracker_model_ = new QStandardItemModel{ this };
-    QTimer recount_timer_;
+
+    QLabel* const count_label_ = {};
+    FilterBarComboBox* const activity_combo_ = createActivityCombo();
+    FilterBarComboBox* const tracker_combo_ = createTrackerCombo(tracker_model_);
     QLineEdit* const line_edit_ = new QLineEdit{ this };
+
+    std::map<QString, int> sitename_counts_;
+    QTimer recount_timer_;
     Pending pending_ = {};
     bool is_bootstrapping_ = {};
 

--- a/qt/MakeDialog.ui
+++ b/qt/MakeDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>566</width>
-    <height>426</height>
+    <width>503</width>
+    <height>472</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -18,193 +18,161 @@
   </property>
   <layout class="QVBoxLayout" name="dialogLayout">
    <item>
-    <widget class="QLabel" name="filesSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="filesSection">
+     <property name="title">
       <string>Files</string>
      </property>
+     <layout class="QGridLayout" name="filesSectionLayout" columnstretch="0,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="destinationLabel">
+        <property name="text">
+         <string>Sa&amp;ve to:</string>
+        </property>
+        <property name="buddy">
+         <cstring>destinationButton</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="PathButton" name="destinationButton"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="sourceFolderRadio">
+        <property name="text">
+         <string>Source f&amp;older:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="PathButton" name="sourceFolderButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="sourceFileRadio">
+        <property name="text">
+         <string>Source &amp;file:</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="PathButton" name="sourceFileButton"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="sourceSizeLabel">
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="pieceSizeLabel">
+        <property name="text">
+         <string>Piece s&amp;ize:</string>
+        </property>
+        <property name="buddy">
+         <cstring>pieceSizeSlider</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSlider" name="pieceSizeSlider">
+        <property name="minimum">
+         <number>14</number>
+        </property>
+        <property name="maximum">
+         <number>28</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <layout class="QGridLayout" name="filesSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="destinationLabel">
-       <property name="text">
-        <string>Sa&amp;ve to:</string>
-       </property>
-       <property name="buddy">
-        <cstring>destinationButton</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="PathButton" name="destinationButton"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QRadioButton" name="sourceFolderRadio">
-       <property name="text">
-        <string>Source f&amp;older:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="PathButton" name="sourceFolderButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QRadioButton" name="sourceFileRadio">
-       <property name="text">
-        <string>Source &amp;file:</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="PathButton" name="sourceFileButton"/>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="sourceSizeLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QSlider" name="pieceSizeSlider">
-       <property name="minimum">
-        <number>14</number>
-       </property>
-       <property name="maximum">
-        <number>28</number>
-       </property>
-       <property name="pageStep">
-        <number>1</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="pieceSizeLabel">
-       <property name="text">
-        <string>Piece s&amp;ize:</string>
-       </property>
-       <property name="buddy">
-        <cstring>pieceSizeSlider</cstring>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="propertiesSectionSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>1</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QLabel" name="propertiesSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="propertiesSection">
+     <property name="title">
       <string>Properties</string>
      </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="propertiesSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="trackersLabel">
-       <property name="text">
-        <string>&amp;Trackers:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="buddy">
-        <cstring>trackersEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QPlainTextEdit" name="trackersEdit">
-       <property name="tabChangesFocus">
-        <bool>true</bool>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="trackersDescriptionLabel">
-       <property name="text">
-        <string>To add a backup URL, add it on the line after the primary URL.
+     <layout class="QGridLayout" name="propertiesSectionLayout" columnstretch="0,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="trackersLabel">
+        <property name="text">
+         <string>&amp;Trackers:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <property name="buddy">
+         <cstring>trackersEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPlainTextEdit" name="trackersEdit">
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
+        <property name="lineWrapMode">
+         <enum>QPlainTextEdit::NoWrap</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="trackersDescriptionLabel">
+        <property name="text">
+         <string>To add a backup URL, add it on the line after the primary URL.
 To add another primary URL, add it after a blank line.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="commentCheck">
-       <property name="text">
-        <string>Co&amp;mment:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="commentEdit">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="sourceCheck">
-       <property name="text">
-        <string>&amp;Source:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="sourceEdit">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="QCheckBox" name="privateCheck">
-       <property name="text">
-        <string>&amp;Private torrent</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="commentCheck">
+        <property name="text">
+         <string>Co&amp;mment:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="commentEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="sourceCheck">
+        <property name="text">
+         <string>&amp;Source:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="sourceEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="privateCheck">
+        <property name="text">
+         <string>&amp;Private torrent</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="dialogButtons">
@@ -234,12 +202,12 @@ To add another primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>76</x>
-     <y>333</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>360</x>
-     <y>333</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -250,12 +218,12 @@ To add another primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>72</x>
-     <y>83</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>360</x>
-     <y>82</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -266,12 +234,12 @@ To add another primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>72</x>
-     <y>119</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>360</x>
-     <y>118</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -282,12 +250,12 @@ To add another primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>75</x>
-     <y>347</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>342</x>
-     <y>347</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -847,89 +847,57 @@ To add a new primary URL, add it after a blank line.</string>
       </attribute>
       <layout class="QVBoxLayout" name="desktopTabLayout">
        <item>
-        <widget class="QLabel" name="desktopSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="desktopSection">
+         <property name="title">
           <string>Desktop</string>
          </property>
+         <layout class="QVBoxLayout" name="desktopSectionLayout">
+          <item>
+           <widget class="QCheckBox" name="showTrayIconCheck">
+            <property name="text">
+             <string>Show Transmission icon in the &amp;notification area</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="startMinimizedCheck">
+            <property name="text">
+             <string>Start &amp;minimized in notification area</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="desktopSectionLayout">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="showTrayIconCheck">
-           <property name="text">
-            <string>Show Transmission icon in the &amp;notification area</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="startMinimizedCheck">
-           <property name="text">
-            <string>Start &amp;minimized in notification area</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="notificationSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="notificationSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="notificationSection">
+         <property name="title">
           <string>Notification</string>
          </property>
+         <layout class="QVBoxLayout" name="notificationSectionLayout">
+          <item>
+           <widget class="QCheckBox" name="notifyOnTorrentAddedCheck">
+            <property name="text">
+             <string>Show a notification when torrents are a&amp;dded</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="notifyOnTorrentCompletedCheck">
+            <property name="text">
+             <string>Show a notification when torrents &amp;finish</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="playSoundOnTorrentCompletedCheck">
+            <property name="text">
+             <string>Play a &amp;sound when torrents finish</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="notificationSectionLayout">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="notifyOnTorrentAddedCheck">
-           <property name="text">
-            <string>Show a notification when torrents are a&amp;dded</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="notifyOnTorrentCompletedCheck">
-           <property name="text">
-            <string>Show a notification when torrents &amp;finish</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="playSoundOnTorrentCompletedCheck">
-           <property name="text">
-            <string>Play a &amp;sound when torrents finish</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="desktopTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -450,89 +450,81 @@
       </attribute>
       <layout class="QVBoxLayout" name="seedingTabLayout">
        <item>
-        <widget class="QLabel" name="limitsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="limitsSection">
+         <property name="title">
           <string>Limits</string>
          </property>
+         <layout class="QGridLayout" name="limitsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="ratioLimitCheck">
+            <property name="text">
+             <string>Stop seeding at &amp;ratio:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="ratioLimitSpin">
+            <property name="maximum">
+             <double>999999999.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.500000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="idleLimitCheck">
+            <property name="text">
+             <string>Stop seedi&amp;ng if idle for:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="idleLimitSpin">
+            <property name="suffix">
+             <string notr="true"> minute(s)</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>40320</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="doneSeedingScriptCheck">
+            <property name="text">
+             <string>Call scrip&amp;t when seeding is completed:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QStackedWidget" name="doneSeedingScriptStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <widget class="PathButton" name="doneSeedingScriptButton"/>
+            <widget class="QLineEdit" name="doneSeedingScriptEdit"/>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="limitsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="ratioLimitCheck">
-           <property name="text">
-            <string>Stop seeding at &amp;ratio:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="ratioLimitSpin">
-           <property name="maximum">
-            <double>999999999.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.500000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="idleLimitCheck">
-           <property name="text">
-            <string>Stop seedi&amp;ng if idle for:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="idleLimitSpin">
-           <property name="suffix">
-            <string notr="true"> minute(s)</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>40320</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="doneSeedingScriptCheck">
-           <property name="text">
-            <string>Call scrip&amp;t when seeding is completed:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QStackedWidget" name="doneSeedingScriptStack">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="PathButton" name="doneSeedingScriptButton"/>
-           <widget class="QLineEdit" name="doneSeedingScriptEdit"/>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="seedingTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -635,276 +635,196 @@
       </attribute>
       <layout class="QVBoxLayout" name="networkTabLayout">
        <item>
-        <widget class="QLabel" name="incomingPeersSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="incomingPeersSection">
+         <property name="title">
           <string>Incoming Peers</string>
          </property>
+         <layout class="QGridLayout" name="incomingPeersSectionLayout" columnstretch="0,1,0">
+          <item row="0" column="0">
+           <widget class="QLabel" name="peerPortLabel">
+            <property name="text">
+             <string>&amp;Port for incoming connections:</string>
+            </property>
+            <property name="buddy">
+             <cstring>peerPortSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QSpinBox" name="peerPortSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>65535</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="peerPortStatusLabel">
+            <property name="text">
+             <string>Status unknown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="testPeerPortButton">
+            <property name="text">
+             <string>Te&amp;st Port</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QCheckBox" name="randomPeerPortCheck">
+            <property name="text">
+             <string>Pick a &amp;random port every time Transmission is started</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="QCheckBox" name="enablePortForwardingCheck">
+            <property name="text">
+             <string>Use UPnP or NAT-PMP port &amp;forwarding from my router</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="incomingPeersSectionLayout" columnstretch="0,1,0">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="peerPortLabel">
-           <property name="text">
-            <string>&amp;Port for incoming connections:</string>
-           </property>
-           <property name="buddy">
-            <cstring>peerPortSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1" colspan="2">
-          <widget class="QSpinBox" name="peerPortSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>65535</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="peerPortStatusLabel">
-           <property name="text">
-            <string>Status unknown</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QPushButton" name="testPeerPortButton">
-           <property name="text">
-            <string>Te&amp;st Port</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="3">
-          <widget class="QCheckBox" name="randomPeerPortCheck">
-           <property name="text">
-            <string>Pick a &amp;random port every time Transmission is started</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="3">
-          <widget class="QCheckBox" name="enablePortForwardingCheck">
-           <property name="text">
-            <string>Use UPnP or NAT-PMP port &amp;forwarding from my router</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="peerLimitsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="peerLimitsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="peerLimitsSection">
+         <property name="title">
           <string>Peer Limits</string>
          </property>
+         <layout class="QGridLayout" name="peerLimitsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="torrentPeerLimitLabel">
+            <property name="text">
+             <string>Maximum peers per &amp;torrent:</string>
+            </property>
+            <property name="buddy">
+             <cstring>torrentPeerLimitSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="torrentPeerLimitSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1024</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="globalPeerLimitLabel">
+            <property name="text">
+             <string>Maximum peers &amp;overall:</string>
+            </property>
+            <property name="buddy">
+             <cstring>globalPeerLimitSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="globalPeerLimitSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>1024</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="peerLimitsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="torrentPeerLimitLabel">
-           <property name="text">
-            <string>Maximum peers per &amp;torrent:</string>
-           </property>
-           <property name="buddy">
-            <cstring>torrentPeerLimitSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="torrentPeerLimitSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>1024</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="globalPeerLimitLabel">
-           <property name="text">
-            <string>Maximum peers &amp;overall:</string>
-           </property>
-           <property name="buddy">
-            <cstring>globalPeerLimitSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="globalPeerLimitSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>1024</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="optionsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="optionsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="optionsSection">
+         <property name="title">
           <string>Options</string>
          </property>
+         <layout class="QVBoxLayout" name="optionsSectionLayout">
+          <item>
+           <widget class="QCheckBox" name="enableUtpCheck">
+            <property name="toolTip">
+             <string>µTP is a tool for reducing network congestion.</string>
+            </property>
+            <property name="text">
+             <string>Enable µ&amp;TP for peer connections</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="enablePexCheck">
+            <property name="toolTip">
+             <string>PEX is a tool for exchanging peer lists with the peers you're connected to.</string>
+            </property>
+            <property name="text">
+             <string>Use PE&amp;X to find more peers</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="enableDhtCheck">
+            <property name="toolTip">
+             <string>DHT is a tool for finding peers without a tracker.</string>
+            </property>
+            <property name="text">
+             <string>Use &amp;DHT to find more peers</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="enableLpdCheck">
+            <property name="toolTip">
+             <string>LPD is a tool for finding peers on your local network.</string>
+            </property>
+            <property name="text">
+             <string>Use &amp;Local Peer Discovery to find more peers</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="optionsSectionLayout">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="enableUtpCheck">
-           <property name="toolTip">
-            <string>µTP is a tool for reducing network congestion.</string>
-           </property>
-           <property name="text">
-            <string>Enable µ&amp;TP for peer connections</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="enablePexCheck">
-           <property name="toolTip">
-            <string>PEX is a tool for exchanging peer lists with the peers you're connected to.</string>
-           </property>
-           <property name="text">
-            <string>Use PE&amp;X to find more peers</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="enableDhtCheck">
-           <property name="toolTip">
-            <string>DHT is a tool for finding peers without a tracker.</string>
-           </property>
-           <property name="text">
-            <string>Use &amp;DHT to find more peers</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="enableLpdCheck">
-           <property name="toolTip">
-            <string>LPD is a tool for finding peers on your local network.</string>
-           </property>
-           <property name="text">
-            <string>Use &amp;Local Peer Discovery to find more peers</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="defaultTrackersSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="defaultTrackersLabel">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="defaultTrackersSection">
+         <property name="title">
           <string>Default Public Trackers</string>
          </property>
+         <layout class="QVBoxLayout" name="defaultTrackersSectionLayout">
+          <item>
+           <widget class="QPlainTextEdit" name="defaultTrackersPlainTextEdit">
+            <property name="toolTip">
+             <string>Trackers to use on all public torrents.
+
+To add a backup URL, add it on the next line after a primary URL.
+To add a new primary URL, add it after a blank line.</string>
+            </property>
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
+            <property name="lineWrapMode">
+             <enum>QPlainTextEdit::NoWrap</enum>
+            </property>
+            <property name="plainText">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="defaultTrackersLayout">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item>
-          <widget class="QPlainTextEdit" name="defaultTrackersPlainTextEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Trackers to use on all public torrents.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;To add a backup URL, add it on the next line after a primary URL.&lt;/p&gt;&lt;p&gt;To add a new primary URL, add it after a blank line.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="tabChangesFocus">
-            <bool>true</bool>
-           </property>
-           <property name="lineWrapMode">
-            <enum>QPlainTextEdit::NoWrap</enum>
-           </property>
-           <property name="plainText">
-            <string notr="true"/>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="networkTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -547,104 +547,72 @@
       </attribute>
       <layout class="QVBoxLayout" name="privacyTabLayout">
        <item>
-        <widget class="QLabel" name="encryptionSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="encryptionSection">
+         <property name="title">
           <string>Encryption</string>
          </property>
+         <layout class="QGridLayout" name="encryptionSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="encryptionModeLabel">
+            <property name="text">
+             <string>&amp;Encryption mode:</string>
+            </property>
+            <property name="buddy">
+             <cstring>encryptionModeCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="encryptionModeCombo"/>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="encryptionSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="encryptionModeLabel">
-           <property name="text">
-            <string>&amp;Encryption mode:</string>
-           </property>
-           <property name="buddy">
-            <cstring>encryptionModeCombo</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="encryptionModeCombo"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="blocklistSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="blocklistSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="blocklistSection">
+         <property name="title">
           <string>Blocklist</string>
          </property>
+         <layout class="QGridLayout" name="blocklistSectionLayout" columnstretch="0,1,0">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="blocklistCheck">
+            <property name="text">
+             <string>Enable &amp;blocklist:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QLineEdit" name="blocklistEdit"/>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QLabel" name="blocklistStatusLabel">
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="updateBlocklistButton">
+            <property name="text">
+             <string>&amp;Update</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QCheckBox" name="autoUpdateBlocklistCheck">
+            <property name="text">
+             <string>Enable &amp;automatic updates</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="blocklistSectionLayout" columnstretch="0,1,0">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="blocklistCheck">
-           <property name="text">
-            <string>Enable &amp;blocklist:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1" colspan="2">
-          <widget class="QLineEdit" name="blocklistEdit"/>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QLabel" name="blocklistStatusLabel">
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QPushButton" name="updateBlocklistButton">
-           <property name="text">
-            <string>&amp;Update</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="3">
-          <widget class="QCheckBox" name="autoUpdateBlocklistCheck">
-           <property name="text">
-            <string>Enable &amp;automatic updates</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="privacyTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -31,212 +31,177 @@
       </attribute>
       <layout class="QVBoxLayout" name="speedTabLayout">
        <item>
-        <widget class="QLabel" name="speedLimitsSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="speedLimitsSection">
+         <property name="title">
           <string>Speed Limits</string>
          </property>
+         <layout class="QGridLayout" name="speedLimitsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="uploadSpeedLimitCheck">
+            <property name="text">
+             <string>&amp;Upload:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="uploadSpeedLimitSpin">
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="downloadSpeedLimitCheck">
+            <property name="text">
+             <string>&amp;Download:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="downloadSpeedLimitSpin">
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="speedLimitsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
+        <widget class="QGroupBox" name="altSpeedLimitsSection">
+         <property name="title">
+          <string>Alternative Speed Limits</string>
          </property>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="uploadSpeedLimitCheck">
-           <property name="text">
-            <string>&amp;Upload:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="uploadSpeedLimitSpin">
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="downloadSpeedLimitCheck">
-           <property name="text">
-            <string>&amp;Download:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="downloadSpeedLimitSpin">
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="altSpeedLimitsSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="altSpeedLimitsSectionTitleLayout" stretch="0,1">
-         <property name="spacing">
-          <number>2</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="altSpeedLimitsSectionLabel">
-           <property name="styleSheet">
-            <string notr="true">font-weight:bold</string>
-           </property>
-           <property name="text">
-            <string>Alternative Speed Limits</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="altSpeedLimitsSectionIconLabel">
-           <property name="pixmap">
-            <pixmap resource="application.qrc">:/icons/alt-limit-off.svg</pixmap>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="altSpeedLimitsSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="altSpeedLimitsSectionDescriptionLabel">
-           <property name="text">
-            <string>&lt;small&gt;Override normal speed limits manually or at scheduled times&lt;/small&gt;</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="altUploadSpeedLimitLabel">
-           <property name="text">
-            <string>U&amp;pload:</string>
-           </property>
-           <property name="buddy">
-            <cstring>altUploadSpeedLimitSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="altUploadSpeedLimitSpin">
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="altDownloadSpeedLimitLabel">
-           <property name="text">
-            <string>Do&amp;wnload:</string>
-           </property>
-           <property name="buddy">
-            <cstring>altDownloadSpeedLimitSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="altDownloadSpeedLimitSpin">
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="altSpeedLimitScheduleCheck">
-           <property name="text">
-            <string>&amp;Scheduled times:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <layout class="QHBoxLayout" name="altSpeedLimitScheduleLayout">
-           <item>
-            <widget class="QTimeEdit" name="altSpeedLimitStartTimeEdit">
-             <property name="displayFormat">
-              <string notr="true">hh:mm</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="altSpeedLimitToLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&amp;to</string>
-             </property>
-             <property name="buddy">
-              <cstring>altSpeedLimitEndTimeEdit</cstring>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QTimeEdit" name="altSpeedLimitEndTimeEdit">
-             <property name="displayFormat">
-              <string notr="true">hh:mm</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="altSpeedLimitDaysLabel">
-           <property name="text">
-            <string>&amp;On days:</string>
-           </property>
-           <property name="buddy">
-            <cstring>altSpeedLimitDaysCombo</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QComboBox" name="altSpeedLimitDaysCombo"/>
-         </item>
-        </layout>
+         <layout class="QGridLayout" name="altSpeedLimitsSectionLayout" columnstretch="0,1">
+          <item row="0" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+            <item>
+             <widget class="QLabel" name="altSpeedLimitsSectionIconLabel">
+              <property name="pixmap">
+               <pixmap resource="application.qrc">:/icons/alt-limit-off.svg</pixmap>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="altSpeedLimitsSectionDescriptionLabel">
+              <property name="text">
+               <string>&lt;small&gt;Override normal speed limits manually or at scheduled times&lt;/small&gt;</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="altUploadSpeedLimitLabel">
+            <property name="text">
+             <string>U&amp;pload:</string>
+            </property>
+            <property name="buddy">
+             <cstring>altUploadSpeedLimitSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="altUploadSpeedLimitSpin">
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="altDownloadSpeedLimitLabel">
+            <property name="text">
+             <string>Do&amp;wnload:</string>
+            </property>
+            <property name="buddy">
+             <cstring>altDownloadSpeedLimitSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="altDownloadSpeedLimitSpin">
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="altSpeedLimitScheduleCheck">
+            <property name="text">
+             <string>&amp;Scheduled times:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="altSpeedLimitScheduleLayout">
+            <item>
+             <widget class="QTimeEdit" name="altSpeedLimitStartTimeEdit">
+              <property name="displayFormat">
+               <string notr="true">hh:mm</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="altSpeedLimitToLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&amp;to</string>
+              </property>
+              <property name="buddy">
+               <cstring>altSpeedLimitEndTimeEdit</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QTimeEdit" name="altSpeedLimitEndTimeEdit">
+              <property name="displayFormat">
+               <string notr="true">hh:mm</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="altSpeedLimitDaysLabel">
+            <property name="text">
+             <string>&amp;On days:</string>
+            </property>
+            <property name="buddy">
+             <cstring>altSpeedLimitDaysCombo</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="altSpeedLimitDaysCombo"/>
+          </item>
+         </layout>
+        </widget>
        </item>
        <item>
         <spacer name="speedTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -224,266 +224,210 @@
       </attribute>
       <layout class="QVBoxLayout" name="downloadingTabLayout">
        <item>
-        <widget class="QLabel" name="addingSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="addingSection">
+         <property name="title">
           <string>Adding</string>
          </property>
+         <layout class="QGridLayout" name="addingSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="watchDirCheck">
+            <property name="text">
+             <string>Automatically add .torrent files &amp;from:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QStackedWidget" name="watchDirStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <widget class="PathButton" name="watchDirButton"/>
+            <widget class="QLineEdit" name="watchDirEdit"/>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="showTorrentOptionsDialogCheck">
+            <property name="text">
+             <string>Show the Torrent Options &amp;dialog</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="startAddedTorrentsCheck">
+            <property name="text">
+             <string>&amp;Start added torrents</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="detectTorrentFromClipboard">
+            <property name="toolTip">
+             <string>Reads user clipboard content for torrents</string>
+            </property>
+            <property name="text">
+             <string>Detect new torrents from clipboard</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QCheckBox" name="trashTorrentFileCheck">
+            <property name="text">
+             <string>Mo&amp;ve the .torrent file to the trash</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="downloadDirLabel">
+            <property name="text">
+             <string>Save to &amp;Location:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QStackedWidget" name="downloadDirStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <widget class="PathButton" name="downloadDirButton"/>
+            <widget class="QLineEdit" name="downloadDirEdit"/>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="FreeSpaceLabel" name="downloadDirFreeSpaceLabel">
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="addingSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="5" column="0">
-          <widget class="QLabel" name="downloadDirLabel">
-           <property name="text">
-            <string>Save to &amp;Location:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="watchDirCheck">
-           <property name="text">
-            <string>Automatically add .torrent files &amp;from:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QCheckBox" name="startAddedTorrentsCheck">
-           <property name="text">
-            <string>&amp;Start added torrents</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="FreeSpaceLabel" name="downloadDirFreeSpaceLabel">
-           <property name="text">
-            <string notr="true">...</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QCheckBox" name="showTorrentOptionsDialogCheck">
-           <property name="text">
-            <string>Show the Torrent Options &amp;dialog</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="trashTorrentFileCheck">
-           <property name="text">
-            <string>Mo&amp;ve the .torrent file to the trash</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QStackedWidget" name="watchDirStack">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="PathButton" name="watchDirButton"/>
-           <widget class="QLineEdit" name="watchDirEdit"/>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QStackedWidget" name="downloadDirStack">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="PathButton" name="downloadDirButton"/>
-           <widget class="QLineEdit" name="downloadDirEdit"/>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="detectTorrentFromClipboard">
-           <property name="toolTip">
-            <string>Reads user clipboard content for torrents</string>
-           </property>
-           <property name="text">
-            <string>Detect new torrents from clipboard</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="downloadQueueSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="downloadQueueSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="downloadQueueSection">
+         <property name="title">
           <string>Download Queue</string>
          </property>
+         <layout class="QGridLayout" name="downloadQueueSectionLayout" columnstretch="0,1">
+          <item row="0" column="0">
+           <widget class="QLabel" name="downloadQueueSizeLabel">
+            <property name="text">
+             <string>Ma&amp;ximum active downloads:</string>
+            </property>
+            <property name="buddy">
+             <cstring>downloadQueueSizeSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="downloadQueueSizeSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="queueStalledMinutesLabel">
+            <property name="text">
+             <string extracomment="Please keep this phrase as short as possible, it's currently the longest and influences dialog width">Download is i&amp;nactive if data sharing stopped:</string>
+            </property>
+            <property name="buddy">
+             <cstring>queueStalledMinutesSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="queueStalledMinutesSpin">
+            <property name="suffix">
+             <string notr="true"> minute(s) ago</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="downloadQueueSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="downloadQueueSizeLabel">
-           <property name="text">
-            <string>Ma&amp;ximum active downloads:</string>
-           </property>
-           <property name="buddy">
-            <cstring>downloadQueueSizeSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="downloadQueueSizeSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>999999999</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="queueStalledMinutesLabel">
-           <property name="text">
-            <string extracomment="Please keep this phrase as short as possible, it's currently the longest and influences dialog width">Download is i&amp;nactive if data sharing stopped:</string>
-           </property>
-           <property name="buddy">
-            <cstring>queueStalledMinutesSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="queueStalledMinutesSpin">
-           <property name="suffix">
-            <string notr="true"> minute(s) ago</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="incompleteSectionSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>1</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="incompleteSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="incompleteSection">
+         <property name="title">
           <string>Incomplete</string>
          </property>
+         <layout class="QGridLayout" name="incompleteSectionLayout" columnstretch="0,1">
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="renamePartialFilesCheck">
+            <property name="text">
+             <string>Append &quot;.&amp;part&quot; to incomplete files' names</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="incompleteDirCheck">
+            <property name="text">
+             <string>Keep &amp;incomplete files in:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QStackedWidget" name="incompleteDirStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <widget class="PathButton" name="incompleteDirButton"/>
+            <widget class="QLineEdit" name="incompleteDirEdit"/>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="doneDownloadingScriptCheck">
+            <property name="text">
+             <string>Call scrip&amp;t when downloading is completed:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QStackedWidget" name="doneDownloadingScriptStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <widget class="PathButton" name="doneDownloadingScriptButton"/>
+            <widget class="QLineEdit" name="doneDownloadingScriptEdit"/>
+           </widget>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="incompleteSectionLayout" columnstretch="0,1">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0" colspan="2">
-          <widget class="QCheckBox" name="renamePartialFilesCheck">
-           <property name="text">
-            <string>Append &quot;.&amp;part&quot; to incomplete files' names</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="incompleteDirCheck">
-           <property name="text">
-            <string>Keep &amp;incomplete files in:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QStackedWidget" name="incompleteDirStack">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="PathButton" name="incompleteDirButton"/>
-           <widget class="QLineEdit" name="incompleteDirEdit"/>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="doneDownloadingScriptCheck">
-           <property name="text">
-            <string>Call scrip&amp;t when downloading is completed:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QStackedWidget" name="doneDownloadingScriptStack">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="PathButton" name="doneDownloadingScriptButton"/>
-           <widget class="QLineEdit" name="doneDownloadingScriptEdit"/>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="downloadingTabBottomSpacer">

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -920,124 +920,116 @@ To add a new primary URL, add it after a blank line.</string>
       </attribute>
       <layout class="QVBoxLayout" name="remoteTabLayout">
        <item>
-        <widget class="QLabel" name="remoteControlSectionLabel">
-         <property name="styleSheet">
-          <string notr="true">font-weight:bold</string>
-         </property>
-         <property name="text">
+        <widget class="QGroupBox" name="remoteControlSection">
+         <property name="title">
           <string>Remote Control</string>
          </property>
+         <layout class="QGridLayout" name="remoteControlSectionLayout" columnstretch="0,1,0">
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="enableRpcCheck">
+            <property name="text">
+             <string>Allow &amp;remote access</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="openWebClientButton">
+            <property name="text">
+             <string>&amp;Open web client</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="rpcPortLabel">
+            <property name="text">
+             <string>HTTP &amp;port:</string>
+            </property>
+            <property name="buddy">
+             <cstring>rpcPortSpin</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="QSpinBox" name="rpcPortSpin">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>65535</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QCheckBox" name="requireRpcAuthCheck">
+            <property name="text">
+             <string>Use &amp;authentication</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="rpcUsernameLabel">
+            <property name="text">
+             <string>&amp;Username:</string>
+            </property>
+            <property name="buddy">
+             <cstring>rpcUsernameEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QLineEdit" name="rpcUsernameEdit"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="rpcPasswordLabel">
+            <property name="text">
+             <string>Pass&amp;word:</string>
+            </property>
+            <property name="buddy">
+             <cstring>rpcPasswordEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" colspan="2">
+           <widget class="QLineEdit" name="rpcPasswordEdit">
+            <property name="echoMode">
+             <enum>QLineEdit::Password</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="3">
+           <widget class="QCheckBox" name="enableRpcWhitelistCheck">
+            <property name="text">
+             <string>Only allow these IP a&amp;ddresses:</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="rpcWhitelistLabel">
+            <property name="text">
+             <string>Addresses:</string>
+            </property>
+            <property name="buddy">
+             <cstring>rpcWhitelistEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1" colspan="2">
+           <widget class="QLineEdit" name="rpcWhitelistEdit"/>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="remoteControlSectionLayout" columnstretch="0,1,0">
-         <property name="leftMargin">
-          <number>18</number>
-         </property>
-         <item row="0" column="0" colspan="2">
-          <widget class="QCheckBox" name="enableRpcCheck">
-           <property name="text">
-            <string>Allow &amp;remote access</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QPushButton" name="openWebClientButton">
-           <property name="text">
-            <string>&amp;Open web client</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="rpcPortLabel">
-           <property name="text">
-            <string>HTTP &amp;port:</string>
-           </property>
-           <property name="buddy">
-            <cstring>rpcPortSpin</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1" colspan="2">
-          <widget class="QSpinBox" name="rpcPortSpin">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>65535</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="3">
-          <widget class="QCheckBox" name="requireRpcAuthCheck">
-           <property name="text">
-            <string>Use &amp;authentication</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="rpcUsernameLabel">
-           <property name="text">
-            <string>&amp;Username:</string>
-           </property>
-           <property name="buddy">
-            <cstring>rpcUsernameEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1" colspan="2">
-          <widget class="QLineEdit" name="rpcUsernameEdit"/>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="rpcPasswordLabel">
-           <property name="text">
-            <string>Pass&amp;word:</string>
-           </property>
-           <property name="buddy">
-            <cstring>rpcPasswordEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1" colspan="2">
-          <widget class="QLineEdit" name="rpcPasswordEdit">
-           <property name="echoMode">
-            <enum>QLineEdit::Password</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0" colspan="3">
-          <widget class="QCheckBox" name="enableRpcWhitelistCheck">
-           <property name="text">
-            <string>Only allow these IP a&amp;ddresses:</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="rpcWhitelistLabel">
-           <property name="text">
-            <string>Addresses:</string>
-           </property>
-           <property name="buddy">
-            <cstring>rpcWhitelistEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1" colspan="2">
-          <widget class="QLineEdit" name="rpcWhitelistEdit"/>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="remoteTabBottomSpacer">
@@ -1091,12 +1083,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1107,12 +1099,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>94</x>
-     <y>79</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>323</x>
-     <y>79</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1123,12 +1115,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>94</x>
-     <y>113</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>323</x>
-     <y>113</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1139,12 +1131,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>129</x>
-     <y>79</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>359</x>
-     <y>79</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1155,12 +1147,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>129</x>
-     <y>113</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>359</x>
-     <y>113</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1171,12 +1163,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>167</x>
-     <y>80</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>392</x>
-     <y>80</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1187,12 +1179,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>169</x>
-     <y>411</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>395</x>
-     <y>411</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1203,12 +1195,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>169</x>
-     <y>447</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>395</x>
-     <y>447</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -1219,12 +1211,12 @@ To add a new primary URL, add it after a blank line.</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>69</x>
-     <y>69</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>69</x>
-     <y>69</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/qt/RelocateDialog.ui
+++ b/qt/RelocateDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>333</width>
-    <height>155</height>
+    <width>275</width>
+    <height>170</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,48 +18,40 @@
     <enum>QLayout::SetFixedSize</enum>
    </property>
    <item>
-    <widget class="QLabel" name="setLocationSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="setLocationSection">
+     <property name="title">
       <string>Set Location</string>
      </property>
+     <layout class="QGridLayout" name="setLocationSectionLayout" columnstretch="0,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="newLocationLabel">
+        <property name="text">
+         <string>New &amp;location:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QStackedWidget" name="newLocationStack">
+        <widget class="PathButton" name="newLocationButton"/>
+        <widget class="QLineEdit" name="newLocationEdit"/>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QRadioButton" name="moveDataRadio">
+        <property name="text">
+         <string>&amp;Move from the current folder</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QRadioButton" name="findDataRadio">
+        <property name="text">
+         <string>Local data is &amp;already there</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="setLocationSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="newLocationLabel">
-       <property name="text">
-        <string>New &amp;location:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QStackedWidget" name="newLocationStack">
-       <widget class="PathButton" name="newLocationButton"/>
-       <widget class="QLineEdit" name="newLocationEdit"/>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="2">
-      <widget class="QRadioButton" name="moveDataRadio">
-       <property name="text">
-        <string>&amp;Move from the current folder</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0" colspan="2">
-      <widget class="QRadioButton" name="findDataRadio">
-       <property name="text">
-        <string>Local data is &amp;already there</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="dialogButtons">

--- a/qt/SessionDialog.ui
+++ b/qt/SessionDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>250</width>
-    <height>265</height>
+    <width>248</width>
+    <height>297</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,105 +18,97 @@
     <enum>QLayout::SetFixedSize</enum>
    </property>
    <item>
-    <widget class="QLabel" name="sourceSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="sourceSection">
+     <property name="title">
       <string>Source</string>
      </property>
+     <layout class="QGridLayout" name="sourceSectionLayout" columnstretch="0,1">
+      <item row="0" column="0" colspan="2">
+       <widget class="QRadioButton" name="localSessionRadio">
+        <property name="text">
+         <string>Start &amp;Local Session</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QRadioButton" name="remoteSessionRadio">
+        <property name="text">
+         <string>Connect to &amp;Remote Session</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="hostLabel">
+        <property name="text">
+         <string>&amp;Host:</string>
+        </property>
+        <property name="buddy">
+         <cstring>hostEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="hostEdit"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="portLabel">
+        <property name="text">
+         <string>&amp;Port:</string>
+        </property>
+        <property name="buddy">
+         <cstring>portSpin</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="portSpin">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="authCheck">
+        <property name="text">
+         <string>&amp;Authentication required</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="usernameLabel">
+        <property name="text">
+         <string>&amp;Username:</string>
+        </property>
+        <property name="buddy">
+         <cstring>usernameEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="usernameEdit"/>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="passwordLabel">
+        <property name="text">
+         <string>Pass&amp;word:</string>
+        </property>
+        <property name="buddy">
+         <cstring>passwordEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="passwordEdit">
+        <property name="echoMode">
+         <enum>QLineEdit::Password</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="sourceSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0" colspan="2">
-      <widget class="QRadioButton" name="localSessionRadio">
-       <property name="text">
-        <string>Start &amp;Local Session</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="2">
-      <widget class="QRadioButton" name="remoteSessionRadio">
-       <property name="text">
-        <string>Connect to &amp;Remote Session</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="hostLabel">
-       <property name="text">
-        <string>&amp;Host:</string>
-       </property>
-       <property name="buddy">
-        <cstring>hostEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="hostEdit"/>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="portLabel">
-       <property name="text">
-        <string>&amp;Port:</string>
-       </property>
-       <property name="buddy">
-        <cstring>portSpin</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QSpinBox" name="portSpin">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>65535</number>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="QCheckBox" name="authCheck">
-       <property name="text">
-        <string>&amp;Authentication required</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="usernameLabel">
-       <property name="text">
-        <string>&amp;Username:</string>
-       </property>
-       <property name="buddy">
-        <cstring>usernameEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLineEdit" name="usernameEdit"/>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="passwordLabel">
-       <property name="text">
-        <string>Pass&amp;word:</string>
-       </property>
-       <property name="buddy">
-        <cstring>passwordEdit</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QLineEdit" name="passwordEdit">
-       <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="dialogButtons">
@@ -139,12 +131,12 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>124</x>
-     <y>244</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>124</x>
-     <y>132</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>
@@ -155,12 +147,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>124</x>
-     <y>244</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>124</x>
-     <y>132</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/qt/StatsDialog.ui
+++ b/qt/StatsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>138</width>
-    <height>315</height>
+    <width>139</width>
+    <height>316</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,173 +18,246 @@
     <enum>QLayout::SetFixedSize</enum>
    </property>
    <item>
-    <widget class="QLabel" name="currentSessionSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="currentSessionSection">
+     <property name="title">
       <string>Current Session</string>
      </property>
+     <layout class="QGridLayout" name="currentSessionSectionLayout" columnstretch="0,1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="currentUploadedLabel">
+        <property name="text">
+         <string>Uploaded:</string>
+        </property>
+        <property name="buddy">
+         <cstring>currentUploadedValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="currentUploadedValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="currentDownloadedLabel">
+        <property name="text">
+         <string>Downloaded:</string>
+        </property>
+        <property name="buddy">
+         <cstring>currentDownloadedValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="currentDownloadedValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="currentRatioLabel">
+        <property name="text">
+         <string>Ratio:</string>
+        </property>
+        <property name="buddy">
+         <cstring>currentRatioValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="currentRatioValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="currentDurationLabel">
+        <property name="text">
+         <string>Duration:</string>
+        </property>
+        <property name="buddy">
+         <cstring>currentDurationValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="currentDurationValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <layout class="QGridLayout" name="currentSessionSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="currentUploadedLabel">
-       <property name="text">
-        <string>Uploaded:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="currentUploadedValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="currentDownloadedLabel">
-       <property name="text">
-        <string>Downloaded:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="currentDownloadedValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="currentRatioLabel">
-       <property name="text">
-        <string>Ratio:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="currentRatioValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="currentDurationLabel">
-       <property name="text">
-        <string>Duration:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="currentDurationValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="totalSectionSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>1</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QLabel" name="totalSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="totalSection">
+     <property name="title">
       <string>Total</string>
      </property>
+     <layout class="QGridLayout" name="totalSectionLayout" columnstretch="0,1">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="startCountLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="totalUploadedLabel">
+        <property name="text">
+         <string>Uploaded:</string>
+        </property>
+        <property name="buddy">
+         <cstring>totalUploadedValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="totalUploadedValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="totalDownloadedLabel">
+        <property name="text">
+         <string>Downloaded:</string>
+        </property>
+        <property name="buddy">
+         <cstring>totalDownloadedValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="totalDownloadedValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="totalRatioLabel">
+        <property name="text">
+         <string>Ratio:</string>
+        </property>
+        <property name="buddy">
+         <cstring>totalRatioValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="totalRatioValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="totalDurationLabel">
+        <property name="text">
+         <string>Duration:</string>
+        </property>
+        <property name="buddy">
+         <cstring>totalDurationValueLabel</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="totalDurationValueLabel">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="text">
+         <string notr="true">...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="totalSectionLayout" columnstretch="0,1">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="0" column="0" colspan="2">
-      <widget class="QLabel" name="startCountLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="totalUploadedLabel">
-       <property name="text">
-        <string>Uploaded:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="totalUploadedValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="totalDownloadedLabel">
-       <property name="text">
-        <string>Downloaded:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="totalDownloadedValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="totalRatioLabel">
-       <property name="text">
-        <string>Ratio:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="totalRatioValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="totalDurationLabel">
-       <property name="text">
-        <string>Duration:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="totalDurationValueLabel">
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="dialogButtons">
@@ -207,12 +280,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>71</x>
-     <y>282</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>71</x>
-     <y>151</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/qt/TrackersDialog.ui
+++ b/qt/TrackersDialog.ui
@@ -18,49 +18,41 @@
   </property>
   <layout class="QVBoxLayout" name="dialogLayout">
    <item>
-    <widget class="QLabel" name="filesSectionLabel">
-     <property name="styleSheet">
-      <string notr="true">font-weight:bold</string>
-     </property>
-     <property name="text">
+    <widget class="QGroupBox" name="filesSection">
+     <property name="title">
       <string>Tracker Announce URLs</string>
      </property>
+     <layout class="QGridLayout" name="filesSectionLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="backupLabel">
+        <property name="text">
+         <string>To add a backup URL, add it on the next line after a primary URL.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="primaryLabel">
+        <property name="text">
+         <string>To add a new primary URL, add it after a blank line.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QPlainTextEdit" name="trackerList">
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="defaultsLabel">
+        <property name="text">
+         <string>Also see Default Public Trackers in Edit &gt; Preferences &gt; Network</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="filesSectionLayout" columnstretch="0">
-     <property name="leftMargin">
-      <number>18</number>
-     </property>
-     <item row="1" column="0">
-      <widget class="QLabel" name="primaryLabel">
-       <property name="text">
-        <string>To add a new primary URL, add it after a blank line.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QPlainTextEdit" name="trackerList">
-       <property name="tabChangesFocus">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="backupLabel">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To add a backup URL, add it on the next line after a primary URL.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="defaultsLabel">
-       <property name="text">
-        <string>Also see Default Public Trackers in Edit &gt; Preferences &gt; Network</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="dialogButtons">


### PR DESCRIPTION
What's in this PR:
* Replace section labels with group boxes, planning on doing the same for GTK client
  * Change where turtle is placed in preferences dialog (group box titles don't handle rich formatting and :turtle: emoji isn't widely supported)
* Fix tab order
* Strip unnecessary HTML in [read-only] text edit controls and tooltips
* Make value labels focusable in torrent properties and statistics dialogs, assign buddies (fixes #6512)
* Replace text browser with read-only plain text edit for comment field in torrent details

What's not in this PR:
* Path button/edit controls accessibility (will need code changes)
* Updating prefix/suffix for plurals in spin edit controls (will need code changes)
* Accessible names/descriptions for controls which need it, mostly those w/o buddy labels (will mean new phrases for translation)

Without whitespace changes: 509 insertions(+), 731 deletions(-)