### PR TITLE
Pin ccache to 4.8.3 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ for:
       choco install nasm
       choco install jom
       choco install wixtoolset --version 3.11.2
-      choco install ccache
+      choco install ccache --version 4.8.3
 
       Remove-Item -Path (Join-Path $Env:SystemDrive OpenSSL-Win32) -Recurse
       Remove-Item -Path (Join-Path $Env:SystemDrive OpenSSL-Win64) -Recurse


### PR DESCRIPTION
Using ccache 4.9 leads to puzzling errors such as C1090 "PDB API call failed, error code '23'" when building for x64.