### PR TITLE
only use a single concurrent queue for timeMachineExclude instead of one queue per torrent

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -345,6 +345,9 @@ static void removeKeRangerRansomware()
 
 + (void)initialize
 {
+    if (self != [Controller self])
+        return;
+
     removeKeRangerRansomware();
 
     //make sure another Transmission.app isn't running already

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
 
 @end
 
-NSMutableSet* creatorWindowControllerSet = nil;
+static NSMutableSet* creatorWindowControllerSet;
 
 @implementation CreatorWindowController
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -102,7 +102,8 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_CONCURRENT);
+        // DISPATCH_QUEUE_SERIAL because DISPATCH_QUEUE_CONCURRENT is limited to 64 simultaneous torrent dispatch_async
+        timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_SERIAL);
     });
 }
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -98,6 +98,14 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
 
 @implementation Torrent
 
++ (void)initialize
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_CONCURRENT);
+    });
+}
+
 - (instancetype)initWithPath:(NSString*)path
                     location:(NSString*)location
            deleteTorrentFile:(BOOL)torrentDelete
@@ -1826,10 +1834,6 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
                                                name:@"GroupValueRemoved"
                                              object:nil];
 
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_CONCURRENT);
-    });
     [self update];
     [self updateTimeMachineExclude];
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -100,11 +100,11 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
 
 + (void)initialize
 {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // DISPATCH_QUEUE_SERIAL because DISPATCH_QUEUE_CONCURRENT is limited to 64 simultaneous torrent dispatch_async
-        timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_SERIAL);
-    });
+    if (self != [Torrent self])
+        return;
+
+    // DISPATCH_QUEUE_SERIAL because DISPATCH_QUEUE_CONCURRENT is limited to 64 simultaneous torrent dispatch_async
+    timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_SERIAL);
 }
 
 - (instancetype)initWithPath:(NSString*)path

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -20,6 +20,10 @@ static CGFloat const kPaddingBetweenLines = 1.0;
 static CGFloat const kPaddingBetweenLinesOnSameLine = 4.0;
 static CGFloat const kCountWidth = 60.0;
 
+// make the favicons accessible to all tracker cells
+static NSCache* fTrackerIconCache;
+static NSMutableSet* fTrackerIconLoading;
+
 @interface TrackerCell ()
 
 @property(nonatomic, readonly) NSImage* favIcon;
@@ -31,12 +35,11 @@ static CGFloat const kCountWidth = 60.0;
 
 @implementation TrackerCell
 
-//make the favicons accessible to all tracker cells
-NSCache* fTrackerIconCache;
-NSMutableSet* fTrackerIconLoading;
-
 + (void)initialize
 {
+    if (self != [TrackerCell self])
+        return;
+
     fTrackerIconCache = [[NSCache alloc] init];
     fTrackerIconLoading = [[NSMutableSet alloc] init];
 }


### PR DESCRIPTION
Attempt to fix #6522. Regression from #4208.

Notes: fix app unable to start when having many torrents and TimeMachine enabled