### PR TITLE
refactor: fix cppcoreguidelines-avoid-do-while warnings

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -23,5 +23,6 @@ Checks: >
   -readability-redundant-access-specifiers
 
 CheckOptions:
-  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
-  modernize-pass-by-value.ValuesOnly: true
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros, value: true }
+  - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: true }
+  - { key: modernize-pass-by-value.ValuesOnly, value: true }

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -676,7 +676,7 @@ std::optional<std::string> get_filename_to_open(tr_torrent const* tor, Gtk::Tree
 {
     auto file = Gio::File::create_for_path(build_filename(tor, iter));
 
-    // if the specified file is complete, open it
+    // if the selected file is complete, use it
     if (iter->get_value(file_cols.prog) == 100 && file->query_exists())
     {
         return file->get_path();
@@ -708,7 +708,7 @@ void FileList::Impl::onRowActivated(Gtk::TreeModel::Path const& path, Gtk::TreeV
         return;
     }
 
-    auto iter = store_->get_iter(path);
+    auto const iter = store_->get_iter(path);
     if (!iter)
     {
         return;

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <list>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <stack>
 #include <string>
@@ -658,7 +659,7 @@ void renderPriority(Gtk::CellRenderer* renderer, Gtk::TreeModel::const_iterator 
 }
 
 /* build a filename from tr_torrentGetCurrentDir() + the model's FC_LABELs */
-std::string buildFilename(tr_torrent const* tor, Gtk::TreeModel::iterator const& iter)
+std::string build_filename(tr_torrent const* tor, Gtk::TreeModel::iterator const& iter)
 {
     std::vector<std::string> tokens;
     for (auto child = iter; child; child = child->parent())
@@ -671,37 +672,52 @@ std::string buildFilename(tr_torrent const* tor, Gtk::TreeModel::iterator const&
     return Glib::build_filename(tokens);
 }
 
+std::optional<std::string> get_filename_to_open(tr_torrent const* tor, Gtk::TreeModel::iterator const& iter)
+{
+    auto file = Gio::File::create_for_path(build_filename(tor, iter));
+
+    // if the specified file is complete, open it
+    if (iter->get_value(file_cols.prog) == 100 && file->query_exists())
+    {
+        return file->get_path();
+    }
+
+    // use nearest existing ancestor instead
+    for (;;)
+    {
+        file = file->get_parent();
+
+        if (!file)
+        {
+            return {};
+        }
+
+        if (file->query_exists())
+        {
+            return file->get_path();
+        }
+    }
+}
 } // namespace
 
 void FileList::Impl::onRowActivated(Gtk::TreeModel::Path const& path, Gtk::TreeViewColumn* /*col*/)
 {
-    bool handled = false;
-
-    if (auto const* tor = core_->find_torrent(torrent_id_); tor != nullptr)
+    auto const* const tor = core_->find_torrent(torrent_id_);
+    if (tor == nullptr)
     {
-        if (auto const iter = store_->get_iter(path); iter)
-        {
-            auto filename = buildFilename(tor, iter);
-            auto const prog = iter->get_value(file_cols.prog);
-
-            /* if the file's not done, walk up the directory tree until we find
-             * an ancestor that exists, and open that instead */
-            if (!filename.empty() && (prog < 100 || !Glib::file_test(filename, TR_GLIB_FILE_TEST(EXISTS))))
-            {
-                do
-                {
-                    filename = Glib::path_get_dirname(filename);
-                } while (!filename.empty() && !Glib::file_test(filename, TR_GLIB_FILE_TEST(EXISTS)));
-            }
-
-            if (handled = !filename.empty(); handled)
-            {
-                gtr_open_file(filename);
-            }
-        }
+        return;
     }
 
-    // return handled;
+    auto iter = store_->get_iter(path);
+    if (!iter)
+    {
+        return;
+    }
+
+    if (auto const filename = get_filename_to_open(tor, iter); filename)
+    {
+        gtr_open_file(*filename);
+    }
 }
 
 bool FileList::Impl::onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel::Path const& path)

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -29,15 +29,18 @@ namespace
 {
 void handle_sigchld(int /*i*/)
 {
-    int rc = 0;
-
-    do
+    for (;;)
     {
-        /* FIXME: Only check for our own PIDs */
-        rc = waitpid(-1, nullptr, WNOHANG);
-    } while (rc > 0 || (rc == -1 && errno == EINTR));
+        // FIXME: only check for our own PIDs
+        auto const res = waitpid(-1, nullptr, WNOHANG);
 
-    /* FIXME: Call old handler, if any */
+        if ((res == 0) || (res == -1 && errno != EINTR))
+        {
+            break;
+        }
+    }
+
+    // FIXME: Call old handler, if any
 }
 
 void set_system_error(tr_error* error, int code, std::string_view what)

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -98,7 +98,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
         if (n_read > 0)
         {
             // child errno was set
-            TR_ASSERT(static_cast<size_t>(count) == sizeof(child_errno));
+            TR_ASSERT(static_cast<size_t>(n_read) == sizeof(child_errno));
             set_system_error(error, child_errno, "Child process setup");
             return false;
         }

--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -38,6 +38,7 @@ Checks: >
   -readability-redundant-access-specifiers, # keep: 'private' vs 'private slots'
 
 CheckOptions:
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
   - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
   - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
   - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -34,6 +34,7 @@ Checks: >
   -readability-qualified-auto,
 
 CheckOptions:
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
   - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
   - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
   - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -17,34 +17,22 @@
 
 TEST(Bitfield, count)
 {
-    auto constexpr IterCount = int{ 10000 };
+    auto constexpr IterCount = size_t{ 10000U };
 
-    for (auto i = 0; i < IterCount; ++i)
+    for (size_t i = 0; i < IterCount; ++i)
     {
-        auto const bit_count = 100U + tr_rand_int(1000U);
-
         // generate a random bitfield
-        tr_bitfield bf(bit_count);
-
-        for (size_t j = 0, n = tr_rand_int(bit_count); j < n; ++j)
+        auto const bit_count = 100U + tr_rand_int(1000U);
+        auto bf = tr_bitfield{ bit_count };
+        for (size_t idx = 0U; idx < bit_count; ++idx)
         {
-            bf.set(tr_rand_int(bit_count));
+            bf.set(idx, tr_rand_int(2U) != 0U);
         }
 
-        int begin = tr_rand_int(bit_count);
-        int end = 0;
-        do
-        {
-            end = tr_rand_int(bit_count);
-        } while (end == begin);
-
-        // ensure end <= begin
-        if (end < begin)
-        {
-            int const tmp = begin;
-            begin = end;
-            end = tmp;
-        }
+        // pick arbitrary endpoints in the 1st and 2nd half of the bitfield
+        auto const midpt = bit_count / 2U;
+        auto const begin = tr_rand_int(midpt);
+        auto const end = midpt + tr_rand_int(midpt);
 
         // test the bitfield
         unsigned long count1 = {};


### PR DESCRIPTION
Each of these changes are each a little involved, which maybe is a sign that the guidelines are correct in their assessment that `do-while` leads to overly complex / bugprone code :man_shrugging: 

I've tried to make these new forms either simpler / easier to read (e.g. `get_filename_to_open()`, `tr_sys_file_lock()`); or failing that, at least not worse (e.g. `handle_sigchld()`)