### PR TITLE
manully create and bind socket on windows platform to support dual stack

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -714,7 +714,7 @@ void start_server(tr_rpc_server* server)
     //     (evhttp_bind_socket(httpd, address.c_str(), port.host()) != -1);
 
     bool success = false;
-    if (server->bind_address_->type == TR_RPC_AF_UNIX)
+    if (server->bind_address_->is_unix_addr())
     {
         success = bindUnixSocket(base, httpd, address.c_str(), server->socket_mode_);
     }


### PR DESCRIPTION
IPV6_V6ONLY on IPv6 sockets is set to false by default on linux and macos, but on windows it is the opposite.
#161 indicates that dual stack ipv6 port can also deal with ipv4 requests, so listening on "::" is just ok on Linux and Macos if we want to listen on the same port on both ipv4 and ipv6. But on windows by default ipv6 socket is V6ONLY.

To support dual stack on windows, we can create socket manually and set IPV6_V6ONLY to false. It brings consistent behavior on listening on ipv6 address. And if it fails, we can fallback to normal `evhttp_bind_socket`.

BTW, the alpha version of libevent support setting this using a flag, maybe in the future this can be much easier.
