### PR TITLE
Support dual stack by manully creating and bindind socket on windows platform

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -643,18 +643,14 @@ void rpc_server_start_retry_cancel(tr_rpc_server* server)
     server->start_retry_counter = 0;
 }
 
-#ifdef _WIN32
-int evhttp_bind_socket_win(struct evhttp* httpd, char* address, ev_uint16_t port)
+int tr_evhttp_bind_socket(struct evhttp* httpd, char const* address, ev_uint16_t port)
 {
+#ifdef _WIN32
     WORD wVersionRequested;
     WSADATA wsaData;
     wVersionRequested = MAKEWORD(2, 2);
-    int iResult = WSAStartup(wVersionRequested, &wsaData);
-    if (iResult != 0)
-    {
-        tr_logAddInfo(fmt::format(FMT_STRING("WSAStartup failed")));
-        return -1;
-    }
+    if (WSAStartup(wVersionRequested, &wsaData) != 0)
+        return evhttp_bind_socket(httpd, address, port);
     struct addrinfo* result = NULL;
     struct addrinfo hints;
     ZeroMemory(&hints, sizeof(hints));
@@ -663,36 +659,54 @@ int evhttp_bind_socket_win(struct evhttp* httpd, char* address, ev_uint16_t port
     hints.ai_protocol = IPPROTO_TCP;
     hints.ai_flags = AI_PASSIVE;
 
-    int ret = getaddrinfo(address, std::to_string(port).c_str(), &hints, &result);
-    if (ret != 0)
+    if (getaddrinfo(address, std::to_string(port).c_str(), &hints, &result) != 0)
     {
-        tr_logAddInfo(fmt::format(FMT_STRING("getaddrinfo failed")));
-        return -1;
+        WSACleanup();
+        return evhttp_bind_socket(httpd, address, port);
     }
 
     int fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
     if (fd == INVALID_SOCKET)
     {
-        return -1;
-        // printf("socket failed with error: %ld\n", WSAGetLastError());
+        freeaddrinfo(result);
+        WSACleanup();
+        return evhttp_bind_socket(httpd, address, port);
     }
     evutil_make_socket_nonblocking(fd);
     evutil_make_listen_socket_reuseable(fd);
-    int off = 0;
+
     // Making dual stack
     if (result->ai_family == AF_INET6)
+    {
+        int off = 0;
         setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&off, (ev_socklen_t)sizeof(off));
+    }
+    // Set keep alive
     int on = 1;
     setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char*)&on, sizeof(on));
-    int res = bind(fd, result->ai_addr, result->ai_addrlen);
-    if (res != 0)
-        return -1;
-    if (listen(fd, 128) == -1)
-        return -1;
-    if (evhttp_accept_socket(httpd, fd) == -1)
+    if (bind(fd, result->ai_addr, result->ai_addrlen) != 0)
+    {
+        freeaddrinfo(result);
+        closesocket(fd);
+        WSACleanup();
         return evhttp_bind_socket(httpd, address, port);
-}
+    }
+    freeaddrinfo(result);
+    if (listen(fd, 128) == -1)
+    {
+        closesocket(fd);
+        WSACleanup();
+        return evhttp_bind_socket(httpd, address, port);
+    }
+    if (evhttp_accept_socket(httpd, fd) == 0)
+        return 0;
+
+    // fallback to evhttp_bind_socket
+    closesocket(fd);
+    WSACleanup();
 #endif
+    return evhttp_bind_socket(httpd, address, port);
+}
 
 void start_server(tr_rpc_server* server)
 {
@@ -709,23 +723,9 @@ void start_server(tr_rpc_server* server)
     auto const address = server->get_bind_address();
     auto const port = server->port();
 
-    // bool const success = server->bind_address_->is_unix_addr() ?
-    //     bindUnixSocket(base, httpd, address.c_str(), server->socket_mode_) :
-    //     (evhttp_bind_socket(httpd, address.c_str(), port.host()) != -1);
-
-    bool success = false;
-    if (server->bind_address_->type == TR_RPC_AF_UNIX)
-    {
-        success = bindUnixSocket(base, httpd, address.c_str(), server->socket_mode_);
-    }
-    else
-    {
-#ifdef _WIN32
-        success = (evhttp_bind_socket_win(httpd, (char*)address.c_str(), port.host()) != -1);
-#else
-        success = (evhttp_bind_socket(httpd, address.c_str(), port.host()) != -1);
-#endif
-    }
+    bool const success = server->bind_address_->is_unix_addr() ?
+        bindUnixSocket(base, httpd, address.c_str(), server->socket_mode_) :
+        (tr_evhttp_bind_socket(httpd, address.c_str(), port.host()) != -1);
 
     auto const addr_port_str = server->bind_address_->to_string(port);
 


### PR DESCRIPTION
`IPV6_V6ONLY` on IPv6 sockets is set to false by default on Linux and Macos, but on windows it is the opposite.
https://github.com/transmission/transmission/pull/161 indicates that dual stack ipv6 port can also deal with ipv4 requests, so listening on "::" is just ok on Linux and Macos if we want to listen on the same port on both ipv4 and ipv6. But on windows by default ipv6 socket is V6ONLY.

To support dual stack on windows, we can create socket manually and set IPV6_V6ONLY to false. It brings consistent behavior on listening on ipv6 address. And if it fails, we can fallback to normal `evhttp_bind_socket`.

BTW, the new alpha version of `libevent` support setting this using a flag, maybe in the future this can be much easier.

This time fixed some memory leak and other issues. Early PR here #6547 