### PR TITLE
perf: restore `3.00` wishlist with cached candidates

### DIFF
--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -3,145 +3,84 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm> // std::min, std::partial_sort
+#include <algorithm> // std::adjacent_find
 #include <cstddef>
-#include <set>
+#include <functional>
 #include <utility>
 #include <vector>
+
+#include <small/set.hpp>
 
 #define LIBTRANSMISSION_PEER_MODULE
 
 #include "libtransmission/transmission.h"
 
+#include "libtransmission/bitfield.h"
 #include "libtransmission/crypto-utils.h" // for tr_salt_shaker
 #include "libtransmission/peer-mgr-wishlist.h"
-#include "libtransmission/utils.h"
 
 namespace
 {
-using SaltType = tr_piece_index_t;
-
-struct Candidate
+std::vector<tr_block_span_t> make_spans(small::set<tr_block_index_t> const& blocks)
 {
-    tr_piece_index_t piece;
-    size_t n_blocks_missing;
-    tr_priority_t priority;
-    SaltType salt;
-
-    Candidate(tr_piece_index_t piece_in, size_t missing_in, tr_priority_t priority_in, SaltType salt_in)
-        : piece{ piece_in }
-        , n_blocks_missing{ missing_in }
-        , priority{ priority_in }
-        , salt{ salt_in }
-    {
-    }
-
-    [[nodiscard]] constexpr auto compare(Candidate const& that) const noexcept // <=>
-    {
-        // prefer pieces closer to completion
-        if (auto const val = tr_compare_3way(n_blocks_missing, that.n_blocks_missing); val != 0)
-        {
-            return val;
-        }
-
-        // prefer higher priority
-        if (auto const val = tr_compare_3way(priority, that.priority); val != 0)
-        {
-            return -val;
-        }
-
-        return tr_compare_3way(salt, that.salt);
-    }
-
-    bool operator<(Candidate const& that) const // less than
-    {
-        return compare(that) < 0;
-    }
-};
-
-std::vector<Candidate> getCandidates(Wishlist::Mediator const& mediator)
-{
-    // count up the pieces that we still want
-    auto wanted_pieces = std::vector<std::pair<tr_piece_index_t, size_t>>{};
-    auto const n_pieces = mediator.countAllPieces();
-    wanted_pieces.reserve(n_pieces);
-    for (tr_piece_index_t i = 0; i < n_pieces; ++i)
-    {
-        if (!mediator.clientCanRequestPiece(i))
-        {
-            continue;
-        }
-
-        size_t const n_missing = mediator.countMissingBlocks(i);
-        if (n_missing == 0)
-        {
-            continue;
-        }
-
-        wanted_pieces.emplace_back(i, n_missing);
-    }
-
-    // transform them into candidates
-    auto salter = tr_salt_shaker<SaltType>{};
-    auto const n = std::size(wanted_pieces);
-    auto candidates = std::vector<Candidate>{};
-    auto const is_sequential = mediator.isSequentialDownload();
-    candidates.reserve(n);
-    for (size_t i = 0; i < n; ++i)
-    {
-        auto const [piece, n_missing] = wanted_pieces[i];
-        auto const salt = is_sequential ? piece : salter();
-        candidates.emplace_back(piece, n_missing, mediator.priority(piece), salt);
-    }
-
-    return candidates;
-}
-
-std::vector<tr_block_span_t> makeSpans(tr_block_index_t const* sorted_blocks, size_t n_blocks)
-{
-    if (n_blocks == 0)
+    if (std::empty(blocks))
     {
         return {};
     }
 
     auto spans = std::vector<tr_block_span_t>{};
-    auto cur = tr_block_span_t{ sorted_blocks[0], sorted_blocks[0] + 1 };
-    for (size_t i = 1; i < n_blocks; ++i)
+    for (auto span_begin = std::begin(blocks), end = std::end(blocks); span_begin != end;)
     {
-        if (cur.end == sorted_blocks[i])
+        static auto constexpr NotAdjacent = [](tr_block_index_t const lhs, tr_block_index_t const rhs)
         {
-            ++cur.end;
-        }
-        else
+            return lhs + 1U != rhs;
+        };
+
+        auto span_end = std::adjacent_find(span_begin, end, NotAdjacent);
+        if (span_end == end)
         {
-            spans.push_back(cur);
-            cur = tr_block_span_t{ sorted_blocks[i], sorted_blocks[i] + 1 };
+            --span_end;
         }
+        spans.push_back({ *span_begin, *span_end + 1 });
+
+        span_begin = std::next(span_end);
     }
-    spans.push_back(cur);
 
     return spans;
 }
-
 } // namespace
 
-std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
+Wishlist::Wishlist(std::unique_ptr<Mediator> mediator_in)
+    : tags_{ {
+          mediator_in->observe_peer_disconnect([this](tr_torrent*, tr_bitfield const& b) { dec_replication_from_bitfield(b); }),
+          mediator_in->observe_got_bitfield([this](tr_torrent*, tr_bitfield const& b) { inc_replication_from_bitfield(b); }),
+          mediator_in->observe_got_block([this](tr_torrent*, tr_piece_index_t p, tr_block_index_t) { resort_piece(p); }),
+          mediator_in->observe_got_have([this](tr_torrent*, tr_piece_index_t p) { inc_replication_piece(p); }),
+          mediator_in->observe_got_have_all([this](tr_torrent*) { inc_replication(); }),
+          mediator_in->observe_piece_completed([this](tr_torrent*, tr_piece_index_t p) { remove_piece(p); }),
+          mediator_in->observe_priority_changed([this](tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t)
+                                                { set_candidates_dirty(); }),
+          mediator_in->observe_sequential_download_changed([this](tr_torrent*, bool) { set_candidates_dirty(); }),
+      } }
+    , mediator_{ std::move(mediator_in) }
 {
-    if (n_wanted_blocks == 0)
+}
+
+std::vector<tr_block_span_t> Wishlist::next(
+    size_t n_wanted_blocks,
+    std::function<bool(tr_piece_index_t)> const& peer_has_piece,
+    std::function<bool(tr_block_index_t)> const& has_active_pending_to_peer)
+{
+    if (n_wanted_blocks == 0U)
     {
         return {};
     }
 
-    auto candidates = getCandidates(mediator_);
+    maybe_rebuild_candidate_list();
 
-    // We usually won't need all the candidates to be sorted until endgame, so don't
-    // waste cycles sorting all of them here. partial sort is enough.
-    static auto constexpr MaxSortedPieces = size_t{ 30 };
-    auto const middle = std::min(std::size(candidates), MaxSortedPieces);
-    std::partial_sort(std::begin(candidates), std::begin(candidates) + middle, std::end(candidates));
-
-    auto blocks = std::set<tr_block_index_t>{};
-    for (auto const& candidate : candidates)
+    auto blocks = small::set<tr_block_index_t>{};
+    blocks.reserve(n_wanted_blocks);
+    for (auto const& candidate : candidates_)
     {
         // do we have enough?
         if (std::size(blocks) >= n_wanted_blocks)
@@ -149,19 +88,27 @@ std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
             break;
         }
 
-        // walk the blocks in this piece
-        auto const [begin, end] = mediator_.blockSpan(candidate.piece);
-        for (tr_block_index_t block = begin; block < end && std::size(blocks) < n_wanted_blocks; ++block)
+        // if the peer doesn't have this piece that we want...
+        if (!peer_has_piece(candidate.piece))
         {
-            // don't request blocks we've already got
-            if (!mediator_.clientCanRequestBlock(block))
+            continue;
+        }
+
+        // walk the blocks in this piece
+        for (auto [block, end] = mediator_->block_span(candidate.piece); block < end && std::size(blocks) < n_wanted_blocks;
+             ++block)
+        {
+            // don't request blocks that:
+            // 1. we've already got, or
+            // 2. already has an active request to that peer
+            if (mediator_->client_has_block(block) || has_active_pending_to_peer(block))
             {
                 continue;
             }
 
             // don't request from too many peers
-            size_t const n_peers = mediator_.countActiveRequests(block);
-            if (size_t const max_peers = mediator_.isEndgame() ? 2 : 1; n_peers >= max_peers)
+            auto const n_peers = mediator_->count_active_requests(block);
+            if (auto const max_peers = mediator_->is_endgame() ? EndgameMaxPeers : NormalMaxPeers; n_peers >= max_peers)
             {
                 continue;
             }
@@ -170,6 +117,211 @@ std::vector<tr_block_span_t> Wishlist::next(size_t n_wanted_blocks)
         }
     }
 
-    auto const blocks_v = std::vector<tr_block_index_t>{ std::begin(blocks), std::end(blocks) };
-    return makeSpans(std::data(blocks_v), std::size(blocks_v));
+    return make_spans(blocks);
+}
+
+void Wishlist::maybe_rebuild_candidate_list()
+{
+    if (!candidates_dirty_)
+    {
+        return;
+    }
+    candidates_dirty_ = false;
+    candidates_.clear();
+
+    auto salter = tr_salt_shaker<tr_piece_index_t>{};
+    auto const is_sequential = mediator_->is_sequential_download();
+    auto const n_pieces = mediator_->piece_count();
+    candidates_.reserve(n_pieces);
+    for (tr_piece_index_t piece = 0U; piece < n_pieces; ++piece)
+    {
+        if (mediator_->count_missing_blocks(piece) <= 0U || !mediator_->client_wants_piece(piece))
+        {
+            continue;
+        }
+
+        auto const salt = is_sequential ? piece : salter();
+        candidates_
+            .emplace_back(piece, mediator_->count_piece_replication(piece), mediator_->priority(piece), salt, mediator_.get());
+    }
+    candidates_.shrink_to_fit();
+    std::sort(std::begin(candidates_), std::end(candidates_));
+}
+
+Wishlist::CandidateVec::iterator Wishlist::piece_lookup(tr_piece_index_t const piece)
+{
+    return std::find_if(
+        std::begin(candidates_),
+        std::end(candidates_),
+        [piece](auto const& candidate) { return candidate.piece == piece; });
+}
+
+void Wishlist::dec_replication()
+{
+    if (!candidates_dirty_)
+    {
+        std::for_each(
+            std::begin(candidates_),
+            std::end(candidates_),
+            [](Candidate& candidate)
+            {
+                TR_ASSERT(candidate.replication > 0U);
+                --candidate.replication;
+            });
+    }
+}
+
+void Wishlist::dec_replication_from_bitfield(tr_bitfield const& bitfield)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    if (bitfield.has_none())
+    {
+        return;
+    }
+
+    if (bitfield.has_all())
+    {
+        dec_replication();
+        return;
+    }
+
+    for (auto& candidate : candidates_)
+    {
+        if (bitfield.test(candidate.piece))
+        {
+            TR_ASSERT(candidate.replication > 0U);
+            --candidate.replication;
+        }
+    }
+
+    std::sort(std::begin(candidates_), std::end(candidates_));
+}
+
+void Wishlist::inc_replication()
+{
+    if (!candidates_dirty_)
+    {
+        std::for_each(std::begin(candidates_), std::end(candidates_), [](Candidate& candidate) { ++candidate.replication; });
+    }
+}
+
+void Wishlist::inc_replication_from_bitfield(tr_bitfield const& bitfield)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    if (bitfield.has_none())
+    {
+        return;
+    }
+
+    if (bitfield.has_all())
+    {
+        inc_replication();
+        return;
+    }
+
+    for (auto& candidate : candidates_)
+    {
+        if (bitfield.test(candidate.piece))
+        {
+            ++candidate.replication;
+        }
+    }
+
+    std::sort(std::begin(candidates_), std::end(candidates_));
+}
+
+void Wishlist::inc_replication_piece(tr_piece_index_t piece)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    if (auto iter = piece_lookup(piece); iter != std::end(candidates_))
+    {
+        ++iter->replication;
+        resort_piece(iter);
+    }
+}
+
+void Wishlist::resort_piece(tr_piece_index_t const piece)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    if (auto iter = piece_lookup(piece); iter != std::end(candidates_))
+    {
+        resort_piece(iter);
+    }
+}
+
+void Wishlist::resort_piece(CandidateVec::iterator const pos_old)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    TR_ASSERT(pos_old != std::end(candidates_));
+    if (auto const pos_next = std::next(pos_old); std::is_sorted(
+            pos_old == std::begin(candidates_) ? pos_old : std::prev(pos_old),
+            pos_next == std::end(candidates_) ? pos_next : std::next(pos_next)))
+    {
+        return;
+    }
+
+    auto const tmp = *pos_old;
+    candidates_.erase(pos_old);
+
+    auto const pos_new = std::lower_bound(std::begin(candidates_), std::end(candidates_), tmp);
+    candidates_.insert(pos_new, tmp);
+}
+
+void Wishlist::remove_piece(tr_piece_index_t const piece)
+{
+    if (candidates_dirty_)
+    {
+        return;
+    }
+
+    if (auto iter = piece_lookup(piece); iter != std::end(candidates_))
+    {
+        candidates_.erase(iter);
+    }
+}
+
+// ---
+
+int Wishlist::Candidate::compare(Wishlist::Candidate const& that) const noexcept
+{
+    // prefer pieces closer to completion
+    if (auto const val = tr_compare_3way(mediator_->count_missing_blocks(piece), mediator_->count_missing_blocks(that.piece));
+        val != 0)
+    {
+        return val;
+    }
+
+    // prefer higher priority
+    if (auto const val = tr_compare_3way(priority, that.priority); val != 0)
+    {
+        return -val;
+    }
+
+    // prefer rarer pieces
+    if (auto const val = tr_compare_3way(replication, that.replication); val != 0)
+    {
+        return val;
+    }
+
+    return tr_compare_3way(salt, that.salt);
 }

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -29,6 +29,7 @@ std::vector<tr_block_span_t> make_spans(small::set<tr_block_index_t> const& bloc
     }
 
     auto spans = std::vector<tr_block_span_t>{};
+    spans.reserve(std::size(blocks));
     for (auto span_begin = std::begin(blocks), end = std::end(blocks); span_begin != end;)
     {
         static auto constexpr NotAdjacent = [](tr_block_index_t const lhs, tr_block_index_t const rhs)

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -144,7 +144,6 @@ void Wishlist::maybe_rebuild_candidate_list()
         candidates_
             .emplace_back(piece, mediator_->count_piece_replication(piece), mediator_->priority(piece), salt, mediator_.get());
     }
-    candidates_.shrink_to_fit();
     std::sort(std::begin(candidates_), std::end(candidates_));
 }
 

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -10,9 +10,16 @@
 #endif
 
 #include <cstddef> // size_t
+#include <functional>
+#include <memory>
 #include <vector>
 
 #include "libtransmission/transmission.h"
+
+#include "libtransmission/observable.h"
+#include "libtransmission/utils.h"
+
+class tr_bitfield;
 
 /**
  * Figures out what blocks we want to request next.
@@ -21,29 +28,117 @@ class Wishlist
 {
 public:
     static auto constexpr EndgameMaxPeers = size_t{ 2U };
+    static auto constexpr NormalMaxPeers = size_t{ 1U };
 
     struct Mediator
     {
-        [[nodiscard]] virtual bool clientCanRequestBlock(tr_block_index_t block) const = 0;
-        [[nodiscard]] virtual bool clientCanRequestPiece(tr_piece_index_t piece) const = 0;
-        [[nodiscard]] virtual bool isEndgame() const = 0;
-        [[nodiscard]] virtual bool isSequentialDownload() const = 0;
-        [[nodiscard]] virtual size_t countActiveRequests(tr_block_index_t block) const = 0;
-        [[nodiscard]] virtual size_t countMissingBlocks(tr_piece_index_t piece) const = 0;
-        [[nodiscard]] virtual tr_block_span_t blockSpan(tr_piece_index_t) const = 0;
-        [[nodiscard]] virtual tr_piece_index_t countAllPieces() const = 0;
-        [[nodiscard]] virtual tr_priority_t priority(tr_piece_index_t) const = 0;
+        [[nodiscard]] virtual bool client_has_block(tr_block_index_t block) const = 0;
+        [[nodiscard]] virtual bool client_wants_piece(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual bool is_endgame() const = 0;
+        [[nodiscard]] virtual bool is_sequential_download() const = 0;
+        [[nodiscard]] virtual size_t count_active_requests(tr_block_index_t block) const = 0;
+        [[nodiscard]] virtual size_t count_missing_blocks(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual size_t count_piece_replication(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual tr_block_span_t block_span(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual tr_piece_index_t piece_count() const = 0;
+        [[nodiscard]] virtual tr_priority_t priority(tr_piece_index_t piece) const = 0;
+
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_peer_disconnect(
+            libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_got_bitfield(
+            libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_got_block(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t, tr_block_index_t>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_got_have(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_got_have_all(
+            libtransmission::SimpleObservable<tr_torrent*>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_piece_completed(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_priority_changed(
+            libtransmission::SimpleObservable<tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t>::Observer
+                observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_sequential_download_changed(
+            libtransmission::SimpleObservable<tr_torrent*, bool>::Observer observer) = 0;
+
         virtual ~Mediator() = default;
     };
 
-    constexpr explicit Wishlist(Mediator const& mediator)
-        : mediator_{ mediator }
+private:
+    struct Candidate
     {
+        Candidate(
+            tr_piece_index_t piece_in,
+            size_t replication_in,
+            tr_priority_t priority_in,
+            tr_piece_index_t salt_in,
+            Mediator const* mediator)
+            : piece{ piece_in }
+            , replication{ replication_in }
+            , priority{ priority_in }
+            , salt{ salt_in }
+            , mediator_{ mediator }
+        {
+        }
+
+        [[nodiscard]] int compare(Candidate const& that) const noexcept; // <=>
+
+        [[nodiscard]] auto operator<(Candidate const& that) const // less than
+        {
+            return compare(that) < 0;
+        }
+
+        tr_piece_index_t piece;
+
+        // Caching the following 2 values are highly beneficial, because:
+        // - they are often used (mainly because resort_piece() is called
+        //   every time we receive a block)
+        // - does not change as often compared to missing blocks
+        // - calculating their values involves sifting through bitfield(s),
+        //   which is expensive.
+        size_t replication;
+        tr_priority_t priority;
+
+        tr_piece_index_t salt;
+
+    private:
+        Mediator const* mediator_;
+    };
+
+public:
+    explicit Wishlist(std::unique_ptr<Mediator> mediator_in);
+
+    constexpr void set_candidates_dirty() noexcept
+    {
+        candidates_dirty_ = true;
     }
 
     // the next blocks that we should request from a peer
-    [[nodiscard]] std::vector<tr_block_span_t> next(size_t n_wanted_blocks);
+    [[nodiscard]] std::vector<tr_block_span_t> next(
+        size_t n_wanted_blocks,
+        std::function<bool(tr_piece_index_t)> const& peer_has_piece,
+        std::function<bool(tr_block_index_t)> const& has_active_pending_to_peer);
+
+    void dec_replication();
+    void dec_replication_from_bitfield(tr_bitfield const& bitfield);
+    void inc_replication();
+    void inc_replication_from_bitfield(tr_bitfield const& bitfield);
+    void inc_replication_piece(tr_piece_index_t piece);
+
+    void remove_piece(tr_piece_index_t piece);
+    void resort_piece(tr_piece_index_t piece);
 
 private:
-    Mediator const& mediator_;
+    using CandidateVec = std::vector<Candidate>;
+
+    CandidateVec::iterator piece_lookup(tr_piece_index_t piece);
+    void maybe_rebuild_candidate_list();
+    void resort_piece(CandidateVec::iterator pos_old);
+
+    CandidateVec candidates_;
+    bool candidates_dirty_ = true;
+
+    std::array<libtransmission::ObserverTag, 8U> const tags_;
+
+    std::unique_ptr<Mediator> const mediator_;
 };

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1002,10 +1002,9 @@ size_t tr_swarm::WishlistMediator::count_missing_blocks(tr_piece_index_t piece) 
 
 size_t tr_swarm::WishlistMediator::count_piece_replication(tr_piece_index_t piece) const
 {
-    auto const& peers = swarm_.peers;
     return std::accumulate(
-        std::begin(peers),
-        std::end(peers),
+        std::begin(swarm_.peers),
+        std::end(swarm_.peers),
         size_t{},
         [piece](size_t acc, tr_peer* peer) { return acc + (peer->hasPiece(piece) ? 1U : 0U); });
 }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1234,9 +1234,9 @@ void tr_peerMgrFree(tr_peerMgr* manager)
  *    This is used for cancelling requests that have been waiting
  *    for too long and avoiding duplicate requests.
  *
- * 2. tr_swarm::pieces, an array of "struct weighted_piece" which lists the
- *    pieces that we want to request. It's used to decide which blocks to
- *    return next when tr_peerMgrGetBlockRequests() is called.
+ * 2. tr_swarm::wishlist, a class that tracks the pieces that we want to
+ *    request. It's used to decide which blocks to return next when
+ *    tr_peerMgrGetNextRequests() is called.
  */
 
 // --- struct block_request

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1945,6 +1945,21 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 
 // ---
 
+void tr_torrent::set_file_priorities(tr_file_index_t const* files, tr_file_index_t file_count, tr_priority_t priority)
+{
+    if (std::any_of(
+            files,
+            files + file_count,
+            [this, priority](tr_file_index_t file) { return priority != file_priorities_.file_priority(file); }))
+    {
+        file_priorities_.set(files, file_count, priority);
+        priority_changed_.emit(this, files, file_count, priority);
+        set_dirty();
+    }
+}
+
+// ---
+
 bool tr_torrent::check_piece(tr_piece_index_t const piece) const
 {
     auto const pass = tr_ioTestPiece(*this, piece);

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -171,7 +171,7 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestPiecesThatAreNotWanted)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // but we only want the first piece
     mediator.client_wants_piece_.insert(0);
@@ -195,7 +195,7 @@ TEST_F(PeerMgrWishlistTest, onlyRequestBlocksThePeerHas)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // and we want all three pieces
     mediator.client_wants_piece_.insert(0);
@@ -235,7 +235,7 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestSameBlockTwiceFromSamePeer)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // and we want all three pieces
     mediator.client_wants_piece_.insert(0);
@@ -274,7 +274,7 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestDupesWhenNotInEndgame)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // and we want all three pieces
     mediator.client_wants_piece_.insert(0);
@@ -313,7 +313,7 @@ TEST_F(PeerMgrWishlistTest, onlyRequestsDupesDuringEndgame)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // and we want all three pieces
     mediator.client_wants_piece_.insert(0);
@@ -359,7 +359,7 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestTooManyBlocks)
     mediator.missing_block_count_[2] = 50;
     mediator.block_span_[0] = { 0, 100 };
     mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 251 };
+    mediator.block_span_[2] = { 200, 250 };
 
     // and we want everything
     for (tr_piece_index_t i = 0; i < 3; ++i)

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -5,6 +5,7 @@
 
 #include <cstddef> // size_t
 #include <map>
+#include <memory>
 #include <set>
 
 #define LIBTRANSMISSION_PEER_MODULE
@@ -19,54 +20,67 @@
 class PeerMgrWishlistTest : public ::testing::Test
 {
 protected:
-    struct MockMediator : public Wishlist::Mediator
+    struct MockMediator final : public Wishlist::Mediator
     {
         mutable std::map<tr_block_index_t, size_t> active_request_count_;
         mutable std::map<tr_piece_index_t, size_t> missing_block_count_;
         mutable std::map<tr_piece_index_t, tr_block_span_t> block_span_;
         mutable std::map<tr_piece_index_t, tr_priority_t> piece_priority_;
-        mutable std::set<tr_block_index_t> can_request_block_;
-        mutable std::set<tr_piece_index_t> can_request_piece_;
+        mutable std::map<tr_piece_index_t, size_t> piece_replication_;
+        mutable std::set<tr_block_index_t> client_has_block_;
+        mutable std::set<tr_piece_index_t> client_wants_piece_;
         tr_piece_index_t piece_count_ = 0;
         bool is_endgame_ = false;
         bool is_sequential_download_ = false;
 
-        [[nodiscard]] bool clientCanRequestBlock(tr_block_index_t block) const final
+        PeerMgrWishlistTest& parent_;
+
+        explicit MockMediator(PeerMgrWishlistTest& parent)
+            : parent_{ parent }
         {
-            return can_request_block_.count(block) != 0;
         }
 
-        [[nodiscard]] bool clientCanRequestPiece(tr_piece_index_t piece) const final
+        [[nodiscard]] bool client_has_block(tr_block_index_t block) const override
         {
-            return can_request_piece_.count(piece) != 0;
+            return client_has_block_.count(block) != 0;
         }
 
-        [[nodiscard]] bool isEndgame() const final
+        [[nodiscard]] bool client_wants_piece(tr_piece_index_t piece) const override
+        {
+            return client_wants_piece_.count(piece) != 0;
+        }
+
+        [[nodiscard]] bool is_endgame() const override
         {
             return is_endgame_;
         }
 
-        [[nodiscard]] bool isSequentialDownload() const final
+        [[nodiscard]] bool is_sequential_download() const override
         {
             return is_sequential_download_;
         }
 
-        [[nodiscard]] size_t countActiveRequests(tr_block_index_t block) const final
+        [[nodiscard]] size_t count_active_requests(tr_block_index_t block) const override
         {
             return active_request_count_[block];
         }
 
-        [[nodiscard]] size_t countMissingBlocks(tr_piece_index_t piece) const final
+        [[nodiscard]] size_t count_missing_blocks(tr_piece_index_t piece) const override
         {
             return missing_block_count_[piece];
         }
 
-        [[nodiscard]] tr_block_span_t blockSpan(tr_piece_index_t piece) const final
+        [[nodiscard]] size_t count_piece_replication(tr_piece_index_t piece) const override
+        {
+            return piece_replication_[piece];
+        }
+
+        [[nodiscard]] tr_block_span_t block_span(tr_piece_index_t piece) const override
         {
             return block_span_[piece];
         }
 
-        [[nodiscard]] tr_piece_index_t countAllPieces() const final
+        [[nodiscard]] tr_piece_index_t piece_count() const override
         {
             return piece_count_;
         }
@@ -75,12 +89,80 @@ protected:
         {
             return piece_priority_[piece];
         }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_peer_disconnect(
+            libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) override
+        {
+            return parent_.peer_disconnect_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_got_bitfield(
+            libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) override
+        {
+            return parent_.got_bitfield_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_got_block(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t, tr_block_index_t>::Observer observer) override
+        {
+            return parent_.got_block_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_got_have(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t>::Observer observer) override
+        {
+            return parent_.got_have_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_got_have_all(
+            libtransmission::SimpleObservable<tr_torrent*>::Observer observer) override
+        {
+            return parent_.got_have_all_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_piece_completed(
+            libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t>::Observer observer) override
+        {
+            return parent_.piece_completed_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_priority_changed(
+            libtransmission::SimpleObservable<tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t>::Observer
+                observer) override
+        {
+            return parent_.priority_changed_.observe(std::move(observer));
+        }
+
+        [[nodiscard]] libtransmission::ObserverTag observe_sequential_download_changed(
+            libtransmission::SimpleObservable<tr_torrent*, bool>::Observer observer) override
+        {
+            return parent_.sequential_download_changed_.observe(std::move(observer));
+        }
+    };
+
+    libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&> peer_disconnect_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&> got_bitfield_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t, tr_block_index_t> got_block_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> got_have_;
+    libtransmission::SimpleObservable<tr_torrent*> got_have_all_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t> piece_completed_;
+    libtransmission::SimpleObservable<tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t> priority_changed_;
+    libtransmission::SimpleObservable<tr_torrent*, bool> sequential_download_changed_;
+
+    static auto constexpr PeerHasAllPieces = [](tr_piece_index_t)
+    {
+        return true;
+    };
+    static auto constexpr ClientHasNoActiveRequests = [](tr_block_index_t)
+    {
+        return false;
     };
 };
 
-TEST_F(PeerMgrWishlistTest, doesNotRequestPiecesThatCannotBeRequested)
+TEST_F(PeerMgrWishlistTest, doesNotRequestPiecesThatAreNotWanted)
 {
-    auto mediator = MockMediator{};
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
 
     // setup: three pieces, all missing
     mediator.piece_count_ = 3;
@@ -92,22 +174,19 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestPiecesThatCannotBeRequested)
     mediator.block_span_[2] = { 200, 251 };
 
     // but we only want the first piece
-    mediator.can_request_piece_.insert(0);
-    for (tr_block_index_t i = mediator.block_span_[0].begin; i < mediator.block_span_[0].end; ++i)
-    {
-        mediator.can_request_block_.insert(i);
-    }
+    mediator.client_wants_piece_.insert(0);
 
     // we should only get the first piece back
-    auto spans = Wishlist{ mediator }.next(1000);
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(1000, PeerHasAllPieces, ClientHasNoActiveRequests);
     ASSERT_EQ(1U, std::size(spans));
     EXPECT_EQ(mediator.block_span_[0].begin, spans[0].begin);
     EXPECT_EQ(mediator.block_span_[0].end, spans[0].end);
 }
 
-TEST_F(PeerMgrWishlistTest, doesNotRequestBlocksThatCannotBeRequested)
+TEST_F(PeerMgrWishlistTest, onlyRequestBlocksThePeerHas)
 {
-    auto mediator = MockMediator{};
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
 
     // setup: three pieces, all missing
     mediator.piece_count_ = 3;
@@ -119,21 +198,61 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestBlocksThatCannotBeRequested)
     mediator.block_span_[2] = { 200, 251 };
 
     // and we want all three pieces
-    mediator.can_request_piece_.insert(0);
-    mediator.can_request_piece_.insert(1);
-    mediator.can_request_piece_.insert(2);
+    mediator.client_wants_piece_.insert(0);
+    mediator.client_wants_piece_.insert(1);
+    mediator.client_wants_piece_.insert(2);
 
-    // but we've already requested blocks [0..10) from someone else,
-    // so we don't want to send repeat requests
-    for (tr_block_index_t i = 10; i < 250; ++i)
+    // but the peer only has the second piece, we don't want to
+    // request blocks other than these
+    static auto constexpr IsPieceOne = [](tr_piece_index_t p)
     {
-        mediator.can_request_block_.insert(i);
-    }
+        return p == 1U;
+    };
 
     // even if we ask wishlist for more blocks than exist,
-    // it should omit blocks 1-10 from the return set
-    auto spans = Wishlist{ mediator }.next(1000);
-    auto requested = tr_bitfield(250);
+    // it should only return blocks [100..200)
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(1000, IsPieceOne, ClientHasNoActiveRequests);
+    auto requested = tr_bitfield{ 250 };
+    for (auto const& span : spans)
+    {
+        requested.set_span(span.begin, span.end);
+    }
+    EXPECT_EQ(100U, requested.count());
+    EXPECT_EQ(0U, requested.count(0, 100));
+    EXPECT_EQ(100U, requested.count(100, 200));
+    EXPECT_EQ(0U, requested.count(200, 250));
+}
+
+TEST_F(PeerMgrWishlistTest, doesNotRequestSameBlockTwiceFromSamePeer)
+{
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
+
+    // setup: three pieces, all missing
+    mediator.piece_count_ = 3;
+    mediator.missing_block_count_[0] = 100;
+    mediator.missing_block_count_[1] = 100;
+    mediator.missing_block_count_[2] = 50;
+    mediator.block_span_[0] = { 0, 100 };
+    mediator.block_span_[1] = { 100, 200 };
+    mediator.block_span_[2] = { 200, 251 };
+
+    // and we want all three pieces
+    mediator.client_wants_piece_.insert(0);
+    mediator.client_wants_piece_.insert(1);
+    mediator.client_wants_piece_.insert(2);
+
+    // but we've already requested blocks [0..10) from this peer,
+    // so we don't want to send repeated requests
+    static auto constexpr IsBetweenZeroToTen = [](tr_block_index_t b)
+    {
+        return b < 10U;
+    };
+
+    // even if we ask wishlist for more blocks than exist,
+    // it should omit blocks [0..10) from the return set
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(1000, PeerHasAllPieces, IsBetweenZeroToTen);
+    auto requested = tr_bitfield{ 250 };
     for (auto const& span : spans)
     {
         requested.set_span(span.begin, span.end);
@@ -143,9 +262,95 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestBlocksThatCannotBeRequested)
     EXPECT_EQ(240U, requested.count(10, 250));
 }
 
+TEST_F(PeerMgrWishlistTest, doesNotRequestDupesWhenNotInEndgame)
+{
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
+
+    // setup: three pieces, all missing
+    mediator.piece_count_ = 3;
+    mediator.missing_block_count_[0] = 100;
+    mediator.missing_block_count_[1] = 100;
+    mediator.missing_block_count_[2] = 50;
+    mediator.block_span_[0] = { 0, 100 };
+    mediator.block_span_[1] = { 100, 200 };
+    mediator.block_span_[2] = { 200, 251 };
+
+    // and we want all three pieces
+    mediator.client_wants_piece_.insert(0);
+    mediator.client_wants_piece_.insert(1);
+    mediator.client_wants_piece_.insert(2);
+
+    // but we've already requested blocks [0..10) from someone else,
+    // and it is not endgame, so we don't want to send repeated requests
+    for (tr_block_index_t block = 0; block < 10; ++block)
+    {
+        mediator.active_request_count_[block] = 1;
+    }
+
+    // even if we ask wishlist for more blocks than exist,
+    // it should omit blocks [0..10) from the return set
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(1000, PeerHasAllPieces, ClientHasNoActiveRequests);
+    auto requested = tr_bitfield{ 250 };
+    for (auto const& span : spans)
+    {
+        requested.set_span(span.begin, span.end);
+    }
+    EXPECT_EQ(240U, requested.count());
+    EXPECT_EQ(0U, requested.count(0, 10));
+    EXPECT_EQ(240U, requested.count(10, 250));
+}
+
+TEST_F(PeerMgrWishlistTest, onlyRequestsDupesDuringEndgame)
+{
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
+
+    // setup: three pieces, all missing
+    mediator.piece_count_ = 3;
+    mediator.missing_block_count_[0] = 100;
+    mediator.missing_block_count_[1] = 100;
+    mediator.missing_block_count_[2] = 50;
+    mediator.block_span_[0] = { 0, 100 };
+    mediator.block_span_[1] = { 100, 200 };
+    mediator.block_span_[2] = { 200, 251 };
+
+    // and we want all three pieces
+    mediator.client_wants_piece_.insert(0);
+    mediator.client_wants_piece_.insert(1);
+    mediator.client_wants_piece_.insert(2);
+
+    // we've already requested blocks [0..10) from someone else,
+    // but it is endgame, so we can request each block twice.
+    // blocks [5..10) are already requested twice
+    mediator.is_endgame_ = true;
+    for (tr_block_index_t block = 0; block < 5; ++block)
+    {
+        mediator.active_request_count_[block] = 1;
+    }
+    for (tr_block_index_t block = 5; block < 10; ++block)
+    {
+        mediator.active_request_count_[block] = 2;
+    }
+
+    // if we ask wishlist for more blocks than exist,
+    // it should omit blocks [5..10) from the return set
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(1000, PeerHasAllPieces, ClientHasNoActiveRequests);
+    auto requested = tr_bitfield{ 250 };
+    for (auto const& span : spans)
+    {
+        requested.set_span(span.begin, span.end);
+    }
+    EXPECT_EQ(245U, requested.count());
+    EXPECT_EQ(5U, requested.count(0, 5));
+    EXPECT_EQ(0U, requested.count(5, 10));
+    EXPECT_EQ(240U, requested.count(10, 250));
+}
+
 TEST_F(PeerMgrWishlistTest, doesNotRequestTooManyBlocks)
 {
-    auto mediator = MockMediator{};
+    auto mediator_ptr = std::make_unique<MockMediator>(*this);
+    auto& mediator = *mediator_ptr;
 
     // setup: three pieces, all missing
     mediator.piece_count_ = 3;
@@ -159,17 +364,13 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestTooManyBlocks)
     // and we want everything
     for (tr_piece_index_t i = 0; i < 3; ++i)
     {
-        mediator.can_request_piece_.insert(i);
-    }
-    for (tr_block_index_t i = 0; i < 250; ++i)
-    {
-        mediator.can_request_block_.insert(i);
+        mediator.client_wants_piece_.insert(i);
     }
 
     // but we only ask for 10 blocks,
     // so that's how many we should get back
     auto const n_wanted = 10U;
-    auto const spans = Wishlist{ mediator }.next(n_wanted);
+    auto const spans = Wishlist{ std::move(mediator_ptr) }.next(n_wanted, PeerHasAllPieces, ClientHasNoActiveRequests);
     auto n_got = size_t{};
     for (auto const& span : spans)
     {
@@ -180,150 +381,100 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestTooManyBlocks)
 
 TEST_F(PeerMgrWishlistTest, prefersHighPriorityPieces)
 {
-    auto mediator = MockMediator{};
-
-    // setup: three pieces, all missing
-    mediator.piece_count_ = 3;
-    mediator.missing_block_count_[0] = 100;
-    mediator.missing_block_count_[1] = 100;
-    mediator.missing_block_count_[2] = 100;
-    mediator.block_span_[0] = { 0, 100 };
-    mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 300 };
-
-    // and we want everything
-    for (tr_piece_index_t i = 0; i < 3; ++i)
+    auto const get_ranges = [this](size_t n_wanted)
     {
-        mediator.can_request_piece_.insert(i);
-    }
-    for (tr_block_index_t i = 0; i < 299; ++i)
-    {
-        mediator.can_request_block_.insert(i);
-    }
+        auto mediator_ptr = std::make_unique<MockMediator>(*this);
+        auto& mediator = *mediator_ptr;
 
-    // and the second piece is high priority
-    mediator.piece_priority_[1] = TR_PRI_HIGH;
+        // setup: three pieces, all missing
+        mediator.piece_count_ = 3;
+        mediator.missing_block_count_[0] = 100;
+        mediator.missing_block_count_[1] = 100;
+        mediator.missing_block_count_[2] = 100;
+        mediator.block_span_[0] = { 0, 100 };
+        mediator.block_span_[1] = { 100, 200 };
+        mediator.block_span_[2] = { 200, 300 };
+
+        // and we want everything
+        for (tr_piece_index_t i = 0; i < 3; ++i)
+        {
+            mediator.client_wants_piece_.insert(i);
+        }
+
+        // and the second piece is high priority
+        mediator.piece_priority_[1] = TR_PRI_HIGH;
+
+        return Wishlist{ std::move(mediator_ptr) }.next(n_wanted, PeerHasAllPieces, ClientHasNoActiveRequests);
+    };
 
     // wishlist should pick the high priority piece's blocks first.
     //
     // NB: when all other things are equal in the wishlist, pieces are
     // picked at random so this test -could- pass even if there's a bug.
     // So test several times to shake out any randomness
-    auto const num_runs = 1000;
-    for (int run = 0; run < num_runs; ++run)
+    static auto constexpr NumRuns = 1000;
+    for (int run = 0; run < NumRuns; ++run)
     {
-        auto const n_wanted = 10U;
-        auto spans = Wishlist{ mediator }.next(n_wanted);
-        auto n_got = size_t{};
+        auto const spans = get_ranges(10);
+        auto requested = tr_bitfield{ 300 };
         for (auto const& span : spans)
         {
-            for (auto block = span.begin; block < span.end; ++block)
-            {
-                EXPECT_LE(mediator.block_span_[1].begin, block);
-                EXPECT_LT(block, mediator.block_span_[1].end);
-            }
-            n_got += span.end - span.begin;
+            requested.set_span(span.begin, span.end);
         }
-        EXPECT_EQ(n_wanted, n_got);
+        EXPECT_EQ(10U, requested.count());
+        EXPECT_EQ(0U, requested.count(0, 100));
+        EXPECT_EQ(10U, requested.count(100, 200));
+        EXPECT_EQ(0U, requested.count(200, 300));
     }
-}
-
-TEST_F(PeerMgrWishlistTest, onlyRequestsDupesDuringEndgame)
-{
-    auto mediator = MockMediator{};
-
-    // setup: three pieces, all missing
-    mediator.piece_count_ = 3;
-    mediator.missing_block_count_[0] = 100;
-    mediator.missing_block_count_[1] = 100;
-    mediator.missing_block_count_[2] = 100;
-    mediator.block_span_[0] = { 0, 100 };
-    mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 300 };
-
-    // and we want everything
-    for (tr_piece_index_t i = 0; i < 3; ++i)
-    {
-        mediator.can_request_piece_.insert(i);
-    }
-    for (tr_block_index_t i = 0; i < 300; ++i)
-    {
-        mediator.can_request_block_.insert(i);
-    }
-
-    // and we've already requested blocks [0-150)
-    for (tr_block_index_t i = 0; i < 150; ++i)
-    {
-        mediator.active_request_count_[i] = 1;
-    }
-
-    // even if we ask wishlist to list more blocks than exist,
-    // those first 150 should be omitted from the return list
-    auto spans = Wishlist{ mediator }.next(1000);
-    auto requested = tr_bitfield(300);
-    for (auto const& span : spans)
-    {
-        requested.set_span(span.begin, span.end);
-    }
-    EXPECT_EQ(150U, requested.count());
-    EXPECT_EQ(0U, requested.count(0, 150));
-    EXPECT_EQ(150U, requested.count(150, 300));
-
-    // BUT during endgame it's OK to request dupes,
-    // so then we _should_ see the first 150 in the list
-    mediator.is_endgame_ = true;
-    spans = Wishlist{ mediator }.next(1000);
-    requested = tr_bitfield(300);
-    for (auto const& span : spans)
-    {
-        requested.set_span(span.begin, span.end);
-    }
-    EXPECT_EQ(300U, requested.count());
-    EXPECT_EQ(150U, requested.count(0, 150));
-    EXPECT_EQ(150U, requested.count(150, 300));
 }
 
 TEST_F(PeerMgrWishlistTest, prefersNearlyCompletePieces)
 {
-    auto mediator = MockMediator{};
-
-    // setup: three pieces, same size
-    mediator.piece_count_ = 3;
-    mediator.block_span_[0] = { 0, 100 };
-    mediator.block_span_[1] = { 100, 200 };
-    mediator.block_span_[2] = { 200, 300 };
-
-    // and we want everything
-    for (tr_piece_index_t i = 0; i < 3; ++i)
+    auto const get_ranges = [this](size_t n_wanted)
     {
-        mediator.can_request_piece_.insert(i);
-    }
+        auto mediator_ptr = std::make_unique<MockMediator>(*this);
+        auto& mediator = *mediator_ptr;
 
-    // but some pieces are closer to completion than others
-    mediator.missing_block_count_[0] = 10;
-    mediator.missing_block_count_[1] = 20;
-    mediator.missing_block_count_[2] = 100;
-    for (tr_piece_index_t piece = 0; piece < 3; ++piece)
-    {
-        auto const& span = mediator.block_span_[piece];
-        auto const& n_missing = mediator.missing_block_count_[piece];
+        // setup: three pieces, same size
+        mediator.piece_count_ = 3;
+        mediator.block_span_[0] = { 0, 100 };
+        mediator.block_span_[1] = { 100, 200 };
+        mediator.block_span_[2] = { 200, 300 };
 
-        for (size_t i = 0; i < n_missing; ++i)
+        // and we want everything
+        for (tr_piece_index_t i = 0; i < 3; ++i)
         {
-            mediator.can_request_block_.insert(span.begin + i);
+            mediator.client_wants_piece_.insert(i);
         }
-    }
+
+        // but some pieces are closer to completion than others
+        mediator.missing_block_count_[0] = 10;
+        mediator.missing_block_count_[1] = 20;
+        mediator.missing_block_count_[2] = 100;
+        for (tr_piece_index_t piece = 0; piece < 3; ++piece)
+        {
+            auto const& span = mediator.block_span_[piece];
+            auto const have_end = span.end - mediator.missing_block_count_[piece];
+
+            for (tr_piece_index_t i = span.begin; i < have_end; ++i)
+            {
+                mediator.client_has_block_.insert(i);
+            }
+        }
+
+        return Wishlist{ std::move(mediator_ptr) }.next(n_wanted, PeerHasAllPieces, ClientHasNoActiveRequests);
+    };
 
     // wishlist prefers to get pieces completed ASAP, so it
     // should pick the ones with the fewest missing blocks first.
     // NB: when all other things are equal in the wishlist, pieces are
     // picked at random so this test -could- pass even if there's a bug.
     // So test several times to shake out any randomness
-    auto const num_runs = 1000;
-    for (int run = 0; run < num_runs; ++run)
+    static auto constexpr NumRuns = 1000;
+    for (int run = 0; run < NumRuns; ++run)
     {
-        auto const ranges = Wishlist{ mediator }.next(10);
-        auto requested = tr_bitfield(300);
+        auto const ranges = get_ranges(10);
+        auto requested = tr_bitfield{ 300 };
         for (auto const& range : ranges)
         {
             requested.set_span(range.begin, range.end);
@@ -336,10 +487,10 @@ TEST_F(PeerMgrWishlistTest, prefersNearlyCompletePieces)
     // Same premise as previous test, but ask for more blocks.
     // Since the second piece is also the second-closest to completion,
     // those blocks should be next in line.
-    for (int run = 0; run < num_runs; ++run)
+    for (int run = 0; run < NumRuns; ++run)
     {
-        auto const ranges = Wishlist{ mediator }.next(20);
-        auto requested = tr_bitfield(300);
+        auto const ranges = get_ranges(20);
+        auto requested = tr_bitfield{ 300 };
         for (auto const& range : ranges)
         {
             requested.set_span(range.begin, range.end);


### PR DESCRIPTION
Fixes #6535, more explanation can be found in the GitHub issue.

This PR basically reintroduces the wishlist implementation in `3.00`, which caches piece candidates, and prefers rarer pieces (`4.0.x` wishlist doesn't do any of these).

If your download speed in `4.0.x` has been bottlenecked by CPU, and if my test results don't lie, then you should notice speed improvements in this PR.

Attached a flamegraph captured in a debug build, I captured many other flamegraphs in this PR, and they look about the same as this one:

![flame](https://github.com/transmission/transmission/assets/46261767/8a5f0784-18c8-4627-92be-af5559334c22)

Notes: Improved libtransmission code to use less CPU.
