### PR TITLE
only use a single concurrent queue for timeMachineExclude instead of one queue per torrent (#6523)

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -307,6 +307,9 @@ static void removeKeRangerRansomware()
 
 + (void)initialize
 {
+    if (self != [Controller self])
+        return;
+
     removeKeRangerRansomware();
 
     //make sure another Transmission.app isn't running already

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
 
 @end
 
-NSMutableSet* creatorWindowControllerSet = nil;
+static NSMutableSet* creatorWindowControllerSet;
 
 @implementation CreatorWindowController
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -23,6 +23,8 @@ NSString* const kTorrentDidChangeGroupNotification = @"TorrentDidChangeGroup";
 
 static int const kETAIdleDisplaySec = 2 * 60;
 
+static dispatch_queue_t timeMachineExcludeQueue;
+
 @interface Torrent ()
 
 @property(nonatomic, readonly) tr_torrent* fHandle;
@@ -44,8 +46,6 @@ static int const kETAIdleDisplaySec = 2 * 60;
 @property(nonatomic) TorrentDeterminationType fDownloadFolderDetermination;
 
 @property(nonatomic) BOOL fResumeOnWake;
-
-@property(nonatomic) dispatch_queue_t timeMachineExcludeQueue;
 
 - (void)renameFinished:(BOOL)success
                  nodes:(NSArray<FileListNode*>*)nodes
@@ -97,6 +97,15 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
 }
 
 @implementation Torrent
+
++ (void)initialize
+{
+    if (self != [Torrent self])
+        return;
+
+    // DISPATCH_QUEUE_SERIAL because DISPATCH_QUEUE_CONCURRENT is limited to 64 simultaneous torrent dispatch_async
+    timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_SERIAL);
+}
 
 - (instancetype)initWithPath:(NSString*)path
                     location:(NSString*)location
@@ -1775,7 +1784,6 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
                                                name:@"GroupValueRemoved"
                                              object:nil];
 
-    _timeMachineExcludeQueue = dispatch_queue_create("updateTimeMachineExclude", DISPATCH_QUEUE_CONCURRENT);
     [self update];
     [self updateTimeMachineExclude];
 
@@ -2106,7 +2114,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error** error)
     NSString* path;
     if ((path = self.dataLocation))
     {
-        dispatch_async(_timeMachineExcludeQueue, ^{
+        dispatch_async(timeMachineExcludeQueue, ^{
             CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:path];
             CSBackupSetItemExcluded(url, exclude, false);
         });

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -20,6 +20,10 @@ static CGFloat const kPaddingBetweenLines = 1.0;
 static CGFloat const kPaddingBetweenLinesOnSameLine = 4.0;
 static CGFloat const kCountWidth = 60.0;
 
+// make the favicons accessible to all tracker cells
+static NSCache* fTrackerIconCache;
+static NSMutableSet* fTrackerIconLoading;
+
 @interface TrackerCell ()
 
 @property(nonatomic, readonly) NSImage* favIcon;
@@ -31,12 +35,11 @@ static CGFloat const kCountWidth = 60.0;
 
 @implementation TrackerCell
 
-//make the favicons accessible to all tracker cells
-NSCache* fTrackerIconCache;
-NSMutableSet* fTrackerIconLoading;
-
 + (void)initialize
 {
+    if (self != [TrackerCell self])
+        return;
+
     fTrackerIconCache = [[NSCache alloc] init];
     fTrackerIconLoading = [[NSMutableSet alloc] init];
 }


### PR DESCRIPTION
cherry pick of #6523 for 4.0.x

note: fix macOS startup when using Time Machine with many torrents