### PR TITLE
chore: backport recently active fixes

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2400,6 +2400,7 @@ void tr_torrent::setDownloadDir(std::string_view path, bool is_new_torrent)
 {
     download_dir = path;
     markEdited();
+    markChanged();
     setDirty();
     refreshCurrentDir();
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -862,6 +862,7 @@ void torrentStop(tr_torrent* const tor)
 
     tor->isRunning = false;
     tor->isStopping = false;
+    tor->markChanged();
 
     if (!tor->session->isClosing())
     {


### PR DESCRIPTION
These needed manual backporting because the API changed.

Notes: Fixed `4.0.0` bugs where some RPC methods don't put torrents in `recently-active` anymore.