### PR TITLE
fix: various DHT bugs

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -93,8 +93,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **preferred-transport:** String ("utp" = Prefer µTP, "tcp" = Prefer TCP; default = "utp") Choose your preferred transport protocol (has no effect if one of them is disabled).
 
 #### Peers
- * **bind-address-ipv4:** String (default = "0.0.0.0") Where to listen for peer connections. When no valid IPv4 address is provided, Transmission will bind to "0.0.0.0".
- * **bind-address-ipv6:** String (default = "::") Where to listen for peer connections. When no valid IPv6 address is provided, Transmission will try to bind to your default global IPv6 address. If that didn't work, then Transmission will bind to "::".
+ * **bind-address-ipv4:** String (default = "") Where to listen for peer connections. When no valid IPv4 address is provided, Transmission will bind to "0.0.0.0".
+ * **bind-address-ipv6:** String (default = "") Where to listen for peer connections. When no valid IPv6 address is provided, Transmission will try to bind to your default global IPv6 address. If that didn't work, then Transmission will bind to "::".
  * **peer-congestion-algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
  * **peer-limit-global:** Number (default = 240)
  * **peer-limit-per-torrent:** Number (default =  60)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -352,11 +352,7 @@ public:
 
         if (session->allowsDHT() && io->supports_dht())
         {
-            // only send PORT over IPv6 iff IPv6 DHT is running (BEP-32).
-            if (auto const addr = session->bind_address(TR_AF_INET6); !addr.is_any())
-            {
-                protocolSendPort(this, session->udpPort());
-            }
+            protocolSendPort(this, session->udpPort());
         }
 
         io->set_callbacks(canRead, didWrite, gotError, this);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1481,7 +1481,7 @@ ReadResult process_peer_message(tr_peerMsgsImpl* msgs, uint8_t id, MessageReader
             if (auto const dht_port = tr_port::from_host(hport); !std::empty(dht_port))
             {
                 msgs->dht_port = dht_port;
-                msgs->session->addDhtNode(msgs->io->address(), msgs->dht_port);
+                msgs->session->maybe_add_dht_node(msgs->io->address(), msgs->dht_port);
             }
         }
         break;

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -21,8 +21,8 @@ struct tr_variant;
 #define SESSION_SETTINGS_FIELDS(V) \
     V(TR_KEY_announce_ip, announce_ip, std::string, "", "") \
     V(TR_KEY_announce_ip_enabled, announce_ip_enabled, bool, false, "") \
-    V(TR_KEY_bind_address_ipv4, bind_address_ipv4, std::string, "0.0.0.0", "") \
-    V(TR_KEY_bind_address_ipv6, bind_address_ipv6, std::string, "::", "") \
+    V(TR_KEY_bind_address_ipv4, bind_address_ipv4, std::string, "", "") \
+    V(TR_KEY_bind_address_ipv6, bind_address_ipv6, std::string, "", "") \
     V(TR_KEY_blocklist_enabled, blocklist_enabled, bool, false, "") \
     V(TR_KEY_blocklist_url, blocklist_url, std::string, "http://www.example.com/blocklist", "") \
     V(TR_KEY_cache_size_mb, cache_size_mbytes, size_t, 4U, "") \

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -901,11 +901,11 @@ public:
 
     void addTorrent(tr_torrent* tor);
 
-    void addDhtNode(tr_address const& addr, tr_port port)
+    void maybe_add_dht_node(tr_address const& addr, tr_port port)
     {
         if (dht_)
         {
-            dht_->add_node(addr, port);
+            dht_->maybe_add_node(addr, port);
         }
     }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -207,7 +207,7 @@ public:
     }
 
 private:
-    [[nodiscard]] constexpr tr_socket_t udpSocket(int af) const noexcept
+    [[nodiscard]] constexpr tr_socket_t udp_socket(int af) const noexcept
     {
         switch (af)
         {
@@ -224,7 +224,7 @@ private:
 
     [[nodiscard]] SwarmStatus swarm_status(int family, int* const setme_node_count = nullptr) const
     {
-        if (udpSocket(family) == TR_BAD_SOCKET)
+        if (udp_socket(family) == TR_BAD_SOCKET)
         {
             if (setme_node_count != nullptr)
             {
@@ -414,11 +414,11 @@ private:
     void save_state() const
     {
         auto constexpr MaxNodes = int{ 300 };
-        auto constexpr PortLen = size_t{ 2 };
-        auto constexpr CompactAddrLen = size_t{ 4 };
-        auto constexpr CompactLen = size_t{ CompactAddrLen + PortLen };
-        auto constexpr Compact6AddrLen = size_t{ 16 };
-        auto constexpr Compact6Len = size_t{ Compact6AddrLen + PortLen };
+        auto constexpr PortLen = tr_port::CompactPortBytes;
+        auto constexpr CompactAddrLen = tr_address::CompactAddrBytes[TR_AF_INET];
+        auto constexpr CompactLen = tr_socket_address::CompactSockAddrBytes[TR_AF_INET];
+        auto constexpr Compact6AddrLen = tr_address::CompactAddrBytes[TR_AF_INET6];
+        auto constexpr Compact6Len = tr_socket_address::CompactSockAddrBytes[TR_AF_INET6];
 
         auto sins4 = std::array<struct sockaddr_in, MaxNodes>{};
         auto sins6 = std::array<struct sockaddr_in6, MaxNodes>{};

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -176,7 +176,7 @@ public:
         tr_logAddTrace("Done uninitializing DHT");
     }
 
-    void add_node(tr_address const& addr, tr_port port) override
+    void maybe_add_node(tr_address const& addr, tr_port port) override
     {
         if (addr.is_ipv4())
         {
@@ -309,7 +309,7 @@ private:
 
         auto [address, port] = bootstrap_queue_.front();
         bootstrap_queue_.pop_front();
-        add_node(address, port);
+        maybe_add_node(address, port);
         ++n_bootstrapped_;
 
         bootstrap_timer_->start_single_shot(bootstrap_interval(n_bootstrapped_));

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -114,6 +114,6 @@ public:
         tr_socket_t udp6_socket);
     virtual ~tr_dht() = default;
 
-    virtual void add_node(tr_address const& address, tr_port port) = 0;
+    virtual void maybe_add_node(tr_address const& address, tr_port port) = 0;
     virtual void handle_message(unsigned char const* msg, size_t msglen, struct sockaddr* from, socklen_t fromlen) = 0;
 };

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -619,7 +619,7 @@ TEST_F(DhtTest, pingsAddedNodes)
     EXPECT_TRUE(addr.has_value());
     assert(addr.has_value());
     auto constexpr Port = tr_port::from_host(128);
-    dht->add_node(*addr, Port);
+    dht->maybe_add_node(*addr, Port);
 
     ASSERT_EQ(1U, std::size(mediator.mock_dht_.pinged_));
     EXPECT_EQ(addr, mediator.mock_dht_.pinged_.front().addrport.address());


### PR DESCRIPTION
Notes: Improved DHT performance.

This PR does 4 things:

1. Fixes a `4.0.0` regression from 5ce503f1ab23efb497c64386615c48a4a75d4b46 where Tr clients on IPv4-only networks does not send DHT Port message *at all*.
2. Fixes a `4.0.0` regression from 9e06cf8f2e23f9aa708d7b6c16f8fd13bda39399 where the node ID is no longer initialised randomly.
3. Modifies Tr's behaviour so that we send a DHT Port message as long as DHT is supported by both ends.

   **Rationale**
   We used to avoid sending IPv6 DHT Port messages if our IPv6 bind address is not a global unicast address, because BEP-32 says that `The IPv6 DHT should use a socket bound to one of the host's global unicast IPv6 addresses rather than the "unspecified address" (::/128).`. I think this should not stop us from sending DHT Port messages.
   
   AFAICT, this is to make sure peers on multi-homed hosts will always correspond to one node in DHT, so that their nodes will not be mistaken as "bad" (in BEP-5's terms) nodes for appearing to be unresponsive to queries, whilst it did in fact send their responses, albeit from an address different from the one they received the query from (or other complications related to multi-homed hosts).
   
   This is not a good enough reason to stop us from sending DHT port messages because:
   - Most OSs today default to the same network interface even if the socket is bound to "any address", so having "multiple DHT nodes representing my client" is not likely.
   - More importantly, having our Tr client appearing as multiple nodes does not come close to crippling DHT. The most that will happen is that our nodes will be considered as "bad" nodes, and be removed from other nodes' routing tables. This is still better than our nodes staying unknown to others.
   
     For what it's worth, the situation in the IPv4 DHT network should be much worse because many DHT nodes behind a NAT cannot respond to queries at all, but the network still functions reasonably well. So I reckon IPv6 multi-homed hosts should be the least of our concern.

4. Changes the defaults of `bind-address-ipv*` settings to an empty string, so that IPv6 DHT can potentially be more effective on default settings.

   **Rationale**
   For IPv4, `0.0.0.0` and an empty string is effectively the same. But we change it anyways just to be consistent with IPv6.
   
   For IPv6, setting an empty string allows Tr to try binding to the default global unicast address instead of "any address", whilst setting `::` will always bind to "any address". So this change may improve IPv6 DHT performance for some people.
   