### PR TITLE
fix(web): don't use 2 rows for upload/download speed info

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -322,7 +322,8 @@ $speed-icon-size: 20px;
 #speed-dn-label,
 #speed-up-label {
   text-align: right;
-  width: 70px;
+  width: 100px;
+  white-space: nowrap;
 }
 
 /// TORRENT CONTAINER


### PR DESCRIPTION
created PR as asked by @tearfur 

fixes #6375 

Screenshot:

<img width="308" alt="image" src="https://github.com/transmission/transmission/assets/223439/26257459-eccd-4090-b3f8-c6be8c92e8cf">