### PR TITLE
fix(web): don't use 2 rows for upload/download speed info

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -397,6 +397,8 @@ a {
 #speed-dn-label,
 #speed-up-label {
   text-align: right;
+  width: 100px;
+  white-space: nowrap;
 }
 
 /// TORRENT CONTAINER


### PR DESCRIPTION
fix on main branch as requested in https://github.com/transmission/transmission/pull/6570#issuecomment-1928574967

Screenshot:

<img width="308" alt="image" src="https://github.com/transmission/transmission/assets/223439/e923e426-4516-443a-9416-6b5c6ac143ed">
