### PR TITLE
feat: support "torrent" in Spotlight indexation

### DIFF
--- a/macosx/en.lproj/InfoPlist.strings
+++ b/macosx/en.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 /* Localized versions of Info.plist keys */
 
 NSHumanReadableCopyright = "Copyright © 2005-2024 The Transmission Project";
-MDItemKeywords = "tor,torrent,torrents,magnet,magnets,bt,bit,btih";
+MDItemKeywords = "torrent,torrents,magnet,magnets,tor,bt,bit";

--- a/macosx/en.lproj/InfoPlist.strings
+++ b/macosx/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 /* Localized versions of Info.plist keys */
 
 NSHumanReadableCopyright = "Copyright © 2005-2024 The Transmission Project";
+MDItemKeywords = "tor,torrent,torrents,magnet,magnets,bt,bit,btih";


### PR DESCRIPTION
Fix the comment in https://github.com/transmission/transmission/issues/6554#issuecomment-1924416885

Testing: on macOS, after running Transmission at least once, in any language (not necessarily English), you can now use Spotlight (CMD+SPACE) to search for "torrent" or "magnet" or other keywords, and it will find Transmission.
<img width="598" alt="Capture d’écran 2024-02-06 à 03 28 06" src="https://github.com/transmission/transmission/assets/839992/dc674e23-24f0-4410-85ad-1a7224fdaf0c">
