### PR TITLE
GTK: Add developer name (and screenshot caption) to metainfo

### DIFF
--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -9,6 +9,10 @@ Copyright 2017 Endless Mobile, Inc.
   <project_license>GPL-2.0 OR GPL-3.0</project_license>
 
   <name>Transmission</name>
+  <developer_name>The Transmission Project</developer_name>
+  <developer id="transmissionbt.com">
+    <name>The Transmission Project</name>
+  </developer>
   <summary>Download and share files over BitTorrent</summary>
 
   <description>

--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -40,6 +40,7 @@ Copyright 2017 Endless Mobile, Inc.
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/transmission/transmission/main/gtk/screenshots/a.png</image>
+      <caption>Main window, showing an ongoing download of Fedora Workstation</caption>
     </screenshot>
   </screenshots>
   <update_contact>info_AT_transmissionbt.com</update_contact>


### PR DESCRIPTION
`developer_name` has become mandatory on Flathub, so I've added these patches to the Flathub build of Transmission.
