### PR TITLE
fix: clang-tidy-19 warnings

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -319,7 +319,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
         tr_announce_response& response_;
         std::string_view const log_name_;
         std::optional<size_t> row_;
-        tr_pex pex_ = {};
+        tr_pex pex_;
 
         explicit AnnounceHandler(tr_announce_response& response, std::string_view log_name)
             : response_{ response }
@@ -480,7 +480,7 @@ public:
 
 private:
     tr_scrape_response response_ = {};
-    tr_scrape_response_func response_func_ = {};
+    tr_scrape_response_func response_func_;
     std::string log_name_;
 };
 

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -586,8 +586,8 @@ private:
     MaybeSockaddr addr_;
     time_t addr_expires_at_ = 0;
 
-    static inline constexpr auto DnsRetryIntervalSecs = time_t{ 3600 };
-    static inline constexpr auto ConnectionRequestTtl = 30;
+    static constexpr auto DnsRetryIntervalSecs = time_t{ 3600 };
+    static constexpr auto ConnectionRequestTtl = 30;
 };
 
 // --- SESSION

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -587,7 +587,7 @@ private:
     time_t addr_expires_at_ = 0;
 
     static inline constexpr auto DnsRetryIntervalSecs = time_t{ 3600 };
-    static inline constexpr auto ConnectionRequestTtl = int{ 30 };
+    static inline constexpr auto ConnectionRequestTtl = 30;
 };
 
 // --- SESSION

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -581,9 +581,9 @@ public:
 private:
     Mediator& mediator_;
 
-    std::optional<std::future<MaybeSockaddr>> addr_pending_dns_ = {};
+    std::optional<std::future<MaybeSockaddr>> addr_pending_dns_;
 
-    MaybeSockaddr addr_ = {};
+    MaybeSockaddr addr_;
     time_t addr_expires_at_ = 0;
 
     static inline constexpr auto DnsRetryIntervalSecs = time_t{ 3600 };

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -51,17 +51,17 @@ using namespace std::literals;
 namespace
 {
 /* unless the tracker says otherwise, rescrape this frequently */
-auto constexpr DefaultScrapeIntervalSec = int{ 60 * 30 };
+auto constexpr DefaultScrapeIntervalSec = 60 * 30;
 
 /* the value of the 'numwant' argument passed in tracker requests. */
-auto constexpr Numwant = int{ 80 };
+auto constexpr Numwant = 80;
 
 /* how often to announce & scrape */
-auto constexpr MaxAnnouncesPerUpkeep = int{ 20 };
-auto constexpr MaxScrapesPerUpkeep = int{ 20 };
+auto constexpr MaxAnnouncesPerUpkeep = 20;
+auto constexpr MaxScrapesPerUpkeep = 20;
 
 /* how many infohashes to remove when we get a scrape-too-long error */
-auto constexpr TrMultiscrapeStep = int{ 5 };
+auto constexpr TrMultiscrapeStep = 5;
 
 struct StopsCompare
 {
@@ -524,10 +524,10 @@ struct tr_tier
 
 private:
     // unless the tracker says otherwise, this is the announce interval
-    static auto constexpr DefaultAnnounceIntervalSec = int{ 60 * 10 };
+    static auto constexpr DefaultAnnounceIntervalSec = 60 * 10;
 
     // unless the tracker says otherwise, this is the announce min_interval
-    static auto constexpr DefaultAnnounceMinIntervalSec = int{ 60 * 2 };
+    static auto constexpr DefaultAnnounceMinIntervalSec = 60 * 2;
 
     [[nodiscard]] static time_t getNextScrapeTime(tr_session const* session, tr_tier const* tier, time_t interval_secs)
     {

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -273,7 +273,7 @@ std::string_view tr_sys_path_dirname(std::string_view path)
 
     auto const has_root = path[0] == '/';
     auto end = std::string_view::npos;
-    auto matched_slash = bool{ true };
+    auto matched_slash = true;
 
     for (auto i = len - 1; i >= 1U; --i)
     {
@@ -1128,7 +1128,7 @@ bool tr_sys_dir_create(char const* path, int flags, int permissions, tr_error* e
 {
     TR_ASSERT(path != nullptr);
 
-    auto ret = bool{ false };
+    auto ret = false;
     auto local_error = tr_error{};
 
     if ((flags & TR_SYS_DIR_CREATE_PARENTS) != 0)

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -994,6 +994,10 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
     case TR_SYS_FILE_LOCK_UN:
         fl.l_type = F_UNLCK;
         break;
+
+    default:
+        errno = EINVAL;
+        break;
     }
 
     fl.l_whence = SEEK_SET;

--- a/libtransmission/global-ip-cache.cc
+++ b/libtransmission/global-ip-cache.cc
@@ -268,7 +268,7 @@ void tr_global_ip_cache::update_source_addr(tr_address_type type) noexcept
 
     auto const protocol = tr_ip_protocol_to_sv(type);
 
-    auto err = int{ 0 };
+    auto err = 0;
     auto const& source_addr = get_global_source_address(bind_addr(type), err);
     if (source_addr)
     {

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -259,7 +259,7 @@ void tr_open_files::close_all()
 
 void tr_open_files::close_torrent(tr_torrent_id_t tor_id)
 {
-    return pool_.erase_if([&tor_id](Key const& key, Val const& /*unused*/) { return key.first == tor_id; });
+    pool_.erase_if([&tor_id](Key const& key, Val const& /*unused*/) { return key.first == tor_id; });
 }
 
 void tr_open_files::close_file(tr_torrent_id_t tor_id, tr_file_index_t file_num)

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -372,8 +372,8 @@ void tr_peerIo::can_read_wrapper()
     auto const keep_alive = shared_from_this();
 
     auto const now = tr_time_msec();
-    auto done = bool{ false };
-    auto err = bool{ false };
+    auto done = false;
+    auto err = false;
 
     // In normal conditions, only continue processing if we still have bandwidth
     // quota for it.

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -58,7 +58,7 @@
 using namespace std::literals;
 using namespace libtransmission::Values;
 
-static auto constexpr CancelHistorySec = int{ 60 };
+static auto constexpr CancelHistorySec = 60;
 
 // ---
 
@@ -954,10 +954,10 @@ private:
     // ---
 
     // number of bad pieces a peer is allowed to send before we ban them
-    static auto constexpr MaxBadPiecesPerPeer = int{ 5 };
+    static auto constexpr MaxBadPiecesPerPeer = 5;
 
     // how long we'll let requests we've made linger before we cancel them
-    static auto constexpr RequestTtlSecs = int{ 90 };
+    static auto constexpr RequestTtlSecs = 90;
 
     std::array<libtransmission::ObserverTag, 8> const tags_;
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -166,27 +166,27 @@ enum LtepMessageIds : uint8_t
 namespace MetadataMsgType
 {
 
-auto constexpr Request = int{ 0 };
-auto constexpr Data = int{ 1 };
-auto constexpr Reject = int{ 2 };
+auto constexpr Request = 0;
+auto constexpr Data = 1;
+auto constexpr Reject = 2;
 
 } // namespace MetadataMsgType
 
-auto constexpr MinChokePeriodSec = int{ 10 };
+auto constexpr MinChokePeriodSec = 10;
 
 // idle seconds before we send a keepalive
-auto constexpr KeepaliveIntervalSecs = int{ 100 };
+auto constexpr KeepaliveIntervalSecs = 100;
 
-auto constexpr MetadataReqQ = int{ 64 };
+auto constexpr MetadataReqQ = 64;
 
-auto constexpr ReqQ = int{ 512 };
+auto constexpr ReqQ = 512;
 
 // used in lowering the outMessages queue period
 
 // when we're making requests from another peer,
 // batch them together to send enough requests to
 // meet our bandwidth goals for the next N seconds
-auto constexpr RequestBufSecs = int{ 10 };
+auto constexpr RequestBufSecs = 10;
 
 // ---
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -112,7 +112,7 @@ public:
     }
 
 private:
-    std::string unix_socket_path_ = {};
+    std::string unix_socket_path_;
 };
 } // namespace
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -576,7 +576,7 @@ void handle_request(struct evhttp_request* req, void* arg)
     }
 }
 
-auto constexpr ServerStartRetryCount = int{ 10 };
+auto constexpr ServerStartRetryCount = 10;
 auto constexpr ServerStartRetryDelayIncrement = 5s;
 auto constexpr ServerStartRetryMaxDelay = 60s;
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -69,8 +69,8 @@ struct tr_rpc_idle_data
 {
     std::optional<int64_t> tag;
     tr_session* session = nullptr;
-    tr_variant::Map args_out = {};
-    tr_rpc_response_func callback = {};
+    tr_variant::Map args_out;
+    tr_rpc_response_func callback;
 };
 
 auto constexpr SuccessResult = "success"sv;

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -122,7 +122,7 @@ bool tr_session_id::is_local(std::string_view session_id) noexcept
         return false;
     }
 
-    auto is_local = bool{ false };
+    auto is_local = false;
     auto lockfile_path = tr_pathbuf{};
     get_lockfile_path(session_id, lockfile_path);
     auto error = tr_error{};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -193,7 +193,7 @@ tr_peer_id_t tr_peerIdInit()
 
     // remainder is randomly-generated characters
     auto constexpr Pool = std::string_view{ "0123456789abcdefghijklmnopqrstuvwxyz" };
-    auto total = int{ 0 };
+    auto total = 0;
     tr_rand_buffer(it, end - it);
     while (it + 1 < end)
     {

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -157,12 +157,12 @@ void tr_ctorSetPeerLimit(tr_ctor* const ctor, tr_ctorMode const mode, uint16_t c
 
 void tr_ctorSetDownloadDir(tr_ctor* const ctor, tr_ctorMode const mode, char const* const dir)
 {
-    return ctor->set_download_dir(mode, std::string_view{ dir != nullptr ? dir : "" });
+    ctor->set_download_dir(mode, std::string_view{ dir != nullptr ? dir : "" });
 }
 
 void tr_ctorSetIncompleteDir(tr_ctor* const ctor, char const* const dir)
 {
-    return ctor->set_incomplete_dir(std::string_view{ dir != nullptr ? dir : "" });
+    ctor->set_incomplete_dir(std::string_view{ dir != nullptr ? dir : "" });
 }
 
 bool tr_ctorGetPeerLimit(tr_ctor const* const ctor, tr_ctorMode const mode, uint16_t* const setme)

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -194,7 +194,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
 
     bool Int64(int64_t value, Context const& /*context*/) override
     {
-        auto unhandled = bool{ false };
+        auto unhandled = false;
 
         if (state_ == State::FilesIgnored)
         {
@@ -272,7 +272,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
     {
         auto const curdepth = depth();
         auto const current_key = currentKey();
-        auto unhandled = bool{ false };
+        auto unhandled = false;
 
         if (state_ == State::FilesIgnored)
         {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1513,7 +1513,7 @@ void tr_torrentAvailability(tr_torrent const* tor, int8_t* tab, int size)
 
 void tr_torrentAmountFinished(tr_torrent const* tor, float* tabs, int n_tabs)
 {
-    return tor->amount_done_bins(tabs, n_tabs);
+    tor->amount_done_bins(tabs, n_tabs);
 }
 
 // --- Start/Stop Callback

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1101,7 +1101,7 @@ void tr_torrent::set_location_in_session_thread(std::string_view const path, boo
 {
     TR_ASSERT(session->am_in_session_thread());
 
-    auto ok = bool{ true };
+    auto ok = true;
     if (move_from_old_path)
     {
         if (setme_state != nullptr)
@@ -2459,7 +2459,7 @@ void tr_torrent::rename_path_in_session_thread(
 {
     using namespace rename_helpers;
 
-    auto error = int{ 0 };
+    auto error = 0;
 
     if (!renameArgsAreValid(this, oldpath, newname))
     {

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -12,7 +12,7 @@
 
 [[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message)
 {
-    std::cerr << "assertion failed: " << message << " (" << file << ':' << line << ')' << std::endl;
+    std::cerr << "assertion failed: " << message << " (" << file << ':' << line << ")\n";
     abort();
 }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -411,7 +411,7 @@ private:
 
     void save_state() const
     {
-        static auto constexpr MaxNodes = int{ 300 };
+        static auto constexpr MaxNodes = 300;
         static auto constexpr PortLen = tr_port::CompactPortBytes;
         static auto constexpr CompactAddrLen = tr_address::CompactAddrBytes[TR_AF_INET];
         static auto constexpr CompactLen = tr_socket_address::CompactSockAddrBytes[TR_AF_INET];

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -269,7 +269,7 @@ private:
      */
     bool initImpl(struct event_base* event_base)
     {
-        auto const opt_on = int{ 1 };
+        auto const opt_on = 1;
 
         static_assert(AnnounceScope > 0);
 
@@ -543,14 +543,14 @@ private:
     // bogus data. Better to drop a few packets than get DoS'ed.
     static auto constexpr DosInterval = 5s;
     std::unique_ptr<libtransmission::Timer> dos_timer_;
-    static auto constexpr MaxIncomingPerSecond = int{ 10 };
+    static auto constexpr MaxIncomingPerSecond = 10;
     static auto constexpr MaxIncomingPerUpkeep = std::chrono::duration_cast<std::chrono::seconds>(DosInterval).count() *
         MaxIncomingPerSecond;
     // @brief throw away messages after this number exceeds MaxIncomingPerUpkeep
     size_t messages_received_since_upkeep_ = 0U;
 
     static auto constexpr TorrentAnnounceIntervalSec = time_t{ 240U }; // how frequently to reannounce the same torrent
-    static auto constexpr TtlSameSubnet = int{ 1 };
+    static auto constexpr TtlSameSubnet = 1;
     static auto constexpr AnnounceScope = int{ TtlSameSubnet }; /**<the maximum scope for LPD datagrams */
 };
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -152,7 +152,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
 
     if (auto sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        auto optval = int{ 1 };
+        auto optval = 1;
         (void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
 
         auto const addr = session_.bind_address(TR_AF_INET);
@@ -186,7 +186,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     }
     else if (auto sock = socket(PF_INET6, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        auto optval = int{ 1 };
+        auto optval = 1;
         setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
 
         auto const addr = session_.bind_address(TR_AF_INET6);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -183,7 +183,7 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     }
 
     // Save the contents. This might take >1 pass.
-    auto ok = bool{ true };
+    auto ok = true;
     while (!std::empty(contents))
     {
         auto n_written = uint64_t{};

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -182,7 +182,7 @@ private:
 
             // NB: `name` may have extra trailing zeroes from inotify;
             // pass the c_str() so that processFile gets the right strlen
-            processFile(name.c_str());
+            processFile(std::data(name));
         }
     }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -736,7 +736,7 @@ public:
                     auto* const e = msg->easy_handle;
 
                     Task* task = nullptr;
-                    curl_easy_getinfo(e, CURLINFO_PRIVATE, (void*)&task);
+                    curl_easy_getinfo(e, CURLINFO_PRIVATE, static_cast<void*>(&task));
 
                     auto req_bytes_sent = long{};
                     auto total_time = double{};

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -736,7 +736,7 @@ public:
                     auto* const e = msg->easy_handle;
 
                     Task* task = nullptr;
-                    curl_easy_getinfo(e, CURLINFO_PRIVATE, static_cast<void*>(&task));
+                    curl_easy_getinfo(e, CURLINFO_PRIVATE, &task);
 
                     auto req_bytes_sent = long{};
                     auto total_time = double{};


### PR DESCRIPTION
fix a handful of warnings found by clang-tidy-19.