### PR TITLE
qt: add dynamic RPC keys

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -520,7 +520,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 {
     std::vector<std::string_view>& names = names_[props];
 
-    if (names.empty())
+    if (names.empty() || !dynamic_main_stat_keys_.empty())
     {
         // unchanging fields needed by the main window
         static auto constexpr MainInfoKeys = std::array<tr_quark, 9>{
@@ -625,6 +625,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
         case TorrentProperties::MainAll:
             std::for_each(MainInfoKeys.begin(), MainInfoKeys.end(), append);
             std::for_each(MainStatKeys.begin(), MainStatKeys.end(), append);
+            std::for_each(dynamic_main_stat_keys_.begin(), dynamic_main_stat_keys_.end(), append);
             break;
 
         case TorrentProperties::MainInfo:
@@ -633,6 +634,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 
         case TorrentProperties::MainStats:
             std::for_each(MainStatKeys.begin(), MainStatKeys.end(), append);
+            std::for_each(dynamic_main_stat_keys_.begin(), dynamic_main_stat_keys_.end(), append);
             break;
 
         case TorrentProperties::Rename:

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -516,11 +516,11 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
     q->run();
 }
 
-std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties props)
+std::set<std::string_view> const& Session::getKeyNames(TorrentProperties props)
 {
-    std::vector<std::string_view>& names = names_[props];
+    std::set<std::string_view>& names = names_[props];
 
-    if (names.empty() || !dynamic_main_stat_keys_.empty())
+    if (names.empty())
     {
         // unchanging fields needed by the main window
         static auto constexpr MainInfoKeys = std::array<tr_quark, 9>{
@@ -609,7 +609,7 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 
         auto const append = [&names](tr_quark key)
         {
-            names.emplace_back(tr_quark_get_string_view(key));
+            names.emplace(tr_quark_get_string_view(key));
         };
 
         switch (props)
@@ -625,7 +625,6 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
         case TorrentProperties::MainAll:
             std::for_each(MainInfoKeys.begin(), MainInfoKeys.end(), append);
             std::for_each(MainStatKeys.begin(), MainStatKeys.end(), append);
-            std::for_each(dynamic_main_stat_keys_.begin(), dynamic_main_stat_keys_.end(), append);
             break;
 
         case TorrentProperties::MainInfo:
@@ -634,7 +633,6 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 
         case TorrentProperties::MainStats:
             std::for_each(MainStatKeys.begin(), MainStatKeys.end(), append);
-            std::for_each(dynamic_main_stat_keys_.begin(), dynamic_main_stat_keys_.end(), append);
             break;
 
         case TorrentProperties::Rename:
@@ -644,10 +642,6 @@ std::vector<std::string_view> const& Session::getKeyNames(TorrentProperties prop
 
         // must be in every torrent req
         append(TR_KEY_id);
-
-        // sort and remove dupes
-        std::sort(names.begin(), names.end());
-        names.erase(std::unique(names.begin(), names.end()), names.end());
     }
 
     return names;

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -9,6 +9,7 @@
 #include <cstdint> // int64_t
 #include <map>
 #include <optional>
+#include <set>
 #include <string_view>
 #include <vector>
 
@@ -69,6 +70,11 @@ public:
     [[nodiscard]] constexpr auto blocklistSize() const noexcept
     {
         return blocklist_size_;
+    }
+
+    [[nodiscard]] constexpr auto& dynamicMainStatKeys() noexcept
+    {
+        return dynamic_main_stat_keys_;
     }
 
     enum PortTestIpProtocol : uint8_t
@@ -183,6 +189,8 @@ private:
     Prefs& prefs_;
 
     std::map<TorrentProperties, std::vector<std::string_view>> names_;
+
+    std::set<tr_quark> dynamic_main_stat_keys_ = {};
 
     int64_t blocklist_size_ = -1;
     std::array<bool, NUM_PORT_TEST_IP_PROTOCOL> port_test_pending_ = {};


### PR DESCRIPTION
Keys for MainStatKeys can now be added dynamically in order to only make certain RPC calls depending on options the user has enabled.

This PR is useful for #6517 and #5319.