### PR TITLE
doc: no need to adopt an alternative to VDKQueue

### DIFF
--- a/macosx/VDKQueue/VDKQueue.h
+++ b/macosx/VDKQueue/VDKQueue.h
@@ -46,7 +46,6 @@
 // - Callbacks are only on the main thread.
 // - Unmaintained as a standalone project.
 
-#warning Adopt an alternative to VDKQueue (UKFSEventsWatcher, EonilFSEvents, FileWatcher, DTFolderMonitor or SFSMonitor)
 // ALTERNATIVES (from archaic to modern)
 //
 //  - FreeBSD 4.1: Kernel Queue API (kevent and kqueue)

--- a/macosx/VDKQueue/VDKQueue.mm
+++ b/macosx/VDKQueue/VDKQueue.mm
@@ -165,7 +165,7 @@ NSString const* VDKQueueAccessRevocationNotification = @"VDKQueueAccessWasRevoke
     }
 }
 
-- (void)watcherThread:(id)sender
+- (void)watcherThread:(id)__unused sender
 {
 #if DEBUG_LOG_THREAD_LIFETIME
     NSLog(@"watcherThread started.");


### PR DESCRIPTION
That #warning was added by me long ago, before knowing that alternatives were also using kqueue under the hood.