### PR TITLE
feat: WebUI add `Error` case in port test result

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -64,7 +64,11 @@ export class PrefsDialog extends EventTarget {
     const element = this.elements.network.port_status_label[ipProtocol];
     const is_open = response.arguments['port-is-open'] || false;
     element.dataset.open = is_open;
-    setTextContent(element, is_open ? 'Open' : 'Closed');
+    if ('port-is-open' in response.arguments) {
+      setTextContent(element, is_open ? 'Open' : 'Closed');
+    } else {
+      setTextContent(element, 'Error');
+    }
   }
 
   _setBlocklistButtonEnabled(b) {

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -48,17 +48,20 @@ export class PrefsDialog extends EventTarget {
     )) {
       delete element.dataset.open;
       setTextContent(element, 'Checking...');
-      this.remote.checkPort(key, this._onPortChecked, this);
+      this.remote.checkPort(
+        key,
+        (response) => this._onPortChecked(key, response),
+        this,
+      );
     }
   }
 
-  _onPortChecked(response) {
+  _onPortChecked(ipProtocol, response) {
     if (this.closed) {
       return;
     }
 
-    const element =
-      this.elements.network.port_status_label[response.arguments['ipProtocol']];
+    const element = this.elements.network.port_status_label[ipProtocol];
     const is_open = response.arguments['port-is-open'] || false;
     element.dataset.open = is_open;
     setTextContent(element, is_open ? 'Open' : 'Closed');


### PR DESCRIPTION
A follow up of #5953.
Align the WebUI with the Qt and GTK changes from #6525, show `Error` instead of `Closed` in the port test if the daemon did not return a result.

Notes: The WebUI now does separate port checks for IPv4 and IPv6.

#### Before

![image](https://github.com/transmission/transmission/assets/46261767/75a0e327-f9a2-4739-ae3b-433fc5c71ab2)

#### After

![image](https://github.com/transmission/transmission/assets/46261767/78b644f2-e08a-4e1e-9089-d5fb32ca90a7)
