### PR TITLE
remove old warning "doesn't like blank addresses"

### DIFF
--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -313,7 +313,6 @@ typedef NS_ENUM(NSInteger, TrackerSegmentTag) {
     self.fSet = YES;
 }
 
-#warning doesn't like blank addresses
 - (void)addTrackers
 {
     [self.view.window makeKeyWindow];


### PR DESCRIPTION
This warning was added by @livings124 in b80a6765e23249fb3e481efda2d826ee0ccde7c4 and is not actionable: there are no bugs to fix.
You can try adding a tracker with a blank address, but AppKit won't call [`tableView:setObjectValue:forTableColumn:row:`](https://developer.apple.com/documentation/appkit/nstableviewdatasource/1526317-tableview) and no tracker will be added.