### PR TITLE
remove old warning: "subclass?"

### DIFF
--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -92,7 +92,6 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
     [self setWebSeedTableHidden:YES animate:NO];
 }
 
-#warning subclass?
 - (void)setInfoForTorrents:(NSArray<Torrent*>*)torrents
 {
     //don't check if it's the same in case the metadata changed


### PR DESCRIPTION
warning was added by @livings124 in d5f4c15fb855ec38994b6eba836181ef092d1d3b and addressed in efce4e9