### PR TITLE
rename "UpdateQueue" to "UpdateTorrentsState"

### DIFF
--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -463,7 +463,7 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
         [FileRenameSheetController presentSheetForTorrent:torrent modalForWindow:self.fOutline.window completionHandler:^(BOOL didRename) {
             if (didRename)
             {
-                [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateQueue" object:self];
+                [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateTorrentsState" object:nil];
                 [NSNotificationCenter.defaultCenter postNotificationName:@"ResetInspector" object:self
                                                                 userInfo:@{ @"Torrent" : torrent }];
             }

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -879,7 +879,7 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     tr_sessionSetQueueEnabled(self.fHandle, TR_UP, [self.fDefaults boolForKey:@"QueueSeed"]);
 
     //handle if any transfers switch from queued to paused
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateQueue" object:self];
+    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateTorrentsState" object:nil];
 }
 
 - (void)setQueueNumber:(id)sender

--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -42,7 +42,6 @@ extern NSString* const kTorrentDidChangeGroupNotification;
 - (void)startTransfer;
 - (void)startMagnetTransferAfterMetaDownload;
 - (void)stopTransfer;
-- (void)startQueue;
 - (void)sleep;
 - (void)wakeUp;
 - (void)idleLimitHit;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -251,7 +251,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     if (wasTransmitting != self.transmitting)
     {
         //posting asynchronously with coalescing to prevent stack overflow on lots of torrents changing state at the same time
-        [NSNotificationQueue.defaultQueue enqueueNotification:[NSNotification notificationWithName:@"UpdateQueue" object:self]
+        [NSNotificationQueue.defaultQueue enqueueNotification:[NSNotification notificationWithName:@"UpdateTorrentsState" object:nil]
                                                  postingStyle:NSPostASAP
                                                  coalesceMask:NSNotificationCoalescingOnName
                                                      forModes:nil];
@@ -1980,11 +1980,6 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
             [self sortFileList:node.children];
         }
     }];
-}
-
-- (void)startQueue
-{
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateQueue" object:self];
 }
 
 - (void)completenessChange:(tr_completeness)status wasRunning:(BOOL)wasRunning


### PR DESCRIPTION
1. Remove `- (void)startQueue` because it's just one line and it just posts a notification. Instead, post this notification directly.
2. Replace that synchronous notification with a `NSNotificationCoalescingOnName`, "_to prevent stack overflow on lots of torrents changing state at the same time_" (same logic as in `- (void)update`)
3. Remove the used object for this notification, since it needs to update the whole list of torrents
4. Rename the notification to UpdateTorrentsState