### PR TITLE
refactor: remove TR_PATH_DELIMITER

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -351,7 +351,7 @@ private:
     };
 
 public:
-    struct Settings : public libtransmission::Settings
+    struct Settings final : public libtransmission::Settings
     {
     public:
         Settings() = default;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2318,15 +2318,13 @@ namespace rename_helpers
 {
 bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
 {
-    if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv ||
-        tr_strv_contains(newname, TR_PATH_DELIMITER))
+    if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv || tr_strv_contains(newname, '/'))
     {
         return false;
     }
 
-    auto const newpath = tr_strv_contains(oldpath, TR_PATH_DELIMITER) ?
-        tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
-        tr_pathbuf{ newname };
+    auto const newpath = tr_strv_contains(oldpath, '/') ? tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
+                                                          tr_pathbuf{ newname };
 
     if (newpath == oldpath)
     {
@@ -2412,7 +2410,7 @@ void renameTorrentFileString(tr_torrent* tor, std::string_view oldpath, std::str
     auto const subpath = std::string_view{ tor->file_subpath(file_index) };
     auto const oldpath_len = std::size(oldpath);
 
-    if (!tr_strv_contains(oldpath, TR_PATH_DELIMITER))
+    if (!tr_strv_contains(oldpath, '/'))
     {
         if (oldpath_len >= std::size(subpath))
         {

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -72,8 +72,6 @@
 
 // ---
 
-#define TR_PATH_DELIMITER '/'
-
 #define TR_INET6_ADDRSTRLEN 46
 
 #define TR_ADDRSTRLEN 64

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -33,7 +33,7 @@ std::string getTestProgramPath(std::string const& filename)
 {
     auto const exe_path = tr_sys_path_resolve(testing::internal::GetArgvs().front().data());
     auto const exe_dir = tr_sys_path_dirname(exe_path);
-    return std::string{ exe_dir } + TR_PATH_DELIMITER + filename;
+    return fmt::format("{:s}/{:s}", exe_dir, filename);
 }
 
 class SubprocessTest
@@ -45,9 +45,7 @@ protected:
 
     [[nodiscard]] std::string buildSandboxPath(std::string const& filename) const
     {
-        auto path = sandbox_.path();
-        path += TR_PATH_DELIMITER;
-        path += filename;
+        auto path = fmt::format("{:s}/{:s}", sandbox_.path(), filename);
         tr_sys_path_native_separators(&path.front());
         return path;
     }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -21,7 +21,6 @@
 #include <libtransmission/crypto-utils.h> // tr_base64_decode()
 #include <libtransmission/error.h>
 #include <libtransmission/file.h> // tr_sys_file_*()
-#include <libtransmission/platform.h> // TR_PATH_DELIMITER
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-ctor.h>
 #include <libtransmission/torrent.h>

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -106,12 +106,8 @@ protected:
 
     static std::string createDir(std::string_view dirname, std::string_view basename)
     {
-        auto path = std::string{ dirname };
-        path += TR_PATH_DELIMITER;
-        path += basename;
-
+        auto path = fmt::format("{:s}/{:s}", dirname, basename);
         tr_sys_dir_create(path, 0, 0700);
-
         return path;
     }
 


### PR DESCRIPTION
Minor cleanup that does what it says on the tin.

`TR_PATH_DELIMITER_STR` was removed in dde626d5e5b9ec4e66dc6ee45addb7e21a1de132; this finishes the job.