### PR TITLE
refactor: inline simple getters in qt client

### DIFF
--- a/libtransmission/makelog
+++ b/libtransmission/makelog
@@ -1,1 +1,0 @@
-ninja: error: loading 'build.ninja': No such file or directory

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -63,11 +63,6 @@ void PathButton::setPath(QString const& path)
     emit pathChanged(path_);
 }
 
-QString const& PathButton::path() const
-{
-    return path_;
-}
-
 QSize PathButton::sizeHint() const
 {
     auto const sh = QToolButton::sizeHint();

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -28,7 +28,11 @@ public:
     void setNameFilter(QString const& name_filter);
 
     void setPath(QString const& path);
-    QString const& path() const;
+
+    [[nodiscard]] constexpr auto const& path() const noexcept
+    {
+        return path_;
+    }
 
     // QWidget
     QSize sizeHint() const override;

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -85,11 +85,6 @@ bool RpcClient::isLocal() const
     return false;
 }
 
-QUrl const& RpcClient::url() const
-{
-    return url_;
-}
-
 RpcResponseFuture RpcClient::exec(tr_quark method, tr_variant* args)
 {
     return exec(tr_quark_get_string_view(method), args);

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -67,22 +67,8 @@ void RpcClient::start(tr_session* session)
 void RpcClient::start(QUrl const& url)
 {
     url_ = url;
+    url_is_loopback_ = QHostAddress{ url_.host() }.isLoopback();
     request_.reset();
-}
-
-bool RpcClient::isLocal() const
-{
-    if (session_ != nullptr)
-    {
-        return true;
-    }
-
-    if (QHostAddress{ url_.host() }.isLoopback())
-    {
-        return true;
-    }
-
-    return false;
 }
 
 RpcResponseFuture RpcClient::exec(tr_quark method, tr_variant* args)

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -60,11 +60,15 @@ public:
         return url_;
     }
 
+    [[nodiscard]] constexpr auto isLocal() const noexcept
+    {
+        return session_ != nullptr || url_is_loopback_;
+    }
+
     void stop();
     void start(tr_session* session);
     void start(QUrl const& url);
 
-    bool isLocal() const;
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
     RpcResponseFuture exec(std::string_view method, tr_variant* args);
 
@@ -97,4 +101,5 @@ private:
     std::unordered_map<int64_t, QFutureInterface<RpcResponse>> local_requests_;
     int64_t next_tag_ = {};
     bool const verbose_ = qEnvironmentVariableIsSet("TR_RPC_VERBOSE");
+    bool url_is_loopback_ = false;
 };

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -55,13 +55,16 @@ class RpcClient : public QObject
 public:
     explicit RpcClient(QObject* parent = nullptr);
 
+    [[nodiscard]] constexpr auto const& url() const noexcept
+    {
+        return url_;
+    }
+
     void stop();
     void start(tr_session* session);
     void start(QUrl const& url);
 
     bool isLocal() const;
-    QUrl const& url() const;
-
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
     RpcResponseFuture exec(std::string_view method, tr_variant* args);
 

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -27,7 +27,7 @@ class RpcQueue : public QObject
 public:
     explicit RpcQueue(QObject* parent = nullptr);
 
-    void setTolerateErrors(bool tolerate_errors = true)
+    constexpr void setTolerateErrors(bool tolerate_errors = true)
     {
         tolerate_errors_ = tolerate_errors;
     }

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -386,11 +386,6 @@ void Session::start()
     emit sourceChanged();
 }
 
-bool Session::isServer() const
-{
-    return session_ != nullptr;
-}
-
 // ---
 
 void Session::addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent_ids) const

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -391,19 +391,7 @@ bool Session::isServer() const
     return session_ != nullptr;
 }
 
-bool Session::isLocal() const
-{
-    if (!session_id_.isEmpty())
-    {
-        return is_definitely_local_session_;
-    }
-
-    return rpc_.isLocal();
-}
-
-/***
-****
-***/
+// ---
 
 void Session::addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent_ids) const
 {

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -86,7 +86,10 @@ public:
     bool portTestPending(PortTestIpProtocol ip_protocol) const noexcept;
 
     /** returns true if the transmission session is being run inside this client */
-    bool isServer() const;
+    [[nodiscard]] constexpr auto isServer() const noexcept
+    {
+        return session_ != nullptr;
+    }
 
     /** returns true if isServer() is true or if the remote address is the localhost */
     [[nodiscard]] constexpr auto isLocal() const noexcept

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -89,7 +89,10 @@ public:
     bool isServer() const;
 
     /** returns true if isServer() is true or if the remote address is the localhost */
-    bool isLocal() const;
+    [[nodiscard]] constexpr auto isLocal() const noexcept
+    {
+        return !session_id_.isEmpty() ? is_definitely_local_session_ : rpc_.isLocal();
+    }
 
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
     RpcResponseFuture exec(std::string_view method, tr_variant* args);

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -46,7 +46,7 @@ public:
     void stop();
     void restart();
 
-    QUrl const& getRemoteUrl() const
+    [[nodiscard]] constexpr auto const& getRemoteUrl() const noexcept
     {
         return rpc_.url();
     }

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -92,7 +92,7 @@ public:
     }
 
     /** returns true if isServer() is true or if the remote address is the localhost */
-    [[nodiscard]] constexpr auto isLocal() const noexcept
+    [[nodiscard]] auto isLocal() const noexcept
     {
         return !session_id_.isEmpty() ? is_definitely_local_session_ : rpc_.isLocal();
     }


### PR DESCRIPTION
There are a handful of getters that are simple one-liners. Inline these and make them `constexpr`.