### PR TITLE
chore: apply clang-format version 17.0.1 (#6054)

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -41,10 +41,6 @@
 
 using namespace std::literals;
 
-#ifndef IN_MULTICAST
-#define IN_MULTICAST(a) (((a)&0xf0000000) == 0xe0000000)
-#endif
-
 std::string tr_net_strerror(int err)
 {
 #ifdef _WIN32


### PR DESCRIPTION
Cherry-pick of #6054 otherwise I can't commit on 4.0.x