### PR TITLE
support macos-14 universal builds in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -277,7 +277,7 @@ jobs:
         run: |
           if grep 'warning:' makelog; then exit 1; fi
 
-  macos-14:
+  macos-14-arm64:
     runs-on: macos-14
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-mac == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
@@ -646,7 +646,7 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  macos-12-from-tarball:
+  macos-12-x86_64-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-mac == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: macos-12

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -599,7 +599,7 @@ jobs:
         run: |
           brew install cmake gettext ninja node pkg-config
       - name: Get Source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-tarball
       - name: Extract Source
@@ -641,7 +641,7 @@ jobs:
         run: cmake -E chdir obj ctest -j $(sysctl -n hw.logicalcpu) --build-config RelWithDebInfo --output-on-failure
       - name: Install
         run: cmake --build obj --config RelWithDebInfo --target install/strip
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ github.job }}
           path: pfx/**/*

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -277,8 +277,8 @@ jobs:
         run: |
           if grep 'warning:' makelog; then exit 1; fi
 
-  macos-12:
-    runs-on: macos-12
+  macos-14:
+    runs-on: macos-14
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-mac == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     steps:
@@ -309,7 +309,7 @@ jobs:
             -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
-            -DCMAKE_OSX_ARCHITECTURES='x86_64' \
+            -DCMAKE_OSX_ARCHITECTURES='arm64' \
             -DCMAKE_PREFIX_PATH=`brew --prefix`/opt/qt \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -584,6 +584,67 @@ jobs:
         with:
           name: source-tarball
           path: obj/transmission*.tar.*
+
+  macos-14-universal-from-tarball:
+    needs: [ make-source-tarball, what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-mac == 'true' }}
+    runs-on: macos-14
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          sw_vers
+      - name: Get Dependencies
+        run: |
+          brew install cmake gettext ninja node pkg-config
+      - name: Get Source
+        uses: actions/download-artifact@v3
+        with:
+          name: source-tarball
+      - name: Extract Source
+        run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Configure
+        run: |
+          cmake \
+            -S src \
+            -B obj \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=pfx \
+            -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
+            -DCMAKE_PREFIX_PATH=`brew --prefix`/opt/qt \
+            -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_GTK=OFF \
+            -DENABLE_MAC=${{ (needs.what-to-make.outputs.make-mac == 'true') && 'ON' || 'OFF' }}  \
+            -DENABLE_QT=OFF \
+            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
+            -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_WERROR=ON \
+            -DRUN_CLANG_TIDY=OFF \
+            -DUSE_SYSTEM_EVENT2=OFF \
+            -DUSE_SYSTEM_DEFLATE=OFF \
+            -DUSE_SYSTEM_DHT=OFF \
+            -DUSE_SYSTEM_MINIUPNPC=OFF \
+            -DUSE_SYSTEM_NATPMP=OFF \
+            -DUSE_SYSTEM_UTP=OFF \
+            -DUSE_SYSTEM_B64=OFF \
+            -DUSE_SYSTEM_PSL=OFF
+      - name: Make
+        run: cmake --build obj --config RelWithDebInfo
+      - name: Test
+        if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
+        env:
+          TMPDIR: /private/tmp
+        run: cmake -E chdir obj ctest -j $(sysctl -n hw.logicalcpu) --build-config RelWithDebInfo --output-on-failure
+      - name: Install
+        run: cmake --build obj --config RelWithDebInfo --target install/strip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binaries-${{ github.job }}
+          path: pfx/**/*
 
   macos-12-from-tarball:
     needs: [ make-source-tarball, what-to-make ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,8 +471,6 @@ if(ENABLE_MAC)
 
     if(APPLE)
         set(MAC_FOUND ON)
-        # unset default to build arm64 on x86_64, or x86_64 on arm64
-        unset(_CMAKE_APPLE_ARCHS_DEFAULT)
     else()
         set(MAC_FOUND OFF)
         if(MAC_IS_REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,8 @@ if(ENABLE_MAC)
 
     if(APPLE)
         set(MAC_FOUND ON)
+        # unset default to build arm64 on x86_64, or x86_64 on arm64
+        unset(_CMAKE_APPLE_ARCHS_DEFAULT)
     else()
         set(MAC_FOUND OFF)
         if(MAC_IS_REQUIRED)


### PR DESCRIPTION
This improves cmake configuration to support building arm64 on x86_64, or x86_64 on arm64.
This configures macos-14-from-tarball to build both (x86_64;arm64).

Note: on macOS, it is not possible to brew install universal dependencies, consequently it is not easy to have a universal qt or universal gtk installation in GitHub actions, consequently the universal build is only defined for the Mac app when all the `USE_SYSTEM_*` are set to OFF.