### PR TITLE
Add torrent priority to completion script environment variables

### DIFF
--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -27,6 +27,7 @@ Transmission can be set to invoke a script when downloads complete. The environm
  * `TR_TORRENT_ID`
  * `TR_TORRENT_LABELS` - A comma-delimited list of the torrent's labels
  * `TR_TORRENT_NAME` - Name of torrent (not filename)
+ * `TR_TORRENT_PRIORITY` - The priority of the torrent (Low is "-1", Normal is "0", High is "1")
  * `TR_TORRENT_TRACKERS` - A comma-delimited list of the torrent's trackers' announce URLs
 
 [Here is an example script](https://trac.transmissionbt.com/browser/trunk/extras/send-email-when-torrent-done.sh) that sends an email when a torrent finishes.

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -384,6 +384,7 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
     auto const trackers_str = buildTrackersString(tor);
     auto const bytes_downloaded_str = std::to_string(tor->bytes_downloaded_.ever());
     auto const localtime_str = fmt::format("{:%a %b %d %T %Y%n}", fmt::localtime(tr_time()));
+    auto const priority_str = std::to_string(tor->get_priority());
 
     auto const env = std::map<std::string_view, std::string_view>{
         { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
@@ -394,6 +395,7 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
         { "TR_TORRENT_ID"sv, id_str },
         { "TR_TORRENT_LABELS"sv, labels_str },
         { "TR_TORRENT_NAME"sv, tor->name() },
+        { "TR_TORRENT_PRIORITY"sv, priority_str },
         { "TR_TORRENT_TRACKERS"sv, trackers_str },
     };
 


### PR DESCRIPTION
This PR adds a `TR_TORRENT_PRIORITY` env var to the completion script, represented by directly stringifying the [`tr_priority_t` enum][priority_enum] values.

[priority_enum]: https://github.com/transmission/transmission/blob/7f029acf6e1057b5e81cc91905b3bdd23ea6170e/libtransmission/transmission.h#L75