### PR TITLE
refactor: remove tr_sys_file_flush()

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -766,20 +766,6 @@ bool tr_sys_file_write_at(
     return ret;
 }
 
-bool tr_sys_file_flush(tr_sys_file_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_FILE);
-
-    bool const ret = (fsync(handle) != -1);
-
-    if (error != nullptr && !ret)
-    {
-        error->set_from_errno(errno);
-    }
-
-    return ret;
-}
-
 bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error* error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1047,20 +1047,6 @@ bool tr_sys_file_write_at(
     return ret;
 }
 
-bool tr_sys_file_flush(tr_sys_file_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_FILE);
-
-    bool ret = FlushFileBuffers(handle);
-
-    if (!ret)
-    {
-        set_system_error(error, GetLastError());
-    }
-
-    return ret;
-}
-
 bool tr_sys_file_truncate(tr_sys_file_t handle, uint64_t size, tr_error* error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -418,17 +418,6 @@ bool tr_sys_file_write_at(
     tr_error* error = nullptr);
 
 /**
- * @brief Portability wrapper for `fsync()`.
- *
- * @param[in]  handle Valid file descriptor.
- * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
- *                    are not interested in error details.
- *
- * @return `True` on success, `false` otherwise (with `error` set accordingly).
- */
-bool tr_sys_file_flush(tr_sys_file_t handle, tr_error* error = nullptr);
-
-/**
  * @brief Portability wrapper for `ftruncate()`.
  *
  * @param[in]  handle Valid file descriptor.

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -55,12 +55,12 @@ int main(int argc, char** argv)
     }
     else
     {
-        std::fclose(out);
-        std::remove(tmp_result_path.c_str());
+        (void)std::fclose(out);
+        (void)std::remove(tmp_result_path.c_str());
         return 1;
     }
 
-    std::fclose(out);
+    (void)std::fclose(out);
     tr_sys_path_rename(tmp_result_path.c_str(), result_path.c_str());
     return 0;
 }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -265,7 +265,14 @@ protected:
         auto const tmperr = errno;
 
         buildParentDir(path);
-        tr_file_save(path, std::string_view{ static_cast<char const*>(payload), n });
+
+        auto const fd = tr_sys_file_open(
+            tr_pathbuf{ path },
+            TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
+            0600,
+            nullptr);
+        blockingFileWrite(fd, payload, n);
+        tr_sys_file_close(fd);
         sync();
 
         errno = tmperr;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -246,8 +246,6 @@ protected:
         auto error = tr_error{};
         auto const fd = tr_sys_file_open_temp(tmpl, &error);
         blockingFileWrite(fd, payload, n, &error);
-        tr_sys_file_flush(fd, &error);
-        tr_sys_file_flush(fd, &error);
         tr_sys_file_close(fd, &error);
         if (error)
         {
@@ -267,16 +265,7 @@ protected:
         auto const tmperr = errno;
 
         buildParentDir(path);
-
-        auto const fd = tr_sys_file_open(
-            tr_pathbuf{ path },
-            TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE | TR_SYS_FILE_TRUNCATE,
-            0600,
-            nullptr);
-        blockingFileWrite(fd, payload, n);
-        tr_sys_file_flush(fd);
-        tr_sys_file_flush(fd);
-        tr_sys_file_close(fd);
+        tr_file_save(path, std::string_view{ static_cast<char const*>(payload), n });
         sync();
 
         errno = tmperr;
@@ -437,8 +426,8 @@ protected:
                     tr_sys_file_write(fd, &ch, 1, nullptr);
                 }
 
-                tr_sys_file_flush(fd);
                 tr_sys_file_close(fd);
+                sync();
             }
         }
 


### PR DESCRIPTION
It was only used in tests. Is it needed? Let's find out by seeing if CI stays green without it.