### PR TITLE
refactor(web): use crypto.randomUUID for UUID if available

### DIFF
--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -140,6 +140,10 @@ export function createDialogContainer(id) {
 }
 
 export function makeUUID() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
   // source: https://stackoverflow.com/a/2117523/6568470
   return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replaceAll(/[018]/g, (c) =>
     (


### PR DESCRIPTION
crypto.randomUUID() is the most up to date way to generate UUIDs. It works in secure context (HTTPS) and for localhost. https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID

It has a wide browser support, but we are keeping the fallback for older browsers and for cases where users are using a custom hostname without HTTPS, that's not consider a secure context. https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts