### PR TITLE
refactor(web): Remove unused functions from utils.js

### DIFF
--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -210,9 +210,6 @@ function setOrDeleteAttribute(element, attribute, b) {
 export function setEnabled(element, b) {
   setOrDeleteAttribute(element, 'disabled', !b);
 }
-export function setChecked(element, b) {
-  setOrDeleteAttribute(element, 'checked', b);
-}
 
 export function addCheckedClass(element, b) {
   element.classList.toggle('checked', b);

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -82,45 +82,6 @@ export function createTextualTabsContainer(id, tabs, callback) {
   };
 }
 
-export function createTabsContainer(id, tabs, callback) {
-  const root = document.createElement('div');
-  root.id = id;
-  root.classList.add('tabs-container');
-
-  const buttons = document.createElement('div');
-  buttons.classList.add('tabs-buttons');
-  root.append(buttons);
-
-  const pages = document.createElement('div');
-  pages.classList.add('tabs-pages');
-  root.append(pages);
-
-  const button_array = [];
-  for (const [button_id, page] of tabs) {
-    const button = document.createElement('button');
-    button.id = button_id;
-    button.classList.add('tabs-button');
-    button.setAttribute('type', 'button');
-    buttons.append(button);
-    button_array.push(button);
-
-    page.classList.add('hidden', 'tabs-page');
-    pages.append(page);
-
-    button.addEventListener('click', () =>
-      toggleClass(buttons, button, pages, page, callback),
-    );
-  }
-
-  button_array[0].classList.add('selected');
-  pages.children[0].classList.remove('hidden');
-
-  return {
-    buttons: button_array,
-    root,
-  };
-}
-
 export function createDialogContainer(id) {
   const root = document.createElement('dialog');
   root.classList.add('dialog-container', 'popup', id);


### PR DESCRIPTION
`createTabsContainer` seems to be superseded by `createTextualTabsContainer` and is unused
```console
$ grep -nr createTabsContainer src/
src/utils.js:85:export function createTabsContainer(id, tabs, callback) {
```

`setChecked` seems to be superseded by `addCheckedClass` (a bit odd naming as it actually toggles the class) and is unused.
```console
$ grep -nr setChecked src/
src/utils.js:213:export function setChecked(element, b) {
```