### PR TITLE
fix(web): close connection failed alert on successful request

### DIFF
--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -23,6 +23,7 @@ export const RPC = {
 export class Remote {
   // TODO: decouple from controller
   constructor(controller) {
+    this._connection_alert = null;
     this._controller = controller;
     this._session_id = '';
   }
@@ -65,13 +66,13 @@ export class Remote {
         }
         console.trace(error);
         this._controller.togglePeriodicSessionRefresh(false);
-        this._controller.setCurrentPopup(
-          new AlertDialog({
-            heading: 'Connection failed',
-            message:
-              'Could not connect to the server. You may need to reload the page to reconnect.',
-          }),
-        );
+
+        this._connection_alert = new AlertDialog({
+          heading: 'Connection failed',
+          message:
+            'Could not connect to the server. You may need to reload the page to reconnect.',
+        });
+        this._controller.setCurrentPopup(this._connection_alert);
       });
   }
 

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -56,6 +56,8 @@ export class Remote {
         if (callback) {
           callback.call(context, payload, response_argument);
         }
+
+        this._connection_alert = null;
       })
       .catch((error) => {
         if (error.message === Remote._SessionHeader) {

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -24,7 +24,6 @@ export class Remote {
   // TODO: decouple from controller
   constructor(controller) {
     this._controller = controller;
-    this._error = '';
     this._session_id = '';
   }
 

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -72,6 +72,8 @@ export class Remote {
           message:
             'Could not connect to the server. You may need to reload the page to reconnect.',
         });
+      })
+      .finally(() => {
         this._controller.setCurrentPopup(this._connection_alert);
       });
   }


### PR DESCRIPTION
Partially fixes [#6396](https://github.com/transmission/transmission/issues/6396)

> But the second problem is a bug in my opinion - when the next POST request succeeds, the error message should disappear and the UI should be updated, but it does not happen.