### PR TITLE
Enabling trace log level for Gtk interface.

### DIFF
--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -97,12 +97,13 @@ private:
     bool isPaused_ = false;
     sigc::connection refresh_tag_;
 
-    static auto inline const level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
+    static auto inline const level_names_ = std::array<std::pair<tr_log_level, char const*>, 6U>{ {
         { TR_LOG_CRITICAL, C_("Logging level", "Critical") },
         { TR_LOG_ERROR, C_("Logging level", "Error") },
         { TR_LOG_WARN, C_("Logging level", "Warning") },
         { TR_LOG_INFO, C_("Logging level", "Information") },
         { TR_LOG_DEBUG, C_("Logging level", "Debug") },
+        { TR_LOG_TRACE, C_("Logging level", "Trace") },
     } };
 };
 


### PR DESCRIPTION
It was useful to me, so I am sharing, but I understand why using log level Trace on the GTK interface might not be a good idea.