### PR TITLE
Support CMake 3.28+ in CI jobs on Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -429,7 +429,7 @@ jobs:
             -G Ninja `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DCMAKE_INSTALL_PREFIX=pfx `
-            -DCMAKE_PREFIX_PATH="${Env:DepsPrefix}" `
+            -DCMAKE_PREFIX_PATH="${Env:DEPS_PREFIX}" `
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_GTK=OFF `

--- a/release/windows/build-qt6.ps1
+++ b/release/windows/build-qt6.ps1
@@ -91,6 +91,8 @@ function global:Build-Qt6([string] $PrefixDir, [string] $Arch, [string] $DepsPre
         '-nomake'; 'tests'
         '-I'; (Join-Path $DepsPrefixDir include).Replace('\', '/')
         '-L'; (Join-Path $DepsPrefixDir lib).Replace('\', '/')
+        '--'
+        "-DCMAKE_PREFIX_PATH=${DepsPrefixDir}"
     )
 
     if ($env:LDFLAGS) {


### PR DESCRIPTION
CMake 3.28 dropped support for deriving installation prefix(es) based on `PATH` environment variable on Windows[^1]. Since all the other built packages already pass necessary prefix path(s) explicitly via `CMAKE_PREFIX_PATH` and it works for them, do the same for Qt 6 as well. Building Qt 5 isn't affected as it doesn't use CMake.

Using wrong environment variable name when configuring Transmission itself resulted in empty `CMAKE_PREFIX_PATH` CMake setting value, which showed the effects of CMake 3.28 changes yet again.

[^1]: https://cmake.org/cmake/help/latest/release/3.28.html#other-changes