### PR TITLE
fix(web): do not close all popups on successful rpc requests

### DIFF
--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -57,7 +57,10 @@ export class Remote {
           callback.call(context, payload, response_argument);
         }
 
-        this._connection_alert = null;
+        if (this._connection_alert) {
+          this._connection_alert.close();
+          this._connection_alert = null;
+        }
       })
       .catch((error) => {
         if (error.message === Remote._SessionHeader) {
@@ -74,8 +77,6 @@ export class Remote {
           message:
             'Could not connect to the server. You may need to reload the page to reconnect.',
         });
-      })
-      .finally(() => {
         this._controller.setCurrentPopup(this._connection_alert);
       });
   }


### PR DESCRIPTION
Fixes regression introduced in 250f43ae, fixes #6674

Somehow didn't figure that the side effect of my previous fix is to always close every other pop-up on successful rpc requests.
