### PR TITLE
docs: fix `torrent-get` `fileStats` and `wanted` docs

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -303,7 +303,7 @@ The 'source' column here corresponds to the data structure there.
 | Key | Value Type | transmission.h source
 |:--|:--|:--
 | `bytesCompleted` | number | tr_file_view
-| `wanted` | boolean | tr_file_view
+| `wanted` | boolean | tr_file_view (**Note:** Not to be confused with `torrent-get.wanted`, which is an array of 0/1 instead of boolean)
 | `priority` | number | tr_file_view
 
 `peers`: an array of objects, each containing:

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -400,7 +400,7 @@ The 'source' column here corresponds to the data structure there.
 | `tier`                    | number     | tr_tracker_view
 
 
-`wanted`: An array of `tr_torrentFileCount()` 0/1, true if the corresponding file is to be downloaded. (Source: `tr_file_view`)
+`wanted`: An array of `tr_torrentFileCount()` 0/1, 1 (true) if the corresponding file is to be downloaded. (Source: `tr_file_view`)
 
 **Note:** For backwards compatibility, in `4.x.x`, `wanted` is serialized as an array of `0` or `1` that should be treated as booleans.
 This will be fixed in `5.0.0` to return an array of booleans.

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -303,7 +303,7 @@ The 'source' column here corresponds to the data structure there.
 | Key | Value Type | transmission.h source
 |:--|:--|:--
 | `bytesCompleted` | number | tr_file_view
-| `wanted` | number | tr_file_view (**Note:** For backwards compatibility, this is serialized as an array of `0` or `1` that should be treated as booleans)
+| `wanted` | boolean | tr_file_view
 | `priority` | number | tr_file_view
 
 `peers`: an array of objects, each containing:
@@ -400,8 +400,10 @@ The 'source' column here corresponds to the data structure there.
 | `tier`                    | number     | tr_tracker_view
 
 
-`wanted`: An array of `tr_torrentFileCount()` Booleans true if the corresponding file is to be downloaded. (Source: `tr_file_view`)
+`wanted`: An array of `tr_torrentFileCount()` 0/1, true if the corresponding file is to be downloaded. (Source: `tr_file_view`)
 
+**Note:** For backwards compatibility, in `4.x.x`, `wanted` is serialized as an array of `0` or `1` that should be treated as booleans.
+This will be fixed in `5.0.0` to return an array of booleans.
 
 Example:
 


### PR DESCRIPTION
#5170 restored the behaviour of `torrent-get.wanted` to pre-4.0.0 behaviour for backward compatibility, but it incorrectly updated the docs for `torrent-get.fileStats.wanted` instead. This PR fixes that.

I also think that we should eventually fix this quirk (say 5.0.0), so I've added a note to announce this change in advance.

Notes: Fixed RPC spec that confused `torrent-get.wanted` with `torrent-get.fileStats.wanted`.