### PR TITLE
Support WiX toolset versions other than 3.11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -387,7 +387,7 @@ jobs:
             nodejs
           & "C:\Program Files\OpenSSL\unins000.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- | Out-Host
           (Join-Path $Env:ProgramFiles NASM) | Out-File $Env:GITHUB_PATH -Append
-          (Join-Path ${Env:ProgramFiles(x86)} 'WiX Toolset v3.11' bin) | Out-File $Env:GITHUB_PATH -Append
+          (Join-Path (Get-Item -Path "${Env:ProgramFiles(x86)}\WiX Toolset v3.*")[0].FullName bin) | Out-File $Env:GITHUB_PATH -Append
 
           Install-Module -Name Pscx -RequiredVersion 4.0.0-beta4 -AllowPrerelease -Force
       - name: Get Source

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ for:
       choco install python3 --pre
       choco install nasm
       choco install jom
-      choco install wixtoolset --version 3.11.2
+      choco install wixtoolset --version 3.14.0
       choco install ccache --version 4.8.3
 
       Remove-Item -Path (Join-Path $Env:SystemDrive OpenSSL-Win32) -Recurse
@@ -74,7 +74,7 @@ for:
       $Env:PATH = @(
           (Join-Path $Env:SystemDrive Strawberry perl bin)
           (Join-Path $Env:ProgramFiles NASM)
-          (Join-Path ${Env:ProgramFiles(x86)} 'WiX Toolset v3.11' bin)
+          (Join-Path (Get-Item -Path "${Env:ProgramFiles(x86)}\WiX Toolset v3.*")[0].FullName bin)
           $Env:PATH
       ) -join [System.IO.Path]::PathSeparator
 


### PR DESCRIPTION
Version 3.14 was recently released with security fixes, and GitHub runners have been updated to use it. Don't hardcode the version in Program Files directory name to support any 3.x. Since 3.x support will be dropped within a year, need to plan migration to 5.x when it's released (4.x isn't suitable because of missing heat replacement).

Fixes #6680.