### PR TITLE
fix compatibility with clang-format 18

### DIFF
--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -44,9 +44,7 @@ public:
         return iter != std::end(icons_) ? &iter->second : nullptr;
     }
 
-    void load(
-        std::string_view url_in,
-        IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
+    void load(std::string_view url_in, IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
     {
         std::call_once(scan_once_flag_, &FaviconCache::scan_file_cache, this);
 

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -44,7 +44,9 @@ public:
         return iter != std::end(icons_) ? &iter->second : nullptr;
     }
 
-    void load(std::string_view url_in, IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
+    void load( //
+        std::string_view url_in,
+        IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
     {
         std::call_once(scan_once_flag_, &FaviconCache::scan_file_cache, this);
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -130,8 +130,7 @@ void RpcClient::sendNetworkRequest(TrVariantPtr req, QFutureInterface<RpcRespons
 
     if (verbose_)
     {
-        qInfo() << "sending"
-                << "POST" << qPrintable(url_.path());
+        qInfo() << "sending" << "POST" << qPrintable(url_.path());
 
         for (QByteArray const& b : request_->rawHeaderList())
         {

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -130,7 +130,7 @@ void RpcClient::sendNetworkRequest(TrVariantPtr req, QFutureInterface<RpcRespons
 
     if (verbose_)
     {
-        qInfo() << "sending" << "POST" << qPrintable(url_.path());
+        qInfo() << "sending POST " << qPrintable(url_.path());
 
         for (QByteArray const& b : request_->rawHeaderList())
         {

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -63,7 +63,10 @@ namespace libtransmission::test
 
 bool waitFor(struct event_base* event_base, std::chrono::milliseconds msec)
 {
-    return waitFor(event_base, []() { return false; }, msec);
+    return waitFor( //
+        event_base,
+        []() { return false; },
+        msec);
 }
 
 namespace
@@ -593,7 +596,10 @@ TEST_F(DhtTest, usesBootstrapFile)
     // Confirm that BootstrapNodeName gets pinged first.
     auto const expected = getSockaddr(BootstrapNodeName, BootstrapNodePort);
     auto& pinged = mediator.mock_dht_.pinged_;
-    waitFor(event_base_, [&pinged]() { return !std::empty(pinged); }, 5s);
+    waitFor( //
+        event_base_,
+        [&pinged]() { return !std::empty(pinged); },
+        5s);
     ASSERT_EQ(1U, std::size(pinged));
     auto const [actual_addrport, time] = pinged.front();
     EXPECT_EQ(expected.address(), actual_addrport.address());

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -63,10 +63,7 @@ namespace libtransmission::test
 
 bool waitFor(struct event_base* event_base, std::chrono::milliseconds msec)
 {
-    return waitFor(
-        event_base,
-        []() { return false; },
-        msec);
+    return waitFor(event_base, []() { return false; }, msec);
 }
 
 namespace
@@ -596,10 +593,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     // Confirm that BootstrapNodeName gets pinged first.
     auto const expected = getSockaddr(BootstrapNodeName, BootstrapNodePort);
     auto& pinged = mediator.mock_dht_.pinged_;
-    waitFor(
-        event_base_,
-        [&pinged]() { return !std::empty(pinged); },
-        5s);
+    waitFor(event_base_, [&pinged]() { return !std::empty(pinged); }, 5s);
     ASSERT_EQ(1U, std::size(pinged));
     auto const [actual_addrport, time] = pinged.front();
     EXPECT_EQ(expected.address(), actual_addrport.address());

--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -42,7 +42,10 @@ protected:
 
     void sleepMsec(std::chrono::milliseconds msec)
     {
-        EXPECT_FALSE(waitFor(evbase_.get(), []() { return false; }, msec));
+        EXPECT_FALSE(waitFor( //
+            evbase_.get(),
+            []() { return false; },
+            msec));
     }
 
     static void expectTime(

--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -42,10 +42,7 @@ protected:
 
     void sleepMsec(std::chrono::milliseconds msec)
     {
-        EXPECT_FALSE(waitFor(
-            evbase_.get(),
-            []() { return false; },
-            msec));
+        EXPECT_FALSE(waitFor(evbase_.get(), []() { return false; }, msec));
     }
 
     static void expectTime(


### PR DESCRIPTION
```
✗ clang-format --version
clang-format version 18.1.1
```