### PR TITLE
feat: periodically refresh dht node id

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -148,6 +148,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "honorsSessionLimits"sv,
     "host"sv,
     "id"sv,
+    "id_timestamp"sv,
     "idle-limit"sv,
     "idle-mode"sv,
     "idle-seeding-limit"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -149,6 +149,7 @@ enum
     TR_KEY_honorsSessionLimits,
     TR_KEY_host,
     TR_KEY_id,
+    TR_KEY_id_timestamp,
     TR_KEY_idle_limit,
     TR_KEY_idle_mode,
     TR_KEY_idle_seeding_limit,

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -140,7 +140,7 @@ public:
         tr_logAddDebug(fmt::format("Starting DHT on port {port}", fmt::arg("port", peer_port.host())));
 
         // init state from scratch, or load from state file if it exists
-        std::tie(id_, bootstrap_queue_) = init_state(state_filename_);
+        init_state(state_filename_);
 
         get_nodes_from_bootstrap_file(tr_pathbuf{ mediator_.config_dir(), "/dht.bootstrap"sv }, bootstrap_queue_);
         get_nodes_from_name("dht.transmissionbt.com", tr_port::from_host(6881), bootstrap_queue_);
@@ -426,8 +426,9 @@ private:
         tr_logAddTrace(fmt::format("Saving {} ({} + {}) nodes", n, num4, num6));
 
         tr_variant benc;
-        tr_variantInitDict(&benc, 3);
+        tr_variantInitDict(&benc, 4);
         tr_variantDictAddRaw(&benc, TR_KEY_id, std::data(id_), std::size(id_));
+        tr_variantDictAddInt(&benc, TR_KEY_id_timestamp, id_timestamp_);
 
         if (num4 > 0)
         {
@@ -462,32 +463,38 @@ private:
         tr_variant_serde::benc().to_file(benc, state_filename_);
     }
 
-    [[nodiscard]] static std::pair<Id, Nodes> init_state(std::string_view filename)
+    void init_state(std::string_view filename)
     {
         // Note that DHT ids need to be distributed uniformly,
         // so it should be something truly random
-        auto id = tr_rand_obj<Id>();
+        id_ = tr_rand_obj<Id>();
+        id_timestamp_ = tr_time();
 
         if (!tr_sys_path_exists(std::data(filename)))
         {
-            return { id, {} };
+            return;
         }
 
         auto otop = tr_variant_serde::benc().parse_file(filename);
         if (!otop)
         {
-            return { id, {} };
+            return;
         }
 
         static auto constexpr CompactLen = tr_socket_address::CompactSockAddrBytes[TR_AF_INET];
         static auto constexpr Compact6Len = tr_socket_address::CompactSockAddrBytes[TR_AF_INET6];
+        static auto constexpr IdTtl = time_t{ 30 * 24 * 60 * 60 }; // 30 days
 
         auto& top = *otop;
-        auto nodes = Nodes{};
 
-        if (auto sv = std::string_view{}; tr_variantDictFindStrView(&top, TR_KEY_id, &sv) && std::size(sv) == std::size(id))
+        if (auto t = int64_t{}; tr_variantDictFindInt(&top, TR_KEY_id_timestamp, &t) && t + IdTtl > id_timestamp_)
         {
-            std::copy(std::begin(sv), std::end(sv), std::begin(id));
+            if (auto sv = std::string_view{};
+                tr_variantDictFindStrView(&top, TR_KEY_id, &sv) && std::size(sv) == std::size(id_))
+            {
+                id_timestamp_ = t;
+                std::copy(std::begin(sv), std::end(sv), std::begin(id_));
+            }
         }
 
         size_t raw_len = 0U;
@@ -502,7 +509,7 @@ private:
                 auto port = tr_port{};
                 std::tie(addr, walk) = tr_address::from_compact_ipv4(walk);
                 std::tie(port, walk) = tr_port::from_compact(walk);
-                nodes.emplace_back(addr, port);
+                bootstrap_queue_.emplace_back(addr, port);
             }
         }
 
@@ -516,11 +523,9 @@ private:
                 auto port = tr_port{};
                 std::tie(addr, walk) = tr_address::from_compact_ipv6(walk);
                 std::tie(port, walk) = tr_port::from_compact(walk);
-                nodes.emplace_back(addr, port);
+                bootstrap_queue_.emplace_back(addr, port);
             }
         }
-
-        return { id, std::move(nodes) };
     }
 
     ///
@@ -601,6 +606,7 @@ private:
     std::unique_ptr<libtransmission::Timer> const periodic_timer_;
 
     Id id_ = {};
+    int64_t id_timestamp_ = {};
 
     Nodes bootstrap_queue_;
     size_t n_bootstrapped_ = 0;


### PR DESCRIPTION
A follow up for #6569.

DHT node ID were indefinitely persistent across sessions, and this PR makes is so that the node ID is refreshed every 30 days.

People who started using Transmission from `4.0.0` or above are stuck with a zero DHT node ID, which is not ideal for their DHT performance. This PR allows their DHT node ID to refresh to a randomly generated one without any user intervention.

Notes: Improved DHT performance.