### PR TITLE
bumping googletest from 1.11.0 to 1.14.0

### DIFF
--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -363,8 +363,8 @@ TEST_F(AnnounceListTest, save)
     // first, set up a scratch torrent
     auto constexpr* const OriginalFile = LIBTRANSMISSION_TEST_ASSETS_DIR "/Android-x86 8.1 r6 iso.torrent";
     auto original_content = std::vector<char>{};
-    std::cout << "::testing::TempDir() " << ::testing::TempDir();
-    auto const test_file = tr_pathbuf{ ::testing::TempDir(), "transmission-announce-list-test.torrent"sv };
+    auto const sandbox = libtransmission::test::Sandbox::create_sandbox(::testing::TempDir(), "transmission-test-XXXXXX");
+    auto const test_file = tr_pathbuf{ sandbox, "transmission-announce-list-test.torrent"sv };
     auto error = tr_error{};
     EXPECT_TRUE(tr_file_read(OriginalFile, original_content, &error));
     EXPECT_FALSE(error) << error;

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -363,6 +363,7 @@ TEST_F(AnnounceListTest, save)
     // first, set up a scratch torrent
     auto constexpr* const OriginalFile = LIBTRANSMISSION_TEST_ASSETS_DIR "/Android-x86 8.1 r6 iso.torrent";
     auto original_content = std::vector<char>{};
+    std::cout << "::testing::TempDir() " << ::testing::TempDir();
     auto const test_file = tr_pathbuf{ ::testing::TempDir(), "transmission-announce-list-test.torrent"sv };
     auto error = tr_error{};
     EXPECT_TRUE(tr_file_read(OriginalFile, original_content, &error));

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -140,6 +140,14 @@ public:
         return sandbox_dir_;
     }
 
+    static std::string create_sandbox(std::string const& parent_dir, std::string const& tmpl)
+    {
+        auto path = fmt::format(FMT_STRING("{:s}/{:s}"sv), tr_sys_path_resolve(parent_dir), tmpl);
+        tr_sys_dir_create_temp(std::data(path));
+        tr_sys_path_native_separators(std::data(path));
+        return path;
+    }
+
 protected:
     static std::string get_default_parent_dir()
     {
@@ -150,14 +158,6 @@ protected:
 
         auto error = tr_error{};
         return tr_sys_dir_get_current(&error);
-    }
-
-    static std::string create_sandbox(std::string const& parent_dir, std::string const& tmpl)
-    {
-        auto path = fmt::format(FMT_STRING("{:s}/{:s}"sv), tr_sys_path_resolve(parent_dir), tmpl);
-        tr_sys_dir_create_temp(std::data(path));
-        tr_sys_path_native_separators(std::data(path));
-        return path;
     }
 
     static void rimraf(std::string const& path, bool verbose = false)

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -134,9 +134,9 @@ TEST_F(TorrentMetainfoTest, AndroidTorrent)
 
 TEST_F(TorrentMetainfoTest, ctorSaveContents)
 {
-    std::cout << "::testing::TempDir() " << ::testing::TempDir();
+    auto const sandbox = libtransmission::test::Sandbox::create_sandbox(::testing::TempDir(), "transmission-test-XXXXXX");
     auto const src_filename = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, "/Android-x86 8.1 r6 iso.torrent"sv };
-    auto const tgt_filename = tr_pathbuf{ ::testing::TempDir(), "save-contents-test.torrent" };
+    auto const tgt_filename = tr_pathbuf{ sandbox, "save-contents-test.torrent" };
 
     // try saving without passing any metainfo.
     auto* ctor = tr_ctorNew(session_);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -134,6 +134,7 @@ TEST_F(TorrentMetainfoTest, AndroidTorrent)
 
 TEST_F(TorrentMetainfoTest, ctorSaveContents)
 {
+    std::cout << "::testing::TempDir() " << ::testing::TempDir();
     auto const src_filename = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, "/Android-x86 8.1 r6 iso.torrent"sv };
     auto const tgt_filename = tr_pathbuf{ ::testing::TempDir(), "save-contents-test.torrent" };
 

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -262,6 +262,7 @@ TEST_F(UtilsTest, saveFile)
     auto filename = tr_pathbuf{};
 
     // save a file to GoogleTest's temp dir
+    std::cout << "::testing::TempDir() " << ::testing::TempDir();
     filename.assign(::testing::TempDir(), "filename.txt"sv);
     auto contents = "these are the contents"sv;
     auto error = tr_error{};

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -262,8 +262,8 @@ TEST_F(UtilsTest, saveFile)
     auto filename = tr_pathbuf{};
 
     // save a file to GoogleTest's temp dir
-    std::cout << "::testing::TempDir() " << ::testing::TempDir();
-    filename.assign(::testing::TempDir(), "filename.txt"sv);
+    auto const sandbox = libtransmission::test::Sandbox::create_sandbox(::testing::TempDir(), "transmission-test-XXXXXX");
+    filename.assign(sandbox, "filename.txt"sv);
     auto contents = "these are the contents"sv;
     auto error = tr_error{};
     EXPECT_TRUE(tr_file_save(filename.sv(), contents, &error));


### PR DESCRIPTION
bumping googletest from 1.11.0 to 1.14.0

Note that this bumps to `cmake_minimum_required(VERSION 3.13)` for tests (while we have `cmake_minimum_required(VERSION 3.12)` for libtransmission).

---

This was originally an attempt to address #6697, unfortunately, with same problem in sanitizer:
https://github.com/transmission/transmission/actions/runs/8294876755/job/22700749870?pr=6702
>Exception: SegFault
