### PR TITLE
add sanitizer-tests-macos

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -202,8 +202,8 @@ jobs:
             -B obj \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,undefined' \
+            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,undefined' \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=OFF \
             -DENABLE_DAEMON=OFF \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -202,9 +202,7 @@ jobs:
             -B obj \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-            -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=OFF \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -115,67 +115,67 @@ jobs:
           echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
           exit 1
 
-  sanitizer-tests-ubuntu:
-    runs-on: ubuntu-22.04
-    needs: [ what-to-make ]
-    if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-    env:
-      NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
-    steps:
-      - name: Show Configuration
-        run: |
-          echo '${{ toJSON(needs) }}'
-          echo '${{ toJSON(runner) }}'
-          cat /etc/os-release
-      - name: Get Dependencies
-        run: |
-          set -ex
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            ca-certificates \
-            clang \
-            cmake \
-            gettext \
-            libcurl4-openssl-dev \
-            libdeflate-dev \
-            libevent-dev \
-            libfmt-dev \
-            libminiupnpc-dev \
-            libnatpmp-dev \
-            libpsl-dev \
-            libssl-dev \
-            ninja-build \
-            npm
-      - name: Get Source
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          path: src
-      - name: Configure
-        run: |
-          cmake \
-            -S src \
-            -B obj \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER='clang++' \
-            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-            -DCMAKE_C_COMPILER='clang' \
-            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-            -DCMAKE_INSTALL_PREFIX=pfx \
-            -DENABLE_CLI=OFF \
-            -DENABLE_DAEMON=OFF \
-            -DENABLE_GTK=OFF \
-            -DENABLE_MAC=OFF \
-            -DENABLE_QT=OFF \
-            -DENABLE_TESTS=ON \
-            -DENABLE_UTILS=ON \
-            -DREBUILD_WEB=OFF \
-            -DRUN_CLANG_TIDY=OFF
-      - name: Make
-        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
-      - name: Test with sanitizers
-        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
+#  sanitizer-tests-ubuntu:
+#    runs-on: ubuntu-22.04
+#    needs: [ what-to-make ]
+#    if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
+#    env:
+#      NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
+#    steps:
+#      - name: Show Configuration
+#        run: |
+#          echo '${{ toJSON(needs) }}'
+#          echo '${{ toJSON(runner) }}'
+#          cat /etc/os-release
+#      - name: Get Dependencies
+#        run: |
+#          set -ex
+#          sudo apt-get update
+#          sudo apt-get install -y --no-install-recommends \
+#            ca-certificates \
+#            clang \
+#            cmake \
+#            gettext \
+#            libcurl4-openssl-dev \
+#            libdeflate-dev \
+#            libevent-dev \
+#            libfmt-dev \
+#            libminiupnpc-dev \
+#            libnatpmp-dev \
+#            libpsl-dev \
+#            libssl-dev \
+#            ninja-build \
+#            npm
+#      - name: Get Source
+#        uses: actions/checkout@v4
+#        with:
+#          submodules: recursive
+#          path: src
+#      - name: Configure
+#        run: |
+#          cmake \
+#            -S src \
+#            -B obj \
+#            -G Ninja \
+#            -DCMAKE_BUILD_TYPE=Debug \
+#            -DCMAKE_CXX_COMPILER='clang++' \
+#            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+#            -DCMAKE_C_COMPILER='clang' \
+#            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+#            -DCMAKE_INSTALL_PREFIX=pfx \
+#            -DENABLE_CLI=OFF \
+#            -DENABLE_DAEMON=OFF \
+#            -DENABLE_GTK=OFF \
+#            -DENABLE_MAC=OFF \
+#            -DENABLE_QT=OFF \
+#            -DENABLE_TESTS=ON \
+#            -DENABLE_UTILS=ON \
+#            -DREBUILD_WEB=OFF \
+#            -DRUN_CLANG_TIDY=OFF
+#      - name: Make
+#        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
+#      - name: Test with sanitizers
+#        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
 
   sanitizer-tests-macos:
     runs-on: macos-14

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -115,7 +115,7 @@ jobs:
           echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
           exit 1
 
-  sanitizer-tests:
+  sanitizer-tests-ubuntu:
     runs-on: ubuntu-22.04
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
@@ -146,6 +146,50 @@ jobs:
             libssl-dev \
             ninja-build \
             npm
+      - name: Get Source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: src
+      - name: Configure
+        run: |
+          cmake \
+            -S src \
+            -B obj \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER='clang++' \
+            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+            -DCMAKE_C_COMPILER='clang' \
+            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+            -DCMAKE_INSTALL_PREFIX=pfx \
+            -DENABLE_CLI=OFF \
+            -DENABLE_DAEMON=OFF \
+            -DENABLE_GTK=OFF \
+            -DENABLE_MAC=OFF \
+            -DENABLE_QT=OFF \
+            -DENABLE_TESTS=ON \
+            -DENABLE_UTILS=ON \
+            -DREBUILD_WEB=OFF \
+            -DRUN_CLANG_TIDY=OFF
+      - name: Make
+        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
+      - name: Test with sanitizers
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
+
+  sanitizer-tests-macos:
+    runs-on: macos-14
+    needs: [ what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          sw_vers
+      - name: Get Dependencies
+        run: |
+          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
       - name: Get Source
         uses: actions/checkout@v4
         with:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,5 @@ add_subdirectory(libtransmission)
 if(ENABLE_UTILS)
     add_subdirectory(utils)
 endif()
+
+# temporary comment to trigger the tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,5 +3,3 @@ add_subdirectory(libtransmission)
 if(ENABLE_UTILS)
     add_subdirectory(utils)
 endif()
-
-# temporary comment to trigger the tests


### PR DESCRIPTION
Fix #6697 by running the tests on macOS instead of Ubuntu.

[edit]
Running on macOS gave me the error that `-fsanitize=leak` is not supported by Clang, so I removed it:
https://github.com/transmission/transmission/actions/runs/8295707626/job/22703306911
>clang: error: unsupported option '-fsanitize=leak' for target 'arm64-apple-darwin23.2.0'