### PR TITLE
perf: restore 3.00 peer info (atom) pool pruning

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -375,28 +375,6 @@ public:
         }
     }
 
-    void remove_inactive_peer_info() noexcept
-    {
-        auto const now = tr_time();
-
-        // N.B. Unlike `std::map`, erasing elements in `small::map` seems to invalidate
-        // iterators other than the one being erased. So make sure `std::end()` is called
-        // every iteration
-        for (auto iter = std::begin(connectable_pool); iter != std::end(connectable_pool);)
-        {
-            auto const& [socket_address, peer_info] = *iter;
-            if (peer_info->is_inactive(now))
-            {
-                --stats.known_peer_from_count[peer_info->from_first()];
-                iter = connectable_pool.erase(iter);
-            }
-            else
-            {
-                ++iter;
-            }
-        }
-    }
-
     [[nodiscard]] uint16_t count_active_webseeds(uint64_t now) const noexcept
     {
         if (!tor->is_running() || tor->is_done())
@@ -1254,7 +1232,6 @@ void tr_peerMgr::refill_upkeep() const
     for (auto* const tor : torrents_)
     {
         tor->swarm->cancel_old_requests();
-        tor->swarm->remove_inactive_peer_info();
     }
 }
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2299,7 +2299,7 @@ namespace peer_info_pulse_helpers
 {
 auto get_max_peer_info_count(tr_torrent const& tor)
 {
-    return std::min(uint16_t{ 50 }, static_cast<uint16_t>(tor.peer_limit() * 3U));
+    return tor.is_done() ? tor.peer_limit() : tor.peer_limit() * 3U;
 }
 
 struct ComparePeerInfo

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -431,7 +431,7 @@ private:
 
     // the minimum we'll wait before attempting to reconnect to a peer
     static auto constexpr MinimumReconnectIntervalSecs = time_t{ 5U };
-    static auto constexpr InactiveThresSecs = time_t{ 24 * 60 * 60 };
+    static auto constexpr InactiveThresSecs = time_t{ 60 * 60 };
 
     static auto inline n_known_connectable = size_t{};
 


### PR DESCRIPTION
Another step for #5261.

No matter how I think about it, the feature that this PR restores sounds like a process that's integral to keeping Transmission fast even after running for a very long time. So I was a bit bewildered by why it was removed completely with no replacement at all.

This is all I can find about the history at the moment:
1. `atomPulse()` was commented out at #3182 to prevent some crashes, the PR description says it was just a hack to unbreak the nightly builds.
2. Afterwards, for whatever reason, what remained of `atomPulse()` got removed completely at #3192. There was no explanation.

So for now, I opted to restore it, with a small change to the calculation for limiting the number of peer info objects.
@ckerr if you still remember where you were going after #3192, I'd be glad to know about it, so I can adjust accordingly.

This PR will replace the code I wrote in #6111. Before I learned about `3.00`'s atom pool pruning, I did #6111 in an attempt to achieve the same goal of keeping Transmission's overhead in check. But it was not good enough, even with just 30 torrents, the total number of peer info objects ballooned to around 110k after 24 hours.

Notes: Improved libtransmission code to use less CPU.