### PR TITLE
re-enabling ubuntu tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -147,7 +147,11 @@ jobs:
             libssl-dev \
             ninja-build \
             npm
-          sudo sysctl kernel.randomize_va_space=0 # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
+      - name: Temporary workaround for sanitizer crashes
+        # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
+        # https://github.com/actions/runner-images/issues/9491
+        # https://github.com/actions/runner-images/pull/9513
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -857,7 +861,7 @@ jobs:
             -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_MAC=OFF \
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
-            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_TESTS=OFF \
             -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
             -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_WERROR=ON \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -116,67 +116,68 @@ jobs:
           echo "When CI is done, the above patch will be uploaded as 'code-style.diff' to https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/ ."
           exit 1
 
-#  sanitizer-tests-ubuntu:
-#    runs-on: ubuntu-22.04
-#    needs: [ what-to-make ]
-#    if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-#    env:
-#      NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
-#    steps:
-#      - name: Show Configuration
-#        run: |
-#          echo '${{ toJSON(needs) }}'
-#          echo '${{ toJSON(runner) }}'
-#          cat /etc/os-release
-#      - name: Get Dependencies
-#        run: |
-#          set -ex
-#          sudo apt-get update
-#          sudo apt-get install -y --no-install-recommends \
-#            ca-certificates \
-#            clang \
-#            cmake \
-#            gettext \
-#            libcurl4-openssl-dev \
-#            libdeflate-dev \
-#            libevent-dev \
-#            libfmt-dev \
-#            libminiupnpc-dev \
-#            libnatpmp-dev \
-#            libpsl-dev \
-#            libssl-dev \
-#            ninja-build \
-#            npm
-#      - name: Get Source
-#        uses: actions/checkout@v4
-#        with:
-#          submodules: recursive
-#          path: src
-#      - name: Configure
-#        run: |
-#          cmake \
-#            -S src \
-#            -B obj \
-#            -G Ninja \
-#            -DCMAKE_BUILD_TYPE=Debug \
-#            -DCMAKE_CXX_COMPILER='clang++' \
-#            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-#            -DCMAKE_C_COMPILER='clang' \
-#            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
-#            -DCMAKE_INSTALL_PREFIX=pfx \
-#            -DENABLE_CLI=OFF \
-#            -DENABLE_DAEMON=OFF \
-#            -DENABLE_GTK=OFF \
-#            -DENABLE_MAC=OFF \
-#            -DENABLE_QT=OFF \
-#            -DENABLE_TESTS=ON \
-#            -DENABLE_UTILS=ON \
-#            -DREBUILD_WEB=OFF \
-#            -DRUN_CLANG_TIDY=OFF
-#      - name: Make
-#        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
-#      - name: Test with sanitizers
-#        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
+  sanitizer-tests-ubuntu:
+    runs-on: ubuntu-22.04
+    needs: [ what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
+    env:
+      NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          cat /etc/os-release
+      - name: Get Dependencies
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates \
+            clang \
+            cmake \
+            gettext \
+            libcurl4-openssl-dev \
+            libdeflate-dev \
+            libevent-dev \
+            libfmt-dev \
+            libminiupnpc-dev \
+            libnatpmp-dev \
+            libpsl-dev \
+            libssl-dev \
+            ninja-build \
+            npm
+          sudo sysctl kernel.randomize_va_space=0 # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
+      - name: Get Source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: src
+      - name: Configure
+        run: |
+          cmake \
+            -S src \
+            -B obj \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER='clang++' \
+            -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+            -DCMAKE_C_COMPILER='clang' \
+            -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
+            -DCMAKE_INSTALL_PREFIX=pfx \
+            -DENABLE_CLI=OFF \
+            -DENABLE_DAEMON=OFF \
+            -DENABLE_GTK=OFF \
+            -DENABLE_MAC=OFF \
+            -DENABLE_QT=OFF \
+            -DENABLE_TESTS=ON \
+            -DENABLE_UTILS=ON \
+            -DREBUILD_WEB=OFF \
+            -DRUN_CLANG_TIDY=OFF
+      - name: Make
+        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
+      - name: Test with sanitizers
+        run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
 
   sanitizer-tests-macos:
     runs-on: macos-14
@@ -311,7 +312,7 @@ jobs:
             -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_MAC=${{ (needs.what-to-make.outputs.make-mac == 'true') && 'ON' || 'OFF' }}  \
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
-            -DENABLE_TESTS=ON \
+            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
             -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_WERROR=ON \
@@ -514,7 +515,7 @@ jobs:
             -DENABLE_GTK=OFF `
             -DENABLE_MAC=OFF `
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_TESTS=ON `
+            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_UTILS=ON `
             -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_WERROR=ON `
@@ -856,7 +857,7 @@ jobs:
             -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_MAC=OFF \
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
-            -DENABLE_TESTS=OFF \
+            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
             -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_WERROR=ON \


### PR DESCRIPTION
This PR is for ubuntu CI.
Note that I also hope to land macOS-14 CI: https://github.com/transmission/transmission/pull/6626

The workaround I used for ubuntu is that extra line:
```
# https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
# https://github.com/actions/runner-images/pull/9513
sudo sysctl vm.mmap_rnd_bits=28
```