### PR TITLE
feat: allow port forwarding state to recover from error

### DIFF
--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -96,7 +96,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
         }
     }
 
-    if ((state_ == State::Idle || state_ == State::Err) && is_mapped_ && (!is_enabled || local_port_ != local_port))
+    if (state_ <= State::Err && is_mapped_ && (!is_enabled || local_port_ != local_port))
     {
         state_ = State::SendUnmap;
     }
@@ -140,16 +140,9 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
         }
     }
 
-    if (state_ <= State::Err)
+    if (state_ <= State::Err && (is_mapped_ ? tr_time() >= renew_time_ : is_enabled && has_discovered_))
     {
-        if (is_enabled && !is_mapped_ && has_discovered_)
-        {
-            state_ = State::SendMap;
-        }
-        else if (is_mapped_ && tr_time() >= renew_time_)
-        {
-            state_ = State::SendMap;
-        }
+        state_ = State::SendMap;
     }
 
     if (state_ == State::SendMap && canSendCommand())

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -140,7 +140,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
         }
     }
 
-    if (state_ == State::Idle)
+    if (state_ <= State::Err)
     {
         if (is_enabled && !is_mapped_ && has_discovered_)
         {

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -96,7 +96,7 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
         }
     }
 
-    if (state_ <= State::Err && is_mapped_ && (!is_enabled || local_port_ != local_port))
+    if ((state_ == State::Idle || state_ == State::Err) && is_mapped_ && (!is_enabled || local_port_ != local_port))
     {
         state_ = State::SendUnmap;
     }
@@ -140,7 +140,8 @@ tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
         }
     }
 
-    if (state_ <= State::Err && (is_mapped_ ? tr_time() >= renew_time_ : is_enabled && has_discovered_))
+    if ((state_ == State::Idle || state_ == State::Err) &&
+        (is_mapped_ ? tr_time() >= renew_time_ : is_enabled && has_discovered_))
     {
         state_ = State::SendMap;
     }

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -306,7 +306,7 @@ tr_port_forwarding_state tr_upnpPulse(
         freeUPNPDevlist(devlist);
     }
 
-    if (handle->state <= UpnpState::Failed && handle->isMapped &&
+    if ((handle->state == UpnpState::Idle || handle->state == UpnpState::Failed) && handle->isMapped &&
         (!is_enabled || handle->advertised_port != advertised_port || handle->local_port != local_port))
     {
         handle->state = UpnpState::WillUnmap;
@@ -339,7 +339,7 @@ tr_port_forwarding_state tr_upnpPulse(
         handle->local_port = {};
     }
 
-    if (handle->state <= UpnpState::Failed && is_enabled && !handle->isMapped)
+    if ((handle->state == UpnpState::Idle || handle->state == UpnpState::Failed) && is_enabled && !handle->isMapped)
     {
         handle->state = UpnpState::WillMap;
     }

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -298,7 +298,7 @@ tr_port_forwarding_state tr_upnpPulse(
         }
         else
         {
-            handle->state = UpnpState::Failed;
+            handle->state = UpnpState::WillDiscover;
             tr_logAddDebug(fmt::format("UPNP_GetValidIGD failed: {} ({})", tr_strerror(errno), errno));
             tr_logAddDebug("If your router supports UPnP, please make sure UPnP is enabled!");
         }

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -306,15 +306,15 @@ tr_port_forwarding_state tr_upnpPulse(
         freeUPNPDevlist(devlist);
     }
 
-    if ((handle->state <= UpnpState::Failed) && (handle->isMapped) &&
+    if (handle->state <= UpnpState::Failed && handle->isMapped &&
         (!is_enabled || handle->advertised_port != advertised_port || handle->local_port != local_port))
     {
         handle->state = UpnpState::WillUnmap;
     }
 
     if (is_enabled && handle->isMapped && do_port_check &&
-        ((get_specific_port_mapping_entry(handle, "TCP") != UPNPCOMMAND_SUCCESS) ||
-         (get_specific_port_mapping_entry(handle, "UDP") != UPNPCOMMAND_SUCCESS)))
+        (get_specific_port_mapping_entry(handle, "TCP") != UPNPCOMMAND_SUCCESS ||
+         get_specific_port_mapping_entry(handle, "UDP") != UPNPCOMMAND_SUCCESS))
     {
         tr_logAddInfo(fmt::format(
             _("Local port {local_port} is not forwarded to {advertised_port}"),
@@ -339,7 +339,7 @@ tr_port_forwarding_state tr_upnpPulse(
         handle->local_port = {};
     }
 
-    if ((handle->state <= UpnpState::Failed) && is_enabled && !handle->isMapped)
+    if (handle->state <= UpnpState::Failed && is_enabled && !handle->isMapped)
     {
         handle->state = UpnpState::WillMap;
     }

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -306,7 +306,7 @@ tr_port_forwarding_state tr_upnpPulse(
         freeUPNPDevlist(devlist);
     }
 
-    if ((handle->state == UpnpState::Idle) && (handle->isMapped) &&
+    if ((handle->state <= UpnpState::Failed) && (handle->isMapped) &&
         (!is_enabled || handle->advertised_port != advertised_port || handle->local_port != local_port))
     {
         handle->state = UpnpState::WillUnmap;
@@ -339,7 +339,7 @@ tr_port_forwarding_state tr_upnpPulse(
         handle->local_port = {};
     }
 
-    if ((handle->state == UpnpState::Idle) && is_enabled && !handle->isMapped)
+    if ((handle->state <= UpnpState::Failed) && is_enabled && !handle->isMapped)
     {
         handle->state = UpnpState::WillMap;
     }


### PR DESCRIPTION
Fixes #462
Fixes #5464

Allow port forwarding state to recover from error, e.g. recover from a temporary network stoppage.

Notes: Allow port forwarding state to automatically recover from error.