### PR TITLE
Disable a long-lived and recurrent flaky test

### DIFF
--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -112,6 +112,7 @@ TEST_F(LpdTest, HelloWorld)
     EXPECT_EQ(0U, std::size(mediator.found_));
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(LpdTest, DISABLED_CanAnnounceAndRead)
 {
     auto mediator_a = MyMediator{ *session_ };
@@ -134,6 +135,7 @@ TEST_F(LpdTest, DISABLED_CanAnnounceAndRead)
     EXPECT_EQ(0U, mediator_b.found_.count(info_hash_str));
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(LpdTest, DISABLED_canMultiAnnounce)
 {
     auto mediator_a = MyMediator{ *session_ };
@@ -170,6 +172,7 @@ TEST_F(LpdTest, DISABLED_canMultiAnnounce)
     }
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(LpdTest, DISABLED_DoesNotReannounceTooSoon)
 {
     auto mediator_a = MyMediator{ *session_ };

--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -177,7 +177,12 @@ TEST_F(TimerTest, repeatingHonorsInterval)
     EXPECT_EQ(DesiredLoops, n_calls);
 }
 
+#ifdef _WIN32
+// TODO: flaky test should be fixed instead of disabled
+TEST_F(TimerTest, DISABLED_restartWithDifferentInterval)
+#else
 TEST_F(TimerTest, restartWithDifferentInterval)
+#endif
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();
@@ -206,7 +211,12 @@ TEST_F(TimerTest, restartWithDifferentInterval)
     test(200ms);
 }
 
+#ifdef _WIN32
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(TimerTest, DISABLED_restartWithSameInterval)
+#else
+TEST_F(TimerTest, restartWithSameInterval)
+#endif
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();
@@ -235,6 +245,7 @@ TEST_F(TimerTest, DISABLED_restartWithSameInterval)
     test(timer->interval());
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(TimerTest, DISABLED_repeatingThenSingleShot)
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
@@ -277,6 +288,7 @@ TEST_F(TimerTest, DISABLED_repeatingThenSingleShot)
     EXPECT_EQ(baseline + 1, n_calls);
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_F(TimerTest, DISABLED_singleShotStop)
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -226,6 +226,7 @@ TEST_P(WatchDirTest, watch)
     EXPECT_TRUE(std::empty(names));
 }
 
+// TODO: flaky test should be fixed instead of disabled
 TEST_P(WatchDirTest, DISABLED_retry)
 {
     auto const path = sandboxDir();


### PR DESCRIPTION
Fix #6464.

Similar idea as #4808: it's only meant to be temporary. But as I had this specific failure hitting my pull requests more than a dozen of times, and often causing them to be mostly ignored because they wouldn't pass all tests, this has been bugging me for too long.

Scope of this PR is to disable the test, not to fix it. If you have a fix in mind, kindly open a separate PR since I don't have a Windows machine. But in the mean time, we should merge this now to make other pull requests green.

Sister pull request which I also recommend to merge: #6715