### PR TITLE
fix: mismatched `class` forward declaration for `struct tr_peer`

### DIFF
--- a/tests/libtransmission/peer-mgr-active-requests-test.cc
+++ b/tests/libtransmission/peer-mgr-active-requests-test.cc
@@ -15,7 +15,7 @@
 
 #include "gtest/gtest.h"
 
-class tr_peer;
+struct tr_peer;
 
 class PeerMgrActiveRequestsTest : public ::testing::Test
 {


### PR DESCRIPTION
Fixes warning:

```
libtransmission/peer-mgr-active-requests-test.cc:18:1: warning: class 'tr_peer' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```