### PR TITLE
fix: more misc `net.cc` fixes

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -707,7 +707,7 @@ int tr_address::compare(tr_address const& that) const noexcept // <=>
 
 std::string tr_socket_address::display_name(tr_address const& address, tr_port port) noexcept
 {
-    return fmt::format("[{:s}]:{:d}", address.display_name(), port.host());
+    return fmt::format(address.is_ipv6() ? "[{:s}]:{:d}" : "{:s}:{:d}", address.display_name(), port.host());
 }
 
 bool tr_socket_address::is_valid_for_peers(tr_peer_from from) const noexcept

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -322,18 +322,13 @@ tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool suppres
     (void)setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<char const*>(&optval), sizeof(optval));
     (void)setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
 
-#ifdef IPV6_V6ONLY
-
-    if (addr.is_ipv6() &&
-        (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char const*>(&optval), sizeof(optval)) == -1) &&
-        (sockerrno != ENOPROTOOPT)) // if the kernel doesn't support it, ignore it
+    if (addr.is_ipv6() && evutil_make_listen_socket_ipv6only(fd) != 0 &&
+        sockerrno != ENOPROTOOPT) // if the kernel doesn't support it, ignore it
     {
         *err_out = sockerrno;
         tr_net_close_socket(fd);
         return TR_BAD_SOCKET;
     }
-
-#endif
 
     auto const [sock, addrlen] = tr_socket_address::to_sockaddr(addr, port);
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -320,7 +320,7 @@ tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool suppres
 
     int optval = 1;
     (void)setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<char const*>(&optval), sizeof(optval));
-    (void)setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
+    (void)evutil_make_listen_socket_reuseable(fd);
 
     if (addr.is_ipv6() && evutil_make_listen_socket_ipv6only(fd) != 0 &&
         sockerrno != ENOPROTOOPT) // if the kernel doesn't support it, ignore it

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -159,8 +159,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
 
     if (auto sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        auto optval = 1;
-        (void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
+        (void)evutil_make_listen_socket_reuseable(sock);
 
         auto const addr = session_.bind_address(TR_AF_INET);
         auto const [ss, sslen] = tr_socket_address::to_sockaddr(addr, udp_port_);
@@ -204,8 +203,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     }
     else if (auto sock = socket(PF_INET6, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
-        auto optval = 1;
-        (void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
+        (void)evutil_make_listen_socket_reuseable(sock);
         (void)evutil_make_listen_socket_ipv6only(sock);
 
         auto const addr = session_.bind_address(TR_AF_INET6);

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -206,6 +206,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     {
         auto optval = 1;
         (void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&optval), sizeof(optval));
+        (void)evutil_make_listen_socket_ipv6only(sock);
 
         auto const addr = session_.bind_address(TR_AF_INET6);
         auto const [ss, sslen] = tr_socket_address::to_sockaddr(addr, udp_port_);
@@ -240,13 +241,6 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
             udp6_socket_ = sock;
             udp6_event_.reset(event_new(session_.event_base(), udp6_socket_, EV_READ | EV_PERSIST, event_callback, &session_));
             event_add(udp6_event_.get(), nullptr);
-
-#ifdef IPV6_V6ONLY
-            // Since we always open an IPv4 socket on the same port,
-            // this shouldn't matter.  But I'm superstitious.
-            int one = 1;
-            (void)setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char const*>(&one), sizeof(one));
-#endif
         }
     }
 }

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -340,8 +340,13 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         auto remain = parsed.authority;
         if (tr_strv_starts_with(remain, '['))
         {
-            remain.remove_prefix(1); // '['
-            parsed.host = tr_strv_sep(&remain, ']');
+            pos = remain.find(']');
+            if (pos == std::string_view::npos)
+            {
+                return std::nullopt;
+            }
+            parsed.host = remain.substr(0, pos + 1);
+            remain.remove_prefix(pos + 1);
             if (tr_strv_starts_with(remain, ':'))
             {
                 remain.remove_prefix(1);
@@ -389,7 +394,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
 std::optional<tr_url_parsed_t> tr_urlParseTracker(std::string_view url)
 {
     auto const parsed = tr_urlParse(url);
-    return parsed && tr_isValidTrackerScheme(parsed->scheme) ? std::make_optional(*parsed) : std::nullopt;
+    return parsed && tr_isValidTrackerScheme(parsed->scheme) ? parsed : std::nullopt;
 }
 
 bool tr_urlIsValidTracker(std::string_view url)

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -84,7 +84,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexCompact)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[127.0.0.1]:64551"sv, response.pex[0].display_name());
+        EXPECT_EQ("127.0.0.1:64551"sv, response.pex[0].display_name());
     }
 }
 
@@ -123,7 +123,7 @@ TEST_F(AnnouncerTest, parseHttpAnnounceResponsePexList)
 
     if (std::size(response.pex) == 1)
     {
-        EXPECT_EQ("[8.8.4.4]:53"sv, response.pex[0].display_name());
+        EXPECT_EQ("8.8.4.4:53"sv, response.pex[0].display_name());
     }
 }
 

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -218,7 +218,9 @@ TEST_F(NetTest, ipCompare)
                                                 std::tuple{ "8.8.8.8"sv, "8.8.8.8"sv, 0 },
                                                 std::tuple{ "8.8.8.8"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, -1 },
                                                 std::tuple{ "2001:1890:1112:1::20"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, 1 },
-                                                std::tuple{ "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv, 0 } };
+                                                std::tuple{ "2001:1890:1112:1::20"sv, "[2001:0:0eab:dead::a0:abcd:4e]"sv, 1 },
+                                                std::tuple{ "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv, 0 },
+                                                std::tuple{ "2001:1890:1112:1::20"sv, "[2001:1890:1112:1::20]"sv, 0 } };
 
     for (auto const& [sv1, sv2, res] : IpPairs)
     {

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -126,8 +126,8 @@ TEST_F(WebUtilsTest, urlParse)
     url = "http://[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]:8080/announce"sv;
     parsed = tr_urlParse(url);
     EXPECT_EQ("http"sv, parsed->scheme);
-    EXPECT_EQ("2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d"sv, parsed->sitename);
-    EXPECT_EQ("2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d"sv, parsed->host);
+    EXPECT_EQ("[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]"sv, parsed->sitename);
+    EXPECT_EQ("[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]"sv, parsed->host);
     EXPECT_EQ("/announce"sv, parsed->path);
     EXPECT_EQ(8080, parsed->port);
 
@@ -135,8 +135,8 @@ TEST_F(WebUtilsTest, urlParse)
     url = "http://[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]/announce"sv;
     parsed = tr_urlParse(url);
     EXPECT_EQ("http"sv, parsed->scheme);
-    EXPECT_EQ("2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d"sv, parsed->sitename);
-    EXPECT_EQ("2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d"sv, parsed->host);
+    EXPECT_EQ("[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]"sv, parsed->sitename);
+    EXPECT_EQ("[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]"sv, parsed->host);
     EXPECT_EQ("/announce"sv, parsed->path);
     EXPECT_EQ(80, parsed->port);
 


### PR DESCRIPTION
More misc fixes for networking functions.

1. To conform to RFC3986[^1], fix `tr_urlParse()` to include the encapsulating square brackets for IPv6 addresses in the `host` component.
2. Modify `tr_address::from_string()` to allow square brackets encapsulating IPv6 address strings.
3. When creating the IPv6 UDP socket, set `IPV6_V6ONLY` *before* binding. Otherwise, the operation will always return `EINVAL` on Linux.
4. Don't set `SO_REUSEADDR` for listening sockets on Windows, because it is equivalent to `SO_REUSEPORT` on Unix systems[^2]. Windows already allow rebinding to `TIME_WAIT` sockets by default[^3], or in other words, its default behaviour is equivalent to explicitly setting `SO_REUSEADDR` on most other systems.
5. Don't enclose IPv4 addresses in square brackets when generating the display name for `tr_socket_address`.

[^1]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
[^2]: https://stackoverflow.com/a/14388707/11390656
[^3]: https://learn.microsoft.com/en-gb/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse