### PR TITLE
webui: fixed width for speed info

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -385,10 +385,13 @@ a {
   }
 
   .speed-container {
-    width: 100px;
     display: inherit;
     align-items: inherit;
     flex-direction: inherit;
+
+    &:not(:nth-child(1 of #mainwin-statusbar .speed-container)) {
+      width: 100px;
+    }
   }
 
   #speed-up-icon,

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -383,20 +383,27 @@ a {
   > * {
     margin-right: 5px;
   }
-}
 
-#speed-up-icon,
-#speed-dn-icon {
-  fill: var(--color-fg-primary);
-
-  svg {
-    width: 20px;
+  .speed-container {
+    width: 100px;
+    display: inherit;
+    align-items: inherit;
+    flex-direction: inherit;
   }
-}
 
-#speed-dn-label,
-#speed-up-label {
-  text-align: right;
+  #speed-up-icon,
+  #speed-dn-icon {
+    fill: var(--color-fg-primary);
+
+    svg {
+      width: 20px;
+    }
+  }
+
+  #speed-dn-label,
+  #speed-up-label {
+    text-align: right;
+  }
 }
 
 /// TORRENT CONTAINER

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -204,6 +204,7 @@
         <span id="filter-count">&nbsp;</span>
         <span class="flexible-space"></span>
         <div class="speed-container">
+          <div id="speed-dn-label"></div>
           <div id="speed-dn-icon">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -220,10 +221,10 @@
               <polyline points="6 9 12 15 18 9"></polyline>
             </svg>
           </div>
-          <div id="speed-dn-label"></div>
         </div>
         <div class="speed-container">
           <span class="flexible-space"></span>
+          <div id="speed-up-label"></div>
           <div id="speed-up-icon">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -240,7 +241,6 @@
               <polyline points="18 15 12 9 6 15"></polyline>
             </svg>
           </div>
-          <div id="speed-up-label"></div>
         </div>
       </header>
 

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -203,23 +203,25 @@
         <input type="search" id="torrent-search" placeholder="Filter" />
         <span id="filter-count">&nbsp;</span>
         <span class="flexible-space"></span>
-        <div id="speed-dn-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="feather feather-chevron-down"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
+        <div class="speed-container">
+          <div id="speed-dn-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="feather feather-chevron-down"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </div>
+          <div id="speed-dn-label"></div>
         </div>
-        <div id="speed-dn-label"></div>
         <div class="speed-container">
           <span class="flexible-space"></span>
           <div id="speed-up-icon">

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -220,23 +220,26 @@
           </svg>
         </div>
         <div id="speed-dn-label"></div>
-        <div id="speed-up-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="feather feather-chevron-up"
-          >
-            <polyline points="18 15 12 9 6 15"></polyline>
-          </svg>
+        <div class="speed-container">
+          <span class="flexible-space"></span>
+          <div id="speed-up-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="feather feather-chevron-up"
+            >
+              <polyline points="18 15 12 9 6 15"></polyline>
+            </svg>
+          </div>
+          <div id="speed-up-label"></div>
         </div>
-        <div id="speed-up-label"></div>
       </header>
 
       <main id="mainwin-workarea">


### PR DESCRIPTION
Implement my suggestion at https://github.com/transmission/transmission/pull/6577#issuecomment-2016481876.

Fix the width of the upload speed info, so that the download speed info will not move around in response to upload speed changes.

| Before | After |
| :--: | :--: |
| ![before](https://github.com/transmission/transmission/assets/46261767/fecbc45d-ebbb-4b63-9de9-4c3b1c6ced8f) | ![after-2](https://github.com/transmission/transmission/assets/46261767/44e981ea-1489-4624-9f6b-e25805b741bf) |

Edit: Moved the arrows to the right of the text as suggested by https://github.com/transmission/transmission/pull/6739#issuecomment-2020649976.

<details>
<summary>previous iteration</summary>

 ![after](https://github.com/transmission/transmission/assets/46261767/53be90eb-2744-456f-8169-132402fa04be)

</details>