### PR TITLE
Disable restartWithDifferentInterval for all platforms

### DIFF
--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -177,12 +177,8 @@ TEST_F(TimerTest, repeatingHonorsInterval)
     EXPECT_EQ(DesiredLoops, n_calls);
 }
 
-#ifdef _WIN32
 // TODO: flaky test should be fixed instead of disabled
 TEST_F(TimerTest, DISABLED_restartWithDifferentInterval)
-#else
-TEST_F(TimerTest, restartWithDifferentInterval)
-#endif
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();
@@ -211,12 +207,8 @@ TEST_F(TimerTest, restartWithDifferentInterval)
     test(200ms);
 }
 
-#ifdef _WIN32
 // TODO: flaky test should be fixed instead of disabled
 TEST_F(TimerTest, DISABLED_restartWithSameInterval)
-#else
-TEST_F(TimerTest, restartWithSameInterval)
-#endif
 {
     auto timer_maker = EvTimerMaker{ evbase_.get() };
     auto timer = timer_maker.create();


### PR DESCRIPTION
I thought when I did #6722 that the failure was exclusive to Windows, but I just found out that it's also happening on Mac:
https://github.com/transmission/transmission/actions/runs/8454701793/job/23160406569

So I'm reverting a part of #6722 and disabling those two tests for all platforms.