### PR TITLE
fix: save sequential download across sessions

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -735,6 +735,13 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
         fields_loaded |= tr_resume::BandwidthPriority;
     }
 
+    if (auto val = bool{};
+        (fields_to_load & tr_resume::SequentialDownload) != 0 && tr_variantDictFindBool(&top, TR_KEY_sequentialDownload, &val))
+    {
+        tor->set_sequential_download(val);
+        fields_loaded |= tr_resume::SequentialDownload;
+    }
+
     if ((fields_to_load & tr_resume::Peers) != 0)
     {
         fields_loaded |= loadPeers(&top, tor);

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -44,6 +44,7 @@ auto inline constexpr Filenames = fields_t{ 1 << 20 };
 auto inline constexpr Name = fields_t{ 1 << 21 };
 auto inline constexpr Labels = fields_t{ 1 << 22 };
 auto inline constexpr Group = fields_t{ 1 << 23 };
+auto inline constexpr SequentialDownload = fields_t{ 1 << 24 };
 
 auto inline constexpr All = ~fields_t{ 0 };
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -729,6 +729,7 @@ struct tr_torrent
         {
             sequential_download_ = is_sequential;
             sequential_download_changed_.emit(this, is_sequential);
+            set_dirty();
         }
     }
 


### PR DESCRIPTION
Save the sequential download setting of each torrent across sessions.

#4795 did try to do this, but the implementation is not complete.