### PR TITLE
fix crash on reconnect

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -645,6 +645,14 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
             handshake->set_state(State::AwaitingHandshake);
             return;
         }
+
+        // the above reconnect() may have invalidated the socket
+        if (!io->socket_address().is_valid())
+        {
+            tr_logAddTraceHand(handshake, "handshake failed and reconnect failed");
+            handshake->done(false);
+            return;
+        }
     }
 
     /* if the error happened while we were sending a public key, we might

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1317,7 +1317,7 @@ void create_bit_torrent_peer(tr_torrent& tor, std::shared_ptr<tr_peerIo> io, tr_
     TR_ASSERT(result.io != nullptr);
     auto const& socket_address = result.io->socket_address();
     auto* const swarm = manager->get_existing_swarm(result.io->torrent_hash());
-    auto* info = swarm != nullptr ? swarm->get_existing_peer_info(socket_address) : nullptr;
+    auto* info = swarm != nullptr && socket_address.is_valid() ? swarm->get_existing_peer_info(socket_address) : nullptr;
 
     if (result.io->is_incoming())
     {


### PR DESCRIPTION
Fix #6744.

Crash au launch regression caused by #6717, making Transmission unusable.

This is an alternative solution to #6749.