### PR TITLE
Revert "fix: misc net.cc and blocklist.cc fixes (#6717)"

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -236,7 +236,7 @@ struct tr_address
 
     [[nodiscard]] bool is_global_unicast_address() const noexcept;
 
-    tr_address_type type = NUM_TR_AF_INET_TYPES;
+    tr_address_type type;
     union
     {
         struct in6_addr addr6;


### PR DESCRIPTION
Fix #6744.

Crash au launch regression caused by #6717, making Transmission unusable.

This is an alternative solution to #6750.