### PR TITLE
fix: invalid socket address in `tr_peerIo::reconnect()`

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -626,6 +626,17 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
 {
     auto* handshake = static_cast<tr_handshake*>(vhandshake);
 
+    auto const retry = [&]()
+    {
+        handshake->send_handshake(io);
+        handshake->set_state(State::AwaitingHandshake);
+    };
+    auto const fail = [&]()
+    {
+        tr_logAddTraceHand(handshake, fmt::format("handshake socket err: {:s} ({:d})", error.message(), error.code()));
+        handshake->done(false);
+    };
+
     if (io->is_utp() && !io->is_incoming() && handshake->is_state(State::AwaitingYb))
     {
         // the peer probably doesn't speak µTP.
@@ -641,10 +652,12 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
 
         if (handshake->mediator_->allows_tcp() && io->reconnect())
         {
-            handshake->send_handshake(io);
-            handshake->set_state(State::AwaitingHandshake);
+            retry();
             return;
         }
+
+        fail();
+        return;
     }
 
     /* if the error happened while we were sending a public key, we might
@@ -654,13 +667,11 @@ void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandsha
         handshake->encryption_mode_ != TR_ENCRYPTION_REQUIRED && handshake->mediator_->allows_tcp() && io->reconnect())
     {
         tr_logAddTraceHand(handshake, "handshake failed, trying plaintext...");
-        handshake->send_handshake(io);
-        handshake->set_state(State::AwaitingHandshake);
+        retry();
         return;
     }
 
-    tr_logAddTraceHand(handshake, fmt::format("handshake socket err: {:s} ({:d})", error.message(), error.code()));
-    handshake->done(false);
+    fail();
 }
 
 // ---

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -245,12 +245,12 @@ bool tr_peerIo::reconnect()
         return false;
     }
 
-    socket_ = tr_netOpenPeerSocket(session_, socket_address(), is_seed());
-
-    if (!socket_.is_tcp())
+    auto sock = tr_netOpenPeerSocket(session_, socket_address(), is_seed());
+    if (!sock.is_tcp())
     {
         return false;
     }
+    socket_ = std::move(sock);
 
     this->event_read_.reset(event_new(session_->event_base(), socket_.handle.tcp, EV_READ, event_read_cb, this));
     this->event_write_.reset(event_new(session_->event_base(), socket_.handle.tcp, EV_WRITE, event_write_cb, this));


### PR DESCRIPTION
Fixes #6744

- Don't discard the `tr_peer_socket` object after `tr_peerIo::reconnect()` failed, because it still contains useful info.
- Ensure `tr_peerIo::reconnect()` is called at most once for each `tr_handshake::on_error()` call.