### PR TITLE
workaround miniupnp.tuxfamily.org not responding

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -343,7 +343,7 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
+          brew install cmake gettext libdeflate libevent libpsl ninja node pkg-config
       - name: Get Source
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -334,7 +334,7 @@ jobs:
   macos-11:
     runs-on: macos-11
     needs: [ what-to-make ]
-    if: false  # ${{ needs.what-to-make.outputs.make-mac == 'true' }}
+    if: ${{ needs.what-to-make.outputs.make-mac == 'true' }}
     steps:
       - name: Show Configuration
         run: |
@@ -343,6 +343,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
+          # we don't include `miniupnpc` because on macOS-11 it attempts to download 2.2.6 which isn't downloadable anymore
+          # https://github.com/homebrew/homebrew-core/blob/master/Formula/m/miniupnpc.rb
           brew install cmake gettext libdeflate libevent libpsl ninja node pkg-config
       - name: Get Source
         uses: actions/checkout@v4


### PR DESCRIPTION
Solving build failure at https://github.com/transmission/transmission/actions/runs/8529346902/job/23364951115

Note that while miniupnp.tuxfamily.org is down, the mirror miniupnp.free.fr is still up. So an alternative to this workaround would be to convince brew to change the download URL from https://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-2.2.6.tar.gz to http://miniupnp.free.fr/files/download.php?file=miniupnpc-2.2.6.tar.gz. But I'm not familiar with brew process, and I hope they don't change download URLs just because some random person is asking nicely.