### PR TITLE
build with -latomic on platforms that need it

### DIFF
--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -1,0 +1,43 @@
+# - Try to find if 64-bits atomics need -latomic linking
+# Once done this will define
+#  HAVE_CXX_ATOMICS_WITHOUT_LIB - Whether atomic types work without -latomic
+
+include(CheckCXXSourceCompiles)
+include(CheckLibraryExists)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics VARNAME)
+    check_cxx_source_compiles("
+        #include <atomic>
+        int main() {
+            std::atomic<long long> x;
+            return std::atomic_is_lock_free(&x);
+        }
+    " ${VARNAME})
+endfunction()
+
+# Check for atomic operations.
+if(MSVC)
+    # This isn't necessary on MSVC.
+    set(HAVE_CXX_ATOMICS_WITHOUT_LIB TRUE)
+else()
+    # First check if atomics work without the library.
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+endif()
+
+# If not, check if the library exists, and atomics work with it.
+if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMIC)
+    if(NOT HAVE_LIBATOMIC)
+        message(STATUS "Host compiler appears to require libatomic, but cannot locate it.")
+    endif()
+
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+    list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "atomic")
+    if(NOT HAVE_CXX_ATOMICS_WITH_LIB)
+        message(FATAL_ERROR "Host compiler must support std::atomic!")
+    endif()
+endif()

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(CheckAtomic)
 include(CheckLibraryExists)
 include(CheckSymbolExists)
 
@@ -298,6 +299,7 @@ target_link_libraries(${TR_NAME}
         $<$<BOOL:${WIN32}>:shlwapi>
         "$<$<BOOL:${APPLE}>:-framework Foundation>"
         "$<$<BOOL:${ANDROID}>:${log-lib}>"
+        $<$<BOOL:${HAVE_LIBATOMIC}>:atomic>
     PUBLIC
         transmission::crypto_impl
         fmt::fmt-header-only


### PR DESCRIPTION
Following https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1067625 and failure to build transmission on specific platforms that require `-latomic`, here is the way to a proper fix.