### PR TITLE
chore: add Add <launchable> tag to GTK client metainfo (#6720)

### DIFF
--- a/gtk/transmission-gtk.metainfo.xml.in
+++ b/gtk/transmission-gtk.metainfo.xml.in
@@ -61,4 +61,5 @@ Copyright 2017 Endless Mobile, Inc.
     <release date="2020-05-03" version="3.00" />
   </releases>
   <translation type="gettext">transmission-gtk</translation>
+  <launchable type="desktop-id">transmission-gtk.desktop</launchable>
 </component>


### PR DESCRIPTION
cherry picked from commit de11cbdf8568c9fbf61a4c896844c2b475836118, aka #6720 