### PR TITLE
Fix incorrect value for SortIncludes in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ PenaltyBreakBeforeFirstCallParameter: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
 ReflowComments: false
-SortIncludes: false
+SortIncludes: Never
 SpaceAfterCStyleCast: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false

--- a/third-party/.clang-format
+++ b/third-party/.clang-format
@@ -1,3 +1,3 @@
 ---
 DisableFormat: true
-SortIncludes: false
+SortIncludes: Never


### PR DESCRIPTION
See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#sortincludes