### PR TITLE
Make std::hash specialization for tr_socket_address a struct

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -404,7 +404,7 @@ struct tr_socket_address
 };
 
 template<>
-class std::hash<tr_socket_address>
+struct std::hash<tr_socket_address>
 {
 public:
     std::size_t operator()(tr_socket_address const& socket_address) const noexcept


### PR DESCRIPTION
To be in line with std::hash declaration

See https://en.cppreference.com/w/cpp/utility/hash