### PR TITLE
Default initialize sleep callback duration in tr_verify_worker

### DIFF
--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -96,5 +96,5 @@ private:
     std::atomic<bool> stop_current_ = false;
     std::condition_variable stop_current_cv_;
 
-    std::chrono::milliseconds sleep_per_seconds_during_verify_;
+    std::chrono::milliseconds sleep_per_seconds_during_verify_ = {};
 };


### PR DESCRIPTION
std::chrono::duration is just a wrapper, underlying numerical value member will be default initialized to zero as expected.

See https://en.cppreference.com/w/cpp/chrono/duration