### PR TITLE
Expected white-space to come before width  order/properties-alphabetical-order

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -322,8 +322,8 @@ $speed-icon-size: 20px;
 #speed-dn-label,
 #speed-up-label {
   text-align: right;
-  width: 100px;
   white-space: nowrap;
+  width: 100px;
 }
 
 /// TORRENT CONTAINER


### PR DESCRIPTION
Fix declaration order, otherwise it's not possible to commit on 4.0.x anymore.