### PR TITLE
compatibility with libfmt v10.0.0

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -395,7 +395,7 @@ void register_magnet_link_handler()
             _("Couldn't register Transmission as a {content_type} handler: {error} ({error_code})"),
             fmt::arg("content_type", content_type),
             fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code())));
+            fmt::arg("error_code", static_cast<int>(e.code()))));
     }
 }
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -560,7 +560,7 @@ tr_sys_file_t tr_sys_file_get_std(tr_std_sys_file_t std_file, tr_error** error)
         break;
 
     default:
-        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), std_file));
+        TR_ASSERT_MSG(false, fmt::format(FMT_STRING("unknown standard file {:d}"), static_cast<int>(std_file)));
         tr_error_set_from_errno(error, EINVAL);
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -99,7 +99,7 @@ void error_handler(jsonsl_t jsn, jsonsl_error_t error, jsonsl_state_st* /*state*
             fmt::arg("position", jsn->pos),
             fmt::arg("text", std::string_view{ buf, std::min(size_t{ 16U }, data->size - jsn->pos) }),
             fmt::arg("error", jsonsl_strerror(error)),
-            fmt::arg("error_code", error)));
+            fmt::arg("error_code", static_cast<int>(error))));
 }
 
 int error_callback(jsonsl_t jsn, jsonsl_error_t error, struct jsonsl_state_st* state, jsonsl_char_t* at)


### PR DESCRIPTION
Fix #6804

Partial cherry-pick of #5635 to make Transmission 4.0.x compilable with both fmt 8 and fmt 10.