### PR TITLE
fix: missing #include in DetailsDialog.cc

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -68,6 +68,7 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#include <sys/socket.h>
 #endif
 
 using namespace std::literals;


### PR DESCRIPTION
Resolves https://github.com/transmission/transmission/issues/5736.

Fixes build on *BSD's.