### PR TITLE
fix: possible heap-use-after-free with magnet links

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2366,6 +2366,7 @@ void tr_peerMgr::bandwidth_pulse()
     for (auto* const tor : torrents_)
     {
         tor->do_idle_work();
+        tor->do_magnet_idle_work();
     }
 
     reconnect_pulse();

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2366,7 +2366,6 @@ void tr_peerMgr::bandwidth_pulse()
     for (auto* const tor : torrents_)
     {
         tor->do_idle_work();
-        tor->do_magnet_idle_work();
     }
 
     reconnect_pulse();

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -39,7 +39,7 @@ public:
         return size > 0 && size <= std::numeric_limits<int>::max();
     }
 
-    [[nodiscard]] constexpr auto is_complete() const noexcept
+    [[nodiscard]] auto is_complete() const noexcept
     {
         return std::empty(pieces_needed_);
     }

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -39,7 +39,12 @@ public:
         return size > 0 && size <= std::numeric_limits<int>::max();
     }
 
-    bool set_metadata_piece(int64_t piece, void const* data, size_t len);
+    [[nodiscard]] constexpr auto is_complete() const noexcept
+    {
+        return std::empty(pieces_needed_);
+    }
+
+    void set_metadata_piece(int64_t piece, void const* data, size_t len);
 
     [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -899,7 +899,7 @@ void tr_torrent::on_metainfo_completed()
         // Potentially, we are in `tr_torrent::init`,
         // and we don't want any file created before `tr_torrent::start`
         // so we Verify but we don't Create files.
-        session->queue_session_thread(tr_torrentVerify, this);
+        tr_torrentVerify(this);
     }
     else
     {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -599,8 +599,6 @@ struct tr_torrent
 
     /// METAINFO - MAGNET
 
-    void do_magnet_idle_work();
-
     void maybe_start_metadata_transfer(int64_t size) noexcept;
 
     [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int64_t piece) const;
@@ -889,6 +887,8 @@ struct tr_torrent
 
     void do_idle_work()
     {
+        do_magnet_idle_work();
+
         if (needs_completeness_check_)
         {
             needs_completeness_check_ = false;
@@ -1246,6 +1246,7 @@ private:
     void create_empty_files() const;
     void recheck_completeness();
 
+    void do_magnet_idle_work();
     [[nodiscard]] bool use_new_metainfo(tr_error* error);
 
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -599,6 +599,8 @@ struct tr_torrent
 
     /// METAINFO - MAGNET
 
+    void do_magnet_idle_work();
+
     void maybe_start_metadata_transfer(int64_t size) noexcept;
 
     [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int64_t piece) const;

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -85,6 +85,7 @@ TEST_F(TorrentMagnetTest, setMetadataPiece)
 
             tor->maybe_start_metadata_transfer(metainfo_size);
             tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
+            tor->do_magnet_idle_work();
             EXPECT_TRUE(tor->has_metainfo());
             EXPECT_EQ(tor->info_dict_size(), metainfo_size);
             EXPECT_EQ(tor->get_metadata_percent(), 1.0);

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -85,7 +85,7 @@ TEST_F(TorrentMagnetTest, setMetadataPiece)
 
             tor->maybe_start_metadata_transfer(metainfo_size);
             tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
-            tor->do_magnet_idle_work();
+            tor->do_idle_work();
             EXPECT_TRUE(tor->has_metainfo());
             EXPECT_EQ(tor->info_dict_size(), metainfo_size);
             EXPECT_EQ(tor->get_metadata_percent(), 1.0);


### PR DESCRIPTION
Fixes #6706.
Stack trace at https://github.com/transmission/transmission/pull/4178#issuecomment-2080390580.

This PR backtracks some changes made in #6383:
- Reverted a change that queues the `tr_torrentVerify()` call instead of executing it immediately after completing the metadata of a magnet link. This is the crux of the bug this PR fixes, more on that below.
- Re-implemented `tr_torrentMagnetDoIdleWork()` that got removed.

#6383 changed `tr_torrent::on_metainfo_completed()` so that it queues `tr_torrentVerify()` to be executed in the session thread when it is free, instead of executing it immediately.

This was needed because `tr_torrentVerify()` will stop the torrent, thus freeing all `tr_peerMsgs` objects belonging to that torrent (i.e. disconnecting all peers), and this might trigger a chain reaction (detailed at https://github.com/transmission/transmission/pull/6383#discussion_r1429202253) that leads to `heap-use-after-free`.

However, an unexpected consequence of this change is, there is a chance that `tr_torrentVerify()` will be executed *after* the original `tr_torrent` object for the magnet link is destructed, causing `heap-use-after-free`. This can happen if the magnet link got removed from Transmission or the session itself got shut down *immediately* after the metadata transfer completed.

A side effect of this PR is that we need to re-introduce the indirection step `tr_torrentMagnetDoIdleWork()`, otherwise there will be `heap-use-after-free`. I made the changes in #6383 because I didn't like how it worked, but for now I don't see any better solution other then reverting to the way it was.