### PR TITLE
fix building with mbedtls 3.X

### DIFF
--- a/libtransmission/crypto-utils-mbedtls.cc
+++ b/libtransmission/crypto-utils-mbedtls.cc
@@ -118,7 +118,7 @@ void tr_sha1::clear()
 {
     mbedtls_sha1_init(&handle_);
 
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha1_starts_ret(&handle_);
 #else
     mbedtls_sha1_starts(&handle_);
@@ -132,7 +132,7 @@ void tr_sha1::add(void const* data, size_t data_length)
         return;
     }
 
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha1_update_ret(&handle_, static_cast<unsigned char const*>(data), data_length);
 #else
     mbedtls_sha1_update(&handle_, static_cast<unsigned char const*>(data), data_length);
@@ -143,7 +143,7 @@ tr_sha1_digest_t tr_sha1::finish()
 {
     auto digest = tr_sha1_digest_t{};
     auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha1_finish_ret(&handle_, digest_as_uchar);
 #else
     mbedtls_sha1_finish(&handle_, digest_as_uchar);
@@ -165,10 +165,10 @@ void tr_sha256::clear()
 {
     mbedtls_sha256_init(&handle_);
 
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha256_starts_ret(&handle_, 0);
 #else
-    mbedtls_sha256_starts(&handle_);
+    mbedtls_sha256_starts(&handle_, 0);
 #endif
 }
 
@@ -179,7 +179,7 @@ void tr_sha256::add(void const* data, size_t data_length)
         return;
     }
 
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha256_update_ret(&handle_, static_cast<unsigned char const*>(data), data_length);
 #else
     mbedtls_sha256_update(&handle_, static_cast<unsigned char const*>(data), data_length);
@@ -190,7 +190,7 @@ tr_sha256_digest_t tr_sha256::finish()
 {
     auto digest = tr_sha256_digest_t{};
     auto* const digest_as_uchar = reinterpret_cast<unsigned char*>(std::data(digest));
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     mbedtls_sha256_finish_ret(&handle_, digest_as_uchar);
 #else
     mbedtls_sha256_finish(&handle_, digest_as_uchar);


### PR DESCRIPTION
per https://github.com/Mbed-TLS/mbedtls/blob/development/docs/3.0-migration-guide.md, functions with _ret prefixs replaced old without return and renamed without suffix.