### PR TITLE
Avoiding &rarr; in UTF-8.

### DIFF
--- a/docs/Why-is-my-port-closed.md
+++ b/docs/Why-is-my-port-closed.md
@@ -22,7 +22,7 @@ Note: NAT-PMP is only for Apple Airport routers.
 ### Double NAT
 Another possible reason your port remains closed could be because your router is not the only device on the network which needs to be configured.
 
-For example, your network might resemble the following: ADSL modem/router &rarr; Netgear router &rarr; laptop.
+For example, your network might resemble the following: ADSL modem/router → Netgear router → laptop.
 
 If you have multiple routers in your home network (such as in the example above), you have two options. The easiest way is to turn one of the routers into 'Bridge mode' which means you then only have to configure one device rather than all of them. So, in our above example, we would set the Netgear router to 'Bridge'. See your router's help documentation for instructions.
 

--- a/macosx/TransmissionHelp/html/FAQ.html
+++ b/macosx/TransmissionHelp/html/FAQ.html
@@ -16,7 +16,7 @@
     </div>
     <p>Read these tips for <a href="speed.html">maximizing your download speed</a>.
     <p>Some Internet Service Providers (ISPs) throttle peer-to-peer traffic, and even block it completely on well known peer-to-peer ports. If your ISP is listed on <a href="http://wiki.vuze.com/w/Bad_ISPs">this page</a>, it is likely you will experience these issues.</p>
-    <p>Transmission's encryption feature may overcome some ISP throttling. Checking the 'Ignore unencrypted peers' box (Preferences &rarr; Peers) also may improve your speed further, at the expense of losing some potential peers in the swarm. Changing the port Transmission uses may help if the ISP targets particular ports.</p>
+    <p>Transmission's encryption feature may overcome some ISP throttling. Checking the 'Ignore unencrypted peers' box (Preferences → Peers) also may improve your speed further, at the expense of losing some potential peers in the swarm. Changing the port Transmission uses may help if the ISP targets particular ports.</p>
 
     <p>Ultimately, the speed you get depends on the quality of the peers you are downloading from. If they have dial up connections, you are only going to be able to download at dial up speeds. Furthermore, if there are few seeds and many peers, more people will be fighting for the same scarce pieces which will slow things down. Best results are achieved when the torrent has more seeds than peers.</p>
 
@@ -24,7 +24,7 @@
         <h1>Why isn't my torrent downloading at all?</h1>
     </div>
 
-    <p>Often this is because the tracker is down, and thus Transmission is unable to interact with other peers. If this is the case, enabling DHT (trackerless torrents) (Preferences &rarr; Peers) might help for public torrents.</p>
+    <p>Often this is because the tracker is down, and thus Transmission is unable to interact with other peers. If this is the case, enabling DHT (trackerless torrents) (Preferences → Peers) might help for public torrents.</p>
     <p>If there are no seeders in the swarm, and all the other peers have sent you what they have, you (and everyone else) will not be able to complete the download, and your speed will drop to zer.</p>
     <p>Torrents take a while to get going and so may not download much (if at all) initially. Most torrents are downloading at some rate after 15 or so minutes.</p>
     <div class="pagetitle">

--- a/macosx/TransmissionHelp/html/check.html
+++ b/macosx/TransmissionHelp/html/check.html
@@ -20,7 +20,7 @@
     <div class="taskbox">
         <ol>
             <li>Select the relevant torrent.</li>
-            <li>Go to the Transfers menu &rarr; Verify Local Data.</li>
+            <li>Go to the Transfers menu → Verify Local Data.</li>
         </ol>
     </div>
 

--- a/macosx/TransmissionHelp/html/gettingstarted.html
+++ b/macosx/TransmissionHelp/html/gettingstarted.html
@@ -83,14 +83,14 @@
         <div class="question">Can I schedule my transfers?</div>
         <div class="answer-thumbnail"><img alt="scheduling" src="../gfx/scheduler.png"/></div>
         <div class="answer-text">
-            <p>Yes, by using 'Speed Limit Mode'. Simply go to Preferences &rarr; Bandwidth, and then set both the speed you would like Transmission to be limited to, as well as the period of time you would like the limits applied.</p>
+            <p>Yes, by using 'Speed Limit Mode'. Simply go to Preferences → Bandwidth, and then set both the speed you would like Transmission to be limited to, as well as the period of time you would like the limits applied.</p>
             <p>When Speed Limit Mode is enabled, the turtle will be illuminated in blue.</p>
         </div>
 
         <div class="question">Can I queue my transfers?</div>
         <div class="answer-thumbnail"><img alt="queue" src="../gfx/queue.png"/></div>
         <div class="answer-text">
-            <p>Yes, you can queue seeding and/or downloading transfers via Preferences &rarr; Transfers &rarr; Management.</p>
+            <p>Yes, you can queue seeding and/or downloading transfers via Preferences → Transfers → Management.</p>
             <p>The queue system is very simple: You start and pause transfers as usual, but if you're over the queue limit starting a transfer will instead make it "Waiting to download..."</p>
             <p>You can force a transfer to start by holding down option and clicking the orange resume button, or by using the Transfers menu item "Resume Selected Without Wait".</p>
         </div>
@@ -100,8 +100,8 @@
         <div class="answer-text">
             <p>Transmission allows you to sort your torrents by various criteria. Choose "Sort Transfers By" in the View menu, as well as the Action menu.</p>
             <p>You can also filter your torrents by their activity state. Simply enable the Filter bar in the View menu.</p>
-            <p>Transmission allows you to group torrents by color labels. Groups can be assigned upon adding a transfer to the list by establishing rules in Preferences &rarr; Groups. Groups can be manually changed with Transfers &rarr; Group and by dragging transfers to different groups in the main window (when "Use Groups" is enabled in the View menu).</p>
-            <p>These groups can be used as sorting and filtering criteria. Add, remove, and modify groups in Preferences &rarr; Groups. Groups can also be used for choosing the data location when adding transfers - this location is also set in the Groups preference window tab.</p>
+            <p>Transmission allows you to group torrents by color labels. Groups can be assigned upon adding a transfer to the list by establishing rules in Preferences → Groups. Groups can be manually changed with Transfers → Group and by dragging transfers to different groups in the main window (when "Use Groups" is enabled in the View menu).</p>
+            <p>These groups can be used as sorting and filtering criteria. Add, remove, and modify groups in Preferences → Groups. Groups can also be used for choosing the data location when adding transfers - this location is also set in the Groups preference window tab.</p>
         </div>
 
         <div class="question">Where can I find more detailed information on my torrents?</div>
@@ -122,7 +122,7 @@
             <p>Yes, either upon opening a torrent, or once it has started. When you open a multi-file torrent, a detailed Open window will appear, allowing you to select specific files.</p>
             <p>For transfers which are already running, double click them to open the Inspector, and then click the 'Files' tab. Simply check the boxes next to the files you want to download (the default is all of them).</p>
             <p>You can even set a priority (high, normal, or low) to each file, if you want some to finish faster than others. To do so, use the selector that appears next to the checkboxes.</p>
-            <p>If the window doesn't appear when opening a torrent, ensure that "Display options window" is checked in Preferences &rarr; Transfers &rarr; Adding.</p>
+            <p>If the window doesn't appear when opening a torrent, ensure that "Display options window" is checked in Preferences → Transfers → Adding.</p>
         </div>
 
     </div><!-- questions-and-answers -->

--- a/macosx/TransmissionHelp/html/peers.html
+++ b/macosx/TransmissionHelp/html/peers.html
@@ -23,13 +23,13 @@
     <div class="pagetitle">
         <h1>What is encryption?</h1>
     </div>
-    <p>Transmission encrypts the connections it makes with other peers when necessary, using the RC4 cipher. The implementation is compatible with other clients such as Vuze and µTorrent. It is always enabled, however you can set Transmission (Preferences &rarr; Peers) to prefer encrypted peers or to ignore unencrypted peers completely.</p>
+    <p>Transmission encrypts the connections it makes with other peers when necessary, using the RC4 cipher. The implementation is compatible with other clients such as Vuze and µTorrent. It is always enabled, however you can set Transmission (Preferences → Peers) to prefer encrypted peers or to ignore unencrypted peers completely.</p>
     <p>Note that the latter option may make Transmission unconnectable in some swarms. The encryption feature does not mean your session is secure or anonymous, it is merely a way to avoid the traffic shaping measures some ISPs have implemented.</p>
     <p>
     <div class="pagetitle">
         <h1>What are 'connections'?</h1>
     </div>
-    <p><em>Global maximum connections</em> (Preferences &rarr; Peers) is the total number of peers that Transmission will connect to across all of your transfers. Connections per torrent can also be adjusted here, as well as in the Inspector.</p>
+    <p><em>Global maximum connections</em> (Preferences → Peers) is the total number of peers that Transmission will connect to across all of your transfers. Connections per torrent can also be adjusted here, as well as in the Inspector.</p>
     <p>It is recommended that these values are left at their default setting, as allowing too many connections will severely hinder web browsing and other online activities, as well as possibly crashing your router. Increase this value at your own risk!</p>
 
     <div class="taskbox">
@@ -43,7 +43,7 @@
     <div class="pagetitle">
         <h1>What is a blocklist?</h1>
     </div>
-    <p>Transmission can block specific peers by utilizing a blocklist. An internet address for a blocklist file containing a list of IP addresses can be entered (Preferences &rarr; Peers) and configured to auto-update weekly. Blocklists can also be manually added into ~/Library/Application Support/Transmission.</p>
+    <p>Transmission can block specific peers by utilizing a blocklist. An internet address for a blocklist file containing a list of IP addresses can be entered (Preferences → Peers) and configured to auto-update weekly. Blocklists can also be manually added into ~/Library/Application Support/Transmission.</p>
     <p>The internet address may be to a text file or compressed file. Most standard compression formats are supported, including ZIP.</p>
 </div>
 </body>

--- a/macosx/TransmissionHelp/html/pffirewall.html
+++ b/macosx/TransmissionHelp/html/pffirewall.html
@@ -19,7 +19,7 @@
     <p>If this doesn't happen, you can add Transmission to the firewall manually:</p>
     <div class="taskbox">
         <ol>
-            <li>Open System Prefs &rarr; Security &rarr; Firewall. Make sure "Set access for specific services and applications" is selected.</li>
+            <li>Open System Prefs → Security → Firewall. Make sure "Set access for specific services and applications" is selected.</li>
             <li>Click the "+" button and select Transmission from your Applications folder.</li>
             <li>Make sure the pull down menu is set to "Allow incoming connections".
         </ol>

--- a/macosx/TransmissionHelp/html/pfrouter.html
+++ b/macosx/TransmissionHelp/html/pfrouter.html
@@ -14,13 +14,13 @@
     <div class="pagetitle">
         <h1>Port Forwarding a Router</h1>
     </div>
-    <p>If you are using a router, it is probably OK to disable the macOS firewall, as you are already being protected by the router. To disable the firewall, open System Prefs &rarr; Security &rarr; Firewall. Click Stop.
+    <p>If you are using a router, it is probably OK to disable the macOS firewall, as you are already being protected by the router. To disable the firewall, open System Prefs → Security → Firewall. Click Stop.
 
     <p>To forward a port in your router manually:
 
     <div class="taskbox">
         <ol>
-            <li>Find out what your IP address is. You can find your computer's IP address by going to System Prefs &rarr; Network, double-clicking on your connection (for instance, Built-in Ethernet), and clicking the TCP/IP tab. It's probably something like 192.168.1.100, or 10.0.1.2.</li>
+            <li>Find out what your IP address is. You can find your computer's IP address by going to System Prefs → Network, double-clicking on your connection (for instance, Built-in Ethernet), and clicking the TCP/IP tab. It's probably something like 192.168.1.100, or 10.0.1.2.</li>
             <li>Open Transmission, go to preferences, and enter a number for the port. It is recommended you pick a random number between 49152 and 65535. Let's use 50001 for now. Then quit Transmission.</li>
             <li>Go into your router configuration screen. Normally this is done via your web browser using the address<a href="http://192.168.0.1">192.168.0.1</a> etc.
                 <br>Note: Apple's AirPort uses an application called 'AirPort Utility' to configure it.</li>
@@ -52,7 +52,7 @@
     </div>
     <div class="taskbox">
         <ol>
-            <li>Go to System Prefs &rarr; Network, double-click on your connection (for instance, Built-in Ethernet), and click the TCP/IP tab.
+            <li>Go to System Prefs → Network, double-click on your connection (for instance, Built-in Ethernet), and click the TCP/IP tab.
             <li>Write down the IP, Subnet Mask and Router addresses.
             <li>Go to your router 'status' page via your web browser (AirPort Admin Utility if you are using an AirPort BS), and write down the DNS Server addresses. Alternatively, you can enter your router's internal IP (e.g. 192.168.0.1). This is sometimes quicker, as it refers to the router instead of the server.
             <li>Then, return to the TCP/IP page in System Prefs.

--- a/macosx/TransmissionHelp/html/portforward.html
+++ b/macosx/TransmissionHelp/html/portforward.html
@@ -19,7 +19,7 @@
     <div class="taskbox">
         <ol>
             <li>Open Transmission.</li>
-            <li>Go to Preferences &rarr; Network, and check 'Automatically map port'.</li>
+            <li>Go to Preferences → Network, and check 'Automatically map port'.</li>
             <li>If you get a green dot and 'Port is Open' then you have successfully port forwarded!</li>
             <li>If you get a red dot and the message 'Port is closed', <a href="troubleshoot.html">click here</a>.</li>
         </ol>

--- a/macosx/TransmissionHelp/html/remote.html
+++ b/macosx/TransmissionHelp/html/remote.html
@@ -24,7 +24,7 @@
             <li>In the address bar, enter "http://localip:port/transmission/web/", where:</li>
             <ul>
                 <li><em>localip</em> is the IP address of the computer Transmission is running on.</li>
-                <li><em>port</em> is the port specified in Preferences &rarr; Remote.</li>
+                <li><em>port</em> is the port specified in Preferences → Remote.</li>
             </ul>
         </ol>
     </div>

--- a/macosx/TransmissionHelp/html/speed.html
+++ b/macosx/TransmissionHelp/html/speed.html
@@ -17,17 +17,17 @@
     <ol>
         <li>Make sure Transmission's <a href="portforward.html">port is forwarded</a>. Port forwarding makes it easier for others to connect to you, which therefore increases your speed.
             <div class="taskbox">
-                <p>If your router supports NAT-PMP, UPnP, or you have Apple AirPort, Transmission can do this automatically; just tick the checkbox in Preferences &rarr; Network.
+                <p>If your router supports NAT-PMP, UPnP, or you have Apple AirPort, Transmission can do this automatically; just tick the checkbox in Preferences → Network.
             </div>
         </li>
 
-        <li>Make sure you cap your upload speed, so that it isn't flooded. A good rule of thumb is about 60-70% of your maximum upload bandwidth. This can be adjusted in Preferences &rarr; Bandwidth, or in real time using the Action menu.
+        <li>Make sure you cap your upload speed, so that it isn't flooded. A good rule of thumb is about 60-70% of your maximum upload bandwidth. This can be adjusted in Preferences → Bandwidth, or in real time using the Action menu.
             <div class="taskbox">
                 <p>eg. If your upload connection is 256 Kilobits/sec, then you should cap it at 21 KB/sec ((<strong>256</strong> / 8) * 0.66 = <strong>21</strong>).
             </div>
         </li>
 
-        <li><a href="gettingstarted.html#queue">Queue</a> your transfers. Transmission's queue preferences are located in Transfers &rarr; Management.
+        <li><a href="gettingstarted.html#queue">Queue</a> your transfers. Transmission's queue preferences are located in Transfers → Management.
             <p>Remember, your download speed is proportional to how fast you upload. If there are many transfers running, then each transfer will only receive a small proportion of your upload bandwidth, reducing their respective download speeds.
                 To avoid spreading your upload too thinly, a good rule of thumb is to have at least 128 KBit/sec of upload bandwidth for every torrent you wish to run simultaneously.
 

--- a/macosx/TransmissionHelp/html/tracker.html
+++ b/macosx/TransmissionHelp/html/tracker.html
@@ -14,7 +14,7 @@
     <div class="pagetitle">
         <h1>Can I add and remove trackers in my torrents?</h1>
     </div>
-    <p>Yes. To add trackers to a currently running torrent, go to Inspector &rarr; Tracker, and click the plus button (+). To remove them, click minus button (-). Multiple trackers can also be added to torrent files you create. Each newly-added tracker will be placed in a new tier.
+    <p>Yes. To add trackers to a currently running torrent, go to Inspector → Tracker, and click the plus button (+). To remove them, click minus button (-). Multiple trackers can also be added to torrent files you create. Each newly-added tracker will be placed in a new tier.
     <p>
     <div class="pagetitle">
         <h1>What is 'Tier 1', 'Tier 2', etc?</h1>
@@ -24,7 +24,7 @@
     <div class="pagetitle">
         <h1>What does 'announce' mean?</h1>
     </div>
-    <p>When Transmission <em>announces</em>, it is updating its presence to the tracker and asking for more peers. This happens periodically, at the discretion of the tracker, however can be manually invoked via Transfers menu &rarr; Update Tracker.
+    <p>When Transmission <em>announces</em>, it is updating its presence to the tracker and asking for more peers. This happens periodically, at the discretion of the tracker, however can be manually invoked via Transfers menu → Update Tracker.
     <p>
     <div class="pagetitle">
         <h1>What does 'scrape' mean?</h1>

--- a/macosx/TransmissionHelp/html/usingt.html
+++ b/macosx/TransmissionHelp/html/usingt.html
@@ -17,14 +17,14 @@
     <ul>
         <li>Torrent files contain information about the actual file you want to download, and connect you to the swarm of peers sharing it.</li>
 
-        <li>Transmission can watch a certain folder (e.g. your Safari download folder) for torrent files and then open them automatically via Preferences &rarr; Transfers &rarr; General.</li>
+        <li>Transmission can watch a certain folder (e.g. your Safari download folder) for torrent files and then open them automatically via Preferences → Transfers → General.</li>
 
         <li>By default, Transmission deletes the original torrent file upon opening. If you remove a transfer, in order to resume it you will need to reopen the original torrent file in Transmission. Simply choose 'Save Torrent File As…' from the File menu before deletion to avoid having to download the torrent file again.</li>
 
-        <li>Once your download is complete, you can set a default ratio to automatically seed to, and then pause. This can be adjusted in Preferences &rarr; Transfers &rarr; Management, or in real time using the Action menu.</li>
+        <li>Once your download is complete, you can set a default ratio to automatically seed to, and then pause. This can be adjusted in Preferences → Transfers → Management, or in real time using the Action menu.</li>
 
         <li>Both seeding and downloading transfers can be queued, and Transmission can skip over stalled transfers, in order to maximise queuing efficiency.
-            Queuing can be configured in Preferences &rarr; Transfers &rarr; Management.</li>
+            Queuing can be configured in Preferences → Transfers → Management.</li>
     </ul>
 
 


### PR DESCRIPTION
Those are UTF-8 documents: no need to use HTML entities, as it makes it harder to read.