### PR TITLE
Avoiding "sec" as abbreviation

### DIFF
--- a/macosx/TransmissionHelp/html/speed.html
+++ b/macosx/TransmissionHelp/html/speed.html
@@ -23,16 +23,16 @@
 
         <li>Make sure you cap your upload speed, so that it isn't flooded. A good rule of thumb is about 60-70% of your maximum upload bandwidth. This can be adjusted in Preferences &rarr; Bandwidth, or in real time using the Action menu.
             <div class="taskbox">
-                <p>eg. If your upload connection is 256 Kilobits/sec, then you should cap it at 21 KB/sec ((<strong>256</strong> / 8) * 0.66 = <strong>21</strong>).
+                <p>eg. If your upload connection is 256 Kilobits/second, then you should cap it at 21 KB/s ((<strong>256</strong> / 8) * 0.66 = <strong>21</strong>).
             </div>
         </li>
 
         <li><a href="gettingstarted.html#queue">Queue</a> your transfers. Transmission's queue preferences are located in Transfers &rarr; Management.
             <p>Remember, your download speed is proportional to how fast you upload. If there are many transfers running, then each transfer will only receive a small proportion of your upload bandwidth, reducing their respective download speeds.
-                To avoid spreading your upload too thinly, a good rule of thumb is to have at least 128 KBit/sec of upload bandwidth for every torrent you wish to run simultaneously.
+                To avoid spreading your upload too thinly, a good rule of thumb is to have at least 128 KBit/s of upload bandwidth for every torrent you wish to run simultaneously.
 
             <div class="taskbox">
-                <p>eg. If your upload bandwidth is 256 KBit/sec, then you should only have two (<strong>256</strong>/128 = <strong>2</strong>) downloading transfers in the queue.
+                <p>eg. If your upload bandwidth is 256 KBit/s, then you should only have two (<strong>256</strong>/128 = <strong>2</strong>) downloading transfers in the queue.
             </div>
         </li>
     </ol>

--- a/macosx/TransmissionHelp/html/speed.html
+++ b/macosx/TransmissionHelp/html/speed.html
@@ -29,10 +29,10 @@
 
         <li><a href="gettingstarted.html#queue">Queue</a> your transfers. Transmission's queue preferences are located in Transfers &rarr; Management.
             <p>Remember, your download speed is proportional to how fast you upload. If there are many transfers running, then each transfer will only receive a small proportion of your upload bandwidth, reducing their respective download speeds.
-                To avoid spreading your upload too thinly, a good rule of thumb is to have at least 128 KBit/s of upload bandwidth for every torrent you wish to run simultaneously.
+                To avoid spreading your upload too thinly, a good rule of thumb is to have at least 128 Kb/s of upload bandwidth for every torrent you wish to run simultaneously.
 
             <div class="taskbox">
-                <p>eg. If your upload bandwidth is 256 KBit/s, then you should only have two (<strong>256</strong>/128 = <strong>2</strong>) downloading transfers in the queue.
+                <p>eg. If your upload bandwidth is 256 Kb/s, then you should only have two (<strong>256</strong>/128 = <strong>2</strong>) downloading transfers in the queue.
             </div>
         </li>
     </ol>

--- a/utils/transmission-remote.1
+++ b/utils/transmission-remote.1
@@ -371,12 +371,12 @@ Rename torrent root folder from "test1/examplefile.txt" to "test2/examplefile.tx
 .Bd -literal -offset indent
 $ transmission-remote -t1 --path test1 --rename test2
 .Ed
-Set download and upload limits to 400 kB/sec and 60 kB/sec:
+Set download and upload limits to 400 kB/s and 60 kB/s:
 .Bd -literal -offset indent
 $ transmission-remote \-d400 \-u60
 $ transmission-remote \-\-downlimit=400 \-\-uplimit=60
 .Ed
-Set alternate download and upload limits to 100 kB/sec and 20 kB/sec:
+Set alternate download and upload limits to 100 kB/s and 20 kB/s:
 .Bd -literal -offset indent
 $ transmission-remote \-asd100 \-asu20
 $ transmission-remote \-\-alt-speed-downlimit=100 \-\-alt-speed-uplimit=20


### PR DESCRIPTION
As discussed in #6739, "sec" is a Canadianism and should be avoided.

cc @killemov