### PR TITLE
refactor: harden idle_seconds

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -394,10 +394,10 @@ public:
         double ratio_limit = 2.0;
         size_t cache_size_mbytes = 4U;
         size_t download_queue_size = 5U;
-        size_t idle_seeding_limit_minutes = 30U;
+        time_t idle_seeding_limit_minutes = 30U;
         size_t peer_limit_global = TR_DEFAULT_PEER_LIMIT_GLOBAL;
         size_t peer_limit_per_torrent = TR_DEFAULT_PEER_LIMIT_TORRENT;
-        size_t queue_stalled_minutes = 30U;
+        time_t queue_stalled_minutes = 30U;
         size_t seed_queue_size = 10U;
         size_t speed_limit_down = 100U;
         size_t speed_limit_up = 100U;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -394,10 +394,10 @@ public:
         double ratio_limit = 2.0;
         size_t cache_size_mbytes = 4U;
         size_t download_queue_size = 5U;
-        time_t idle_seeding_limit_minutes = 30U;
+        size_t idle_seeding_limit_minutes = 30U;
         size_t peer_limit_global = TR_DEFAULT_PEER_LIMIT_GLOBAL;
         size_t peer_limit_per_torrent = TR_DEFAULT_PEER_LIMIT_TORRENT;
-        time_t queue_stalled_minutes = 30U;
+        size_t queue_stalled_minutes = 30U;
         size_t seed_queue_size = 10U;
         size_t speed_limit_down = 100U;
         size_t speed_limit_up = 100U;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1285,7 +1285,7 @@ bool tr_torrentCanManualUpdate(tr_torrent const* tor)
 
 tr_stat tr_torrent::stats() const
 {
-    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<time_t> idle_secs)
+    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<size_t> idle_secs)
     {
         return tor->session->queueStalledEnabled() && idle_secs > tor->session->queueStalledMinutes() * 60U;
     };
@@ -1303,7 +1303,7 @@ tr_stat tr_torrent::stats() const
     stats.activity = activity;
     stats.error = this->error().error_type();
     stats.queuePosition = queue_position();
-    stats.idleSecs = idle_seconds ? *idle_seconds : -1;
+    stats.idleSecs = idle_seconds ? static_cast<time_t>(*idle_seconds) : -1;
     stats.isStalled = IsStalled(this, idle_seconds);
     stats.errorString = this->error().errmsg().c_str();
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -446,7 +446,7 @@ void tr_torrent::stop_if_seed_limit_reached()
         session->onRatioLimitHit(this);
     }
     /* if we're seeding and reach our inactivity limit, stop the torrent */
-    else if (auto const secs_left = idle_seconds_left(tr_time()); secs_left && *secs_left == 0U)
+    else if (auto const secs_left = idle_seconds_left(tr_time()); secs_left && *secs_left <= 0U)
     {
         tr_logAddInfoTor(this, _("Seeding idle limit reached; pausing torrent"));
 
@@ -1285,7 +1285,7 @@ bool tr_torrentCanManualUpdate(tr_torrent const* tor)
 
 tr_stat tr_torrent::stats() const
 {
-    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<size_t> idle_secs)
+    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<time_t> idle_secs)
     {
         return tor->session->queueStalledEnabled() && idle_secs > tor->session->queueStalledMinutes() * 60U;
     };
@@ -1303,7 +1303,7 @@ tr_stat tr_torrent::stats() const
     stats.activity = activity;
     stats.error = this->error().error_type();
     stats.queuePosition = queue_position();
-    stats.idleSecs = idle_seconds ? static_cast<time_t>(*idle_seconds) : -1;
+    stats.idleSecs = idle_seconds ? *idle_seconds : -1;
     stats.isStalled = IsStalled(this, idle_seconds);
     stats.errorString = this->error().errmsg().c_str();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -818,7 +818,7 @@ struct tr_torrent
         return idle_limit_minutes_;
     }
 
-    [[nodiscard]] constexpr std::optional<time_t> idle_seconds(time_t now) const noexcept
+    [[nodiscard]] constexpr std::optional<size_t> idle_seconds(time_t now) const noexcept
     {
         auto const activity = this->activity();
 
@@ -827,7 +827,7 @@ struct tr_torrent
             if (auto const latest = std::max(date_started_, date_active_); latest != 0)
             {
                 TR_ASSERT(now >= latest);
-                return std::max(now - latest, time_t{ 0 });
+                return static_cast<size_t>(std::max(now - latest, time_t{ 0 }));
             }
         }
 
@@ -1128,7 +1128,7 @@ private:
         return {};
     }
 
-    [[nodiscard]] constexpr std::optional<time_t> idle_seconds_left(time_t now) const noexcept
+    [[nodiscard]] constexpr std::optional<size_t> idle_seconds_left(time_t now) const noexcept
     {
         auto const idle_limit_minutes = effective_idle_limit_minutes();
         if (!idle_limit_minutes)
@@ -1142,7 +1142,7 @@ private:
             return {};
         }
 
-        auto const idle_limit_seconds = time_t{ *idle_limit_minutes } * 60U;
+        auto const idle_limit_seconds = size_t{ *idle_limit_minutes } * 60U;
         return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : 0U;
     }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -818,7 +818,7 @@ struct tr_torrent
         return idle_limit_minutes_;
     }
 
-    [[nodiscard]] constexpr std::optional<size_t> idle_seconds(time_t now) const noexcept
+    [[nodiscard]] constexpr std::optional<time_t> idle_seconds(time_t now) const noexcept
     {
         auto const activity = this->activity();
 
@@ -827,7 +827,7 @@ struct tr_torrent
             if (auto const latest = std::max(date_started_, date_active_); latest != 0)
             {
                 TR_ASSERT(now >= latest);
-                return now - latest;
+                return std::max(now - latest, time_t{ 0 });
             }
         }
 
@@ -1128,7 +1128,7 @@ private:
         return {};
     }
 
-    [[nodiscard]] constexpr std::optional<size_t> idle_seconds_left(time_t now) const noexcept
+    [[nodiscard]] constexpr std::optional<time_t> idle_seconds_left(time_t now) const noexcept
     {
         auto const idle_limit_minutes = effective_idle_limit_minutes();
         if (!idle_limit_minutes)
@@ -1142,7 +1142,7 @@ private:
             return {};
         }
 
-        auto const idle_limit_seconds = size_t{ *idle_limit_minutes } * 60U;
+        auto const idle_limit_seconds = time_t{ *idle_limit_minutes } * 60U;
         return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : 0U;
     }
 


### PR DESCRIPTION
That change wouldn't fix the root cause of #6833, but it would avoid further issues in release by preventing returning a negative idle_seconds.

I see for instance that we read `date_active_` from a resume file, so that could be a scenario where date_active_ is above now. Or the system clock was modified.