### PR TITLE
feat: improve GTK torrent piece size picker

### DIFF
--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -409,7 +409,7 @@ void MakeDialog::Impl::configurePieceSizeComboBox(uint32_t piece_size)
     auto active_index = PieceSizeStart;
     auto options = std::vector<std::pair<Glib::ustring, int>>();
 
-    for (std::size_t i = PieceSizeStart; i <= PieceSizeEnd; i++)
+    for (int i = PieceSizeStart; i <= PieceSizeEnd; i++)
     {
         std::size_t size = std::pow(2, i);
         options.emplace_back(Memory{ size, MemoryUnits::Bytes }.to_string(), i);

--- a/gtk/ui/gtk3/MakeDialog.ui
+++ b/gtk/ui/gtk3/MakeDialog.ui
@@ -192,7 +192,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Piece size:</property>
                     <property name="use-underline">True</property>
-                    <property name="mnemonic-widget">piece_size_scale</property>
+                    <property name="mnemonic-widget">piece_size_combo</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
@@ -201,13 +201,10 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkScale" id="piece_size_scale">
+                  <object class="GtkComboBox" id="piece_size_combo">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="hexpand">True</property>
-                    <property name="digits">0</property>
-                    <property name="draw-value">False</property>
-                    <property name="value-pos">left</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>

--- a/gtk/ui/gtk4/MakeDialog.ui
+++ b/gtk/ui/gtk4/MakeDialog.ui
@@ -114,7 +114,7 @@
                   <object class="GtkLabel" id="piece_size_label">
                     <property name="label" translatable="1">Piece size:</property>
                     <property name="use-underline">1</property>
-                    <property name="mnemonic-widget">piece_size_scale</property>
+                    <property name="mnemonic-widget">piece_size_combo</property>
                     <property name="xalign">0</property>
                     <layout>
                       <property name="column">0</property>
@@ -123,11 +123,9 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkScale" id="piece_size_scale">
+                  <object class="GtkComboBox" id="piece_size_combo">
                     <property name="focusable">1</property>
                     <property name="hexpand">1</property>
-                    <property name="digits">0</property>
-                    <property name="value-pos">left</property>
                     <layout>
                       <property name="column">1</property>
                       <property name="row">4</property>


### PR DESCRIPTION
## Description
Replaced GtkScale with GtkComboBox. The scale was not really working as expected, it was impossible to pick a certain piece size due to implementation issues. This PR replaces it with GtkComboBox, like in qbit. 
Also, instead of hiding it until the source is selected, I made it inactive. I think it looks a bit better.

Fixes https://github.com/transmission/transmission/issues/5617.
Also, enabled support for up to 256 MiB piece sizes, fixes https://github.com/transmission/transmission/issues/5955.

## Some screenshots
### Before:
![before](https://github.com/transmission/transmission/assets/35456194/9b06844d-64d0-4a47-922e-aa7a9ae0b903)
### Now:
![now1](https://github.com/transmission/transmission/assets/35456194/892832e8-3d6f-490f-ba65-0e6cf19bd5a3)
![now2](https://github.com/transmission/transmission/assets/35456194/db040552-3e9b-4034-9f86-967ff316256f)
