### PR TITLE
build error fix: #6842

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -23,6 +23,10 @@
 #include <sys/stat.h>
 #include <unistd.h> /* lseek(), write(), ftruncate(), pread(), pwrite(), pathconf(), etc */
 
+#ifdef HAVE_FLOCK
+#include <sys/file.h> /* flock() */
+#endif
+
 #ifdef HAVE_XFS_XFS_H
 #include <sys/file.h> /* flock() */
 #include <xfs/xfs.h>


### PR DESCRIPTION
fix compile error with gcc 8.2: no matching function for call to ‘flock::flock(tr_sys_file_t&, const int&)'
see detail: #6842