### PR TITLE
fix: store seconds downloading/seeding when stopping torrent

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -758,6 +758,7 @@ void tr_torrent::stop_now()
 
     auto const now = tr_time();
     seconds_downloading_before_current_start_ = seconds_downloading(now);
+    seconds_seeding_before_current_start_ = seconds_seeding(now);
 
     is_running_ = false;
     is_stopping_ = false;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -756,6 +756,9 @@ void tr_torrent::stop_now()
     TR_ASSERT(session->am_in_session_thread());
     auto const lock = unique_lock();
 
+    auto const now = tr_time();
+    seconds_downloading_before_current_start_ = seconds_downloading(now);
+
     is_running_ = false;
     is_stopping_ = false;
     mark_changed();


### PR DESCRIPTION
Fixes #6528.
Regression from #4393.

`tr_torrent::seconds_downloading_before_current_start_` and `tr_torrent::seconds_seeding_before_current_start_` needs to be updated when the torrent is stopped, otherwise these stats will be reset.

Notes: Fixed `4.0.0` bug where `secondsDownloading` and `secondsSeeding` will be reset when stopping the torrent.