### PR TITLE
fix: escape single file torrent name

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -522,7 +522,7 @@ private:
         // In the single file case, length maps to the length of the file in bytes.
         if (tm_.file_count() == 0 && length_ != 0 && !std::empty(tm_.name_))
         {
-            tm_.files_.add(tm_.name_, length_);
+            tm_.files_.add(tr_torrent_files::makeSubpathPortable(tm_.name_), length_);
         }
 
         if (auto const has_metainfo = tm_.info_dict_size() != 0U; has_metainfo)


### PR DESCRIPTION
Fixes #6799.
Regression from #2542.

Since the regression PR, Transmission does not sanitize the filename for single-file torrents.

Notes: Fixed `4.0.0` bug where the filename for single-file torrents aren't sanitized.

P.S. `tr_torrent_files::makeSubpathPortable()` doesn't seem like an appropriate name for what it currently does, so I'll be making another PR for it.