### PR TITLE
feat: display seed percentage in progressbar

### DIFF
--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -50,6 +50,13 @@ std::optional<double> Torrent::getSeedRatioLimit() const
     return {};
 }
 
+double Torrent::seedRatioPercentDone() const
+{
+    auto const r = ratio();
+    auto const g = getSeedRatioLimit().value_or(r);
+    return r > 0.0 && g > 0.0 ? r / g : 0.0;
+}
+
 bool Torrent::includesTracker(QString const& sitename) const
 {
     return std::binary_search(std::begin(sitenames_), std::end(sitenames_), sitename);

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -320,19 +320,11 @@ public:
         return s ? static_cast<double>(s - l) / static_cast<double>(s) : 0.0;
     }
 
-    [[nodiscard]] constexpr double seedRatioPercentDone() const noexcept
-    {
-        auto const r = ratio();
-        auto const g = getSeedRatioLimit();
-        return static_cast<double>(r) / static_cast<double>(g.value_or(r));
-    }
+    double seedRatioPercentDone() const;
 
     [[nodiscard]] constexpr double activityPercentDone() const noexcept
     {
-        if (isDone())
-            return seedRatioPercentDone();
-        else
-            return percentDone();
+        return isDone() ? seedRatioPercentDone() : percentDone();
     }
 
     [[nodiscard]] constexpr auto failedEver() const noexcept

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -320,6 +320,21 @@ public:
         return s ? static_cast<double>(s - l) / static_cast<double>(s) : 0.0;
     }
 
+    [[nodiscard]] constexpr double seedRatioPercentDone() const noexcept
+    {
+        auto const r = ratio();
+        auto const g = getSeedRatioLimit();
+        return static_cast<double>(r) / static_cast<double>(g.value_or(r));
+    }
+
+    [[nodiscard]] constexpr double activityPercentDone() const noexcept
+    {
+        if (isDone())
+            return seedRatioPercentDone();
+        else
+            return percentDone();
+    }
+
     [[nodiscard]] constexpr auto failedEver() const noexcept
     {
         return failed_ever_;

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -267,7 +267,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
 
     progress_bar_style_.state = progress_bar_state;
     progress_bar_style_.text = QStringLiteral("%1%").arg(
-        static_cast<int>(tr_truncd(100.0 * (tor.isSeeding() ? tor.ratio() / *tor.getSeedRatioLimit() : tor.percentDone()), 0)));
+        static_cast<int>(tr_truncd(100.0 * (tor.isDone() ? tor.ratio() / *tor.getSeedRatioLimit() : tor.percentDone()), 0)));
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -266,8 +266,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     }
 
     progress_bar_style_.state = progress_bar_state;
-    progress_bar_style_.text = QStringLiteral("%1%").arg(
-        static_cast<int>(tr_truncd(100.0 * (tor.isDone() ? tor.ratio() / *tor.getSeedRatioLimit() : tor.percentDone()), 0)));
+    progress_bar_style_.text = QStringLiteral("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.activityPercentDone(), 0)));
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -266,7 +266,8 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     }
 
     progress_bar_style_.state = progress_bar_state;
-    progress_bar_style_.text = QStringLiteral("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
+    progress_bar_style_.text = QStringLiteral("%1%").arg(
+        static_cast<int>(tr_truncd(100.0 * (tor.isSeeding() ? tor.ratio() / *tor.getSeedRatioLimit() : tor.percentDone()), 0)));
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);


### PR DESCRIPTION
fixes #6851

i think the calculation for calculating progress (irrelevant of download or seed) should be abstracted into the existing api and should be integrated into places like [here](https://github.com/transmission/transmission/blob/main/qt/TorrentDelegate.cc#L467). im not sure of the best way to go about this.