### PR TITLE
fix: cert-err58 warning in GTK client

### DIFF
--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -55,12 +55,12 @@ namespace
 {
 
 #if !defined(TR_SYS_TRAY_IMPL_NONE)
-auto const TrayIconName = Glib::ustring("transmission-tray-icon"s);
-auto const AppIconName = Glib::ustring("transmission"s);
+char const* const TrayIconName = "transmission-tray-icon";
+char const* const AppIconName = "transmission";
 #endif
 
 #if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
-auto const AppName = Glib::ustring("transmission-gtk"s);
+char const* const AppName = "transmission-gtk";
 #endif
 
 } // namespace
@@ -138,23 +138,11 @@ namespace
 
 Glib::ustring getIconName()
 {
-    Glib::ustring icon_name;
-
     // if the tray's icon is a 48x48 file, use it.
     // otherwise, use the fallback builtin icon.
-    if (auto theme = Gtk::IconTheme::get_default(); !theme->has_icon(TrayIconName))
-    {
-        icon_name = AppIconName;
-    }
-    else
-    {
-        auto const icon_info = theme->lookup_icon(TrayIconName, 48, Gtk::ICON_LOOKUP_USE_BUILTIN);
-        bool const icon_is_builtin = icon_info.get_filename().empty();
 
-        icon_name = icon_is_builtin ? AppIconName : TrayIconName;
-    }
-
-    return icon_name;
+    auto const icon = Gtk::IconTheme::get_default()->lookup_icon(TrayIconName, 48, Gtk::ICON_LOOKUP_USE_BUILTIN);
+    return icon && !icon.get_filename().empty() ? TrayIconName : AppIconName;
 }
 
 #endif
@@ -199,7 +187,7 @@ SystemTrayIcon::Impl::Impl([[maybe_unused]] Gtk::Window& main_window, Glib::RefP
 #endif
 
 #if defined(TR_SYS_TRAY_IMPL_APPINDICATOR)
-    indicator_ = app_indicator_new(AppName.c_str(), icon_name.c_str(), APP_INDICATOR_CATEGORY_SYSTEM_SERVICES);
+    indicator_ = app_indicator_new(AppName, icon_name.c_str(), APP_INDICATOR_CATEGORY_SYSTEM_SERVICES);
     app_indicator_set_status(indicator_, APP_INDICATOR_STATUS_ACTIVE);
     app_indicator_set_menu(indicator_, Glib::unwrap(menu_));
     app_indicator_set_title(indicator_, Glib::get_application_name().c_str());


### PR DESCRIPTION
Fix these `cert-err58-cpp` warnings:


> [95/150] Building CXX object gtk/CMakeFiles/transmission-gtk.dir/SystemTrayIcon.cc.o
/home/charles/src/transmission/gtk/SystemTrayIcon.cc:58:12: warning: initialization of 'TrayIconName' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp]
auto const TrayIconName = Glib::ustring("transmission-tray-icon"s);
           ^
/usr/include/glibmm-2.4/glibmm/ustring.h:403:14: note: possibly throwing constructor declared here
  GLIBMM_API ustring(std::string&& src);
             ^
/home/charles/src/transmission/gtk/SystemTrayIcon.cc:59:12: warning: initialization of 'AppIconName' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp]
auto const AppIconName = Glib::ustring("transmission"s);
           ^
/usr/include/glibmm-2.4/glibmm/ustring.h:403:14: note: possibly throwing constructor declared here
  GLIBMM_API ustring(std::string&& src);
             ^
/home/charles/src/transmission/gtk/SystemTrayIcon.cc:63:12: warning: initialization of 'AppName' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp]
auto const AppName = Glib::ustring("transmission-gtk"s);
           ^
/usr/include/glibmm-2.4/glibmm/ustring.h:403:14: note: possibly throwing constructor declared here
  GLIBMM_API ustring(std::string&& src);
             ^
