### PR TITLE
feat: use requestAnimationFrame for web page refresh interval

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -373,11 +373,24 @@ export class Transmission extends EventTarget {
         break;
 
       case Prefs.RefreshRate: {
-        clearInterval(this.refreshTorrentsInterval);
+        clearTimeout(this.refreshTimeoutId);
         const callback = this.refreshTorrents.bind(this);
         const pref = this.prefs.refresh_rate_sec;
         const msec = pref > 0 ? pref * 1000 : 1000;
-        this.refreshTorrentsInterval = setInterval(callback, msec);
+
+        const refreshTorrentsInterval = () => {
+          callback();
+          this.refreshTimeoutId = setTimeout(() => {
+            this.refreshTimeoutId = null;
+            requestAnimationFrame(() => {
+              if (!this.refreshTimeoutId) {
+                refreshTorrentsInterval();
+              }
+            });
+          }, msec);
+        };
+
+        refreshTorrentsInterval();
         break;
       }
 


### PR DESCRIPTION
- `setInterval` -> `requestAnimationFrame` to allow pausing the UI in background.

Notes: Added support pausing the UI in background.