### PR TITLE
fix: reset wishlist when stopping torrent

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -639,6 +639,7 @@ private:
 
         is_running = false;
         remove_all_peers();
+        wishlist.reset();
         for (auto& [sockaddr, peer_info] : connectable_pool)
         {
             peer_info->destroy_handshake();


### PR DESCRIPTION
This is needed because if the torrent is stopped to be verified, the pieces we have may change, and the wishlist will need to be re-calculated from scatch.