### PR TITLE
fix: update partial file suffix after verifying torrent

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1625,7 +1625,7 @@ void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, 
 {
     auto const had_piece = tor_->has_piece(piece);
 
-    if (has_piece || had_piece)
+    if (has_piece != had_piece)
     {
         tor_->set_has_piece(piece, has_piece);
         tor_->set_dirty();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2165,7 +2165,7 @@ void tr_torrent::on_piece_completed(tr_piece_index_t const piece)
     // if this piece completes any file, invoke the fileCompleted func for it
     for (auto [file, file_end] = fpm_.file_span_for_piece(piece); file < file_end; ++file)
     {
-        if (completion_.has_blocks(block_span_for_file(file)))
+        if (has_file(file))
         {
             on_file_completed(file);
         }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1254,6 +1254,8 @@ private:
     void do_magnet_idle_work();
     [[nodiscard]] bool use_new_metainfo(tr_error* error);
 
+    void update_file_path(tr_file_index_t file, std::optional<bool> has_file) const;
+
     void set_location_in_session_thread(std::string_view path, bool move_from_old_path, int volatile* setme_state);
 
     void rename_path_in_session_thread(

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -325,6 +325,11 @@ struct tr_torrent
         return completion_.has_none();
     }
 
+    [[nodiscard]] auto has_file(tr_file_index_t file) const
+    {
+        return completion_.has_blocks(block_span_for_file(file));
+    }
+
     [[nodiscard]] auto has_piece(tr_piece_index_t piece) const
     {
         return completion_.has_piece(piece);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -372,7 +372,7 @@ struct tr_torrent
 
     void amount_done_bins(float* tab, int n_tabs) const
     {
-        return completion_.amount_done(tab, n_tabs);
+        completion_.amount_done(tab, n_tabs);
     }
 
     /// FILE <-> PIECE

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -56,6 +56,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
 
     // init an incomplete torrent.
     // the test zero_torrent will be missing its first piece.
+    tr_sessionSetIncompleteFileNamingEnabled(session_, true);
     auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
     auto path = tr_pathbuf{};
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -449,6 +449,8 @@ TEST_F(RenameTest, partialFile)
     ****  create our test torrent with an incomplete .part file
     ***/
 
+    tr_sessionSetIncompleteFileNamingEnabled(session_, true);
+
     auto* tor = zeroTorrentInit(ZeroTorrentState::Partial);
     EXPECT_EQ(TotalSize, tor->total_size());
     EXPECT_EQ(PieceSize, tor->piece_size());


### PR DESCRIPTION
Fixes #690.

Notes: Partial file suffixes will now be updated after torrent verification.