### PR TITLE
correct "Queue for download" last activity

### DIFF
--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -766,7 +766,7 @@ void DetailsDialog::refreshUI()
 
         auto const seconds = static_cast<int>(std::difftime(now, latest));
 
-        if (seconds < 0 || static_cast<int>(std::difftime(seconds, std::time(0))) == 0)
+        if (latest == 0)
         {
             string = none;
         }

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -766,7 +766,7 @@ void DetailsDialog::refreshUI()
 
         auto const seconds = static_cast<int>(std::difftime(now, latest));
 
-        if (seconds < 0)
+        if (seconds < 0 || static_cast<int>(std::difftime(seconds, std::time(0))) == 0)
         {
             string = none;
         }


### PR DESCRIPTION
fixes https://github.com/transmission/transmission/issues/6859

doesn't display last activity if there was no last activity (if the torrent started in a paused state)