### PR TITLE
libtransmission: fix copyright header generation

### DIFF
--- a/libtransmission/mime-types.h
+++ b/libtransmission/mime-types.h
@@ -1,3 +1,6 @@
+// This file was generated with libtransmission/mime-types.js
+// DO NOT EDIT MANUALLY
+
 // This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.

--- a/libtransmission/mime-types.js
+++ b/libtransmission/mime-types.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 const copyright =
-`// This file Copyright © 2021-${new Date().getFullYear()} Mnemosyne LLC.
+`// This file was generated with libtransmission/mime-types.js
+// DO NOT EDIT MANUALLY
+
+// This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.`;


### PR DESCRIPTION
This is related to #4850 since libtransmission/mime-types.js generates libtransmission/mime-types.h and puts it there. Also add a note that the file is automatically generated for good measure.