### PR TITLE
fix: limit number of bad pieces to accept from a webseed

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -231,9 +231,6 @@ struct tr_peer
     // whether or not this peer sent us any given block
     tr_bitfield blame;
 
-    // whether or not we should free this peer soon.
-    bool do_purge = false;
-
     // how many bad pieces this piece has contributed to
     uint8_t strikes = 0;
 

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -215,6 +215,8 @@ struct tr_peer
     {
     }
 
+    virtual void ban() = 0;
+
     tr_session* const session;
 
     tr_swarm* const swarm;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -735,9 +735,7 @@ private:
 
     void on_got_bad_piece(tr_piece_index_t piece)
     {
-        auto const byte_count = tor->piece_size(piece);
-
-        for (auto* const peer : peers)
+        auto const maybe_add_strike = [this, piece](tr_peer* const peer)
         {
             if (peer->blame.test(piece))
             {
@@ -750,6 +748,18 @@ private:
                         peer->strikes + 1));
                 add_strike(peer);
             }
+        };
+
+        auto const byte_count = tor->piece_size(piece);
+
+        for (auto* const peer : peers)
+        {
+            maybe_add_strike(peer);
+        }
+
+        for (auto& webseed : webseeds)
+        {
+            maybe_add_strike(webseed.get());
         }
 
         tr_announcerAddBytes(tor, TR_ANN_CORRUPT, byte_count);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -791,6 +791,7 @@ private:
                 auto const loc = tor->piece_loc(event.pieceIndex, event.offset);
                 s->cancel_all_requests_for_block(loc.block, peer);
                 peer->blocks_sent_to_client.add(tr_time(), 1);
+                peer->blame.set(loc.piece);
                 tor->on_block_received(loc.block);
                 s->got_block.emit(tor, event.pieceIndex, loc.block);
             }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -619,7 +619,7 @@ private:
         stats.active_webseed_count = 0;
     }
 
-    void add_strike(tr_peerMsgs* peer) const
+    void add_strike(tr_peer* peer) const
     {
         tr_logAddTraceSwarm(
             this,
@@ -627,7 +627,7 @@ private:
 
         if (++peer->strikes >= MaxBadPiecesPerPeer)
         {
-            peer->peer_info->ban();
+            peer->ban();
             peer->do_purge = true;
             tr_logAddTraceSwarm(this, fmt::format("banning peer {}", peer->display_name()));
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1152,7 +1152,7 @@ private:
 tr_peer::tr_peer(tr_torrent const& tor)
     : session{ tor.session }
     , swarm{ tor.swarm }
-    , blame{ tor.block_count() }
+    , blame{ tor.piece_count() }
 {
 }
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -397,6 +397,11 @@ public:
 
     // ---
 
+    void ban() override
+    {
+        peer_info->ban();
+    }
+
     void on_torrent_got_metainfo() noexcept override
     {
         update_active();

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1682,7 +1682,6 @@ int tr_peerMsgsImpl::client_got_block(std::unique_ptr<Cache::BlockData> block_da
         return err;
     }
 
-    blame.set(loc.piece);
     publish(tr_peer_event::GotBlock(tor_.block_info(), block));
 
     return 0;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -400,6 +400,7 @@ public:
     void ban() override
     {
         peer_info->ban();
+        disconnect_soon();
     }
 
     void on_torrent_got_metainfo() noexcept override

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -95,6 +95,16 @@ public:
         return is_active_[direction];
     }
 
+    [[nodiscard]] constexpr auto is_disconnecting() const noexcept
+    {
+        return is_disconnecting_;
+    }
+
+    constexpr void disconnect_soon() noexcept
+    {
+        is_disconnecting_ = true;
+    }
+
     [[nodiscard]] virtual tr_socket_address socket_address() const = 0;
 
     virtual void set_choke(bool peer_is_choked) = 0;
@@ -172,6 +182,9 @@ private:
 
     // whether or not the peer has indicated it will download from us
     bool peer_is_interested_ = false;
+
+    // whether or not we should free this peer soon.
+    bool is_disconnecting_ = false;
 };
 
 /* @} */


### PR DESCRIPTION
Fixes #267.

Notes: Limit the number of bad pieces to accept from a webseed before banning it.