### PR TITLE
fix: don't call `tr_logAddTraceIo` before `tr_peerIo::set_socket()`

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -525,7 +525,7 @@ std::string_view tr_address::display_name(char* out, size_t outlen) const
 
 [[nodiscard]] std::string tr_address::display_name() const
 {
-    auto buf = std::array<char, std::max(INET_ADDRSTRLEN, INET6_ADDRSTRLEN) /* just in case */>{};
+    auto buf = std::array<char, std::max(INET_ADDRSTRLEN, INET6_ADDRSTRLEN)>{};
     return std::string{ display_name(std::data(buf), std::size(buf)) };
 }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -525,7 +525,7 @@ std::string_view tr_address::display_name(char* out, size_t outlen) const
 
 [[nodiscard]] std::string tr_address::display_name() const
 {
-    auto buf = std::array<char, INET6_ADDRSTRLEN>{};
+    auto buf = std::array<char, std::max(INET_ADDRSTRLEN, INET6_ADDRSTRLEN) /* just in case */>{};
     return std::string{ display_name(std::data(buf), std::size(buf)) };
 }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -516,6 +516,10 @@ std::optional<tr_address> tr_address::from_string(std::string_view address_sv)
 std::string_view tr_address::display_name(char* out, size_t outlen) const
 {
     TR_ASSERT(is_valid());
+    if (!is_valid())
+    {
+        return "Invalid address"sv;
+    }
     return evutil_inet_ntop(tr_ip_protocol_to_af(type), &addr, out, outlen);
 }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -516,11 +516,11 @@ std::optional<tr_address> tr_address::from_string(std::string_view address_sv)
 std::string_view tr_address::display_name(char* out, size_t outlen) const
 {
     TR_ASSERT(is_valid());
-    if (!is_valid())
+    if (auto* name = evutil_inet_ntop(tr_ip_protocol_to_af(type), &addr, out, outlen))
     {
-        return "Invalid address"sv;
+        return name;
     }
-    return evutil_inet_ntop(tr_ip_protocol_to_af(type), &addr, out, outlen);
+    return "Invalid address"sv;
 }
 
 [[nodiscard]] std::string tr_address::display_name() const

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -100,7 +100,6 @@ std::shared_ptr<tr_peerIo> tr_peerIo::create(
 
     auto io = std::make_shared<tr_peerIo>(session, info_hash, is_incoming, is_seed, parent);
     io->bandwidth().set_peer(io);
-    tr_logAddTraceIo(io, fmt::format("bandwidth is {}; its parent is {}", fmt::ptr(&io->bandwidth()), fmt::ptr(parent)));
     return io;
 }
 
@@ -110,6 +109,9 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_incoming(tr_session* session, tr_bandw
 
     auto peer_io = tr_peerIo::create(session, parent, nullptr, true, false);
     peer_io->set_socket(std::move(socket));
+    tr_logAddTraceIo(
+        peer_io,
+        fmt::format("bandwidth is {}; its parent is {}", fmt::ptr(&peer_io->bandwidth()), fmt::ptr(parent)));
     return peer_io;
 }
 
@@ -140,6 +142,9 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
                   auto* const sock = utp_create_socket(session->utp_context);
                   utp_set_userdata(sock, peer_io.get());
                   peer_io->set_socket(tr_peer_socket{ socket_address, sock });
+                  tr_logAddTraceIo(
+                      peer_io,
+                      fmt::format("bandwidth is {}; its parent is {}", fmt::ptr(&peer_io->bandwidth()), fmt::ptr(parent)));
 
                   auto const [ss, sslen] = socket_address.to_sockaddr();
                   if (utp_connect(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) == 0)
@@ -158,6 +163,9 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
                   if (auto sock = tr_netOpenPeerSocket(session, socket_address, is_seed); sock.is_valid())
                   {
                       peer_io->set_socket(std::move(sock));
+                      tr_logAddTraceIo(
+                          peer_io,
+                          fmt::format("bandwidth is {}; its parent is {}", fmt::ptr(&peer_io->bandwidth()), fmt::ptr(parent)));
                       return true;
                   }
               }


### PR DESCRIPTION
Fixes #6880.

Before `tr_peerIo::set_socket()` is called on a new `tr_peerIo` object, the underlying socket address object is not yet well defined (maybe causing `inet_ntop()` to return a nullptr? idk), so `tr_peerIo::display_name()` may cause problems.