### PR TITLE
chore: update older macos build verification workflow to macos-12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -334,7 +334,7 @@ jobs:
   macos-12:
     runs-on: macos-12
     needs: [ what-to-make ]
-    if: false  # ${{ needs.what-to-make.outputs.make-mac == 'true' }}
+    if: ${{ needs.what-to-make.outputs.make-mac == 'true' }}
     steps:
       - name: Show Configuration
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -330,9 +330,9 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  # Only verify build support on old macOS
-  macos-11:
-    runs-on: macos-11
+  # Only verify build support on older macOS and SDK
+  macos-12:
+    runs-on: macos-12
     needs: [ what-to-make ]
     if: false  # ${{ needs.what-to-make.outputs.make-mac == 'true' }}
     steps:
@@ -349,6 +349,9 @@ jobs:
         with:
           path: src
           submodules: recursive
+      - name: Set Xcode to 13.2.1
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: Configure
         run: |
           cmake \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -361,8 +361,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_OSX_ARCHITECTURES='x86_64' \
-            -DCMAKE_PREFIX_PATH=`brew --prefix`/opt/qt \
+            -DENABLE_GTK=OFF \
             -DENABLE_MAC=${{ (needs.what-to-make.outputs.make-mac == 'true') && 'ON' || 'OFF' }}  \
+            -DENABLE_QT=OFF \
             -DENABLE_TESTS=OFF \
             -DENABLE_WERROR=ON \
             -DRUN_CLANG_TIDY=OFF
@@ -611,7 +612,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
-            -DCMAKE_PREFIX_PATH=`brew --prefix`/opt/qt \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_GTK=OFF \


### PR DESCRIPTION
Manually set Xcode to the version was used in macos-11 runner.

See:
https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode