### PR TITLE
Remove warning "don't cut off end"

### DIFF
--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -323,7 +323,6 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
     }
 }
 
-#warning don't cut off end
 - (CGFloat)tableView:(NSTableView*)tableView heightOfRow:(NSInteger)row
 {
     NSString* message = self.fDisplayedMessages[row][@"Message"];


### PR DESCRIPTION
Warning introduced in fa687d092846ee38baf6a83afba4dcf6b762358b (18 November 2007 by @livings124)
Formula modified in 84b10c43127990857e5bfeadc443ec68f3d9d445 (18 November 2007 by @livings124)
As of Today, 3 June 2024, I'm not seeing any cutoff, so I'm suspecting that the issue got fixed on the same day that the warning was introduced?
No actions needed, so removing the warning.