### PR TITLE
fix: `tr_variant_serde::parse_json()` bug fixes

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -89,7 +89,7 @@ struct json_to_variant_handler : public rapidjson::BaseReaderHandler<>
 
     bool String(Ch const* const str, rapidjson::SizeType const len, bool const copy)
     {
-        *get_leaf() = copy ? tr_variant{ std::string{ str, len } } : tr_variant::unmanaged_string({ str, len });
+        *get_leaf() = copy ? tr_variant{ std::string_view{ str, len } } : tr_variant::unmanaged_string({ str, len });
         return true;
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -218,6 +218,8 @@ std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
     auto reader = rapidjson::GenericReader<rapidjson::AutoUTF<unsigned>, rapidjson::UTF8<char>>{};
     reader.Parse(eis, handler);
 
+    end_ = begin + eis.Tell();
+
     if (!reader.HasParseError())
     {
         return std::optional<tr_variant>{ std::move(top) };

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -216,7 +216,7 @@ std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
     auto ms = rapidjson::MemoryStream{ begin, size };
     auto eis = rapidjson::AutoUTFInputStream<unsigned, rapidjson::MemoryStream>{ ms };
     auto reader = rapidjson::GenericReader<rapidjson::AutoUTF<unsigned>, rapidjson::UTF8<char>>{};
-    reader.Parse(eis, handler);
+    reader.Parse<rapidjson::kParseStopWhenDoneFlag>(eis, handler);
 
     // Due to the nature of how AutoUTFInputStream works, when AutoUTFInputStream
     // is used with MemoryStream, the read cursor position is always 1 ahead of

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -543,8 +543,8 @@ TEST_F(VariantTest, serdeEnd)
         std::tuple{ R"({ "json1": 1 })"sv, '\0', 14U },
     };
     static auto constexpr TestsBenc = std::array{
-        std::tuple{ "d5:json1i1eed5:json2i2ee"sv, 'd', 12U },
-        std::tuple{ "d5:json1i1ee"sv, '\0', 12U },
+        std::tuple{ "d5:benc1i1eed5:benc2i2ee"sv, 'd', 12U },
+        std::tuple{ "d5:benc1i1ee"sv, '\0', 12U },
     };
 
     for (auto [in, c, pos] : TestsJson)

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -535,3 +535,33 @@ TEST_F(VariantTest, variantFromBufFuzz)
         (void)json_serde.inplace().parse(buf);
     }
 }
+
+TEST_F(VariantTest, serdeEnd)
+{
+    static auto constexpr TestsJson = std::array{
+        std::tuple{ R"({ "json1": 1 }{ "json2": 2 })"sv, '{', 14U },
+        std::tuple{ R"({ "json1": 1 })"sv, '\0', 14U },
+    };
+    static auto constexpr TestsBenc = std::array{
+        std::tuple{ "d5:json1i1eed5:json2i2ee"sv, 'd', 12U },
+        std::tuple{ "d5:json1i1ee"sv, '\0', 12U },
+    };
+
+    for (auto [in, c, pos] : TestsJson)
+    {
+        auto json_serde = tr_variant_serde::json().inplace();
+        auto json_var = json_serde.parse(in).value_or(tr_variant{});
+        EXPECT_TRUE(json_var.holds_alternative<tr_variant::Map>()) << json_serde.error_;
+        EXPECT_EQ(*json_serde.end(), c);
+        EXPECT_EQ(json_serde.end() - std::data(in), pos);
+    }
+
+    for (auto [in, c, pos] : TestsBenc)
+    {
+        auto benc_serde = tr_variant_serde::benc().inplace();
+        auto benc_var = benc_serde.parse(in).value_or(tr_variant{});
+        EXPECT_TRUE(benc_var.holds_alternative<tr_variant::Map>()) << benc_serde.error_;
+        EXPECT_EQ(*benc_serde.end(), c);
+        EXPECT_EQ(benc_serde.end() - std::data(in), pos);
+    }
+}


### PR DESCRIPTION
- Fixes a regression from #6138 where `tr_variant_serde::end_` isn't set after calling `parse_json()`.
- Fixed the cursor position used to generate the error string.
- Fixed the parser to stop when a complete JSON root is parsed, matching the behaviour of our benc parser.