### PR TITLE
fix: process BT messages that immediately follows handshake

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -565,34 +565,63 @@ ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* p
 
     tr_logAddTraceHand(handshake, fmt::format("handling can_read; state is [{}]", handshake->state_string()));
 
-    switch (handshake->state())
+    ReadState ret = READ_NOW;
+    while (ret == READ_NOW)
     {
-    case State::AwaitingHandshake:
-        return handshake->read_handshake(peer_io);
-    case State::AwaitingPeerId:
-        return handshake->read_peer_id(peer_io);
-    case State::AwaitingYa:
-        return handshake->read_ya(peer_io);
-    case State::AwaitingPadA:
-        return handshake->read_pad_a(peer_io);
-    case State::AwaitingCryptoProvide:
-        return handshake->read_crypto_provide(peer_io);
-    case State::AwaitingPadC:
-        return handshake->read_pad_c(peer_io);
-    case State::AwaitingIa:
-        return handshake->read_ia(peer_io);
-    case State::AwaitingYb:
-        return handshake->read_yb(peer_io);
-    case State::AwaitingVc:
-        return handshake->read_vc(peer_io);
-    case State::AwaitingCryptoSelect:
-        return handshake->read_crypto_select(peer_io);
-    case State::AwaitingPadD:
-        return handshake->read_pad_d(peer_io);
-    default:
-        TR_ASSERT_MSG(false, fmt::format("unhandled handshake state {:d}", static_cast<int>(handshake->state())));
-        return READ_ERR;
+        switch (handshake->state())
+        {
+        case State::AwaitingHandshake:
+            ret = handshake->read_handshake(peer_io);
+            break;
+
+        case State::AwaitingPeerId:
+            ret = handshake->read_peer_id(peer_io);
+            break;
+
+        case State::AwaitingYa:
+            ret = handshake->read_ya(peer_io);
+            break;
+
+        case State::AwaitingPadA:
+            ret = handshake->read_pad_a(peer_io);
+            break;
+
+        case State::AwaitingCryptoProvide:
+            ret = handshake->read_crypto_provide(peer_io);
+            break;
+
+        case State::AwaitingPadC:
+            ret = handshake->read_pad_c(peer_io);
+            break;
+
+        case State::AwaitingIa:
+            ret = handshake->read_ia(peer_io);
+            break;
+
+        case State::AwaitingYb:
+            ret = handshake->read_yb(peer_io);
+            break;
+
+        case State::AwaitingVc:
+            ret = handshake->read_vc(peer_io);
+            break;
+
+        case State::AwaitingCryptoSelect:
+            ret = handshake->read_crypto_select(peer_io);
+            break;
+
+        case State::AwaitingPadD:
+            ret = handshake->read_pad_d(peer_io);
+            break;
+
+        default:
+            TR_ASSERT_MSG(false, fmt::format("unhandled handshake state {:d}", static_cast<int>(handshake->state())));
+            ret = READ_ERR;
+            break;
+        }
     }
+
+    return ret;
 }
 
 void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandshake)

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -565,63 +565,34 @@ ReadState tr_handshake::can_read(tr_peerIo* peer_io, void* vhandshake, size_t* p
 
     tr_logAddTraceHand(handshake, fmt::format("handling can_read; state is [{}]", handshake->state_string()));
 
-    ReadState ret = READ_NOW;
-    while (ret == READ_NOW)
+    switch (handshake->state())
     {
-        switch (handshake->state())
-        {
-        case State::AwaitingHandshake:
-            ret = handshake->read_handshake(peer_io);
-            break;
-
-        case State::AwaitingPeerId:
-            ret = handshake->read_peer_id(peer_io);
-            break;
-
-        case State::AwaitingYa:
-            ret = handshake->read_ya(peer_io);
-            break;
-
-        case State::AwaitingPadA:
-            ret = handshake->read_pad_a(peer_io);
-            break;
-
-        case State::AwaitingCryptoProvide:
-            ret = handshake->read_crypto_provide(peer_io);
-            break;
-
-        case State::AwaitingPadC:
-            ret = handshake->read_pad_c(peer_io);
-            break;
-
-        case State::AwaitingIa:
-            ret = handshake->read_ia(peer_io);
-            break;
-
-        case State::AwaitingYb:
-            ret = handshake->read_yb(peer_io);
-            break;
-
-        case State::AwaitingVc:
-            ret = handshake->read_vc(peer_io);
-            break;
-
-        case State::AwaitingCryptoSelect:
-            ret = handshake->read_crypto_select(peer_io);
-            break;
-
-        case State::AwaitingPadD:
-            ret = handshake->read_pad_d(peer_io);
-            break;
-
-        default:
-            TR_ASSERT_MSG(false, fmt::format("unhandled handshake state {:d}", static_cast<int>(handshake->state())));
-            ret = READ_ERR;
-            break;
-        }
+    case State::AwaitingHandshake:
+        return handshake->read_handshake(peer_io);
+    case State::AwaitingPeerId:
+        return handshake->read_peer_id(peer_io);
+    case State::AwaitingYa:
+        return handshake->read_ya(peer_io);
+    case State::AwaitingPadA:
+        return handshake->read_pad_a(peer_io);
+    case State::AwaitingCryptoProvide:
+        return handshake->read_crypto_provide(peer_io);
+    case State::AwaitingPadC:
+        return handshake->read_pad_c(peer_io);
+    case State::AwaitingIa:
+        return handshake->read_ia(peer_io);
+    case State::AwaitingYb:
+        return handshake->read_yb(peer_io);
+    case State::AwaitingVc:
+        return handshake->read_vc(peer_io);
+    case State::AwaitingCryptoSelect:
+        return handshake->read_crypto_select(peer_io);
+    case State::AwaitingPadD:
+        return handshake->read_pad_d(peer_io);
+    default:
+        TR_ASSERT_MSG(false, fmt::format("unhandled handshake state {:d}", static_cast<int>(handshake->state())));
+        return READ_ERR;
     }
-
-    return ret;
 }
 
 void tr_handshake::on_error(tr_peerIo* io, tr_error const& error, void* vhandshake)

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -136,8 +136,8 @@ private:
         peer_io_->clear_callbacks();
 
         // The responding client of a handshake usually starts sending BT messages immediately after
-        // the handshake, so we need to return ReadState::Now to ensure those messages are processed.
-        return fire_done(is_connected) ? ReadState::Now : ReadState::Err;
+        // the handshake, so we need to return ReadState::Break to ensure those messages are processed.
+        return fire_done(is_connected) ? ReadState::Break : ReadState::Err;
     }
 
     [[nodiscard]] auto is_incoming() const noexcept

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -135,7 +135,7 @@ private:
     {
         peer_io_->clear_callbacks();
 
-        // The responding client of a handshake can immediately start sending BT messages after
+        // The responding client of a handshake usually starts sending BT messages immediately after
         // the handshake, so we need to return READ_NOW to ensure those messages are processed.
         return fire_done(is_connected) ? READ_NOW : READ_ERR;
     }

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -136,8 +136,8 @@ private:
         peer_io_->clear_callbacks();
 
         // The responding client of a handshake usually starts sending BT messages immediately after
-        // the handshake, so we need to return READ_NOW to ensure those messages are processed.
-        return fire_done(is_connected) ? READ_NOW : READ_ERR;
+        // the handshake, so we need to return ReadState::Now to ensure those messages are processed.
+        return fire_done(is_connected) ? ReadState::Now : ReadState::Err;
     }
 
     [[nodiscard]] auto is_incoming() const noexcept

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -134,7 +134,10 @@ private:
     ReadState done(bool is_connected)
     {
         peer_io_->clear_callbacks();
-        return fire_done(is_connected) ? READ_LATER : READ_ERR;
+
+        // The responding client of a handshake can immediately start sending BT messages after
+        // the handshake, so we need to return READ_NOW to ensure those messages are processed.
+        return fire_done(is_connected) ? READ_NOW : READ_ERR;
     }
 
     [[nodiscard]] auto is_incoming() const noexcept

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -389,7 +389,7 @@ void tr_peerIo::can_read_wrapper()
     {
         size_t piece = 0U;
         auto const old_len = read_buffer_size();
-        auto const read_state = can_read_ != nullptr ? can_read_(this, user_data_, &piece) : READ_ERR;
+        auto const read_state = can_read_ != nullptr ? can_read_(this, user_data_, &piece) : ReadState::Err;
         auto const used = old_len - read_buffer_size();
         auto const overhead = socket_.guess_packet_overhead(used);
 
@@ -410,7 +410,7 @@ void tr_peerIo::can_read_wrapper()
 
         switch (read_state)
         {
-        case READ_NOW:
+        case ReadState::Now:
             if (!std::empty(inbuf_))
             {
                 continue;
@@ -419,11 +419,11 @@ void tr_peerIo::can_read_wrapper()
             done = true;
             break;
 
-        case READ_LATER:
+        case ReadState::Later:
             done = true;
             break;
 
-        case READ_ERR:
+        case ReadState::Err:
             err = true;
             break;
         }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -411,12 +411,11 @@ void tr_peerIo::can_read_wrapper()
         switch (read_state)
         {
         case ReadState::Now:
-            if (!std::empty(inbuf_))
+        case ReadState::Break:
+            if (std::empty(inbuf_))
             {
-                continue;
+                done = true;
             }
-
-            done = true;
             break;
 
         case ReadState::Later:

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -39,11 +39,11 @@ namespace libtransmission::test
 class HandshakeTest;
 } // namespace libtransmission::test
 
-enum ReadState
+enum class ReadState : uint8_t
 {
-    READ_NOW,
-    READ_LATER,
-    READ_ERR
+    Now,
+    Later,
+    Err
 };
 
 enum tr_preferred_transport : uint8_t

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -43,6 +43,7 @@ enum class ReadState : uint8_t
 {
     Now,
     Later,
+    Break,
     Err
 };
 


### PR DESCRIPTION
Fixes #6909.

Notes: Fixed a bug where BT messages that immediately follows a handshake might be discarded.