### PR TITLE
refactor: convert `tr_net_init_mgr` to singleton

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -306,7 +306,7 @@ void sigHandler(int signal)
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -946,7 +946,7 @@ void tr_daemon::handle_error(tr_error const& error) const
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -49,7 +49,7 @@ Glib::OptionEntry create_option_entry(Glib::ustring const& long_name, gchar shor
 int main(int argc, char** argv)
 {
     /* init libtransmission */
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     /* init i18n */
     tr_locale_set_global("");

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -733,36 +733,47 @@ std::string tr_env_get_string(std::string_view key, std::string_view default_val
 
 // ---
 
-tr_net_init_mgr::tr_net_init_mgr()
+namespace
 {
-    // try to init curl with default settings (currently ssl support + win32 sockets)
-    // but if that fails, we need to init win32 sockets as a bare minimum
-    if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+namespace tr_net_init_impl
+{
+class tr_net_init_mgr
+{
+private:
+    tr_net_init_mgr()
     {
-        curl_global_init(CURL_GLOBAL_WIN32);
+        // try to init curl with default settings (currently ssl support + win32 sockets)
+        // but if that fails, we need to init win32 sockets as a bare minimum
+        if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+        {
+            curl_global_init(CURL_GLOBAL_WIN32);
+        }
     }
-}
 
-tr_net_init_mgr::~tr_net_init_mgr()
-{
-    curl_global_cleanup();
-}
-
-std::unique_ptr<tr_net_init_mgr> tr_net_init_mgr::create()
-{
-    if (!initialised)
+public:
+    TR_DISABLE_COPY_MOVE(tr_net_init_mgr)
+    ~tr_net_init_mgr()
     {
-        initialised = true;
-        return std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
+        curl_global_cleanup();
     }
-    return {};
-}
 
-bool tr_net_init_mgr::initialised = false;
+    static void create()
+    {
+        if (!instance)
+        {
+            instance = std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
+        }
+    }
 
-std::unique_ptr<tr_net_init_mgr> tr_lib_init()
+private:
+    static inline std::unique_ptr<tr_net_init_mgr> instance;
+};
+} // namespace tr_net_init_impl
+} // namespace
+
+void tr_lib_init()
 {
-    return tr_net_init_mgr::create();
+    tr_net_init_impl::tr_net_init_mgr::create();
 }
 
 // --- mime-type

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -751,7 +751,10 @@ private:
     }
 
 public:
-    TR_DISABLE_COPY_MOVE(tr_net_init_mgr)
+    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
+    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
+    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
+    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
     ~tr_net_init_mgr()
     {
         curl_global_cleanup();

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -302,23 +302,5 @@ constexpr void tr_timeUpdate(time_t now) noexcept
 
 // ---
 
-class tr_net_init_mgr
-{
-public:
-    ~tr_net_init_mgr();
-    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
-    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
-
-    static std::unique_ptr<tr_net_init_mgr> create();
-
-private:
-    tr_net_init_mgr();
-
-    static bool initialised;
-};
-
-/** @brief Initialise libtransmission for each app
- *  @return A manager object to be kept in scope of main() */
-std::unique_ptr<tr_net_init_mgr> tr_lib_init();
+/** @brief Initialise libtransmission for each app */
+void tr_lib_init();

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -10,7 +10,7 @@
 
 int main(int argc, char** argv)
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -93,7 +93,7 @@ bool tryDelegate(QStringList const& filenames)
 
 int tr_main(int argc, char** argv)
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -57,7 +57,7 @@ private:
     void SetUp() override
     {
         ::testing::Test::SetUp();
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
         tr_timeUpdate(time(nullptr));
     }
 
@@ -330,8 +330,6 @@ protected:
 
         return tr_socket_address{ *addr, tr_port::from_host(parsed_url->port) }.to_sockaddr();
     }
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 
     // https://www.bittorrent.org/beps/bep_0015.html
     static auto constexpr ProtocolId = uint64_t{ 0x41727101980ULL };

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -416,7 +416,7 @@ protected:
     {
         SandboxedTest::SetUp();
 
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
 
         tr_session_thread::tr_evthread_init();
         event_base_ = event_base_new();
@@ -431,8 +431,6 @@ protected:
     }
 
     struct event_base* event_base_ = nullptr;
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 
     // Arbitrary values. Several tests requires socket/port values
     // to be provided but they aren't central to the tests, so they're

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -489,7 +489,7 @@ protected:
     {
         SandboxedTest::SetUp();
 
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
 
         session_ = sessionInit(*settings());
     }
@@ -507,8 +507,6 @@ private:
     std::mutex verified_mutex_;
     std::condition_variable verified_cv_;
     std::vector<tr_torrent*> verified_;
-
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
 };
 
 } // namespace test

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -64,13 +64,11 @@ private:
     std::shared_ptr<struct event_base> ev_base_;
     std::unique_ptr<libtransmission::TimerMaker> timer_maker_;
 
-    std::unique_ptr<tr_net_init_mgr> init_mgr_;
-
 protected:
     void SetUp() override
     {
         SandboxedTest::SetUp();
-        init_mgr_ = tr_lib_init();
+        tr_lib_init();
         ev_base_.reset(event_base_new(), event_base_free);
         timer_maker_ = std::make_unique<libtransmission::EvTimerMaker>(ev_base_.get());
         Watchdir::set_generic_rescan_interval(GenericRescanInterval);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -3418,7 +3418,7 @@ void get_host_and_port_and_rpc_url(
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -403,7 +403,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
 int tr_main(int argc, char* argv[])
 {
-    auto const init_mgr = tr_lib_init();
+    tr_lib_init();
 
     tr_locale_set_global("");
 


### PR DESCRIPTION
A follow up of #5702.

This is just to hide more implementation details.