### PR TITLE
fix: restore tr_optind in all getConfigDir branches

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -167,8 +167,8 @@ void onTorrentFileDownloaded(tr_web::FetchResponse const& response)
     {
         if (c == 'g')
         {
+            tr_optind = ind;
             return my_optarg;
-            break;
         }
     }
 


### PR DESCRIPTION
When the --config-dir/-g option was passed, this bug caused all options
preceeding it on the command line to be ignored.

Also remove the superfluous break statement.

Regression introduced by e49747ab51953a3c2f81767b320f1f415eba9150.
