### PR TITLE
ci: bump `clang-tidy` from 14 to 18

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -221,7 +221,7 @@ jobs:
         run: cmake -E chdir obj ctest -j $(nproc) --build-config Debug --output-on-failure
 
   clang-tidy-libtransmission:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.test-style == 'true' }}
     steps:

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -343,7 +343,7 @@ struct tau_tracker
             return;
         }
 
-        auto const& [ss, sslen] = *addr_[ip_protocol];
+        auto const& [ss, sslen] = *addr_[ip_protocol]; // NOLINT(bugprone-unchecked-optional-access)
         mediator_.sendto(buf, buflen, reinterpret_cast<sockaddr const*>(&ss), sslen);
     }
 
@@ -388,12 +388,14 @@ struct tau_tracker
         for (ipp_t ipp = 0; ipp < NUM_TR_AF_INET_TYPES; ++ipp)
         {
             // do we have a DNS request that's ready?
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
             if (addr_pending_dns_[ipp] && addr_pending_dns_[ipp]->wait_for(0ms) == std::future_status::ready)
             {
                 addr_[ipp] = addr_pending_dns_[ipp]->get();
                 addr_pending_dns_[ipp].reset();
                 addr_expires_at_[ipp] = now + DnsRetryIntervalSecs;
             }
+            // NOLINTEND(bugprone-unchecked-optional-access)
         }
 
         // are there any tracker requests pending?
@@ -437,6 +439,7 @@ struct tau_tracker
             // also need a valid connection ID...
             if (addr_[ipp] && !is_connected(ipp_enum, now) && connecting_at[ipp] == 0)
             {
+                // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                 TR_ASSERT(addr_[ipp]->first.ss_family == tr_ip_protocol_to_af(ipp_enum));
 
                 connecting_at[ipp] = now;

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -160,7 +160,7 @@ struct tau_scrape_request
 
     tr_scrape_response response = {};
 
-    static auto constexpr ip_protocol = TR_AF_UNSPEC; // NOLINT readability-identifier-naming
+    static auto constexpr ip_protocol = TR_AF_UNSPEC; // NOLINT(readability-identifier-naming)
 
 private:
     time_t const created_at_ = tr_time();

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -337,13 +337,14 @@ struct tau_tracker
             return;
         }
 
-        TR_ASSERT(addr_[ip_protocol]);
-        if (!addr_[ip_protocol])
+        auto const& addr = addr_[ip_protocol];
+        TR_ASSERT(addr);
+        if (!addr)
         {
             return;
         }
 
-        auto const& [ss, sslen] = *addr_[ip_protocol]; // NOLINT(bugprone-unchecked-optional-access)
+        auto const& [ss, sslen] = *addr;
         mediator_.sendto(buf, buflen, reinterpret_cast<sockaddr const*>(&ss), sslen);
     }
 
@@ -388,14 +389,12 @@ struct tau_tracker
         for (ipp_t ipp = 0; ipp < NUM_TR_AF_INET_TYPES; ++ipp)
         {
             // do we have a DNS request that's ready?
-            // NOLINTBEGIN(bugprone-unchecked-optional-access)
-            if (addr_pending_dns_[ipp] && addr_pending_dns_[ipp]->wait_for(0ms) == std::future_status::ready)
+            if (auto& dns = addr_pending_dns_[ipp]; dns && dns->wait_for(0ms) == std::future_status::ready)
             {
-                addr_[ipp] = addr_pending_dns_[ipp]->get();
-                addr_pending_dns_[ipp].reset();
+                addr_[ipp] = dns->get();
+                dns.reset();
                 addr_expires_at_[ipp] = now + DnsRetryIntervalSecs;
             }
-            // NOLINTEND(bugprone-unchecked-optional-access)
         }
 
         // are there any tracker requests pending?
@@ -437,10 +436,9 @@ struct tau_tracker
                     connecting_at[ipp]));
 
             // also need a valid connection ID...
-            if (addr_[ipp] && !is_connected(ipp_enum, now) && connecting_at[ipp] == 0)
+            if (auto const& addr = addr_[ipp]; addr && !is_connected(ipp_enum, now) && connecting_at[ipp] == 0)
             {
-                // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                TR_ASSERT(addr_[ipp]->first.ss_family == tr_ip_protocol_to_af(ipp_enum));
+                TR_ASSERT(addr->first.ss_family == tr_ip_protocol_to_af(ipp_enum));
 
                 connecting_at[ipp] = now;
                 connection_transaction_id[ipp] = tau_transaction_new();


### PR DESCRIPTION
`clang-tidy-14` has been crashing when being run on `peer-mgr.cc` since 96de1706af82e8141f5ec31ce2c0f09a38b7d695.

According to https://github.com/llvm/llvm-project/issues/95631, upgrading to `clang-tidy-18` fixes this.