### PR TITLE
refactor: alternative x/y coords to account for zoomed in browser

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -239,18 +239,16 @@ export class Transmission extends EventTarget {
 
       const boundingElement = document.querySelector('#torrent-container');
       const bounds = boundingElement.getBoundingClientRect();
-      const x =
-        Math.min(
-          this.isTouch ? event_.touches[0].clientX : event_.x,
-          bounds.x + bounds.width - popup.root.clientWidth,
-        ) + (this.isTouch ? window.visualViewport.offsetLeft : 0);
-      const y =
-        Math.min(
-          this.isTouch ? event_.touches[0].clientY : event_.y,
-          bounds.y + bounds.height - popup.root.clientHeight,
-        ) + (this.isTouch ? window.visualViewport.offsetTop : 0);
-      popup.root.style.left = `${x > 0 ? x : 0}px`;
-      popup.root.style.top = `${y > 0 ? y : 0}px`;
+      const x = Math.min(
+        this.isTouch ? event_.touches[0].pageX : event_.pageX,
+        bounds.right + globalThis.scrollX - popup.root.clientWidth,
+      );
+      const y = Math.min(
+        this.isTouch ? event_.touches[0].pageY : event_.pageY,
+        bounds.bottom + globalThis.scrollY - popup.root.clientHeight,
+      );
+      popup.root.style.left = `${Math.max(x, 0)}px`;
+      popup.root.style.top = `${Math.max(y, 0)}px`;
       event_.preventDefault();
     };
 

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -239,14 +239,16 @@ export class Transmission extends EventTarget {
 
       const boundingElement = document.querySelector('#torrent-container');
       const bounds = boundingElement.getBoundingClientRect();
-      const x = Math.min(
-        this.isTouch ? event_.touches[0].clientX : event_.x,
-        bounds.x + bounds.width - popup.root.clientWidth,
-      );
-      const y = Math.min(
-        this.isTouch ? event_.touches[0].clientY : event_.y,
-        bounds.y + bounds.height - popup.root.clientHeight,
-      );
+      const x =
+        Math.min(
+          this.isTouch ? event_.touches[0].clientX : event_.x,
+          bounds.x + bounds.width - popup.root.clientWidth,
+        ) + (this.isTouch ? window.visualViewport.offsetLeft : 0);
+      const y =
+        Math.min(
+          this.isTouch ? event_.touches[0].clientY : event_.y,
+          bounds.y + bounds.height - popup.root.clientHeight,
+        ) + (this.isTouch ? window.visualViewport.offsetTop : 0);
       popup.root.style.left = `${x > 0 ? x : 0}px`;
       popup.root.style.top = `${y > 0 ? y : 0}px`;
       event_.preventDefault();


### PR DESCRIPTION
Allows context menu to be placed to where the fingertip is on a zoomed in browser (Safari iOS)

This is a refinement upon #5928 along with small refactors.