### PR TITLE
perf: lazy initialise Diffie-Hellman in handshake

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -233,8 +233,6 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
         return READ_LATER;
     }
 
-    have_read_anything_from_peer_ = true;
-
     if (ia_len_ > 0U)
     {
         // do nothing, the check below won't work correctly
@@ -257,6 +255,8 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
         tr_logAddTraceHand(this, "peer is encrypted, and that does not agree with our handshake");
         return done(false);
     }
+
+    have_read_anything_from_peer_ = true;
 
     auto name = decltype(HandshakeName){};
     peer_io->read_bytes(std::data(name), std::size(name));

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -41,6 +41,7 @@ using key_bigend_t = tr_message_stream_encryption::DH::key_bigend_t;
 void tr_handshake::send_ya(tr_peerIo* io)
 {
     tr_logAddTraceHand(this, "sending MSE handshake (Ya)");
+    dh_ = get_dh(mediator_);
     send_public_key_and_pad<PadaMaxlen>(io);
     set_state(tr_handshake::State::AwaitingYb);
 }
@@ -363,6 +364,7 @@ ReadState tr_handshake::read_ya(tr_peerIo* peer_io)
         return READ_LATER;
     }
 
+    dh_ = get_dh(mediator_);
     have_read_anything_from_peer_ = true;
 
     /* read the incoming peer's public key */
@@ -821,8 +823,7 @@ std::string_view tr_handshake::state_string(State state) noexcept
 }
 
 tr_handshake::tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode, DoneFunc on_done)
-    : dh_{ tr_handshake::get_dh(mediator) }
-    , on_done_{ std::move(on_done) }
+    : on_done_{ std::move(on_done) }
     , peer_io_{ std::move(peer_io) }
     , timeout_timer_{ mediator->timer_maker().create([this]() { fire_done(false); }) }
     , mediator_{ mediator }

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -84,6 +84,11 @@ public:
 
     tr_handshake(Mediator* mediator, std::shared_ptr<tr_peerIo> peer_io, tr_encryption_mode mode_in, DoneFunc on_done);
 
+    ~tr_handshake()
+    {
+        maybe_recycle_dh();
+    }
+
 private:
     enum class State : uint8_t
     {

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -21,6 +21,8 @@
 #include <string_view>
 #include <utility>
 
+#include <small/vector.hpp>
+
 #include "libtransmission/transmission.h"
 
 #include "libtransmission/peer-mse.h" // tr_message_stream_encryption::DH
@@ -255,19 +257,17 @@ private:
     ///
 
     static constexpr auto DhPoolMaxSize = size_t{ 32 };
-    static inline auto dh_pool_size = size_t{};
-    static inline auto dh_pool = std::array<tr_message_stream_encryption::DH, DhPoolMaxSize>{};
+    static inline auto dh_pool = small::max_size_vector<DH, DhPoolMaxSize>{};
     static inline auto dh_pool_mutex = std::mutex{};
 
     [[nodiscard]] static DH get_dh(Mediator* mediator)
     {
         auto lock = std::unique_lock(dh_pool_mutex);
 
-        if (dh_pool_size > 0U)
+        if (!std::empty(dh_pool))
         {
-            auto dh = DH{};
-            std::swap(dh, dh_pool[dh_pool_size - 1U]);
-            --dh_pool_size;
+            auto const dh = dh_pool.back();
+            dh_pool.pop_back();
             return dh;
         }
 
@@ -278,10 +278,9 @@ private:
     {
         auto lock = std::unique_lock(dh_pool_mutex);
 
-        if (dh_pool_size < std::size(dh_pool))
+        if (std::size(dh_pool) < dh_pool.max_size())
         {
-            dh_pool[dh_pool_size] = dh;
-            ++dh_pool_size;
+            dh_pool.emplace_back(std::move(dh));
         }
     }
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -293,9 +293,12 @@ private:
             return;
         }
 
-        auto dh = DH{};
-        std::swap(dh_, dh);
-        add_dh(dh);
+        if (!dh_.is_dummy())
+        {
+            auto dh = DH{};
+            std::swap(dh_, dh);
+            add_dh(std::move(dh));
+        }
     }
 
     ///

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -170,7 +170,7 @@ private:
     template<size_t PadMax>
     void send_public_key_and_pad(tr_peerIo* io)
     {
-        auto const public_key = dh_.publicKey();
+        auto const public_key = get_dh().publicKey();
         auto outbuf = std::array<std::byte, std::size(public_key) + PadMax>{};
         auto const data = std::data(outbuf);
         auto walk = data;
@@ -260,21 +260,21 @@ private:
     static inline auto dh_pool = small::max_size_vector<DH, DhPoolMaxSize>{};
     static inline auto dh_pool_mutex = std::mutex{};
 
-    [[nodiscard]] static DH get_dh(Mediator* mediator)
+    [[nodiscard]] static std::optional<DH> pop_dh_pool()
     {
         auto lock = std::unique_lock(dh_pool_mutex);
 
-        if (!std::empty(dh_pool))
+        if (std::empty(dh_pool))
         {
-            auto const dh = dh_pool.back();
-            dh_pool.pop_back();
-            return dh;
+            return {};
         }
 
-        return DH{ mediator->private_key() };
+        auto dh = std::move(dh_pool.back());
+        dh_pool.pop_back();
+        return dh;
     }
 
-    static void add_dh(DH dh)
+    static void push_dh_pool(DH dh)
     {
         auto lock = std::unique_lock(dh_pool_mutex);
 
@@ -282,6 +282,16 @@ private:
         {
             dh_pool.emplace_back(std::move(dh));
         }
+    }
+
+    [[nodiscard]] DH& get_dh()
+    {
+        if (!dh_)
+        {
+            dh_.emplace(pop_dh_pool().value_or(DH{ mediator_->private_key() }));
+        }
+
+        return *dh_;
     }
 
     void maybe_recycle_dh()
@@ -293,17 +303,16 @@ private:
             return;
         }
 
-        if (!dh_.is_dummy())
+        if (dh_)
         {
-            auto dh = DH{};
-            std::swap(dh_, dh);
-            add_dh(std::move(dh));
+            push_dh_pool(std::move(*dh_));
+            dh_.reset();
         }
     }
 
     ///
 
-    DH dh_{};
+    std::optional<DH> dh_{};
 
     DoneFunc on_done_;
 

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -14,6 +14,7 @@
 #include "libtransmission/crypto-utils.h" // tr_sha1
 #include "libtransmission/peer-mse.h"
 #include "libtransmission/tr-arc4.h"
+#include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-macros.h" // tr_sha1_digest_t
 
 using namespace std::literals;
@@ -86,6 +87,7 @@ namespace tr_message_stream_encryption
 
 DH::key_bigend_t DH::publicKey() noexcept
 {
+    TR_ASSERT(!is_dummy());
     if (public_key_ == key_bigend_t{})
     {
         public_key_ = generatePublicKey(private_key_);
@@ -96,6 +98,7 @@ DH::key_bigend_t DH::publicKey() noexcept
 
 void DH::setPeerPublicKey(key_bigend_t const& peer_public_key)
 {
+    TR_ASSERT(!is_dummy());
     auto const secret = math::wide_integer::powm(
         wi::import_bits<wi::key_t>(peer_public_key),
         wi::import_bits<wi::private_key_t>(private_key_),

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -87,7 +87,6 @@ namespace tr_message_stream_encryption
 
 DH::key_bigend_t DH::publicKey() noexcept
 {
-    TR_ASSERT(!is_dummy());
     if (public_key_ == key_bigend_t{})
     {
         public_key_ = generatePublicKey(private_key_);
@@ -98,7 +97,6 @@ DH::key_bigend_t DH::publicKey() noexcept
 
 void DH::setPeerPublicKey(key_bigend_t const& peer_public_key)
 {
-    TR_ASSERT(!is_dummy());
     auto const secret = math::wide_integer::powm(
         wi::import_bits<wi::key_t>(peer_public_key),
         wi::import_bits<wi::private_key_t>(private_key_),

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -45,20 +45,11 @@ public:
     using private_key_bigend_t = std::array<std::byte, PrivateKeySize>;
     using key_bigend_t = std::array<std::byte, KeySize>;
 
-    // This produces dummy objects that shouldn't be used for key exchange
-    constexpr DH() = default;
-
     // In actual code, a private key is randomly generated.
     // Providing a predefined one is useful for reproducible unit tests.
     constexpr explicit DH(private_key_bigend_t const& private_key) noexcept
         : private_key_{ private_key }
     {
-    }
-
-    // Check if this object is a dummy object
-    [[nodiscard]] bool is_dummy() const noexcept
-    {
-        return private_key_ == private_key_bigend_t{};
     }
 
     // Returns our own public key to be shared with a peer.

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -55,6 +55,12 @@ public:
     {
     }
 
+    // Check if this object is a dummy object
+    [[nodiscard]] bool is_dummy() const noexcept
+    {
+        return private_key_ == private_key_bigend_t{};
+    }
+
     // Returns our own public key to be shared with a peer.
     [[nodiscard]] key_bigend_t publicKey() noexcept;
 

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -45,9 +45,12 @@ public:
     using private_key_bigend_t = std::array<std::byte, PrivateKeySize>;
     using key_bigend_t = std::array<std::byte, KeySize>;
 
-    // By default, a private key is randomly generated.
+    // This produces dummy objects that shouldn't be used for key exchange
+    constexpr DH() = default;
+
+    // In actual code, a private key is randomly generated.
     // Providing a predefined one is useful for reproducible unit tests.
-    constexpr DH(private_key_bigend_t const& private_key = randomPrivateKey()) noexcept
+    constexpr explicit DH(private_key_bigend_t const& private_key) noexcept
         : private_key_{ private_key }
     {
     }
@@ -67,7 +70,7 @@ public:
     [[nodiscard]] static private_key_bigend_t randomPrivateKey() noexcept;
 
 private:
-    private_key_bigend_t private_key_;
+    private_key_bigend_t private_key_ = {};
     key_bigend_t public_key_ = {};
     key_bigend_t secret_ = {};
 };

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -48,8 +48,8 @@ std::string toString(std::array<std::byte, N> const& array)
 
 TEST(Crypto, DH)
 {
-    auto a = tr_message_stream_encryption::DH{};
-    auto b = tr_message_stream_encryption::DH{};
+    auto a = tr_message_stream_encryption::DH{ tr_message_stream_encryption::DH::randomPrivateKey() };
+    auto b = tr_message_stream_encryption::DH{ tr_message_stream_encryption::DH::randomPrivateKey() };
 
     a.setPeerPublicKey(b.publicKey());
     b.setPeerPublicKey(a.publicKey());
@@ -57,7 +57,7 @@ TEST(Crypto, DH)
     EXPECT_EQ(a.secret(), b.secret());
     EXPECT_EQ(96U, std::size(a.secret()));
 
-    auto c = tr_message_stream_encryption::DH{};
+    auto c = tr_message_stream_encryption::DH{ tr_message_stream_encryption::DH::randomPrivateKey() };
     c.setPeerPublicKey(b.publicKey());
     EXPECT_NE(a.secret(), c.secret());
     EXPECT_NE(toString(a.secret()), toString(c.secret()));
@@ -65,8 +65,8 @@ TEST(Crypto, DH)
 
 TEST(Crypto, encryptDecrypt)
 {
-    auto a_dh = tr_message_stream_encryption::DH{};
-    auto b_dh = tr_message_stream_encryption::DH{};
+    auto a_dh = tr_message_stream_encryption::DH{ tr_message_stream_encryption::DH::randomPrivateKey() };
+    auto b_dh = tr_message_stream_encryption::DH{ tr_message_stream_encryption::DH::randomPrivateKey() };
 
     a_dh.setPeerPublicKey(b_dh.publicKey());
     b_dh.setPeerPublicKey(a_dh.publicKey());


### PR DESCRIPTION
Avoid generating a Diffie-Hellman private key when we are using a plain connection.