### PR TITLE
clarify MSE crypto algo usage

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -246,7 +246,7 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
             tr_logAddTraceHand(this, "peer is unencrypted, and we're disallowing that");
             return done(false);
         }
-        if (crypto_select_ == CryptoProvideCrypto)
+        if (crypto_select_ == CryptoProvideRC4)
         {
             tr_logAddTraceHand(this, "peer is unencrypted, and that does not agree with our handshake");
             return done(false);
@@ -725,11 +725,11 @@ uint32_t tr_handshake::crypto_provide() const noexcept
     {
     case TR_ENCRYPTION_REQUIRED:
     case TR_ENCRYPTION_PREFERRED:
-        provide |= CryptoProvideCrypto;
+        provide |= CryptoProvideRC4;
         break;
 
     case TR_CLEAR_PREFERRED:
-        provide |= CryptoProvideCrypto | CryptoProvidePlaintext;
+        provide |= CryptoProvideRC4 | CryptoProvidePlaintext;
         break;
     }
 
@@ -744,17 +744,17 @@ uint32_t tr_handshake::crypto_provide() const noexcept
     switch (encryption_mode)
     {
     case TR_ENCRYPTION_REQUIRED:
-        choices[n_choices++] = CryptoProvideCrypto;
+        choices[n_choices++] = CryptoProvideRC4;
         break;
 
     case TR_ENCRYPTION_PREFERRED:
-        choices[n_choices++] = CryptoProvideCrypto;
+        choices[n_choices++] = CryptoProvideRC4;
         choices[n_choices++] = CryptoProvidePlaintext;
         break;
 
     case TR_CLEAR_PREFERRED:
         choices[n_choices++] = CryptoProvidePlaintext;
-        choices[n_choices++] = CryptoProvideCrypto;
+        choices[n_choices++] = CryptoProvideRC4;
         break;
     }
 

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -229,7 +229,7 @@ private:
     // > As of now 0x01 means plaintext, 0x02 means RC4. (see Functions)
     // > The remaining bits are reserved for future use.
     static auto constexpr CryptoProvidePlaintext = uint32_t{ 0x01 };
-    static auto constexpr CryptoProvideCrypto = uint32_t{ 0x02 };
+    static auto constexpr CryptoProvideRC4 = uint32_t{ 0x02 };
 
     // MSE constants.
     // http://wiki.vuze.com/w/Message_Stream_Encryption


### PR DESCRIPTION
 this is a per-algorithm key, not for crypto generally. If additional algos are ever added, they would be "CryptoProvideXXX" and "CryptoProvideYYY".

