### PR TITLE
refactor: save outgoing `len(PadA)`, `len(PadB)` and `len(IA)`

### DIFF
--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -119,6 +119,7 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
     outbuf.add_uint16(0);
 
     /* ENCRYPT len(IA)), ENCRYPT(IA) */
+    ia_len_ = HandshakeSize;
     outbuf.add_uint16(HandshakeSize);
     if (build_handshake_message(peer_io, outbuf))
     {
@@ -244,7 +245,7 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
         return ReadState::Later;
     }
 
-    if (ia_len_ > 0U)
+    if (is_incoming() && ia_len_ > 0U)
     {
         // do nothing, the check below won't work correctly
     }

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -40,8 +40,8 @@ using key_bigend_t = tr_message_stream_encryption::DH::key_bigend_t;
 // 1 A->B: our public key (Ya) and some padding (PadA)
 void tr_handshake::send_ya(tr_peerIo* io)
 {
-    tr_logAddTraceHand(this, "sending MSE handshake (Ya)");
     pad_a_len_ = send_public_key_and_pad<PadaMaxlen>(io);
+    tr_logAddTraceHand(this, fmt::format("sent MSE handshake (Ya)... len(PadA) = {}", pad_a_len_));
     set_state(tr_handshake::State::AwaitingYb);
 }
 
@@ -390,8 +390,8 @@ ReadState tr_handshake::read_ya(tr_peerIo* peer_io)
     peer_io->read_buffer_discard(pad_a_len_);
 
     // send our public key to the peer
-    tr_logAddTraceHand(this, "sending B->A: Diffie Hellman Yb, PadB");
     pad_b_len_ = send_public_key_and_pad<PadbMaxlen>(peer_io);
+    tr_logAddTraceHand(this, fmt::format("sent B->A: Diffie Hellman Yb, PadB... len(PadB) = {}", pad_b_len_));
 
     set_state(State::AwaitingPadA);
     // LATER, not NOW: recv buffer was just drained and peer was blocking

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -235,15 +235,17 @@ private:
     bool send_handshake(tr_peerIo* io);
 
     template<size_t PadMax>
-    void send_public_key_and_pad(tr_peerIo* io)
+    auto send_public_key_and_pad(tr_peerIo* io)
     {
         auto const public_key = get_dh().publicKey();
         auto outbuf = std::array<std::byte, std::size(public_key) + PadMax>{};
         auto const data = std::data(outbuf);
         auto walk = data;
         walk = std::copy(std::begin(public_key), std::end(public_key), walk);
-        walk += mediator_->pad(walk, PadMax);
+        auto const pad_len = mediator_->pad(walk, PadMax);
+        walk += pad_len;
         io->write_bytes(data, walk - data, false);
+        return pad_len;
     }
 
     [[nodiscard]] uint32_t crypto_provide() const noexcept;
@@ -334,12 +336,11 @@ private:
 
     uint32_t crypto_select_ = {};
     uint32_t crypto_provide_ = {};
+    uint16_t pad_a_len_ = {};
+    uint16_t pad_b_len_ = {};
     uint16_t pad_c_len_ = {};
     uint16_t pad_d_len_ = {};
     uint16_t ia_len_ = {};
-
-    uint16_t pad_a_recv_len_ = {};
-    uint16_t pad_b_recv_len_ = {};
 
     bool have_read_anything_from_peer_ = false;
 


### PR DESCRIPTION
https://github.com/transmission/transmission/pull/6949#pullrequestreview-2152187191

CC @reardonia 