### PR TITLE
compatibility with libfmt v11

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -48,6 +48,7 @@
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
This adds the required include of `<fmt/ranges.h>` for compatibility with fmt 11.