### PR TITLE
fix: silence bugprone-unchecked-optional-access warnings

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cerrno>
 #include <climits> /* PATH_MAX */
 #include <cstdint> /* SIZE_MAX */
@@ -986,6 +987,7 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
 
 #endif
 
+    assert(result);
     if (!*result && errno == EAGAIN)
     {
         errno = EWOULDBLOCK;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cerrno>
 #include <climits> /* PATH_MAX */
 #include <cstdint> /* SIZE_MAX */
@@ -987,7 +986,7 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
 
 #endif
 
-    assert(result);
+    TR_ASSERT(result);
     if (!*result && errno == EAGAIN)
     {
         errno = EWOULDBLOCK;


### PR DESCRIPTION
clang-tidy emits bugprone-unchecked-optional-access warning for `tr_sys_file_lock`. however, this is a false positive: the lines warned about cannot be reached if the optional does not contain a value. adding an `assert` silences these warnings.