### PR TITLE
refactor: removed refresh rate restriction

### DIFF
--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -77,9 +77,6 @@ export class Prefs extends EventTarget {
     if (value === 'false') {
       return false;
     }
-    if (/^\d+$/.test(value)) {
-      return Number.parseInt(value, 10);
-    }
     return value;
   }
 

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -376,7 +376,8 @@ export class Transmission extends EventTarget {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
         const msec =
-          !Number.isNaN(this.prefs.refresh_rate_sec) && this.prefs.refresh_rate_sec > 0
+          !Number.isNaN(this.prefs.refresh_rate_sec) &&
+          this.prefs.refresh_rate_sec > 0
             ? this.prefs.refresh_rate_sec * 1000
             : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -376,7 +376,7 @@ export class Transmission extends EventTarget {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
         const msec =
-          parseFloat(this.prefs.refresh_rate_sec) > 0
+          Number.parseFloat(this.prefs.refresh_rate_sec) > 0
             ? this.prefs.refresh_rate_sec * 1000
             : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -375,7 +375,10 @@ export class Transmission extends EventTarget {
       case Prefs.RefreshRate: {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
-        const msec = this.prefs.refresh_rate_sec * 1000;
+        const msec =
+          parseFloat(this.prefs.refresh_rate_sec) > 0
+            ? this.prefs.refresh_rate_sec * 1000
+            : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);
         break;
       }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -375,7 +375,7 @@ export class Transmission extends EventTarget {
       case Prefs.RefreshRate: {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
-        const msec = Math.max(2, this.prefs.refresh_rate_sec) * 1000;
+        const msec = this.prefs.refresh_rate_sec * 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);
         break;
       }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -376,7 +376,7 @@ export class Transmission extends EventTarget {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
         const msec =
-          Number.parseFloat(this.prefs.refresh_rate_sec) > 0
+          !isNaN(this.prefs.refresh_rate_sec) && this.prefs.refresh_rate_sec > 0
             ? this.prefs.refresh_rate_sec * 1000
             : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -376,7 +376,7 @@ export class Transmission extends EventTarget {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
         const msec =
-          !isNaN(this.prefs.refresh_rate_sec) && this.prefs.refresh_rate_sec > 0
+          !Number.isNaN(this.prefs.refresh_rate_sec) && this.prefs.refresh_rate_sec > 0
             ? this.prefs.refresh_rate_sec * 1000
             : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);


### PR DESCRIPTION
Removed max allowed refresh rate (2 seconds -> unrestricted). Editing refresh rate from cookie is considered Easter egg. If one ever to attempt a fraction number to update faster than 1 second through editing cookies then that user will know fully well what they wished for.

When #6867 ships, the refresh rate will be as fast as monitor Hz allows (due to `requestAnimationFrame`).