### PR TITLE
refactor: parse cookie pref values as their default values types

### DIFF
--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -81,7 +81,8 @@ export class Prefs extends EventTarget {
         return false;
       }
       return fallback;
-    } else if (type === 'number') {
+    }
+    if (type === 'number') {
       const f = Number.parseFloat(value);
       return Number.isNaN(f) ? fallback : f;
     }

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -77,10 +77,8 @@ export class Prefs extends EventTarget {
     if (value === 'false') {
       return false;
     }
-    if (/^\d+$/.test(value)) {
-      return Number.parseInt(value, 10);
-    }
-    return value;
+    const f = Number.parseFloat(value);
+    return Number.isNaN(f) ? value : f;
   }
 
   static _readCookie(key) {

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -71,14 +71,21 @@ export class Prefs extends EventTarget {
     if (value === null) {
       return fallback;
     }
-    if (value === 'true') {
-      return true;
+
+    const type = typeof fallback;
+    if (type === 'boolean') {
+      if (value === 'true') {
+        return true;
+      }
+      if (value === 'false') {
+        return false;
+      }
+      return fallback;
+    } else if (type === 'number') {
+      const f = Number.parseFloat(value);
+      return Number.isNaN(f) ? fallback : f;
     }
-    if (value === 'false') {
-      return false;
-    }
-    const f = Number.parseFloat(value);
-    return Number.isNaN(f) ? value : f;
+    return value;
   }
 
   static _readCookie(key) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -376,7 +376,7 @@ export class Transmission extends EventTarget {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
         const pref = this.prefs.refresh_rate_sec;
-        const msec = typeof pref === 'number' && pref > 0 ? pref * 1000 : 1000;
+        const msec = pref > 0 ? pref * 1000 : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);
         break;
       }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -375,7 +375,8 @@ export class Transmission extends EventTarget {
       case Prefs.RefreshRate: {
         clearInterval(this.refreshTorrentsInterval);
         const callback = this.refreshTorrents.bind(this);
-        const msec = Math.max(2, this.prefs.refresh_rate_sec) * 1000;
+        const pref = this.prefs.refresh_rate_sec;
+        const msec = typeof pref === 'number' && pref > 0 ? pref * 1000 : 1000;
         this.refreshTorrentsInterval = setInterval(callback, msec);
         break;
       }


### PR DESCRIPTION
Alternative of #6998.

This PR make sure that the pref values read from the cookie is always going to be the same type as the default value.

Allowing pref values to have different types from their default value creates a need to implement error checking in all places where the pref values are used, but there is no benefit to it.

Also the fallback value of the web refresh rate has been reduced from 2 seconds to 1 second, like the original PR did.